### PR TITLE
feat(skills): add sort and skill type filter to installed skills view

### DIFF
--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -1,9 +1,20 @@
-import { ExternalLink, X } from 'lucide-react'
+import {
+  ArrowDownAZ,
+  ArrowUpAZ,
+  ChevronDown,
+  ExternalLink,
+  X,
+} from 'lucide-react'
 import React, { useState } from 'react'
 
 import { FEATURE_FLAGS } from '../../../../shared/featureFlags'
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
-import { selectAgent } from '../../redux/slices/uiSlice'
+import type { SkillTypeFilter } from '../../redux/slices/uiSlice'
+import {
+  selectAgent,
+  setSkillTypeFilter,
+  toggleSortOrder,
+} from '../../redux/slices/uiSlice'
 import { SkillsMarketplace } from '../marketplace'
 import { SyncConflictDialog } from '../sidebar/SyncConflictDialog'
 import { AddSymlinkModal } from '../skills/AddSymlinkModal'
@@ -13,7 +24,24 @@ import { SearchBox } from '../skills/SearchBox'
 import { SkillsList } from '../skills/SkillsList'
 import { UnlinkDialog } from '../skills/UnlinkDialog'
 import { Button } from '../ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '../ui/dropdown-menu'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs'
+
+const SKILL_TYPE_FILTER_OPTIONS: {
+  value: SkillTypeFilter
+  label: string
+  /** Colored dot class to match skill type visual indicators */
+  dotClass?: string
+}[] = [
+  { value: 'all', label: 'All' },
+  { value: 'symlinked', label: 'Symlinked', dotClass: 'bg-cyan-400' },
+  { value: 'local', label: 'Local', dotClass: 'bg-emerald-400' },
+]
 
 const SKILLS_SH_URL = 'https://skills.sh'
 
