### PR TITLE
fix(shell): open external URLs in default browser

### DIFF
--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -1,5 +1,6 @@
 import { registerAgentsHandlers } from './agents'
 import { registerFilesHandlers } from './files'
+import { registerShellHandlers } from './shell'
 import { registerSkillsHandlers } from './skills'
 import { registerSkillsCliHandlers } from './skillsCli'
 import { registerSourceHandlers } from './source'
@@ -18,4 +19,5 @@ export function registerAllHandlers(): void {
   registerFilesHandlers()
   registerUpdateHandlers()
   registerSyncHandlers()
+  registerShellHandlers()
 }

--- a/src/main/ipc/ipc-schemas.ts
+++ b/src/main/ipc/ipc-schemas.ts
@@ -75,4 +75,14 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
       replaceConflicts: z.array(z.string()),
     }),
   ]),
+
+  // Shell — restrict to http/https to prevent opening arbitrary URI schemes
+  'shell:openExternal': z.tuple([
+    z
+      .string()
+      .url()
+      .refine((u) => /^https?:\/\//i.test(u), {
+        message: 'Only http(s) URLs are allowed',
+      }),
+  ]),
 }

--- a/src/main/ipc/shell.ts
+++ b/src/main/ipc/shell.ts
@@ -9,7 +9,6 @@ import { typedHandle } from './typedHandle'
  *
  * The `shell` module is main-process-only — it is unavailable in sandboxed
  * preload scripts — so callers in the renderer must route through IPC.
