### PR TITLE
refactor: replace colorless primitives with domain-rich types

### DIFF
--- a/src/renderer/src/components/skills/skillItemHelpers.test.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.test.ts
@@ -144,11 +144,11 @@ describe('getSkillItemVisibility', () => {
       expect(result.showCopyButton).toBe(false)
     })
 
-    it('returns false when universal filter is selected', () => {
+    it('returns false when selected agent has no symlink for the skill', () => {
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: false }),
       ]
-      const result = getSkillItemVisibility('universal', symlinks)
+      const result = getSkillItemVisibility('codex', symlinks)
       expect(result.showCopyButton).toBe(false)
     })
 

--- a/src/renderer/src/components/skills/skillItemHelpers.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.ts
@@ -1,4 +1,4 @@
-import type { SymlinkInfo } from '../../../../shared/types'
+import type { AgentId, SymlinkInfo } from '../../../../shared/types'
 
 /**
  * Visibility state for SkillItem action buttons.
@@ -45,7 +45,7 @@ export interface SkillItemVisibility {
  * // => { showDeleteButton: false, showUnlinkButton: true, isLocalSkill: true, selectedLocalSkillInfo: {...}, ... }
  */
 export function getSkillItemVisibility(
-  selectedAgentId: string | null,
+  selectedAgentId: AgentId | null,
   symlinks: SymlinkInfo[],
 ): SkillItemVisibility {
   const selectedAgentSymlink = selectedAgentId

--- a/src/renderer/src/components/theme/ThemeSelector.tsx
+++ b/src/renderer/src/components/theme/ThemeSelector.tsx
@@ -1,6 +1,7 @@
 import { Moon, Palette, Sun } from 'lucide-react'
 import React from 'react'
 
+import type { ColorThemePresetName } from '../../../../shared/constants'
 import { THEME_HUES } from '../../../../shared/constants'
 import { cn } from '../../lib/utils'
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
@@ -34,7 +35,10 @@ export const ThemeSelector = React.memo(
       dispatch(toggleMode())
     }
 
-    const handleSelectColorTheme = (name: string, themeHue: number): void => {
+    const handleSelectColorTheme = (
+      name: ColorThemePresetName,
+      themeHue: number,
+    ): void => {
       dispatch(setColorTheme({ preset: name, hue: themeHue }))
     }
 
@@ -82,7 +86,9 @@ export const ThemeSelector = React.memo(
             Color Themes
           </DropdownMenuLabel>
           <div className="grid grid-cols-6 gap-0.5 p-1">
-            {Object.entries(THEME_HUES).map(([name, themeHue]) => (
+            {(
+              Object.entries(THEME_HUES) as [ColorThemePresetName, number][]
+            ).map(([name, themeHue]) => (
               <button
                 key={name}
                 type="button"

--- a/src/renderer/src/redux/selectors.test.ts
+++ b/src/renderer/src/redux/selectors.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import type { BookmarkedSkill, Skill, SymlinkInfo } from '../../../shared/types'
+import type {
+  AgentId,
+  BookmarkedSkill,
+  Skill,
+  SymlinkInfo,
+} from '../../../shared/types'
 
 import {
   selectBookmarksWithInstallStatus,
@@ -11,7 +16,7 @@ import {
 function buildState(overrides: {
   skills?: Skill[]
   searchQuery?: string
-  selectedAgentId?: string | null
+  selectedAgentId?: AgentId | null
   sortOrder?: 'asc' | 'desc'
   skillTypeFilter?: 'all' | 'symlinked' | 'local'
   bookmarks?: BookmarkedSkill[]
@@ -83,7 +88,7 @@ function buildState(overrides: {
 /**
  * @param isLocal - false = symlinked (default), true = local folder
  */
-const makeSkill = (name: string, agentId: string, isLocal = false): Skill => ({
+const makeSkill = (name: string, agentId: AgentId, isLocal = false): Skill => ({
   name,
   description: `${name} skill`,
   path: `/home/user/.agents/skills/${name}`,

--- a/src/renderer/src/redux/slices/themeSlice.test.ts
+++ b/src/renderer/src/redux/slices/themeSlice.test.ts
@@ -21,16 +21,16 @@ describe('themeSlice', () => {
     const store = await createTestStore()
     store.dispatch(
       setTheme({
-        hue: 270,
+        hue: 300,
         mode: 'light',
-        preset: 'purple',
+        preset: 'violet',
         presetType: 'color',
       }),
     )
     const state = store.getState().theme
-    expect(state.hue).toBe(270)
+    expect(state.hue).toBe(300)
     expect(state.mode).toBe('light')
-    expect(state.preset).toBe('purple')
+    expect(state.preset).toBe('violet')
     expect(state.presetType).toBe('color')
   })
 
@@ -61,11 +61,11 @@ describe('themeSlice', () => {
   it('setColorTheme updates preset, hue, and presetType', async () => {
     const { setColorTheme } = await import('./themeSlice')
     const store = await createTestStore()
-    store.dispatch(setColorTheme({ preset: 'emerald', hue: 160 }))
+    store.dispatch(setColorTheme({ preset: 'green', hue: 145 }))
 
     const state = store.getState().theme
-    expect(state.preset).toBe('emerald')
-    expect(state.hue).toBe(160)
+    expect(state.preset).toBe('green')
+    expect(state.hue).toBe(145)
     expect(state.presetType).toBe('color')
   })
 

--- a/src/renderer/src/redux/slices/themeSlice.ts
+++ b/src/renderer/src/redux/slices/themeSlice.ts
@@ -1,15 +1,19 @@
 import type { PayloadAction } from '@reduxjs/toolkit'
 import { createSlice } from '@reduxjs/toolkit'
 
-import type { ThemePresetType } from '../../../../shared/constants'
+import type {
+  ColorThemePresetName,
+  ThemePresetName,
+  ThemePresetType,
+} from '../../../../shared/constants'
 
 export interface ThemeState {
-  /** Current theme hue (0-360, only used for 'color' type) */
+  /** Current theme hue (0–360, only meaningful for 'color' presetType). @example 195 */
   hue: number
   /** Light or dark mode */
   mode: 'light' | 'dark'
-  /** Preset name (e.g., 'cyan', 'neutral-dark') */
-  preset: string
+  /** Active theme preset identifier. @example "cyan", "neutral-dark" */
+  preset: ThemePresetName
   /** Preset type: 'color' (OKLCH) or 'neutral' (shadcn default) */
   presetType: ThemePresetType
 }
@@ -55,7 +59,7 @@ export const themeSlice = createSlice({
      */
     setColorTheme: (
       state,
-      action: PayloadAction<{ preset: string; hue: number }>,
+      action: PayloadAction<{ preset: ColorThemePresetName; hue: number }>,
     ) => {
       state.preset = action.payload.preset
       state.hue = action.payload.hue
@@ -69,7 +73,10 @@ export const themeSlice = createSlice({
      */
     setNeutralTheme: (
       state,
-      action: PayloadAction<{ preset: string; mode: 'light' | 'dark' }>,
+      action: PayloadAction<{
+        preset: ThemePresetName
+        mode: 'light' | 'dark'
+      }>,
     ) => {
       state.preset = action.payload.preset
       state.mode = action.payload.mode

--- a/src/renderer/src/redux/slices/themeSlice.ts
+++ b/src/renderer/src/redux/slices/themeSlice.ts
@@ -3,6 +3,7 @@ import { createSlice } from '@reduxjs/toolkit'
 
 import type {
   ColorThemePresetName,
+  NeutralThemePresetName,
   ThemePresetName,
   ThemePresetType,
 } from '../../../../shared/constants'
@@ -74,7 +75,7 @@ export const themeSlice = createSlice({
     setNeutralTheme: (
       state,
       action: PayloadAction<{
-        preset: ThemePresetName
+        preset: NeutralThemePresetName
         mode: 'light' | 'dark'
       }>,
     ) => {

--- a/src/renderer/src/redux/slices/uiSlice.ts
+++ b/src/renderer/src/redux/slices/uiSlice.ts
@@ -2,6 +2,7 @@ import type { PayloadAction } from '@reduxjs/toolkit'
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit'
 
 import type {
+  AgentId,
   BookmarkedSkill,
   SourceStats,
   SyncExecuteOptions,
@@ -19,7 +20,8 @@ interface UiState {
   searchQuery: string
   sourceStats: SourceStats | null
   isRefreshing: boolean
-  selectedAgentId: string | null
+  /** Currently selected agent filter (null = global/all-agents view). */
+  selectedAgentId: AgentId | null
   /** Sort direction for skill name (A→Z / Z→A) */
   sortOrder: SortOrder
   /** Filter by skill type in agent view (all / symlinked / local) */
@@ -89,7 +91,7 @@ const uiSlice = createSlice({
     setRefreshing: (state, action: PayloadAction<boolean>) => {
       state.isRefreshing = action.payload
     },
-    selectAgent: (state, action: PayloadAction<string | null>) => {
+    selectAgent: (state, action: PayloadAction<AgentId | null>) => {
       state.selectedAgentId = action.payload
       state.skillTypeFilter = 'all'
     },
@@ -159,7 +161,7 @@ export default uiSlice.reducer
 // --- Named selectors ---
 export const selectSearchQuery = (state: RootState): string =>
   state.ui.searchQuery
-export const selectSelectedAgentId = (state: RootState): string | null =>
+export const selectSelectedAgentId = (state: RootState): AgentId | null =>
   state.ui.selectedAgentId
 export const selectSourceStats = (state: RootState): SourceStats | null =>
   state.ui.sourceStats

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -169,13 +169,16 @@ export const AGENT_DEFINITIONS = [
 export type ColorThemePresetName = keyof typeof THEME_HUES
 
 /**
+ * Neutral theme preset name (shadcn/ui defaults).
+ * @example 'neutral-dark', 'neutral-light'
+ */
+export type NeutralThemePresetName = 'neutral-dark' | 'neutral-light'
+
+/**
  * Any valid theme preset name — color hue or neutral variant.
  * @example 'cyan', 'neutral-dark'
  */
-export type ThemePresetName =
-  | ColorThemePresetName
-  | 'neutral-dark'
-  | 'neutral-light'
+export type ThemePresetName = ColorThemePresetName | NeutralThemePresetName
 
 /**
  * Agent IDs used in app state and IPC.

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -162,6 +162,22 @@ export const AGENT_DEFINITIONS = [
 ] as const
 
 /**
+ * Color theme preset name, one of the 12 OKLCH hue-based themes.
+ * Derived from THEME_HUES keys to stay in sync with available presets.
+ * @example 'cyan', 'rose', 'indigo'
+ */
+export type ColorThemePresetName = keyof typeof THEME_HUES
+
+/**
+ * Any valid theme preset name — color hue or neutral variant.
+ * @example 'cyan', 'neutral-dark'
+ */
+export type ThemePresetName =
+  | ColorThemePresetName
+  | 'neutral-dark'
+  | 'neutral-light'
+
+/**
  * Agent IDs used in app state and IPC.
  * Derived from AGENT_DEFINITIONS to stay in sync with skills CLI.
  */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,6 +1,10 @@
 import type { AgentId, AgentName } from './constants'
 export type { AgentId, AgentName } from './constants'
-export type { ColorThemePresetName, ThemePresetName } from './constants'
+export type {
+  ColorThemePresetName,
+  NeutralThemePresetName,
+  ThemePresetName,
+} from './constants'
 
 /**
  * A reusable AI agent capability package containing a SKILL.md manifest.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,43 +1,89 @@
 import type { AgentId, AgentName } from './constants'
 export type { AgentId, AgentName } from './constants'
+export type { ColorThemePresetName, ThemePresetName } from './constants'
 
 /**
- * Skill entity representing an installed skill
+ * A reusable AI agent capability package containing a SKILL.md manifest.
+ * Installed in ~/.agents/skills/ and symlinked into agent skill directories.
+ * @example
+ * {
+ *   name: 'tdd-workflow',
+ *   description: 'Test-driven development workflow for TypeScript projects',
+ *   path: '/Users/me/.agents/skills/tdd-workflow',
+ *   symlinkCount: 3,
+ *   symlinks: [...],
+ *   source: 'vercel-labs/skills',
+ *   sourceUrl: 'https://github.com/vercel-labs/skills.git',
+ * }
  */
 export interface Skill {
+  /** Human-readable identifier matching the directory name. @example "tdd-workflow" */
   name: string
+  /** Summary from SKILL.md frontmatter. @example "Test-driven development workflow" */
   description: string
+  /** Absolute filesystem path to the skill directory. @example "/Users/me/.agents/skills/tdd-workflow" */
   path: string
+  /** Number of agents this skill is symlinked to (valid symlinks only). @example 3 */
   symlinkCount: number
+  /** Per-agent symlink status entries */
   symlinks: SymlinkInfo[]
-  /** Short source identifier, e.g. "pbakaus/impeccable" */
+  /** Short source identifier in owner/repo format. @example "vercel-labs/skills" */
   source?: string
-  /** Full URL to the source repository, e.g. "https://github.com/pbakaus/impeccable.git" */
+  /** Full URL to the source repository. @example "https://github.com/vercel-labs/skills.git" */
   sourceUrl?: string
 }
 
 /**
- * AI agent that can use skills
+ * An AI coding agent that can use skills via symlinks.
+ * Each agent has a home directory (e.g. ~/.claude) containing a skills/ subdirectory.
+ * @example
+ * {
+ *   id: 'claude-code',
+ *   name: 'Claude Code',
+ *   path: '/Users/me/.claude/skills',
+ *   exists: true,
+ *   skillCount: 12,
+ *   localSkillCount: 2,
+ * }
  */
 export interface Agent {
+  /** Internal identifier matching skills CLI agent ID. @example "claude-code" */
   id: AgentId
+  /** Display name shown in the UI. @example "Claude Code" */
   name: AgentName
+  /** Absolute path to the agent's skills directory. @example "/Users/me/.claude/skills" */
   path: string
+  /** Whether the agent's skills directory exists on disk */
   exists: boolean
-  /** Number of valid symlinked skills */
+  /** Number of valid symlinked skills. @example 12 */
   skillCount: number
-  /** Number of local skills (real folders, not symlinks) */
+  /** Number of local skills (real folders, not symlinks). @example 2 */
   localSkillCount: number
 }
 
 /**
- * Information about a symlink between skill and agent
+ * Symlink status between a skill source and an agent's skills directory.
+ * Each skill has one SymlinkInfo per agent, describing the link state.
+ * @example
+ * {
+ *   agentId: 'cursor',
+ *   agentName: 'Cursor',
+ *   status: 'valid',
+ *   targetPath: '/Users/me/.agents/skills/tdd-workflow',
+ *   linkPath: '/Users/me/.cursor/skills/tdd-workflow',
+ *   isLocal: false,
+ * }
  */
 export interface SymlinkInfo {
+  /** Agent this symlink belongs to. @example "cursor" */
   agentId: AgentId
+  /** Agent display name. @example "Cursor" */
   agentName: AgentName
+  /** Current symlink state: valid (linked), broken (dangling), or missing (no link) */
   status: SymlinkStatus
+  /** Where the symlink points to (skill source directory). @example "/Users/me/.agents/skills/tdd-workflow" */
   targetPath: string
+  /** Where the symlink lives (in agent's skills dir). @example "/Users/me/.cursor/skills/tdd-workflow" */
   linkPath: string
   /** true = real folder in agent dir (local skill), false = symlink */
   isLocal: boolean
@@ -59,58 +105,86 @@ export type SymlinkStatus = 'valid' | 'broken' | 'missing'
 export type SkillType = 'source' | 'local'
 
 /**
- * Statistics for the source directory
+ * Statistics for the ~/.agents/skills/ source directory.
+ * Shown in the sidebar SourceCard.
+ * @example
+ * { path: '/Users/me/.agents/skills', skillCount: 15, totalSize: '2.4 MB', lastModified: '2026-04-10' }
  */
 export interface SourceStats {
+  /** Absolute path to the source directory. @example "/Users/me/.agents/skills" */
   path: string
+  /** Total number of skill directories. @example 15 */
   skillCount: number
+  /** Human-readable total size. @example "2.4 MB" */
   totalSize: string
+  /** Human-readable last modified date. @example "2026-04-10" */
   lastModified: string
 }
 
 /**
- * Skill metadata from SKILL.md frontmatter
+ * Skill metadata parsed from SKILL.md frontmatter.
+ * @example { name: 'tdd-workflow', description: 'Test-driven development workflow' }
  */
 export interface SkillMetadata {
+  /** Skill name from frontmatter `name` field. @example "tdd-workflow" */
   name: string
+  /** Skill description from frontmatter `description` field. @example "Test-driven development workflow" */
   description: string
 }
 
 /**
- * File info for skill directory contents
+ * File entry within a skill directory (for the code preview panel).
+ * @example { name: 'SKILL.md', path: '/Users/me/.agents/skills/tdd/SKILL.md', extension: 'md', size: 1024 }
  */
 export interface SkillFile {
+  /** File name with extension. @example "SKILL.md" */
   name: string
+  /** Absolute path to the file. @example "/Users/me/.agents/skills/tdd/SKILL.md" */
   path: string
+  /** File extension without dot. @example "md" */
   extension: string
+  /** File size in bytes. @example 1024 */
   size: number
 }
 
 /**
- * File content with metadata
+ * File content loaded for the code preview panel.
+ * @example { name: 'SKILL.md', content: '---\nname: tdd\n---', extension: 'md', lineCount: 42 }
  */
 export interface SkillFileContent {
+  /** File name with extension. @example "SKILL.md" */
   name: string
+  /** Full text content of the file */
   content: string
+  /** File extension without dot. @example "md" */
   extension: string
+  /** Number of lines in the file. @example 42 */
   lineCount: number
 }
 
 /**
- * Update information from electron-updater
+ * Update information from electron-updater.
+ * @example { version: '0.8.0', releaseNotes: 'Added marketplace search' }
  */
 export interface UpdateInfo {
+  /** Semantic version string of the available update. @example "0.8.0" */
   version: string
+  /** Markdown release notes (may be absent for minor releases) */
   releaseNotes?: string
 }
 
 /**
- * Download progress information
+ * Download progress during auto-update.
+ * @example { percent: 45.2, bytesPerSecond: 524288, total: 10485760, transferred: 4739174 }
  */
 export interface DownloadProgress {
+  /** Download completion percentage (0–100). @example 45.2 */
   percent: number
+  /** Current download speed in bytes per second. @example 524288 */
   bytesPerSecond: number
+  /** Total download size in bytes. @example 10485760 */
   total: number
+  /** Bytes transferred so far. @example 4739174 */
   transferred: number
 }
 


### PR DESCRIPTION
## Summary

- Replace `string` primitives with domain union types where they represent specific concepts — `AgentId` (42-value union), `ThemePresetName` (14-value union), `ColorThemePresetName` (12 hue names) — adding compile-time safety that catches invalid values
- Add property-level JSDoc with `@example` to 9 core domain interfaces (`Skill`, `Agent`, `SymlinkInfo`, `SourceStats`, `SkillMetadata`, `SkillFile`, `SkillFileContent`, `UpdateInfo`, `DownloadProgress`)
- Fix test values caught by stricter types: `'emerald'`→`'green'`, `'purple'`→`'violet'`, `'universal'`→`'codex'`

## Test plan

- [x] `pnpm typecheck` — zero errors
- [x] `pnpm vitest run` — 236/236 tests pass
- [x] `pnpm lint` — no new warnings (3 pre-existing `.bridgespace/` errors unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Tightened internal type safety around agent selection and theme presets to improve reliability.

* **Documentation**
  * Expanded and clarified domain documentation for shared data types and interfaces.

* **Tests**
  * Updated tests to align with stronger type contracts and revised theme values in expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->