### PR TITLE
feat(marketplace): live leaderboard with per-filter caching

### DIFF
--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -1,5 +1,6 @@
 import { registerAgentsHandlers } from './agents'
 import { registerFilesHandlers } from './files'
+import { registerLeaderboardHandlers } from './leaderboard'
 import { registerShellHandlers } from './shell'
 import { registerSkillsHandlers } from './skills'
 import { registerSkillsCliHandlers } from './skillsCli'
@@ -14,6 +15,7 @@ import { registerUpdateHandlers } from './update'
 export function registerAllHandlers(): void {
   registerSkillsHandlers()
   registerSkillsCliHandlers()
+  registerLeaderboardHandlers()
   registerAgentsHandlers()
   registerSourceHandlers()
   registerFilesHandlers()

--- a/src/main/ipc/ipc-schemas.ts
+++ b/src/main/ipc/ipc-schemas.ts
@@ -69,6 +69,13 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
     }),
   ]),
 
+  // Marketplace Leaderboard
+  'marketplace:leaderboard': z.tuple([
+    z.object({
+      filter: z.enum(['all-time', 'trending', 'hot']),
+    }),
+  ]),
+
   // Sync operations
   'sync:execute': z.tuple([
     z.object({

--- a/src/main/ipc/leaderboard.ts
+++ b/src/main/ipc/leaderboard.ts
@@ -1,0 +1,15 @@
+import { IPC_CHANNELS } from '../../shared/ipc-channels'
+import { fetchLeaderboard } from '../services/leaderboardService'
+
+import { typedHandle } from './typedHandle'
+
+/**
+ * Register IPC handler for marketplace leaderboard.
+ * Fetches and parses skills.sh HTML leaderboard pages in the main process.
+ * Raw HTML never reaches the renderer, only structured SkillSearchResult[].
+ */
+export function registerLeaderboardHandlers(): void {
+  typedHandle(IPC_CHANNELS.MARKETPLACE_LEADERBOARD, async (_, { filter }) => {
+    return fetchLeaderboard(filter)
+  })
+}

--- a/src/main/services/leaderboardService.test.ts
+++ b/src/main/services/leaderboardService.test.ts
@@ -106,14 +106,17 @@ describe('parseLeaderboardHtml', () => {
     expect(results[0].installCount).toBe(927)
   })
 
-  it('returns empty array when stability signature is missing', () => {
+  it('throws when stability signature is missing', () => {
     const html = '<html><body><p>This page has no leaderboard</p></body></html>'
-    const results = parseLeaderboardHtml(html)
-    expect(results).toEqual([])
+    expect(() => parseLeaderboardHtml(html)).toThrow(
+      'Leaderboard HTML structure mismatch',
+    )
   })
 
-  it('returns empty array for empty string', () => {
-    expect(parseLeaderboardHtml('')).toEqual([])
+  it('throws for empty string', () => {
+    expect(() => parseLeaderboardHtml('')).toThrow(
+      'Leaderboard HTML structure mismatch',
+    )
   })
 
   it('limits results to 50', () => {

--- a/src/main/services/leaderboardService.test.ts
+++ b/src/main/services/leaderboardService.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+import {
+  parseFormattedCount,
+  parseLeaderboardHtml,
+  fetchLeaderboard,
+} from './leaderboardService'
+
+describe('parseFormattedCount', () => {
+  it('parses plain numbers', () => {
+    expect(parseFormattedCount('927')).toBe(927)
+    expect(parseFormattedCount('0')).toBe(0)
+    expect(parseFormattedCount('42')).toBe(42)
+  })
+
+  it('parses K suffix', () => {
+    expect(parseFormattedCount('731.2K')).toBe(731200)
+    expect(parseFormattedCount('20.0K')).toBe(20000)
+    expect(parseFormattedCount('1K')).toBe(1000)
+    expect(parseFormattedCount('12.3K')).toBe(12300)
+  })
+
+  it('parses M suffix', () => {
+    expect(parseFormattedCount('1.5M')).toBe(1500000)
+    expect(parseFormattedCount('2M')).toBe(2000000)
+  })
+
+  it('parses B suffix', () => {
+    expect(parseFormattedCount('1.2B')).toBe(1200000000)
+  })
+
+  it('handles case insensitive suffixes', () => {
+    expect(parseFormattedCount('731.2k')).toBe(731200)
+    expect(parseFormattedCount('1.5m')).toBe(1500000)
+  })
+
+  it('handles whitespace', () => {
+    expect(parseFormattedCount('  731.2K  ')).toBe(731200)
+    expect(parseFormattedCount(' 927 ')).toBe(927)
+  })
+
+  it('handles commas in numbers', () => {
+    expect(parseFormattedCount('1,234')).toBe(1234)
+  })
+
+  it('returns 0 for invalid input', () => {
+    expect(parseFormattedCount('')).toBe(0)
+    expect(parseFormattedCount('abc')).toBe(0)
+    expect(parseFormattedCount('---')).toBe(0)
+  })
+})
+
+describe('parseLeaderboardHtml', () => {
+  it('parses skill rows from anchor tags', () => {
+    const html = `
+      <div>
+        <a href="/vercel-labs/skills/find-skills">
+          <div><span>#</span><span>1</span></div>
+          <div><h3>find-skills</h3></div>
+          <div><span>vercel-labs/skills</span></div>
+          <div><span>731.2K</span></div>
+        </a>
+        <a href="/owner/repo/my-skill">
+          <div><span>#</span><span>2</span></div>
+          <div><h3>my-skill</h3></div>
+          <div><span>owner/repo</span></div>
+          <div><span>42</span></div>
+        </a>
+      </div>
+    `
+    const results = parseLeaderboardHtml(html)
+
+    expect(results).toHaveLength(2)
+    expect(results[0]).toEqual({
+      rank: 1,
+      name: 'find-skills',
+      repo: 'vercel-labs/skills',
+      url: 'https://skills.sh/vercel-labs/skills/find-skills',
+      installCount: 731200,
+    })
+    expect(results[1]).toEqual({
+      rank: 2,
+      name: 'my-skill',
+      repo: 'owner/repo',
+      url: 'https://skills.sh/owner/repo/my-skill',
+      installCount: 42,
+    })
+  })
+
+  it('parses hot page with delta counts', () => {
+    const html = `
+      <a href="/vercel-labs/skills/find-skills">
+        <div>
+          <span>#</span><span>1</span>
+        </div>
+        <div><h3>find-skills</h3></div>
+        <div><span>vercel-labs/skills</span></div>
+        <div><span>927</span><span>+294</span></div>
+      </a>
+    `
+    const results = parseLeaderboardHtml(html)
+
+    expect(results).toHaveLength(1)
+    // +294 is excluded by the negative lookbehind (?<![+-])
+    // So only 927 matches as the install count
+    expect(results[0].installCount).toBe(927)
+  })
+
+  it('returns empty array when stability signature is missing', () => {
+    const html = '<html><body><p>This page has no leaderboard</p></body></html>'
+    const results = parseLeaderboardHtml(html)
+    expect(results).toEqual([])
+  })
+
+  it('returns empty array for empty string', () => {
+    expect(parseLeaderboardHtml('')).toEqual([])
+  })
+
+  it('limits results to 50', () => {
+    // Generate 60 skill anchors
+    const anchors = Array.from(
+      { length: 60 },
+      (_, i) => `
+      <a href="/owner/repo/skill-${i}">
+        <h3>skill-${i}</h3>
+        <span>${i * 100}</span>
+      </a>
+    `,
+    ).join('\n')
+    const html = `<div>${anchors}</div>`
+
+    const results = parseLeaderboardHtml(html)
+    expect(results).toHaveLength(50)
+  })
+
+  it('skips anchors without h3', () => {
+    const html = `
+      <a href="/owner/repo/good-skill">
+        <h3>good-skill</h3>
+        <span>100</span>
+      </a>
+      <a href="/owner/repo/bad-link">
+        <span>No heading here</span>
+      </a>
+    `
+    const results = parseLeaderboardHtml(html)
+    expect(results).toHaveLength(1)
+    expect(results[0].name).toBe('good-skill')
+  })
+
+  it('handles table-based layout (all-time page)', () => {
+    const html = `
+      <table>
+        <tr>
+          <td>
+            <a href="/vercel-labs/skills/find-skills">
+              <h3>find-skills</h3>
+            </a>
+          </td>
+          <td>731.2K</td>
+        </tr>
+      </table>
+    `
+    // The anchor is inside a td, which is fine for our regex
+    const results = parseLeaderboardHtml(html)
+    expect(results).toHaveLength(1)
+    expect(results[0].name).toBe('find-skills')
+  })
+
+  it('assigns sequential ranks', () => {
+    const html = `
+      <a href="/a/b/skill-one"><h3>skill-one</h3><span>100</span></a>
+      <a href="/c/d/skill-two"><h3>skill-two</h3><span>50</span></a>
+      <a href="/e/f/skill-three"><h3>skill-three</h3><span>25</span></a>
+    `
+    const results = parseLeaderboardHtml(html)
+    expect(results.map((r) => r.rank)).toEqual([1, 2, 3])
+  })
+})
+
+describe('fetchLeaderboard', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('fetches and parses leaderboard HTML', async () => {
+    const mockHtml = `
+      <a href="/vercel-labs/skills/find-skills">
+        <h3>find-skills</h3>
+        <span>731.2K</span>
+      </a>
+    `
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(mockHtml, { status: 200 }),
+    )
+
+    const results = await fetchLeaderboard('all-time')
+    expect(results).toHaveLength(1)
+    expect(results[0].name).toBe('find-skills')
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://skills.sh/',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'User-Agent': 'skills-desktop/1.0',
+        }),
+      }),
+    )
+  })
+
+  it('fetches correct URL for each filter', async () => {
+    const spy = vi.spyOn(globalThis, 'fetch')
+
+    spy.mockResolvedValueOnce(new Response('<h3>x</h3>', { status: 200 }))
+    await fetchLeaderboard('all-time')
+    expect(spy).toHaveBeenLastCalledWith(
+      'https://skills.sh/',
+      expect.anything(),
+    )
+
+    spy.mockResolvedValueOnce(new Response('<h3>x</h3>', { status: 200 }))
+    await fetchLeaderboard('trending')
+    expect(spy).toHaveBeenLastCalledWith(
+      'https://skills.sh/trending',
+      expect.anything(),
+    )
+
+    spy.mockResolvedValueOnce(new Response('<h3>x</h3>', { status: 200 }))
+    await fetchLeaderboard('hot')
+    expect(spy).toHaveBeenLastCalledWith(
+      'https://skills.sh/hot',
+      expect.anything(),
+    )
+  })
+
+  it('throws on non-200 response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Not Found', { status: 404, statusText: 'Not Found' }),
+    )
+
+    await expect(fetchLeaderboard('all-time')).rejects.toThrow(
+      'Failed to fetch leaderboard: 404 Not Found',
+    )
+  })
+})

