### PR TITLE
chore(cli): sync with skills CLI v1.5.1 + pin SKILLS_CLI_VERSION

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -659,11 +659,11 @@ APPLE_KEYCHAIN_PROFILE=skills-desktop pnpm build:mac
 
 The Marketplace feature wraps `npx skills@<SKILLS_CLI_VERSION>` CLI commands (version pinned in `src/shared/constants.ts`):
 
-| Feature | CLI Command                | Options                          |
-| ------- | -------------------------- | -------------------------------- |
-| Search  | `npx skills find <query>`  | -                                |
-| Install | `npx skills add <repo>`    | `-y`, `-g`, `--agent`, `--skill` |
-| Remove  | `npx skills remove <name>` | -                                |
+| Feature | CLI Command                                     | Options                          |
+| ------- | ----------------------------------------------- | -------------------------------- |
+| Search  | `npx skills@<SKILLS_CLI_VERSION> find <query>`  | -                                |
+| Install | `npx skills@<SKILLS_CLI_VERSION> add <repo>`    | `-y`, `-g`, `--agent`, `--skill` |
+| Remove  | `npx skills@<SKILLS_CLI_VERSION> remove <name>` | -                                |
 
 **CLI Output Parsing:**
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -657,7 +657,7 @@ APPLE_KEYCHAIN_PROFILE=skills-desktop pnpm build:mac
 
 ## Skills CLI Integration
 
-The Marketplace feature wraps `npx skills@1.3.0` CLI commands:
+The Marketplace feature wraps `npx skills@<SKILLS_CLI_VERSION>` CLI commands (version pinned in `src/shared/constants.ts`):
 
 | Feature | CLI Command                | Options                          |
 | ------- | -------------------------- | -------------------------------- |

--- a/src/main/services/skillsCliService.ts
+++ b/src/main/services/skillsCliService.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from 'events'
 
 import { match, P } from 'ts-pattern'
 
-import { AGENT_DEFINITIONS } from '../../shared/constants'
+import { AGENT_DEFINITIONS, SKILLS_CLI_VERSION } from '../../shared/constants'
 import { repositoryId } from '../../shared/types'
 import type {
   SkillSearchResult,
@@ -30,8 +30,9 @@ function stripAnsi(text: string): string {
 }
 
 /**
- * Service for executing skills CLI commands via npx
- * Wraps `npx skills@1.3.0` with proper output parsing
+ * Service for executing skills CLI commands via npx.
+ * Wraps `npx skills@<SKILLS_CLI_VERSION>` with proper output parsing — the
+ * version is imported from shared constants so upgrades happen in one place.
  */
 class SkillsCliService extends EventEmitter {
   private currentProcess: ChildProcess | null = null
@@ -130,7 +131,7 @@ class SkillsCliService extends EventEmitter {
       let stderr = ''
 
       // Use npx to run skills CLI with FORCE_COLOR=0 to disable ANSI colors
-      const proc = spawn('npx', ['skills@1.3.0', ...args], {
+      const proc = spawn('npx', [`skills@${SKILLS_CLI_VERSION}`, ...args], {
         env: { ...process.env, FORCE_COLOR: '0' },
       })
 

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -13,10 +13,10 @@ describe('AGENT_DEFINITIONS', () => {
     expect(new Set(cliIds).size).toBe(cliIds.length)
   })
 
-  it('windsurf uses .windsurf dir (not legacy .codeium/windsurf)', () => {
+  it('windsurf uses .codeium/windsurf dir (matches skills CLI globalSkillsDir)', () => {
     const windsurf = AGENT_DEFINITIONS.find((a) => a.id === 'windsurf')
     expect(windsurf).toBeDefined()
-    expect(windsurf!.dir).toBe('.windsurf')
+    expect(windsurf!.dir).toBe('.codeium/windsurf')
   })
 
   it('all dirs start with a dot', () => {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -94,7 +94,12 @@ export const AGENT_DEFINITIONS = [
   { id: 'roo', cliId: 'roo', name: 'Roo Code', dir: '.roo' },
   { id: 'amp', cliId: 'amp', name: 'Amp', dir: '.config/amp' },
   { id: 'goose', cliId: 'goose', name: 'Goose', dir: '.config/goose' },
-  { id: 'windsurf', cliId: 'windsurf', name: 'Windsurf', dir: '.windsurf' },
+  {
+    id: 'windsurf',
+    cliId: 'windsurf',
+    name: 'Windsurf',
+    dir: '.codeium/windsurf',
+  },
   { id: 'continue', cliId: 'continue', name: 'Continue', dir: '.continue' },
   { id: 'trae', cliId: 'trae', name: 'Trae', dir: '.trae' },
   { id: 'junie', cliId: 'junie', name: 'Junie', dir: '.junie' },

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -222,6 +222,18 @@ export const UNIVERSAL_AGENT_IDS = [
 ] as const satisfies readonly AgentId[]
 
 /**
+ * Pinned `vercel-labs/skills` CLI version used by the main-process
+ * `skillsCliService` when spawning `npx skills@<version> ...`. Kept in the
+ * shared module so the `/cli-upgrade` maintenance skill has a single place
+ * to bump alongside `AGENT_DEFINITIONS`. Consumers must template this into
+ * their spawn args rather than hard-coding a version string — drift here
+ * would silently run a stale CLI against up-to-date agent definitions.
+ * @example
+ * spawn('npx', [`skills@${SKILLS_CLI_VERSION}`, 'find', 'react'])
+ */
+export const SKILLS_CLI_VERSION = '1.5.1'
+
+/**
  * Undo window for bulk skill deletes (ms). The trashService tombstone TTL and
  * the renderer undo-toast duration must stay in lockstep — if the on-disk
  * tombstone expires before the toast, a user's "undo" click races an empty


### PR DESCRIPTION
## Summary

- Sync `AGENT_DEFINITIONS` with `vercel-labs/skills` CLI **v1.5.1** — restore `windsurf` to `.codeium/windsurf` to match CLI's `globalSkillsDir` (Feb 2026 deviation in `ccebb60` was based on a misreading of the CLI source).
- Introduce `SKILLS_CLI_VERSION = '1.5.1'` in `src/shared/constants.ts` and thread it through `skillsCliService` — replaces a hard-coded `skills@1.3.0` spawn target that would have silently dropped `--agent` flags the older CLI doesn't recognize.
- Update `/cli-upgrade` skill procedure (local-only, gitignored) to make version bump a mandatory step alongside agent sync, gated by a `rg \"skills@[0-9]\" src/` sanity check.

## Why both changes in one branch

Agent-definition drift and CLI-version drift are two halves of the same sync — splitting them would create a window where the app invokes one CLI version against agent IDs valid in another. See commit messages on `cca078a` and `5d05019` for full reasoning.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` — 420/420 passing, includes updated `windsurf` dir assertion
- [x] `rg \"skills@[0-9]\" src/` — zero literal pins remain
- [ ] Manual: launch app, open Marketplace, install a skill, confirm spawn uses `skills@1.5.1`

## Related

- Follows agent sync groundwork from #80
- Issue #81 tracks the downstream "skill update" CLI feature introduced in v1.5.x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned the Skills CLI version to 1.5.1 via a centralized constant.
  * Updated the Windsurf agent directory to .codeium/windsurf.

* **Documentation**
  * Replaced hardcoded CLI invocations with a version placeholder so commands reflect the pinned CLI version.

* **Tests**
  * Adjusted tests to match the updated directory and dynamic CLI version behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->