### PR TITLE
feat: add skill/agent management features

### DIFF
--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -3,6 +3,7 @@ import { registerFilesHandlers } from './files'
 import { registerSkillsHandlers } from './skills'
 import { registerSkillsCliHandlers } from './skillsCli'
 import { registerSourceHandlers } from './source'
+import { registerSyncHandlers } from './sync'
 import { registerUpdateHandlers } from './update'
 
 /**
@@ -16,4 +17,5 @@ export function registerAllHandlers(): void {
   registerSourceHandlers()
   registerFilesHandlers()
   registerUpdateHandlers()
+  registerSyncHandlers()
 }

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -1,9 +1,20 @@
 import * as fs from 'node:fs/promises'
+import { join } from 'node:path'
 
 import { ipcMain } from 'electron'
 
 import { IPC_CHANNELS } from '../../shared/ipc-channels'
-import type { UnlinkFromAgentOptions, UnlinkResult } from '../../shared/types'
+import type {
+  CreateSymlinksOptions,
+  CreateSymlinksResult,
+  DeleteSkillOptions,
+  DeleteSkillResult,
+  RemoveAllFromAgentOptions,
+  RemoveAllFromAgentResult,
+  UnlinkFromAgentOptions,
+  UnlinkResult,
+} from '../../shared/types'
+import { AGENTS, SOURCE_DIR } from '../constants'
 import { scanSkills } from '../services/skillScanner'
 
 /**
@@ -43,6 +54,137 @@ export function registerSkillsHandlers(): void {
           error instanceof Error ? error.message : 'Unknown error occurred'
         return { success: false, error: message }
       }
+    },
+  )
+
+  /**
+   * Remove all symlinks from a specific agent's skills directory
+   * @param options - agentId, agentPath
+   * @returns RemoveAllFromAgentResult with removed count
+   */
+  ipcMain.handle(
+    IPC_CHANNELS.SKILLS_REMOVE_ALL_FROM_AGENT,
+    async (
+      _,
+      options: RemoveAllFromAgentOptions,
+    ): Promise<RemoveAllFromAgentResult> => {
+      const { agentPath } = options
+
+      try {
+        const entries = await fs.readdir(agentPath, { withFileTypes: true })
+        let removedCount = 0
+
+        for (const entry of entries) {
+          const entryPath = join(agentPath, entry.name)
+          try {
+            const stats = await fs.lstat(entryPath)
+            if (stats.isSymbolicLink()) {
+              await fs.unlink(entryPath)
+              removedCount++
+            }
+          } catch {
+            // Skip entries that can't be checked
+          }
+        }
+
+        return { success: true, removedCount }
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : 'Unknown error occurred'
+        return { success: false, removedCount: 0, error: message }
+      }
+    },
+  )
+
+  /**
+   * Delete a skill entirely: remove all agent symlinks/copies, then source dir
+   * @param options - skillName, skillPath
+   * @returns DeleteSkillResult with symlinks removed count
+   */
+  ipcMain.handle(
+    IPC_CHANNELS.SKILLS_DELETE,
+    async (_, options: DeleteSkillOptions): Promise<DeleteSkillResult> => {
+      const { skillName, skillPath } = options
+      let symlinksRemoved = 0
+
+      try {
+        // Remove symlinks and local copies across all agents
+        for (const agent of AGENTS) {
+          const agentSkillPath = join(agent.path, skillName)
+          try {
+            const stats = await fs.lstat(agentSkillPath)
+            if (stats.isSymbolicLink()) {
+              await fs.unlink(agentSkillPath)
+              symlinksRemoved++
+            } else if (stats.isDirectory()) {
+              await fs.rm(agentSkillPath, { recursive: true, force: true })
+            }
+          } catch {
+            // Agent skill path doesn't exist, skip
+          }
+        }
+
+        // Remove source directory if under SOURCE_DIR
+        if (skillPath.startsWith(SOURCE_DIR)) {
+          await fs.rm(skillPath, { recursive: true, force: true })
+        }
+
+        return { success: true, symlinksRemoved }
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : 'Unknown error occurred'
+        return { success: false, symlinksRemoved, error: message }
+      }
+    },
+  )
+
+  /**
+   * Create symlinks for a skill to multiple agents
+   * @param options - skillName, skillPath, agentIds
+   * @returns CreateSymlinksResult with created count and per-agent failures
+   */
+  ipcMain.handle(
+    IPC_CHANNELS.SKILLS_CREATE_SYMLINKS,
+    async (
+      _,
+      options: CreateSymlinksOptions,
+    ): Promise<CreateSymlinksResult> => {
+      const { skillName, skillPath, agentIds } = options
+      let created = 0
+      const failures: CreateSymlinksResult['failures'] = []
+
+      for (const agentId of agentIds) {
+        const agent = AGENTS.find((a) => a.id === agentId)
+        if (!agent) {
+          failures.push({ agentId, error: 'Agent not found' })
+          continue
+        }
+
+        const linkPath = join(agent.path, skillName)
+
+        try {
+          // Ensure agent skills directory exists
+          await fs.mkdir(agent.path, { recursive: true })
+
+          // Check if something already exists at the link path
+          try {
+            await fs.lstat(linkPath)
+            failures.push({ agentId, error: 'Already exists' })
+            continue
+          } catch {
+            // Nothing exists, proceed with symlink creation
+          }
+
+          await fs.symlink(skillPath, linkPath)
+          created++
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : 'Unknown error occurred'
+          failures.push({ agentId, error: message })
+        }
+      }
+
+      return { success: failures.length === 0, created, failures }
     },
   )
 }

--- a/src/main/ipc/sync.ts
+++ b/src/main/ipc/sync.ts
@@ -1,0 +1,21 @@
+import { ipcMain } from 'electron'
+
+import { IPC_CHANNELS } from '../../shared/ipc-channels'
+import type { SyncExecuteOptions } from '../../shared/types'
+import { syncExecute, syncPreview } from '../services/syncService'
+
+/**
+ * Register IPC handlers for sync operations
+ */
+export function registerSyncHandlers(): void {
+  ipcMain.handle(IPC_CHANNELS.SYNC_PREVIEW, async () => {
+    return syncPreview()
+  })
+
+  ipcMain.handle(
+    IPC_CHANNELS.SYNC_EXECUTE,
+    async (_, options: SyncExecuteOptions) => {
+      return syncExecute(options)
+    },
+  )
+}

