### PR TITLE
feat(sidebar): add tooltip showing skills folder path on agent hover

### DIFF
--- a/src/renderer/src/components/sidebar/AgentItem.tsx
+++ b/src/renderer/src/components/sidebar/AgentItem.tsx
@@ -127,7 +127,7 @@ export function AgentItem({ agent }: AgentItemProps): React.ReactElement {
       </DropdownMenu>
       {tooltipPath && (
         <TooltipContent side="right">
-          <span className="text-muted-foreground">{tooltipPath}</span>
+          <span>{tooltipPath}</span>
         </TooltipContent>
       )}
     </Tooltip>


### PR DESCRIPTION
## Summary
- Show `~/.{dir}/skills/` path tooltip when hovering agent items in sidebar
- Radix Tooltip composed with existing DropdownMenu via `asChild` pattern
- Path derived from `AGENT_DEFINITIONS` — no IPC changes needed

## Test plan
- [ ] Typecheck passes (`pnpm typecheck`)
- [ ] Lint passes (`pnpm lint`)
- [ ] Tests pass (66/66)
- [ ] Hover over agent names in sidebar → tooltip shows correct path
- [ ] Right-click context menu still works alongside tooltip
- [ ] Universal item tooltip unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hover tooltips to agent items in the sidebar that show the agent's skills folder path.
  * Tooltip appears alongside the item and does not change existing click, context‑menu, skill count, or delete behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->