### PR TITLE
test: add broken symlink test coverage

### DIFF
--- a/src/main/services/agentScanner.test.ts
+++ b/src/main/services/agentScanner.test.ts
@@ -1,0 +1,259 @@
+import { join } from 'node:path'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Create a minimal Dirent-like object for readdir mocks.
+ * @param name - Entry name
+ * @param options - Directory/symlink flags
+ * @returns Dirent-compatible object used by scan logic
+ * @example
+ * createDirent('my-skill', { isDirectory: true, isSymbolicLink: true })
+ */
+function createDirent(
+  name: string,
+  options: { isDirectory: boolean; isSymbolicLink: boolean },
+): {
+  name: string
+  isDirectory: () => boolean
+  isSymbolicLink: () => boolean
+} {
+  return {
+    name,
+    isDirectory: () => options.isDirectory,
+    isSymbolicLink: () => options.isSymbolicLink,
+  }
+}
+
+const readdirMock = vi.fn()
+const accessMock = vi.fn()
+
+vi.mock('fs/promises', () => ({
+  readdir: readdirMock,
+  access: accessMock,
+}))
+
+const checkSymlinkStatusMock = vi.fn()
+
+vi.mock('./symlinkChecker', () => ({
+  checkSymlinkStatus: checkSymlinkStatusMock,
+}))
+
+vi.mock('../constants', () => ({
+  SOURCE_DIR: '/mock/source/skills',
+  AGENTS: [
+    {
+      id: 'claude-code',
+      name: 'Claude Code',
+      path: '/mock/agents/claude/skills',
+    },
+    { id: 'cursor', name: 'Cursor', path: '/mock/agents/cursor/skills' },
+  ],
+}))
+
+describe('scanAgents', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('counts only valid symlinks, excluding broken ones', async () => {
+    // Both agent dirs exist
+    accessMock.mockResolvedValue(undefined)
+
+    readdirMock.mockImplementation(async (path: string) => {
+      if (path === '/mock/agents/claude/skills') {
+        return [
+          createDirent('skill-a', { isDirectory: false, isSymbolicLink: true }),
+          createDirent('skill-b', { isDirectory: false, isSymbolicLink: true }),
+          createDirent('skill-c', { isDirectory: false, isSymbolicLink: true }),
+          createDirent('skill-d', { isDirectory: false, isSymbolicLink: true }),
+          createDirent('skill-e', { isDirectory: false, isSymbolicLink: true }),
+        ]
+      }
+      return []
+    })
+
+    checkSymlinkStatusMock.mockImplementation(async (linkPath: string) => {
+      // 3 valid, 2 broken
+      if (
+        linkPath.includes('skill-a') ||
+        linkPath.includes('skill-b') ||
+        linkPath.includes('skill-c')
+      ) {
+        return 'valid'
+      }
+      return 'broken'
+    })
+
+    const { scanAgents } = await import('./agentScanner')
+    const agents = await scanAgents()
+
+    const claude = agents.find((a) => a.id === 'claude-code')!
+    expect(claude.exists).toBe(true)
+    expect(claude.skillCount).toBe(3)
+    expect(claude.localSkillCount).toBe(0)
+  })
+
+  it('returns skillCount 0 when all symlinks are broken', async () => {
+    accessMock.mockResolvedValue(undefined)
+
+    readdirMock.mockImplementation(async (path: string) => {
+      if (path === '/mock/agents/claude/skills') {
+        return [
+          createDirent('broken-a', {
+            isDirectory: false,
+            isSymbolicLink: true,
+          }),
+          createDirent('broken-b', {
+            isDirectory: false,
+            isSymbolicLink: true,
+          }),
+        ]
+      }
+      return []
+    })
+
+    checkSymlinkStatusMock.mockResolvedValue('broken')
+
+    const { scanAgents } = await import('./agentScanner')
+    const agents = await scanAgents()
+
+    const claude = agents.find((a) => a.id === 'claude-code')!
+    expect(claude.skillCount).toBe(0)
+  })
+
+  it('counts local skills independently from symlinked skills', async () => {
+    accessMock.mockImplementation(async (path: string) => {
+      // Agent dirs exist
+      if (path === '/mock/agents/claude/skills') return
+      if (path === '/mock/agents/cursor/skills') return
+      // SKILL.md exists for local-skill
+      if (
+        path === join('/mock/agents/claude/skills', 'local-skill', 'SKILL.md')
+      )
+        return
+      throw new Error(`ENOENT: ${path}`)
+    })
+
+    readdirMock.mockImplementation(async (path: string) => {
+      if (path === '/mock/agents/claude/skills') {
+        return [
+          createDirent('symlink-skill', {
+            isDirectory: false,
+            isSymbolicLink: true,
+          }),
+          createDirent('local-skill', {
+            isDirectory: true,
+            isSymbolicLink: false,
+          }),
+        ]
+      }
+      return []
+    })
+
+    checkSymlinkStatusMock.mockResolvedValue('valid')
+
+    const { scanAgents } = await import('./agentScanner')
+    const agents = await scanAgents()
+
+    const claude = agents.find((a) => a.id === 'claude-code')!
+    expect(claude.skillCount).toBe(1)
+    expect(claude.localSkillCount).toBe(1)
+  })
+
+  it('returns exists: false with zero counts when agent dir is missing', async () => {
+    accessMock.mockImplementation(async (path: string) => {
+      if (path === '/mock/agents/claude/skills') {
+        throw new Error('ENOENT')
+      }
+      // Cursor exists but empty
+      return
+    })
+
+    readdirMock.mockResolvedValue([])
+
+    const { scanAgents } = await import('./agentScanner')
+    const agents = await scanAgents()
+
+    const claude = agents.find((a) => a.id === 'claude-code')!
+    expect(claude.exists).toBe(false)
+    expect(claude.skillCount).toBe(0)
+    expect(claude.localSkillCount).toBe(0)
+  })
+
+  it('sorts existing agents before non-existing agents', async () => {
+    accessMock.mockImplementation(async (path: string) => {
+      // Claude doesn't exist, Cursor does
+      if (path === '/mock/agents/claude/skills') {
+        throw new Error('ENOENT')
+      }
+      return
+    })
+
+    readdirMock.mockResolvedValue([])
+
+    const { scanAgents } = await import('./agentScanner')
+    const agents = await scanAgents()
+
+    // Cursor exists -> sorted first
+    expect(agents[0].id).toBe('cursor')
+    expect(agents[0].exists).toBe(true)
+    expect(agents[1].id).toBe('claude-code')
+    expect(agents[1].exists).toBe(false)
+  })
+
+  it('excludes dot-prefixed directories from local skill count', async () => {
+    accessMock.mockResolvedValue(undefined)
+
+    readdirMock.mockImplementation(async (path: string) => {
+      if (path === '/mock/agents/claude/skills') {
+        return [
+          createDirent('.hidden-dir', {
+            isDirectory: true,
+            isSymbolicLink: false,
+          }),
+          createDirent('visible-skill', {
+            isDirectory: true,
+            isSymbolicLink: false,
+          }),
+        ]
+      }
+      return []
+    })
+
+    const { scanAgents } = await import('./agentScanner')
+    const agents = await scanAgents()
+
+    const claude = agents.find((a) => a.id === 'claude-code')!
+    // .hidden-dir is excluded, visible-skill has SKILL.md (access resolves)
+    expect(claude.localSkillCount).toBe(1)
+  })
+
+  it('does not count local dirs without SKILL.md', async () => {
+    accessMock.mockImplementation(async (path: string) => {
+      // Agent dirs exist
+      if (path === '/mock/agents/claude/skills') return
+      if (path === '/mock/agents/cursor/skills') return
+      // No SKILL.md in any local dir
+      throw new Error(`ENOENT: ${path}`)
+    })
+
+    readdirMock.mockImplementation(async (path: string) => {
+      if (path === '/mock/agents/claude/skills') {
+        return [
+          createDirent('no-skillmd', {
+            isDirectory: true,
+            isSymbolicLink: false,
+          }),
+        ]
+      }
+      return []
+    })
+
+    const { scanAgents } = await import('./agentScanner')
+    const agents = await scanAgents()
+
+    const claude = agents.find((a) => a.id === 'claude-code')!
+    expect(claude.localSkillCount).toBe(0)
+  })
+})