- * URL shape is already validated upstream by Zod (http(s) only).
  */
 export function registerShellHandlers(): void {
   typedHandle(IPC_CHANNELS.SHELL_OPEN_EXTERNAL, async (_event, url) => {

--- a/src/main/ipc/shell.ts
+++ b/src/main/ipc/shell.ts
@@ -1,0 +1,18 @@
+import { shell } from 'electron'
+
+import { IPC_CHANNELS } from '../../shared/ipc-channels'
+
+import { typedHandle } from './typedHandle'
+
+/**
+ * Register IPC handlers for Electron `shell` APIs.
+ *
+ * The `shell` module is main-process-only — it is unavailable in sandboxed
+ * preload scripts — so callers in the renderer must route through IPC.
+ * URL shape is already validated upstream by Zod (http(s) only).
+ */
+export function registerShellHandlers(): void {
+  typedHandle(IPC_CHANNELS.SHELL_OPEN_EXTERNAL, async (_event, url) => {
+    await shell.openExternal(url)
+  })
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer, shell } from 'electron'
+import { contextBridge, ipcRenderer } from 'electron'
 
 import { IPC_CHANNELS } from '../shared/ipc-channels'
 import type {
@@ -11,14 +11,16 @@ import { typedInvoke } from './typedInvoke'
 
 // Expose protected methods to renderer process
 contextBridge.exposeInMainWorld('electron', {
-  // Shell API (external links)
+  // Shell API (external links).
+  // Must go through IPC: the `shell` module is unavailable in sandboxed
+  // preload scripts and is only callable from the main process.
   shell: {
     openExternal: async (url: string) => {
       const parsed = new URL(url)
       if (!['http:', 'https:'].includes(parsed.protocol)) {
         throw new Error('Unsupported URL protocol')
       }
-      return shell.openExternal(url)
+      return typedInvoke('shell:openExternal', url)
     },
   },
   // Skills API

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -14,14 +14,9 @@ contextBridge.exposeInMainWorld('electron', {
   // Shell API (external links).
   // Must go through IPC: the `shell` module is unavailable in sandboxed
   // preload scripts and is only callable from the main process.
+  // URL shape (http/https only) is enforced by the Zod schema at the handler.
   shell: {
-    openExternal: async (url: string) => {
-      const parsed = new URL(url)
-      if (!['http:', 'https:'].includes(parsed.protocol)) {
-        throw new Error('Unsupported URL protocol')
-      }
-      return typedInvoke('shell:openExternal', url)
-    },
+    openExternal: async (url: string) => typedInvoke('shell:openExternal', url),
   },
   // Skills API
   skills: {

--- a/src/renderer/src/components/skills/SourceLink.tsx
+++ b/src/renderer/src/components/skills/SourceLink.tsx
@@ -1,6 +1,8 @@
 import { ExternalLink } from 'lucide-react'
 import React from 'react'
 
+import { getSourceLinkModel } from './sourceLinkHelpers'
+
 interface SourceLinkProps {
   source?: string
   sourceUrl?: string
@@ -20,31 +22,31 @@ export const SourceLink = React.memo(function SourceLink({
   source,
   sourceUrl,
 }: SourceLinkProps): React.ReactElement {
-  if (!source) {
+  const model = getSourceLinkModel(source, sourceUrl)
+
+  if (model.kind === 'local') {
     return (
       <span className="text-sm text-muted-foreground/70 mb-2 block">Local</span>
     )
   }
 
-  const href = sourceUrl ? sourceUrl.replace(/\.git$/, '') : undefined
-
-  if (!href) {
+  if (model.kind === 'text') {
     return (
       <span className="text-sm text-muted-foreground inline-flex items-center gap-1 mb-2">
-        {source}
+        {model.source}
       </span>
     )
   }
 
   return (
     <a
-      href={href}
+      href={model.href}
       target="_blank"
       rel="noreferrer"
       onClick={(e) => e.stopPropagation()}
       className="text-sm text-muted-foreground hover:text-foreground transition-colors inline-flex items-center gap-1 mb-2"
     >
-      {source}
+      {model.source}
       <ExternalLink className="h-3 w-3" />
     </a>
   )

--- a/src/renderer/src/components/skills/SourceLink.tsx
+++ b/src/renderer/src/components/skills/SourceLink.tsx
@@ -8,17 +8,11 @@ interface SourceLinkProps {
 
 /**
  * Display skill source as a clickable external link or "Local" label.
- *
- * Uses a native `<a target="_blank">` which Electron intercepts via
- * `setWindowOpenHandler` (src/main/index.ts) and routes http(s) URLs to the
- * system browser through `shell.openExternal`. `stopPropagation` prevents the
- * parent Card's click handler from firing alongside the navigation.
- *
  * @param source - Short source identifier, e.g. "pbakaus/impeccable"
  * @param sourceUrl - Full URL to repository, e.g. "https://github.com/pbakaus/impeccable.git"
  * @example
  * <SourceLink source="pbakaus/impeccable" sourceUrl="https://github.com/pbakaus/impeccable.git" />
- * // => clickable "pbakaus/impeccable ↗" link that opens in the default browser
+ * // => clickable "pbakaus/impeccable ↗" link
  * <SourceLink />
  * // => "Local" text
  */

--- a/src/renderer/src/components/skills/SourceLink.tsx
+++ b/src/renderer/src/components/skills/SourceLink.tsx
@@ -7,12 +7,18 @@ interface SourceLinkProps {
 }
 
 /**
- * Display skill source as a clickable external link or "Local" label
+ * Display skill source as a clickable external link or "Local" label.
+ *
+ * Uses a native `<a target="_blank">` which Electron intercepts via
+ * `setWindowOpenHandler` (src/main/index.ts) and routes http(s) URLs to the
+ * system browser through `shell.openExternal`. `stopPropagation` prevents the
+ * parent Card's click handler from firing alongside the navigation.
+ *
  * @param source - Short source identifier, e.g. "pbakaus/impeccable"
  * @param sourceUrl - Full URL to repository, e.g. "https://github.com/pbakaus/impeccable.git"
  * @example
  * <SourceLink source="pbakaus/impeccable" sourceUrl="https://github.com/pbakaus/impeccable.git" />
- * // => clickable "pbakaus/impeccable ↗" link
+ * // => clickable "pbakaus/impeccable ↗" link that opens in the default browser
  * <SourceLink />
  * // => "Local" text
  */
@@ -28,19 +34,24 @@ export const SourceLink = React.memo(function SourceLink({
 
   const href = sourceUrl ? sourceUrl.replace(/\.git$/, '') : undefined
 
+  if (!href) {
+    return (
+      <span className="text-sm text-muted-foreground inline-flex items-center gap-1 mb-2">
+        {source}
+      </span>
+    )
+  }
+
   return (
-    <button
-      type="button"
-      onClick={(e) => {
-        e.stopPropagation()
-        if (href) {
-          window.electron.shell.openExternal(href)
-        }
-      }}
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      onClick={(e) => e.stopPropagation()}
       className="text-sm text-muted-foreground hover:text-foreground transition-colors inline-flex items-center gap-1 mb-2"
     >
       {source}
       <ExternalLink className="h-3 w-3" />
-    </button>
+    </a>
   )
 })

--- a/src/renderer/src/components/skills/sourceLinkHelpers.test.ts
+++ b/src/renderer/src/components/skills/sourceLinkHelpers.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+
+import { getSourceLinkModel } from './sourceLinkHelpers'
+
+describe('getSourceLinkModel', () => {
+  describe('local (no source)', () => {
+    it('returns local when source is undefined', () => {
+      expect(getSourceLinkModel()).toEqual({ kind: 'local' })
+    })
+
+    it('returns local even when sourceUrl is provided but source is missing', () => {
+      expect(getSourceLinkModel(undefined, 'https://github.com/x/y')).toEqual({
+        kind: 'local',
+      })
+    })
+
+    it('returns local when source is empty string', () => {
+      expect(getSourceLinkModel('')).toEqual({ kind: 'local' })
+    })
+  })
+
+  describe('text (source without URL)', () => {
+    it('returns text when source is present but sourceUrl is undefined', () => {
+      expect(getSourceLinkModel('pbakaus/impeccable')).toEqual({
+        kind: 'text',
+        source: 'pbakaus/impeccable',
+      })
+    })
+
+    it('returns text when sourceUrl is empty string', () => {
+      expect(getSourceLinkModel('pbakaus/impeccable', '')).toEqual({
+        kind: 'text',
+        source: 'pbakaus/impeccable',
+      })
+    })
+  })
+
+  describe('link (source with URL)', () => {
+    it('strips trailing .git from sourceUrl', () => {
+      expect(
+        getSourceLinkModel(
+          'pbakaus/impeccable',
+          'https://github.com/pbakaus/impeccable.git',
+        ),
+      ).toEqual({
+        kind: 'link',
+        source: 'pbakaus/impeccable',
+        href: 'https://github.com/pbakaus/impeccable',
+      })
+    })
+
+    it('leaves non-.git URLs unchanged', () => {
+      expect(
+        getSourceLinkModel(
+          'pbakaus/impeccable',
+          'https://github.com/pbakaus/impeccable',
+        ),
+      ).toEqual({
+        kind: 'link',
+        source: 'pbakaus/impeccable',
+        href: 'https://github.com/pbakaus/impeccable',
+      })
+    })
+
+    it('only strips .git at the end, not mid-string', () => {
+      expect(
+        getSourceLinkModel(
+          'foo/bar.git-assets',
+          'https://github.com/foo/bar.git-assets',
+        ),
+      ).toEqual({
+        kind: 'link',
+        source: 'foo/bar.git-assets',
+        href: 'https://github.com/foo/bar.git-assets',
+      })
+    })
+  })
+})

--- a/src/renderer/src/components/skills/sourceLinkHelpers.ts
+++ b/src/renderer/src/components/skills/sourceLinkHelpers.ts
@@ -1,0 +1,42 @@
+/**
+ * Discriminated render model for `SourceLink`.
+ * - `local`  — no source identifier; render the "Local" label
+ * - `text`   — identifier present but no URL; render as plain text
+ * - `link`   — identifier and URL present; render as an external anchor
+ */
+export type SourceLinkModel =
+  | { kind: 'local' }
+  | { kind: 'text'; source: string }
+  | { kind: 'link'; source: string; href: string }
+
+/**
+ * Compute the render model for `SourceLink` from its props.
+ *
+ * Strips a trailing `.git` suffix from `sourceUrl` so GitHub web URLs work
+ * when the source was a clone URL.
+ *
+ * @param source - Short source identifier, e.g. "pbakaus/impeccable"
+ * @param sourceUrl - Full URL to repository, e.g. "https://github.com/pbakaus/impeccable.git"
+ * @returns
+ * - `{ kind: 'local' }` when `source` is missing
+ * - `{ kind: 'text', source }` when `source` exists but `sourceUrl` is missing
+ * - `{ kind: 'link', source, href }` when both are present (href is `.git`-stripped)
+ * @example
+ * getSourceLinkModel()
+ * // => { kind: 'local' }
+ * @example
+ * getSourceLinkModel('pbakaus/impeccable')
+ * // => { kind: 'text', source: 'pbakaus/impeccable' }
+ * @example
+ * getSourceLinkModel('pbakaus/impeccable', 'https://github.com/pbakaus/impeccable.git')
+ * // => { kind: 'link', source: 'pbakaus/impeccable', href: 'https://github.com/pbakaus/impeccable' }
+ */
+export function getSourceLinkModel(
+  source?: string,
+  sourceUrl?: string,
+): SourceLinkModel {
+  if (!source) return { kind: 'local' }
+  const href = sourceUrl ? sourceUrl.replace(/\.git$/, '') : undefined
+  if (!href) return { kind: 'text', source }
+  return { kind: 'link', source, href }
+}

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -33,6 +33,9 @@ export const IPC_CHANNELS = {
   SYNC_PREVIEW: 'sync:preview',
   SYNC_EXECUTE: 'sync:execute',
 
+  // Shell (main-process-only APIs exposed via IPC)
+  SHELL_OPEN_EXTERNAL: 'shell:openExternal',
+
   // Update
   UPDATE_DOWNLOAD: 'update:download',
   UPDATE_INSTALL: 'update:install',

--- a/src/shared/ipc-contract.test.ts
+++ b/src/shared/ipc-contract.test.ts
@@ -26,10 +26,11 @@ describe('IPC contract alignment', () => {
       [IPC_CHANNELS.UPDATE_DOWNLOAD]: true,
       [IPC_CHANNELS.UPDATE_INSTALL]: true,
       [IPC_CHANNELS.UPDATE_CHECK]: true,
+      [IPC_CHANNELS.SHELL_OPEN_EXTERNAL]: true,
     } as const satisfies Record<keyof IpcInvokeContract, true>
 
     // Runtime assertion: mapping covers exactly the contract keys
-    expect(Object.keys(invokeMapping)).toHaveLength(19)
+    expect(Object.keys(invokeMapping)).toHaveLength(20)
   })
 
   it('all IPC_CHANNELS event values are valid event contract keys', () => {

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -70,6 +70,7 @@ export interface IpcInvokeContract {
   'update:download': { args: []; result: void }
   'update:install': { args: []; result: void }
   'update:check': { args: []; result: void }
+  'shell:openExternal': { args: [string]; result: void }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fix skill card GitHub links silently failing because `shell` is `undefined` in sandboxed preloads (`sandbox: true` in `src/main/index.ts`)
- Route `shell.openExternal` through IPC with a Zod-validated http(s)-only schema at `src/main/ipc/shell.ts`
- Refactor `SourceLink` to use native `<a target="_blank">` so Electron's existing `setWindowOpenHandler` forwards the click, restoring middle-click / Cmd+click / "Copy Link Address" semantics
- Consolidate URL validation at the Zod boundary (was duplicated across preload + schema + window handler)

## Test plan
- [ ] `pnpm typecheck`
- [ ] `pnpm lint`
- [ ] `pnpm test` (IPC contract length updated 19 → 20)
- [ ] Marketplace: click a skill card's source link → default browser opens the repo
- [ ] Middle-click / Cmd+click on the source link → opens in a new browser tab
- [ ] `SidebarFooter` and `MainContent` external links still work via the IPC path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * External link handling moved out of the renderer into a centralized process; URL validation now occurs there.
  * Link UI simplified: external sources render as standard anchor elements instead of custom buttons.

* **New Features**
  * Added a vetted mechanism to open external http(s) links from the app.

* **Tests**
  * Added unit tests for source link resolution and updated IPC contract coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->