### PR TITLE
feat(skills): bulk-select toggle + colorful types + ts-pattern refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ CLAUDE.md
 .superpowers/
 .gstack/
 .bridgespace/
+
+# QA reports
+qa-reports/

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs/promises'
 import { join } from 'node:path'
 
 import type { IpcMainInvokeEvent } from 'electron'
+import { match } from 'ts-pattern'
 
 import { BULK_PROGRESS_THRESHOLD } from '../../shared/constants'
 import { IPC_CHANNELS } from '../../shared/ipc-channels'
@@ -81,26 +82,27 @@ async function removeFromAgent(
   }
 
   try {
-    if (stats.isSymbolicLink()) {
-      await fs.unlink(linkPath)
-    } else if (stats.isDirectory()) {
-      // A real directory inside an agent dir is a "local skill" — actual
-      // user-owned files, not a symlink. Bulk unlink is advertised as a
-      // non-destructive op, so we refuse to delete the data here. The user
-      // must go through bulk Delete (which moves to trash with 15s undo)
-      // if they actually want the files gone.
-      return {
-        success: false,
+    // Discriminate on file-stat kind: symlink → unlink, local directory →
+    // refuse (bulk unlink is non-destructive; user must go through bulk
+    // Delete), everything else (files, sockets, etc.) → refuse as unsupported.
+    const kindResult = await match({
+      isSymlink: stats.isSymbolicLink(),
+      isDirectory: stats.isDirectory(),
+    })
+      .with({ isSymlink: true }, async () => {
+        await fs.unlink(linkPath)
+        return { success: true } as const
+      })
+      .with({ isSymlink: false, isDirectory: true }, async () => ({
+        success: false as const,
         error:
           'Cannot unlink a local skill. Use Delete to move it to trash instead.',
-      }
-    } else {
-      return {
-        success: false,
+      }))
+      .otherwise(async () => ({
+        success: false as const,
         error: 'Cannot remove: path is neither a symlink nor a directory',
-      }
-    }
-    return { success: true }
+      }))
+    return kindResult
   } catch (error) {
     return {
       success: false,
@@ -133,20 +135,27 @@ export function registerSkillsHandlers(): void {
       // symlinked-skill unlink fails with "Path traversal attempt detected".
       validatePath(linkPath, getAllowedBases())
       const stats = await fs.lstat(linkPath)
-      if (stats.isSymbolicLink()) {
-        // Remove symlink
-        await fs.unlink(linkPath)
-      } else if (stats.isDirectory()) {
-        // Remove local skill folder
-        await fs.rm(linkPath, { recursive: true, force: true })
-      } else {
-        return {
-          success: false,
+      // Discriminate on file-stat kind: symlink → unlink, directory → rm -rf
+      // (destructive is OK here because the single-unlink handler has its own
+      // confirmation UX in the renderer), else → refuse.
+      const unlinkResult = await match({
+        isSymlink: stats.isSymbolicLink(),
+        isDirectory: stats.isDirectory(),
+      })
+        .with({ isSymlink: true }, async () => {
+          await fs.unlink(linkPath)
+          return { success: true } as const
+        })
+        .with({ isSymlink: false, isDirectory: true }, async () => {
+          await fs.rm(linkPath, { recursive: true, force: true })
+          return { success: true } as const
+        })
+        .otherwise(async () => ({
+          success: false as const,
           error: 'Cannot remove: path is neither a symlink nor a directory',
-        }
-      }
+        }))
 
-      return { success: true }
+      return unlinkResult
     } catch (error) {
       return { success: false, error: extractErrorMessage(error) }
     }
@@ -449,20 +458,33 @@ export function registerSkillsHandlers(): void {
       error: string
     }> = []
 
-    // Detect source type
+    // Detect source type. Discriminate on file-stat kind:
+    //   symlink   → record target so we replicate the link
+    //   directory → physical copy path (isSymlink stays false)
+    //   other     → reject all targets with a per-agent failure row
     let isSymlink = false
     let symlinkTarget = ''
     try {
       const stats = await fs.lstat(linkPath)
-      if (stats.isSymbolicLink()) {
-        isSymlink = true
-        symlinkTarget = await fs.readlink(linkPath)
-        // Validate the resolved symlink target is within allowed bases.
-        // After the CREATE_SYMLINKS fix, symlinks may legitimately point at
-        // either SOURCE_DIR (source skills) or another agent's dir (local
-        // skills linked across agents), so [SOURCE_DIR] alone is too strict.
-        validatePath(symlinkTarget, getAllowedBases())
-      } else if (!stats.isDirectory()) {
+      const detectionOutcome = await match({
+        isSymlink: stats.isSymbolicLink(),
+        isDirectory: stats.isDirectory(),
+      })
+        .with({ isSymlink: true }, async () => {
+          const target = await fs.readlink(linkPath)
+          // Validate the resolved symlink target is within allowed bases.
+          // After the CREATE_SYMLINKS fix, symlinks may legitimately point at
+          // either SOURCE_DIR (source skills) or another agent's dir (local
+          // skills linked across agents), so [SOURCE_DIR] alone is too strict.
+          validatePath(target, getAllowedBases())
+          return { kind: 'symlink' as const, target }
+        })
+        .with({ isSymlink: false, isDirectory: true }, async () => ({
+          kind: 'directory' as const,
+        }))
+        .otherwise(async () => ({ kind: 'invalid' as const }))
+
+      if (detectionOutcome.kind === 'invalid') {
         return {
           success: false,
           copied: 0,
@@ -471,6 +493,10 @@ export function registerSkillsHandlers(): void {
             error: 'Source is neither a symlink nor a directory',
           })),
         }
+      }
+      if (detectionOutcome.kind === 'symlink') {
+        isSymlink = true
+        symlinkTarget = detectionOutcome.target
       }
     } catch (error) {
       return {

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -1,5 +1,5 @@
 import * as fs from 'node:fs/promises'
-import { join } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 
 import type { IpcMainInvokeEvent } from 'electron'
 import { match } from 'ts-pattern'
@@ -471,13 +471,18 @@ export function registerSkillsHandlers(): void {
         isDirectory: stats.isDirectory(),
       })
         .with({ isSymlink: true }, async () => {
-          const target = await fs.readlink(linkPath)
+          // `readlink` returns the raw target, which can be relative to the
+          // symlink's own directory. Resolve it against `dirname(linkPath)`
+          // so validation and replication see an absolute filesystem path
+          // rather than a cwd-relative string.
+          const rawTarget = await fs.readlink(linkPath)
+          const resolvedTarget = resolve(dirname(linkPath), rawTarget)
           // Validate the resolved symlink target is within allowed bases.
           // After the CREATE_SYMLINKS fix, symlinks may legitimately point at
           // either SOURCE_DIR (source skills) or another agent's dir (local
           // skills linked across agents), so [SOURCE_DIR] alone is too strict.
-          validatePath(target, getAllowedBases())
-          return { kind: 'symlink' as const, target }
+          validatePath(resolvedTarget, getAllowedBases())
+          return { kind: 'symlink' as const, target: resolvedTarget }
         })
         .with({ isSymlink: false, isDirectory: true }, async () => ({
           kind: 'directory' as const,

--- a/src/main/services/dirScanner.ts
+++ b/src/main/services/dirScanner.ts
@@ -1,16 +1,20 @@
 import { readdir } from 'fs/promises'
 import { join } from 'path'
 
+import type { AbsolutePath, SkillName } from '../../shared/types'
 import { SOURCE_DIR } from '../constants'
 
 import { isValidSkillDir } from './skillValidation'
 
 /**
- * Entry representing a valid skill directory on disk
+ * Entry representing a valid skill directory on disk.
+ * @example { name: 'tdd-workflow', path: '/Users/me/.agents/skills/tdd-workflow' }
  */
 export interface SkillDirEntry {
-  name: string
-  path: string
+  /** Directory name, matches the skill's identifier. @example "tdd-workflow" */
+  name: SkillName
+  /** Absolute path to the skill directory on disk. */
+  path: AbsolutePath
 }
 
 /**

--- a/src/main/services/skillScanner.ts
+++ b/src/main/services/skillScanner.ts
@@ -4,7 +4,14 @@ import { join } from 'path'
 
 import { formatBytes } from '../../shared/fileTypes'
 import { repositoryId } from '../../shared/types'
-import type { Skill, SourceStats, SymlinkInfo } from '../../shared/types'
+import type {
+  HttpUrl,
+  RepositoryId,
+  Skill,
+  SkillName,
+  SourceStats,
+  SymlinkInfo,
+} from '../../shared/types'
 import { AGENTS, SOURCE_DIR } from '../constants'
 
 import { listValidSourceSkillDirs } from './dirScanner'
@@ -14,11 +21,20 @@ import { checkSkillSymlinks, countValidSymlinks } from './symlinkChecker'
 
 /**
  * Entry from ~/.agents/.skill-lock.json
+ * @example
+ * {
+ *   source: 'pbakaus/impeccable',
+ *   sourceType: 'github',
+ *   sourceUrl: 'https://github.com/pbakaus/impeccable.git',
+ * }
  */
 interface SkillLockEntry {
-  source: string
+  /** Repository identifier in GitHub owner/repo form. @example "pbakaus/impeccable" */
+  source: RepositoryId
+  /** Source kind tag (free-form string from skills CLI). @example "github" */
   sourceType: string
-  sourceUrl: string
+  /** Full clone URL to the source repository. */
+  sourceUrl: HttpUrl
 }
 
 /**
@@ -28,7 +44,7 @@ interface SkillLockEntry {
  * readSkillLock()
  * // => Map { 'frontend-design' => { source: 'pbakaus/impeccable', sourceUrl: '...' } }
  */
-async function readSkillLock(): Promise<Map<string, SkillLockEntry>> {
+async function readSkillLock(): Promise<Map<SkillName, SkillLockEntry>> {
   try {
     const lockPath = join(homedir(), '.agents', '.skill-lock.json')
     const content = await readFile(lockPath, 'utf-8')
@@ -174,7 +190,7 @@ async function scanAllLocalSkills(): Promise<Skill[]> {
  * getSkill('theme-generator')
  * // => { name: 'theme-generator', ... } or null
  */
-export async function getSkill(skillName: string): Promise<Skill | null> {
+export async function getSkill(skillName: SkillName): Promise<Skill | null> {
   const skillPath = join(SOURCE_DIR, skillName)
 
   try {

--- a/src/main/services/symlinkChecker.ts
+++ b/src/main/services/symlinkChecker.ts
@@ -1,7 +1,12 @@
 import { lstat, readlink, access } from 'fs/promises'
 import { dirname, join, resolve } from 'path'
 
-import type { SymlinkInfo, SymlinkStatus } from '../../shared/types'
+import type {
+  AbsolutePath,
+  SkillName,
+  SymlinkInfo,
+  SymlinkStatus,
+} from '../../shared/types'
 import { AGENTS } from '../constants'
 
 /**
@@ -61,7 +66,7 @@ async function checkLinkOrLocal(path: string): Promise<LinkOrLocalResult> {
  * // => [{ agentId: 'claude', status: 'valid', isLocal: false, ... }, ...]
  */
 export async function checkSkillSymlinks(
-  skillName: string,
+  skillName: SkillName,
 ): Promise<SymlinkInfo[]> {
   const results = await Promise.all(
     AGENTS.map(async (agent) => {
@@ -100,7 +105,7 @@ export async function checkSkillSymlinks(
  * // => 'valid' (if symlink exists and target exists)
  */
 export async function checkSymlinkStatus(
-  linkPath: string,
+  linkPath: AbsolutePath,
 ): Promise<SymlinkStatus> {
   try {
     const stats = await lstat(linkPath)

--- a/src/main/services/symlinkChecker.ts
+++ b/src/main/services/symlinkChecker.ts
@@ -1,6 +1,8 @@
 import { lstat, readlink, access } from 'fs/promises'
 import { dirname, join, resolve } from 'path'
 
+import { match } from 'ts-pattern'
+
 import type {
   AbsolutePath,
   SkillName,
@@ -33,25 +35,39 @@ async function checkLinkOrLocal(path: string): Promise<LinkOrLocalResult> {
   try {
     const stats = await lstat(path)
 
-    if (stats.isSymbolicLink()) {
-      // It's a symlink - check if target exists
-      // resolve() handles both absolute and relative targets correctly:
-      // absolute target → returned as-is, relative → resolved from symlink's directory
-      const target = await readlink(path)
-      const resolvedTarget = resolve(dirname(path), target)
-      try {
-        await access(resolvedTarget)
-        return { status: 'valid', isLocal: false }
-      } catch {
-        return { status: 'broken', isLocal: false }
-      }
-    } else if (stats.isDirectory()) {
-      // Real folder = local skill
-      return { status: 'valid', isLocal: true }
-    }
-
-    // It's a file (not directory), treat as missing
-    return { status: 'missing', isLocal: false }
+    // Discriminate on file-stat kind:
+    //   symlink   → check target (valid vs broken)
+    //   directory → local skill (real folder)
+    //   other     → treat as missing (file, socket, etc.)
+    return await match({
+      isSymlink: stats.isSymbolicLink(),
+      isDirectory: stats.isDirectory(),
+    })
+      .with({ isSymlink: true }, async (): Promise<LinkOrLocalResult> => {
+        // resolve() handles both absolute and relative targets correctly:
+        // absolute target → returned as-is, relative → resolved from symlink's directory
+        const target = await readlink(path)
+        const resolvedTarget = resolve(dirname(path), target)
+        try {
+          await access(resolvedTarget)
+          return { status: 'valid', isLocal: false }
+        } catch {
+          return { status: 'broken', isLocal: false }
+        }
+      })
+      .with(
+        { isSymlink: false, isDirectory: true },
+        async (): Promise<LinkOrLocalResult> => ({
+          status: 'valid',
+          isLocal: true,
+        }),
+      )
+      .otherwise(
+        async (): Promise<LinkOrLocalResult> => ({
+          status: 'missing',
+          isLocal: false,
+        }),
+      )
   } catch {
     return { status: 'missing', isLocal: false }
   }

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { dirname, isAbsolute, join, resolve } from 'node:path'
 
+import { match } from 'ts-pattern'
 import type { z } from 'zod'
 
 import { UNDO_WINDOW_MS } from '../../shared/constants'
@@ -214,26 +215,34 @@ export async function moveToTrash(
     await fs.rename(sourcePath, entrySourceDir)
   } catch (error) {
     const code = errorCode(error)
-    const trashError =
-      code === 'EXDEV'
-        ? await (async () => {
-            try {
-              await fs.cp(sourcePath, entrySourceDir, { recursive: true })
-              await fs.rm(sourcePath, { recursive: true, force: true })
-              return null
-            } catch (fallbackError) {
-              return new TrashError(
-                `Failed to move source to trash (cross-device): ${extractErrorMessage(fallbackError)}`,
-                errorCode(fallbackError),
-              )
-            }
-          })()
-        : code === 'ENOENT'
-          ? new TrashError('Skill not found (already deleted?)', code)
-          : new TrashError(
-              `Failed to move source to trash: ${extractErrorMessage(error)}`,
-              code,
-            )
+    // Discriminate on the errno code:
+    //   EXDEV  → cross-device rename; fall back to copy + remove (returns null on success)
+    //   ENOENT → source already gone
+    //   other  → generic failure surfacing the underlying message
+    const trashError = await match(code)
+      .with('EXDEV', async () => {
+        try {
+          await fs.cp(sourcePath, entrySourceDir, { recursive: true })
+          await fs.rm(sourcePath, { recursive: true, force: true })
+          return null
+        } catch (fallbackError) {
+          return new TrashError(
+            `Failed to move source to trash (cross-device): ${extractErrorMessage(fallbackError)}`,
+            errorCode(fallbackError),
+          )
+        }
+      })
+      .with(
+        'ENOENT',
+        async () => new TrashError('Skill not found (already deleted?)', code),
+      )
+      .otherwise(
+        async () =>
+          new TrashError(
+            `Failed to move source to trash: ${extractErrorMessage(error)}`,
+            code,
+          ),
+      )
 
     if (trashError !== null) {
       // Rollback: re-create symlinks we unlinked earlier, and drop the empty

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2,9 +2,24 @@ import { contextBridge } from 'electron'
 
 import { IPC_CHANNELS } from '../shared/ipc-channels'
 import type {
+  AbsolutePath,
+  CopyToAgentsOptions,
+  CreateSymlinksOptions,
   DeleteProgressPayload,
+  DeleteSkillOptions,
+  DeleteSkillsOptions,
   DownloadProgress,
+  HttpUrl,
+  InstallOptions,
   InstallProgress,
+  RankingFilter,
+  RemoveAllFromAgentOptions,
+  RestoreDeletedSkillOptions,
+  SearchQuery,
+  SkillName,
+  SyncExecuteOptions,
+  UnlinkFromAgentOptions,
+  UnlinkManyFromAgentOptions,
   UpdateInfo,
 } from '../shared/types'
 
@@ -18,37 +33,30 @@ contextBridge.exposeInMainWorld('electron', {
   // preload scripts and is only callable from the main process.
   // URL shape (http/https only) is enforced by the Zod schema at the handler.
   shell: {
-    openExternal: async (url: string) => typedInvoke('shell:openExternal', url),
+    openExternal: async (url: HttpUrl) =>
+      typedInvoke('shell:openExternal', url),
   },
   // Skills API
   skills: {
     getAll: async () => typedInvoke('skills:getAll'),
-    unlinkFromAgent: async (
-      options: Parameters<typeof typedInvoke<'skills:unlinkFromAgent'>>[1],
-    ) => typedInvoke('skills:unlinkFromAgent', options),
-    removeAllFromAgent: async (
-      options: Parameters<typeof typedInvoke<'skills:removeAllFromAgent'>>[1],
-    ) => typedInvoke('skills:removeAllFromAgent', options),
-    deleteSkill: async (
-      options: Parameters<typeof typedInvoke<'skills:deleteSkill'>>[1],
-    ) => typedInvoke('skills:deleteSkill', options),
-    createSymlinks: async (
-      options: Parameters<typeof typedInvoke<'skills:createSymlinks'>>[1],
-    ) => typedInvoke('skills:createSymlinks', options),
-    copyToAgents: async (
-      options: Parameters<typeof typedInvoke<'skills:copyToAgents'>>[1],
-    ) => typedInvoke('skills:copyToAgents', options),
+    unlinkFromAgent: async (options: UnlinkFromAgentOptions) =>
+      typedInvoke('skills:unlinkFromAgent', options),
+    removeAllFromAgent: async (options: RemoveAllFromAgentOptions) =>
+      typedInvoke('skills:removeAllFromAgent', options),
+    deleteSkill: async (options: DeleteSkillOptions) =>
+      typedInvoke('skills:deleteSkill', options),
+    createSymlinks: async (options: CreateSymlinksOptions) =>
+      typedInvoke('skills:createSymlinks', options),
+    copyToAgents: async (options: CopyToAgentsOptions) =>
+      typedInvoke('skills:copyToAgents', options),
     // Bulk delete + undo (Section E of the bulk-delete plan).
     // deleteSkills runs serially in main; batches of >=10 emit progress events.
-    deleteSkills: async (
-      options: Parameters<typeof typedInvoke<'skills:deleteSkills'>>[1],
-    ) => typedInvoke('skills:deleteSkills', options),
-    unlinkManyFromAgent: async (
-      options: Parameters<typeof typedInvoke<'skills:unlinkManyFromAgent'>>[1],
-    ) => typedInvoke('skills:unlinkManyFromAgent', options),
-    restoreDeletedSkill: async (
-      options: Parameters<typeof typedInvoke<'skills:restoreDeletedSkill'>>[1],
-    ) => typedInvoke('skills:restoreDeletedSkill', options),
+    deleteSkills: async (options: DeleteSkillsOptions) =>
+      typedInvoke('skills:deleteSkills', options),
+    unlinkManyFromAgent: async (options: UnlinkManyFromAgentOptions) =>
+      typedInvoke('skills:unlinkManyFromAgent', options),
+    restoreDeletedSkill: async (options: RestoreDeletedSkillOptions) =>
+      typedInvoke('skills:restoreDeletedSkill', options),
     onDeleteProgress: createIpcListener<DeleteProgressPayload>(
       IPC_CHANNELS.SKILLS_DELETE_PROGRESS,
     ),
@@ -63,9 +71,10 @@ contextBridge.exposeInMainWorld('electron', {
   },
   // Files API
   files: {
-    list: async (skillPath: string) => typedInvoke('files:list', skillPath),
-    read: async (filePath: string) => typedInvoke('files:read', filePath),
-    readBinary: async (filePath: string) =>
+    list: async (skillPath: AbsolutePath) =>
+      typedInvoke('files:list', skillPath),
+    read: async (filePath: AbsolutePath) => typedInvoke('files:read', filePath),
+    readBinary: async (filePath: AbsolutePath) =>
       typedInvoke('files:readBinary', filePath),
   },
   // Update API
@@ -86,11 +95,11 @@ contextBridge.exposeInMainWorld('electron', {
   },
   // Skills CLI API (Marketplace)
   skillsCli: {
-    search: async (query: string) => typedInvoke('skills:cli:search', query),
-    install: async (
-      options: Parameters<typeof typedInvoke<'skills:cli:install'>>[1],
-    ) => typedInvoke('skills:cli:install', options),
-    remove: async (skillName: string) =>
+    search: async (query: SearchQuery) =>
+      typedInvoke('skills:cli:search', query),
+    install: async (options: InstallOptions) =>
+      typedInvoke('skills:cli:install', options),
+    remove: async (skillName: SkillName) =>
       typedInvoke('skills:cli:remove', skillName),
     cancel: async () => typedInvoke('skills:cli:cancel'),
     onProgress: createIpcListener<InstallProgress>(
@@ -99,15 +108,13 @@ contextBridge.exposeInMainWorld('electron', {
   },
   // Marketplace Leaderboard
   marketplace: {
-    leaderboard: async (
-      options: Parameters<typeof typedInvoke<'marketplace:leaderboard'>>[1],
-    ) => typedInvoke('marketplace:leaderboard', options),
+    leaderboard: async (options: { filter: RankingFilter }) =>
+      typedInvoke('marketplace:leaderboard', options),
   },
   // Sync API
   sync: {
     preview: async () => typedInvoke('sync:preview'),
-    execute: async (
-      options: Parameters<typeof typedInvoke<'sync:execute'>>[1],
-    ) => typedInvoke('sync:execute', options),
+    execute: async (options: SyncExecuteOptions) =>
+      typedInvoke('sync:execute', options),
   },
 })

--- a/src/renderer/src/components/dashboard/DashboardCanvas.tsx
+++ b/src/renderer/src/components/dashboard/DashboardCanvas.tsx
@@ -15,7 +15,7 @@ import {
 
 import { DashboardEditToolbar } from './DashboardEditToolbar'
 import { DashboardPageTabs } from './DashboardPageTabs'
-import type { WidgetInstance } from './types'
+import type { DashboardPageId, WidgetInstance } from './types'
 import { useDashboardKeyboardShortcuts } from './useDashboardKeyboardShortcuts'
 import {
   GRID_COLS,
@@ -82,11 +82,7 @@ export const DashboardCanvas = React.memo(
 // ----------------------------------------------------------------------------
 
 interface DashboardGridProps {
-  pageId: ReturnType<typeof selectCurrentPage> extends infer T
-    ? T extends { id: infer I }
-      ? I
-      : never
-    : never
+  pageId: DashboardPageId
   widgets: readonly WidgetInstance[]
   isEditMode: boolean
 }

--- a/src/renderer/src/components/dashboard/DashboardCanvas.tsx
+++ b/src/renderer/src/components/dashboard/DashboardCanvas.tsx
@@ -116,7 +116,6 @@ const DashboardGrid = React.memo(function DashboardGrid({
 
   const handleLayoutChange = useCallback(
     (next: Layout) => {
-      if (!pageId) return
       dispatch(
         updateLayout({
           pageId,

--- a/src/renderer/src/components/dashboard/DashboardPageTabs.tsx
+++ b/src/renderer/src/components/dashboard/DashboardPageTabs.tsx
@@ -1,5 +1,6 @@
 import { MoreHorizontal, Pencil, Plus, Trash2 } from 'lucide-react'
 import React, { useEffect, useRef, useState } from 'react'
+import { match } from 'ts-pattern'
 
 import { cn } from '../../lib/utils'
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
@@ -64,23 +65,19 @@ export const DashboardPageTabs = React.memo(
       if (pages.length === 0) return
 
       const currentIndex = pages.findIndex((page) => page.id === currentPageId)
-      let nextIndex = -1
-      switch (keyboardEvent.key) {
-        case 'ArrowLeft':
-          nextIndex = currentIndex > 0 ? currentIndex - 1 : pages.length - 1
-          break
-        case 'ArrowRight':
-          nextIndex = currentIndex < pages.length - 1 ? currentIndex + 1 : 0
-          break
-        case 'Home':
-          nextIndex = 0
-          break
-        case 'End':
-          nextIndex = pages.length - 1
-          break
-        default:
-          return
-      }
+      // -1 signals "no navigation for this key" — falls through to the early
+      // return below so unrelated keys don't swallow default browser behavior.
+      const nextIndex = match(keyboardEvent.key)
+        .with('ArrowLeft', () =>
+          currentIndex > 0 ? currentIndex - 1 : pages.length - 1,
+        )
+        .with('ArrowRight', () =>
+          currentIndex < pages.length - 1 ? currentIndex + 1 : 0,
+        )
+        .with('Home', () => 0)
+        .with('End', () => pages.length - 1)
+        .otherwise(() => -1)
+      if (nextIndex === -1) return
       keyboardEvent.preventDefault()
       const nextPage = pages[nextIndex]
       if (!nextPage) return

--- a/src/renderer/src/components/dashboard/widgets/BookmarksWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/BookmarksWidget.tsx
@@ -1,7 +1,7 @@
 import { Bookmark, ExternalLink, X } from 'lucide-react'
 import React from 'react'
 
-import type { BookmarkedSkill } from '../../../../../shared/types'
+import type { BookmarkedSkill, SkillName } from '../../../../../shared/types'
 import { useAppDispatch, useAppSelector } from '../../../redux/hooks'
 import {
   removeBookmark,
@@ -15,7 +15,7 @@ import {
 
 interface BookmarkRowProps {
   bookmark: BookmarkedSkill
-  onRemove: (name: BookmarkedSkill['name']) => void
+  onRemove: (name: SkillName) => void
 }
 
 const BookmarkRow = React.memo(function BookmarkRow({
@@ -82,7 +82,7 @@ export const BookmarksWidget = React.memo(
     const dispatch = useAppDispatch()
     const bookmarks = useAppSelector(selectBookmarkItems)
 
-    const handleRemove = (name: BookmarkedSkill['name']): void => {
+    const handleRemove = (name: SkillName): void => {
       dispatch(removeBookmark(name))
     }
 

--- a/src/renderer/src/components/dashboard/widgets/CoverageWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/CoverageWidget.tsx
@@ -1,7 +1,7 @@
 import { FolderDot, Link2 } from 'lucide-react'
 import React, { useMemo } from 'react'
 
-import type { Agent } from '../../../../../shared/types'
+import type { Agent, AgentId } from '../../../../../shared/types'
 import { useAppDispatch, useAppSelector } from '../../../redux/hooks'
 import { selectAgentItems } from '../../../redux/slices/agentsSlice'
 import { selectSkillsItems } from '../../../redux/slices/skillsSlice'
@@ -62,7 +62,7 @@ function buildCoverageRows(
 
 interface CoverageRowViewProps {
   row: CoverageRow
-  onSelect: (agentId: Agent['id']) => void
+  onSelect: (agentId: AgentId) => void
 }
 
 const CoverageRowView = React.memo(function CoverageRowView({
@@ -145,7 +145,7 @@ export const CoverageWidget = React.memo(
       [agents, skills.length],
     )
 
-    const handleSelect = (agentId: Agent['id']): void => {
+    const handleSelect = (agentId: AgentId): void => {
       dispatch(selectAgent(agentId))
     }
 

--- a/src/renderer/src/components/layout/MainContent.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.test.tsx
@@ -1,0 +1,332 @@
+// @vitest-environment happy-dom
+import { configureStore } from '@reduxjs/toolkit'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SkillName } from '../../../../shared/types'
+import { TooltipProvider } from '../ui/tooltip'
+
+const mockGetAll = vi.fn()
+const mockShellOpenExternal = vi.fn()
+const mockOnDeleteProgress = vi.fn(() => () => {})
+
+/**
+ * Short-circuit every heavy child MainContent renders so tests focus on the
+ * toggle button and the document-level keyboard shortcuts this file owns.
+ * Without these mocks the default render would drag in SkillsMarketplace,
+ * SkillsList (which fetches via IPC on mount), six dialogs, and the UndoToast.
+ */
+vi.mock('../skills/SkillsList', () => ({
+  SkillsList: () => null,
+}))
+vi.mock('../marketplace', () => ({
+  SkillsMarketplace: () => null,
+}))
+vi.mock('../skills/SearchBox', () => ({
+  SearchBox: () => null,
+}))
+vi.mock('../skills/SelectionToolbar', () => ({
+  SelectionToolbar: () => null,
+}))
+vi.mock('../skills/UnlinkDialog', () => ({
+  UnlinkDialog: () => null,
+}))
+vi.mock('../skills/AddSymlinkModal', () => ({
+  AddSymlinkModal: () => null,
+}))
+vi.mock('../skills/CopyToAgentsModal', () => ({
+  CopyToAgentsModal: () => null,
+}))
+vi.mock('../sidebar/SyncConfirmDialog', () => ({
+  SyncConfirmDialog: () => null,
+}))
+vi.mock('../sidebar/SyncConflictDialog', () => ({
+  SyncConflictDialog: () => null,
+}))
+vi.mock('../sidebar/SyncResultDialog', () => ({
+  SyncResultDialog: () => null,
+}))
+vi.mock('../skills/UndoToast', () => ({
+  UndoToast: () => null,
+}))
+vi.mock('../../redux/thunks', () => ({
+  refreshAllData: vi.fn(),
+}))
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    custom: vi.fn(() => 'toast-id'),
+    dismiss: vi.fn(),
+  }),
+}))
+
+beforeEach(() => {
+  mockGetAll.mockReset()
+  mockShellOpenExternal.mockReset()
+  mockOnDeleteProgress.mockReset()
+  mockOnDeleteProgress.mockImplementation(() => () => {})
+  // Stub only the `electron` global. happy-dom's globalThis IS the window, so
+  // `window.electron` resolves to this value while `window.addEventListener`
+  // and the rest of the Window prototype stay intact. Replacing `window`
+  // via spread would drop prototype methods SkillItem and friends rely on.
+  vi.stubGlobal('electron', {
+    skills: {
+      getAll: mockGetAll,
+      onDeleteProgress: mockOnDeleteProgress,
+    },
+    shell: {
+      openExternal: mockShellOpenExternal,
+    },
+  })
+})
+
+afterEach(() => {
+  // Without globals:true in vitest.config, @testing-library/react's auto-cleanup
+  // doesn't register. Call cleanup() explicitly so each render mounts into a
+  // fresh DOM — otherwise MainContents from prior tests stay mounted and the
+  // document keydown listener fires multiple times per event.
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+/**
+ * Build a combined store using each slice's own initialState so tests exercise
+ * real defaults without hand-crafting every field. Tests that need non-default
+ * state dispatch actions after rendering.
+ * @returns Redux store wired with the slices MainContent reads
+ */
+async function createStore() {
+  const { default: uiReducer } = await import('../../redux/slices/uiSlice')
+  const { default: skillsReducer } =
+    await import('../../redux/slices/skillsSlice')
+  const { default: agentsReducer } =
+    await import('../../redux/slices/agentsSlice')
+  const { default: bookmarksReducer } =
+    await import('../../redux/slices/bookmarkSlice')
+  const { default: marketplaceReducer } =
+    await import('../../redux/slices/marketplaceSlice')
+  return configureStore({
+    reducer: {
+      ui: uiReducer,
+      skills: skillsReducer,
+      agents: agentsReducer,
+      bookmarks: bookmarksReducer,
+      marketplace: marketplaceReducer,
+    },
+  })
+}
+
+/**
+ * Render MainContent inside its required provider stack (Redux + Tooltip).
+ * @returns Rendered result + store for dispatching setup actions or asserting state
+ */
+async function renderMainContent() {
+  const store = await createStore()
+  const { MainContent } = await import('./MainContent')
+  const utils = render(
+    <Provider store={store}>
+      <TooltipProvider>
+        <MainContent />
+      </TooltipProvider>
+    </Provider>,
+  )
+  return { ...utils, store }
+}
+
+describe('MainContent bulk-select toggle button', () => {
+  it('shows "Select" and aria-pressed=false by default', async () => {
+    await renderMainContent()
+
+    const toggleButton = screen.getByRole('button', {
+      name: /Enter bulk select mode/i,
+    })
+    expect(toggleButton.textContent).toContain('Select')
+    expect(toggleButton.getAttribute('aria-pressed')).toBe('false')
+  })
+
+  it('clicking "Select" enters bulk select mode', async () => {
+    const { store } = await renderMainContent()
+
+    const toggleButton = screen.getByRole('button', {
+      name: /Enter bulk select mode/i,
+    })
+    fireEvent.click(toggleButton)
+
+    expect(store.getState().ui.bulkSelectMode).toBe(true)
+  })
+
+  it('after entering mode the label flips to "Cancel" and aria-pressed=true', async () => {
+    const { store } = await renderMainContent()
+    const { enterBulkSelectMode } = await import('../../redux/slices/uiSlice')
+
+    await act(async () => {
+      store.dispatch(enterBulkSelectMode())
+    })
+
+    const toggleButton = screen.getByRole('button', {
+      name: /Exit bulk select mode/i,
+    })
+    expect(toggleButton.textContent).toContain('Cancel')
+    expect(toggleButton.getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('clicking "Cancel" exits mode AND clears accumulated selection', async () => {
+    const { store } = await renderMainContent()
+    const { enterBulkSelectMode } = await import('../../redux/slices/uiSlice')
+    const { toggleSelection } = await import('../../redux/slices/skillsSlice')
+
+    await act(async () => {
+      store.dispatch(enterBulkSelectMode())
+      store.dispatch(toggleSelection('task' as SkillName))
+      store.dispatch(toggleSelection('tdd' as SkillName))
+    })
+    expect(store.getState().skills.selectedSkillNames.length).toBe(2)
+
+    const toggleButton = screen.getByRole('button', {
+      name: /Exit bulk select mode/i,
+    })
+    fireEvent.click(toggleButton)
+
+    expect(store.getState().ui.bulkSelectMode).toBe(false)
+    expect(store.getState().skills.selectedSkillNames).toEqual([])
+  })
+})
+
+describe('MainContent keyboard shortcuts (Cmd+A)', () => {
+  it('Cmd+A is a no-op when bulkSelectMode=false (guards against hidden selection)', async () => {
+    const { store } = await renderMainContent()
+
+    fireEvent.keyDown(document, { key: 'a', metaKey: true })
+
+    expect(store.getState().skills.selectedSkillNames).toEqual([])
+  })
+
+  it('Ctrl+A is also a no-op when bulkSelectMode=false', async () => {
+    const { store } = await renderMainContent()
+
+    fireEvent.keyDown(document, { key: 'a', ctrlKey: true })
+
+    expect(store.getState().skills.selectedSkillNames).toEqual([])
+  })
+
+  it('Cmd+A dispatches selectAll over visible names when bulkSelectMode=true', async () => {
+    const { store } = await renderMainContent()
+    const { enterBulkSelectMode } = await import('../../redux/slices/uiSlice')
+    const { fetchSkills } = await import('../../redux/slices/skillsSlice')
+    const skillFixtures = [
+      {
+        name: 'task' as SkillName,
+        description: '',
+        path: '/skills/task' as never,
+        symlinkCount: 0,
+        symlinks: [],
+      },
+      {
+        name: 'tdd' as SkillName,
+        description: '',
+        path: '/skills/tdd' as never,
+        symlinkCount: 0,
+        symlinks: [],
+      },
+    ]
+
+    // Seeding via the thunk's fulfilled action avoids mocking the IPC call
+    // and exercises the real reducer path that fills `items` in production.
+    // act() wraps setup so useEffect flushes and `bulkSelectModeRef.current`
+    // sees the new mode before the keydown handler reads it.
+    await act(async () => {
+      store.dispatch(fetchSkills.fulfilled(skillFixtures, 'req-id'))
+      store.dispatch(enterBulkSelectMode())
+    })
+
+    fireEvent.keyDown(document, { key: 'a', metaKey: true })
+
+    const selectedNames = store.getState().skills.selectedSkillNames
+    expect(selectedNames).toContain('task')
+    expect(selectedNames).toContain('tdd')
+    expect(selectedNames.length).toBe(2)
+  })
+
+  it('Cmd+A is ignored when focus is inside an editable target', async () => {
+    const { store } = await renderMainContent()
+    const { enterBulkSelectMode } = await import('../../redux/slices/uiSlice')
+
+    await act(async () => {
+      store.dispatch(enterBulkSelectMode())
+    })
+
+    const textInput = document.createElement('input')
+    document.body.appendChild(textInput)
+    textInput.focus()
+    fireEvent.keyDown(textInput, { key: 'a', metaKey: true })
+
+    expect(store.getState().skills.selectedSkillNames).toEqual([])
+
+    document.body.removeChild(textInput)
+  })
+})
+
+describe('MainContent keyboard shortcuts (Esc 2-step)', () => {
+  it('first Esc with non-empty selection clears selection only (mode stays on)', async () => {
+    const { store } = await renderMainContent()
+    const { enterBulkSelectMode } = await import('../../redux/slices/uiSlice')
+    const { toggleSelection } = await import('../../redux/slices/skillsSlice')
+
+    await act(async () => {
+      store.dispatch(enterBulkSelectMode())
+      store.dispatch(toggleSelection('task' as SkillName))
+    })
+    expect(store.getState().skills.selectedSkillNames.length).toBe(1)
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(store.getState().skills.selectedSkillNames).toEqual([])
+    expect(store.getState().ui.bulkSelectMode).toBe(true)
+  })
+
+  it('second Esc with empty selection exits bulk select mode', async () => {
+    const { store } = await renderMainContent()
+    const { enterBulkSelectMode } = await import('../../redux/slices/uiSlice')
+
+    await act(async () => {
+      store.dispatch(enterBulkSelectMode())
+    })
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(store.getState().ui.bulkSelectMode).toBe(false)
+  })
+
+  it('Esc is a no-op when bulkSelectMode=false', async () => {
+    const { store } = await renderMainContent()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(store.getState().ui.bulkSelectMode).toBe(false)
+    expect(store.getState().skills.selectedSkillNames).toEqual([])
+  })
+
+  it('Esc is ignored when focus is inside an editable target', async () => {
+    const { store } = await renderMainContent()
+    const { enterBulkSelectMode } = await import('../../redux/slices/uiSlice')
+    const { toggleSelection } = await import('../../redux/slices/skillsSlice')
+
+    await act(async () => {
+      store.dispatch(enterBulkSelectMode())
+      store.dispatch(toggleSelection('task' as SkillName))
+    })
+
+    const textInput = document.createElement('input')
+    document.body.appendChild(textInput)
+    textInput.focus()
+    fireEvent.keyDown(textInput, { key: 'Escape' })
+
+    expect(store.getState().skills.selectedSkillNames).toEqual(['task'])
+    expect(store.getState().ui.bulkSelectMode).toBe(true)
+
+    document.body.removeChild(textInput)
+  })
+})

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -17,6 +17,7 @@ import type {
   SkillName,
   TombstoneId,
 } from '../../../../shared/types'
+import { cn } from '../../lib/utils'
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
 import {
   selectSelectedVisibleNames,
@@ -454,7 +455,7 @@ export const MainContent = React.memo(
                   activates Cmd/Ctrl+A + Esc shortcuts. Exiting clears any
                   accumulated selection so hidden state can't leak. */}
               <Button
-                variant={bulkSelectMode ? 'secondary' : 'ghost'}
+                variant="ghost"
                 size="sm"
                 aria-pressed={bulkSelectMode}
                 aria-label={
@@ -470,14 +471,19 @@ export const MainContent = React.memo(
                     dispatch(enterBulkSelectMode())
                   }
                 }}
-                className={`shrink-0 gap-1.5 min-h-[44px] ${
+                className={cn(
+                  'shrink-0 gap-1.5 min-h-[44px]',
                   bulkSelectMode
-                    ? ''
-                    : 'text-muted-foreground hover:text-foreground'
-                }`}
+                    ? 'text-primary'
+                    : 'text-muted-foreground hover:text-foreground',
+                )}
               >
-                <CheckSquare className="h-4 w-4" />
-                {bulkSelectMode ? 'Done' : 'Select'}
+                {bulkSelectMode ? (
+                  <X className="h-4 w-4" />
+                ) : (
+                  <CheckSquare className="h-4 w-4" />
+                )}
+                {bulkSelectMode ? 'Cancel' : 'Select'}
               </Button>
 
               {/* Skill type filter — agent view only */}

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -1,6 +1,7 @@
 import {
   ArrowDownAZ,
   ArrowUpAZ,
+  CheckSquare,
   ChevronDown,
   ExternalLink,
   X,
@@ -35,8 +36,11 @@ import type { ActiveTab, SkillTypeFilter } from '../../redux/slices/uiSlice'
 import {
   clearBulkConfirm,
   clearUndoToast,
+  enterBulkSelectMode,
+  exitBulkSelectMode,
   selectAgent,
   selectBulkConfirm,
+  selectBulkSelectMode,
   setActiveTab,
   setBulkConfirm,
   setSkillTypeFilter,
@@ -111,6 +115,7 @@ export const MainContent = React.memo(
     const selectedAllNames = useAppSelector(selectSelectedSkillNames)
 
     const bulkConfirm = useAppSelector(selectBulkConfirm)
+    const bulkSelectMode = useAppSelector(selectBulkSelectMode)
 
     const selectedAgent = agents.find((a) => a.id === selectedAgentId)
 
@@ -134,18 +139,27 @@ export const MainContent = React.memo(
     // listener — functionally correct but wasteful during active use.
     const visibleNamesRef = useRef(visibleNames)
     const selectedCountRef = useRef(selectedAllNames.length)
+    const bulkSelectModeRef = useRef(bulkSelectMode)
     useEffect(() => {
       visibleNamesRef.current = visibleNames
     }, [visibleNames])
     useEffect(() => {
       selectedCountRef.current = selectedAllNames.length
     }, [selectedAllNames.length])
+    useEffect(() => {
+      bulkSelectModeRef.current = bulkSelectMode
+    }, [bulkSelectMode])
 
     // Scoped to the Installed tab — Marketplace has its own selection context.
+    // Shortcuts are further gated on `bulkSelectMode` so a user outside of
+    // selection mode doesn't silently accumulate ticks they can't see (the
+    // "hidden selection" anti-pattern).
     useEffect(() => {
       if (activeTab !== 'installed') return
       const handleKey = (event: KeyboardEvent): void => {
         if (isEditableTarget(document.activeElement)) return
+        if (!bulkSelectModeRef.current) return
+
         // Cmd/Ctrl+A: select all visible
         if (
           (event.metaKey || event.ctrlKey) &&
@@ -155,10 +169,16 @@ export const MainContent = React.memo(
           dispatch(selectAll(visibleNamesRef.current))
           return
         }
-        // Esc: clear selection (only when selection is non-empty)
-        if (event.key === 'Escape' && selectedCountRef.current > 0) {
+        // Esc is 2-step: first press clears accumulated selection (protects
+        // against fat-finger mode exit mid-batch); a second Esc with empty
+        // selection then exits mode. Matches Gmail's multi-select pattern.
+        if (event.key === 'Escape') {
           event.preventDefault()
-          dispatch(clearSelection())
+          if (selectedCountRef.current > 0) {
+            dispatch(clearSelection())
+          } else {
+            dispatch(exitBulkSelectMode())
+          }
           return
         }
       }
@@ -428,6 +448,36 @@ export const MainContent = React.memo(
                 ) : (
                   <ArrowUpAZ className="h-4 w-4" />
                 )}
+              </Button>
+
+              {/* Bulk-select toggle — reveals checkboxes on skill cards and
+                  activates Cmd/Ctrl+A + Esc shortcuts. Exiting clears any
+                  accumulated selection so hidden state can't leak. */}
+              <Button
+                variant={bulkSelectMode ? 'secondary' : 'ghost'}
+                size="sm"
+                aria-pressed={bulkSelectMode}
+                aria-label={
+                  bulkSelectMode
+                    ? 'Exit bulk select mode'
+                    : 'Enter bulk select mode'
+                }
+                onClick={() => {
+                  if (bulkSelectMode) {
+                    dispatch(exitBulkSelectMode())
+                    dispatch(clearSelection())
+                  } else {
+                    dispatch(enterBulkSelectMode())
+                  }
+                }}
+                className={`shrink-0 gap-1.5 min-h-[44px] ${
+                  bulkSelectMode
+                    ? ''
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                <CheckSquare className="h-4 w-4" />
+                {bulkSelectMode ? 'Done' : 'Select'}
               </Button>
 
               {/* Skill type filter — agent view only */}

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -465,8 +465,12 @@ export const MainContent = React.memo(
                 }
                 onClick={() => {
                   if (bulkSelectMode) {
-                    dispatch(exitBulkSelectMode())
+                    // Order matters: clear selection first so no subscriber
+                    // can observe `mode=false` with stale `selectedSkillNames`
+                    // between dispatches. Preserves the SelectionToolbar
+                    // render-gate invariant "mode off ⇒ no selection".
                     dispatch(clearSelection())
+                    dispatch(exitBulkSelectMode())
                   } else {
                     dispatch(enterBulkSelectMode())
                   }

--- a/src/renderer/src/components/sidebar/AgentItem.tsx
+++ b/src/renderer/src/components/sidebar/AgentItem.tsx
@@ -2,7 +2,7 @@ import { Trash2 } from 'lucide-react'
 import React, { useMemo, useState } from 'react'
 
 import { AGENT_DEFINITIONS } from '../../../../shared/constants'
-import type { Agent } from '../../../../shared/types'
+import type { Agent, AgentId } from '../../../../shared/types'
 import { cn } from '../../lib/utils'
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
 import { setAgentToDelete } from '../../redux/slices/agentsSlice'
@@ -47,7 +47,7 @@ function buildSkillCountText(linked: number, local: number): string | null {
  * getAgentTooltipPath('claude-code') // => "~/.claude/skills/"
  * getAgentTooltipPath('cursor')      // => "~/.cursor/skills/"
  */
-function getAgentTooltipPath(agentId: string): string | undefined {
+function getAgentTooltipPath(agentId: AgentId): string | undefined {
   const def = AGENT_DEFINITIONS.find((d) => d.id === agentId)
   return def ? `~/${def.dir}/skills/` : undefined
 }

--- a/src/renderer/src/components/skills/FileTabs.tsx
+++ b/src/renderer/src/components/skills/FileTabs.tsx
@@ -2,14 +2,14 @@ import * as TabsPrimitive from '@radix-ui/react-tabs'
 import { FileCode, FileImage, FileText } from 'lucide-react'
 import React from 'react'
 
-import type { SkillFile } from '../../../../shared/types'
+import type { AbsolutePath, SkillFile } from '../../../../shared/types'
 import { cn } from '../../lib/utils'
 
 interface FileTabsProps {
   /** Pre-sorted list of previewable files (SKILL.md first, then alphabetical). */
   files: SkillFile[]
   /** Absolute path of the currently selected file, or null if none is active. */
-  activeFilePath: string | null
+  activeFilePath: AbsolutePath | null
 }
 
 /**

--- a/src/renderer/src/components/skills/SelectionToolbar.tsx
+++ b/src/renderer/src/components/skills/SelectionToolbar.tsx
@@ -17,7 +17,10 @@ import {
   selectBulkProgress,
   selectBulkUnlinking,
 } from '../../redux/slices/skillsSlice'
-import { selectSelectedAgentId } from '../../redux/slices/uiSlice'
+import {
+  selectBulkSelectMode,
+  selectSelectedAgentId,
+} from '../../redux/slices/uiSlice'
 import { Button } from '../ui/button'
 
 import { getToolbarState } from './bulkDeleteHelpers'
@@ -63,13 +66,18 @@ export const SelectionToolbar = React.memo(function SelectionToolbar({
   const hiddenSelectedCount = useAppSelector(selectHiddenSelectedCount)
   const visibleNames = useAppSelector(selectVisibleSkillNames)
   const selectedAgentId = useAppSelector(selectSelectedAgentId)
+  const bulkSelectMode = useAppSelector(selectBulkSelectMode)
   const bulkDeleting = useAppSelector(selectBulkDeleting)
   const bulkUnlinking = useAppSelector(selectBulkUnlinking)
   const bulkProgress = useAppSelector(selectBulkProgress)
 
-  // Hidden when there is nothing ticked — saves a DOM reflow and prevents
-  // the toolbar from briefly rendering with count=0 during deselection.
-  if (selectedCount === 0) return null
+  // Belt-and-suspenders: the listener middleware already clears selection on
+  // any context switch that exits bulkSelectMode, but gating here enforces the
+  // invariant at the render boundary too. The destructive Delete/Unlink action
+  // must only be reachable while the selection is visually auditable (i.e. the
+  // per-row checkboxes are rendered). If selection were ever to outlive mode,
+  // this gate prevents a Delete click over invisible state.
+  if (!bulkSelectMode || selectedCount === 0) return null
 
   const toolbarState = getToolbarState({
     view: selectedAgentId ? 'agent' : 'global',

--- a/src/renderer/src/components/skills/SkillItem.test.tsx
+++ b/src/renderer/src/components/skills/SkillItem.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment happy-dom
+import { configureStore } from '@reduxjs/toolkit'
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { Skill, SkillName } from '../../../../shared/types'
+import { TooltipProvider } from '../ui/tooltip'
+
+const mockGetAll = vi.fn()
+
+beforeEach(() => {
+  // Stub only the `electron` global. happy-dom's globalThis IS the window, so
+  // `window.electron` resolves to this value while `window.addEventListener`
+  // and the rest of the Window prototype stay intact. Replacing `window`
+  // itself via spread would drop everything on the prototype.
+  vi.stubGlobal('electron', {
+    skills: {
+      getAll: mockGetAll,
+      onDeleteProgress: vi.fn(() => () => {}),
+    },
+  })
+})
+
+afterEach(() => {
+  // Without globals:true in vitest.config, @testing-library/react's auto-cleanup
+  // afterEach doesn't register. Call cleanup() explicitly so each render mounts
+  // into a fresh DOM — otherwise earlier tests' SkillItems accumulate and
+  // queryByRole returns multi-match.
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+/**
+ * Build a minimal Skill fixture.
+ * @param overrides - Partial Skill overrides
+ * @returns Complete Skill object
+ * @example makeSkill({ name: 'browse' as SkillName })
+ */
+function makeSkill(overrides: Partial<Skill> = {}): Skill {
+  return {
+    name: 'task' as SkillName,
+    description: 'Task management skill',
+    path: '/home/user/.agents/skills/task' as Skill['path'],
+    symlinkCount: 0,
+    symlinks: [],
+    ...overrides,
+  }
+}
+
+/**
+ * Build a combined store with the slices SkillItem reads. Uses each slice's
+ * own initialState so tests exercise real defaults without hand-crafting
+ * every field.
+ * @returns Redux store
+ */
+async function createStore() {
+  const { default: uiReducer } = await import('../../redux/slices/uiSlice')
+  const { default: skillsReducer } =
+    await import('../../redux/slices/skillsSlice')
+  const { default: agentsReducer } =
+    await import('../../redux/slices/agentsSlice')
+  const { default: bookmarkReducer } =
+    await import('../../redux/slices/bookmarkSlice')
+  return configureStore({
+    reducer: {
+      ui: uiReducer,
+      skills: skillsReducer,
+      agents: agentsReducer,
+      bookmarks: bookmarkReducer,
+    },
+  })
+}
+
+/**
+ * Render SkillItem inside the provider stack it needs (Redux + Tooltip).
+ * @returns Rendered result + store so tests can dispatch extra setup actions.
+ */
+async function renderSkillItem(skill: Skill) {
+  const store = await createStore()
+  const { SkillItem } = await import('./SkillItem')
+  const utils = render(
+    <Provider store={store}>
+      <TooltipProvider>
+        <SkillItem skill={skill} />
+      </TooltipProvider>
+    </Provider>,
+  )
+  return { ...utils, store }
+}
+
+describe('SkillItem bulk-select checkbox visibility', () => {
+  it('hides the checkbox when bulkSelectMode=false (default clean list)', async () => {
+    await renderSkillItem(makeSkill())
+
+    expect(screen.queryByRole('checkbox')).toBeNull()
+  })
+
+  it('renders the checkbox when bulkSelectMode=true', async () => {
+    const { store } = await renderSkillItem(makeSkill())
+    const { enterBulkSelectMode } = await import('../../redux/slices/uiSlice')
+
+    await act(async () => {
+      store.dispatch(enterBulkSelectMode())
+    })
+
+    expect(screen.queryByRole('checkbox')).not.toBeNull()
+  })
+
+  it('checkbox aria-label is "Select {name}" when not ticked', async () => {
+    const { store } = await renderSkillItem(
+      makeSkill({ name: 'task' as SkillName }),
+    )
+    const { enterBulkSelectMode } = await import('../../redux/slices/uiSlice')
+    await act(async () => {
+      store.dispatch(enterBulkSelectMode())
+    })
+
+    expect(
+      screen.queryByRole('checkbox', { name: /Select task/i }),
+    ).not.toBeNull()
+  })
+
+  it('checkbox aria-label flips to "Deselect {name}" once ticked', async () => {
+    const { store } = await renderSkillItem(
+      makeSkill({ name: 'task' as SkillName }),
+    )
+    const { enterBulkSelectMode } = await import('../../redux/slices/uiSlice')
+    const { toggleSelection } = await import('../../redux/slices/skillsSlice')
+
+    await act(async () => {
+      store.dispatch(enterBulkSelectMode())
+      store.dispatch(toggleSelection('task' as SkillName))
+    })
+
+    expect(
+      screen.queryByRole('checkbox', { name: /Deselect task/i }),
+    ).not.toBeNull()
+  })
+
+  it('exiting bulk mode removes the checkbox from the DOM', async () => {
+    const { store } = await renderSkillItem(makeSkill())
+    const { enterBulkSelectMode, exitBulkSelectMode } =
+      await import('../../redux/slices/uiSlice')
+
+    await act(async () => {
+      store.dispatch(enterBulkSelectMode())
+    })
+    expect(screen.queryByRole('checkbox')).not.toBeNull()
+
+    await act(async () => {
+      store.dispatch(exitBulkSelectMode())
+    })
+    expect(screen.queryByRole('checkbox')).toBeNull()
+  })
+})

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -31,6 +31,7 @@ import {
   setSkillToUnlink,
   toggleSelection,
 } from '../../redux/slices/skillsSlice'
+import { selectBulkSelectMode } from '../../redux/slices/uiSlice'
 import { StatusBadge } from '../status/StatusBadge'
 import { Button } from '../ui/button'
 import { Card, CardContent } from '../ui/card'
@@ -90,6 +91,7 @@ export const SkillItem = React.memo(function SkillItem({
   const inFlightDeleteSet = useAppSelector(selectInFlightDeleteNamesSet)
   const selectionAnchor = useAppSelector(selectSelectionAnchor)
   const visibleNames = useAppSelector(selectVisibleSkillNames)
+  const bulkSelectMode = useAppSelector(selectBulkSelectMode)
   const isTicked = selectedNamesSet.has(skill.name)
   const isInFlight = inFlightDeleteSet.has(skill.name)
 
@@ -349,20 +351,26 @@ export const SkillItem = React.memo(function SkillItem({
               {/* 44×44 hit area via the wrapper; the visual Checkbox stays
                   16×16 per shadcn default. The focusable Checkbox below owns
                   the accessible name — duplicating `aria-label` on the wrapper
-                  caused some screen readers to announce the skill twice. */}
-              <label
-                className="shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center -mt-1 -ml-1 cursor-pointer"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <Checkbox
-                  checked={isTicked}
-                  onCheckedChange={handleCheckedChange}
-                  onPointerDown={handleCheckboxPointerDown}
-                  aria-label={
-                    isTicked ? `Deselect ${skill.name}` : `Select ${skill.name}`
-                  }
-                />
-              </label>
+                  caused some screen readers to announce the skill twice.
+                  Rendered only when the user has entered bulk-select mode via
+                  the filter-row toggle; the default view stays clean. */}
+              {bulkSelectMode && (
+                <label
+                  className="shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center -mt-1 -ml-1 cursor-pointer"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <Checkbox
+                    checked={isTicked}
+                    onCheckedChange={handleCheckedChange}
+                    onPointerDown={handleCheckboxPointerDown}
+                    aria-label={
+                      isTicked
+                        ? `Deselect ${skill.name}`
+                        : `Select ${skill.name}`
+                    }
+                  />
+                </label>
+              )}
               <div className="flex-1 min-w-0">
                 <h3 className="font-medium truncate flex items-center gap-1.5">
                   {isLinked && (

--- a/src/renderer/src/components/skills/SourceLink.tsx
+++ b/src/renderer/src/components/skills/SourceLink.tsx
@@ -1,11 +1,13 @@
 import { ExternalLink } from 'lucide-react'
 import React from 'react'
 
+import type { HttpUrl, RepositoryId } from '../../../../shared/types'
+
 import { getSourceLinkModel } from './sourceLinkHelpers'
 
 interface SourceLinkProps {
-  source?: string
-  sourceUrl?: string
+  source?: RepositoryId
+  sourceUrl?: HttpUrl
 }
 
 /**

--- a/src/renderer/src/components/skills/UndoToast.tsx
+++ b/src/renderer/src/components/skills/UndoToast.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import type {
   IsoTimestamp,
   SkillName,
+  ToastId,
   TombstoneId,
 } from '../../../../shared/types'
 import { cn } from '../../lib/utils'
@@ -16,7 +17,7 @@ const URGENT_SECONDS_THRESHOLD = 5
 
 interface UndoToastProps {
   /** sonner toast id — passed back so callbacks can `toast.dismiss(id)`. */
-  toastId: string | number
+  toastId: ToastId
   skillNames: SkillName[]
   /** Empty for unlink (no tombstones produced). */
   tombstoneIds: TombstoneId[]

--- a/src/renderer/src/components/skills/sourceLinkHelpers.test.ts
+++ b/src/renderer/src/components/skills/sourceLinkHelpers.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
+import { repositoryId } from '../../../../shared/types'
+
 import { getSourceLinkModel } from './sourceLinkHelpers'
 
 describe('getSourceLinkModel', () => {
@@ -15,20 +17,22 @@ describe('getSourceLinkModel', () => {
     })
 
     it('returns local when source is empty string', () => {
-      expect(getSourceLinkModel('')).toEqual({ kind: 'local' })
+      expect(getSourceLinkModel(repositoryId(''))).toEqual({ kind: 'local' })
     })
   })
 
   describe('text (source without URL)', () => {
     it('returns text when source is present but sourceUrl is undefined', () => {
-      expect(getSourceLinkModel('pbakaus/impeccable')).toEqual({
+      expect(getSourceLinkModel(repositoryId('pbakaus/impeccable'))).toEqual({
         kind: 'text',
         source: 'pbakaus/impeccable',
       })
     })
 
     it('returns text when sourceUrl is empty string', () => {
-      expect(getSourceLinkModel('pbakaus/impeccable', '')).toEqual({
+      expect(
+        getSourceLinkModel(repositoryId('pbakaus/impeccable'), ''),
+      ).toEqual({
         kind: 'text',
         source: 'pbakaus/impeccable',
       })
@@ -39,7 +43,7 @@ describe('getSourceLinkModel', () => {
     it('strips trailing .git from sourceUrl', () => {
       expect(
         getSourceLinkModel(
-          'pbakaus/impeccable',
+          repositoryId('pbakaus/impeccable'),
           'https://github.com/pbakaus/impeccable.git',
         ),
       ).toEqual({
@@ -52,7 +56,7 @@ describe('getSourceLinkModel', () => {
     it('leaves non-.git URLs unchanged', () => {
       expect(
         getSourceLinkModel(
-          'pbakaus/impeccable',
+          repositoryId('pbakaus/impeccable'),
           'https://github.com/pbakaus/impeccable',
         ),
       ).toEqual({
@@ -65,7 +69,7 @@ describe('getSourceLinkModel', () => {
     it('only strips .git at the end, not mid-string', () => {
       expect(
         getSourceLinkModel(
-          'foo/bar.git-assets',
+          repositoryId('foo/bar.git-assets'),
           'https://github.com/foo/bar.git-assets',
         ),
       ).toEqual({

--- a/src/renderer/src/components/skills/sourceLinkHelpers.ts
+++ b/src/renderer/src/components/skills/sourceLinkHelpers.ts
@@ -1,3 +1,5 @@
+import type { HttpUrl, RepositoryId } from '../../../../shared/types'
+
 /**
  * Discriminated render model for `SourceLink`.
  * - `local`  — no source identifier; render the "Local" label
@@ -6,8 +8,8 @@
  */
 export type SourceLinkModel =
   | { kind: 'local' }
-  | { kind: 'text'; source: string }
-  | { kind: 'link'; source: string; href: string }
+  | { kind: 'text'; source: RepositoryId }
+  | { kind: 'link'; source: RepositoryId; href: HttpUrl }
 
 /**
  * Compute the render model for `SourceLink` from its props.
@@ -32,8 +34,8 @@ export type SourceLinkModel =
  * // => { kind: 'link', source: 'pbakaus/impeccable', href: 'https://github.com/pbakaus/impeccable' }
  */
 export function getSourceLinkModel(
-  source?: string,
-  sourceUrl?: string,
+  source?: RepositoryId,
+  sourceUrl?: HttpUrl,
 ): SourceLinkModel {
   if (!source) return { kind: 'local' }
   const href = sourceUrl ? sourceUrl.replace(/\.git$/, '') : undefined

--- a/src/renderer/src/hooks/useCodePreview.ts
+++ b/src/renderer/src/hooks/useCodePreview.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import type {
+  AbsolutePath,
   SkillBinaryContent,
   SkillFile,
   SkillFileContent,
@@ -18,8 +19,8 @@ export type PreviewContent =
 
 interface UseCodePreviewReturn {
   files: SkillFile[]
-  activeFile: string | null
-  setActiveFile: (path: string | null) => Promise<void>
+  activeFile: AbsolutePath | null
+  setActiveFile: (path: AbsolutePath | null) => Promise<void>
   content: PreviewContent
   loading: boolean
 }
@@ -40,16 +41,18 @@ interface UseCodePreviewReturn {
  * const { files, content, setActiveFile } = useCodePreview('/skills/tdd')
  * // content.kind === 'text' | 'image' | 'binary' | 'empty'
  */
-export function useCodePreview(skillPath: string): UseCodePreviewReturn {
+export function useCodePreview(skillPath: AbsolutePath): UseCodePreviewReturn {
   const [files, setFiles] = useState<SkillFile[]>([])
-  const [loadedPath, setLoadedPath] = useState<string | null>(null)
-  const [userSelectedFile, setUserSelectedFile] = useState<string | null>(null)
+  const [loadedPath, setLoadedPath] = useState<AbsolutePath | null>(null)
+  const [userSelectedFile, setUserSelectedFile] = useState<AbsolutePath | null>(
+    null,
+  )
   const [content, setContent] = useState<PreviewContent>({ kind: 'empty' })
   const prevSkillPathRef = useRef(skillPath)
   // Mirror of userSelectedFile readable synchronously from the initial-load
   // effect. The effect must check the *current* selection when its async IPC
   // resolves; reading state via closure would see a stale null snapshot.
-  const userSelectedFileRef = useRef<string | null>(null)
+  const userSelectedFileRef = useRef<AbsolutePath | null>(null)
 
   if (prevSkillPathRef.current !== skillPath) {
     prevSkillPathRef.current = skillPath
@@ -84,7 +87,7 @@ export function useCodePreview(skillPath: string): UseCodePreviewReturn {
   }, [skillPath])
 
   const setActiveFile = useCallback(
-    async (path: string | null) => {
+    async (path: AbsolutePath | null) => {
       if (path === activeFile) return
       userSelectedFileRef.current = path
       setUserSelectedFile(path)

--- a/src/renderer/src/lib/syncHelpers.ts
+++ b/src/renderer/src/lib/syncHelpers.ts
@@ -4,6 +4,7 @@ import {
   XCircle,
   type LucideIcon,
 } from 'lucide-react'
+import { match } from 'ts-pattern'
 
 import type {
   SyncExecuteResult,
@@ -71,17 +72,22 @@ export function getSyncResultPresentation(
   const hasErrors = result.errors.length > 0
   const hasSuccess = result.created > 0 || result.replaced > 0
 
-  const HeaderIcon: LucideIcon = hasErrors
-    ? hasSuccess
-      ? AlertTriangle
-      : XCircle
-    : CheckCircle2
-
-  const iconColor = hasErrors
-    ? hasSuccess
-      ? 'text-amber-500'
-      : 'text-destructive'
-    : 'text-emerald-500'
+  // Pair (hasErrors, hasSuccess) → 3 outcomes: all-success, partial, all-errors.
+  // The { hasErrors: false, hasSuccess: false } case (no work done) falls
+  // through to the success icon — matches the "No changes were made" summary.
+  const { HeaderIcon, iconColor } = match({ hasErrors, hasSuccess })
+    .with({ hasErrors: true, hasSuccess: true }, () => ({
+      HeaderIcon: AlertTriangle as LucideIcon,
+      iconColor: 'text-amber-500',
+    }))
+    .with({ hasErrors: true, hasSuccess: false }, () => ({
+      HeaderIcon: XCircle as LucideIcon,
+      iconColor: 'text-destructive',
+    }))
+    .otherwise(() => ({
+      HeaderIcon: CheckCircle2 as LucideIcon,
+      iconColor: 'text-emerald-500',
+    }))
 
   const parts: string[] = []
   if (result.created > 0)

--- a/src/renderer/src/lib/syncHelpers.ts
+++ b/src/renderer/src/lib/syncHelpers.ts
@@ -73,21 +73,24 @@ export function getSyncResultPresentation(
   const hasSuccess = result.created > 0 || result.replaced > 0
 
   // Pair (hasErrors, hasSuccess) → 3 outcomes: all-success, partial, all-errors.
-  // The { hasErrors: false, hasSuccess: false } case (no work done) falls
-  // through to the success icon — matches the "No changes were made" summary.
+  // The { hasErrors: false } branches (with or without success) both land on
+  // the success icon — matches the "No changes were made" summary when the
+  // work set was empty. `.exhaustive()` locks all four boolean combinations at
+  // compile time so a future refactor can't silently skip one.
   const { HeaderIcon, iconColor } = match({ hasErrors, hasSuccess })
     .with({ hasErrors: true, hasSuccess: true }, () => ({
-      HeaderIcon: AlertTriangle as LucideIcon,
+      HeaderIcon: AlertTriangle,
       iconColor: 'text-amber-500',
     }))
     .with({ hasErrors: true, hasSuccess: false }, () => ({
-      HeaderIcon: XCircle as LucideIcon,
+      HeaderIcon: XCircle,
       iconColor: 'text-destructive',
     }))
-    .otherwise(() => ({
-      HeaderIcon: CheckCircle2 as LucideIcon,
+    .with({ hasErrors: false }, () => ({
+      HeaderIcon: CheckCircle2,
       iconColor: 'text-emerald-500',
     }))
+    .exhaustive()
 
   const parts: string[] = []
   if (result.created > 0)

--- a/src/renderer/src/redux/listener.ts
+++ b/src/renderer/src/redux/listener.ts
@@ -1,11 +1,7 @@
 import { ACTION_HYDRATE_COMPLETE } from '@laststance/redux-storage-middleware'
 import { createListenerMiddleware, isAnyOf } from '@reduxjs/toolkit'
 
-import {
-  clearSelection,
-  deleteSelectedSkills,
-  unlinkSelectedFromAgent,
-} from './slices/skillsSlice'
+import { clearSelection } from './slices/skillsSlice'
 import {
   setTheme,
   setColorTheme,
@@ -79,15 +75,17 @@ listenerMiddleware.startListening({
  * Delete/Unlink button commits against invisible ticks the user can no longer
  * audit. Living in listener.ts keeps both slices self-contained (one-way
  * consumer; no circular imports).
+ *
+ * Note: `deleteSelectedSkills.pending` and `unlinkSelectedFromAgent.pending`
+ * are intentionally NOT in this matcher. Those thunks rely on the `.fulfilled`
+ * reducers in skillsSlice to narrow `selectedSkillNames` to only the items
+ * that actually succeeded, so failed rows stay ticked for retry. A blanket
+ * clear on `.pending` would wipe the selection before the reconciliation can
+ * run. uiSlice already clears `bulkSelectMode` on those same pending actions,
+ * so the toolbar still hides during the in-flight op.
  */
 listenerMiddleware.startListening({
-  matcher: isAnyOf(
-    setActiveTab,
-    selectAgent,
-    fetchSyncPreview.pending,
-    deleteSelectedSkills.pending,
-    unlinkSelectedFromAgent.pending,
-  ),
+  matcher: isAnyOf(setActiveTab, selectAgent, fetchSyncPreview.pending),
   effect: (_action, listenerApi) => {
     listenerApi.dispatch(clearSelection())
   },

--- a/src/renderer/src/redux/listener.ts
+++ b/src/renderer/src/redux/listener.ts
@@ -2,12 +2,18 @@ import { ACTION_HYDRATE_COMPLETE } from '@laststance/redux-storage-middleware'
 import { createListenerMiddleware, isAnyOf } from '@reduxjs/toolkit'
 
 import {
+  clearSelection,
+  deleteSelectedSkills,
+  unlinkSelectedFromAgent,
+} from './slices/skillsSlice'
+import {
   setTheme,
   setColorTheme,
   setNeutralTheme,
   toggleMode,
 } from './slices/themeSlice'
 import type { ThemeState } from './slices/themeSlice'
+import { fetchSyncPreview, selectAgent, setActiveTab } from './slices/uiSlice'
 
 export const listenerMiddleware = createListenerMiddleware()
 
@@ -61,5 +67,28 @@ listenerMiddleware.startListening({
   effect: (_action, listenerApi) => {
     const state = listenerApi.getState() as ListenerState
     applyThemeToDOM(state.theme)
+  },
+})
+
+/**
+ * Cross-slice atomic clear: dispatches `clearSelection` from skillsSlice on any
+ * context switch that uiSlice already clears its own ephemeral state for
+ * (bulkSelectMode, undoToast, bulkConfirm). Without this bridge the selection
+ * survives across tab/agent changes, enabling the "action-over-hidden-state"
+ * anti-pattern: SelectionToolbar renders on selection count alone and its
+ * Delete/Unlink button commits against invisible ticks the user can no longer
+ * audit. Living in listener.ts keeps both slices self-contained (one-way
+ * consumer; no circular imports).
+ */
+listenerMiddleware.startListening({
+  matcher: isAnyOf(
+    setActiveTab,
+    selectAgent,
+    fetchSyncPreview.pending,
+    deleteSelectedSkills.pending,
+    unlinkSelectedFromAgent.pending,
+  ),
+  effect: (_action, listenerApi) => {
+    listenerApi.dispatch(clearSelection())
   },
 })

--- a/src/renderer/src/redux/slices/marketplaceSlice.ts
+++ b/src/renderer/src/redux/slices/marketplaceSlice.ts
@@ -4,6 +4,7 @@ import { createSlice, createAsyncThunk } from '@reduxjs/toolkit'
 import type {
   LeaderboardData,
   RankingFilter,
+  SearchQuery,
   SkillName,
   SkillSearchResult,
   InstallOptions,
@@ -18,7 +19,7 @@ interface MarketplaceState {
   /** Current marketplace operation state (search / install / remove / idle). */
   status: MarketplaceStatus
   /** Live value of the search input. */
-  searchQuery: string
+  searchQuery: SearchQuery
   /** Results from the most recent `skills find` call. */
   searchResults: SkillSearchResult[]
   /** Skill chosen in the install modal. */
@@ -54,7 +55,7 @@ const initialState: MarketplaceState = {
  */
 export const searchSkills = createAsyncThunk(
   'marketplace/search',
-  async (query: string) => {
+  async (query: SearchQuery) => {
     const results = await window.electron.skillsCli.search(query)
     return results
   },
@@ -119,7 +120,7 @@ const marketplaceSlice = createSlice({
   name: 'marketplace',
   initialState,
   reducers: {
-    setSearchQuery: (state, action: PayloadAction<string>) => {
+    setSearchQuery: (state, action: PayloadAction<SearchQuery>) => {
       state.searchQuery = action.payload
     },
     selectSkillForInstall: (

--- a/src/renderer/src/redux/slices/skillsSlice.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.ts
@@ -2,9 +2,11 @@ import type { PayloadAction } from '@reduxjs/toolkit'
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 
 import type {
+  AbsolutePath,
   AgentId,
   BulkDeleteResult,
   BulkUnlinkResult,
+  RestoreDeletedSkillResult,
   Skill,
   SkillName,
   SymlinkInfo,
@@ -163,7 +165,11 @@ export const createSymlinks = createAsyncThunk(
  */
 export const copyToAgents = createAsyncThunk(
   'skills/copyToAgents',
-  async (params: { skill: Skill; linkPath: string; agentIds: AgentId[] }) => {
+  async (params: {
+    skill: Skill
+    linkPath: AbsolutePath
+    agentIds: AgentId[]
+  }) => {
     const { skill, linkPath, agentIds } = params
     const result = await window.electron.skills.copyToAgents({
       skillName: skill.name,
@@ -244,9 +250,7 @@ export const undoLastBulkDelete = createAsyncThunk(
   async (tombstoneIds: TombstoneId[]) => {
     const outcomes: Array<{
       tombstoneId: TombstoneId
-      result: Awaited<
-        ReturnType<typeof window.electron.skills.restoreDeletedSkill>
-      >
+      result: RestoreDeletedSkillResult
     }> = []
     // Serial: each restore is an fs op; parallelism offers no real gain and
     // makes failure attribution harder. Per-item try/catch ensures one IPC

--- a/src/renderer/src/redux/slices/skillsSlice.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.ts
@@ -1,5 +1,6 @@
 import type { PayloadAction } from '@reduxjs/toolkit'
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
+import { match } from 'ts-pattern'
 
 import type {
   AbsolutePath,
@@ -439,14 +440,24 @@ const skillsSlice = createSlice({
         state.selectedSkillNames = state.selectedSkillNames.filter(
           (name) => !deletedNames.has(name),
         )
-        if (state.selectedSkillNames.length === 0) {
-          state.selectionAnchor = null
-        } else if (
-          state.selectionAnchor !== null &&
-          deletedNames.has(state.selectionAnchor)
-        ) {
-          state.selectionAnchor = null
-        }
+        // Reconcile anchor: drop if selection emptied or if anchor itself was
+        // deleted. Otherwise leave it so Shift+click continues from the same
+        // origin.
+        const anchorReconciliation = match({
+          isEmpty: state.selectedSkillNames.length === 0,
+          anchorDeleted:
+            state.selectionAnchor !== null &&
+            deletedNames.has(state.selectionAnchor),
+        })
+          .with({ isEmpty: true }, () => 'clear' as const)
+          .with({ anchorDeleted: true }, () => 'clear' as const)
+          .otherwise(() => 'keep' as const)
+        match(anchorReconciliation)
+          .with('clear', () => {
+            state.selectionAnchor = null
+          })
+          .with('keep', () => {})
+          .exhaustive()
       })
       .addCase(deleteSelectedSkills.rejected, (state, action) => {
         state.inFlightDeleteNames = []
@@ -474,14 +485,23 @@ const skillsSlice = createSlice({
         state.selectedSkillNames = state.selectedSkillNames.filter(
           (name) => !unlinkedNames.has(name),
         )
-        if (state.selectedSkillNames.length === 0) {
-          state.selectionAnchor = null
-        } else if (
-          state.selectionAnchor !== null &&
-          unlinkedNames.has(state.selectionAnchor)
-        ) {
-          state.selectionAnchor = null
-        }
+        // Mirror the delete path: clear anchor when selection empties or when
+        // the anchor itself was unlinked; keep it otherwise.
+        const anchorReconciliation = match({
+          isEmpty: state.selectedSkillNames.length === 0,
+          anchorUnlinked:
+            state.selectionAnchor !== null &&
+            unlinkedNames.has(state.selectionAnchor),
+        })
+          .with({ isEmpty: true }, () => 'clear' as const)
+          .with({ anchorUnlinked: true }, () => 'clear' as const)
+          .otherwise(() => 'keep' as const)
+        match(anchorReconciliation)
+          .with('clear', () => {
+            state.selectionAnchor = null
+          })
+          .with('keep', () => {})
+          .exhaustive()
       })
       .addCase(unlinkSelectedFromAgent.rejected, (state, action) => {
         state.inFlightUnlinkNames = []

--- a/src/renderer/src/redux/slices/skillsSlice.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.ts
@@ -1,6 +1,5 @@
 import type { PayloadAction } from '@reduxjs/toolkit'
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
-import { match } from 'ts-pattern'
 
 import type {
   AbsolutePath,
@@ -443,21 +442,12 @@ const skillsSlice = createSlice({
         // Reconcile anchor: drop if selection emptied or if anchor itself was
         // deleted. Otherwise leave it so Shift+click continues from the same
         // origin.
-        const anchorReconciliation = match({
-          isEmpty: state.selectedSkillNames.length === 0,
-          anchorDeleted:
-            state.selectionAnchor !== null &&
-            deletedNames.has(state.selectionAnchor),
-        })
-          .with({ isEmpty: true }, () => 'clear' as const)
-          .with({ anchorDeleted: true }, () => 'clear' as const)
-          .otherwise(() => 'keep' as const)
-        match(anchorReconciliation)
-          .with('clear', () => {
-            state.selectionAnchor = null
-          })
-          .with('keep', () => {})
-          .exhaustive()
+        const anchorWasDeleted =
+          state.selectionAnchor !== null &&
+          deletedNames.has(state.selectionAnchor)
+        if (state.selectedSkillNames.length === 0 || anchorWasDeleted) {
+          state.selectionAnchor = null
+        }
       })
       .addCase(deleteSelectedSkills.rejected, (state, action) => {
         state.inFlightDeleteNames = []
@@ -487,21 +477,12 @@ const skillsSlice = createSlice({
         )
         // Mirror the delete path: clear anchor when selection empties or when
         // the anchor itself was unlinked; keep it otherwise.
-        const anchorReconciliation = match({
-          isEmpty: state.selectedSkillNames.length === 0,
-          anchorUnlinked:
-            state.selectionAnchor !== null &&
-            unlinkedNames.has(state.selectionAnchor),
-        })
-          .with({ isEmpty: true }, () => 'clear' as const)
-          .with({ anchorUnlinked: true }, () => 'clear' as const)
-          .otherwise(() => 'keep' as const)
-        match(anchorReconciliation)
-          .with('clear', () => {
-            state.selectionAnchor = null
-          })
-          .with('keep', () => {})
-          .exhaustive()
+        const anchorWasUnlinked =
+          state.selectionAnchor !== null &&
+          unlinkedNames.has(state.selectionAnchor)
+        if (state.selectedSkillNames.length === 0 || anchorWasUnlinked) {
+          state.selectionAnchor = null
+        }
       })
       .addCase(unlinkSelectedFromAgent.rejected, (state, action) => {
         state.inFlightUnlinkNames = []

--- a/src/renderer/src/redux/slices/uiSlice.test.ts
+++ b/src/renderer/src/redux/slices/uiSlice.test.ts
@@ -442,3 +442,119 @@ describe('uiSlice undoToast (v2.4 bulk delete)', () => {
     await promise
   })
 })
+
+describe('uiSlice bulkSelectMode', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('starts with bulkSelectMode=false (default is clean list)', async () => {
+    const store = await createTestStore()
+    expect(store.getState().ui.bulkSelectMode).toBe(false)
+  })
+
+  it('enterBulkSelectMode flips the flag to true', async () => {
+    const store = await createTestStore()
+    const { enterBulkSelectMode } = await import('./uiSlice')
+
+    store.dispatch(enterBulkSelectMode())
+    expect(store.getState().ui.bulkSelectMode).toBe(true)
+  })
+
+  it('exitBulkSelectMode flips the flag back to false', async () => {
+    const store = await createTestStore()
+    const { enterBulkSelectMode, exitBulkSelectMode } =
+      await import('./uiSlice')
+
+    store.dispatch(enterBulkSelectMode())
+    store.dispatch(exitBulkSelectMode())
+    expect(store.getState().ui.bulkSelectMode).toBe(false)
+  })
+
+  it('setActiveTab clears bulkSelectMode (tab switch exits mode)', async () => {
+    const store = await createTestStore()
+    const { enterBulkSelectMode, setActiveTab } = await import('./uiSlice')
+
+    store.dispatch(enterBulkSelectMode())
+    expect(store.getState().ui.bulkSelectMode).toBe(true)
+
+    store.dispatch(setActiveTab('marketplace'))
+    expect(store.getState().ui.bulkSelectMode).toBe(false)
+  })
+
+  it('selectAgent clears bulkSelectMode (agent swap exits mode)', async () => {
+    const store = await createTestStore()
+    const { enterBulkSelectMode, selectAgent } = await import('./uiSlice')
+
+    store.dispatch(enterBulkSelectMode())
+    store.dispatch(selectAgent('cursor' as AgentId))
+    expect(store.getState().ui.bulkSelectMode).toBe(false)
+  })
+
+  it('fetchSyncPreview.pending clears bulkSelectMode', async () => {
+    const store = await createTestStore()
+    const { enterBulkSelectMode, fetchSyncPreview } = await import('./uiSlice')
+
+    store.dispatch(enterBulkSelectMode())
+
+    let resolve!: (value: SyncPreviewResult) => void
+    mockSyncPreview.mockReturnValue(
+      new Promise<SyncPreviewResult>((r) => {
+        resolve = r
+      }),
+    )
+    const promise = store.dispatch(fetchSyncPreview())
+
+    expect(store.getState().ui.bulkSelectMode).toBe(false)
+
+    resolve(previewNoConflicts)
+    await promise
+  })
+
+  it('deleteSelectedSkills.pending clears bulkSelectMode (combined store)', async () => {
+    const store = await createCombinedStore()
+    const { enterBulkSelectMode } = await import('./uiSlice')
+    const { deleteSelectedSkills } = await import('./skillsSlice')
+
+    store.dispatch(enterBulkSelectMode())
+
+    let resolve!: (value: BulkDeleteResult) => void
+    mockDeleteSkills.mockReturnValue(
+      new Promise<BulkDeleteResult>((r) => {
+        resolve = r
+      }),
+    )
+    const promise = store.dispatch(deleteSelectedSkills(['task']))
+
+    expect(store.getState().ui.bulkSelectMode).toBe(false)
+
+    resolve({ items: [] })
+    await promise
+  })
+
+  it('unlinkSelectedFromAgent.pending clears bulkSelectMode (combined store)', async () => {
+    const store = await createCombinedStore()
+    const { enterBulkSelectMode } = await import('./uiSlice')
+    const { unlinkSelectedFromAgent } = await import('./skillsSlice')
+
+    store.dispatch(enterBulkSelectMode())
+
+    let resolve!: (value: BulkUnlinkResult) => void
+    mockUnlinkManyFromAgent.mockReturnValue(
+      new Promise<BulkUnlinkResult>((r) => {
+        resolve = r
+      }),
+    )
+    const promise = store.dispatch(
+      unlinkSelectedFromAgent({
+        agentId: 'cursor' as AgentId,
+        selectedNames: ['task'],
+      }),
+    )
+
+    expect(store.getState().ui.bulkSelectMode).toBe(false)
+
+    resolve({ items: [] })
+    await promise
+  })
+})

--- a/src/renderer/src/redux/slices/uiSlice.test.ts
+++ b/src/renderer/src/redux/slices/uiSlice.test.ts
@@ -1,4 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit'
+import type { UnknownAction } from '@reduxjs/toolkit'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type {
@@ -556,5 +557,230 @@ describe('uiSlice bulkSelectMode', () => {
 
     resolve({ items: [] })
     await promise
+  })
+
+  // ── Idempotency ───────────────────────────────────────────────────────
+  // Guards against a future refactor splitting the reducer into conditional
+  // branches; if "already-true enter" started side-effecting, toggling rapidly
+  // could wipe unrelated state. The invariant is a plain boolean assignment.
+
+  it('enterBulkSelectMode is idempotent when already true', async () => {
+    const store = await createTestStore()
+    const { enterBulkSelectMode } = await import('./uiSlice')
+
+    store.dispatch(enterBulkSelectMode())
+    store.dispatch(enterBulkSelectMode())
+    expect(store.getState().ui.bulkSelectMode).toBe(true)
+  })
+
+  it('exitBulkSelectMode is idempotent when already false', async () => {
+    const store = await createTestStore()
+    const { exitBulkSelectMode } = await import('./uiSlice')
+
+    store.dispatch(exitBulkSelectMode())
+    store.dispatch(exitBulkSelectMode())
+    expect(store.getState().ui.bulkSelectMode).toBe(false)
+  })
+})
+
+/**
+ * Atomic-clear contract: every context-switch action that clears
+ * `bulkSelectMode` MUST also clear `undoToast` + `bulkConfirm` in the same
+ * reducer tick. These tests assert the *full* invariant (not individual
+ * flags) so a future refactor that drops one co-clear fails CI instead of
+ * regressing the hidden-selection anti-pattern in production.
+ */
+describe('uiSlice atomic-clear contract on context switch', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  /**
+   * Pre-populate all three ephemeral flags so each test can assert co-clear.
+   * Narrowed to `{ dispatch }` so both the ui-only and combined stores satisfy
+   * the signature — the helper never reads state, just seeds it.
+   */
+  async function seedAllEphemeralState(store: {
+    dispatch: (action: UnknownAction) => unknown
+  }): Promise<void> {
+    const { enterBulkSelectMode, setUndoToast, setBulkConfirm } =
+      await import('./uiSlice')
+    store.dispatch(enterBulkSelectMode())
+    store.dispatch(
+      setUndoToast({
+        id: 'toast-seed',
+        kind: 'delete',
+        skillNames: ['a'],
+        tombstoneIds: [tombstoneId('1-a-aaaaaaaa')],
+        expiresAt: '2026-04-17T12:00:15.000Z',
+        summary: 'Deleted 1 skill.',
+      }),
+    )
+    store.dispatch(
+      setBulkConfirm({
+        kind: 'delete',
+        skillNames: ['a'],
+        agentId: null,
+        agentName: null,
+      }),
+    )
+  }
+
+  it('setActiveTab atomically clears bulkSelectMode + undoToast + bulkConfirm', async () => {
+    const store = await createTestStore()
+    await seedAllEphemeralState(store)
+    const { setActiveTab } = await import('./uiSlice')
+
+    store.dispatch(setActiveTab('marketplace'))
+
+    expect(store.getState().ui).toMatchObject({
+      bulkSelectMode: false,
+      undoToast: null,
+      bulkConfirm: null,
+    })
+  })
+
+  it('selectAgent atomically clears bulkSelectMode + undoToast + bulkConfirm', async () => {
+    const store = await createTestStore()
+    await seedAllEphemeralState(store)
+    const { selectAgent } = await import('./uiSlice')
+
+    store.dispatch(selectAgent('cursor' as AgentId))
+
+    expect(store.getState().ui).toMatchObject({
+      bulkSelectMode: false,
+      undoToast: null,
+      bulkConfirm: null,
+    })
+  })
+
+  it('fetchSyncPreview.pending atomically clears all ephemeral UI state', async () => {
+    const store = await createTestStore()
+    await seedAllEphemeralState(store)
+    const { fetchSyncPreview } = await import('./uiSlice')
+
+    let resolve!: (value: SyncPreviewResult) => void
+    mockSyncPreview.mockReturnValue(
+      new Promise<SyncPreviewResult>((r) => {
+        resolve = r
+      }),
+    )
+    const promise = store.dispatch(fetchSyncPreview())
+
+    expect(store.getState().ui).toMatchObject({
+      bulkSelectMode: false,
+      undoToast: null,
+      bulkConfirm: null,
+    })
+
+    resolve(previewNoConflicts)
+    await promise
+  })
+
+  it('deleteSelectedSkills.pending atomically clears all ephemeral UI state', async () => {
+    const store = await createCombinedStore()
+    await seedAllEphemeralState(store)
+    const { deleteSelectedSkills } = await import('./skillsSlice')
+
+    let resolve!: (value: BulkDeleteResult) => void
+    mockDeleteSkills.mockReturnValue(
+      new Promise<BulkDeleteResult>((r) => {
+        resolve = r
+      }),
+    )
+    const promise = store.dispatch(deleteSelectedSkills(['a']))
+
+    expect(store.getState().ui).toMatchObject({
+      bulkSelectMode: false,
+      undoToast: null,
+      bulkConfirm: null,
+    })
+
+    resolve({ items: [] })
+    await promise
+  })
+
+  it('unlinkSelectedFromAgent.pending atomically clears all ephemeral UI state', async () => {
+    const store = await createCombinedStore()
+    await seedAllEphemeralState(store)
+    const { unlinkSelectedFromAgent } = await import('./skillsSlice')
+
+    let resolve!: (value: BulkUnlinkResult) => void
+    mockUnlinkManyFromAgent.mockReturnValue(
+      new Promise<BulkUnlinkResult>((r) => {
+        resolve = r
+      }),
+    )
+    const promise = store.dispatch(
+      unlinkSelectedFromAgent({
+        agentId: 'cursor' as AgentId,
+        selectedNames: ['a'],
+      }),
+    )
+
+    expect(store.getState().ui).toMatchObject({
+      bulkSelectMode: false,
+      undoToast: null,
+      bulkConfirm: null,
+    })
+
+    resolve({ items: [] })
+    await promise
+  })
+})
+
+/**
+ * Rejection-path coverage for bulkSelectMode. `.pending` clears the flag
+ * (proved above), but nothing re-enters the mode on failure. These tests
+ * document that behavior: after a failed bulk op or sync preview, the user
+ * has to explicitly re-enter mode to retry — no auto-resume into a
+ * partially-stale selection.
+ */
+describe('uiSlice bulkSelectMode on rejection', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('fetchSyncPreview.rejected leaves bulkSelectMode=false (no auto re-enter)', async () => {
+    const store = await createTestStore()
+    const { enterBulkSelectMode, fetchSyncPreview } = await import('./uiSlice')
+
+    store.dispatch(enterBulkSelectMode())
+    mockSyncPreview.mockRejectedValue(new Error('Network error'))
+
+    await store.dispatch(fetchSyncPreview())
+
+    expect(store.getState().ui.bulkSelectMode).toBe(false)
+  })
+
+  it('deleteSelectedSkills.rejected keeps bulkSelectMode=false (no auto re-enter)', async () => {
+    const store = await createCombinedStore()
+    const { enterBulkSelectMode } = await import('./uiSlice')
+    const { deleteSelectedSkills } = await import('./skillsSlice')
+
+    store.dispatch(enterBulkSelectMode())
+    mockDeleteSkills.mockRejectedValue(new Error('FS error'))
+
+    await store.dispatch(deleteSelectedSkills(['task']))
+
+    expect(store.getState().ui.bulkSelectMode).toBe(false)
+  })
+
+  it('unlinkSelectedFromAgent.rejected keeps bulkSelectMode=false', async () => {
+    const store = await createCombinedStore()
+    const { enterBulkSelectMode } = await import('./uiSlice')
+    const { unlinkSelectedFromAgent } = await import('./skillsSlice')
+
+    store.dispatch(enterBulkSelectMode())
+    mockUnlinkManyFromAgent.mockRejectedValue(new Error('Permission denied'))
+
+    await store.dispatch(
+      unlinkSelectedFromAgent({
+        agentId: 'cursor' as AgentId,
+        selectedNames: ['task'],
+      }),
+    )
+
+    expect(store.getState().ui.bulkSelectMode).toBe(false)
   })
 })

--- a/src/renderer/src/redux/slices/uiSlice.ts
+++ b/src/renderer/src/redux/slices/uiSlice.ts
@@ -96,6 +96,14 @@ interface UiState {
    * Cleared on tab/agent change (same rationale as `undoToast`).
    */
   bulkConfirm: BulkConfirmState | null
+  /**
+   * When true, skill cards render a checkbox and bulk selection shortcuts
+   * (Cmd/Ctrl+A, Esc) are active. Default false so the list is clean for
+   * users who never perform bulk operations. Cleared atomically alongside
+   * `undoToast` / `bulkConfirm` / selection on any context switch that makes
+   * the current selection stale (tab, agent, sync op, competing bulk op).
+   */
+  bulkSelectMode: boolean
 }
 
 const initialState: UiState = {
@@ -113,6 +121,7 @@ const initialState: UiState = {
   selectedBookmarkForDetail: null,
   undoToast: null,
   bulkConfirm: null,
+  bulkSelectMode: false,
 }
 
 /**
@@ -160,6 +169,8 @@ const uiSlice = createSlice({
       // Same reasoning for an open bulk confirm — the ticked rows belong to
       // the previous tab's list.
       state.bulkConfirm = null
+      // The bulk-select affordance is list-scoped; leaving the list exits mode.
+      state.bulkSelectMode = false
     },
     setSearchQuery: (state, action: PayloadAction<SearchQuery>) => {
       state.searchQuery = action.payload
@@ -175,6 +186,8 @@ const uiSlice = createSlice({
       state.undoToast = null
       // The pending confirm may target a different agent; abandon it.
       state.bulkConfirm = null
+      // Selection is agent-scoped in skillsSlice; mode should follow.
+      state.bulkSelectMode = false
     },
     toggleSortOrder: (state) => {
       state.sortOrder = state.sortOrder === 'asc' ? 'desc' : 'asc'
@@ -232,6 +245,27 @@ const uiSlice = createSlice({
     clearBulkConfirm: (state) => {
       state.bulkConfirm = null
     },
+    /**
+     * Enter bulk-select mode. Reveals checkboxes on skill cards and activates
+     * Cmd/Ctrl+A and Esc keyboard shortcuts. Does not touch selection state —
+     * the user starts with an empty tick set and explicitly builds it up.
+     * @example dispatch(enterBulkSelectMode())
+     */
+    enterBulkSelectMode: (state) => {
+      state.bulkSelectMode = true
+    },
+    /**
+     * Exit bulk-select mode. Hides checkboxes and deactivates the shortcuts.
+     * The caller (MainContent) is responsible for also dispatching
+     * `clearSelection()` from skillsSlice — we intentionally do not
+     * cross-dispatch across slices here, keeping each slice self-contained.
+     * @example
+     *   dispatch(exitBulkSelectMode())
+     *   dispatch(clearSelection())
+     */
+    exitBulkSelectMode: (state) => {
+      state.bulkSelectMode = false
+    },
   },
   extraReducers: (builder) => {
     builder
@@ -246,6 +280,8 @@ const uiSlice = createSlice({
         state.undoToast = null
         // Close an open bulk confirm — sync conflict dialog will render on top.
         state.bulkConfirm = null
+        // Sync preview supersedes bulk affordance; user's attention shifts.
+        state.bulkSelectMode = false
       })
       .addCase(fetchSyncPreview.fulfilled, (state, action) => {
         state.syncPreview = action.payload
@@ -274,10 +310,14 @@ const uiSlice = createSlice({
       .addCase(deleteSelectedSkills.pending, (state) => {
         state.undoToast = null
         state.bulkConfirm = null
+        // Bulk op committed — leaving mode ON would strand a checkbox column
+        // over a fresh post-delete list the user is now observing for result.
+        state.bulkSelectMode = false
       })
       .addCase(unlinkSelectedFromAgent.pending, (state) => {
         state.undoToast = null
         state.bulkConfirm = null
+        state.bulkSelectMode = false
       })
   },
 })
@@ -297,6 +337,8 @@ export const {
   clearUndoToast,
   setBulkConfirm,
   clearBulkConfirm,
+  enterBulkSelectMode,
+  exitBulkSelectMode,
 } = uiSlice.actions
 export default uiSlice.reducer
 
@@ -328,3 +370,5 @@ export const selectUndoToast = (state: RootState): UndoToastState | null =>
   state.ui.undoToast
 export const selectBulkConfirm = (state: RootState): BulkConfirmState | null =>
   state.ui.bulkConfirm
+export const selectBulkSelectMode = (state: RootState): boolean =>
+  state.ui.bulkSelectMode

--- a/src/renderer/src/redux/slices/uiSlice.ts
+++ b/src/renderer/src/redux/slices/uiSlice.ts
@@ -6,11 +6,13 @@ import type {
   AgentName,
   BookmarkedSkill,
   IsoTimestamp,
+  SearchQuery,
   SkillName,
   SourceStats,
   SyncExecuteOptions,
   SyncExecuteResult,
   SyncPreviewResult,
+  ToastId,
   TombstoneId,
 } from '../../../../shared/types'
 import type { RootState } from '../store'
@@ -36,7 +38,7 @@ export type ActiveTab = 'installed' | 'marketplace'
  * - `summary`: pre-formatted display string ("Deleted 3 skills. 7 symlinks removed.").
  */
 export interface UndoToastState {
-  id: string | number
+  id: ToastId
   kind: 'delete' | 'unlink'
   skillNames: SkillName[]
   tombstoneIds: TombstoneId[]
@@ -65,7 +67,7 @@ export interface BulkConfirmState {
 interface UiState {
   /** Active main content tab */
   activeTab: ActiveTab
-  searchQuery: string
+  searchQuery: SearchQuery
   sourceStats: SourceStats | null
   isRefreshing: boolean
   /** Currently selected agent filter (null = global/all-agents view). */
@@ -159,7 +161,7 @@ const uiSlice = createSlice({
       // the previous tab's list.
       state.bulkConfirm = null
     },
-    setSearchQuery: (state, action: PayloadAction<string>) => {
+    setSearchQuery: (state, action: PayloadAction<SearchQuery>) => {
       state.searchQuery = action.payload
     },
     setRefreshing: (state, action: PayloadAction<boolean>) => {
@@ -301,7 +303,7 @@ export default uiSlice.reducer
 // --- Named selectors ---
 export const selectActiveTab = (state: RootState): ActiveTab =>
   state.ui.activeTab
-export const selectSearchQuery = (state: RootState): string =>
+export const selectSearchQuery = (state: RootState): SearchQuery =>
   state.ui.searchQuery
 export const selectSelectedAgentId = (state: RootState): AgentId | null =>
   state.ui.selectedAgentId

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -1,4 +1,5 @@
 import type {
+  AbsolutePath,
   Agent,
   BulkDeleteResult,
   BulkUnlinkResult,
@@ -11,6 +12,7 @@ import type {
   DeleteSkillResult,
   DeleteSkillsOptions,
   DownloadProgress,
+  HttpUrl,
   InstallOptions,
   InstallProgress,
   RankingFilter,
@@ -18,10 +20,12 @@ import type {
   RemoveAllFromAgentResult,
   RestoreDeletedSkillOptions,
   RestoreDeletedSkillResult,
+  SearchQuery,
   Skill,
   SkillBinaryContent,
   SkillFile,
   SkillFileContent,
+  SkillName,
   SkillSearchResult,
   SourceStats,
   SyncExecuteOptions,
@@ -79,12 +83,15 @@ export interface IpcInvokeContract {
   }
   'agents:getAll': { args: []; result: Agent[] }
   'source:getStats': { args: []; result: SourceStats }
-  'files:list': { args: [string]; result: SkillFile[] }
-  'files:read': { args: [string]; result: SkillFileContent | null }
-  'files:readBinary': { args: [string]; result: SkillBinaryContent | null }
-  'skills:cli:search': { args: [string]; result: SkillSearchResult[] }
+  'files:list': { args: [AbsolutePath]; result: SkillFile[] }
+  'files:read': { args: [AbsolutePath]; result: SkillFileContent | null }
+  'files:readBinary': {
+    args: [AbsolutePath]
+    result: SkillBinaryContent | null
+  }
+  'skills:cli:search': { args: [SearchQuery]; result: SkillSearchResult[] }
   'skills:cli:install': { args: [InstallOptions]; result: CliCommandResult }
-  'skills:cli:remove': { args: [string]; result: CliCommandResult }
+  'skills:cli:remove': { args: [SkillName]; result: CliCommandResult }
   'skills:cli:cancel': { args: []; result: void }
   'marketplace:leaderboard': {
     args: [{ filter: RankingFilter }]
@@ -95,7 +102,7 @@ export interface IpcInvokeContract {
   'update:download': { args: []; result: void }
   'update:install': { args: []; result: void }
   'update:check': { args: []; result: void }
-  'shell:openExternal': { args: [string]; result: void }
+  'shell:openExternal': { args: [HttpUrl]; result: void }
 }
 
 /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -87,6 +87,23 @@ export type HumanFileSize = string
 export type HumanDate = string
 
 /**
+ * Free-form marketplace search text typed by the user.
+ * Not branded because the value is user input with no nominal safety payoff —
+ * the alias exists so signatures read "search text" rather than "any string".
+ * @example "react hooks"
+ */
+export type SearchQuery = string
+
+/**
+ * Sonner toast id returned by `toast.custom(...)` and passed to `toast.dismiss(...)`.
+ * Sonner treats this identifier as opaque (`string | number`); mirroring that
+ * union here keeps imperative dismiss calls honest without widening to `any`.
+ * @example "abc-123"
+ * @example 42
+ */
+export type ToastId = string | number
+
+/**
  * Repository identifier in GitHub `owner/repo` format.
  * Branded because structurally-identical strings (skill names, file names)
  * could otherwise be passed where a repo slug is required.


### PR DESCRIPTION
## Summary

This PR bundles three independent workstreams that landed on the `colorful-types` branch. They're unrelated in intent but touch overlapping files, so reviewing together avoids merge churn.

### 1. Colorful types (`fa608b3`)
Replaces colorless primitives (`string` / `number` / `boolean`) with branded and named domain types across IPC, Redux slices, and the renderer. No runtime changes — annotations only. Factory functions at trust boundaries (`repositoryId()`, etc.) preserve narrow-on-construction semantics without `as` casts.

### 2. ts-pattern refactor (`5859316`)
Replaces 7 sites of if/else-if chains, nested ternaries, and discriminated switches with `ts-pattern`'s `match(...).with(...).exhaustive() | .otherwise(...)`. Touched files:
- `src/main/ipc/skills.ts` — COPY_TO_AGENTS 3-outcome dispatch
- `src/main/services/symlinkChecker.ts` — isSymbolic/isDirectory 3-branch
- `src/main/services/trashService.ts` — errno code 3-level nested ternary
- `src/renderer/src/components/dashboard/DashboardPageTabs.tsx` — `switch(event.key)` tablist nav
- `src/renderer/src/lib/syncHelpers.ts` — twin parallel nested ternaries collapsed into one object-returning match
- `src/renderer/src/redux/slices/skillsSlice.ts` — 2 reducer if/else-if chains (selectionAnchor reconciliation)

### 3. Bulk-select toggle + hidden-selection guard (`243f144`, `2f05684`)
Gates bulk-delete checkboxes behind an explicit `Enter bulk select mode` / `Exit bulk select mode` toggle (previously checkboxes were always visible on hover). Adds the **hidden-selection vector fix**: when a search filter hides selected rows, the SelectionToolbar shows `N selected +M hidden by filter` and disables the Delete button to prevent destructive actions on rows the user can no longer see. Includes 35 new unit tests across `MainContent.test.tsx`, `SkillItem.test.tsx`, and `uiSlice.test.ts`.

### 4. QA ignore (`52e7863`)
Adds `qa-reports/` to `.gitignore` so local `/qa-electron` artifacts don't pollute the working tree.

## Commits

| SHA | Message |
|---|---|
| `fa608b3` | refactor(types): extend domain types across IPC, Redux, and renderer |
| `5859316` | refactor(ts-pattern): replace if/else chains and nested ternaries with match |
| `243f144` | feat(skills): gate bulk-delete checkboxes behind Select/Done toggle |
| `2f05684` | fix(bulk-select): patch hidden-selection vector + tests + UX polish |
| `52e7863` | chore(git): ignore qa-reports/ directory |

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 34 files / 455 tests passing (↑ from 420 pre-bulk-select)
- [x] `/qa-electron` Bulk Select scope — 13 scenarios verified, no bugs found
- [ ] Reviewer: verify `Enter bulk select mode` → 3 selected → search `zzznomatch` → Delete button shows `[disabled]`
- [ ] Reviewer: switch agent filter while selection active → selection + Select mode clear atomically
- [ ] Reviewer: tab to Marketplace → selection + Select mode clear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk-select mode for managing multiple skills with a dedicated UI toggle button.
  * Added keyboard shortcuts for bulk operations: Cmd/Ctrl+A selects all visible skills; Escape clears selection or exits bulk-select mode.

* **Improvements**
  * Enhanced type safety throughout the application for better reliability.
  * Improved error handling and control-flow patterns for file operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->