--- a/src/main/services/symlinkChecker.test.ts
+++ b/src/main/services/symlinkChecker.test.ts
@@ -1,0 +1,312 @@
+import { join } from 'node:path'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Create a mock Stats-like object for lstat results.
+ * @param options - Whether the entry is a symbolic link or directory
+ * @returns Object compatible with fs.Stats used by symlinkChecker
+ * @example
+ * createStats({ isSymbolicLink: true, isDirectory: false })
+ * // => { isSymbolicLink: () => true, isDirectory: () => false }
+ */
+function createStats(options: {
+  isSymbolicLink: boolean
+  isDirectory: boolean
+}): {
+  isSymbolicLink: () => boolean
+  isDirectory: () => boolean
+} {
+  return {
+    isSymbolicLink: () => options.isSymbolicLink,
+    isDirectory: () => options.isDirectory,
+  }
+}
+
+const lstatMock = vi.fn()
+const readlinkMock = vi.fn()
+const accessMock = vi.fn()
+
+vi.mock('fs/promises', () => ({
+  lstat: lstatMock,
+  readlink: readlinkMock,
+  access: accessMock,
+}))
+
+vi.mock('../constants', () => ({
+  SOURCE_DIR: '/mock/source/skills',
+  AGENTS: [
+    {
+      id: 'claude-code',
+      name: 'Claude Code',
+      path: '/mock/agents/claude/skills',
+    },
+    { id: 'cursor', name: 'Cursor', path: '/mock/agents/cursor/skills' },
+  ],
+}))
+
+describe('checkSymlinkStatus', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('returns valid when symlink exists and target is accessible', async () => {
+    lstatMock.mockResolvedValue(
+      createStats({ isSymbolicLink: true, isDirectory: false }),
+    )
+    readlinkMock.mockResolvedValue('/mock/source/skills/my-skill')
+    accessMock.mockResolvedValue(undefined)
+
+    const { checkSymlinkStatus } = await import('./symlinkChecker')
+    const result = await checkSymlinkStatus(
+      '/mock/agents/claude/skills/my-skill',
+    )
+
+    expect(result).toBe('valid')
+    expect(lstatMock).toHaveBeenCalledWith(
+      '/mock/agents/claude/skills/my-skill',
+    )
+    expect(readlinkMock).toHaveBeenCalledWith(
+      '/mock/agents/claude/skills/my-skill',
+    )
+  })
+
+  it('returns broken when symlink exists but target is missing', async () => {
+    lstatMock.mockResolvedValue(
+      createStats({ isSymbolicLink: true, isDirectory: false }),
+    )
+    readlinkMock.mockResolvedValue('/mock/source/skills/deleted-skill')
+    accessMock.mockRejectedValue(new Error('ENOENT'))
+
+    const { checkSymlinkStatus } = await import('./symlinkChecker')
+    const result = await checkSymlinkStatus(
+      '/mock/agents/claude/skills/deleted-skill',
+    )
+
+    expect(result).toBe('broken')
+  })
+
+  it('returns missing when path does not exist (lstat throws ENOENT)', async () => {
+    lstatMock.mockRejectedValue(new Error('ENOENT'))
+
+    const { checkSymlinkStatus } = await import('./symlinkChecker')
+    const result = await checkSymlinkStatus(
+      '/mock/agents/claude/skills/nonexistent',
+    )
+
+    expect(result).toBe('missing')
+  })
+
+  it('returns missing when path is a real directory (not a symlink)', async () => {
+    lstatMock.mockResolvedValue(
+      createStats({ isSymbolicLink: false, isDirectory: true }),
+    )
+
+    const { checkSymlinkStatus } = await import('./symlinkChecker')
+    const result = await checkSymlinkStatus(
+      '/mock/agents/claude/skills/local-folder',
+    )
+
+    expect(result).toBe('missing')
+    expect(readlinkMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('checkSkillSymlinks', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('returns correct status for each agent with broken symlink', async () => {
+    lstatMock.mockImplementation(async (path: string) => {
+      if (path === join('/mock/agents/claude/skills', 'my-skill')) {
+        return createStats({ isSymbolicLink: true, isDirectory: false })
+      }
+      if (path === join('/mock/agents/cursor/skills', 'my-skill')) {
+        return createStats({ isSymbolicLink: true, isDirectory: false })
+      }
+      throw new Error('ENOENT')
+    })
+
+    readlinkMock.mockResolvedValue('/mock/source/skills/my-skill')
+
+    accessMock.mockImplementation(async (path: string) => {
+      if (path === '/mock/source/skills/my-skill') {
+        throw new Error('ENOENT')
+      }
+    })
+
+    const { checkSkillSymlinks } = await import('./symlinkChecker')
+    const results = await checkSkillSymlinks('my-skill')
+
+    expect(results).toHaveLength(2)
+    // Both symlinks point to missing target -> broken
+    expect(results[0]).toMatchObject({
+      agentId: 'claude-code',
+      status: 'broken',
+    })
+    expect(results[1]).toMatchObject({ agentId: 'cursor', status: 'broken' })
+  })
+
+  it('returns broken for one agent and missing for another', async () => {
+    lstatMock.mockImplementation(async (path: string) => {
+      if (path === join('/mock/agents/claude/skills', 'partial-skill')) {
+        return createStats({ isSymbolicLink: true, isDirectory: false })
+      }
+      // Cursor has no entry
+      throw new Error('ENOENT')
+    })
+
+    readlinkMock.mockResolvedValue('/mock/source/skills/deleted-target')
+    accessMock.mockRejectedValue(new Error('ENOENT'))
+
+    const { checkSkillSymlinks } = await import('./symlinkChecker')
+    const results = await checkSkillSymlinks('partial-skill')
+
+    const claude = results.find((r) => r.agentId === 'claude-code')!
+    const cursor = results.find((r) => r.agentId === 'cursor')!
+
+    expect(claude.status).toBe('broken')
+    expect(claude.targetPath).toBe('/mock/source/skills/deleted-target')
+    expect(cursor.status).toBe('missing')
+    expect(cursor.targetPath).toBe('')
+  })
+
+  it('returns valid with populated targetPath for valid symlinks', async () => {
+    lstatMock.mockResolvedValue(
+      createStats({ isSymbolicLink: true, isDirectory: false }),
+    )
+    readlinkMock.mockResolvedValue('/mock/source/skills/good-skill')
+    accessMock.mockResolvedValue(undefined)
+
+    const { checkSkillSymlinks } = await import('./symlinkChecker')
+    const results = await checkSkillSymlinks('good-skill')
+
+    expect(results).toHaveLength(2)
+    for (const r of results) {
+      expect(r.status).toBe('valid')
+      expect(r.targetPath).toBe('/mock/source/skills/good-skill')
+      expect(r.isLocal).toBe(false)
+    }
+  })
+
+  it('detects local folder as isLocal: true with valid status', async () => {
+    lstatMock.mockResolvedValue(
+      createStats({ isSymbolicLink: false, isDirectory: true }),
+    )
+
+    const { checkSkillSymlinks } = await import('./symlinkChecker')
+    const results = await checkSkillSymlinks('local-skill')
+
+    expect(results).toHaveLength(2)
+    for (const r of results) {
+      expect(r.status).toBe('valid')
+      expect(r.isLocal).toBe(true)
+      expect(r.targetPath).toBe('')
+    }
+  })
+
+  it('returns missing for all agents when no entries exist', async () => {
+    lstatMock.mockRejectedValue(new Error('ENOENT'))
+
+    const { checkSkillSymlinks } = await import('./symlinkChecker')
+    const results = await checkSkillSymlinks('nonexistent-skill')
+
+    expect(results).toHaveLength(2)
+    for (const r of results) {
+      expect(r.status).toBe('missing')
+      expect(r.isLocal).toBe(false)
+      expect(r.targetPath).toBe('')
+    }
+  })
+
+  it('populates linkPath for each agent correctly', async () => {
+    lstatMock.mockRejectedValue(new Error('ENOENT'))
+
+    const { checkSkillSymlinks } = await import('./symlinkChecker')
+    const results = await checkSkillSymlinks('any-skill')
+
+    const claude = results.find((r) => r.agentId === 'claude-code')!
+    const cursor = results.find((r) => r.agentId === 'cursor')!
+
+    expect(claude.linkPath).toBe(
+      join('/mock/agents/claude/skills', 'any-skill'),
+    )
+    expect(cursor.linkPath).toBe(
+      join('/mock/agents/cursor/skills', 'any-skill'),
+    )
+  })
+})
+
+describe('countValidSymlinks', () => {
+  it('counts only valid symlinks from mixed array', async () => {
+    const { countValidSymlinks } = await import('./symlinkChecker')
+
+    const symlinks = [
+      {
+        agentId: 'claude-code',
+        agentName: 'Claude Code',
+        status: 'valid' as const,
+        targetPath: '',
+        linkPath: '',
+        isLocal: false,
+      },
+      {
+        agentId: 'cursor',
+        agentName: 'Cursor',
+        status: 'broken' as const,
+        targetPath: '',
+        linkPath: '',
+        isLocal: false,
+      },
+      {
+        agentId: 'codex',
+        agentName: 'Codex',
+        status: 'valid' as const,
+        targetPath: '',
+        linkPath: '',
+        isLocal: false,
+      },
+      {
+        agentId: 'copilot',
+        agentName: 'Copilot',
+        status: 'missing' as const,
+        targetPath: '',
+        linkPath: '',
+        isLocal: false,
+      },
+    ]
+
+    expect(countValidSymlinks(symlinks as any)).toBe(2)
+  })
+
+  it('returns 0 when all symlinks are broken', async () => {
+    const { countValidSymlinks } = await import('./symlinkChecker')
+
+    const symlinks = [
+      {
+        agentId: 'claude-code',
+        agentName: 'Claude Code',
+        status: 'broken' as const,
+        targetPath: '',
+        linkPath: '',
+        isLocal: false,
+      },
+      {
+        agentId: 'cursor',
+        agentName: 'Cursor',
+        status: 'broken' as const,
+        targetPath: '',
+        linkPath: '',
+        isLocal: false,
+      },
+    ]
+
+    expect(countValidSymlinks(symlinks as any)).toBe(0)
+  })
+
+  it('returns 0 for empty array', async () => {
+    const { countValidSymlinks } = await import('./symlinkChecker')
+    expect(countValidSymlinks([])).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
- Add unit tests for `symlinkChecker.ts` covering valid, broken, and missing symlink states
- Add unit tests for `agentScanner.ts` covering skill counting with broken symlinks
- Prevents regression of the skill count mismatch bug

## Test plan
- [x] `pnpm test` passes (54 tests, 7 test files)
- [x] `pnpm typecheck` passes

Closes #1