### PR TITLE
feat(sync): show per-item sync diff after symlink sync (#49)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ CLAUDE.md
 .todos/
 .superpowers/
 .gstack/
+.bridgespace/

--- a/src/main/services/syncService.test.ts
+++ b/src/main/services/syncService.test.ts
@@ -245,7 +245,9 @@ describe('syncExecute', () => {
     expect(result.created).toBe(0)
     expect(result.replaced).toBe(0)
     expect(result.skipped).toBe(2) // 1 skill × 2 agents, all already symlinked
-    expect(result.details).toHaveLength(0) // skipped items not tracked in details
+    // Skipped items now appear per-item in details so the dialog can show them
+    expect(result.details).toHaveLength(2)
+    expect(result.details.every((item) => item.action === 'skipped')).toBe(true)
     expect(symlinkMock).not.toHaveBeenCalled()
     expect(rmMock).not.toHaveBeenCalled()
   })
@@ -322,8 +324,22 @@ describe('syncExecute', () => {
     expect(rmMock).not.toHaveBeenCalled()
     // Cursor path: created
     expect(result.created).toBe(1)
-    expect(result.details).toHaveLength(1) // only the created item
-    expect(result.details[0]).toMatchObject({ action: 'created' })
+    // Declined conflict is now surfaced as a skipped detail row (not folded into aggregate)
+    expect(result.details).toHaveLength(2)
+    expect(result.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          skillName: 'local-skill',
+          agentName: 'Claude Code',
+          action: 'skipped',
+        }),
+        expect.objectContaining({
+          skillName: 'local-skill',
+          agentName: 'Cursor',
+          action: 'created',
+        }),
+      ]),
+    )
   })
 
   it('records errors when symlink creation fails', async () => {

--- a/src/main/services/syncService.test.ts
+++ b/src/main/services/syncService.test.ts
@@ -214,7 +214,14 @@ describe('syncExecute', () => {
 
     expect(result.created).toBe(2) // 1 skill × 2 agents
     expect(result.replaced).toBe(0)
+    expect(result.skipped).toBe(0)
     expect(result.success).toBe(true)
+    expect(result.details).toHaveLength(2)
+    expect(result.details[0]).toMatchObject({
+      skillName: 'new-skill',
+      agentName: 'Claude Code',
+      action: 'created',
+    })
     expect(symlinkMock).toHaveBeenCalledTimes(2)
     expect(symlinkMock).toHaveBeenCalledWith(
       join('/mock/source/skills', 'new-skill'),
@@ -237,6 +244,8 @@ describe('syncExecute', () => {
 
     expect(result.created).toBe(0)
     expect(result.replaced).toBe(0)
+    expect(result.skipped).toBe(2) // 1 skill × 2 agents, all already symlinked
+    expect(result.details).toHaveLength(0) // skipped items not tracked in details
     expect(symlinkMock).not.toHaveBeenCalled()
     expect(rmMock).not.toHaveBeenCalled()
   })
@@ -262,6 +271,20 @@ describe('syncExecute', () => {
     const result = await syncExecute({ replaceConflicts: [conflictPath] })
 
     expect(result.replaced).toBe(1)
+    expect(result.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          skillName: 'local-skill',
+          agentName: 'Claude Code',
+          action: 'replaced',
+        }),
+        expect.objectContaining({
+          skillName: 'local-skill',
+          agentName: 'Cursor',
+          action: 'created',
+        }),
+      ]),
+    )
     expect(rmMock).toHaveBeenCalledWith(conflictPath, {
       recursive: true,
       force: true,
@@ -295,9 +318,12 @@ describe('syncExecute', () => {
     const result = await syncExecute({ replaceConflicts: [] }) // Not approved
 
     expect(result.replaced).toBe(0)
+    expect(result.skipped).toBe(1) // unapproved conflict skipped
     expect(rmMock).not.toHaveBeenCalled()
     // Cursor path: created
     expect(result.created).toBe(1)
+    expect(result.details).toHaveLength(1) // only the created item
+    expect(result.details[0]).toMatchObject({ action: 'created' })
   })
 
   it('records errors when symlink creation fails', async () => {
@@ -318,6 +344,14 @@ describe('syncExecute', () => {
     expect(result.errors).toHaveLength(2)
     expect(result.errors[0]).toMatchObject({
       path: join('/mock/agents/claude/skills', 'fail-skill'),
+      error: 'EPERM: operation not permitted',
+    })
+    // Error items tracked in details with action='error'
+    expect(result.details).toHaveLength(2)
+    expect(result.details[0]).toMatchObject({
+      skillName: 'fail-skill',
+      agentName: 'Claude Code',
+      action: 'error',
       error: 'EPERM: operation not permitted',
     })
   })

--- a/src/main/services/syncService.ts
+++ b/src/main/services/syncService.ts
@@ -106,11 +106,9 @@ export async function syncExecute(
   let skipped = 0
   const errors: SyncExecuteResult['errors'] = []
   const details: SyncResultItem[] = []
-
-  // Pre-create all agent skill directories (M calls instead of N×M)
-  for (const agent of agents) {
-    await mkdir(agent.path, { recursive: true })
-  }
+  // Track agent dirs we've already mkdir'd so per-skill loop does at most M mkdirs total,
+  // while keeping the call inside the per-item try-path (errors become per-item, not global).
+  const ensuredAgentDirs = new Set<string>()
 
   for (const skill of skills) {
     for (const agent of agents) {
@@ -129,6 +127,10 @@ export async function syncExecute(
         }
 
         if (!exists) {
+          if (!ensuredAgentDirs.has(agent.path)) {
+            await mkdir(agent.path, { recursive: true })
+            ensuredAgentDirs.add(agent.path)
+          }
           await symlink(skill.path, linkPath)
           created++
           details.push({
@@ -138,6 +140,11 @@ export async function syncExecute(
           })
         } else if (isSymlink) {
           skipped++
+          details.push({
+            skillName: skill.name,
+            agentName: agent.name,
+            action: 'skipped',
+          })
         } else if (replaceSet.has(linkPath)) {
           await rm(linkPath, { recursive: true, force: true })
           await symlink(skill.path, linkPath)
@@ -148,7 +155,14 @@ export async function syncExecute(
             action: 'replaced',
           })
         } else {
+          // Conflict the user declined to replace. Track as skipped so the dialog
+          // can show it per-item, rather than silently folding it into the aggregate.
           skipped++
+          details.push({
+            skillName: skill.name,
+            agentName: agent.name,
+            action: 'skipped',
+          })
         }
       } catch (error) {
         const msg = extractErrorMessage(error)

--- a/src/main/services/syncService.ts
+++ b/src/main/services/syncService.ts
@@ -107,14 +107,16 @@ export async function syncExecute(
   const errors: SyncExecuteResult['errors'] = []
   const details: SyncResultItem[] = []
 
+  // Pre-create all agent skill directories (M calls instead of N×M)
+  for (const agent of agents) {
+    await mkdir(agent.path, { recursive: true })
+  }
+
   for (const skill of skills) {
     for (const agent of agents) {
       const linkPath = join(agent.path, skill.name)
 
       try {
-        // Ensure agent skills directory exists
-        await mkdir(agent.path, { recursive: true })
-
         let exists = false
         let isSymlink = false
 
@@ -127,7 +129,6 @@ export async function syncExecute(
         }
 
         if (!exists) {
-          // Create new symlink
           await symlink(skill.path, linkPath)
           created++
           details.push({
@@ -136,10 +137,8 @@ export async function syncExecute(
             action: 'created',
           })
         } else if (isSymlink) {
-          // Already synced, skip
           skipped++
         } else if (replaceSet.has(linkPath)) {
-          // Conflict approved for replacement
           await rm(linkPath, { recursive: true, force: true })
           await symlink(skill.path, linkPath)
           replaced++
@@ -149,16 +148,16 @@ export async function syncExecute(
             action: 'replaced',
           })
         } else {
-          // Conflict not approved, skip
           skipped++
         }
       } catch (error) {
-        errors.push({ path: linkPath, error: extractErrorMessage(error) })
+        const msg = extractErrorMessage(error)
+        errors.push({ path: linkPath, error: msg })
         details.push({
           skillName: skill.name,
           agentName: agent.name,
           action: 'error',
-          error: extractErrorMessage(error),
+          error: msg,
         })
       }
     }

--- a/src/main/services/syncService.ts
+++ b/src/main/services/syncService.ts
@@ -6,6 +6,7 @@ import type {
   SyncExecuteOptions,
   SyncExecuteResult,
   SyncPreviewResult,
+  SyncResultItem,
 } from '../../shared/types'
 import { AGENTS } from '../constants'
 import { extractErrorMessage } from '../utils/errors'
@@ -83,12 +84,13 @@ export async function syncPreview(): Promise<SyncPreviewResult> {
 }
 
 /**
- * Execute sync: create symlinks and optionally replace conflicts
+ * Execute sync: create symlinks and optionally replace conflicts.
+ * Tracks per-item details for displaying a sync diff after completion.
  * @param options - replaceConflicts: paths to replace with symlinks
- * @returns SyncExecuteResult with created/replaced counts and errors
+ * @returns SyncExecuteResult with counts, per-item details, and errors
  * @example
  * syncExecute({ replaceConflicts: ['/Users/x/.claude/skills/my-skill'] })
- * // => { success: true, created: 10, replaced: 1, errors: [] }
+ * // => { success: true, created: 10, replaced: 1, skipped: 5, errors: [], details: [...] }
  */
 export async function syncExecute(
   options: SyncExecuteOptions,
@@ -101,7 +103,9 @@ export async function syncExecute(
 
   let created = 0
   let replaced = 0
+  let skipped = 0
   const errors: SyncExecuteResult['errors'] = []
+  const details: SyncResultItem[] = []
 
   for (const skill of skills) {
     for (const agent of agents) {
@@ -126,17 +130,36 @@ export async function syncExecute(
           // Create new symlink
           await symlink(skill.path, linkPath)
           created++
+          details.push({
+            skillName: skill.name,
+            agentName: agent.name,
+            action: 'created',
+          })
         } else if (isSymlink) {
           // Already synced, skip
+          skipped++
         } else if (replaceSet.has(linkPath)) {
           // Conflict approved for replacement
           await rm(linkPath, { recursive: true, force: true })
           await symlink(skill.path, linkPath)
           replaced++
+          details.push({
+            skillName: skill.name,
+            agentName: agent.name,
+            action: 'replaced',
+          })
+        } else {
+          // Conflict not approved, skip
+          skipped++
         }
-        // else: conflict not approved, skip
       } catch (error) {
         errors.push({ path: linkPath, error: extractErrorMessage(error) })
+        details.push({
+          skillName: skill.name,
+          agentName: agent.name,
+          action: 'error',
+          error: extractErrorMessage(error),
+        })
       }
     }
   }
@@ -145,6 +168,8 @@ export async function syncExecute(
     success: errors.length === 0,
     created,
     replaced,
+    skipped,
     errors,
+    details,
   }
 }

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -20,6 +20,7 @@ import {
 import { SkillsMarketplace } from '../marketplace'
 import { SyncConfirmDialog } from '../sidebar/SyncConfirmDialog'
 import { SyncConflictDialog } from '../sidebar/SyncConflictDialog'
+import { SyncResultDialog } from '../sidebar/SyncResultDialog'
 import { AddSymlinkModal } from '../skills/AddSymlinkModal'
 import { CopyToAgentsModal } from '../skills/CopyToAgentsModal'
 import { DeleteSkillDialog } from '../skills/DeleteSkillDialog'
@@ -235,6 +236,7 @@ export const MainContent = React.memo(
         <CopyToAgentsModal />
         <SyncConfirmDialog />
         <SyncConflictDialog />
+        <SyncResultDialog />
       </main>
     )
   },

--- a/src/renderer/src/components/sidebar/SyncConfirmDialog.tsx
+++ b/src/renderer/src/components/sidebar/SyncConfirmDialog.tsx
@@ -5,7 +5,6 @@ import { toast } from 'sonner'
 import { shouldShowSyncConfirm } from '../../lib/syncHelpers'
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
 import { executeSyncAction, setSyncPreview } from '../../redux/slices/uiSlice'
-import { refreshAllData } from '../../redux/thunks'
 import { Button } from '../ui/button'
 import {
   Dialog,
@@ -42,19 +41,8 @@ export const SyncConfirmDialog = React.memo(
 
       const result = await dispatch(executeSyncAction({ replaceConflicts: [] }))
 
-      if (executeSyncAction.fulfilled.match(result)) {
-        const { created, errors } = result.payload
-        if (errors.length > 0) {
-          toast.warning('Sync completed with errors', {
-            description: `Created ${created} symlinks, ${errors.length} failed`,
-          })
-        } else {
-          toast.success('Sync completed', {
-            description: `Created ${created} symlinks`,
-          })
-        }
-        refreshAllData(dispatch)
-      } else {
+      // Success feedback + refreshAllData handled by SyncResultDialog
+      if (executeSyncAction.rejected.match(result)) {
         toast.error('Sync failed', {
           description: result.error?.message || 'An unexpected error occurred',
         })

--- a/src/renderer/src/components/sidebar/SyncConflictDialog.tsx
+++ b/src/renderer/src/components/sidebar/SyncConflictDialog.tsx
@@ -4,7 +4,6 @@ import { toast } from 'sonner'
 
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
 import { executeSyncAction, setSyncPreview } from '../../redux/slices/uiSlice'
-import { refreshAllData } from '../../redux/thunks'
 import { Button } from '../ui/button'
 import { Checkbox } from '../ui/checkbox'
 import {
@@ -60,19 +59,8 @@ export const SyncConflictDialog = React.memo(
 
       const result = await dispatch(executeSyncAction({ replaceConflicts }))
 
-      if (executeSyncAction.fulfilled.match(result)) {
-        const { created, replaced, errors } = result.payload
-        if (errors.length > 0) {
-          toast.warning('Sync completed with errors', {
-            description: `Created ${created}, replaced ${replaced}, ${errors.length} failed`,
-          })
-        } else {
-          toast.success('Sync completed', {
-            description: `Created ${created} symlinks, replaced ${replaced} conflicts`,
-          })
-        }
-        refreshAllData(dispatch)
-      } else {
+      // Success feedback + refreshAllData handled by SyncResultDialog
+      if (executeSyncAction.rejected.match(result)) {
         toast.error('Sync failed', {
           description: result.error?.message || 'An unexpected error occurred',
         })

--- a/src/renderer/src/components/sidebar/SyncResultDialog.tsx
+++ b/src/renderer/src/components/sidebar/SyncResultDialog.tsx
@@ -41,20 +41,28 @@ const ACTION_LABEL: Record<SyncResultAction, string> = {
  * Displays a scrollable list of each skill x agent action with color-coded badges.
  */
 export const SyncResultDialog = React.memo(
-  function SyncResultDialog(): React.ReactElement {
+  function SyncResultDialog(): React.ReactElement | null {
     const dispatch = useAppDispatch()
     const syncResult = useAppSelector((state) => state.ui.syncResult)
     const isOpen = shouldShowSyncResult(syncResult)
 
     const handleClose = (): void => {
+      const hadChanges =
+        syncResult !== null &&
+        (syncResult.created > 0 ||
+          syncResult.replaced > 0 ||
+          syncResult.errors.length > 0)
       dispatch(clearSyncResult())
-      refreshAllData(dispatch)
+      if (hadChanges) {
+        refreshAllData(dispatch)
+      }
     }
 
-    // Determine header icon based on result status
-    const hasErrors = (syncResult?.errors.length ?? 0) > 0
-    const hasSuccess =
-      (syncResult?.created ?? 0) > 0 || (syncResult?.replaced ?? 0) > 0
+    // Skip all derivations when dialog is closed
+    if (!isOpen || !syncResult) return null
+
+    const hasErrors = syncResult.errors.length > 0
+    const hasSuccess = syncResult.created > 0 || syncResult.replaced > 0
     const HeaderIcon = hasErrors
       ? hasSuccess
         ? AlertTriangle // partial: some succeeded, some failed
@@ -66,20 +74,17 @@ export const SyncResultDialog = React.memo(
         : 'text-destructive'
       : 'text-emerald-500'
 
-    // Build description summary
     const parts: string[] = []
-    if (syncResult) {
-      if (syncResult.created > 0)
-        parts.push(
-          `Created ${syncResult.created} symlink${syncResult.created !== 1 ? 's' : ''}`,
-        )
-      if (syncResult.replaced > 0)
-        parts.push(
-          `replaced ${syncResult.replaced} conflict${syncResult.replaced !== 1 ? 's' : ''}`,
-        )
-      if (syncResult.errors.length > 0)
-        parts.push(`${syncResult.errors.length} failed`)
-    }
+    if (syncResult.created > 0)
+      parts.push(
+        `Created ${syncResult.created} symlink${syncResult.created !== 1 ? 's' : ''}`,
+      )
+    if (syncResult.replaced > 0)
+      parts.push(
+        `Replaced ${syncResult.replaced} conflict${syncResult.replaced !== 1 ? 's' : ''}`,
+      )
+    if (syncResult.errors.length > 0)
+      parts.push(`${syncResult.errors.length} failed`)
     const description =
       parts.length > 0 ? parts.join(', ') : 'No changes were made'
 
@@ -94,68 +99,64 @@ export const SyncResultDialog = React.memo(
             <DialogDescription>{description}</DialogDescription>
           </DialogHeader>
 
-          {syncResult && (
-            <div className="py-4 space-y-3">
-              {/* Summary stats row */}
-              <div className="flex gap-4 text-sm">
-                {syncResult.created > 0 && (
-                  <span className="text-cyan-400">
-                    {syncResult.created} created
-                  </span>
-                )}
-                {syncResult.replaced > 0 && (
-                  <span className="text-amber-400">
-                    {syncResult.replaced} replaced
-                  </span>
-                )}
-                {syncResult.errors.length > 0 && (
-                  <span className="text-destructive">
-                    {syncResult.errors.length} errors
-                  </span>
-                )}
-                {syncResult.skipped > 0 && (
-                  <span className="text-muted-foreground">
-                    {syncResult.skipped} skipped
-                  </span>
-                )}
-              </div>
-
-              {/* Per-item detail list */}
-              {syncResult.details.length > 0 ? (
-                <ScrollArea className="max-h-[300px] rounded-md border p-2">
-                  <div className="space-y-1">
-                    {syncResult.details.map((item, index) => (
-                      <div
-                        key={`${item.skillName}-${item.agentName}-${index}`}
-                        className="flex items-center gap-3 p-2 rounded-md text-sm"
-                      >
-                        <Badge variant={ACTION_BADGE_VARIANT[item.action]}>
-                          {ACTION_LABEL[item.action]}
-                        </Badge>
-                        <div className="min-w-0 flex-1">
-                          <span className="font-medium">{item.skillName}</span>
-                          <span className="text-muted-foreground">
-                            {' '}
-                            → {item.agentName}
-                          </span>
-                          {item.error && (
-                            <span className="text-xs text-destructive block truncate">
-                              {item.error}
-                            </span>
-                          )}
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </ScrollArea>
-              ) : (
-                <p className="text-sm text-muted-foreground">
-                  No changes were made. {syncResult.skipped} item
-                  {syncResult.skipped !== 1 ? 's' : ''} already synced.
-                </p>
+          <div className="py-4 space-y-3">
+            <div className="flex gap-4 text-sm">
+              {syncResult.created > 0 && (
+                <span className="text-cyan-400">
+                  {syncResult.created} created
+                </span>
+              )}
+              {syncResult.replaced > 0 && (
+                <span className="text-amber-400">
+                  {syncResult.replaced} replaced
+                </span>
+              )}
+              {syncResult.errors.length > 0 && (
+                <span className="text-destructive">
+                  {syncResult.errors.length} errors
+                </span>
+              )}
+              {syncResult.skipped > 0 && (
+                <span className="text-muted-foreground">
+                  {syncResult.skipped} skipped
+                </span>
               )}
             </div>
-          )}
+
+            {syncResult.details.length > 0 ? (
+              <ScrollArea className="max-h-[300px] rounded-md border p-2">
+                <div className="space-y-1">
+                  {syncResult.details.map((item, index) => (
+                    <div
+                      key={`${item.skillName}-${item.agentName}-${index}`}
+                      className="flex items-center gap-3 p-2 rounded-md text-sm"
+                    >
+                      <Badge variant={ACTION_BADGE_VARIANT[item.action]}>
+                        {ACTION_LABEL[item.action]}
+                      </Badge>
+                      <div className="min-w-0 flex-1">
+                        <span className="font-medium">{item.skillName}</span>
+                        <span className="text-muted-foreground">
+                          {' '}
+                          → {item.agentName}
+                        </span>
+                        {item.error && (
+                          <span className="text-xs text-destructive block truncate">
+                            {item.error}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </ScrollArea>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                No changes were made. {syncResult.skipped} item
+                {syncResult.skipped !== 1 ? 's' : ''} already synced.
+              </p>
+            )}
+          </div>
 
           <DialogFooter>
             <Button onClick={handleClose}>Close</Button>

--- a/src/renderer/src/components/sidebar/SyncResultDialog.tsx
+++ b/src/renderer/src/components/sidebar/SyncResultDialog.tsx
@@ -1,0 +1,167 @@
+import { AlertTriangle, CheckCircle2, XCircle } from 'lucide-react'
+import React from 'react'
+
+import type { SyncResultAction } from '../../../../shared/types'
+import { shouldShowSyncResult } from '../../lib/syncHelpers'
+import { useAppDispatch, useAppSelector } from '../../redux/hooks'
+import { clearSyncResult } from '../../redux/slices/uiSlice'
+import { refreshAllData } from '../../redux/thunks'
+import { Badge } from '../ui/badge'
+import { Button } from '../ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog'
+import { ScrollArea } from '../ui/scroll-area'
+
+/** Maps sync result action to Badge variant for consistent status colors */
+const ACTION_BADGE_VARIANT: Record<
+  SyncResultAction,
+  'valid' | 'broken' | 'destructive'
+> = {
+  created: 'valid',
+  replaced: 'broken',
+  error: 'destructive',
+}
+
+/** Human-readable labels for each action type */
+const ACTION_LABEL: Record<SyncResultAction, string> = {
+  created: 'Created',
+  replaced: 'Replaced',
+  error: 'Error',
+}
+
+/**
+ * Dialog showing per-item sync results after execution.
+ * Auto-opens when syncResult is populated by executeSyncAction.fulfilled.
+ * Displays a scrollable list of each skill x agent action with color-coded badges.
+ */
+export const SyncResultDialog = React.memo(
+  function SyncResultDialog(): React.ReactElement {
+    const dispatch = useAppDispatch()
+    const syncResult = useAppSelector((state) => state.ui.syncResult)
+    const isOpen = shouldShowSyncResult(syncResult)
+
+    const handleClose = (): void => {
+      dispatch(clearSyncResult())
+      refreshAllData(dispatch)
+    }
+
+    // Determine header icon based on result status
+    const hasErrors = (syncResult?.errors.length ?? 0) > 0
+    const hasSuccess =
+      (syncResult?.created ?? 0) > 0 || (syncResult?.replaced ?? 0) > 0
+    const HeaderIcon = hasErrors
+      ? hasSuccess
+        ? AlertTriangle // partial: some succeeded, some failed
+        : XCircle // all errors
+      : CheckCircle2 // all success
+    const iconColor = hasErrors
+      ? hasSuccess
+        ? 'text-amber-500'
+        : 'text-destructive'
+      : 'text-emerald-500'
+
+    // Build description summary
+    const parts: string[] = []
+    if (syncResult) {
+      if (syncResult.created > 0)
+        parts.push(
+          `Created ${syncResult.created} symlink${syncResult.created !== 1 ? 's' : ''}`,
+        )
+      if (syncResult.replaced > 0)
+        parts.push(
+          `replaced ${syncResult.replaced} conflict${syncResult.replaced !== 1 ? 's' : ''}`,
+        )
+      if (syncResult.errors.length > 0)
+        parts.push(`${syncResult.errors.length} failed`)
+    }
+    const description =
+      parts.length > 0 ? parts.join(', ') : 'No changes were made'
+
+    return (
+      <Dialog open={isOpen} onOpenChange={handleClose}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <div className="flex items-center gap-2">
+              <HeaderIcon className={`h-5 w-5 ${iconColor}`} />
+              <DialogTitle>Sync Results</DialogTitle>
+            </div>
+            <DialogDescription>{description}</DialogDescription>
+          </DialogHeader>
+
+          {syncResult && (
+            <div className="py-4 space-y-3">
+              {/* Summary stats row */}
+              <div className="flex gap-4 text-sm">
+                {syncResult.created > 0 && (
+                  <span className="text-cyan-400">
+                    {syncResult.created} created
+                  </span>
+                )}
+                {syncResult.replaced > 0 && (
+                  <span className="text-amber-400">
+                    {syncResult.replaced} replaced
+                  </span>
+                )}
+                {syncResult.errors.length > 0 && (
+                  <span className="text-destructive">
+                    {syncResult.errors.length} errors
+                  </span>
+                )}
+                {syncResult.skipped > 0 && (
+                  <span className="text-muted-foreground">
+                    {syncResult.skipped} skipped
+                  </span>
+                )}
+              </div>
+
+              {/* Per-item detail list */}
+              {syncResult.details.length > 0 ? (
+                <ScrollArea className="max-h-[300px] rounded-md border p-2">
+                  <div className="space-y-1">
+                    {syncResult.details.map((item, index) => (
+                      <div
+                        key={`${item.skillName}-${item.agentName}-${index}`}
+                        className="flex items-center gap-3 p-2 rounded-md text-sm"
+                      >
+                        <Badge variant={ACTION_BADGE_VARIANT[item.action]}>
+                          {ACTION_LABEL[item.action]}
+                        </Badge>
+                        <div className="min-w-0 flex-1">
+                          <span className="font-medium">{item.skillName}</span>
+                          <span className="text-muted-foreground">
+                            {' '}
+                            → {item.agentName}
+                          </span>
+                          {item.error && (
+                            <span className="text-xs text-destructive block truncate">
+                              {item.error}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </ScrollArea>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  No changes were made. {syncResult.skipped} item
+                  {syncResult.skipped !== 1 ? 's' : ''} already synced.
+                </p>
+              )}
+            </div>
+          )}
+
+          <DialogFooter>
+            <Button onClick={handleClose}>Close</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    )
+  },
+)

--- a/src/renderer/src/components/sidebar/SyncResultDialog.tsx
+++ b/src/renderer/src/components/sidebar/SyncResultDialog.tsx
@@ -1,8 +1,10 @@
-import { AlertTriangle, CheckCircle2, XCircle } from 'lucide-react'
 import React from 'react'
 
 import type { SyncResultAction } from '../../../../shared/types'
-import { shouldShowSyncResult } from '../../lib/syncHelpers'
+import {
+  getSyncResultPresentation,
+  shouldShowSyncResult,
+} from '../../lib/syncHelpers'
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
 import { clearSyncResult } from '../../redux/slices/uiSlice'
 import { refreshAllData } from '../../redux/thunks'
@@ -21,10 +23,11 @@ import { ScrollArea } from '../ui/scroll-area'
 /** Maps sync result action to Badge variant for consistent status colors */
 const ACTION_BADGE_VARIANT: Record<
   SyncResultAction,
-  'valid' | 'broken' | 'destructive'
+  'valid' | 'broken' | 'destructive' | 'secondary'
 > = {
   created: 'valid',
   replaced: 'broken',
+  skipped: 'secondary',
   error: 'destructive',
 }
 
@@ -32,6 +35,7 @@ const ACTION_BADGE_VARIANT: Record<
 const ACTION_LABEL: Record<SyncResultAction, string> = {
   created: 'Created',
   replaced: 'Replaced',
+  skipped: 'Skipped',
   error: 'Error',
 }
 
@@ -61,32 +65,8 @@ export const SyncResultDialog = React.memo(
     // Skip all derivations when dialog is closed
     if (!isOpen || !syncResult) return null
 
-    const hasErrors = syncResult.errors.length > 0
-    const hasSuccess = syncResult.created > 0 || syncResult.replaced > 0
-    const HeaderIcon = hasErrors
-      ? hasSuccess
-        ? AlertTriangle // partial: some succeeded, some failed
-        : XCircle // all errors
-      : CheckCircle2 // all success
-    const iconColor = hasErrors
-      ? hasSuccess
-        ? 'text-amber-500'
-        : 'text-destructive'
-      : 'text-emerald-500'
-
-    const parts: string[] = []
-    if (syncResult.created > 0)
-      parts.push(
-        `Created ${syncResult.created} symlink${syncResult.created !== 1 ? 's' : ''}`,
-      )
-    if (syncResult.replaced > 0)
-      parts.push(
-        `Replaced ${syncResult.replaced} conflict${syncResult.replaced !== 1 ? 's' : ''}`,
-      )
-    if (syncResult.errors.length > 0)
-      parts.push(`${syncResult.errors.length} failed`)
-    const description =
-      parts.length > 0 ? parts.join(', ') : 'No changes were made'
+    const { HeaderIcon, iconColor, description } =
+      getSyncResultPresentation(syncResult)
 
     return (
       <Dialog open={isOpen} onOpenChange={handleClose}>
@@ -140,7 +120,7 @@ export const SyncResultDialog = React.memo(
                           {' '}
                           → {item.agentName}
                         </span>
-                        {item.error && (
+                        {item.action === 'error' && (
                           <span className="text-xs text-destructive block truncate">
                             {item.error}
                           </span>
@@ -152,8 +132,7 @@ export const SyncResultDialog = React.memo(
               </ScrollArea>
             ) : (
               <p className="text-sm text-muted-foreground">
-                No changes were made. {syncResult.skipped} item
-                {syncResult.skipped !== 1 ? 's' : ''} already synced.
+                No items were processed.
               </p>
             )}
           </div>

--- a/src/renderer/src/lib/syncHelpers.test.ts
+++ b/src/renderer/src/lib/syncHelpers.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import type { SyncPreviewResult } from '../../../shared/types'
+import type {
+  SyncExecuteResult,
+  SyncPreviewResult,
+} from '../../../shared/types'
 
-import { shouldShowSyncConfirm } from './syncHelpers'
+import { shouldShowSyncConfirm, shouldShowSyncResult } from './syncHelpers'
 
 /** Helper to build a SyncPreviewResult with sensible defaults */
 function buildPreview(
@@ -51,5 +54,44 @@ describe('shouldShowSyncConfirm', () => {
   it('returns false when both toCreate is 0 and no conflicts', () => {
     const preview = buildPreview({ toCreate: 0, conflicts: [] })
     expect(shouldShowSyncConfirm(preview)).toBe(false)
+  })
+})
+
+describe('shouldShowSyncResult', () => {
+  it('returns false when result is null', () => {
+    expect(shouldShowSyncResult(null)).toBe(false)
+  })
+
+  it('returns true when a valid result is provided', () => {
+    const result: SyncExecuteResult = {
+      success: true,
+      created: 3,
+      replaced: 0,
+      skipped: 2,
+      errors: [],
+      details: [
+        { skillName: 'my-skill', agentName: 'Claude Code', action: 'created' },
+      ],
+    }
+    expect(shouldShowSyncResult(result)).toBe(true)
+  })
+
+  it('returns true even when result has errors', () => {
+    const result: SyncExecuteResult = {
+      success: false,
+      created: 0,
+      replaced: 0,
+      skipped: 0,
+      errors: [{ path: '/test', error: 'fail' }],
+      details: [
+        {
+          skillName: 'fail-skill',
+          agentName: 'Cursor',
+          action: 'error',
+          error: 'fail',
+        },
+      ],
+    }
+    expect(shouldShowSyncResult(result)).toBe(true)
   })
 })

--- a/src/renderer/src/lib/syncHelpers.test.ts
+++ b/src/renderer/src/lib/syncHelpers.test.ts
@@ -1,3 +1,4 @@
+import { AlertTriangle, CheckCircle2, XCircle } from 'lucide-react'
 import { describe, expect, it } from 'vitest'
 
 import type {
@@ -5,7 +6,26 @@ import type {
   SyncPreviewResult,
 } from '../../../shared/types'
 
-import { shouldShowSyncConfirm, shouldShowSyncResult } from './syncHelpers'
+import {
+  getSyncResultPresentation,
+  shouldShowSyncConfirm,
+  shouldShowSyncResult,
+} from './syncHelpers'
+
+/** Helper to build a SyncExecuteResult with sensible defaults */
+function buildResult(
+  overrides: Partial<SyncExecuteResult> = {},
+): SyncExecuteResult {
+  return {
+    success: true,
+    created: 0,
+    replaced: 0,
+    skipped: 0,
+    errors: [],
+    details: [],
+    ...overrides,
+  }
+}
 
 /** Helper to build a SyncPreviewResult with sensible defaults */
 function buildPreview(
@@ -93,5 +113,85 @@ describe('shouldShowSyncResult', () => {
       ],
     }
     expect(shouldShowSyncResult(result)).toBe(true)
+  })
+})
+
+describe('getSyncResultPresentation', () => {
+  it('returns success icon and "No changes were made" when result is empty', () => {
+    const { HeaderIcon, iconColor, description } =
+      getSyncResultPresentation(buildResult())
+    expect(HeaderIcon).toBe(CheckCircle2)
+    expect(iconColor).toBe('text-emerald-500')
+    expect(description).toBe('No changes were made')
+  })
+
+  it('returns success icon when only created > 0', () => {
+    const { HeaderIcon, iconColor, description } = getSyncResultPresentation(
+      buildResult({ created: 3 }),
+    )
+    expect(HeaderIcon).toBe(CheckCircle2)
+    expect(iconColor).toBe('text-emerald-500')
+    expect(description).toBe('Created 3 symlinks')
+  })
+
+  it('uses singular "symlink" when created is 1', () => {
+    const { description } = getSyncResultPresentation(
+      buildResult({ created: 1 }),
+    )
+    expect(description).toBe('Created 1 symlink')
+  })
+
+  it('uses singular "conflict" when replaced is 1', () => {
+    const { description } = getSyncResultPresentation(
+      buildResult({ replaced: 1 }),
+    )
+    expect(description).toBe('Replaced 1 conflict')
+  })
+
+  it('joins multiple non-zero parts with comma', () => {
+    const { description } = getSyncResultPresentation(
+      buildResult({
+        created: 2,
+        replaced: 3,
+        errors: [{ path: '/a', error: 'x' }],
+      }),
+    )
+    expect(description).toBe(
+      'Created 2 symlinks, Replaced 3 conflicts, 1 failed',
+    )
+  })
+
+  it('returns XCircle + destructive when there are only errors', () => {
+    const { HeaderIcon, iconColor, description } = getSyncResultPresentation(
+      buildResult({ errors: [{ path: '/a', error: 'boom' }] }),
+    )
+    expect(HeaderIcon).toBe(XCircle)
+    expect(iconColor).toBe('text-destructive')
+    expect(description).toBe('1 failed')
+  })
+
+  it('returns AlertTriangle + amber when errors and successes coexist (partial)', () => {
+    const { HeaderIcon, iconColor } = getSyncResultPresentation(
+      buildResult({ created: 2, errors: [{ path: '/a', error: 'boom' }] }),
+    )
+    expect(HeaderIcon).toBe(AlertTriangle)
+    expect(iconColor).toBe('text-amber-500')
+  })
+
+  it('treats replaced > 0 as success for partial detection', () => {
+    const { HeaderIcon, iconColor } = getSyncResultPresentation(
+      buildResult({ replaced: 1, errors: [{ path: '/a', error: 'boom' }] }),
+    )
+    expect(HeaderIcon).toBe(AlertTriangle)
+    expect(iconColor).toBe('text-amber-500')
+  })
+
+  it('skipped-only is treated as success (all clean, nothing to do)', () => {
+    const { HeaderIcon, iconColor, description } = getSyncResultPresentation(
+      buildResult({ skipped: 5 }),
+    )
+    expect(HeaderIcon).toBe(CheckCircle2)
+    expect(iconColor).toBe('text-emerald-500')
+    expect(description).toBe('No changes were made')
   })
 })

--- a/src/renderer/src/lib/syncHelpers.ts
+++ b/src/renderer/src/lib/syncHelpers.ts
@@ -1,4 +1,7 @@
-import type { SyncPreviewResult } from '../../../shared/types'
+import type {
+  SyncExecuteResult,
+  SyncPreviewResult,
+} from '../../../shared/types'
 
 /**
  * Whether to show the sync confirmation dialog (no-conflict case).
@@ -16,4 +19,19 @@ export function shouldShowSyncConfirm(
 ): boolean {
   if (!preview) return false
   return preview.toCreate > 0 && preview.conflicts.length === 0
+}
+
+/**
+ * Whether to show the sync result dialog (per-item diff after sync execution).
+ * Returns true when there is a sync result to display.
+ * @param result - Sync execution result, or null if not available
+ * @returns true if the result dialog should be shown
+ * @example
+ * shouldShowSyncResult(null) // => false
+ * shouldShowSyncResult({ success: true, created: 3, ... }) // => true
+ */
+export function shouldShowSyncResult(
+  result: SyncExecuteResult | null,
+): boolean {
+  return result !== null
 }

--- a/src/renderer/src/lib/syncHelpers.ts
+++ b/src/renderer/src/lib/syncHelpers.ts
@@ -1,3 +1,10 @@
+import {
+  AlertTriangle,
+  CheckCircle2,
+  XCircle,
+  type LucideIcon,
+} from 'lucide-react'
+
 import type {
   SyncExecuteResult,
   SyncPreviewResult,
@@ -34,4 +41,61 @@ export function shouldShowSyncResult(
   result: SyncExecuteResult | null,
 ): boolean {
   return result !== null
+}
+
+/** Derived presentation fields for the sync result dialog header */
+export interface SyncResultPresentation {
+  HeaderIcon: LucideIcon
+  iconColor: string
+  description: string
+}
+
+/**
+ * Compute the header icon, icon color, and summary description for a sync result.
+ * Extracted as a pure function so it can be tested without rendering the dialog.
+ * @param result - Sync execution result
+ * @returns
+ * - `HeaderIcon`: CheckCircle2 (all success) | AlertTriangle (partial) | XCircle (all errors)
+ * - `iconColor`: Tailwind class matching the icon
+ * - `description`: Human-readable summary (e.g. "Created 3 symlinks, 1 failed") or "No changes were made"
+ * @example
+ * getSyncResultPresentation({ created: 3, replaced: 0, skipped: 0, errors: [], ... })
+ * // => { HeaderIcon: CheckCircle2, iconColor: 'text-emerald-500', description: 'Created 3 symlinks' }
+ * @example
+ * getSyncResultPresentation({ created: 0, replaced: 0, skipped: 0, errors: [{...}], ... })
+ * // => { HeaderIcon: XCircle, iconColor: 'text-destructive', description: '1 failed' }
+ */
+export function getSyncResultPresentation(
+  result: SyncExecuteResult,
+): SyncResultPresentation {
+  const hasErrors = result.errors.length > 0
+  const hasSuccess = result.created > 0 || result.replaced > 0
+
+  const HeaderIcon: LucideIcon = hasErrors
+    ? hasSuccess
+      ? AlertTriangle
+      : XCircle
+    : CheckCircle2
+
+  const iconColor = hasErrors
+    ? hasSuccess
+      ? 'text-amber-500'
+      : 'text-destructive'
+    : 'text-emerald-500'
+
+  const parts: string[] = []
+  if (result.created > 0)
+    parts.push(
+      `Created ${result.created} symlink${result.created !== 1 ? 's' : ''}`,
+    )
+  if (result.replaced > 0)
+    parts.push(
+      `Replaced ${result.replaced} conflict${result.replaced !== 1 ? 's' : ''}`,
+    )
+  if (result.errors.length > 0) parts.push(`${result.errors.length} failed`)
+
+  const description =
+    parts.length > 0 ? parts.join(', ') : 'No changes were made'
+
+  return { HeaderIcon, iconColor, description }
 }

--- a/src/renderer/src/redux/slices/uiSlice.test.ts
+++ b/src/renderer/src/redux/slices/uiSlice.test.ts
@@ -1,7 +1,10 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { SyncPreviewResult } from '../../../../shared/types'
+import type {
+  SyncExecuteResult,
+  SyncPreviewResult,
+} from '../../../../shared/types'
 
 // Stub window.electron before importing the slice (thunks reference it at call time)
 const mockSyncPreview = vi.fn()
@@ -125,8 +128,12 @@ describe('uiSlice sync thunks', () => {
       success: true,
       created: 3,
       replaced: 1,
+      skipped: 4,
       errors: [],
-    })
+      details: [
+        { skillName: 'skill-a', agentName: 'Claude Code', action: 'created' },
+      ],
+    } satisfies SyncExecuteResult)
 
     const store = await createTestStore()
     const { fetchSyncPreview, executeSyncAction } = await import('./uiSlice')
@@ -145,9 +152,13 @@ describe('uiSlice sync thunks', () => {
     const state = store.getState().ui
     expect(state.syncPreview).toBeNull()
     expect(state.isSyncing).toBe(false)
+    // syncResult populated for SyncResultDialog
+    expect(state.syncResult).not.toBeNull()
+    expect(state.syncResult!.created).toBe(3)
+    expect(state.syncResult!.details).toHaveLength(1)
   })
 
-  it('resets isSyncing on executeSyncAction rejected', async () => {
+  it('sets syncResult to null on executeSyncAction rejected', async () => {
     mockSyncExecute.mockRejectedValue(new Error('Permission denied'))
 
     const store = await createTestStore()
@@ -155,6 +166,60 @@ describe('uiSlice sync thunks', () => {
     await store.dispatch(executeSyncAction({ replaceConflicts: [] }))
 
     expect(store.getState().ui.isSyncing).toBe(false)
+    expect(store.getState().ui.syncResult).toBeNull()
+  })
+
+  it('clears syncResult via clearSyncResult action', async () => {
+    mockSyncExecute.mockResolvedValue({
+      success: true,
+      created: 1,
+      replaced: 0,
+      skipped: 0,
+      errors: [],
+      details: [{ skillName: 's', agentName: 'a', action: 'created' }],
+    } satisfies SyncExecuteResult)
+
+    const store = await createTestStore()
+    const { executeSyncAction, clearSyncResult } = await import('./uiSlice')
+
+    await store.dispatch(executeSyncAction({ replaceConflicts: [] }))
+    expect(store.getState().ui.syncResult).not.toBeNull()
+
+    store.dispatch(clearSyncResult())
+    expect(store.getState().ui.syncResult).toBeNull()
+  })
+
+  it('clears syncResult when fetchSyncPreview.pending fires (prevents overlapping dialogs)', async () => {
+    // First: populate syncResult via a completed sync
+    mockSyncExecute.mockResolvedValue({
+      success: true,
+      created: 1,
+      replaced: 0,
+      skipped: 0,
+      errors: [],
+      details: [{ skillName: 's', agentName: 'a', action: 'created' }],
+    } satisfies SyncExecuteResult)
+
+    const store = await createTestStore()
+    const { executeSyncAction, fetchSyncPreview } = await import('./uiSlice')
+
+    await store.dispatch(executeSyncAction({ replaceConflicts: [] }))
+    expect(store.getState().ui.syncResult).not.toBeNull()
+
+    // Now: start a new preview. Pending should clear the old result.
+    let resolve!: (value: SyncPreviewResult) => void
+    mockSyncPreview.mockReturnValue(
+      new Promise<SyncPreviewResult>((r) => {
+        resolve = r
+      }),
+    )
+    const promise = store.dispatch(fetchSyncPreview())
+
+    // While pending, syncResult should already be cleared
+    expect(store.getState().ui.syncResult).toBeNull()
+
+    resolve(previewNoConflicts)
+    await promise
   })
 
   it('clears syncPreview via setSyncPreview(null)', async () => {

--- a/src/renderer/src/redux/slices/uiSlice.ts
+++ b/src/renderer/src/redux/slices/uiSlice.ts
@@ -6,6 +6,7 @@ import type {
   BookmarkedSkill,
   SourceStats,
   SyncExecuteOptions,
+  SyncExecuteResult,
   SyncPreviewResult,
 } from '../../../../shared/types'
 import type { RootState } from '../store'
@@ -33,6 +34,8 @@ interface UiState {
   isSyncing: boolean
   /** Sync preview result (null when not previewing) */
   syncPreview: SyncPreviewResult | null
+  /** Sync execution result for showing per-item diff (null when not displaying) */
+  syncResult: SyncExecuteResult | null
   error: string | null
   /** Bookmark selected for detail modal (null when modal closed) */
   selectedBookmarkForDetail: BookmarkForDetail | null
@@ -48,6 +51,7 @@ const initialState: UiState = {
   skillTypeFilter: 'all',
   isSyncing: false,
   syncPreview: null,
+  syncResult: null,
   error: null,
   selectedBookmarkForDetail: null,
 }
@@ -114,6 +118,9 @@ const uiSlice = createSlice({
     ) => {
       state.syncPreview = action.payload
     },
+    clearSyncResult: (state) => {
+      state.syncResult = null
+    },
     setSelectedBookmarkForDetail: (
       state,
       action: PayloadAction<BookmarkForDetail>,
@@ -131,6 +138,8 @@ const uiSlice = createSlice({
       })
       .addCase(fetchSyncPreview.pending, (state) => {
         state.isSyncing = true
+        // Close result dialog when starting a new sync preview (prevents overlapping dialogs)
+        state.syncResult = null
       })
       .addCase(fetchSyncPreview.fulfilled, (state, action) => {
         state.syncPreview = action.payload
@@ -142,12 +151,15 @@ const uiSlice = createSlice({
         state.isSyncing = false
         state.error = action.error.message ?? 'Failed to fetch sync preview'
       })
-      .addCase(executeSyncAction.fulfilled, (state) => {
+      .addCase(executeSyncAction.fulfilled, (state, action) => {
         state.isSyncing = false
         state.syncPreview = null
+        // Store result for SyncResultDialog to display per-item diff
+        state.syncResult = action.payload
       })
       .addCase(executeSyncAction.rejected, (state, action) => {
         state.isSyncing = false
+        state.syncResult = null
         state.error = action.error.message ?? 'Sync failed'
       })
   },
@@ -161,6 +173,7 @@ export const {
   toggleSortOrder,
   setSkillTypeFilter,
   setSyncPreview,
+  clearSyncResult,
   setSelectedBookmarkForDetail,
   clearSelectedBookmarkForDetail,
 } = uiSlice.actions
@@ -180,6 +193,8 @@ export const selectIsRefreshing = (state: RootState): boolean =>
 export const selectIsSyncing = (state: RootState): boolean => state.ui.isSyncing
 export const selectSyncPreview = (state: RootState): SyncPreviewResult | null =>
   state.ui.syncPreview
+export const selectSyncResult = (state: RootState): SyncExecuteResult | null =>
+  state.ui.syncResult
 export const selectUiError = (state: RootState): string | null => state.ui.error
 export const selectSortOrder = (state: RootState): SortOrder =>
   state.ui.sortOrder

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -463,22 +463,31 @@ export interface SyncExecuteOptions {
 }
 
 /**
- * Action type for each item processed during sync execution
+ * Action type for each item processed during sync execution.
+ * - `created`: new symlink was created
+ * - `replaced`: existing conflict was overwritten with a symlink
+ * - `skipped`: already-synced symlink or user-declined conflict (no filesystem change)
+ * - `error`: operation failed; message is carried on the item
  */
-export type SyncResultAction = 'created' | 'replaced' | 'error'
+export type SyncResultAction = 'created' | 'replaced' | 'skipped' | 'error'
+
+/** Shared fields for every sync result row */
+type SyncResultBase = {
+  skillName: string
+  agentName: string
+}
 
 /**
  * Per-item detail from sync execution, used to show a diff of what happened.
- * Only action items (created/replaced/error) are tracked; skipped items use an aggregate count.
+ * Discriminated union guarantees error rows always carry a message.
  * @example
  * { skillName: 'my-skill', agentName: 'Claude Code', action: 'created' }
+ * @example
+ * { skillName: 's', agentName: 'a', action: 'error', error: 'EACCES' }
  */
-export interface SyncResultItem {
-  skillName: string
-  agentName: string
-  action: SyncResultAction
-  error?: string
-}
+export type SyncResultItem =
+  | (SyncResultBase & { action: 'created' | 'replaced' | 'skipped' })
+  | (SyncResultBase & { action: 'error'; error: string })
 
 /**
  * Result from executing sync

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -463,13 +463,35 @@ export interface SyncExecuteOptions {
 }
 
 /**
+ * Action type for each item processed during sync execution
+ */
+export type SyncResultAction = 'created' | 'replaced' | 'error'
+
+/**
+ * Per-item detail from sync execution, used to show a diff of what happened.
+ * Only action items (created/replaced/error) are tracked; skipped items use an aggregate count.
+ * @example
+ * { skillName: 'my-skill', agentName: 'Claude Code', action: 'created' }
+ */
+export interface SyncResultItem {
+  skillName: string
+  agentName: string
+  action: SyncResultAction
+  error?: string
+}
+
+/**
  * Result from executing sync
  * @example
- * { success: true, created: 10, replaced: 2, errors: [] }
+ * { success: true, created: 10, replaced: 2, skipped: 5, errors: [], details: [...] }
  */
 export interface SyncExecuteResult {
   success: boolean
   created: number
   replaced: number
+  /** Number of already-synced items that were skipped */
+  skipped: number
   errors: Array<{ path: string; error: string }>
+  /** Per-item action details for displaying sync diff */
+  details: SyncResultItem[]
 }


### PR DESCRIPTION
## Summary

Closes #49

After sync, users previously saw "Created 3 symlinks" in a toast with no detail. Now they get a per-item result dialog showing exactly which skills were linked to which agents, with color-coded status badges.

- **New `SyncResultDialog`** auto-opens after sync execution with scrollable per-item detail list
- **Extended `SyncExecuteResult`** with `details[]` array and `skipped` count, tracked through IPC boundary
- **Atomic Redux transition**: `syncPreview=null` + `syncResult=payload` in single reducer case prevents overlapping dialogs
- **Removed success toasts** from SyncConfirmDialog/SyncConflictDialog (dialog replaces toast)
- **Conditional data refresh**: `refreshAllData` only fires on dialog close when sync actually changed something

## Changes

| File | What |
|------|------|
| `src/shared/types.ts` | `SyncResultAction`, `SyncResultItem`, extended `SyncExecuteResult` |
| `src/main/services/syncService.ts` | `details[]` collector, `skipped` counter, hoisted `mkdir` |
| `src/renderer/.../SyncResultDialog.tsx` | New dialog: badges, stats, scrollable detail list |
| `src/renderer/.../uiSlice.ts` | `syncResult` state lifecycle, `clearSyncResult` action |
| `src/renderer/.../syncHelpers.ts` | `shouldShowSyncResult` visibility helper |
| `src/renderer/.../SyncConfirmDialog.tsx` | Removed toasts + refreshAllData |
| `src/renderer/.../SyncConflictDialog.tsx` | Same simplification |
| `src/renderer/.../MainContent.tsx` | Mount `<SyncResultDialog />` |

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 271/271 pass (24 test files)
- [x] `pnpm lint` — 0 errors
- [ ] Manual: Sync with no conflicts → result dialog shows all created (green badges)
- [ ] Manual: Sync with conflicts → replace → result dialog shows created + replaced
- [ ] Manual: Already synced → toast "Already synced" (no dialog)
- [ ] Manual: Close result dialog → data refreshes
- [ ] Manual: Re-sync while result dialog open → result closes, confirm opens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Sync Results dialog that shows aggregated counts and a per-item list (created, replaced, skipped, error) with messages and badges; closing it triggers a data refresh when changes occurred.
  * UI now records and exposes per-sync-item outcomes so results can be reviewed separately from the sync confirmation flow.

* **Chores**
  * Ignored local cache directory in version control.

* **Tests**
  * Expanded tests to cover new result presentation and per-item outcome handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->