--- a/src/main/services/leaderboardService.ts
+++ b/src/main/services/leaderboardService.ts
@@ -28,7 +28,7 @@ const MAX_RESULTS = 50
  */
 export function parseFormattedCount(text: string): number {
   const trimmed = text.trim().replace(/,/g, '')
-  const match = trimmed.match(/^([\d.]+)\s*([KMB])?$/i)
+  const match = trimmed.match(/^(\d+(?:\.\d+)?)\s*([KMB])?$/i)
   if (!match) return 0
 
   const num = parseFloat(match[1])
@@ -55,7 +55,9 @@ export function parseFormattedCount(text: string): number {
 export function parseLeaderboardHtml(html: string): SkillSearchResult[] {
   // Stability check: verify the page contains expected markup
   if (!html.includes(STABILITY_SIGNATURE)) {
-    return []
+    throw new Error(
+      'Leaderboard HTML structure mismatch (stability signature missing)',
+    )
   }
 
   const results: SkillSearchResult[] = []
@@ -89,11 +91,11 @@ export function parseLeaderboardHtml(html: string): SkillSearchResult[] {
     )
     let installCount = 0
     if (countCandidates) {
-      // Take the last matching number (install count is typically rightmost)
+      // Prefer the largest parsed number to avoid trailing-metric corruption
       for (const candidate of countCandidates) {
         const parsed = parseFormattedCount(candidate)
         if (parsed > 0) {
-          installCount = parsed
+          installCount = Math.max(installCount, parsed)
         }
       }
     }

--- a/src/main/services/leaderboardService.ts
+++ b/src/main/services/leaderboardService.ts
@@ -1,0 +1,145 @@
+import type { RankingFilter, SkillSearchResult } from '../../shared/types'
+
+/** Maps ranking filter to skills.sh URL */
+const LEADERBOARD_URLS: Record<RankingFilter, string> = {
+  'all-time': 'https://skills.sh/',
+  trending: 'https://skills.sh/trending',
+  hot: 'https://skills.sh/hot',
+}
+
+/**
+ * Known CSS class signature to verify the page is a skills.sh leaderboard.
+ * If this is missing from the response, the HTML structure likely changed.
+ */
+const STABILITY_SIGNATURE = '<h3'
+
+/** Maximum number of skills to return per leaderboard page */
+const MAX_RESULTS = 50
+
+/**
+ * Parse a formatted install count string to a number.
+ * @param text - Formatted count string from skills.sh
+ * @returns Parsed integer count
+ * @example
+ * parseFormattedCount('731.2K') // => 731200
+ * parseFormattedCount('1.5M')   // => 1500000
+ * parseFormattedCount('927')    // => 927
+ * parseFormattedCount('12.3K')  // => 12300
+ */
+export function parseFormattedCount(text: string): number {
+  const trimmed = text.trim().replace(/,/g, '')
+  const match = trimmed.match(/^([\d.]+)\s*([KMB])?$/i)
+  if (!match) return 0
+
+  const num = parseFloat(match[1])
+  const suffix = match[2]?.toUpperCase()
+
+  if (suffix === 'K') return Math.round(num * 1_000)
+  if (suffix === 'M') return Math.round(num * 1_000_000)
+  if (suffix === 'B') return Math.round(num * 1_000_000_000)
+  return Math.round(num)
+}
+
+/**
+ * Parse skills.sh leaderboard HTML into structured results.
+ * Uses a common anchor pattern that works across all three pages:
+ * each skill row is an `<a href="/owner/repo/skill">` containing
+ * an `<h3>skill-name</h3>` and a formatted install count.
+ *
+ * @param html - Raw HTML string from skills.sh
+ * @returns Parsed skill results (max 50)
+ * @example
+ * parseLeaderboardHtml('<a href="/vercel-labs/skills/find-skills"><h3>find-skills</h3>...')
+ * // => [{ rank: 1, name: 'find-skills', repo: 'vercel-labs/skills', url: '...', installCount: 731200 }]
+ */
+export function parseLeaderboardHtml(html: string): SkillSearchResult[] {
+  // Stability check: verify the page contains expected markup
+  if (!html.includes(STABILITY_SIGNATURE)) {
+    return []
+  }
+
+  const results: SkillSearchResult[] = []
+  let rank = 1
+
+  // Match anchor tags linking to skill detail pages: /owner/repo/skill-name
+  // The href pattern is consistent across all three leaderboard pages
+  const anchorPattern =
+    /<a\s[^>]*href="\/([^"\/]+\/[^"\/]+)\/([^"\/]+)"[^>]*>([\s\S]*?)<\/a>/gi
+  let anchorMatch: RegExpExecArray | null
+
+  while (
+    (anchorMatch = anchorPattern.exec(html)) !== null &&
+    results.length < MAX_RESULTS
+  ) {
+    const repo = anchorMatch[1]
+    const skillSlug = anchorMatch[2]
+    const innerHtml = anchorMatch[3]
+
+    // Extract skill name from <h3> inside the anchor
+    const h3Match = innerHtml.match(/<h3[^>]*>(.*?)<\/h3>/i)
+    if (!h3Match) continue
+
+    const name = h3Match[1].trim()
+
+    // Extract install count: look for numbers with optional K/M/B suffix.
+    // Excludes rank numbers (preceded by #) and delta numbers (preceded by +/-)
+    // This appears as standalone text like "731.2K", "20.0K", "927"
+    const countCandidates = innerHtml.match(
+      /(?<!#)(?<![+-])\b(\d[\d,.]*\s*[KMB]?)\b/gi,
+    )
+    let installCount = 0
+    if (countCandidates) {
+      // Take the last matching number (install count is typically rightmost)
+      for (const candidate of countCandidates) {
+        const parsed = parseFormattedCount(candidate)
+        if (parsed > 0) {
+          installCount = parsed
+        }
+      }
+    }
+
+    results.push({
+      rank: rank++,
+      name,
+      repo,
+      url: `https://skills.sh/${repo}/${skillSlug}`,
+      installCount,
+    })
+  }
+
+  return results
+}
+
+/**
+ * Fetch and parse a skills.sh leaderboard page.
+ * Runs in the main process (Node.js). Returns structured skill data
+ * that crosses the IPC boundary to the renderer.
+ *
+ * @param filter - Which leaderboard to fetch
+ * @returns Parsed skill results
+ * @throws Error if fetch fails or returns non-200 status
+ * @example
+ * fetchLeaderboard('all-time')
+ * // => [{ rank: 1, name: 'find-skills', ... }, ...]
+ */
+export async function fetchLeaderboard(
+  filter: RankingFilter,
+): Promise<SkillSearchResult[]> {
+  const url = LEADERBOARD_URLS[filter]
+  const response = await fetch(url, {
+    headers: {
+      'User-Agent': 'skills-desktop/1.0',
+      Accept: 'text/html',
+    },
+    signal: AbortSignal.timeout(15_000),
+  })
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch leaderboard: ${response.status} ${response.statusText}`,
+    )
+  }
+
+  const html = await response.text()
+  return parseLeaderboardHtml(html)
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -80,6 +80,12 @@ contextBridge.exposeInMainWorld('electron', {
       IPC_CHANNELS.SKILLS_CLI_PROGRESS,
     ),
   },
+  // Marketplace Leaderboard
+  marketplace: {
+    leaderboard: async (
+      options: Parameters<typeof typedInvoke<'marketplace:leaderboard'>>[1],
+    ) => typedInvoke('marketplace:leaderboard', options),
+  },
   // Sync API
   sync: {
     preview: async () => typedInvoke('sync:preview'),

--- a/src/renderer/src/components/marketplace/LeaderboardSkeleton.tsx
+++ b/src/renderer/src/components/marketplace/LeaderboardSkeleton.tsx
@@ -11,8 +11,7 @@ export const LeaderboardSkeleton = React.memo(
         {Array.from({ length: 6 }, (_, i) => (
           <div
             key={i}
-            className="rounded-lg bg-card p-4 flex items-center gap-4"
-            style={{ height: 76 }}
+            className="rounded-lg bg-card p-4 flex items-center gap-4 h-[76px]"
           >
             {/* Rank square */}
             <div className="h-8 w-8 rounded bg-muted animate-pulse shrink-0" />

--- a/src/renderer/src/components/marketplace/LeaderboardSkeleton.tsx
+++ b/src/renderer/src/components/marketplace/LeaderboardSkeleton.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+
+/**
+ * Skeleton loading state for the leaderboard.
+ * 6 pulsing rows matching the 76px height of SkillRowMarketplace.
+ */
+export const LeaderboardSkeleton = React.memo(
+  function LeaderboardSkeleton(): React.ReactElement {
+    return (
+      <div className="flex flex-col gap-2">
+        {Array.from({ length: 6 }, (_, i) => (
+          <div
+            key={i}
+            className="rounded-lg bg-card p-4 flex items-center gap-4"
+            style={{ height: 76 }}
+          >
+            {/* Rank square */}
+            <div className="h-8 w-8 rounded bg-muted animate-pulse shrink-0" />
+            {/* Name + repo */}
+            <div className="flex-1 space-y-2">
+              <div
+                className="h-4 bg-muted animate-pulse rounded"
+                style={{ width: '40%' }}
+              />
+              <div
+                className="h-3 bg-muted animate-pulse rounded"
+                style={{ width: '30%' }}
+              />
+            </div>
+            {/* Install count */}
+            <div className="h-4 w-12 bg-muted animate-pulse rounded shrink-0" />
+            {/* Button placeholder */}
+            <div className="h-8 w-20 bg-muted animate-pulse rounded shrink-0" />
+          </div>
+        ))}
+      </div>
+    )
+  },
+)

--- a/src/renderer/src/components/marketplace/MarketplaceSearch.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceSearch.tsx
@@ -5,6 +5,7 @@ import { useAppDispatch, useAppSelector } from '../../redux/hooks'
 import {
   searchSkills,
   setSearchQuery,
+  clearSearchResults,
 } from '../../redux/slices/marketplaceSlice'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
@@ -26,6 +27,16 @@ export const MarketplaceSearch = React.memo(
       }
     }
 
+    /** Clear search input and return to leaderboard */
+    function handleChange(e: React.ChangeEvent<HTMLInputElement>): void {
+      const value = e.target.value
+      setLocalQuery(value)
+      // When input is cleared (native X button or manual), reset search state
+      if (value === '') {
+        dispatch(clearSearchResults())
+      }
+    }
+
     const handleKeyDown = (e: React.KeyboardEvent): void => {
       if (e.key === 'Enter') {
         handleSearch()
@@ -40,7 +51,7 @@ export const MarketplaceSearch = React.memo(
             type="search"
             placeholder="Search skills (e.g., react, vercel, nextjs)..."
             value={localQuery}
-            onChange={(e) => setLocalQuery(e.target.value)}
+            onChange={handleChange}
             onKeyDown={handleKeyDown}
             className="pl-10 bg-background h-11"
             disabled={isSearching}

--- a/src/renderer/src/components/marketplace/RankingTabs.tsx
+++ b/src/renderer/src/components/marketplace/RankingTabs.tsx
@@ -1,12 +1,13 @@
 import React from 'react'
 
+import type { RankingFilter } from '../../../../shared/types'
 import { cn } from '../../lib/utils'
-
-type RankingFilter = 'all-time' | 'trending' | 'hot'
 
 interface RankingTabsProps {
   value: RankingFilter
   onChange: (value: RankingFilter) => void
+  /** When true, tabs are visually dimmed and non-interactive (during search) */
+  disabled?: boolean
 }
 
 const tabs: { id: RankingFilter; label: string }[] = [
@@ -16,20 +17,47 @@ const tabs: { id: RankingFilter; label: string }[] = [
 ]
 
 /**
- * Ranking filter tabs for marketplace skills
+ * Ranking filter tabs for marketplace leaderboard.
+ * Follows WAI-ARIA Tabs pattern: role=tablist, role=tab, aria-selected, arrow-key navigation.
  * @param value - Currently selected ranking filter
  * @param onChange - Callback when filter changes
+ * @param disabled - Dims and disables tabs (during active search)
  */
 export const RankingTabs = React.memo(function RankingTabs({
   value,
   onChange,
+  disabled = false,
 }: RankingTabsProps): React.ReactElement {
+  /** Arrow key navigation: Left/Right cycle between tabs */
+  function handleKeyDown(e: React.KeyboardEvent): void {
+    if (disabled) return
+    const currentIndex = tabs.findIndex((t) => t.id === value)
+    if (e.key === 'ArrowRight') {
+      e.preventDefault()
+      const next = tabs[(currentIndex + 1) % tabs.length]
+      onChange(next.id)
+    } else if (e.key === 'ArrowLeft') {
+      e.preventDefault()
+      const prev = tabs[(currentIndex - 1 + tabs.length) % tabs.length]
+      onChange(prev.id)
+    }
+  }
+
   return (
-    <div className="flex gap-2">
+    <div
+      role="tablist"
+      aria-label="Leaderboard ranking"
+      className={cn('flex gap-2', disabled && 'opacity-50 pointer-events-none')}
+      onKeyDown={handleKeyDown}
+    >
       {tabs.map((tab) => (
         <button
           key={tab.id}
+          role="tab"
+          aria-selected={value === tab.id}
+          tabIndex={value === tab.id ? 0 : -1}
           onClick={() => onChange(tab.id)}
+          disabled={disabled}
           className={cn(
             'px-4 py-2 rounded-md text-[13px] font-medium transition-colors min-h-[44px] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
             value === tab.id

--- a/src/renderer/src/components/marketplace/SkillsMarketplace.tsx
+++ b/src/renderer/src/components/marketplace/SkillsMarketplace.tsx
@@ -13,6 +13,13 @@ import { RankingTabs } from './RankingTabs'
 import { RemoveDialog } from './RemoveDialog'
 import { SkillRowMarketplace } from './SkillRowMarketplace'
 
+/** Display labels for each ranking filter tab */
+const FILTER_LABELS: Record<RankingFilter, string> = {
+  'all-time': 'All Time',
+  trending: 'Trending',
+  hot: 'Hot',
+}
+
 /**
  * Format a timestamp into relative time for the "Updated X min ago" label.
  * @param timestamp - ms since epoch
@@ -188,12 +195,7 @@ export const SkillsMarketplace = React.memo(
                         {leaderboardSkills.length} skill
                         {leaderboardSkills.length !== 1
                           ? 's'
-                          : ''} &middot;{' '}
-                        {rankingFilter === 'all-time'
-                          ? 'All Time'
-                          : rankingFilter === 'trending'
-                            ? 'Trending'
-                            : 'Hot'}
+                          : ''} &middot; {FILTER_LABELS[rankingFilter]}
                       </p>
                       {leaderboardLastFetched > 0 && (
                         <p className="font-mono text-xs text-muted-foreground">

--- a/src/renderer/src/components/marketplace/SkillsMarketplace.tsx
+++ b/src/renderer/src/components/marketplace/SkillsMarketplace.tsx
@@ -1,29 +1,52 @@
-import { Package } from 'lucide-react'
-import React, { useMemo, useState } from 'react'
+import { Package, WifiOff } from 'lucide-react'
+import React, { useEffect, useMemo, useState } from 'react'
 
+import type { RankingFilter } from '../../../../shared/types'
 import { useMarketplaceProgress } from '../../hooks/useMarketplaceProgress'
-import { useAppSelector } from '../../redux/hooks'
+import { useAppDispatch, useAppSelector } from '../../redux/hooks'
+import { loadLeaderboard } from '../../redux/slices/marketplaceSlice'
 
 import { InstallModal } from './InstallModal'
+import { LeaderboardSkeleton } from './LeaderboardSkeleton'
 import { MarketplaceSearch } from './MarketplaceSearch'
-import { type RankingFilter, RankingTabs } from './RankingTabs'
+import { RankingTabs } from './RankingTabs'
 import { RemoveDialog } from './RemoveDialog'
 import { SkillRowMarketplace } from './SkillRowMarketplace'
 
 /**
- * Main marketplace container with ranking tabs, search and results
+ * Format a timestamp into relative time for the "Updated X min ago" label.
+ * @param timestamp - ms since epoch
+ * @returns Human-readable relative time string
+ * @example
+ * formatUpdatedAgo(Date.now() - 60000) // => "1 min ago"
+ * formatUpdatedAgo(Date.now() - 900000) // => "15 min ago"
+ */
+function formatUpdatedAgo(timestamp: number): string {
+  if (timestamp === 0) return ''
+  const seconds = Math.floor((Date.now() - timestamp) / 1000)
+  if (seconds < 60) return 'just now'
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes} min ago`
+  const hours = Math.floor(minutes / 60)
+  return `${hours}h ago`
+}
+
+/**
+ * Main marketplace container with ranking tabs, search, leaderboard, and results.
+ * Shows leaderboard data when no search is active.
+ * Auto-loads "all-time" leaderboard on mount.
  */
 export const SkillsMarketplace = React.memo(
   function SkillsMarketplace(): React.ReactElement {
     // Subscribe to installation progress events
     useMarketplaceProgress()
 
+    const dispatch = useAppDispatch()
     const [rankingFilter, setRankingFilter] =
       useState<RankingFilter>('all-time')
 
-    const { searchResults, status, searchQuery, error } = useAppSelector(
-      (state) => state.marketplace,
-    )
+    const { searchResults, status, searchQuery, error, leaderboard } =
+      useAppSelector((state) => state.marketplace)
     const { items: installedSkills } = useAppSelector((state) => state.skills)
 
     // Check if a skill is already installed
@@ -34,6 +57,26 @@ export const SkillsMarketplace = React.memo(
 
     const hasSearched = searchQuery.length > 0
     const isSearching = status === 'searching'
+
+    // Current leaderboard data for active filter
+    const currentLeaderboard = leaderboard[rankingFilter]
+    const leaderboardSkills = currentLeaderboard?.skills ?? []
+    const leaderboardStatus = currentLeaderboard?.status ?? 'idle'
+    const leaderboardLastFetched = currentLeaderboard?.lastFetched ?? 0
+    const isLeaderboardLoading =
+      leaderboardStatus === 'loading' && leaderboardSkills.length === 0
+    const isLeaderboardError =
+      leaderboardStatus === 'error' && leaderboardSkills.length === 0
+
+    // Auto-load leaderboard on mount and when filter changes
+    useEffect(() => {
+      dispatch(loadLeaderboard(rankingFilter))
+    }, [dispatch, rankingFilter])
+
+    /** Handle tab change: switch filter and load data */
+    const handleFilterChange = (filter: RankingFilter): void => {
+      setRankingFilter(filter)
+    }
 
     return (
       <div className="h-full flex flex-col">
@@ -50,7 +93,11 @@ export const SkillsMarketplace = React.memo(
           </div>
 
           {/* Ranking Tabs */}
-          <RankingTabs value={rankingFilter} onChange={setRankingFilter} />
+          <RankingTabs
+            value={rankingFilter}
+            onChange={handleFilterChange}
+            disabled={hasSearched}
+          />
 
           {/* Search */}
           <MarketplaceSearch />
@@ -65,55 +112,121 @@ export const SkillsMarketplace = React.memo(
 
         {/* Results area */}
         <div className="flex-1 overflow-y-auto px-6">
-          <div className="pb-6 min-w-0">
-            {/* Initial state */}
-            {!hasSearched && !isSearching && (
-              <div className="flex flex-col items-center justify-center py-16 text-center">
-                <Package className="h-12 w-12 text-muted-foreground mb-4" />
-                <p className="text-lg font-medium mb-2">Search for Skills</p>
-                <p className="text-sm text-muted-foreground max-w-md">
-                  Try searching for &quot;react&quot;, &quot;vercel&quot;, or
-                  &quot;nextjs&quot; to discover skills.
-                </p>
-              </div>
+          <div
+            className="pb-6 min-w-0"
+            aria-busy={isLeaderboardLoading || isSearching}
+            aria-live="polite"
+          >
+            {/* === Search results (takes priority over leaderboard) === */}
+            {hasSearched && (
+              <>
+                {/* Loading state */}
+                {isSearching && (
+                  <div className="flex items-center justify-center py-16">
+                    <div className="text-muted-foreground">Searching...</div>
+                  </div>
+                )}
+
+                {/* No results */}
+                {!isSearching && searchResults.length === 0 && (
+                  <div className="flex flex-col items-center justify-center py-16 text-center">
+                    <p className="text-muted-foreground">
+                      No skills found for &quot;{searchQuery}&quot;
+                    </p>
+                    <p className="text-sm text-muted-foreground mt-2">
+                      Try a different search term
+                    </p>
+                  </div>
+                )}
+
+                {/* Results list */}
+                {searchResults.length > 0 && (
+                  <div className="flex flex-col gap-2">
+                    <p className="text-sm text-muted-foreground mb-3">
+                      Found {searchResults.length} skill
+                      {searchResults.length !== 1 ? 's' : ''} for &quot;
+                      {searchQuery}
+                      &quot;
+                    </p>
+                    {searchResults.map((skill) => (
+                      <SkillRowMarketplace
+                        key={`${skill.repo}@${skill.name}`}
+                        skill={skill}
+                        isInstalled={installedSkillNames.has(skill.name)}
+                      />
+                    ))}
+                  </div>
+                )}
+              </>
             )}
 
-            {/* Loading state */}
-            {isSearching && (
-              <div className="flex items-center justify-center py-16">
-                <div className="text-muted-foreground">Searching...</div>
-              </div>
-            )}
+            {/* === Leaderboard (shown when no search is active) === */}
+            {!hasSearched && (
+              <>
+                {/* Skeleton loading */}
+                {isLeaderboardLoading && <LeaderboardSkeleton />}
 
-            {/* No results */}
-            {hasSearched && !isSearching && searchResults.length === 0 && (
-              <div className="flex flex-col items-center justify-center py-16 text-center">
-                <p className="text-muted-foreground">
-                  No skills found for &quot;{searchQuery}&quot;
-                </p>
-                <p className="text-sm text-muted-foreground mt-2">
-                  Try a different search term
-                </p>
-              </div>
-            )}
+                {/* Network error with no cache */}
+                {isLeaderboardError && (
+                  <div className="flex flex-col items-center justify-center py-16 text-center">
+                    <WifiOff className="h-12 w-12 text-muted-foreground mb-4" />
+                    <p className="text-lg font-medium mb-2">
+                      Leaderboard unavailable
+                    </p>
+                    <p className="text-sm text-muted-foreground max-w-md">
+                      Check your connection and try again
+                    </p>
+                  </div>
+                )}
 
-            {/* Results list */}
-            {searchResults.length > 0 && (
-              <div className="flex flex-col gap-2">
-                <p className="text-sm text-muted-foreground mb-3">
-                  Found {searchResults.length} skill
-                  {searchResults.length !== 1 ? 's' : ''} for &quot;
-                  {searchQuery}
-                  &quot;
-                </p>
-                {searchResults.map((skill) => (
-                  <SkillRowMarketplace
-                    key={`${skill.repo}@${skill.name}`}
-                    skill={skill}
-                    isInstalled={installedSkillNames.has(skill.name)}
-                  />
-                ))}
-              </div>
+                {/* Leaderboard data */}
+                {leaderboardSkills.length > 0 && (
+                  <div className="flex flex-col gap-2">
+                    {/* Header: count + filter label (left) + updated timestamp (right) */}
+                    <div className="flex items-center justify-between mb-3">
+                      <p className="text-sm text-muted-foreground">
+                        {leaderboardSkills.length} skill
+                        {leaderboardSkills.length !== 1
+                          ? 's'
+                          : ''} &middot;{' '}
+                        {rankingFilter === 'all-time'
+                          ? 'All Time'
+                          : rankingFilter === 'trending'
+                            ? 'Trending'
+                            : 'Hot'}
+                      </p>
+                      {leaderboardLastFetched > 0 && (
+                        <p className="font-mono text-xs text-muted-foreground">
+                          Updated {formatUpdatedAgo(leaderboardLastFetched)}
+                        </p>
+                      )}
+                    </div>
+                    {leaderboardSkills.map((skill) => (
+                      <SkillRowMarketplace
+                        key={`${skill.repo}@${skill.name}`}
+                        skill={skill}
+                        isInstalled={installedSkillNames.has(skill.name)}
+                      />
+                    ))}
+                  </div>
+                )}
+
+                {/* Edge case: fetch succeeded but returned 0 skills */}
+                {!isLeaderboardLoading &&
+                  !isLeaderboardError &&
+                  leaderboardSkills.length === 0 &&
+                  leaderboardLastFetched > 0 && (
+                    <div className="flex flex-col items-center justify-center py-16 text-center">
+                      <Package className="h-12 w-12 text-muted-foreground mb-4" />
+                      <p className="text-lg font-medium mb-2">
+                        No skills found
+                      </p>
+                      <p className="text-sm text-muted-foreground max-w-md">
+                        The leaderboard is temporarily empty. Try again later.
+                      </p>
+                    </div>
+                  )}
+              </>
             )}
           </div>
         </div>

--- a/src/renderer/src/redux/slices/marketplaceSlice.test.ts
+++ b/src/renderer/src/redux/slices/marketplaceSlice.test.ts
@@ -341,6 +341,8 @@ describe('marketplaceSlice', () => {
     ).toHaveLength(1)
 
     // Advance time past TTL (31 min) to make cache stale
+    // Note: useFakeTimers() initializes to current real time, so
+    // setSystemTime correctly offsets from the first fetch's timestamp
     vi.useFakeTimers()
     vi.setSystemTime(Date.now() + 31 * 60 * 1000)
 

--- a/src/renderer/src/redux/slices/marketplaceSlice.test.ts
+++ b/src/renderer/src/redux/slices/marketplaceSlice.test.ts
@@ -7,6 +7,7 @@ const mockSearch = vi.fn()
 const mockInstall = vi.fn()
 const mockRemove = vi.fn()
 const mockCancel = vi.fn()
+const mockLeaderboard = vi.fn()
 
 vi.stubGlobal('window', {
   electron: {
@@ -15,6 +16,9 @@ vi.stubGlobal('window', {
       install: mockInstall,
       remove: mockRemove,
       cancel: mockCancel,
+    },
+    marketplace: {
+      leaderboard: mockLeaderboard,
     },
   },
 })
@@ -44,6 +48,7 @@ describe('marketplaceSlice', () => {
     expect(state.searchResults).toEqual([])
     expect(state.selectedSkill).toBeNull()
     expect(state.error).toBeNull()
+    expect(state.leaderboard).toEqual({})
   })
 
   // --- Sync reducers ---
@@ -251,5 +256,116 @@ describe('marketplaceSlice', () => {
 
     expect(store.getState().marketplace.status).toBe('error')
     expect(store.getState().marketplace.error).toBe('Not found')
+  })
+
+  // --- loadLeaderboard thunk ---
+  it('loadLeaderboard sets loading state for new filter', async () => {
+    let resolve!: (value: SkillSearchResult[]) => void
+    mockLeaderboard.mockReturnValue(
+      new Promise<SkillSearchResult[]>((r) => {
+        resolve = r
+      }),
+    )
+
+    const store = await createTestStore()
+    const { loadLeaderboard } = await import('./marketplaceSlice')
+    const promise = store.dispatch(loadLeaderboard('all-time'))
+
+    const lb = store.getState().marketplace.leaderboard['all-time']
+    expect(lb?.status).toBe('loading')
+    expect(lb?.skills).toEqual([])
+
+    resolve([sampleResult])
+    await promise
+  })
+
+  it('loadLeaderboard populates per-filter cache on fulfilled', async () => {
+    mockLeaderboard.mockResolvedValue([sampleResult])
+
+    const store = await createTestStore()
+    const { loadLeaderboard } = await import('./marketplaceSlice')
+    await store.dispatch(loadLeaderboard('trending'))
+
+    const lb = store.getState().marketplace.leaderboard['trending']
+    expect(lb?.status).toBe('idle')
+    expect(lb?.skills).toHaveLength(1)
+    expect(lb?.skills[0].name).toBe('task')
+    expect(lb?.lastFetched).toBeGreaterThan(0)
+  })
+
+  it('loadLeaderboard skips fetch when cache is fresh', async () => {
+    mockLeaderboard.mockResolvedValue([sampleResult])
+
+    const store = await createTestStore()
+    const { loadLeaderboard } = await import('./marketplaceSlice')
+
+    // First fetch populates cache
+    await store.dispatch(loadLeaderboard('all-time'))
+    expect(mockLeaderboard).toHaveBeenCalledTimes(1)
+
+    // Second fetch skips (cache is fresh)
+    await store.dispatch(loadLeaderboard('all-time'))
+    expect(mockLeaderboard).toHaveBeenCalledTimes(1)
+  })
+
+  it('loadLeaderboard stores different data per filter', async () => {
+    const trendingResult: SkillSearchResult = {
+      ...sampleResult,
+      name: 'trending-skill',
+    }
+    mockLeaderboard
+      .mockResolvedValueOnce([sampleResult])
+      .mockResolvedValueOnce([trendingResult])
+
+    const store = await createTestStore()
+    const { loadLeaderboard } = await import('./marketplaceSlice')
+
+    await store.dispatch(loadLeaderboard('all-time'))
+    await store.dispatch(loadLeaderboard('trending'))
+
+    const state = store.getState().marketplace
+    expect(state.leaderboard['all-time']?.skills[0].name).toBe('task')
+    expect(state.leaderboard['trending']?.skills[0].name).toBe('trending-skill')
+  })
+
+  it('loadLeaderboard keeps stale data on error', async () => {
+    mockLeaderboard.mockResolvedValueOnce([sampleResult])
+
+    const store = await createTestStore()
+    const { loadLeaderboard } = await import('./marketplaceSlice')
+
+    // First fetch succeeds
+    await store.dispatch(loadLeaderboard('hot'))
+    expect(
+      store.getState().marketplace.leaderboard['hot']?.skills,
+    ).toHaveLength(1)
+
+    // Advance time past TTL (31 min) to make cache stale
+    vi.useFakeTimers()
+    vi.setSystemTime(Date.now() + 31 * 60 * 1000)
+
+    // Second fetch fails
+    mockLeaderboard.mockRejectedValueOnce(new Error('Network error'))
+    await store.dispatch(loadLeaderboard('hot'))
+
+    vi.useRealTimers()
+
+    // Should still have the stale data but status is error
+    const state = store.getState().marketplace.leaderboard['hot']
+    expect(state?.skills).toHaveLength(1)
+    expect(state?.status).toBe('error')
+  })
+
+  it('loadLeaderboard sets error when no cache exists', async () => {
+    mockLeaderboard.mockRejectedValue(new Error('Offline'))
+
+    const store = await createTestStore()
+    const { loadLeaderboard } = await import('./marketplaceSlice')
+    await store.dispatch(loadLeaderboard('all-time'))
+
+    const lb = store.getState().marketplace.leaderboard['all-time']
+    expect(lb?.status).toBe('error')
+    expect(lb?.error).toBe('Offline')
+    expect(lb?.skills).toEqual([])
   })
 })

--- a/src/renderer/src/redux/slices/marketplaceSlice.ts
+++ b/src/renderer/src/redux/slices/marketplaceSlice.ts
@@ -2,11 +2,16 @@ import type { PayloadAction } from '@reduxjs/toolkit'
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit'
 
 import type {
+  LeaderboardData,
+  RankingFilter,
   SkillSearchResult,
   InstallOptions,
   InstallProgress,
   MarketplaceStatus,
 } from '../../../../shared/types'
+
+/** Cache TTL: 30 minutes in milliseconds */
+const CACHE_TTL_MS = 30 * 60 * 1000
 
 interface MarketplaceState {
   status: MarketplaceStatus
@@ -16,6 +21,8 @@ interface MarketplaceState {
   installProgress: InstallProgress | null
   skillToRemove: string | null
   error: string | null
+  /** Per-filter leaderboard cache. Each filter tracks its own data and loading state. */
+  leaderboard: Partial<Record<RankingFilter, LeaderboardData>>
 }
 
 const initialState: MarketplaceState = {
@@ -26,6 +33,7 @@ const initialState: MarketplaceState = {
   installProgress: null,
   skillToRemove: null,
   error: null,
+  leaderboard: {},
 }
 
 /**
@@ -64,6 +72,35 @@ export const removeSkill = createAsyncThunk(
   async (skillName: string) => {
     const result = await window.electron.skillsCli.remove(skillName)
     return result.success
+  },
+)
+
+/**
+ * Fetch leaderboard data from skills.sh for a ranking filter.
+ * Respects per-filter cache TTL: skips fetch if cached data is fresh.
+ * @param filter - Ranking filter ('all-time' | 'trending' | 'hot')
+ * @returns Skills array and filter, or null if cache is fresh
+ */
+export const loadLeaderboard = createAsyncThunk(
+  'marketplace/loadLeaderboard',
+  async (
+    filter: RankingFilter,
+    { getState },
+  ): Promise<{ skills: SkillSearchResult[]; filter: RankingFilter } | null> => {
+    const state = (getState() as { marketplace: MarketplaceState }).marketplace
+    const cached = state.leaderboard[filter]
+
+    // Skip fetch if cache is fresh
+    if (
+      cached &&
+      cached.status !== 'error' &&
+      Date.now() - cached.lastFetched < CACHE_TTL_MS
+    ) {
+      return null
+    }
+
+    const skills = await window.electron.marketplace.leaderboard({ filter })
+    return { skills, filter }
   },
 )
 
@@ -146,6 +183,48 @@ const marketplaceSlice = createSlice({
         state.status = 'error'
         state.error = action.error.message || 'Remove failed'
         state.skillToRemove = null
+      })
+      // Leaderboard
+      .addCase(loadLeaderboard.pending, (state, action) => {
+        const filter = action.meta.arg
+        const existing = state.leaderboard[filter]
+        // Only show loading if no cached data exists yet
+        if (!existing || existing.skills.length === 0) {
+          state.leaderboard[filter] = {
+            skills: [],
+            lastFetched: 0,
+            filter,
+            status: 'loading',
+          }
+        }
+      })
+      .addCase(loadLeaderboard.fulfilled, (state, action) => {
+        // null means cache was fresh, no update needed
+        if (action.payload === null) return
+        const { skills, filter } = action.payload
+        state.leaderboard[filter] = {
+          skills,
+          lastFetched: Date.now(),
+          filter,
+          status: 'idle',
+        }
+      })
+      .addCase(loadLeaderboard.rejected, (state, action) => {
+        const filter = action.meta.arg
+        const existing = state.leaderboard[filter]
+        if (existing) {
+          // Keep stale data, just mark status as error
+          existing.status = 'error'
+          existing.error = action.error.message || 'Failed to load leaderboard'
+        } else {
+          state.leaderboard[filter] = {
+            skills: [],
+            lastFetched: 0,
+            filter,
+            status: 'error',
+            error: action.error.message || 'Failed to load leaderboard',
+          }
+        }
       })
   },
 })

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -6,6 +6,7 @@ import type {
   SkillFileContent,
   UpdateInfo,
   DownloadProgress,
+  RankingFilter,
   SkillSearchResult,
   InstallOptions,
   CliCommandResult,
@@ -80,6 +81,11 @@ declare global {
         onProgress: (
           callback: (progress: InstallProgress) => void,
         ) => () => void
+      }
+      marketplace: {
+        leaderboard: (options: {
+          filter: RankingFilter
+        }) => Promise<SkillSearchResult[]>
       }
       sync: {
         preview: () => Promise<SyncPreviewResult>

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -22,6 +22,9 @@ export const IPC_CHANNELS = {
   SKILLS_CLI_CANCEL: 'skills:cli:cancel',
   SKILLS_CLI_PROGRESS: 'skills:cli:progress',
 
+  // Marketplace Leaderboard
+  MARKETPLACE_LEADERBOARD: 'marketplace:leaderboard',
+
   // Skills management
   SKILLS_UNLINK_FROM_AGENT: 'skills:unlinkFromAgent',
   SKILLS_REMOVE_ALL_FROM_AGENT: 'skills:removeAllFromAgent',

--- a/src/shared/ipc-contract.test.ts
+++ b/src/shared/ipc-contract.test.ts
@@ -21,6 +21,7 @@ describe('IPC contract alignment', () => {
       [IPC_CHANNELS.SKILLS_CLI_INSTALL]: true,
       [IPC_CHANNELS.SKILLS_CLI_REMOVE]: true,
       [IPC_CHANNELS.SKILLS_CLI_CANCEL]: true,
+      [IPC_CHANNELS.MARKETPLACE_LEADERBOARD]: true,
       [IPC_CHANNELS.SYNC_PREVIEW]: true,
       [IPC_CHANNELS.SYNC_EXECUTE]: true,
       [IPC_CHANNELS.UPDATE_DOWNLOAD]: true,
@@ -30,7 +31,7 @@ describe('IPC contract alignment', () => {
     } as const satisfies Record<keyof IpcInvokeContract, true>
 
     // Runtime assertion: mapping covers exactly the contract keys
-    expect(Object.keys(invokeMapping)).toHaveLength(20)
+    expect(Object.keys(invokeMapping)).toHaveLength(21)
   })
 
   it('all IPC_CHANNELS event values are valid event contract keys', () => {

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -10,6 +10,7 @@ import type {
   DownloadProgress,
   InstallOptions,
   InstallProgress,
+  RankingFilter,
   RemoveAllFromAgentOptions,
   RemoveAllFromAgentResult,
   Skill,
@@ -65,6 +66,10 @@ export interface IpcInvokeContract {
   'skills:cli:install': { args: [InstallOptions]; result: CliCommandResult }
   'skills:cli:remove': { args: [string]; result: CliCommandResult }
   'skills:cli:cancel': { args: []; result: void }
+  'marketplace:leaderboard': {
+    args: [{ filter: RankingFilter }]
+    result: SkillSearchResult[]
+  }
   'sync:preview': { args: []; result: SyncPreviewResult }
   'sync:execute': { args: [SyncExecuteOptions]; result: SyncExecuteResult }
   'update:download': { args: []; result: void }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -285,6 +285,41 @@ export type MarketplaceStatus =
   | 'error'
 
 /**
+ * Filter for marketplace leaderboard ranking tabs.
+ * Maps to skills.sh pages: / (all-time), /trending, /hot
+ */
+export type RankingFilter = 'all-time' | 'trending' | 'hot'
+
+/**
+ * Per-filter leaderboard loading status
+ */
+export type LeaderboardStatus = 'idle' | 'loading' | 'error'
+
+/**
+ * Cached leaderboard data for a single ranking filter.
+ * Each filter key tracks its own fetch state and TTL independently.
+ * @example
+ * {
+ *   skills: [...],
+ *   lastFetched: 1713045600000,
+ *   filter: 'trending',
+ *   status: 'idle',
+ * }
+ */
+export interface LeaderboardData {
+  /** Ranked skills parsed from skills.sh HTML */
+  skills: SkillSearchResult[]
+  /** Timestamp (ms since epoch) of last successful fetch */
+  lastFetched: number
+  /** Which ranking filter this data belongs to */
+  filter: RankingFilter
+  /** Current loading state for this filter */
+  status: LeaderboardStatus
+  /** Error message if status is 'error' */
+  error?: string
+}
+
+/**
  * Options for unlinking a skill from a specific agent
  */
 export interface UnlinkFromAgentOptions {


### PR DESCRIPTION
## Summary

- **Live leaderboard**: All Time / Trending / Hot tabs now fetch and parse real data from skills.sh (50 results per filter)
- **30-min TTL cache**: Per-filter Redux cache prevents redundant fetches. Stale data shown while reloading
- **Search→leaderboard transition**: Clearing the search input (native X button or manual delete) returns to leaderboard view
- **Full IPC pipeline**: Channel → Contract → Zod schema → Handler → Preload bridge → Renderer types (6 layers)
- **Accessibility**: WAI-ARIA Tabs pattern with arrow-key navigation, aria-live regions, skeleton loading

## What changed (17 files)

| Layer | Files | What |
|-------|-------|------|
| Shared | `types.ts`, `ipc-channels.ts`, `ipc-contract.ts` | `RankingFilter`, `LeaderboardData` types, IPC contract |
| Main | `leaderboardService.ts`, `leaderboard.ts`, `handlers.ts`, `ipc-schemas.ts` | HTML parser, fetch with 15s timeout, Zod validation |
| Preload | `index.ts` | `marketplace.leaderboard()` bridge |
| Renderer | `SkillsMarketplace.tsx`, `RankingTabs.tsx`, `MarketplaceSearch.tsx`, `LeaderboardSkeleton.tsx` | UI, Redux thunk, cache TTL logic |
| Tests | `leaderboardService.test.ts`, `marketplaceSlice.test.ts`, `ipc-contract.test.ts` | 25+ new tests |

## QA Results

- **Tests**: 261/261 passing
- **Typecheck**: Clean
- **Live HTML validation**: 150 results parsed correctly across all 3 filters
- **Health score**: 97/100
- **Bug found & fixed**: Search clear → leaderboard return (commit 6bbe6d0)

## Test plan

- [ ] Open Marketplace tab → "All Time" leaderboard loads automatically with 50 skills
- [ ] Switch to Trending / Hot tabs → each loads independently, cached for 30 min
- [ ] Search for a skill → results replace leaderboard
- [ ] Clear search (X button or delete all text) → leaderboard returns
- [ ] Disconnect network → error state shows "Leaderboard unavailable" with WifiOff icon
- [ ] Wait 30+ min → next tab switch triggers fresh fetch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added marketplace leaderboard displaying ranked skills with three filter options: all-time, trending, and hot
  * Leaderboard shows install counts and displays last-updated timestamp
  * Loading skeleton states and network error handling for leaderboard data
  * Auto-clearing search results when search input is emptied

* **Improvements**
  * Enhanced tab navigation with keyboard support and accessibility labels
  * Filter tabs now disable during active search queries

* **Tests**
  * Comprehensive test coverage added for leaderboard functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->