### PR TITLE
fix(bookmarks): allow bookmarking all installed skills

### DIFF
--- a/src/renderer/src/components/sidebar/BookmarkDetailModal.tsx
+++ b/src/renderer/src/components/sidebar/BookmarkDetailModal.tsx
@@ -93,18 +93,24 @@ export const BookmarkDetailModal = React.memo(
                 </DialogTitle>
               </DialogHeader>
 
-              <button
-                type="button"
-                onClick={() => {
-                  window.electron.shell.openExternal(bookmark.url).catch(() => {
-                    // URL validation failed or shell.openExternal errored
-                  })
-                }}
-                className="text-sm text-muted-foreground hover:text-foreground flex items-center gap-1 text-left"
-              >
-                {bookmark.repo}
-                <ExternalLink className="h-3 w-3" />
-              </button>
+              {bookmark.repo ? (
+                <button
+                  type="button"
+                  onClick={() => {
+                    window.electron.shell
+                      .openExternal(bookmark.url)
+                      .catch(() => {
+                        // URL validation failed or shell.openExternal errored
+                      })
+                  }}
+                  className="text-sm text-muted-foreground hover:text-foreground flex items-center gap-1 text-left"
+                >
+                  {bookmark.repo}
+                  <ExternalLink className="h-3 w-3" />
+                </button>
+              ) : (
+                <span className="text-sm text-muted-foreground/70">Local</span>
+              )}
 
               <Separator />
 
@@ -114,7 +120,7 @@ export const BookmarkDetailModal = React.memo(
                     <Check className="h-4 w-4" />
                     Installed
                   </span>
-                ) : (
+                ) : bookmark.repo ? (
                   <Button
                     onClick={handleInstall}
                     disabled={isInstalling}
@@ -125,6 +131,10 @@ export const BookmarkDetailModal = React.memo(
                     )}
                     {isInstalling ? 'Installing...' : 'Install'}
                   </Button>
+                ) : (
+                  <span className="text-sm text-muted-foreground">
+                    Not installed
+                  </span>
                 )}
                 <Button
                   variant="ghost"

--- a/src/renderer/src/components/skills/bookmarkHelpers.test.ts
+++ b/src/renderer/src/components/skills/bookmarkHelpers.test.ts
@@ -29,12 +29,12 @@ describe('canBookmarkSkill', () => {
     )
   })
 
-  it('returns false when source is undefined', () => {
-    expect(canBookmarkSkill(makeSkill({ source: undefined }))).toBe(false)
+  it('returns true when source is undefined (local skill)', () => {
+    expect(canBookmarkSkill(makeSkill({ source: undefined }))).toBe(true)
   })
 
-  it('returns false when source is empty string', () => {
-    expect(canBookmarkSkill(makeSkill({ source: '' }))).toBe(false)
+  it('returns true when source is empty string', () => {
+    expect(canBookmarkSkill(makeSkill({ source: '' }))).toBe(true)
   })
 })
 

--- a/src/renderer/src/components/skills/bookmarkHelpers.ts
+++ b/src/renderer/src/components/skills/bookmarkHelpers.ts
@@ -1,16 +1,16 @@
 import type { Skill } from '../../../../shared/types'
 
 /**
- * Whether a skill can be bookmarked (has repo source info).
- * Local skills have no source and cannot be reinstalled from a repo.
- * @param skill - Installed skill
- * @returns true if skill has source (non-local), false otherwise
+ * Whether a skill can be bookmarked from the Installed tab.
+ * All installed skills are bookmarkable regardless of source info.
+ * @param _skill - Installed skill (unused, kept for call-site compatibility)
+ * @returns always true
  * @example
  * canBookmarkSkill({ source: 'pbakaus/impeccable', ... }) // => true
- * canBookmarkSkill({ source: undefined, ... })            // => false
+ * canBookmarkSkill({ source: undefined, ... })            // => true
  */
-export function canBookmarkSkill(skill: Skill): boolean {
-  return skill.source !== undefined && skill.source !== ''
+export function canBookmarkSkill(_skill: Skill): boolean {
+  return true
 }
 
 /**


### PR DESCRIPTION
## Summary
- `canBookmarkSkill()` now returns `true` for all skills, not just those with source metadata in the lock file
- `BookmarkDetailModal` handles empty repo gracefully: shows "Local" label instead of broken link, hides Install button for local skills
- 17 of 73 skills were unbookmarkable because they were missing from `~/.agents/.skill-lock.json`

## Test plan
- [x] `canBookmarkSkill` returns true for skills with source, undefined source, and empty source
- [x] `skillToBookmarkData` handles missing sourceUrl with GitHub fallback
- [x] All 218 tests pass
- [x] Typecheck: zero errors
- [x] Lint: zero warnings
- [ ] Manual: verify bookmark icon appears on hover for all skills in Installed tab
- [ ] Manual: bookmark a local skill, open detail modal, confirm "Local" label and no Install button