@@ -24,7 +52,9 @@ const SKILLS_SH_URL = 'https://skills.sh'
 export const MainContent = React.memo(
   function MainContent(): React.ReactElement {
     const dispatch = useAppDispatch()
-    const { selectedAgentId } = useAppSelector((state) => state.ui)
+    const { selectedAgentId, sortOrder, skillTypeFilter } = useAppSelector(
+      (state) => state.ui,
+    )
     const { items: agents } = useAppSelector((state) => state.agents)
     const [activeTab, setActiveTab] = useState<string>('installed')
 
@@ -87,8 +117,74 @@ export const MainContent = React.memo(
             value="installed"
             className="flex-1 m-0 data-[state=active]:flex data-[state=active]:flex-col min-h-0 overflow-hidden"
           >
-            <div className="p-4 border-b border-border shrink-0">
-              <SearchBox />
+            <div className="p-4 border-b border-border shrink-0 flex items-center gap-2">
+              <div className="flex-1 min-w-0">
+                <SearchBox />
+              </div>
+
+              {/* Sort toggle: A→Z ⟷ Z→A */}
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label={
+                  sortOrder === 'asc'
+                    ? 'Sorted A to Z, click to reverse'
+                    : 'Sorted Z to A, click to reverse'
+                }
+                onClick={() => dispatch(toggleSortOrder())}
+                className="shrink-0 text-muted-foreground hover:text-foreground min-h-[44px] min-w-[44px]"
+              >
+                {sortOrder === 'asc' ? (
+                  <ArrowDownAZ className="h-4 w-4" />
+                ) : (
+                  <ArrowUpAZ className="h-4 w-4" />
+                )}
+              </Button>
+
+              {/* Skill type filter — agent view only */}
+              {selectedAgentId && (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className={`shrink-0 gap-1.5 min-h-[44px] ${
+                        skillTypeFilter !== 'all'
+                          ? 'text-primary'
+                          : 'text-muted-foreground hover:text-foreground'
+                      }`}
+                    >
+                      {SKILL_TYPE_FILTER_OPTIONS.find(
+                        (o) => o.value === skillTypeFilter,
+                      )?.label ?? 'All'}
+                      <ChevronDown className="h-3 w-3" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    {SKILL_TYPE_FILTER_OPTIONS.map((option) => (
+                      <DropdownMenuItem
+                        key={option.value}
+                        onClick={() =>
+                          dispatch(setSkillTypeFilter(option.value))
+                        }
+                        className="gap-2"
+                      >
+                        {option.dotClass ? (
+                          <span
+                            className={`h-2 w-2 rounded-full ${option.dotClass}`}
+                          />
+                        ) : (
+                          <span className="h-2 w-2" />
+                        )}
+                        {option.label}
+                        {skillTypeFilter === option.value && (
+                          <span className="ml-auto text-primary">✓</span>
+                        )}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
             </div>
 
             {/* Agent filter indicator */}

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -27,7 +27,8 @@ import { Button } from '../ui/button'
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs'
@@ -52,9 +53,9 @@ const SKILLS_SH_URL = 'https://skills.sh'
 export const MainContent = React.memo(
   function MainContent(): React.ReactElement {
     const dispatch = useAppDispatch()
-    const { selectedAgentId, sortOrder, skillTypeFilter } = useAppSelector(
-      (state) => state.ui,
-    )
+    const selectedAgentId = useAppSelector((state) => state.ui.selectedAgentId)
+    const sortOrder = useAppSelector((state) => state.ui.sortOrder)
+    const skillTypeFilter = useAppSelector((state) => state.ui.skillTypeFilter)
     const { items: agents } = useAppSelector((state) => state.agents)
     const [activeTab, setActiveTab] = useState<string>('installed')
 
@@ -154,34 +155,38 @@ export const MainContent = React.memo(
                           : 'text-muted-foreground hover:text-foreground'
                       }`}
                     >
-                      {SKILL_TYPE_FILTER_OPTIONS.find(
-                        (o) => o.value === skillTypeFilter,
-                      )?.label ?? 'All'}
+                      {
+                        SKILL_TYPE_FILTER_OPTIONS.find(
+                          (o) => o.value === skillTypeFilter,
+                        )!.label
+                      }
                       <ChevronDown className="h-3 w-3" />
                     </Button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">
-                    {SKILL_TYPE_FILTER_OPTIONS.map((option) => (
-                      <DropdownMenuItem
-                        key={option.value}
-                        onClick={() =>
-                          dispatch(setSkillTypeFilter(option.value))
-                        }
-                        className="gap-2"
-                      >
-                        {option.dotClass ? (
-                          <span
-                            className={`h-2 w-2 rounded-full ${option.dotClass}`}
-                          />
-                        ) : (
-                          <span className="h-2 w-2" />
-                        )}
-                        {option.label}
-                        {skillTypeFilter === option.value && (
-                          <span className="ml-auto text-primary">✓</span>
-                        )}
-                      </DropdownMenuItem>
-                    ))}
+                    <DropdownMenuRadioGroup
+                      value={skillTypeFilter}
+                      onValueChange={(v) =>
+                        dispatch(setSkillTypeFilter(v as SkillTypeFilter))
+                      }
+                    >
+                      {SKILL_TYPE_FILTER_OPTIONS.map((option) => (
+                        <DropdownMenuRadioItem
+                          key={option.value}
+                          value={option.value}
+                          className="gap-2"
+                        >
+                          {option.dotClass ? (
+                            <span
+                              className={`h-2 w-2 rounded-full ${option.dotClass}`}
+                            />
+                          ) : (
+                            <span className="h-2 w-2" />
+                          )}
+                          {option.label}
+                        </DropdownMenuRadioItem>
+                      ))}
+                    </DropdownMenuRadioGroup>
                   </DropdownMenuContent>
                 </DropdownMenu>
               )}

--- a/src/renderer/src/components/skills/SkillsList.tsx
+++ b/src/renderer/src/components/skills/SkillsList.tsx
@@ -10,7 +10,10 @@ import {
   selectSkillsItems,
   selectSkillsLoading,
 } from '../../redux/slices/skillsSlice'
-import { selectSelectedAgentId } from '../../redux/slices/uiSlice'
+import {
+  selectSelectedAgentId,
+  selectSkillTypeFilter,
+} from '../../redux/slices/uiSlice'
 
 import { SkillItem } from './SkillItem'
 
@@ -59,6 +62,7 @@ export const SkillsList = React.memo(function SkillsList(): React.ReactElement {
   const loading = useAppSelector(selectSkillsLoading)
   const error = useAppSelector(selectSkillsError)
   const selectedAgentId = useAppSelector(selectSelectedAgentId)
+  const skillTypeFilter = useAppSelector(selectSkillTypeFilter)
   const filteredSkills = useAppSelector(selectFilteredSkills)
 
   useEffect(() => {
@@ -116,7 +120,9 @@ export const SkillsList = React.memo(function SkillsList(): React.ReactElement {
       <div className="flex items-center justify-center py-12">
         <div className="text-muted-foreground">
           {selectedAgentId
-            ? 'No skills installed for this agent'
+            ? skillTypeFilter !== 'all'
+              ? `No ${skillTypeFilter} skills for this agent`
+              : 'No skills installed for this agent'
             : 'No skills match your search'}
         </div>
       </div>

--- a/src/renderer/src/components/skills/SkillsList.tsx
+++ b/src/renderer/src/components/skills/SkillsList.tsx
@@ -11,6 +11,7 @@ import {
   selectSkillsLoading,
 } from '../../redux/slices/skillsSlice'
 import {
+  selectSearchQuery,
   selectSelectedAgentId,
   selectSkillTypeFilter,
 } from '../../redux/slices/uiSlice'
@@ -63,6 +64,7 @@ export const SkillsList = React.memo(function SkillsList(): React.ReactElement {
   const error = useAppSelector(selectSkillsError)
   const selectedAgentId = useAppSelector(selectSelectedAgentId)
   const skillTypeFilter = useAppSelector(selectSkillTypeFilter)
+  const searchQuery = useAppSelector(selectSearchQuery)
   const filteredSkills = useAppSelector(selectFilteredSkills)
 
   useEffect(() => {
@@ -120,9 +122,11 @@ export const SkillsList = React.memo(function SkillsList(): React.ReactElement {
       <div className="flex items-center justify-center py-12">
         <div className="text-muted-foreground">
           {selectedAgentId
-            ? skillTypeFilter !== 'all'
-              ? `No ${skillTypeFilter} skills for this agent`
-              : 'No skills installed for this agent'
+            ? searchQuery
+              ? 'No skills match your search'
+              : skillTypeFilter !== 'all'
+                ? `No ${skillTypeFilter} skills for this agent`
+                : 'No skills installed for this agent'
             : 'No skills match your search'}
         </div>
       </div>

--- a/src/renderer/src/redux/selectors.test.ts
+++ b/src/renderer/src/redux/selectors.test.ts
@@ -12,6 +12,8 @@ function buildState(overrides: {
   skills?: Skill[]
   searchQuery?: string
   selectedAgentId?: string | null
+  sortOrder?: 'asc' | 'desc'
+  skillTypeFilter?: 'all' | 'symlinked' | 'local'
   bookmarks?: BookmarkedSkill[]
 }) {
   return {
@@ -34,9 +36,12 @@ function buildState(overrides: {
       sourceStats: null,
       isRefreshing: false,
       selectedAgentId: overrides.selectedAgentId ?? null,
+      sortOrder: overrides.sortOrder ?? 'asc',
+      skillTypeFilter: overrides.skillTypeFilter ?? 'all',
       isSyncing: false,
       syncPreview: null,
       error: null,
+      selectedBookmarkForDetail: null,
     },
     // Other slices needed for RootState shape
     agents: {
@@ -181,6 +186,123 @@ describe('selectFilteredSkills', () => {
     const skills = [makeSkill('task', 'claude-code')]
     const state = buildState({ skills, searchQuery: 'nonexistent' })
     expect(selectFilteredSkills(state as never)).toHaveLength(0)
+  })
+
+  it('sorts skills A→Z by default (asc)', () => {
+    const skills = [
+      makeSkill('zebra', 'claude-code'),
+      makeSkill('alpha', 'claude-code'),
+      makeSkill('middle', 'claude-code'),
+    ]
+    const state = buildState({ skills, sortOrder: 'asc' })
+    const result = selectFilteredSkills(state as never)
+    expect(result.map((s) => s.name)).toEqual(['alpha', 'middle', 'zebra'])
+  })
+
+  it('sorts skills Z→A when desc', () => {
+    const skills = [
+      makeSkill('alpha', 'claude-code'),
+      makeSkill('zebra', 'claude-code'),
+      makeSkill('middle', 'claude-code'),
+    ]
+    const state = buildState({ skills, sortOrder: 'desc' })
+    const result = selectFilteredSkills(state as never)
+    expect(result.map((s) => s.name)).toEqual(['zebra', 'middle', 'alpha'])
+  })
+
+  it('filters by skillTypeFilter=symlinked in agent view', () => {
+    const symlinkedSkill: Skill = {
+      name: 'linked-one',
+      description: '',
+      path: '/source/linked-one',
+      symlinkCount: 1,
+      symlinks: [
+        {
+          agentId: 'cursor' as SymlinkInfo['agentId'],
+          agentName: 'Cursor' as SymlinkInfo['agentName'],
+          linkPath: '/home/.cursor/skills/linked-one',
+          targetPath: '/source/linked-one',
+          status: 'valid',
+          isLocal: false,
+        },
+      ],
+    }
+    const localSkill: Skill = {
+      name: 'local-one',
+      description: '',
+      path: '/source/local-one',
+      symlinkCount: 0,
+      symlinks: [
+        {
+          agentId: 'cursor' as SymlinkInfo['agentId'],
+          agentName: 'Cursor' as SymlinkInfo['agentName'],
+          linkPath: '/home/.cursor/skills/local-one',
+          targetPath: '/home/.cursor/skills/local-one',
+          status: 'valid',
+          isLocal: true,
+        },
+      ],
+    }
+    const state = buildState({
+      skills: [symlinkedSkill, localSkill],
+      selectedAgentId: 'cursor',
+      skillTypeFilter: 'symlinked',
+    })
+    const result = selectFilteredSkills(state as never)
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('linked-one')
+  })
+
+  it('filters by skillTypeFilter=local in agent view', () => {
+    const symlinkedSkill: Skill = {
+      name: 'linked-one',
+      description: '',
+      path: '/source/linked-one',
+      symlinkCount: 1,
+      symlinks: [
+        {
+          agentId: 'cursor' as SymlinkInfo['agentId'],
+          agentName: 'Cursor' as SymlinkInfo['agentName'],
+          linkPath: '/home/.cursor/skills/linked-one',
+          targetPath: '/source/linked-one',
+          status: 'valid',
+          isLocal: false,
+        },
+      ],
+    }
+    const localSkill: Skill = {
+      name: 'local-one',
+      description: '',
+      path: '/source/local-one',
+      symlinkCount: 0,
+      symlinks: [
+        {
+          agentId: 'cursor' as SymlinkInfo['agentId'],
+          agentName: 'Cursor' as SymlinkInfo['agentName'],
+          linkPath: '/home/.cursor/skills/local-one',
+          targetPath: '/home/.cursor/skills/local-one',
+          status: 'valid',
+          isLocal: true,
+        },
+      ],
+    }
+    const state = buildState({
+      skills: [symlinkedSkill, localSkill],
+      selectedAgentId: 'cursor',
+      skillTypeFilter: 'local',
+    })
+    const result = selectFilteredSkills(state as never)
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('local-one')
+  })
+
+  it('skillTypeFilter is ignored in global view (no agent selected)', () => {
+    const skills = [
+      makeSkill('task', 'claude-code'),
+      makeSkill('browse', 'cursor'),
+    ]
+    const state = buildState({ skills, skillTypeFilter: 'symlinked' })
+    expect(selectFilteredSkills(state as never)).toHaveLength(2)
   })
 
   it('is memoized (returns same reference for same inputs)', () => {

--- a/src/renderer/src/redux/selectors.test.ts
+++ b/src/renderer/src/redux/selectors.test.ts
@@ -80,19 +80,24 @@ function buildState(overrides: {
   }
 }
 
-const makeSkill = (name: string, agentId: string): Skill => ({
+/**
+ * @param isLocal - false = symlinked (default), true = local folder
+ */
+const makeSkill = (name: string, agentId: string, isLocal = false): Skill => ({
   name,
   description: `${name} skill`,
   path: `/home/user/.agents/skills/${name}`,
-  symlinkCount: 1,
+  symlinkCount: isLocal ? 0 : 1,
   symlinks: [
     {
       agentId: agentId as SymlinkInfo['agentId'],
       agentName: agentId as SymlinkInfo['agentName'],
       linkPath: `/home/user/.${agentId}/skills/${name}`,
-      targetPath: `/home/user/.agents/skills/${name}`,
+      targetPath: isLocal
+        ? `/home/user/.${agentId}/skills/${name}`
+        : `/home/user/.agents/skills/${name}`,
       status: 'valid',
-      isLocal: false,
+      isLocal,
     },
   ],
 })
@@ -211,40 +216,12 @@ describe('selectFilteredSkills', () => {
   })
 
   it('filters by skillTypeFilter=symlinked in agent view', () => {
-    const symlinkedSkill: Skill = {
-      name: 'linked-one',
-      description: '',
-      path: '/source/linked-one',
-      symlinkCount: 1,
-      symlinks: [
-        {
-          agentId: 'cursor' as SymlinkInfo['agentId'],
-          agentName: 'Cursor' as SymlinkInfo['agentName'],
-          linkPath: '/home/.cursor/skills/linked-one',
-          targetPath: '/source/linked-one',
-          status: 'valid',
-          isLocal: false,
-        },
-      ],
-    }
-    const localSkill: Skill = {
-      name: 'local-one',
-      description: '',
-      path: '/source/local-one',
-      symlinkCount: 0,
-      symlinks: [
-        {
-          agentId: 'cursor' as SymlinkInfo['agentId'],
-          agentName: 'Cursor' as SymlinkInfo['agentName'],
-          linkPath: '/home/.cursor/skills/local-one',
-          targetPath: '/home/.cursor/skills/local-one',
-          status: 'valid',
-          isLocal: true,
-        },
-      ],
-    }
+    const skills = [
+      makeSkill('linked-one', 'cursor'),
+      makeSkill('local-one', 'cursor', true),
+    ]
     const state = buildState({
-      skills: [symlinkedSkill, localSkill],
+      skills,
       selectedAgentId: 'cursor',
       skillTypeFilter: 'symlinked',
     })
@@ -254,40 +231,12 @@ describe('selectFilteredSkills', () => {
   })
 
   it('filters by skillTypeFilter=local in agent view', () => {
-    const symlinkedSkill: Skill = {
-      name: 'linked-one',
-      description: '',
-      path: '/source/linked-one',
-      symlinkCount: 1,
-      symlinks: [
-        {
-          agentId: 'cursor' as SymlinkInfo['agentId'],
-          agentName: 'Cursor' as SymlinkInfo['agentName'],
-          linkPath: '/home/.cursor/skills/linked-one',
-          targetPath: '/source/linked-one',
-          status: 'valid',
-          isLocal: false,
-        },
-      ],
-    }
-    const localSkill: Skill = {
-      name: 'local-one',
-      description: '',
-      path: '/source/local-one',
-      symlinkCount: 0,
-      symlinks: [
-        {
-          agentId: 'cursor' as SymlinkInfo['agentId'],
-          agentName: 'Cursor' as SymlinkInfo['agentName'],
-          linkPath: '/home/.cursor/skills/local-one',
-          targetPath: '/home/.cursor/skills/local-one',
-          status: 'valid',
-          isLocal: true,
-        },
-      ],
-    }
+    const skills = [
+      makeSkill('linked-one', 'cursor'),
+      makeSkill('local-one', 'cursor', true),
+    ]
     const state = buildState({
-      skills: [symlinkedSkill, localSkill],
+      skills,
       selectedAgentId: 'cursor',
       skillTypeFilter: 'local',
     })

--- a/src/renderer/src/redux/selectors.test.ts
+++ b/src/renderer/src/redux/selectors.test.ts
@@ -199,7 +199,7 @@ describe('selectFilteredSkills', () => {
       makeSkill('alpha', 'claude-code'),
       makeSkill('middle', 'claude-code'),
     ]
-    const state = buildState({ skills, sortOrder: 'asc' })
+    const state = buildState({ skills })
     const result = selectFilteredSkills(state as never)
     expect(result.map((s) => s.name)).toEqual(['alpha', 'middle', 'zebra'])
   })

--- a/src/renderer/src/redux/selectors.test.ts
+++ b/src/renderer/src/redux/selectors.test.ts
@@ -245,6 +245,21 @@ describe('selectFilteredSkills', () => {
     expect(result[0].name).toBe('local-one')
   })
 
+  it('returns empty when search + type filter combined exclude all', () => {
+    const skills = [
+      makeSkill('linked-one', 'cursor'),
+      makeSkill('local-one', 'cursor', true),
+    ]
+    const state = buildState({
+      skills,
+      selectedAgentId: 'cursor',
+      skillTypeFilter: 'local',
+      searchQuery: 'linked',
+    })
+    const result = selectFilteredSkills(state as never)
+    expect(result).toHaveLength(0)
+  })
+
   it('skillTypeFilter is ignored in global view (no agent selected)', () => {
     const skills = [
       makeSkill('task', 'claude-code'),

--- a/src/renderer/src/redux/selectors.test.ts
+++ b/src/renderer/src/redux/selectors.test.ts
@@ -263,10 +263,11 @@ describe('selectFilteredSkills', () => {
   it('skillTypeFilter is ignored in global view (no agent selected)', () => {
     const skills = [
       makeSkill('task', 'claude-code'),
-      makeSkill('browse', 'cursor'),
+      makeSkill('local-task', 'cursor', true),
     ]
     const state = buildState({ skills, skillTypeFilter: 'symlinked' })
-    expect(selectFilteredSkills(state as never)).toHaveLength(2)
+    const result = selectFilteredSkills(state as never)
+    expect(result.map((s) => s.name)).toEqual(['local-task', 'task'])
   })
 
   it('is memoized (returns same reference for same inputs)', () => {

--- a/src/renderer/src/redux/selectors.ts
+++ b/src/renderer/src/redux/selectors.ts
@@ -27,27 +27,18 @@ export const selectFilteredSkills = createSelector(
   (skills, searchQuery, selectedAgentId, sortOrder, skillTypeFilter) => {
     let result = skills
 
-    // Filter by selected agent
+    // Filter by selected agent (and optionally by skill type)
     if (selectedAgentId) {
+      const checkType = skillTypeFilter !== 'all'
+      const wantLocal = skillTypeFilter === 'local'
       result = result.filter((skill) =>
         skill.symlinks.some(
-          (symlink) =>
-            symlink.agentId === selectedAgentId && symlink.status === 'valid',
+          (s) =>
+            s.agentId === selectedAgentId &&
+            s.status === 'valid' &&
+            (!checkType || s.isLocal === wantLocal),
         ),
       )
-
-      // Filter by skill type (symlinked vs local) — agent view only
-      if (skillTypeFilter !== 'all') {
-        const wantLocal = skillTypeFilter === 'local'
-        result = result.filter((skill) =>
-          skill.symlinks.some(
-            (s) =>
-              s.agentId === selectedAgentId &&
-              s.status === 'valid' &&
-              s.isLocal === wantLocal,
-          ),
-        )
-      }
     }
 
     // Filter by search query (name only)

--- a/src/renderer/src/redux/selectors.ts
+++ b/src/renderer/src/redux/selectors.ts
@@ -2,19 +2,29 @@ import { createSelector } from '@reduxjs/toolkit'
 
 import { selectBookmarkItems } from './slices/bookmarkSlice'
 import { selectSkillsItems } from './slices/skillsSlice'
-import { selectSearchQuery, selectSelectedAgentId } from './slices/uiSlice'
+import {
+  selectSearchQuery,
+  selectSelectedAgentId,
+  selectSkillTypeFilter,
+  selectSortOrder,
+} from './slices/uiSlice'
 
 /**
- * Memoized selector for filtered skills list.
- * Combines skills items, search query, and selected agent filter.
- * Only recomputes when one of the inputs changes.
- * @returns Filtered skills array
+ * Memoized selector for filtered and sorted skills list.
+ * Applies agent filter, skill type filter, search query, and name sort.
+ * @returns Filtered + sorted skills array
  * @example
  * const filteredSkills = useAppSelector(selectFilteredSkills)
  */
 export const selectFilteredSkills = createSelector(
-  [selectSkillsItems, selectSearchQuery, selectSelectedAgentId],
-  (skills, searchQuery, selectedAgentId) => {
+  [
+    selectSkillsItems,
+    selectSearchQuery,
+    selectSelectedAgentId,
+    selectSortOrder,
+    selectSkillTypeFilter,
+  ],
+  (skills, searchQuery, selectedAgentId, sortOrder, skillTypeFilter) => {
     let result = skills
 
     // Filter by selected agent
@@ -25,6 +35,19 @@ export const selectFilteredSkills = createSelector(
             symlink.agentId === selectedAgentId && symlink.status === 'valid',
         ),
       )
+
+      // Filter by skill type (symlinked vs local) — agent view only
+      if (skillTypeFilter !== 'all') {
+        const wantLocal = skillTypeFilter === 'local'
+        result = result.filter((skill) =>
+          skill.symlinks.some(
+            (s) =>
+              s.agentId === selectedAgentId &&
+              s.status === 'valid' &&
+              s.isLocal === wantLocal,
+          ),
+        )
+      }
     }
 
     // Filter by search query (name only)
@@ -35,7 +58,13 @@ export const selectFilteredSkills = createSelector(
       )
     }
 
-    return result
+    // Sort by name
+    const sorted = [...result].sort((a, b) => {
+      const cmp = a.name.localeCompare(b.name)
+      return sortOrder === 'asc' ? cmp : -cmp
+    })
+
+    return sorted
   },
 )
 

--- a/src/renderer/src/redux/slices/uiSlice.ts
+++ b/src/renderer/src/redux/slices/uiSlice.ts
@@ -91,7 +91,6 @@ const uiSlice = createSlice({
     },
     selectAgent: (state, action: PayloadAction<string | null>) => {
       state.selectedAgentId = action.payload
-      // Reset skill type filter when switching agents (filter is agent-view only)
       state.skillTypeFilter = 'all'
     },
     toggleSortOrder: (state) => {

--- a/src/renderer/src/redux/slices/uiSlice.ts
+++ b/src/renderer/src/redux/slices/uiSlice.ts
@@ -12,11 +12,18 @@ import type { RootState } from '../store'
 /** Bookmark with install status, used for the detail modal */
 export type BookmarkForDetail = BookmarkedSkill & { isInstalled: boolean }
 
+export type SortOrder = 'asc' | 'desc'
+export type SkillTypeFilter = 'all' | 'symlinked' | 'local'
+
 interface UiState {
   searchQuery: string
   sourceStats: SourceStats | null
   isRefreshing: boolean
   selectedAgentId: string | null
+  /** Sort direction for skill name (A→Z / Z→A) */
+  sortOrder: SortOrder
+  /** Filter by skill type in agent view (all / symlinked / local) */
+  skillTypeFilter: SkillTypeFilter
   /** Whether sync operation is in progress */
   isSyncing: boolean
   /** Sync preview result (null when not previewing) */
@@ -31,6 +38,8 @@ const initialState: UiState = {
   sourceStats: null,
   isRefreshing: false,
   selectedAgentId: null,
+  sortOrder: 'asc',
+  skillTypeFilter: 'all',
   isSyncing: false,
   syncPreview: null,
   error: null,
@@ -82,6 +91,14 @@ const uiSlice = createSlice({
     },
     selectAgent: (state, action: PayloadAction<string | null>) => {
       state.selectedAgentId = action.payload
+      // Reset skill type filter when switching agents (filter is agent-view only)
+      state.skillTypeFilter = 'all'
+    },
+    toggleSortOrder: (state) => {
+      state.sortOrder = state.sortOrder === 'asc' ? 'desc' : 'asc'
+    },
+    setSkillTypeFilter: (state, action: PayloadAction<SkillTypeFilter>) => {
+      state.skillTypeFilter = action.payload
     },
     setSyncPreview: (
       state,
@@ -132,6 +149,8 @@ export const {
   setSearchQuery,
   setRefreshing,
   selectAgent,
+  toggleSortOrder,
+  setSkillTypeFilter,
   setSyncPreview,
   setSelectedBookmarkForDetail,
   clearSelectedBookmarkForDetail,
@@ -151,6 +170,10 @@ export const selectIsSyncing = (state: RootState): boolean => state.ui.isSyncing
 export const selectSyncPreview = (state: RootState): SyncPreviewResult | null =>
   state.ui.syncPreview
 export const selectUiError = (state: RootState): string | null => state.ui.error
+export const selectSortOrder = (state: RootState): SortOrder =>
+  state.ui.sortOrder
+export const selectSkillTypeFilter = (state: RootState): SkillTypeFilter =>
+  state.ui.skillTypeFilter
 export const selectSelectedBookmarkForDetail = (
   state: RootState,
 ): BookmarkForDetail | null => state.ui.selectedBookmarkForDetail


### PR DESCRIPTION
## Summary

- **Sort toggle** (A→Z / Z→A) in the installed skills toolbar, using `localeCompare` on skill names
- **Skill type filter** (All / Symlinked / Local) dropdown in agent view, filtering by `SymlinkInfo.isLocal`
- **Filter-aware empty state** message: shows "No local skills for this agent" instead of generic "No skills installed" when a type filter narrows results to zero

## Changes

- `uiSlice.ts`: Added `sortOrder` and `skillTypeFilter` state with `toggleSortOrder` and `setSkillTypeFilter` actions
- `selectors.ts`: Extended `selectFilteredSkills` with single-pass agent+type filter, search filter, and name sort
- `MainContent.tsx`: Sort button (ArrowDownAZ/ArrowUpAZ icons) + conditional DropdownMenuRadioGroup for type filter
- `SkillsList.tsx`: Filter-aware empty state messaging
- `selectors.test.ts`: 5 new tests covering asc/desc sort, symlinked/local filter, filter-ignored-in-global-view

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` on changed files — clean
- [x] `pnpm test` — 235 tests passing (22 suites)
- [ ] Manual: toggle sort A→Z / Z→A, verify list reorders
- [ ] Manual: select agent → filter by Local → verify only local skills shown
- [ ] Manual: select agent → filter by Symlinked with no matches → verify "No symlinked skills for this agent" message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sort toggle to order the skills list alphabetically (asc/desc), with visual state indicating direction
  * Skill type filter dropdown (All, Symlinked, Local) to scope skills for a selected agent; filter resets when changing agents
* **Bug Fixes / UX**
  * Improved empty-state messages to reflect active search and type filters
* **Tests**
  * Added/updated tests covering sorting and skill-type filtering behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->