--- a/src/main/services/syncService.ts
+++ b/src/main/services/syncService.ts
@@ -1,0 +1,189 @@
+import { access, lstat, mkdir, readdir, rm, symlink } from 'fs/promises'
+import { join } from 'path'
+
+import type {
+  SyncConflict,
+  SyncExecuteOptions,
+  SyncExecuteResult,
+  SyncPreviewResult,
+} from '../../shared/types'
+import { AGENTS, SOURCE_DIR } from '../constants'
+
+/**
+ * Check if a directory is a valid skill (has SKILL.md)
+ * @param dirPath - Path to the directory
+ * @returns True if SKILL.md exists
+ */
+async function isValidSkillDir(dirPath: string): Promise<boolean> {
+  try {
+    await access(join(dirPath, 'SKILL.md'))
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Get names of all valid source skills in ~/.agents/skills/
+ * @returns Array of skill directory names
+ */
+async function getSourceSkillNames(): Promise<
+  Array<{ name: string; path: string }>
+> {
+  try {
+    const entries = await readdir(SOURCE_DIR, { withFileTypes: true })
+    const skillDirs = entries.filter(
+      (e) => e.isDirectory() && !e.name.startsWith('.'),
+    )
+
+    const results: Array<{ name: string; path: string }> = []
+    for (const dir of skillDirs) {
+      const skillPath = join(SOURCE_DIR, dir.name)
+      if (await isValidSkillDir(skillPath)) {
+        results.push({ name: dir.name, path: skillPath })
+      }
+    }
+    return results
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Get agents whose base directory exists on disk
+ * @returns Array of agents with existing directories
+ */
+async function getExistingAgents(): Promise<
+  Array<{ id: string; name: string; path: string }>
+> {
+  const existing: Array<{ id: string; name: string; path: string }> = []
+  for (const agent of AGENTS) {
+    try {
+      // Check parent dir (e.g. ~/.claude) not skills dir
+      const parentDir = join(agent.path, '..')
+      await access(parentDir)
+      existing.push(agent)
+    } catch {
+      // Agent directory doesn't exist
+    }
+  }
+  return existing
+}
+
+/**
+ * Preview sync: detect what would happen without making changes
+ * @returns SyncPreviewResult with counts and conflicts
+ * @example
+ * syncPreview()
+ * // => { totalSkills: 5, totalAgents: 3, toCreate: 10, alreadySynced: 5, conflicts: [] }
+ */
+export async function syncPreview(): Promise<SyncPreviewResult> {
+  const skills = await getSourceSkillNames()
+  const agents = await getExistingAgents()
+
+  let toCreate = 0
+  let alreadySynced = 0
+  const conflicts: SyncConflict[] = []
+
+  for (const skill of skills) {
+    for (const agent of agents) {
+      const linkPath = join(agent.path, skill.name)
+
+      try {
+        const stats = await lstat(linkPath)
+
+        if (stats.isSymbolicLink()) {
+          alreadySynced++
+        } else {
+          // Real directory or file = conflict
+          conflicts.push({
+            skillName: skill.name,
+            agentId: agent.id as SyncConflict['agentId'],
+            agentName: agent.name as SyncConflict['agentName'],
+            agentSkillPath: linkPath,
+          })
+        }
+      } catch {
+        // Path doesn't exist = needs creation
+        toCreate++
+      }
+    }
+  }
+
+  return {
+    totalSkills: skills.length,
+    totalAgents: agents.length,
+    toCreate,
+    alreadySynced,
+    conflicts,
+  }
+}
+
+/**
+ * Execute sync: create symlinks and optionally replace conflicts
+ * @param options - replaceConflicts: paths to replace with symlinks
+ * @returns SyncExecuteResult with created/replaced counts and errors
+ * @example
+ * syncExecute({ replaceConflicts: ['/Users/x/.claude/skills/my-skill'] })
+ * // => { success: true, created: 10, replaced: 1, errors: [] }
+ */
+export async function syncExecute(
+  options: SyncExecuteOptions,
+): Promise<SyncExecuteResult> {
+  const { replaceConflicts } = options
+  const replaceSet = new Set(replaceConflicts)
+
+  const skills = await getSourceSkillNames()
+  const agents = await getExistingAgents()
+
+  let created = 0
+  let replaced = 0
+  const errors: SyncExecuteResult['errors'] = []
+
+  for (const skill of skills) {
+    for (const agent of agents) {
+      const linkPath = join(agent.path, skill.name)
+
+      try {
+        // Ensure agent skills directory exists
+        await mkdir(agent.path, { recursive: true })
+
+        let exists = false
+        let isSymlink = false
+
+        try {
+          const stats = await lstat(linkPath)
+          exists = true
+          isSymlink = stats.isSymbolicLink()
+        } catch {
+          // Path doesn't exist
+        }
+
+        if (!exists) {
+          // Create new symlink
+          await symlink(skill.path, linkPath)
+          created++
+        } else if (isSymlink) {
+          // Already synced, skip
+        } else if (replaceSet.has(linkPath)) {
+          // Conflict approved for replacement
+          await rm(linkPath, { recursive: true, force: true })
+          await symlink(skill.path, linkPath)
+          replaced++
+        }
+        // else: conflict not approved, skip
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : 'Unknown error occurred'
+        errors.push({ path: linkPath, error: message })
+      }
+    }
+  }
+
+  return {
+    success: errors.length === 0,
+    created,
+    replaced,
+    errors,
+  }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2,8 +2,17 @@ import { contextBridge, ipcRenderer, shell } from 'electron'
 
 import type { UpdateInfo, DownloadProgress } from '../main/updater'
 import type {
+  CreateSymlinksOptions,
+  CreateSymlinksResult,
+  DeleteSkillOptions,
+  DeleteSkillResult,
   InstallOptions,
   InstallProgress,
+  RemoveAllFromAgentOptions,
+  RemoveAllFromAgentResult,
+  SyncExecuteOptions,
+  SyncExecuteResult,
+  SyncPreviewResult,
   UnlinkFromAgentOptions,
   UnlinkResult,
 } from '../shared/types'
@@ -21,6 +30,18 @@ contextBridge.exposeInMainWorld('electron', {
       options: UnlinkFromAgentOptions,
     ): Promise<UnlinkResult> =>
       ipcRenderer.invoke('skills:unlinkFromAgent', options),
+    removeAllFromAgent: async (
+      options: RemoveAllFromAgentOptions,
+    ): Promise<RemoveAllFromAgentResult> =>
+      ipcRenderer.invoke('skills:removeAllFromAgent', options),
+    deleteSkill: async (
+      options: DeleteSkillOptions,
+    ): Promise<DeleteSkillResult> =>
+      ipcRenderer.invoke('skills:deleteSkill', options),
+    createSymlinks: async (
+      options: CreateSymlinksOptions,
+    ): Promise<CreateSymlinksResult> =>
+      ipcRenderer.invoke('skills:createSymlinks', options),
   },
   // Agents API
   agents: {
@@ -100,5 +121,12 @@ contextBridge.exposeInMainWorld('electron', {
       ipcRenderer.on('skills:cli:progress', handler)
       return () => ipcRenderer.removeListener('skills:cli:progress', handler)
     },
+  },
+  // Sync API
+  sync: {
+    preview: async (): Promise<SyncPreviewResult> =>
+      ipcRenderer.invoke('sync:preview'),
+    execute: async (options: SyncExecuteOptions): Promise<SyncExecuteResult> =>
+      ipcRenderer.invoke('sync:execute', options),
   },
 })

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -5,6 +5,9 @@ import { FEATURE_FLAGS } from '../../../../shared/featureFlags'
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
 import { selectAgent } from '../../redux/slices/uiSlice'
 import { SkillsMarketplace } from '../marketplace'
+import { SyncConflictDialog } from '../sidebar/SyncConflictDialog'
+import { AddSymlinkModal } from '../skills/AddSymlinkModal'
+import { DeleteSkillDialog } from '../skills/DeleteSkillDialog'
 import { SearchBox } from '../skills/SearchBox'
 import { SkillsList } from '../skills/SkillsList'
 import { UnlinkDialog } from '../skills/UnlinkDialog'
@@ -114,8 +117,11 @@ export function MainContent(): React.ReactElement {
         </TabsContent>
       </Tabs>
 
-      {/* Unlink skill from agent confirmation dialog */}
+      {/* Dialogs */}
       <UnlinkDialog />
+      <DeleteSkillDialog />
+      <AddSymlinkModal />
+      <SyncConflictDialog />
     </main>
   )
 }

--- a/src/renderer/src/components/layout/Sidebar.tsx
+++ b/src/renderer/src/components/layout/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { AgentDeleteDialog } from '../sidebar/AgentDeleteDialog'
 import { AgentsSection } from '../sidebar/AgentsSection'
 import { SidebarFooter } from '../sidebar/SidebarFooter'
 import { SidebarHeader } from '../sidebar/SidebarHeader'
@@ -22,6 +23,7 @@ export function Sidebar(): React.ReactElement {
         </div>
       </ScrollArea>
       <SidebarFooter />
+      <AgentDeleteDialog />
     </aside>
   )
 }

--- a/src/renderer/src/components/sidebar/AgentDeleteDialog.tsx
+++ b/src/renderer/src/components/sidebar/AgentDeleteDialog.tsx
@@ -1,0 +1,96 @@
+import { AlertTriangle, Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
+
+import { useAppDispatch, useAppSelector } from '../../redux/hooks'
+import {
+  fetchAgents,
+  removeAllSymlinksFromAgent,
+  setAgentToDelete,
+} from '../../redux/slices/agentsSlice'
+import { fetchSkills } from '../../redux/slices/skillsSlice'
+import { fetchSourceStats } from '../../redux/slices/uiSlice'
+import { Button } from '../ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog'
+
+/**
+ * Confirmation dialog for removing all skill symlinks from an agent
+ * Only removes symlinks, not local skills
+ */
+export function AgentDeleteDialog(): React.ReactElement {
+  const dispatch = useAppDispatch()
+  const { agentToDelete, deleting } = useAppSelector((state) => state.agents)
+
+  const handleClose = (): void => {
+    if (!deleting) {
+      dispatch(setAgentToDelete(null))
+    }
+  }
+
+  const handleDelete = async (): Promise<void> => {
+    if (!agentToDelete) return
+
+    const result = await dispatch(removeAllSymlinksFromAgent(agentToDelete))
+
+    if (removeAllSymlinksFromAgent.fulfilled.match(result)) {
+      toast.success(
+        `Removed ${result.payload.removedCount} symlinks from ${result.payload.agentName}`,
+      )
+      dispatch(fetchSkills())
+      dispatch(fetchAgents())
+      dispatch(fetchSourceStats())
+    } else {
+      toast.error('Failed to remove symlinks', {
+        description: result.error?.message || 'An unexpected error occurred',
+      })
+    }
+  }
+
+  return (
+    <Dialog open={!!agentToDelete} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-[400px]">
+        <DialogHeader>
+          <div className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-amber-500" />
+            <DialogTitle>Remove All Symlinks</DialogTitle>
+          </div>
+          <DialogDescription>
+            Remove all skill symlinks from{' '}
+            <strong>{agentToDelete?.name}</strong>?
+            <br />
+            <span className="text-muted-foreground mt-2 block">
+              This only removes symlinks. Local skills and source skills will
+              remain available.
+            </span>
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogFooter className="mt-4">
+          <Button variant="outline" onClick={handleClose} disabled={deleting}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleDelete}
+            disabled={deleting}
+          >
+            {deleting ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                Removing...
+              </>
+            ) : (
+              'Remove'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/src/components/sidebar/AgentItem.tsx
+++ b/src/renderer/src/components/sidebar/AgentItem.tsx
@@ -1,7 +1,17 @@
+import { Trash2 } from 'lucide-react'
+import { useState } from 'react'
+
 import type { Agent } from '../../../../shared/types'
 import { cn } from '../../lib/utils'
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
+import { setAgentToDelete } from '../../redux/slices/agentsSlice'
 import { selectAgent } from '../../redux/slices/uiSlice'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '../ui/dropdown-menu'
 
 interface AgentItemProps {
   agent: Agent
@@ -29,18 +39,29 @@ function buildSkillCountText(linked: number, local: number): string | null {
 
 /**
  * Single agent item in the sidebar
- * Clicking filters skills list to show only skills installed for this agent
+ * Left-click filters skills list. Right-click opens context menu for delete.
  * Shows "N linked, M local" skill counts
  */
 export function AgentItem({ agent }: AgentItemProps): React.ReactElement {
   const dispatch = useAppDispatch()
   const { selectedAgentId } = useAppSelector((state) => state.ui)
   const isSelected = selectedAgentId === agent.id
+  const [contextOpen, setContextOpen] = useState(false)
 
   const handleClick = (): void => {
     if (!agent.exists) return
-    // Toggle selection: if already selected, deselect (show all)
     dispatch(selectAgent(isSelected ? null : agent.id))
+  }
+
+  const handleContextMenu = (e: React.MouseEvent): void => {
+    e.preventDefault()
+    if (!agent.exists || agent.skillCount === 0) return
+    setContextOpen(true)
+  }
+
+  const handleDelete = (): void => {
+    dispatch(setAgentToDelete(agent))
+    setContextOpen(false)
   }
 
   const skillCountText = agent.exists
@@ -48,20 +69,34 @@ export function AgentItem({ agent }: AgentItemProps): React.ReactElement {
     : null
 
   return (
-    <div
-      className={cn(
-        'flex items-center justify-between py-1.5 px-2 rounded-md transition-colors',
-        agent.exists && 'cursor-pointer hover:bg-muted/50',
-        isSelected && 'bg-primary/10 border border-primary/30',
-      )}
-      onClick={handleClick}
-    >
-      <span className="text-sm truncate">{agent.name}</span>
-      {skillCountText && (
-        <span className="text-xs text-muted-foreground whitespace-nowrap ml-2">
-          {skillCountText}
-        </span>
-      )}
-    </div>
+    <DropdownMenu open={contextOpen} onOpenChange={setContextOpen}>
+      <DropdownMenuTrigger asChild>
+        <div
+          className={cn(
+            'flex items-center justify-between py-1.5 px-2 rounded-md transition-colors',
+            agent.exists && 'cursor-pointer hover:bg-muted/50',
+            isSelected && 'bg-primary/10 border border-primary/30',
+          )}
+          onClick={handleClick}
+          onContextMenu={handleContextMenu}
+        >
+          <span className="text-sm truncate">{agent.name}</span>
+          {skillCountText && (
+            <span className="text-xs text-muted-foreground whitespace-nowrap ml-2">
+              {skillCountText}
+            </span>
+          )}
+        </div>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuItem
+          onClick={handleDelete}
+          className="text-destructive focus:text-destructive"
+        >
+          <Trash2 className="h-4 w-4 mr-2" />
+          Remove all symlinks
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }

--- a/src/renderer/src/components/sidebar/SourceCard.tsx
+++ b/src/renderer/src/components/sidebar/SourceCard.tsx
@@ -1,19 +1,29 @@
-import { Folder, RefreshCw } from 'lucide-react'
+import { Folder, Loader2, RefreshCw, FolderSync } from 'lucide-react'
 import { useEffect } from 'react'
+import { toast } from 'sonner'
 
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
 import { fetchAgents } from '../../redux/slices/agentsSlice'
 import { fetchSkills } from '../../redux/slices/skillsSlice'
-import { fetchSourceStats } from '../../redux/slices/uiSlice'
+import {
+  executeSyncAction,
+  fetchSourceStats,
+  fetchSyncPreview,
+  selectAgent,
+  setSearchQuery,
+} from '../../redux/slices/uiSlice'
 import { Button } from '../ui/button'
 import { Card, CardContent } from '../ui/card'
 
 /**
- * Source directory card showing stats and refresh button
+ * Source directory card showing stats, refresh, and sync buttons
+ * Clicking the path clears all filters to show all skills
  */
 export function SourceCard(): React.ReactElement {
   const dispatch = useAppDispatch()
-  const { sourceStats, isRefreshing } = useAppSelector((state) => state.ui)
+  const { sourceStats, isRefreshing, isSyncing } = useAppSelector(
+    (state) => state.ui,
+  )
 
   useEffect(() => {
     dispatch(fetchSourceStats())
@@ -27,15 +37,78 @@ export function SourceCard(): React.ReactElement {
     ])
   }
 
+  /**
+   * Click path text → clear all filters and show all skills
+   */
+  const handlePathClick = (): void => {
+    dispatch(selectAgent(null))
+    dispatch(setSearchQuery(''))
+  }
+
+  /**
+   * Sync all source skills to all agents as symlinks
+   * If no conflicts, executes immediately. If conflicts, opens dialog.
+   */
+  const handleSync = async (): Promise<void> => {
+    const previewResult = await dispatch(fetchSyncPreview())
+
+    if (fetchSyncPreview.fulfilled.match(previewResult)) {
+      const preview = previewResult.payload
+
+      if (preview.totalSkills === 0) {
+        toast.info('No skills to sync')
+        return
+      }
+
+      if (preview.toCreate === 0 && preview.conflicts.length === 0) {
+        toast.info('Already synced', {
+          description: `All ${preview.alreadySynced} skills are already linked`,
+        })
+        return
+      }
+
+      // If no conflicts, execute immediately
+      if (preview.conflicts.length === 0) {
+        const result = await dispatch(
+          executeSyncAction({ replaceConflicts: [] }),
+        )
+        if (executeSyncAction.fulfilled.match(result)) {
+          toast.success('Sync completed', {
+            description: `Created ${result.payload.created} symlinks`,
+          })
+          dispatch(fetchSkills())
+          dispatch(fetchAgents())
+          dispatch(fetchSourceStats())
+        } else {
+          toast.error('Sync failed')
+        }
+      }
+      // If conflicts exist, the dialog will open via syncPreview state
+    } else {
+      toast.error('Failed to preview sync')
+    }
+  }
+
   return (
     <Card className="bg-card/50">
       <CardContent className="p-3">
         <div className="flex items-center justify-between mb-2">
           <div className="flex items-center gap-2">
             <Folder className="h-4 w-4 text-primary" />
-            <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Source
-            </span>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-5 px-1.5 text-xs font-medium gap-1"
+              onClick={handleSync}
+              disabled={isSyncing}
+            >
+              {isSyncing ? (
+                <Loader2 className="h-3 w-3 animate-spin" />
+              ) : (
+                <FolderSync className="h-3 w-3" />
+              )}
+              Sync
+            </Button>
           </div>
           <Button
             variant="ghost"
@@ -49,7 +122,13 @@ export function SourceCard(): React.ReactElement {
             />
           </Button>
         </div>
-        <p className="text-sm font-medium truncate">~/.agents/skills</p>
+        <p
+          className="text-sm font-medium truncate cursor-pointer hover:text-primary transition-colors"
+          onClick={handlePathClick}
+          title="Click to clear filters and show all skills"
+        >
+          ~/.agents/skills
+        </p>
         {sourceStats && (
           <div className="flex gap-4 mt-2 text-xs text-muted-foreground">
             <span>{sourceStats.skillCount} skills</span>

--- a/src/renderer/src/components/sidebar/SyncConflictDialog.tsx
+++ b/src/renderer/src/components/sidebar/SyncConflictDialog.tsx
@@ -1,0 +1,152 @@
+import { AlertTriangle, Loader2 } from 'lucide-react'
+import { useState } from 'react'
+import { toast } from 'sonner'
+
+import { useAppDispatch, useAppSelector } from '../../redux/hooks'
+import { fetchAgents } from '../../redux/slices/agentsSlice'
+import { fetchSkills } from '../../redux/slices/skillsSlice'
+import {
+  executeSyncAction,
+  fetchSourceStats,
+  setSyncPreview,
+} from '../../redux/slices/uiSlice'
+import { Button } from '../ui/button'
+import { Checkbox } from '../ui/checkbox'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog'
+
+/**
+ * Dialog for resolving sync conflicts (local folders that would be replaced by symlinks)
+ * Users can select which conflicts to replace and which to skip
+ */
+export function SyncConflictDialog(): React.ReactElement {
+  const dispatch = useAppDispatch()
+  const { syncPreview, isSyncing } = useAppSelector((state) => state.ui)
+
+  const conflicts = syncPreview?.conflicts ?? []
+  const hasConflicts = conflicts.length > 0
+  const isOpen = hasConflicts && !!syncPreview
+
+  const [selectedPaths, setSelectedPaths] = useState<Set<string>>(new Set())
+  const [isExecuting, setIsExecuting] = useState(false)
+
+  const handleClose = (): void => {
+    if (!isExecuting) {
+      dispatch(setSyncPreview(null))
+      setSelectedPaths(new Set())
+    }
+  }
+
+  const handleToggle = (path: string): void => {
+    setSelectedPaths((prev) => {
+      const next = new Set(prev)
+      if (next.has(path)) {
+        next.delete(path)
+      } else {
+        next.add(path)
+      }
+      return next
+    })
+  }
+
+  const handleSync = async (replaceAll: boolean): Promise<void> => {
+    setIsExecuting(true)
+
+    const replaceConflicts = replaceAll
+      ? conflicts.map((c) => c.agentSkillPath)
+      : Array.from(selectedPaths)
+
+    const result = await dispatch(executeSyncAction({ replaceConflicts }))
+
+    if (executeSyncAction.fulfilled.match(result)) {
+      const { created, replaced } = result.payload
+      toast.success('Sync completed', {
+        description: `Created ${created} symlinks, replaced ${replaced} conflicts`,
+      })
+      dispatch(fetchSkills())
+      dispatch(fetchAgents())
+      dispatch(fetchSourceStats())
+    } else {
+      toast.error('Sync failed', {
+        description: result.error?.message || 'An unexpected error occurred',
+      })
+    }
+
+    setIsExecuting(false)
+    setSelectedPaths(new Set())
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleClose}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <div className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-amber-500" />
+            <DialogTitle>Sync Conflicts</DialogTitle>
+          </div>
+          <DialogDescription>
+            {conflicts.length} local folder(s) found where symlinks would be
+            created. Select which to replace with symlinks.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="py-4">
+          <div className="max-h-[300px] overflow-y-auto rounded-md border p-2 space-y-1">
+            {conflicts.map((conflict) => (
+              <label
+                key={conflict.agentSkillPath}
+                className="flex items-center gap-3 p-2 rounded-md hover:bg-muted cursor-pointer"
+              >
+                <Checkbox
+                  checked={selectedPaths.has(conflict.agentSkillPath)}
+                  onCheckedChange={() => handleToggle(conflict.agentSkillPath)}
+                  disabled={isExecuting}
+                />
+                <div className="text-sm">
+                  <span className="font-medium">{conflict.skillName}</span>
+                  <span className="text-muted-foreground">
+                    {' '}
+                    in {conflict.agentName}
+                  </span>
+                  <span className="text-xs text-muted-foreground block">
+                    Local folder will be replaced with symlink
+                  </span>
+                </div>
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <DialogFooter className="flex gap-2">
+          <Button
+            variant="outline"
+            onClick={async () => handleSync(false)}
+            disabled={isExecuting || isSyncing}
+          >
+            {isExecuting ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                Syncing...
+              </>
+            ) : (
+              `Skip${selectedPaths.size > 0 ? ' unselected' : ' all conflicts'}`
+            )}
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={async () => handleSync(true)}
+            disabled={isExecuting || isSyncing}
+          >
+            Replace all
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/src/components/skills/AddSymlinkModal.tsx
+++ b/src/renderer/src/components/skills/AddSymlinkModal.tsx
@@ -1,0 +1,168 @@
+import { Loader2, Plus } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { toast } from 'sonner'
+
+import type { AgentId } from '../../../../shared/types'
+import { cn } from '../../lib/utils'
+import { useAppDispatch, useAppSelector } from '../../redux/hooks'
+import { fetchAgents } from '../../redux/slices/agentsSlice'
+import {
+  createSymlinks,
+  fetchSkills,
+  setSkillToAddSymlinks,
+} from '../../redux/slices/skillsSlice'
+import { fetchSourceStats } from '../../redux/slices/uiSlice'
+import { Button } from '../ui/button'
+import { Checkbox } from '../ui/checkbox'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog'
+
+/**
+ * Modal for selecting agents to add skill symlinks to
+ * Shows agent checkboxes with already-linked agents disabled
+ */
+export function AddSymlinkModal(): React.ReactElement {
+  const dispatch = useAppDispatch()
+  const { skillToAddSymlinks, addingSymlinks } = useAppSelector(
+    (state) => state.skills,
+  )
+  const { items: agents } = useAppSelector((state) => state.agents)
+
+  const [selectedAgents, setSelectedAgents] = useState<AgentId[]>([])
+
+  const existingAgents = useMemo(() => agents.filter((a) => a.exists), [agents])
+
+  const alreadyLinkedAgentIds = useMemo(() => {
+    if (!skillToAddSymlinks) return new Set<AgentId>()
+    return new Set(
+      skillToAddSymlinks.symlinks
+        .filter((s) => s.status === 'valid')
+        .map((s) => s.agentId),
+    )
+  }, [skillToAddSymlinks])
+
+  const handleClose = (): void => {
+    if (!addingSymlinks) {
+      dispatch(setSkillToAddSymlinks(null))
+      setSelectedAgents([])
+    }
+  }
+
+  const handleAgentToggle = (agentId: AgentId): void => {
+    if (alreadyLinkedAgentIds.has(agentId)) return
+    setSelectedAgents((prev) =>
+      prev.includes(agentId)
+        ? prev.filter((id) => id !== agentId)
+        : [...prev, agentId],
+    )
+  }
+
+  const handleAddSymlinks = async (): Promise<void> => {
+    if (!skillToAddSymlinks || selectedAgents.length === 0) return
+
+    const result = await dispatch(
+      createSymlinks({ skill: skillToAddSymlinks, agentIds: selectedAgents }),
+    )
+
+    if (createSymlinks.fulfilled.match(result)) {
+      toast.success(`Added to ${result.payload.created} agent(s)`, {
+        description: `${skillToAddSymlinks.name} symlinks created`,
+      })
+      dispatch(fetchSkills())
+      dispatch(fetchAgents())
+      dispatch(fetchSourceStats())
+    } else {
+      toast.error('Failed to create symlinks', {
+        description: result.error?.message || 'An unexpected error occurred',
+      })
+    }
+  }
+
+  const hasNewSelections = selectedAgents.length > 0
+
+  return (
+    <Dialog open={!!skillToAddSymlinks} onOpenChange={handleClose}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <div className="flex items-center gap-2">
+            <Plus className="h-5 w-5 text-primary" />
+            <DialogTitle>Add Symlink</DialogTitle>
+          </div>
+          <DialogDescription>
+            Select agents to link <strong>{skillToAddSymlinks?.name}</strong> to
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="py-4">
+          <h4 className="text-sm font-medium mb-3">Select Agents</h4>
+          <div className="max-h-[240px] overflow-y-auto rounded-md border p-2 space-y-1">
+            {existingAgents.map((agent) => {
+              const isAlreadyLinked = alreadyLinkedAgentIds.has(agent.id)
+              return (
+                <label
+                  key={agent.id}
+                  className={cn(
+                    'flex items-center gap-3 p-2 rounded-md',
+                    isAlreadyLinked
+                      ? 'opacity-50 cursor-not-allowed'
+                      : 'hover:bg-muted cursor-pointer',
+                  )}
+                >
+                  <Checkbox
+                    checked={
+                      isAlreadyLinked || selectedAgents.includes(agent.id)
+                    }
+                    onCheckedChange={() => handleAgentToggle(agent.id)}
+                    disabled={addingSymlinks || isAlreadyLinked}
+                  />
+                  <span className="text-sm">
+                    {agent.name}
+                    {isAlreadyLinked && (
+                      <span className="text-xs text-muted-foreground ml-2">
+                        (linked)
+                      </span>
+                    )}
+                  </span>
+                </label>
+              )
+            })}
+          </div>
+          {!hasNewSelections && (
+            <p className="text-sm text-muted-foreground mt-2">
+              Select at least one new agent
+            </p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={handleClose}
+            disabled={addingSymlinks}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handleAddSymlinks}
+            disabled={addingSymlinks || !hasNewSelections}
+          >
+            {addingSymlinks ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                Adding...
+              </>
+            ) : (
+              'Add Symlink'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/src/components/skills/DeleteSkillDialog.tsx
+++ b/src/renderer/src/components/skills/DeleteSkillDialog.tsx
@@ -1,0 +1,95 @@
+import { AlertTriangle, Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
+
+import { useAppDispatch, useAppSelector } from '../../redux/hooks'
+import { fetchAgents } from '../../redux/slices/agentsSlice'
+import {
+  deleteSkill,
+  fetchSkills,
+  setSkillToDelete,
+} from '../../redux/slices/skillsSlice'
+import { fetchSourceStats } from '../../redux/slices/uiSlice'
+import { Button } from '../ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog'
+
+/**
+ * Confirmation dialog for permanently deleting a skill
+ * Removes source directory and all agent symlinks/copies
+ */
+export function DeleteSkillDialog(): React.ReactElement {
+  const dispatch = useAppDispatch()
+  const { skillToDelete, deleting } = useAppSelector((state) => state.skills)
+
+  const handleClose = (): void => {
+    if (!deleting) {
+      dispatch(setSkillToDelete(null))
+    }
+  }
+
+  const handleDelete = async (): Promise<void> => {
+    if (!skillToDelete) return
+
+    const result = await dispatch(deleteSkill(skillToDelete))
+
+    if (deleteSkill.fulfilled.match(result)) {
+      toast.success(`Deleted ${result.payload.skillName}`, {
+        description: `Removed skill and ${result.payload.symlinksRemoved} symlinks`,
+      })
+      dispatch(fetchSkills())
+      dispatch(fetchAgents())
+      dispatch(fetchSourceStats())
+    } else {
+      toast.error('Failed to delete skill', {
+        description: result.error?.message || 'An unexpected error occurred',
+      })
+    }
+  }
+
+  return (
+    <Dialog open={!!skillToDelete} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-[400px]">
+        <DialogHeader>
+          <div className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-destructive" />
+            <DialogTitle>Delete Skill</DialogTitle>
+          </div>
+          <DialogDescription>
+            Permanently delete <strong>{skillToDelete?.name}</strong> and all
+            its symlinks across all agents?
+            <br />
+            <span className="text-destructive/80 mt-2 block">
+              This action cannot be undone.
+            </span>
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogFooter className="mt-4">
+          <Button variant="outline" onClick={handleClose} disabled={deleting}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleDelete}
+            disabled={deleting}
+          >
+            {deleting ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                Deleting...
+              </>
+            ) : (
+              'Remove'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -1,10 +1,16 @@
-import { Trash2 } from 'lucide-react'
+import { Plus, Trash2, X } from 'lucide-react'
 
 import type { Skill } from '../../../../shared/types'
 import { cn } from '../../lib/utils'
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
-import { selectSkill, setSkillToUnlink } from '../../redux/slices/skillsSlice'
+import {
+  selectSkill,
+  setSkillToAddSymlinks,
+  setSkillToDelete,
+  setSkillToUnlink,
+} from '../../redux/slices/skillsSlice'
 import { StatusBadge } from '../status/StatusBadge'
+import { Button } from '../ui/button'
 import { Card, CardContent } from '../ui/card'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 
@@ -14,8 +20,7 @@ interface SkillItemProps {
 
 /**
  * Single skill card in the skills list
- * Shows 🔗 prefix for symlinked skills when an agent is selected
- * Shows trash icon on hover for linked (non-local) skills
+ * Shows X button for deletion, trash icon for unlinking, Add button for symlink creation
  */
 export function SkillItem({ skill }: SkillItemProps): React.ReactElement {
   const dispatch = useAppDispatch()
@@ -45,30 +50,63 @@ export function SkillItem({ skill }: SkillItemProps): React.ReactElement {
   const selectedAgentName =
     agents.find((a) => a.id === selectedAgentId)?.name || 'agent'
 
-  /**
-   * Handle trash icon click - open unlink confirmation dialog
-   */
   const handleUnlinkClick = (e: React.MouseEvent): void => {
-    e.stopPropagation() // Prevent card selection
+    e.stopPropagation()
     if (selectedAgentSymlink) {
       dispatch(setSkillToUnlink({ skill, symlink: selectedAgentSymlink }))
     }
   }
 
+  const handleDeleteClick = (e: React.MouseEvent): void => {
+    e.stopPropagation()
+    dispatch(setSkillToDelete(skill))
+  }
+
+  const handleAddClick = (e: React.MouseEvent): void => {
+    e.stopPropagation()
+    dispatch(setSkillToAddSymlinks(skill))
+  }
+
   return (
     <Card
       className={cn(
-        'group cursor-pointer transition-colors hover:border-primary/50',
+        'group cursor-pointer transition-colors hover:border-primary/50 relative',
         isSelected && 'border-primary bg-primary/5',
       )}
       onClick={() => dispatch(selectSkill(skill))}
     >
-      <CardContent className="p-4">
+      {/* X button - always visible at top-right corner */}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={handleDeleteClick}
+            className="absolute top-2 right-2 p-1 rounded-md hover:bg-destructive/10 text-muted-foreground hover:text-destructive z-10 opacity-0 group-hover:opacity-100 transition-opacity"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="left">Delete skill</TooltipContent>
+      </Tooltip>
+
+      <CardContent className="p-4 pr-8">
         <div className="flex items-start justify-between gap-2">
           <div className="flex-1 min-w-0">
-            <h3 className="font-medium truncate">
+            <h3 className="font-medium truncate flex items-center gap-1">
               {isLinked && <span title="Linked skill">🔗 </span>}
-              {skill.name}
+              <span className="truncate">{skill.name}</span>
+              {/* Add button - only when viewing all skills (no agent filter) */}
+              {!selectedAgentId && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleAddClick}
+                  className="h-5 px-1.5 text-xs shrink-0 ml-1"
+                >
+                  <Plus className="h-3 w-3 mr-0.5" />
+                  Add
+                </Button>
+              )}
             </h3>
             {skill.description && (
               <p className="text-sm text-muted-foreground line-clamp-2 mt-1">

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -14,6 +14,15 @@ import type {
   InstallProgress,
   UnlinkFromAgentOptions,
   UnlinkResult,
+  RemoveAllFromAgentOptions,
+  RemoveAllFromAgentResult,
+  DeleteSkillOptions,
+  DeleteSkillResult,
+  CreateSymlinksOptions,
+  CreateSymlinksResult,
+  SyncPreviewResult,
+  SyncExecuteOptions,
+  SyncExecuteResult,
 } from '../../../shared/types'
 
 declare global {
@@ -28,6 +37,13 @@ declare global {
         unlinkFromAgent: (
           options: UnlinkFromAgentOptions,
         ) => Promise<UnlinkResult>
+        removeAllFromAgent: (
+          options: RemoveAllFromAgentOptions,
+        ) => Promise<RemoveAllFromAgentResult>
+        deleteSkill: (options: DeleteSkillOptions) => Promise<DeleteSkillResult>
+        createSymlinks: (
+          options: CreateSymlinksOptions,
+        ) => Promise<CreateSymlinksResult>
       }
       agents: {
         getAll: () => Promise<Agent[]>
@@ -66,6 +82,10 @@ declare global {
         onProgress: (
           callback: (progress: InstallProgress) => void,
         ) => () => void
+      }
+      sync: {
+        preview: () => Promise<SyncPreviewResult>
+        execute: (options: SyncExecuteOptions) => Promise<SyncExecuteResult>
       }
     }
   }

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -24,6 +24,13 @@ export const IPC_CHANNELS = {
 
   // Skills management
   SKILLS_UNLINK_FROM_AGENT: 'skills:unlinkFromAgent',
+  SKILLS_REMOVE_ALL_FROM_AGENT: 'skills:removeAllFromAgent',
+  SKILLS_DELETE: 'skills:deleteSkill',
+  SKILLS_CREATE_SYMLINKS: 'skills:createSymlinks',
+
+  // Sync
+  SYNC_PREVIEW: 'sync:preview',
+  SYNC_EXECUTE: 'sync:execute',
 } as const
 
 export type IpcChannel = (typeof IPC_CHANNELS)[keyof typeof IPC_CHANNELS]

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -196,3 +196,111 @@ export interface UnlinkResult {
   success: boolean
   error?: string
 }
+
+/**
+ * Options for removing all symlinks from a specific agent
+ * @example
+ * { agentId: 'claude-code', agentPath: '/Users/x/.claude/skills' }
+ */
+export interface RemoveAllFromAgentOptions {
+  agentId: AgentId
+  agentPath: string
+}
+
+/**
+ * Result from removing all symlinks from an agent
+ * @example
+ * { success: true, removedCount: 5 }
+ */
+export interface RemoveAllFromAgentResult {
+  success: boolean
+  removedCount: number
+  error?: string
+}
+
+/**
+ * Options for deleting a skill entirely (source dir + all agent symlinks)
+ * @example
+ * { skillName: 'theme-generator', skillPath: '/Users/x/.agents/skills/theme-generator' }
+ */
+export interface DeleteSkillOptions {
+  skillName: string
+  skillPath: string
+}
+
+/**
+ * Result from deleting a skill
+ * @example
+ * { success: true, symlinksRemoved: 3 }
+ */
+export interface DeleteSkillResult {
+  success: boolean
+  symlinksRemoved: number
+  error?: string
+}
+
+/**
+ * Options for creating symlinks for a skill to multiple agents
+ * @example
+ * { skillName: 'theme-generator', skillPath: '/...', agentIds: ['claude-code', 'cursor'] }
+ */
+export interface CreateSymlinksOptions {
+  skillName: string
+  skillPath: string
+  agentIds: AgentId[]
+}
+
+/**
+ * Result from creating symlinks
+ * @example
+ * { success: true, created: 2, failures: [] }
+ */
+export interface CreateSymlinksResult {
+  success: boolean
+  created: number
+  failures: Array<{ agentId: AgentId; error: string }>
+}
+
+/**
+ * A conflict found during sync preview (local folder exists where symlink would go)
+ */
+export interface SyncConflict {
+  skillName: string
+  agentId: AgentId
+  agentName: AgentName
+  agentSkillPath: string
+}
+
+/**
+ * Result from sync preview (dry run)
+ * @example
+ * { totalSkills: 5, totalAgents: 3, toCreate: 10, alreadySynced: 5, conflicts: [] }
+ */
+export interface SyncPreviewResult {
+  totalSkills: number
+  totalAgents: number
+  toCreate: number
+  alreadySynced: number
+  conflicts: SyncConflict[]
+}
+
+/**
+ * Options for executing sync with conflict resolution choices
+ * @example
+ * { replaceConflicts: ['/Users/x/.claude/skills/my-skill'] }
+ */
+export interface SyncExecuteOptions {
+  replaceConflicts: string[]
+}
+
+/**
+ * Result from executing sync
+ * @example
+ * { success: true, created: 10, replaced: 2, errors: [] }
+ */
+export interface SyncExecuteResult {
+  success: boolean
+  created: number
+  replaced: number
+  errors: Array<{ path: string; error: string }>
+}


### PR DESCRIPTION
## Summary

- **Agent context menu delete**: Right-click agent in sidebar → "Remove all symlinks" → confirmation dialog → removes all symlinked skills from agent
- **Source path filter reset**: Click `~/.agents/skills` path → clears search query and agent filter → shows all skills
- **Skill card delete (X button)**: X button on skill card → confirmation modal → deletes skill directory + all symlinks across agents
- **Add symlink modal**: "Add" button on skill card → agent multi-select modal → creates symlinks to selected agents
- **Sync button**: Replaces "Source" label → bulk-creates symlinks from all source skills to all agents, with conflict resolution dialog for existing local folders

## Test plan

- [ ] Right-click an agent with symlinks → context menu appears → "Remove all symlinks" → confirm → symlinks removed, counts updated
- [ ] Right-click an agent with 0 symlinks → menu item is disabled
- [ ] Click `~/.agents/skills` path text → search query cleared, agent filter cleared, all source skills shown
- [ ] Hover skill card → X button appears top-right → click → confirm deletion → skill removed from source + all agent symlinks
- [ ] View source skills (no agent filter) → "Add" button visible next to skill name → click → agent multi-select modal → select agents → "Add Symlink" → symlinks created
- [ ] Already-linked agents show as disabled checkboxes in Add modal
- [ ] Click "Sync" button → if no conflicts → all source skills symlinked to all agents → toast success
- [ ] Click "Sync" button → if local folder conflicts exist → conflict dialog with checkboxes → "Replace Selected" or "Skip All"
- [ ] Verify typecheck passes: `pnpm typecheck`
- [ ] Verify lint passes: `pnpm lint`