### PR TITLE
feat(sync): add confirmation dialog before sync execution

### DIFF
--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -18,6 +18,7 @@ import {
   toggleSortOrder,
 } from '../../redux/slices/uiSlice'
 import { SkillsMarketplace } from '../marketplace'
+import { SyncConfirmDialog } from '../sidebar/SyncConfirmDialog'
 import { SyncConflictDialog } from '../sidebar/SyncConflictDialog'
 import { AddSymlinkModal } from '../skills/AddSymlinkModal'
 import { CopyToAgentsModal } from '../skills/CopyToAgentsModal'
@@ -232,6 +233,7 @@ export const MainContent = React.memo(
         <DeleteSkillDialog />
         <AddSymlinkModal />
         <CopyToAgentsModal />
+        <SyncConfirmDialog />
         <SyncConflictDialog />
       </main>
     )

--- a/src/renderer/src/components/sidebar/SourceCard.tsx
+++ b/src/renderer/src/components/sidebar/SourceCard.tsx
@@ -7,7 +7,6 @@ import { useAppDispatch, useAppSelector } from '../../redux/hooks'
 import { fetchAgents } from '../../redux/slices/agentsSlice'
 import { fetchSkills } from '../../redux/slices/skillsSlice'
 import {
-  executeSyncAction,
   fetchSourceStats,
   fetchSyncPreview,
   selectAgent,
@@ -47,8 +46,10 @@ export const SourceCard = React.memo(function SourceCard(): React.ReactElement {
   }
 
   /**
-   * Sync all source skills to all agents as symlinks
-   * If no conflicts, executes immediately. If conflicts, opens dialog.
+   * Fetch sync preview and let the appropriate dialog handle execution.
+   * SyncConfirmDialog opens when there are symlinks to create (no conflicts).
+   * SyncConflictDialog opens when conflicts exist.
+   * Edge cases (no skills, already synced) are handled with toasts.
    */
   const handleSync = async (): Promise<void> => {
     const previewResult = await dispatch(fetchSyncPreview())
@@ -67,24 +68,7 @@ export const SourceCard = React.memo(function SourceCard(): React.ReactElement {
         })
         return
       }
-
-      // If no conflicts, execute immediately
-      if (preview.conflicts.length === 0) {
-        const result = await dispatch(
-          executeSyncAction({ replaceConflicts: [] }),
-        )
-        if (executeSyncAction.fulfilled.match(result)) {
-          toast.success('Sync completed', {
-            description: `Created ${result.payload.created} symlinks`,
-          })
-          dispatch(fetchSkills())
-          dispatch(fetchAgents())
-          dispatch(fetchSourceStats())
-        } else {
-          toast.error('Sync failed')
-        }
-      }
-      // If conflicts exist, the dialog will open via syncPreview state
+      // Otherwise, syncPreview state in Redux will open the appropriate dialog
     } else {
       toast.error('Failed to preview sync')
     }

--- a/src/renderer/src/components/sidebar/SourceCard.tsx
+++ b/src/renderer/src/components/sidebar/SourceCard.tsx
@@ -11,6 +11,7 @@ import {
   fetchSyncPreview,
   selectAgent,
   setSearchQuery,
+  setSyncPreview,
 } from '../../redux/slices/uiSlice'
 import { Button } from '../ui/button'
 import { Card, CardContent } from '../ui/card'
@@ -58,11 +59,13 @@ export const SourceCard = React.memo(function SourceCard(): React.ReactElement {
       const preview = previewResult.payload
 
       if (preview.totalSkills === 0) {
+        dispatch(setSyncPreview(null))
         toast.info('No skills to sync')
         return
       }
 
       if (preview.toCreate === 0 && preview.conflicts.length === 0) {
+        dispatch(setSyncPreview(null))
         toast.info('Already synced', {
           description: `All ${preview.alreadySynced} skills are already linked`,
         })

--- a/src/renderer/src/components/sidebar/SyncConfirmDialog.tsx
+++ b/src/renderer/src/components/sidebar/SyncConfirmDialog.tsx
@@ -43,9 +43,16 @@ export const SyncConfirmDialog = React.memo(
       const result = await dispatch(executeSyncAction({ replaceConflicts: [] }))
 
       if (executeSyncAction.fulfilled.match(result)) {
-        toast.success('Sync completed', {
-          description: `Created ${result.payload.created} symlinks`,
-        })
+        const { created, errors } = result.payload
+        if (errors.length > 0) {
+          toast.warning('Sync completed with errors', {
+            description: `Created ${created} symlinks, ${errors.length} failed`,
+          })
+        } else {
+          toast.success('Sync completed', {
+            description: `Created ${created} symlinks`,
+          })
+        }
         refreshAllData(dispatch)
       } else {
         toast.error('Sync failed', {

--- a/src/renderer/src/components/sidebar/SyncConfirmDialog.tsx
+++ b/src/renderer/src/components/sidebar/SyncConfirmDialog.tsx
@@ -1,0 +1,123 @@
+import { FolderSync, Loader2 } from 'lucide-react'
+import React, { useState } from 'react'
+import { toast } from 'sonner'
+
+import { shouldShowSyncConfirm } from '../../lib/syncHelpers'
+import { useAppDispatch, useAppSelector } from '../../redux/hooks'
+import { executeSyncAction, setSyncPreview } from '../../redux/slices/uiSlice'
+import { refreshAllData } from '../../redux/thunks'
+import { Button } from '../ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog'
+
+/**
+ * Confirmation dialog shown before sync execution (no-conflict case).
+ * Explains what the sync operation will do: how many symlinks will be created
+ * across how many agents, and how many are already linked.
+ * Opens when syncPreview has toCreate > 0 and no conflicts.
+ */
+export const SyncConfirmDialog = React.memo(
+  function SyncConfirmDialog(): React.ReactElement {
+    const dispatch = useAppDispatch()
+    const syncPreview = useAppSelector((state) => state.ui.syncPreview)
+    const isSyncing = useAppSelector((state) => state.ui.isSyncing)
+    const isOpen = shouldShowSyncConfirm(syncPreview)
+
+    const [isExecuting, setIsExecuting] = useState(false)
+
+    const handleClose = (): void => {
+      if (!isExecuting) {
+        dispatch(setSyncPreview(null))
+      }
+    }
+
+    const handleSync = async (): Promise<void> => {
+      setIsExecuting(true)
+
+      const result = await dispatch(executeSyncAction({ replaceConflicts: [] }))
+
+      if (executeSyncAction.fulfilled.match(result)) {
+        toast.success('Sync completed', {
+          description: `Created ${result.payload.created} symlinks`,
+        })
+        refreshAllData(dispatch)
+      } else {
+        toast.error('Sync failed', {
+          description: result.error?.message || 'An unexpected error occurred',
+        })
+      }
+
+      setIsExecuting(false)
+    }
+
+    return (
+      <Dialog open={isOpen} onOpenChange={handleClose}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <div className="flex items-center gap-2">
+              <FolderSync className="h-5 w-5 text-primary" />
+              <DialogTitle>Sync Skills</DialogTitle>
+            </div>
+            <DialogDescription>
+              Create symlinks from your source skills to all agents.
+            </DialogDescription>
+          </DialogHeader>
+
+          {syncPreview && (
+            <div className="py-4 space-y-2 text-sm">
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Skills → Agents</span>
+                <span className="font-medium">
+                  {syncPreview.totalSkills} skills → {syncPreview.totalAgents}{' '}
+                  agents
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">
+                  New symlinks to create
+                </span>
+                <span className="font-medium text-primary">
+                  {syncPreview.toCreate}
+                </span>
+              </div>
+              {syncPreview.alreadySynced > 0 && (
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Already synced</span>
+                  <span className="font-medium">
+                    {syncPreview.alreadySynced}
+                  </span>
+                </div>
+              )}
+            </div>
+          )}
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={handleClose}
+              disabled={isExecuting}
+            >
+              Cancel
+            </Button>
+            <Button onClick={handleSync} disabled={isExecuting || isSyncing}>
+              {isExecuting ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                  Syncing...
+                </>
+              ) : (
+                'Sync'
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    )
+  },
+)

--- a/src/renderer/src/components/sidebar/SyncConflictDialog.tsx
+++ b/src/renderer/src/components/sidebar/SyncConflictDialog.tsx
@@ -61,10 +61,16 @@ export const SyncConflictDialog = React.memo(
       const result = await dispatch(executeSyncAction({ replaceConflicts }))
 
       if (executeSyncAction.fulfilled.match(result)) {
-        const { created, replaced } = result.payload
-        toast.success('Sync completed', {
-          description: `Created ${created} symlinks, replaced ${replaced} conflicts`,
-        })
+        const { created, replaced, errors } = result.payload
+        if (errors.length > 0) {
+          toast.warning('Sync completed with errors', {
+            description: `Created ${created}, replaced ${replaced}, ${errors.length} failed`,
+          })
+        } else {
+          toast.success('Sync completed', {
+            description: `Created ${created} symlinks, replaced ${replaced} conflicts`,
+          })
+        }
         refreshAllData(dispatch)
       } else {
         toast.error('Sync failed', {

--- a/src/renderer/src/lib/syncHelpers.test.ts
+++ b/src/renderer/src/lib/syncHelpers.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SyncPreviewResult } from '../../../shared/types'
+
+import { shouldShowSyncConfirm } from './syncHelpers'
+
+/** Helper to build a SyncPreviewResult with sensible defaults */
+function buildPreview(
+  overrides: Partial<SyncPreviewResult> = {},
+): SyncPreviewResult {
+  return {
+    totalSkills: 5,
+    totalAgents: 10,
+    toCreate: 0,
+    alreadySynced: 0,
+    conflicts: [],
+    ...overrides,
+  }
+}
+
+describe('shouldShowSyncConfirm', () => {
+  it('returns false when preview is null', () => {
+    expect(shouldShowSyncConfirm(null)).toBe(false)
+  })
+
+  it('returns true when toCreate > 0 and no conflicts', () => {
+    const preview = buildPreview({ toCreate: 8 })
+    expect(shouldShowSyncConfirm(preview)).toBe(true)
+  })
+
+  it('returns false when toCreate is 0 (already synced)', () => {
+    const preview = buildPreview({ toCreate: 0, alreadySynced: 50 })
+    expect(shouldShowSyncConfirm(preview)).toBe(false)
+  })
+
+  it('returns false when conflicts exist (conflict dialog handles this)', () => {
+    const preview = buildPreview({
+      toCreate: 3,
+      conflicts: [
+        {
+          skillName: 'test-skill',
+          agentId: 'claude' as never,
+          agentName: 'Claude' as never,
+          agentSkillPath: '/home/user/.claude/skills/test-skill',
+        },
+      ],
+    })
+    expect(shouldShowSyncConfirm(preview)).toBe(false)
+  })
+
+  it('returns false when both toCreate is 0 and no conflicts', () => {
+    const preview = buildPreview({ toCreate: 0, conflicts: [] })
+    expect(shouldShowSyncConfirm(preview)).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/syncHelpers.ts
+++ b/src/renderer/src/lib/syncHelpers.ts
@@ -1,0 +1,19 @@
+import type { SyncPreviewResult } from '../../../shared/types'
+
+/**
+ * Whether to show the sync confirmation dialog (no-conflict case).
+ * Returns true when there are new symlinks to create but no conflicts to resolve.
+ * @param preview - Sync preview result from the main process, or null if not available
+ * @returns true if the confirm dialog should be shown
+ * @example
+ * shouldShowSyncConfirm(null) // => false
+ * shouldShowSyncConfirm({ toCreate: 5, conflicts: [] }) // => true
+ * shouldShowSyncConfirm({ toCreate: 5, conflicts: [conflict] }) // => false (conflict dialog handles this)
+ * shouldShowSyncConfirm({ toCreate: 0, conflicts: [] }) // => false (already synced)
+ */
+export function shouldShowSyncConfirm(
+  preview: SyncPreviewResult | null,
+): boolean {
+  if (!preview) return false
+  return preview.toCreate > 0 && preview.conflicts.length === 0
+}


### PR DESCRIPTION
## Summary

Previously, clicking Sync with no conflicts would execute immediately — creating symlinks without any user confirmation. Now a confirmation dialog appears showing exactly what will happen: how many skills, how many agents, how many new symlinks to create, and how many are already linked.

**Changes:**
- **New `SyncConfirmDialog` component** — Shows preview stats before execution. Opens when `toCreate > 0` and no conflicts exist. Follows the same pattern as `SyncConflictDialog`.
- **`shouldShowSyncConfirm` helper** — Pure function extracted to `lib/syncHelpers.ts` with 5 unit tests covering null, conflicts, already-synced, and boundary cases.
- **SourceCard refactored** — Removed inline auto-execute logic. Now delegates to the appropriate dialog via Redux `syncPreview` state.
- **Review fixes:** Clean up stale `syncPreview` on early-return paths (no skills / already synced). Handle partial sync failures with `toast.warning` in both `SyncConfirmDialog` and `SyncConflictDialog`.

## Test Coverage
- `syncHelpers.test.ts`: 5 unit tests for `shouldShowSyncConfirm` (null, toCreate > 0, toCreate === 0, conflicts exist, zero + no conflicts)
- Tests: 24 files, 266 tests all passing

## Pre-Landing Review
Pre-Landing Review: 2 informational issues — both fixed.
- `SourceCard.tsx:60` — syncPreview leak on early returns → fixed (dispatch `setSyncPreview(null)`)
- `SyncConfirmDialog.tsx:45` + `SyncConflictDialog.tsx:63` — partial failures silently ignored → fixed (`toast.warning` for `errors.length > 0`)

Adversarial review (Claude + Codex): TOCTOU window between preview and execute noted as architectural (low practical risk for desktop app). No critical findings.

## Plan Completion
Plan: 8/8 items DONE (confirm dialog, cancel, conflict path, all 4 edge cases).

## Scope Drift
Scope Check: CLEAN — delivered exactly what was planned, plus review-driven fixes for partial failure handling (applied to both dialogs for consistency).

## Test plan
- [x] All vitest tests pass (266 tests, 24 files)
- [x] TypeScript typecheck passes
- [x] Pre-landing review: 0 critical, 2 informational (both fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a confirmation dialog for sync operations that previews changes (skills, agents, new symlinks) before execution.
  * Enhanced sync completion notifications with detailed error reporting when syncs complete with issues.

* **Tests**
  * Added validation tests for sync preview functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->