### PR TITLE
feat(marketplace): add right-pane dashboard and webview skill preview

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -24,6 +24,7 @@ function createWindow(): void {
       sandbox: true,
       contextIsolation: true,
       nodeIntegration: false,
+      webviewTag: true,
     },
   })
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -45,7 +45,7 @@ function createWindow(): void {
       let isAllowed = false
       try {
         const url = new URL(params.src)
-        isAllowed = url.protocol === 'https:' && url.hostname === 'skills.sh'
+        isAllowed = url.origin === 'https://skills.sh'
       } catch {
         isAllowed = false
       }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -33,6 +33,13 @@ function createWindow(): void {
     mainWindow.show()
   })
 
+  /** Enforce safe webview options before attachment (Electron security recommendation) */
+  mainWindow.webContents.on('will-attach-webview', (_event, webPreferences) => {
+    webPreferences.nodeIntegration = false
+    webPreferences.contextIsolation = true
+    delete webPreferences.preload
+  })
+
   mainWindow.webContents.setWindowOpenHandler((details) => {
     try {
       const url = new URL(details.url)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -33,12 +33,32 @@ function createWindow(): void {
     mainWindow.show()
   })
 
-  /** Enforce safe webview options before attachment (Electron security recommendation) */
-  mainWindow.webContents.on('will-attach-webview', (_event, webPreferences) => {
-    webPreferences.nodeIntegration = false
-    webPreferences.contextIsolation = true
-    delete webPreferences.preload
-  })
+  /** Enforce safe webview options before attachment (Electron security recommendation).
+   * Deny-by-default: only allow https://skills.sh origins.
+   * @param event - Prevents webview attachment when URL is disallowed
+   * @param webPreferences - Hardened to disable node integration
+   * @param params - Contains the src URL to validate
+   */
+  mainWindow.webContents.on(
+    'will-attach-webview',
+    (event, webPreferences, params) => {
+      let isAllowed = false
+      try {
+        const url = new URL(params.src)
+        isAllowed = url.protocol === 'https:' && url.hostname === 'skills.sh'
+      } catch {
+        isAllowed = false
+      }
+      if (!isAllowed) {
+        event.preventDefault()
+        return
+      }
+
+      webPreferences.nodeIntegration = false
+      webPreferences.contextIsolation = true
+      delete webPreferences.preload
+    },
+  )
 
   mainWindow.webContents.setWindowOpenHandler((details) => {
     try {

--- a/src/renderer/src/components/layout/DetailPanel.tsx
+++ b/src/renderer/src/components/layout/DetailPanel.tsx
@@ -3,23 +3,25 @@ import React from 'react'
 
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
 import { selectSkill } from '../../redux/slices/skillsSlice'
+import { MarketplaceDetailPanel } from '../marketplace/MarketplaceDetailPanel'
 import { SkillDetail } from '../skills/SkillDetail'
 
 /**
  * Collapsible Inspector panel (Apple HIG pattern)
- * Shows selected skill details with file preview
- * Hidden by default, expands when a skill card is clicked
+ * Routes between:
+ * - Installed tab → SkillDetail (existing)
+ * - Marketplace tab → MarketplaceDetailPanel (dashboard or webview preview)
  */
 export const DetailPanel = React.memo(
   function DetailPanel(): React.ReactElement {
     const dispatch = useAppDispatch()
-    const { selectedSkill } = useAppSelector((state) => state.skills)
+    const activeTab = useAppSelector((state) => state.ui.activeTab)
+    const selectedSkill = useAppSelector((state) => state.skills.selectedSkill)
 
     return (
       <aside className="h-full border-l border-border bg-card flex flex-col overflow-hidden">
-        {/* Draggable title bar area with close button */}
         <div className="h-8 drag-region shrink-0 flex items-center justify-end pr-2">
-          {selectedSkill && (
+          {activeTab !== 'marketplace' && selectedSkill && (
             <button
               type="button"
               onClick={() => dispatch(selectSkill(null))}
@@ -30,7 +32,9 @@ export const DetailPanel = React.memo(
             </button>
           )}
         </div>
-        {selectedSkill ? (
+        {activeTab === 'marketplace' ? (
+          <MarketplaceDetailPanel />
+        ) : selectedSkill ? (
           <SkillDetail skill={selectedSkill} />
         ) : (
           <div className="flex-1 flex items-center justify-center">

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -5,13 +5,15 @@ import {
   ExternalLink,
   X,
 } from 'lucide-react'
-import React, { useState } from 'react'
+import React from 'react'
 
 import { FEATURE_FLAGS } from '../../../../shared/featureFlags'
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
-import type { SkillTypeFilter } from '../../redux/slices/uiSlice'
+import { setPreviewSkill } from '../../redux/slices/marketplaceSlice'
+import type { ActiveTab, SkillTypeFilter } from '../../redux/slices/uiSlice'
 import {
   selectAgent,
+  setActiveTab,
   setSkillTypeFilter,
   toggleSortOrder,
 } from '../../redux/slices/uiSlice'
@@ -57,7 +59,7 @@ export const MainContent = React.memo(
     const sortOrder = useAppSelector((state) => state.ui.sortOrder)
     const skillTypeFilter = useAppSelector((state) => state.ui.skillTypeFilter)
     const { items: agents } = useAppSelector((state) => state.agents)
-    const [activeTab, setActiveTab] = useState<string>('installed')
+    const activeTab = useAppSelector((state) => state.ui.activeTab)
 
     const selectedAgent = agents.find((a) => a.id === selectedAgentId)
 
@@ -70,7 +72,8 @@ export const MainContent = React.memo(
      * Marketplace external link is handled separately to avoid Radix state issues.
      */
     const handleTabChange = (value: string): void => {
-      setActiveTab(value)
+      dispatch(setActiveTab(value as ActiveTab))
+      dispatch(setPreviewSkill(null))
     }
 
     /**

--- a/src/renderer/src/components/marketplace/MarketplaceDashboard.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceDashboard.tsx
@@ -1,0 +1,108 @@
+import { Download, Star, TrendingUp } from 'lucide-react'
+import React from 'react'
+
+import type { SkillSearchResult } from '../../../../shared/types'
+import { formatInstallCount } from '../../lib/utils'
+import { useAppDispatch, useAppSelector } from '../../redux/hooks'
+import { setPreviewSkill } from '../../redux/slices/marketplaceSlice'
+
+/**
+ * Dashboard shown in the right pane when Marketplace tab is active
+ * and no skill is selected for preview.
+ * Data sources: installed skills count, bookmarks count, trending leaderboard cache.
+ */
+export const MarketplaceDashboard = React.memo(
+  function MarketplaceDashboard(): React.ReactElement {
+    const dispatch = useAppDispatch()
+    const installedCount = useAppSelector((state) => state.skills.items.length)
+    const bookmarkedCount = useAppSelector(
+      (state) => state.bookmarks.items.length,
+    )
+    const trendingData = useAppSelector(
+      (state) => state.marketplace.leaderboard.trending,
+    )
+    const trendingSkills = trendingData?.skills.slice(0, 5) ?? []
+
+    const handleSkillClick = (skill: SkillSearchResult): void => {
+      dispatch(setPreviewSkill(skill))
+    }
+
+    return (
+      <div className="flex-1 flex flex-col p-6 gap-6 overflow-auto">
+        <h2 className="text-xl font-bold text-foreground">Marketplace</h2>
+
+        {/* Stats cards */}
+        <div className="flex gap-4">
+          <div className="flex-1 rounded-lg bg-muted border border-border p-4 flex flex-col gap-2">
+            <span className="text-xs font-medium text-muted-foreground">
+              Installed Skills
+            </span>
+            <span className="text-3xl font-bold text-primary">
+              {installedCount}
+            </span>
+          </div>
+          <div className="flex-1 rounded-lg bg-muted border border-border p-4 flex flex-col gap-2">
+            <span className="text-xs font-medium text-muted-foreground">
+              Bookmarked
+            </span>
+            <span className="text-3xl font-bold text-amber-500">
+              {bookmarkedCount}
+            </span>
+          </div>
+        </div>
+
+        {/* Trending section */}
+        <div className="flex items-center gap-2">
+          <TrendingUp className="h-4 w-4 text-primary" />
+          <h3 className="text-base font-semibold text-foreground">Trending</h3>
+          <span className="text-[11px] font-semibold text-primary bg-primary/15 px-2 py-0.5 rounded-full">
+            Top 5
+          </span>
+        </div>
+
+        {trendingSkills.length > 0 ? (
+          <div className="flex flex-col gap-2">
+            {trendingSkills.map((skill) => (
+              <button
+                key={skill.name}
+                type="button"
+                onClick={() => handleSkillClick(skill)}
+                className="flex items-center gap-3 p-3 rounded-lg bg-background border border-border hover:border-primary/50 transition-colors text-left min-h-[44px]"
+              >
+                <div className="flex items-center justify-center w-7 h-7 shrink-0 rounded-md bg-muted font-mono text-[13px] font-semibold text-primary">
+                  {skill.rank}
+                </div>
+                <div className="flex-1 min-w-0 flex flex-col gap-0.5">
+                  <span className="text-sm font-semibold text-foreground truncate">
+                    {skill.name}
+                  </span>
+                  <span className="font-mono text-xs text-muted-foreground truncate">
+                    {skill.repo}
+                  </span>
+                </div>
+                <div className="flex items-center gap-1 text-muted-foreground shrink-0">
+                  <Download className="h-3 w-3" />
+                  <span className="font-mono text-xs font-medium">
+                    {formatInstallCount(skill.installCount)}
+                  </span>
+                </div>
+              </button>
+            ))}
+          </div>
+        ) : (
+          <div className="flex items-center justify-center py-8 text-sm text-muted-foreground">
+            Loading trending skills...
+          </div>
+        )}
+
+        {/* Browse prompt */}
+        <div className="flex items-center justify-center py-4">
+          <p className="text-[13px] text-muted-foreground flex items-center gap-1.5">
+            <Star className="h-3.5 w-3.5" />
+            Click a skill to view its details
+          </p>
+        </div>
+      </div>
+    )
+  },
+)

--- a/src/renderer/src/components/marketplace/MarketplaceDashboard.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceDashboard.tsx
@@ -21,7 +21,7 @@ export const MarketplaceDashboard = React.memo(
     const trendingData = useAppSelector(
       (state) => state.marketplace.leaderboard.trending,
     )
-    const trendingSkills = trendingData?.skills.slice(0, 5) ?? []
+    const trendingSkills = trendingData?.skills?.slice(0, 5) ?? []
 
     const handleSkillClick = (skill: SkillSearchResult): void => {
       dispatch(setPreviewSkill(skill))

--- a/src/renderer/src/components/marketplace/MarketplaceDetailPanel.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceDetailPanel.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+
+import { useAppSelector } from '../../redux/hooks'
+
+import { MarketplaceDashboard } from './MarketplaceDashboard'
+import { MarketplaceSkillPreview } from './MarketplaceSkillPreview'
+
+/**
+ * Router for the right pane during Marketplace view.
+ * previewSkill === null → Dashboard (stats overview)
+ * previewSkill !== null → Webview preview of the selected skill
+ */
+export const MarketplaceDetailPanel = React.memo(
+  function MarketplaceDetailPanel(): React.ReactElement {
+    const previewSkill = useAppSelector(
+      (state) => state.marketplace.previewSkill,
+    )
+
+    if (previewSkill) {
+      return <MarketplaceSkillPreview skill={previewSkill} />
+    }
+
+    return <MarketplaceDashboard />
+  },
+)

--- a/src/renderer/src/components/marketplace/MarketplaceSkillPreview.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceSkillPreview.tsx
@@ -1,0 +1,132 @@
+import { ArrowLeft } from 'lucide-react'
+import React, { useEffect, useRef, useState } from 'react'
+
+import type { SkillSearchResult } from '../../../../shared/types'
+import { useAppDispatch } from '../../redux/hooks'
+import { setPreviewSkill } from '../../redux/slices/marketplaceSlice'
+
+interface MarketplaceSkillPreviewProps {
+  skill: SkillSearchResult
+}
+
+/**
+ * Right-pane webview embed of a skills.sh page.
+ * Renders skill.url in an Electron <webview> tag, with loading skeleton
+ * and a back button to return to the dashboard.
+ *
+ * Electron <webview> bypasses X-Frame-Options (separate renderer process),
+ * unlike iframe which is blocked by skills.sh CSP.
+ */
+export const MarketplaceSkillPreview = React.memo(
+  function MarketplaceSkillPreview({
+    skill,
+  }: MarketplaceSkillPreviewProps): React.ReactElement {
+    const dispatch = useAppDispatch()
+    const webviewRef = useRef<Electron.WebviewTag>(null)
+    const [isLoading, setIsLoading] = useState(true)
+
+    const handleBack = (): void => {
+      dispatch(setPreviewSkill(null))
+    }
+
+    useEffect(() => {
+      const wv = webviewRef.current
+      if (!wv) return
+
+      setIsLoading(true)
+
+      const handleLoaded = (): void => setIsLoading(false)
+      const handleNavigate = (e: Electron.WillNavigateEvent): void => {
+        if (!e.url.startsWith('https://skills.sh')) {
+          e.preventDefault()
+          window.open(e.url)
+        }
+      }
+
+      wv.addEventListener('did-finish-load', handleLoaded)
+      wv.addEventListener('will-navigate', handleNavigate)
+      return () => {
+        wv.removeEventListener('did-finish-load', handleLoaded)
+        wv.removeEventListener('will-navigate', handleNavigate)
+      }
+    }, [skill.url])
+
+    return (
+      <div className="flex-1 flex flex-col overflow-hidden">
+        {/* Back bar */}
+        <div className="flex items-center justify-between px-3 py-2 shrink-0">
+          <button
+            type="button"
+            onClick={handleBack}
+            className="flex items-center gap-1.5 px-2 py-1.5 rounded text-xs text-muted-foreground hover:text-foreground transition-colors min-h-[44px]"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" />
+            Back to Dashboard
+          </button>
+          <span className="text-xs text-muted-foreground font-medium">
+            {skill.name}
+          </span>
+        </div>
+
+        {/* Separator */}
+        <div className="h-px bg-border shrink-0" />
+
+        {/* Webview area */}
+        <div className="flex-1 relative min-h-0">
+          {isLoading && <WebviewSkeleton />}
+          <webview
+            ref={webviewRef}
+            src={skill.url}
+            partition="persist:marketplace"
+            className={`absolute inset-0 ${isLoading ? 'opacity-0' : 'opacity-100'} transition-opacity`}
+            style={{ width: '100%', height: '100%' }}
+          />
+        </div>
+
+        {/* URL bar */}
+        <div className="px-3 py-1.5 bg-background border-t border-border shrink-0">
+          <span className="text-[11px] text-muted-foreground font-mono">
+            {skill.url}
+          </span>
+        </div>
+      </div>
+    )
+  },
+)
+
+/**
+ * Skeleton placeholder while webview loads (~2-3s).
+ * Mimics the skills.sh page layout with pulse animations.
+ */
+const WebviewSkeleton = React.memo(
+  function WebviewSkeleton(): React.ReactElement {
+    return (
+      <div className="absolute inset-0 p-8 flex flex-col gap-5 bg-background">
+        {/* Title */}
+        <div className="h-7 w-48 bg-muted animate-pulse rounded" />
+        {/* Subtitle */}
+        <div className="h-4 w-36 bg-muted animate-pulse rounded" />
+        {/* Description lines */}
+        <div className="flex flex-col gap-2">
+          <div className="h-4 w-full bg-muted animate-pulse rounded" />
+          <div className="h-4 w-4/5 bg-muted animate-pulse rounded" />
+          <div className="h-4 w-3/5 bg-muted animate-pulse rounded" />
+        </div>
+        {/* Stats row */}
+        <div className="flex gap-6 pt-2">
+          <div className="h-10 w-16 bg-muted animate-pulse rounded" />
+          <div className="h-10 w-16 bg-muted animate-pulse rounded" />
+          <div className="h-10 w-16 bg-muted animate-pulse rounded" />
+        </div>
+        {/* Separator */}
+        <div className="h-px bg-border" />
+        {/* README placeholder */}
+        <div className="h-4 w-24 bg-muted animate-pulse rounded" />
+        <div className="flex flex-col gap-2">
+          <div className="h-4 w-full bg-muted animate-pulse rounded" />
+          <div className="h-4 w-5/6 bg-muted animate-pulse rounded" />
+        </div>
+      </div>
+    )
+  },
+)

--- a/src/renderer/src/components/marketplace/MarketplaceSkillPreview.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceSkillPreview.tsx
@@ -29,39 +29,74 @@ export const MarketplaceSkillPreview = React.memo(
       dispatch(setPreviewSkill(null))
     }
 
+    /**
+     * Strict origin check — blocks skills.sh.evil.com style bypasses.
+     * Only allows https://skills.sh hostnames.
+     * @param url - URL string to validate
+     * @returns true if hostname is exactly 'skills.sh'
+     * @example isAllowedUrl('https://skills.sh/foo') // => true
+     * @example isAllowedUrl('https://evil.com') // => false
+     */
+    const isAllowedUrl = (url: string): boolean => {
+      try {
+        const parsed = new URL(url)
+        return parsed.protocol === 'https:' && parsed.hostname === 'skills.sh'
+      } catch {
+        return false
+      }
+    }
+
+    // Validate initial src before rendering the webview
+    const isSrcAllowed = isAllowedUrl(skill.url)
+
     useEffect(() => {
       const wv = webviewRef.current
-      if (!wv) return
+      if (!wv || !isSrcAllowed) return
 
       setIsLoading(true)
 
       const handleLoaded = (): void => setIsLoading(false)
       const handleFailed = (): void => setIsLoading(false)
 
-      /** Strict origin check — blocks skills.sh.evil.com style bypasses */
-      const isAllowedUrl = (url: string): boolean => {
-        try {
-          return new URL(url).hostname === 'skills.sh'
-        } catch {
-          return false
-        }
-      }
-
+      /** Block in-page navigations to non-allowed origins */
       const handleNavigate = (e: Electron.WillNavigateEvent): void => {
         if (!isAllowedUrl(e.url)) {
           e.preventDefault()
         }
       }
 
+      /** Block window.open() / target="_blank" links from escaping the allowlist */
+      const handleNewWindow = (e: Event): void => {
+        e.preventDefault()
+      }
+
       wv.addEventListener('did-finish-load', handleLoaded)
       wv.addEventListener('did-fail-load', handleFailed)
       wv.addEventListener('will-navigate', handleNavigate)
+      wv.addEventListener('new-window', handleNewWindow)
       return () => {
         wv.removeEventListener('did-finish-load', handleLoaded)
         wv.removeEventListener('did-fail-load', handleFailed)
         wv.removeEventListener('will-navigate', handleNavigate)
+        wv.removeEventListener('new-window', handleNewWindow)
       }
-    }, [skill.url])
+    }, [skill.url, isSrcAllowed])
+
+    // Early return when initial URL fails hostname validation
+    if (!isSrcAllowed) {
+      return (
+        <div className="flex-1 flex flex-col items-center justify-center gap-2 text-muted-foreground">
+          <span>Preview unavailable for external URLs</span>
+          <button
+            type="button"
+            onClick={handleBack}
+            className="text-primary underline min-h-[44px]"
+          >
+            Back to Dashboard
+          </button>
+        </div>
+      )
+    }
 
     return (
       <div className="flex-1 flex flex-col overflow-hidden">

--- a/src/renderer/src/components/marketplace/MarketplaceSkillPreview.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceSkillPreview.tsx
@@ -36,17 +36,29 @@ export const MarketplaceSkillPreview = React.memo(
       setIsLoading(true)
 
       const handleLoaded = (): void => setIsLoading(false)
+      const handleFailed = (): void => setIsLoading(false)
+
+      /** Strict origin check — blocks skills.sh.evil.com style bypasses */
+      const isAllowedUrl = (url: string): boolean => {
+        try {
+          return new URL(url).hostname === 'skills.sh'
+        } catch {
+          return false
+        }
+      }
+
       const handleNavigate = (e: Electron.WillNavigateEvent): void => {
-        if (!e.url.startsWith('https://skills.sh')) {
+        if (!isAllowedUrl(e.url)) {
           e.preventDefault()
-          window.open(e.url)
         }
       }
 
       wv.addEventListener('did-finish-load', handleLoaded)
+      wv.addEventListener('did-fail-load', handleFailed)
       wv.addEventListener('will-navigate', handleNavigate)
       return () => {
         wv.removeEventListener('did-finish-load', handleLoaded)
+        wv.removeEventListener('did-fail-load', handleFailed)
         wv.removeEventListener('will-navigate', handleNavigate)
       }
     }, [skill.url])
@@ -95,7 +107,7 @@ export const MarketplaceSkillPreview = React.memo(
 )
 
 /**
- * Skeleton placeholder while webview loads (~2-3s).
+ * Skeleton placeholder shown until webview fires did-finish-load or did-fail-load.
  * Mimics the skills.sh page layout with pulse animations.
  */
 const WebviewSkeleton = React.memo(

--- a/src/renderer/src/components/marketplace/MarketplaceSkillPreview.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceSkillPreview.tsx
@@ -39,8 +39,7 @@ export const MarketplaceSkillPreview = React.memo(
      */
     const isAllowedUrl = (url: string): boolean => {
       try {
-        const parsed = new URL(url)
-        return parsed.protocol === 'https:' && parsed.hostname === 'skills.sh'
+        return new URL(url).origin === 'https://skills.sh'
       } catch {
         return false
       }
@@ -124,7 +123,7 @@ export const MarketplaceSkillPreview = React.memo(
           <webview
             ref={webviewRef}
             src={skill.url}
-            partition="persist:marketplace"
+            partition="marketplace"
             className={`absolute inset-0 ${isLoading ? 'opacity-0' : 'opacity-100'} transition-opacity`}
             style={{ width: '100%', height: '100%' }}
           />

--- a/src/renderer/src/components/marketplace/SkillRowMarketplace.tsx
+++ b/src/renderer/src/components/marketplace/SkillRowMarketplace.tsx
@@ -2,7 +2,7 @@ import { Check, Download, Plus, Star, Trash2 } from 'lucide-react'
 import React from 'react'
 
 import type { SkillSearchResult } from '../../../../shared/types'
-import { cn } from '../../lib/utils'
+import { cn, formatInstallCount } from '../../lib/utils'
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
 import {
   addBookmark,
@@ -11,28 +11,13 @@ import {
 } from '../../redux/slices/bookmarkSlice'
 import {
   selectSkillForInstall,
+  setPreviewSkill,
   setSkillToRemove,
 } from '../../redux/slices/marketplaceSlice'
 
 interface SkillRowMarketplaceProps {
   skill: SkillSearchResult
   isInstalled?: boolean
-}
-
-/**
- * Format install count for display (e.g., 72900 -> "72.9K")
- * @param count - Raw install count number
- * @returns Formatted string with K/M suffix
- */
-function formatInstallCount(count: number | undefined): string {
-  if (!count) return '—'
-  if (count >= 1_000_000) {
-    return `${(count / 1_000_000).toFixed(1)}M`
-  }
-  if (count >= 1_000) {
-    return `${(count / 1_000).toFixed(1)}K`
-  }
-  return count.toString()
 }
 
 /**
@@ -50,15 +35,22 @@ export const SkillRowMarketplace = React.memo(function SkillRowMarketplace({
     selectIsBookmarked(state, skill.name),
   )
 
-  const handleInstall = (): void => {
+  const handleRowClick = (): void => {
+    dispatch(setPreviewSkill(skill))
+  }
+
+  const handleInstall = (e: React.MouseEvent): void => {
+    e.stopPropagation()
     dispatch(selectSkillForInstall(skill))
   }
 
-  const handleRemove = (): void => {
+  const handleRemove = (e: React.MouseEvent): void => {
+    e.stopPropagation()
     dispatch(setSkillToRemove(skill.name))
   }
 
-  const handleToggleBookmark = (): void => {
+  const handleToggleBookmark = (e: React.MouseEvent): void => {
+    e.stopPropagation()
     if (isBookmarked) {
       dispatch(removeBookmark(skill.name))
     } else {
@@ -69,7 +61,18 @@ export const SkillRowMarketplace = React.memo(function SkillRowMarketplace({
   }
 
   return (
-    <div className="flex items-center gap-4 p-4 rounded-lg bg-card h-[76px] min-w-0 border border-card hover:border-primary/50 transition-colors">
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={handleRowClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          handleRowClick()
+        }
+      }}
+      className="flex items-center gap-4 p-4 rounded-lg bg-card h-[76px] min-w-0 border border-card hover:border-primary/50 transition-colors cursor-pointer"
+    >
       {/* Rank Badge */}
       <div className="flex items-center justify-center w-8 h-8 shrink-0 rounded-md bg-muted font-mono text-sm font-semibold text-primary">
         {skill.rank}

--- a/src/renderer/src/components/marketplace/SkillRowMarketplace.tsx
+++ b/src/renderer/src/components/marketplace/SkillRowMarketplace.tsx
@@ -69,21 +69,9 @@ export const SkillRowMarketplace = React.memo(function SkillRowMarketplace({
   }
 
   return (
-    <div
-      className={cn(
-        'flex items-center gap-4 p-4 rounded-lg bg-card h-[76px] min-w-0',
-        'border transition-colors',
-        isInstalled ? 'border-primary' : 'border-card hover:border-primary/50',
-      )}
-    >
+    <div className="flex items-center gap-4 p-4 rounded-lg bg-card h-[76px] min-w-0 border border-card hover:border-primary/50 transition-colors">
       {/* Rank Badge */}
-      <div
-        className={cn(
-          'flex items-center justify-center w-8 h-8 shrink-0 rounded-md bg-muted',
-          'font-mono text-sm font-semibold',
-          isInstalled ? 'text-muted-foreground' : 'text-primary',
-        )}
-      >
+      <div className="flex items-center justify-center w-8 h-8 shrink-0 rounded-md bg-muted font-mono text-sm font-semibold text-primary">
         {skill.rank}
       </div>
 

--- a/src/renderer/src/components/marketplace/SkillRowMarketplace.tsx
+++ b/src/renderer/src/components/marketplace/SkillRowMarketplace.tsx
@@ -39,18 +39,15 @@ export const SkillRowMarketplace = React.memo(function SkillRowMarketplace({
     dispatch(setPreviewSkill(skill))
   }
 
-  const handleInstall = (e: React.MouseEvent): void => {
-    e.stopPropagation()
+  const handleInstall = (): void => {
     dispatch(selectSkillForInstall(skill))
   }
 
-  const handleRemove = (e: React.MouseEvent): void => {
-    e.stopPropagation()
+  const handleRemove = (): void => {
     dispatch(setSkillToRemove(skill.name))
   }
 
-  const handleToggleBookmark = (e: React.MouseEvent): void => {
-    e.stopPropagation()
+  const handleToggleBookmark = (): void => {
     if (isBookmarked) {
       dispatch(removeBookmark(skill.name))
     } else {
@@ -61,32 +58,25 @@ export const SkillRowMarketplace = React.memo(function SkillRowMarketplace({
   }
 
   return (
-    <div
-      role="button"
-      tabIndex={0}
-      onClick={handleRowClick}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault()
-          handleRowClick()
-        }
-      }}
-      className="flex items-center gap-4 p-4 rounded-lg bg-card h-[76px] min-w-0 border border-card hover:border-primary/50 transition-colors cursor-pointer"
-    >
-      {/* Rank Badge */}
-      <div className="flex items-center justify-center w-8 h-8 shrink-0 rounded-md bg-muted font-mono text-sm font-semibold text-primary">
-        {skill.rank}
-      </div>
-
-      {/* Skill Info */}
-      <div className="flex-1 min-w-0 flex flex-col gap-1">
-        <span className="font-semibold text-[15px] text-foreground truncate">
-          {skill.name}
-        </span>
-        <span className="font-mono text-xs text-muted-foreground truncate">
-          {skill.repo}
-        </span>
-      </div>
+    <div className="flex items-center gap-4 p-4 rounded-lg bg-card h-[76px] min-w-0 border border-card hover:border-primary/50 transition-colors">
+      {/* Rank Badge + Skill Info — clickable preview area */}
+      <button
+        type="button"
+        onClick={handleRowClick}
+        className="flex items-center gap-4 flex-1 min-w-0 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded"
+      >
+        <div className="flex items-center justify-center w-8 h-8 shrink-0 rounded-md bg-muted font-mono text-sm font-semibold text-primary">
+          {skill.rank}
+        </div>
+        <div className="flex-1 min-w-0 flex flex-col gap-1">
+          <span className="font-semibold text-[15px] text-foreground truncate">
+            {skill.name}
+          </span>
+          <span className="font-mono text-xs text-muted-foreground truncate">
+            {skill.repo}
+          </span>
+        </div>
+      </button>
 
       {/* Bookmark Toggle */}
       <button

--- a/src/renderer/src/lib/utils.ts
+++ b/src/renderer/src/lib/utils.ts
@@ -19,7 +19,7 @@ export function cn(...inputs: ClassValue[]): string {
  * formatInstallCount(undefined) // => "—"
  */
 export function formatInstallCount(count: number | undefined): string {
-  if (!count) return '—'
+  if (count === undefined || count === null) return '—'
   if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`
   if (count >= 1_000) return `${(count / 1_000).toFixed(1)}K`
   return count.toString()

--- a/src/renderer/src/lib/utils.ts
+++ b/src/renderer/src/lib/utils.ts
@@ -9,3 +9,18 @@ import { twMerge } from 'tailwind-merge'
 export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Format install count for display
+ * @param count - Raw install count number
+ * @returns Formatted string with K/M suffix
+ * @example
+ * formatInstallCount(72900) // => "72.9K"
+ * formatInstallCount(undefined) // => "—"
+ */
+export function formatInstallCount(count: number | undefined): string {
+  if (!count) return '—'
+  if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`
+  if (count >= 1_000) return `${(count / 1_000).toFixed(1)}K`
+  return count.toString()
+}

--- a/src/renderer/src/lib/utils.ts
+++ b/src/renderer/src/lib/utils.ts
@@ -11,16 +11,22 @@ export function cn(...inputs: ClassValue[]): string {
 }
 
 /**
- * Format install count for display
+ * Format install count for display with K/M suffixes.
+ * Handles rounding overflow: values near 1M that round to "1000.0K"
+ * are promoted to the M tier instead.
  * @param count - Raw install count number
- * @returns Formatted string with K/M suffix
- * @example
- * formatInstallCount(72900) // => "72.9K"
- * formatInstallCount(undefined) // => "—"
+ * @returns Formatted string with K/M suffix, or '—' for undefined
+ * @example formatInstallCount(72900)     // => "72.9K"
+ * @example formatInstallCount(999_950)   // => "1.0M"  (not "1000.0K")
+ * @example formatInstallCount(undefined) // => "—"
+ * @example formatInstallCount(0)         // => "0"
  */
 export function formatInstallCount(count: number | undefined): string {
   if (count === undefined || count === null) return '—'
-  if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`
-  if (count >= 1_000) return `${(count / 1_000).toFixed(1)}K`
+  const k = count / 1_000
+  if (count >= 1_000_000 || Math.round(k * 10) / 10 >= 1_000) {
+    return `${(count / 1_000_000).toFixed(1)}M`
+  }
+  if (count >= 1_000) return `${k.toFixed(1)}K`
   return count.toString()
 }

--- a/src/renderer/src/redux/slices/marketplaceSlice.ts
+++ b/src/renderer/src/redux/slices/marketplaceSlice.ts
@@ -172,6 +172,7 @@ const marketplaceSlice = createSlice({
       .addCase(installSkill.fulfilled, (state) => {
         state.status = 'idle'
         state.selectedSkill = null
+        state.previewSkill = null
         state.installProgress = null
       })
       .addCase(installSkill.rejected, (state, action) => {

--- a/src/renderer/src/redux/slices/marketplaceSlice.ts
+++ b/src/renderer/src/redux/slices/marketplaceSlice.ts
@@ -18,6 +18,8 @@ interface MarketplaceState {
   searchQuery: string
   searchResults: SkillSearchResult[]
   selectedSkill: SkillSearchResult | null
+  /** Skill selected for right-pane webview preview (separate from install modal) */
+  previewSkill: SkillSearchResult | null
   installProgress: InstallProgress | null
   skillToRemove: string | null
   error: string | null
@@ -30,6 +32,7 @@ const initialState: MarketplaceState = {
   searchQuery: '',
   searchResults: [],
   selectedSkill: null,
+  previewSkill: null,
   installProgress: null,
   skillToRemove: null,
   error: null,
@@ -122,6 +125,12 @@ const marketplaceSlice = createSlice({
       action: PayloadAction<InstallProgress | null>,
     ) => {
       state.installProgress = action.payload
+    },
+    setPreviewSkill: (
+      state,
+      action: PayloadAction<SkillSearchResult | null>,
+    ) => {
+      state.previewSkill = action.payload
     },
     setSkillToRemove: (state, action: PayloadAction<string | null>) => {
       state.skillToRemove = action.payload
@@ -232,6 +241,7 @@ const marketplaceSlice = createSlice({
 export const {
   setSearchQuery,
   selectSkillForInstall,
+  setPreviewSkill,
   setInstallProgress,
   setSkillToRemove,
   cancelOperation,

--- a/src/renderer/src/redux/slices/marketplaceSlice.ts
+++ b/src/renderer/src/redux/slices/marketplaceSlice.ts
@@ -169,11 +169,16 @@ const marketplaceSlice = createSlice({
         state.status = 'installing'
         state.error = null
       })
-      .addCase(installSkill.fulfilled, (state) => {
-        state.status = 'idle'
-        state.selectedSkill = null
-        state.previewSkill = null
+      .addCase(installSkill.fulfilled, (state, action) => {
         state.installProgress = null
+        if (action.payload) {
+          state.status = 'idle'
+          state.selectedSkill = null
+          state.previewSkill = null
+        } else {
+          state.status = 'error'
+          state.error = 'Installation failed'
+        }
       })
       .addCase(installSkill.rejected, (state, action) => {
         state.status = 'error'

--- a/src/renderer/src/redux/slices/uiSlice.ts
+++ b/src/renderer/src/redux/slices/uiSlice.ts
@@ -15,8 +15,11 @@ export type BookmarkForDetail = BookmarkedSkill & { isInstalled: boolean }
 
 export type SortOrder = 'asc' | 'desc'
 export type SkillTypeFilter = 'all' | 'symlinked' | 'local'
+export type ActiveTab = 'installed' | 'marketplace'
 
 interface UiState {
+  /** Active main content tab */
+  activeTab: ActiveTab
   searchQuery: string
   sourceStats: SourceStats | null
   isRefreshing: boolean
@@ -36,6 +39,7 @@ interface UiState {
 }
 
 const initialState: UiState = {
+  activeTab: 'installed',
   searchQuery: '',
   sourceStats: null,
   isRefreshing: false,
@@ -85,6 +89,9 @@ const uiSlice = createSlice({
   name: 'ui',
   initialState,
   reducers: {
+    setActiveTab: (state, action: PayloadAction<ActiveTab>) => {
+      state.activeTab = action.payload
+    },
     setSearchQuery: (state, action: PayloadAction<string>) => {
       state.searchQuery = action.payload
     },
@@ -147,6 +154,7 @@ const uiSlice = createSlice({
 })
 
 export const {
+  setActiveTab,
   setSearchQuery,
   setRefreshing,
   selectAgent,
@@ -159,6 +167,8 @@ export const {
 export default uiSlice.reducer
 
 // --- Named selectors ---
+export const selectActiveTab = (state: RootState): ActiveTab =>
+  state.ui.activeTab
 export const selectSearchQuery = (state: RootState): string =>
   state.ui.searchQuery
 export const selectSelectedAgentId = (state: RootState): AgentId | null =>

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -96,3 +96,19 @@ declare global {
 }
 
 export {}
+
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements {
+      webview: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement> & {
+          src?: string
+          partition?: string
+          preload?: string
+          allowpopups?: boolean
+        },
+        HTMLElement
+      >
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Marketplace tab right pane now shows a **dashboard** (installed/bookmarked stats, trending top 5) by default, and an **embedded webview** of the skills.sh page when a skill row is clicked
- `activeTab` lifted from local state to Redux so `DetailPanel` can route between Installed and Marketplace views
- Webview security hardened: strict hostname validation, `will-attach-webview` gate, `did-fail-load` handler, no untrusted URL passthrough to `shell.openExternal`
- ARIA fix: skill row uses sibling buttons instead of nested `role="button"` with inner buttons

## New files
| File | Purpose |
|------|---------|
| `MarketplaceDashboard.tsx` | Stats dashboard (installed count, bookmarked count, trending top 5) |
| `MarketplaceSkillPreview.tsx` | Webview embed with back button, loading skeleton, URL bar |
| `MarketplaceDetailPanel.tsx` | Router: `previewSkill === null` → dashboard, `!== null` → webview |

## Test plan
- [ ] Switch to Marketplace tab — right pane shows dashboard with installed count, bookmarked count, trending skills
- [ ] Click a trending skill row — right pane switches to webview loading the skills.sh page
- [ ] Click "Back to Dashboard" — returns to dashboard view
- [ ] Click Install/Remove/Bookmark buttons on skill rows — actions fire without opening preview
- [ ] Switch tabs (Installed ↔ Marketplace) — preview state clears, no stale webview
- [ ] Install a skill while preview is open — preview clears on success
- [ ] Verify `formatInstallCount(0)` displays "0" not "—"
- [ ] Keyboard navigation: Tab through skill row buttons independently

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Marketplace tab and dashboard for browsing skills, stats, and top trending items
  * Right-pane marketplace preview with embedded skill preview and “Back to Dashboard” control
  * Clickable trending items and rows update the preview pane

* **Bug Fixes / Security**
  * Preview blocks external/unallowed URLs and shows a fallback when unavailable
  * Navigation from embedded previews is constrained

* **Refactor**
  * Centralized tab and preview state; install flow now clears preview on success

* **Style**
  * Close button hidden on the Marketplace tab for cleaner UI
<!-- end of auto-generated comment: release notes by coderabbit.ai -->