### PR TITLE
feat: CLI-managed skill removal with mixed-batch bulk delete

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -134,6 +134,17 @@ interface Agent {
 }
 ```
 
+### Skill Types
+
+Skills fall into two categories based on their installation path. The distinction drives deletion UX (irreversible CLI remove vs trash-with-undo):
+
+| Type        | Installation                   | Lock file tracked                  | Uninstall path                      |
+| ----------- | ------------------------------ | ---------------------------------- | ----------------------------------- |
+| CLI-managed | `npx skills add <owner/repo>`  | Yes (`~/.agents/.skill-lock.json`) | `npx skills remove` (irreversible)  |
+| Plain       | Created directly in skills dir | No                                 | Move to app trash (undo within 15s) |
+
+The app detects CLI-managed skills by the `source` field on the Skill record (populated during scan from the lock file). The in-app delete button and bulk-delete flow route each skill through the matching path.
+
 ### Skill Metadata
 
 Each skill displays:
@@ -145,14 +156,14 @@ Each skill displays:
 
 ### Actions
 
-| Action                 | Status     | Notes                                                                                                                                    |
-| ---------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| View skill details     | ✅ Done    | -                                                                                                                                        |
-| View symlink status    | ✅ Done    | -                                                                                                                                        |
-| Search skills          | ✅ Done    | Marketplace tab                                                                                                                          |
-| Install skill          | ✅ Done    | With agent selection                                                                                                                     |
-| Uninstall skill        | ✅ Done    | In-app X / bulk-delete routes CLI-managed skills through `npx skills remove` (irreversible, no undo); plain skills go to trash with undo |
-| Repair broken symlinks | 🚧 Planned | -                                                                                                                                        |
+| Action                 | Status     | Notes                                                                                                                                          |
+| ---------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| View skill details     | ✅ Done    | -                                                                                                                                              |
+| View symlink status    | ✅ Done    | -                                                                                                                                              |
+| Search skills          | ✅ Done    | Marketplace tab                                                                                                                                |
+| Install skill          | ✅ Done    | With agent selection                                                                                                                           |
+| Uninstall skill        | ✅ Done    | Delete button and bulk-delete route CLI-managed skills through `npx skills remove` (irreversible, no undo); plain skills go to trash with undo |
+| Repair broken symlinks | 🚧 Planned | -                                                                                                                                              |
 
 ## Tech Stack
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -145,14 +145,14 @@ Each skill displays:
 
 ### Actions
 
-| Action                 | Status     | Notes                                                  |
-| ---------------------- | ---------- | ------------------------------------------------------ |
-| View skill details     | ✅ Done    | -                                                      |
-| View symlink status    | ✅ Done    | -                                                      |
-| Search skills          | ✅ Done    | Marketplace tab                                        |
-| Install skill          | ✅ Done    | With agent selection                                   |
-| Uninstall skill        | ✅ CLI     | `npx skills remove <name> --global` (no in-app button) |
-| Repair broken symlinks | 🚧 Planned | -                                                      |
+| Action                 | Status     | Notes                                                                                                                                    |
+| ---------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| View skill details     | ✅ Done    | -                                                                                                                                        |
+| View symlink status    | ✅ Done    | -                                                                                                                                        |
+| Search skills          | ✅ Done    | Marketplace tab                                                                                                                          |
+| Install skill          | ✅ Done    | With agent selection                                                                                                                     |
+| Uninstall skill        | ✅ Done    | In-app X / bulk-delete routes CLI-managed skills through `npx skills remove` (irreversible, no undo); plain skills go to trash with undo |
+| Repair broken symlinks | 🚧 Planned | -                                                                                                                                        |
 
 ## Tech Stack
 

--- a/src/main/ipc/ipc-schemas.test.ts
+++ b/src/main/ipc/ipc-schemas.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest'
+
+import { IPC_ARG_SCHEMAS } from './ipc-schemas'
+
+/**
+ * Runtime validation tests for IPC boundary schemas.
+ *
+ * These schemas are the trust boundary between the renderer (compromised-by-
+ * default in threat modeling) and the main process (filesystem/network
+ * access). A regression here can turn a bug in the renderer into a
+ * sandbox escape.
+ */
+
+describe('skills:cli:remove schema', () => {
+  const schema = IPC_ARG_SCHEMAS['skills:cli:remove']!
+
+  it('accepts a valid skill name', () => {
+    expect(schema.safeParse([{ skillName: 'brainstorming' }]).success).toBe(
+      true,
+    )
+  })
+
+  it('accepts skill names with hyphens, digits, dots', () => {
+    expect(
+      schema.safeParse([{ skillName: 'theme-generator-2.0' }]).success,
+    ).toBe(true)
+  })
+
+  it('rejects a skill name containing a forward slash (path traversal)', () => {
+    // `../etc/passwd` would pass a naive string check but escape SOURCE_DIR
+    // when joined. The regex guard is the first line of defense; `validatePath`
+    // in removeSkillViaCli is the second.
+    const result = schema.safeParse([{ skillName: '../etc/passwd' }])
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a skill name containing a backslash (Windows path separator)', () => {
+    expect(schema.safeParse([{ skillName: '..\\windows' }]).success).toBe(false)
+  })
+
+  it('rejects a skill name containing a null byte', () => {
+    // Some libc wrappers truncate at `\0`, so `evil\0.good` could pass later
+    // string checks while opening `evil`. Zod's refine is the explicit catch.
+    expect(schema.safeParse([{ skillName: 'evil\0.good' }]).success).toBe(false)
+  })
+
+  it('rejects an empty skill name', () => {
+    expect(schema.safeParse([{ skillName: '' }]).success).toBe(false)
+  })
+
+  it('rejects a missing skill name field', () => {
+    expect(schema.safeParse([{}]).success).toBe(false)
+  })
+
+  it('rejects a non-string skill name', () => {
+    expect(schema.safeParse([{ skillName: 123 }]).success).toBe(false)
+  })
+
+  it('rejects a non-array call payload', () => {
+    expect(schema.safeParse({ skillName: 'task' }).success).toBe(false)
+  })
+})
+
+describe('skills:cli:removeBatch schema', () => {
+  const schema = IPC_ARG_SCHEMAS['skills:cli:removeBatch']!
+
+  it('accepts a single-item batch', () => {
+    expect(
+      schema.safeParse([{ items: [{ skillName: 'brainstorming' }] }]).success,
+    ).toBe(true)
+  })
+
+  it('accepts a large batch', () => {
+    const items = Array.from({ length: 50 }, (_, i) => ({
+      skillName: `skill-${i}`,
+    }))
+    expect(schema.safeParse([{ items }]).success).toBe(true)
+  })
+
+  it('rejects an empty batch (must be at least 1)', () => {
+    // Length-zero batches would spawn zero CLI calls and return an empty
+    // result — a trivially-safe no-op, but also a silent bug. Better to
+    // fail loudly at the IPC boundary so the caller's bug surfaces early.
+    const result = schema.safeParse([{ items: [] }])
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a batch where any item has a path-separator skill name', () => {
+    // If a single item in a batch is malicious, the whole batch must reject —
+    // we cannot partially execute because removeBatch is all-or-nothing from
+    // the Zod perspective (per-item outcomes happen AFTER validation).
+    const result = schema.safeParse([
+      {
+        items: [{ skillName: 'valid' }, { skillName: '../escape' }],
+      },
+    ])
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a batch with a null-byte skill name in any position', () => {
+    const result = schema.safeParse([
+      {
+        items: [{ skillName: 'valid' }, { skillName: 'a\0b' }],
+      },
+    ])
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a missing items field', () => {
+    expect(schema.safeParse([{}]).success).toBe(false)
+  })
+
+  it('rejects a batch larger than 100 items (DoS cap)', () => {
+    // Each item spawns an `npx skills remove` child process serially, so an
+    // unbounded array could pin a CPU core and exhaust file descriptors on a
+    // cold npm cache. The cap forces a malicious/buggy renderer to fail at
+    // the IPC boundary instead of the spawn loop.
+    const items = Array.from({ length: 101 }, (_, i) => ({
+      skillName: `skill-${i}`,
+    }))
+    const result = schema.safeParse([{ items }])
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts a batch of exactly 100 items (DoS cap boundary)', () => {
+    const items = Array.from({ length: 100 }, (_, i) => ({
+      skillName: `skill-${i}`,
+    }))
+    expect(schema.safeParse([{ items }]).success).toBe(true)
+  })
+})
+
+describe('skillNameString consistency across channels', () => {
+  // The same refined string is used by every skill-name-accepting channel;
+  // a regression in one place would undermine the overall boundary. This
+  // test asserts the uniformity explicitly — if someone adds a new channel
+  // and forgets to use skillNameString, this will not catch it directly
+  // but the `../` rejections above will (all channels share the refinement).
+  it('rejects "../etc/passwd" across every skill-name-accepting channel', () => {
+    const channels: Array<keyof typeof IPC_ARG_SCHEMAS> = [
+      'skills:cli:remove',
+      'skills:unlinkFromAgent',
+      'skills:deleteSkill',
+      'skills:createSymlinks',
+      'skills:copyToAgents',
+    ]
+
+    const malicious = '../etc/passwd'
+    for (const channel of channels) {
+      const schema = IPC_ARG_SCHEMAS[channel]!
+      // Build a minimally-valid payload but inject the malicious skillName.
+      // This avoids asserting the exact shape of each channel (too brittle)
+      // while still exercising the skillName refinement.
+      const payload: { skillName: string; [k: string]: unknown } = {
+        skillName: malicious,
+      }
+      // Supply the other required fields for schemas that need them.
+      if (channel === 'skills:unlinkFromAgent') {
+        payload.agentId = 'cursor'
+        payload.linkPath = '/tmp/x'
+      } else if (channel === 'skills:createSymlinks') {
+        payload.skillPath = '/tmp/x'
+        payload.agentIds = ['cursor']
+      } else if (channel === 'skills:copyToAgents') {
+        payload.linkPath = '/tmp/x'
+        payload.targetAgentIds = ['cursor']
+      }
+      const result = schema.safeParse([payload])
+      expect(
+        result.success,
+        `channel ${channel} should reject ${malicious}`,
+      ).toBe(false)
+    }
+  })
+})

--- a/src/main/ipc/ipc-schemas.ts
+++ b/src/main/ipc/ipc-schemas.ts
@@ -11,11 +11,16 @@ import type { IpcInvokeChannel } from '../../shared/ipc-contract'
  */
 
 const nonEmptyString = z.string().min(1)
-/** Skill name must not contain path separators to prevent directory traversal */
+/**
+ * Skill name must not contain path separators (prevents `../` traversal) or
+ * null bytes (defense in depth: some libc wrappers truncate at `\0`, which
+ * could let `evil\0.good` pass a later string check while opening `evil`).
+ */
 const skillNameString = z
   .string()
   .min(1)
   .regex(/^[^/\\]+$/, 'Skill name must not contain path separators')
+  .refine((s) => !s.includes('\0'), 'Skill name must not contain null bytes')
 
 /**
  * Tombstone id format: `<unix_ms>-<skillName>-<rand8hex>`.
@@ -71,6 +76,23 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
       global: z.boolean(),
       agents: z.array(z.string()),
       skills: z.array(z.string()).optional(),
+    }),
+  ]),
+  'skills:cli:remove': z.tuple([
+    z.object({
+      skillName: skillNameString,
+    }),
+  ]),
+  'skills:cli:removeBatch': z.tuple([
+    z.object({
+      // Cap batch size. Each item spawns an `npx skills remove` child process
+      // (serial), so an unbounded array could pin a CPU core and exhaust file
+      // descriptors on cold npm cache. 100 covers realistic user selections
+      // with generous headroom while closing the local-DoS footprint.
+      items: z
+        .array(z.object({ skillName: skillNameString }))
+        .min(1, 'At least one skill required for batch CLI remove')
+        .max(100, 'Batch CLI remove limited to 100 skills'),
     }),
   ]),
 

--- a/src/main/ipc/skillsCli.ts
+++ b/src/main/ipc/skillsCli.ts
@@ -1,10 +1,21 @@
+import { join } from 'node:path'
+
 import { BrowserWindow } from 'electron'
 
+import { BULK_PROGRESS_THRESHOLD } from '../../shared/constants'
 import { IPC_CHANNELS } from '../../shared/ipc-channels'
-import type { InstallProgress } from '../../shared/types'
+import type {
+  CliRemoveSkillResult,
+  CliRemoveSkillsResult,
+  InstallProgress,
+} from '../../shared/types'
+import { SOURCE_DIR } from '../constants'
+import { validatePath } from '../services/pathValidation'
 import { skillsCliService } from '../services/skillsCliService'
+import { extractErrorMessage } from '../utils/errors'
 
 import { typedHandle } from './typedHandle'
+import { typedSend } from './typedSend'
 
 /**
  * Register IPC handlers for Skills CLI (Marketplace) operations
@@ -35,4 +46,64 @@ export function registerSkillsCliHandlers(): void {
   typedHandle(IPC_CHANNELS.SKILLS_CLI_CANCEL, () => {
     skillsCliService.cancel()
   })
+
+  /**
+   * Deregister a single skill from `~/.agents/.skill-lock.json` via
+   * `npx skills remove`. The CLI owns the lock-file schema, so we never
+   * touch it directly.
+   * @param options - { skillName }
+   * @returns CliRemoveSkillResult (discriminated on outcome)
+   */
+  typedHandle(IPC_CHANNELS.SKILLS_CLI_REMOVE, async (_, options) => {
+    return removeSkillViaCli(options.skillName)
+  })
+
+  /**
+   * Batch-deregister N skills via sequential CLI spawns. Runs serially
+   * because `npx skills remove` rewrites the shared `.skill-lock.json`
+   * on every call — parallel spawns would race the lock file.
+   *
+   * Emits `SKILLS_DELETE_PROGRESS` after each item when the batch is big
+   * enough to justify UI progress (>= BULK_PROGRESS_THRESHOLD). Each spawn
+   * takes ~600ms–2s, so without this a 20-item batch looks hung.
+   * @param options - { items: Array<{ skillName }> }
+   * @returns CliRemoveSkillsResult with per-item discriminated outcome
+   */
+  typedHandle(IPC_CHANNELS.SKILLS_CLI_REMOVE_BATCH, async (event, options) => {
+    const total = options.items.length
+    const emitProgress = total >= BULK_PROGRESS_THRESHOLD
+    const results: CliRemoveSkillResult[] = []
+
+    for (const [itemIndex, { skillName }] of options.items.entries()) {
+      results.push(await removeSkillViaCli(skillName))
+      if (emitProgress) {
+        typedSend(event.sender, IPC_CHANNELS.SKILLS_DELETE_PROGRESS, {
+          current: itemIndex + 1,
+          total,
+        })
+      }
+    }
+
+    return { items: results } satisfies CliRemoveSkillsResult
+  })
+}
+
+/**
+ * Defense in depth: Zod's `skillNameString` already rejects path separators,
+ * but we re-validate the derived source path stays inside SOURCE_DIR before
+ * spawning — a bug in Zod would still not allow escaping the trust root.
+ */
+async function removeSkillViaCli(
+  skillName: CliRemoveSkillResult['skillName'],
+): Promise<CliRemoveSkillResult> {
+  try {
+    validatePath(join(SOURCE_DIR, skillName), [SOURCE_DIR])
+  } catch (error) {
+    return {
+      skillName,
+      outcome: 'error',
+      error: { message: extractErrorMessage(error, 'Invalid skill name') },
+    }
+  }
+  return skillsCliService.remove(skillName)
 }

--- a/src/main/ipc/skillsCli.ts
+++ b/src/main/ipc/skillsCli.ts
@@ -77,10 +77,16 @@ export function registerSkillsCliHandlers(): void {
     for (const [itemIndex, { skillName }] of options.items.entries()) {
       results.push(await removeSkillViaCli(skillName))
       if (emitProgress) {
-        typedSend(event.sender, IPC_CHANNELS.SKILLS_DELETE_PROGRESS, {
-          current: itemIndex + 1,
-          total,
-        })
+        // Mirror the SKILLS_CLI_INSTALL guard (lines 30-35): a renderer closed
+        // mid-batch (6-20s per PR) would otherwise throw on typedSend because
+        // webContents is destroyed but event.sender still holds a reference.
+        const win = BrowserWindow.fromWebContents(event.sender)
+        if (win && !win.isDestroyed()) {
+          typedSend(event.sender, IPC_CHANNELS.SKILLS_DELETE_PROGRESS, {
+            current: itemIndex + 1,
+            total,
+          })
+        }
       }
     }
 

--- a/src/main/services/skillsCliService.test.ts
+++ b/src/main/services/skillsCliService.test.ts
@@ -1,0 +1,174 @@
+import { EventEmitter } from 'events'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SkillName } from '../../shared/types'
+
+/**
+ * Fake child process so we can drive stdout/stderr/close from the test.
+ * The real `ChildProcess` has ~40 fields we do not touch; the cast is safe
+ * because execCli() only consumes `.stdout.on('data')`, `.stderr.on('data')`,
+ * `.on('close')`, `.on('error')`, and `.kill()`.
+ */
+class FakeChildProcess extends EventEmitter {
+  stdout = new EventEmitter()
+  stderr = new EventEmitter()
+  kill = vi.fn()
+}
+
+// vi.mock factories are HOISTED to the top of the file — any closure vars
+// they reference must be declared inside vi.hoisted() so they exist at mock
+// evaluation time. Otherwise spawnMock is `undefined` when the service first
+// imports child_process and the handlers never fire (→ test timeouts).
+const { spawnMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn<() => FakeChildProcess>(),
+}))
+
+vi.mock('child_process', () => ({
+  spawn: (...args: unknown[]) => spawnMock(...(args as [])),
+}))
+
+// Pin homedir so sanitizeCliMessage's regex matches deterministically —
+// the service caches homedir() at module load, so mocking must happen before
+// importing the service under test.
+const FAKE_HOME = '/Users/testuser'
+vi.mock('os', async () => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const actual = await vi.importActual<typeof import('os')>('os')
+  return {
+    ...actual,
+    homedir: () => FAKE_HOME,
+  }
+})
+
+/**
+ * Drive the fake process to simulate a CLI invocation. `spawn` is called by
+ * `execCli` synchronously, so we stage the fake ahead of the call and emit
+ * events on the next microtask — after the Promise handlers register.
+ *
+ * @param stdout - stdout text chunks to emit
+ * @param stderr - stderr text chunks to emit
+ * @param exitCode - close event code (0 = success)
+ */
+function simulateCli({
+  stdout = '',
+  stderr = '',
+  exitCode = 0,
+}: {
+  stdout?: string
+  stderr?: string
+  exitCode?: number
+}): void {
+  const fake = new FakeChildProcess()
+  spawnMock.mockImplementationOnce(() => {
+    // Defer emission until after execCli finishes attaching listeners
+    queueMicrotask(() => {
+      if (stdout) fake.stdout.emit('data', Buffer.from(stdout))
+      if (stderr) fake.stderr.emit('data', Buffer.from(stderr))
+      fake.emit('close', exitCode)
+    })
+    return fake
+  })
+}
+
+describe('skillsCliService.remove', () => {
+  beforeEach(() => {
+    spawnMock.mockReset()
+  })
+
+  it('returns outcome:"removed" on exit code 0', async () => {
+    simulateCli({ exitCode: 0 })
+
+    const { skillsCliService } = await import('./skillsCliService')
+    const result = await skillsCliService.remove('brainstorming' as SkillName)
+
+    expect(result).toEqual({
+      skillName: 'brainstorming',
+      outcome: 'removed',
+    })
+  })
+
+  it('returns sanitized stderr as the error message on non-zero exit', async () => {
+    // stderr contains the user's home directory — must be stripped before
+    // crossing the IPC boundary. The message stays actionable (the skill
+    // name + the ENOENT) just without the user-identifying prefix.
+    simulateCli({
+      stderr: `ENOENT: /Users/testuser/.agents/skills/missing not found\n`,
+      exitCode: 1,
+    })
+
+    const { skillsCliService } = await import('./skillsCliService')
+    const result = await skillsCliService.remove('missing' as SkillName)
+
+    if (result.outcome !== 'error') {
+      throw new Error('Expected error outcome')
+    }
+    expect(result.error.message).toBe(
+      'ENOENT: ~/.agents/skills/missing not found',
+    )
+    expect(result.error.code).toBe(1)
+  })
+
+  it('strips ANSI escape sequences from the error message', async () => {
+    // Some CLI tools emit ANSI even with FORCE_COLOR=0 (e.g. in pipes or when
+    // respecting user TTY state). sanitize must drop them so toasts stay
+    // readable in non-terminal contexts.
+    simulateCli({
+      stderr: '\x1B[31mFailed to remove brainstorming\x1B[0m',
+      exitCode: 1,
+    })
+
+    const { skillsCliService } = await import('./skillsCliService')
+    const result = await skillsCliService.remove('brainstorming' as SkillName)
+
+    if (result.outcome !== 'error') {
+      throw new Error('Expected error outcome')
+    }
+    expect(result.error.message).toBe('Failed to remove brainstorming')
+  })
+
+  it('falls back to stdout when stderr is empty on failure', async () => {
+    simulateCli({
+      stdout: 'Skill not found in lock file',
+      stderr: '',
+      exitCode: 1,
+    })
+
+    const { skillsCliService } = await import('./skillsCliService')
+    const result = await skillsCliService.remove('ghost' as SkillName)
+
+    if (result.outcome !== 'error') {
+      throw new Error('Expected error outcome')
+    }
+    expect(result.error.message).toBe('Skill not found in lock file')
+  })
+
+  it('falls back to a default message when both streams are empty', async () => {
+    simulateCli({ stdout: '', stderr: '', exitCode: 1 })
+
+    const { skillsCliService } = await import('./skillsCliService')
+    const result = await skillsCliService.remove('x' as SkillName)
+
+    if (result.outcome !== 'error') {
+      throw new Error('Expected error outcome')
+    }
+    expect(result.error.message).toBe('CLI remove failed')
+  })
+
+  it('invokes spawn with npx skills@<VERSION> remove <name> --global -y', async () => {
+    simulateCli({ exitCode: 0 })
+
+    const { skillsCliService } = await import('./skillsCliService')
+    await skillsCliService.remove('brainstorming' as SkillName)
+
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+    const [command, args] = spawnMock.mock.calls[0] as unknown as [
+      string,
+      string[],
+      object,
+    ]
+    expect(command).toBe('npx')
+    expect(args[0]).toMatch(/^skills@/)
+    expect(args.slice(1)).toEqual(['remove', 'brainstorming', '--global', '-y'])
+  })
+})

--- a/src/main/services/skillsCliService.ts
+++ b/src/main/services/skillsCliService.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcess } from 'child_process'
 import { EventEmitter } from 'events'
+import { homedir } from 'os'
 
 import { match, P } from 'ts-pattern'
 
@@ -10,6 +11,8 @@ import type {
   InstallOptions,
   CliCommandResult,
   InstallProgress,
+  CliRemoveSkillResult,
+  SkillName,
 } from '../../shared/types'
 import { REPO_PATTERN, SKILL_NAME_PATTERN } from '../utils/skillIdentifiers'
 
@@ -22,12 +25,54 @@ const AGENT_ID_TO_CLI_NAME = Object.fromEntries(
 )
 
 /**
+ * CLI flag constants so every `npx skills ...` call uses the same strings.
+ * Centralized to keep install/remove flag semantics in one obvious place —
+ * the `--global` default matches skill registration (`.skill-lock.json` lives
+ * under the global scope), and `-y` suppresses the interactive confirmation
+ * prompt the CLI would otherwise hang on.
+ */
+const CLI_FLAGS = {
+  GLOBAL: '--global',
+  YES: '-y',
+} as const
+
+/**
  * Remove ANSI escape sequences from a string
  * @param text - Text with potential ANSI codes
  * @returns Clean text without ANSI codes
  */
 function stripAnsi(text: string): string {
   return text.replace(/\x1B\[[0-9;]*[a-zA-Z]/g, '').replace(/\[[\d;]*m/g, '')
+}
+
+/**
+ * Cached at module scope so we don't hit the OS on every CLI invocation.
+ * The home directory cannot change during a process lifetime on macOS/Linux
+ * (the scenarios where it would change — `sudo -u`, `HOME=` env override —
+ * we don't support for Skills Desktop).
+ */
+const HOME_DIR = homedir()
+const HOME_DIR_REGEX = new RegExp(
+  HOME_DIR.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
+  'g',
+)
+
+/**
+ * Sanitize CLI output destined for the renderer (toasts, error UI, logs).
+ * Strips ANSI and replaces the user's home directory with `~` so a stderr
+ * like `ENOENT: /Users/alice/.agents/skills/foo` surfaces as `ENOENT:
+ * ~/.agents/skills/foo` — keeps the actionable context, drops the username.
+ *
+ * Not a security boundary (the renderer is our own code), but defense-in-depth
+ * against leaking PII into screenshots, bug reports, and log files.
+ * @param text - Raw text from CLI stdout/stderr
+ * @returns Sanitized text safe to surface in UI
+ * @example
+ * sanitizeCliMessage('ENOENT: /Users/alice/.agents/skills/foo')
+ * // => 'ENOENT: ~/.agents/skills/foo'
+ */
+function sanitizeCliMessage(text: string): string {
+  return stripAnsi(text).replace(HOME_DIR_REGEX, '~')
 }
 
 /**
@@ -62,10 +107,10 @@ class SkillsCliService extends EventEmitter {
    * install({ repo: 'vercel-labs/agent-skills', global: true, agents: ['claude-code'] })
    */
   async install(options: InstallOptions): Promise<CliCommandResult> {
-    const args = ['add', options.repo, '-y'] // -y to skip interactive prompts
+    const args = ['add', options.repo, CLI_FLAGS.YES]
 
     if (options.global) {
-      args.push('--global')
+      args.push(CLI_FLAGS.GLOBAL)
     }
 
     for (const agent of options.agents) {
@@ -92,6 +137,42 @@ class SkillsCliService extends EventEmitter {
     }
 
     return result
+  }
+
+  /**
+   * Deregister a skill from `~/.agents/.skill-lock.json` via `npx skills remove`.
+   * CLI handles lock file update and filesystem removal in one shot — we never
+   * touch the lock file directly, so schema drift stays the CLI's problem.
+   * @param skillName - Skill name as tracked in the lock file
+   * @returns Discriminated result: `{outcome:'removed'}` on exit 0, else `{outcome:'error', error}`
+   * @example
+   * remove('brainstorming' as SkillName)
+   * // => { skillName: 'brainstorming', outcome: 'removed' }
+   */
+  async remove(skillName: SkillName): Promise<CliRemoveSkillResult> {
+    const result = await this.execCli([
+      'remove',
+      skillName,
+      CLI_FLAGS.GLOBAL,
+      CLI_FLAGS.YES,
+    ])
+
+    if (result.success) {
+      return { skillName, outcome: 'removed' }
+    }
+
+    // stderr often has the actionable message (e.g., "Skill not found").
+    // Fall back to stdout when CLI writes errors there instead.
+    // sanitize strips ANSI + home-directory paths before this string crosses
+    // the IPC boundary into the renderer (toasts, future logging, crash
+    // reports). See sanitizeCliMessage docstring.
+    const rawMessage =
+      result.stderr.trim() || result.stdout.trim() || 'CLI remove failed'
+    return {
+      skillName,
+      outcome: 'error',
+      error: { message: sanitizeCliMessage(rawMessage), code: result.code },
+    }
   }
 
   /**

--- a/src/main/services/skillsCliService.ts
+++ b/src/main/services/skillsCliService.ts
@@ -52,8 +52,15 @@ function stripAnsi(text: string): string {
  * we don't support for Skills Desktop).
  */
 const HOME_DIR = homedir()
+/**
+ * Anchor HOME_DIR matches to a path boundary so `/Users/alice-work/foo` is
+ * not rewritten to `~-work/foo` when HOME_DIR is `/Users/alice`. The
+ * lookahead accepts: path separator (`/` or `\`), end-of-string, whitespace,
+ * or a quote char — all the places a path legitimately terminates inside
+ * CLI stderr output.
+ */
 const HOME_DIR_REGEX = new RegExp(
-  HOME_DIR.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
+  HOME_DIR.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '(?=[/\\\\]|$|\\s|["\'`])',
   'g',
 )
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3,6 +3,8 @@ import { contextBridge } from 'electron'
 import { IPC_CHANNELS } from '../shared/ipc-channels'
 import type {
   AbsolutePath,
+  CliRemoveSkillOptions,
+  CliRemoveSkillsOptions,
   CopyToAgentsOptions,
   CreateSymlinksOptions,
   DeleteProgressPayload,
@@ -102,6 +104,13 @@ contextBridge.exposeInMainWorld('electron', {
     onProgress: createIpcListener<InstallProgress>(
       IPC_CHANNELS.SKILLS_CLI_PROGRESS,
     ),
+    // CLI-based remove (deregister from ~/.agents/.skill-lock.json).
+    // Used when a skill's `source` field is set — filesystem removal alone
+    // would leave a stale lock entry, so we delegate to the CLI.
+    remove: async (options: CliRemoveSkillOptions) =>
+      typedInvoke('skills:cli:remove', options),
+    removeBatch: async (options: CliRemoveSkillsOptions) =>
+      typedInvoke('skills:cli:removeBatch', options),
   },
   // Marketplace Leaderboard
   marketplace: {

--- a/src/renderer/src/components/layout/MainContent.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.browser.test.tsx
@@ -555,7 +555,9 @@ describe('MainContent handleConfirmBulk — mixed-partition dispatch', () => {
     await expect.poll(() => mockSkillsDeleteSkills.mock.calls.length).toBe(1)
     // Symmetric to the all-CLI case: a plain-only batch must not spawn a CLI
     // subprocess. (Cold-start npx latency is ~1s; firing it for nothing
-    // would be a gratuitous UX hit.)
-    expect(mockSkillsCliRemoveBatch).not.toHaveBeenCalled()
+    // would be a gratuitous UX hit.) Poll the negative assertion too — a
+    // bare `.not.toHaveBeenCalled()` would pass spuriously on the first tick
+    // before the (forbidden) CLI spawn would have settled on the slow path.
+    await expect.poll(() => mockSkillsCliRemoveBatch.mock.calls.length).toBe(0)
   })
 })

--- a/src/renderer/src/components/layout/MainContent.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.browser.test.tsx
@@ -3,12 +3,20 @@ import { Provider } from 'react-redux'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
-import type { SkillName } from '../../../../shared/types'
+import type {
+  BulkDeleteResult,
+  CliRemoveSkillsResult,
+  Skill,
+  SkillName,
+} from '../../../../shared/types'
+import { repositoryId, tombstoneId } from '../../../../shared/types'
 import { TooltipProvider } from '../ui/tooltip'
 
 const mockGetAll = vi.fn()
 const mockShellOpenExternal = vi.fn()
 const mockOnDeleteProgress = vi.fn(() => () => {})
+const mockSkillsCliRemoveBatch = vi.fn()
+const mockSkillsDeleteSkills = vi.fn()
 
 /**
  * Short-circuit every heavy child MainContent renders so tests focus on the
@@ -67,6 +75,8 @@ beforeEach(() => {
   mockShellOpenExternal.mockReset()
   mockOnDeleteProgress.mockReset()
   mockOnDeleteProgress.mockImplementation(() => () => {})
+  mockSkillsCliRemoveBatch.mockReset()
+  mockSkillsDeleteSkills.mockReset()
   // Install the `electron` IPC bridge — browser mode replaces the preload
   // context, so tests that exercise `window.electron.*` must plant a fake
   // before MainContent's mount effect fires.
@@ -74,6 +84,10 @@ beforeEach(() => {
     skills: {
       getAll: mockGetAll,
       onDeleteProgress: mockOnDeleteProgress,
+      deleteSkills: mockSkillsDeleteSkills,
+    },
+    skillsCli: {
+      removeBatch: mockSkillsCliRemoveBatch,
     },
     shell: {
       openExternal: mockShellOpenExternal,
@@ -357,5 +371,191 @@ describe('MainContent keyboard shortcuts (Esc 2-step)', () => {
     } finally {
       document.body.removeChild(textInput)
     }
+  })
+})
+
+describe('MainContent handleConfirmBulk — mixed-partition dispatch', () => {
+  // Global-view bulk delete partitions the batch into CLI-managed (source set,
+  // tracked in ~/.agents/.skill-lock.json) vs. plain skills. The CLI bucket
+  // MUST fire first: the awaited spawn has to settle before the reversible
+  // trash op runs, otherwise the UndoToast's tombstone ids can reference a
+  // skill the CLI already removed — the restore would then try to resurrect
+  // a ghost. This test pins down that invariant.
+
+  /**
+   * Build a Skill fixture with either a `source` (CLI-managed) or no source
+   * (plain). Keeps the test's seeding block readable.
+   */
+  function makeSkill(name: SkillName, cli: boolean): Skill {
+    return {
+      name,
+      description: '',
+      path: `/home/user/.agents/skills/${name}` as Skill['path'],
+      symlinkCount: 0,
+      symlinks: [],
+      ...(cli ? { source: repositoryId('vercel-labs/agent-skills') } : {}),
+    }
+  }
+
+  it('dispatches cliRemoveSelectedSkills BEFORE deleteSelectedSkills for a mixed batch', async () => {
+    const { screen, store } = await renderMainContent()
+    const { enterBulkSelectMode } = await import('../../redux/slices/uiSlice')
+    const { setBulkConfirm } = await import('../../redux/slices/uiSlice')
+    const { fetchSkills } = await import('../../redux/slices/skillsSlice')
+
+    // Stub IPC results. The partition has brainstorming (CLI) + local-skill
+    // (plain), so removeBatch returns one item and deleteSkills returns one.
+    const cliResult: CliRemoveSkillsResult = {
+      items: [{ skillName: 'brainstorming' as SkillName, outcome: 'removed' }],
+    }
+    const plainResult: BulkDeleteResult = {
+      items: [
+        {
+          skillName: 'local-skill' as SkillName,
+          outcome: 'deleted',
+          tombstoneId: tombstoneId('1729180800000-local-skill-a1b2c3d4'),
+          symlinksRemoved: 0,
+          cascadeAgents: [],
+        },
+      ],
+    }
+    mockSkillsCliRemoveBatch.mockResolvedValue(cliResult)
+    mockSkillsDeleteSkills.mockResolvedValue(plainResult)
+
+    // Seed items via the real thunk's fulfilled action — same pattern as the
+    // Cmd+A test — so the partition step sees a live item list.
+    store.dispatch(
+      fetchSkills.fulfilled(
+        [
+          makeSkill('brainstorming' as SkillName, true),
+          makeSkill('local-skill' as SkillName, false),
+        ],
+        'req-id',
+      ),
+    )
+    store.dispatch(enterBulkSelectMode())
+    store.dispatch(
+      setBulkConfirm({
+        kind: 'delete',
+        skillNames: ['brainstorming' as SkillName, 'local-skill' as SkillName],
+        agentId: null,
+        agentName: null,
+      }),
+    )
+
+    // The inline BulkConfirmDialog renders a "Delete" button (destructive
+    // variant) when kind === 'delete'. Clicking it invokes handleConfirmBulk.
+    await screen.getByRole('button', { name: /^Delete$/ }).click()
+
+    await expect.poll(() => mockSkillsCliRemoveBatch.mock.calls.length).toBe(1)
+    await expect.poll(() => mockSkillsDeleteSkills.mock.calls.length).toBe(1)
+
+    // Ordering is load-bearing: invocation-order comparison uses vitest's
+    // call timestamps (available via `mock.invocationCallOrder` — monotonic
+    // across all mocks in the run).
+    const cliCall = mockSkillsCliRemoveBatch.mock.invocationCallOrder[0]
+    const plainCall = mockSkillsDeleteSkills.mock.invocationCallOrder[0]
+    expect(cliCall).toBeLessThan(plainCall)
+
+    // Payload shape: CLI got the CLI-managed name only, plain got the plain
+    // name only — the partition correctly separated the two buckets.
+    expect(mockSkillsCliRemoveBatch.mock.calls[0][0]).toEqual({
+      items: [{ skillName: 'brainstorming' }],
+    })
+    // The deleteSkills IPC takes `{ items: [{ skillName }] }` (same shape as
+    // removeBatch), NOT a flat string array. Assert the exact payload so a
+    // future thunk tweak that drops the wrapper surfaces here.
+    expect(mockSkillsDeleteSkills.mock.calls[0][0]).toEqual({
+      items: [{ skillName: 'local-skill' }],
+    })
+  })
+
+  it('skips deleteSkills entirely when every selected skill is CLI-managed', async () => {
+    const { screen, store } = await renderMainContent()
+    const { enterBulkSelectMode, setBulkConfirm } =
+      await import('../../redux/slices/uiSlice')
+    const { fetchSkills } = await import('../../redux/slices/skillsSlice')
+
+    const cliResult: CliRemoveSkillsResult = {
+      items: [
+        { skillName: 'brainstorming' as SkillName, outcome: 'removed' },
+        { skillName: 'theme-generator' as SkillName, outcome: 'removed' },
+      ],
+    }
+    mockSkillsCliRemoveBatch.mockResolvedValue(cliResult)
+
+    store.dispatch(
+      fetchSkills.fulfilled(
+        [
+          makeSkill('brainstorming' as SkillName, true),
+          makeSkill('theme-generator' as SkillName, true),
+        ],
+        'req-id',
+      ),
+    )
+    store.dispatch(enterBulkSelectMode())
+    store.dispatch(
+      setBulkConfirm({
+        kind: 'delete',
+        skillNames: [
+          'brainstorming' as SkillName,
+          'theme-generator' as SkillName,
+        ],
+        agentId: null,
+        agentName: null,
+      }),
+    )
+
+    await screen.getByRole('button', { name: /^Delete$/ }).click()
+
+    await expect.poll(() => mockSkillsCliRemoveBatch.mock.calls.length).toBe(1)
+    // Crucial: deleteSkills IPC never fires for an all-CLI batch. Calling it
+    // with an empty array would spin the trash service for no reason AND
+    // leave an empty UndoToast tombstone list on screen.
+    expect(mockSkillsDeleteSkills).not.toHaveBeenCalled()
+  })
+
+  it('skips cliRemoveBatch entirely when every selected skill is plain', async () => {
+    const { screen, store } = await renderMainContent()
+    const { enterBulkSelectMode, setBulkConfirm } =
+      await import('../../redux/slices/uiSlice')
+    const { fetchSkills } = await import('../../redux/slices/skillsSlice')
+
+    const plainResult: BulkDeleteResult = {
+      items: [
+        {
+          skillName: 'local-skill' as SkillName,
+          outcome: 'deleted',
+          tombstoneId: tombstoneId('1729180800000-local-skill-a1b2c3d4'),
+          symlinksRemoved: 0,
+          cascadeAgents: [],
+        },
+      ],
+    }
+    mockSkillsDeleteSkills.mockResolvedValue(plainResult)
+
+    store.dispatch(
+      fetchSkills.fulfilled(
+        [makeSkill('local-skill' as SkillName, false)],
+        'req-id',
+      ),
+    )
+    store.dispatch(enterBulkSelectMode())
+    store.dispatch(
+      setBulkConfirm({
+        kind: 'delete',
+        skillNames: ['local-skill' as SkillName],
+        agentId: null,
+        agentName: null,
+      }),
+    )
+
+    await screen.getByRole('button', { name: /^Delete$/ }).click()
+
+    await expect.poll(() => mockSkillsDeleteSkills.mock.calls.length).toBe(1)
+    // Symmetric to the all-CLI case: a plain-only batch must not spawn a CLI
+    // subprocess. (Cold-start npx latency is ~1s; firing it for nothing
+    // would be a gratuitous UX hit.)
+    expect(mockSkillsCliRemoveBatch).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -14,21 +14,23 @@ import { FEATURE_FLAGS } from '../../../../shared/featureFlags'
 import type {
   BulkDeleteItemResult,
   IsoTimestamp,
-  SkillName,
   TombstoneId,
 } from '../../../../shared/types'
 import { cn } from '../../lib/utils'
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
 import {
+  selectBulkCliCount,
   selectSelectedVisibleNames,
   selectVisibleSkillNames,
 } from '../../redux/selectors'
 import { setPreviewSkill } from '../../redux/slices/marketplaceSlice'
 import {
   clearSelection,
+  cliRemoveSelectedSkills,
   deleteSelectedSkills,
   selectAll,
   selectSelectedSkillNames,
+  selectSkillsItems,
   setBulkProgress,
   undoLastBulkDelete,
   unlinkSelectedFromAgent,
@@ -49,6 +51,10 @@ import {
   toggleSortOrder,
 } from '../../redux/slices/uiSlice'
 import { refreshAllData } from '../../redux/thunks'
+import {
+  flashFailedRows,
+  settleCliRemoveBatch,
+} from '../../utils/bulkOpVisuals'
 import { errorToastDescription } from '../../utils/errorToastDescription'
 import { isEditableTarget } from '../../utils/isEditableTarget'
 import { pluralize } from '../../utils/pluralize'
@@ -57,11 +63,14 @@ import { SyncConfirmDialog } from '../sidebar/SyncConfirmDialog'
 import { SyncConflictDialog } from '../sidebar/SyncConflictDialog'
 import { SyncResultDialog } from '../sidebar/SyncResultDialog'
 import { AddSymlinkModal } from '../skills/AddSymlinkModal'
+import { renderBulkDeleteDescription } from '../skills/bulkDeleteCopy'
 import {
   formatCascadeSummary,
   formatUnlinkSummary,
+  partitionSkillsForDelete,
 } from '../skills/bulkDeleteHelpers'
 import { CopyToAgentsModal } from '../skills/CopyToAgentsModal'
+import { DeleteCliSkillDialog } from '../skills/DeleteCliSkillDialog'
 import { SearchBox } from '../skills/SearchBox'
 import { SelectionToolbar } from '../skills/SelectionToolbar'
 import { SkillsList } from '../skills/SkillsList'
@@ -114,6 +123,7 @@ export const MainContent = React.memo(
     const visibleNames = useAppSelector(selectVisibleSkillNames)
     const selectedVisibleNames = useAppSelector(selectSelectedVisibleNames)
     const selectedAllNames = useAppSelector(selectSelectedSkillNames)
+    const skillItems = useAppSelector(selectSkillsItems)
 
     const bulkConfirm = useAppSelector(selectBulkConfirm)
     const bulkSelectMode = useAppSelector(selectBulkSelectMode)
@@ -197,22 +207,6 @@ export const MainContent = React.memo(
       })
       return unsubscribe
     }, [dispatch])
-
-    /**
-     * Emit per-item failure flash for rows that errored out of a bulk op.
-     * SkillItem rows listen for `skills:bulkItemFailed` and flash a red left
-     * edge for 3s. Keeping this imperative avoids piping per-row failure state
-     * through Redux for a transient visual.
-     */
-    const flashFailedRows = useCallback((failedNames: SkillName[]) => {
-      for (const skillName of failedNames) {
-        window.dispatchEvent(
-          new CustomEvent<{ skillName: SkillName }>('skills:bulkItemFailed', {
-            detail: { skillName },
-          }),
-        )
-      }
-    }, [])
 
     /**
      * Handle the restore callback from inside the UndoToast. Dispatches the
@@ -316,8 +310,37 @@ export const MainContent = React.memo(
         return
       }
 
-      // Global view — bulk delete (tombstoned, undo toast).
-      const action = await dispatch(deleteSelectedSkills(skillNames))
+      // Global view — bulk delete. Mixed selections are partitioned:
+      //  - CLI-tracked skills (have `source`) dispatch through
+      //    `cliRemoveSelectedSkills` so `.skill-lock.json` stays in sync;
+      //    these are IRREVERSIBLE (no UndoToast wiring).
+      //  - Plain skills flow through the existing trash + UndoToast pipeline.
+      // CLI first so the awaited spawn settles before the reversible trash
+      // op runs, keeping `state.skills.items` stable while the UndoToast is
+      // live (restore targets would otherwise risk referencing ghosts).
+      const { cliNames, plainNames } = partitionSkillsForDelete(
+        skillNames,
+        skillItems,
+      )
+
+      if (cliNames.length > 0) {
+        const cliAction = await dispatch(cliRemoveSelectedSkills(cliNames))
+        if (cliRemoveSelectedSkills.fulfilled.match(cliAction)) {
+          settleCliRemoveBatch(cliAction.payload)
+        } else {
+          toast.error('CLI remove failed', {
+            description: errorToastDescription(cliAction),
+          })
+        }
+      }
+
+      // All-CLI case: no trash dispatch needed. Refresh and return.
+      if (plainNames.length === 0) {
+        refreshAllData(dispatch)
+        return
+      }
+
+      const action = await dispatch(deleteSelectedSkills(plainNames))
       if (deleteSelectedSkills.fulfilled.match(action)) {
         const tombstoneIds = action.payload.items
           .filter(
@@ -384,11 +407,13 @@ export const MainContent = React.memo(
           description: errorToastDescription(action),
         })
       }
-    }, [bulkConfirm, dispatch, flashFailedRows, handleUndoDelete])
+    }, [bulkConfirm, dispatch, handleUndoDelete, skillItems])
 
     const handleCancelBulkConfirm = useCallback((): void => {
       dispatch(clearBulkConfirm())
     }, [dispatch])
+
+    const bulkCliCount = useAppSelector(selectBulkCliCount)
 
     return (
       <main
@@ -581,6 +606,7 @@ export const MainContent = React.memo(
         <UnlinkDialog />
         <AddSymlinkModal />
         <CopyToAgentsModal />
+        <DeleteCliSkillDialog />
         <SyncConfirmDialog />
         <SyncConflictDialog />
         <SyncResultDialog />
@@ -604,7 +630,10 @@ export const MainContent = React.memo(
               </DialogTitle>
               <DialogDescription>
                 {bulkConfirm?.kind === 'delete'
-                  ? 'This moves the skills to the app trash and removes every symlink pointing to them. You can restore within 15 seconds from the notification.'
+                  ? renderBulkDeleteDescription({
+                      cliCount: bulkCliCount,
+                      totalCount: bulkConfirm.skillNames.length,
+                    })
                   : `This removes the symlinks in ${bulkConfirm?.agentName ?? 'this agent'}. The underlying skill files stay in your source directory.`}
               </DialogDescription>
             </DialogHeader>

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -331,6 +331,12 @@ export const MainContent = React.memo(
           toast.error('CLI remove failed', {
             description: errorToastDescription(cliAction),
           })
+          // Transport-level rejection (IPC/spawn broke). Don't fall through
+          // to the plain-delete partition — the CLI batch never ran, so the
+          // user can retry the whole selection. Partial per-item failures
+          // still take the fulfilled branch above.
+          refreshAllData(dispatch)
+          return
         }
       }
 

--- a/src/renderer/src/components/skills/DeleteCliSkillDialog.browser.test.tsx
+++ b/src/renderer/src/components/skills/DeleteCliSkillDialog.browser.test.tsx
@@ -1,0 +1,334 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import type { CliRemoveSkillsResult, SkillName } from '../../../../shared/types'
+import { TooltipProvider } from '../ui/tooltip'
+
+const mockSkillsCliRemoveBatch = vi.fn()
+const mockGetAll = vi.fn()
+const mockAgentsGetAll = vi.fn()
+const mockSourceGetStats = vi.fn()
+const mockOnDeleteProgress = vi.fn(() => () => {})
+
+const toastSuccess = vi.fn()
+const toastError = vi.fn()
+const toastWarning = vi.fn()
+
+// The dialog uses `sonner`'s top-level `toast.error` directly on thunk rejection
+// and `settleCliRemoveBatch` routes through `toastCliRemoveBatchResult` which
+// calls `toast.success/error/warning`. Sharing one mock object keeps the
+// surface identical to production.
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccess(...args),
+    error: (...args: unknown[]) => toastError(...args),
+    warning: (...args: unknown[]) => toastWarning(...args),
+  },
+}))
+
+beforeEach(() => {
+  mockSkillsCliRemoveBatch.mockReset()
+  mockGetAll.mockReset()
+  mockAgentsGetAll.mockReset()
+  mockSourceGetStats.mockReset()
+  toastSuccess.mockReset()
+  toastError.mockReset()
+  toastWarning.mockReset()
+  // `refreshAllData` dispatches fetchSkills/fetchAgents/fetchSourceStats after
+  // every confirm — stubbed to resolve immediately so the dialog's async
+  // confirm handler settles deterministically.
+  mockGetAll.mockResolvedValue([])
+  mockAgentsGetAll.mockResolvedValue([])
+  mockSourceGetStats.mockResolvedValue(null)
+  vi.stubGlobal('electron', {
+    skillsCli: {
+      removeBatch: mockSkillsCliRemoveBatch,
+    },
+    skills: {
+      getAll: mockGetAll,
+      onDeleteProgress: mockOnDeleteProgress,
+    },
+    agents: {
+      getAll: mockAgentsGetAll,
+    },
+    source: {
+      getStats: mockSourceGetStats,
+    },
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+/**
+ * Real reducers — the dialog reads `state.skills.cliRemoveTarget` and
+ * `state.skills.bulkCliRemoving`, both produced by `skillsSlice`. Using the
+ * real slice keeps the test honest: if a future reducer change breaks the
+ * pending→fulfilled flag flip, this test catches it.
+ */
+async function createStore() {
+  const { default: skillsReducer } =
+    await import('../../redux/slices/skillsSlice')
+  const { default: uiReducer } = await import('../../redux/slices/uiSlice')
+  const { default: agentsReducer } =
+    await import('../../redux/slices/agentsSlice')
+  return configureStore({
+    reducer: {
+      skills: skillsReducer,
+      ui: uiReducer,
+      agents: agentsReducer,
+    },
+  })
+}
+
+async function renderDialog() {
+  const store = await createStore()
+  const { DeleteCliSkillDialog } = await import('./DeleteCliSkillDialog')
+  const screen = await render(
+    <Provider store={store}>
+      <TooltipProvider>
+        <DeleteCliSkillDialog />
+      </TooltipProvider>
+    </Provider>,
+  )
+  return { screen, store }
+}
+
+describe('DeleteCliSkillDialog visibility', () => {
+  it('renders nothing while cliRemoveTarget is null', async () => {
+    const { screen } = await renderDialog()
+
+    // No dialog → no "Remove CLI-managed Skill" title. `.query()` returns null
+    // instead of throwing, so the assertion passes cleanly for the default
+    // closed state.
+    expect(
+      screen.getByRole('dialog', { name: /Remove CLI-managed Skill/i }).query(),
+    ).toBeNull()
+  })
+
+  it('opens with singular title when cliRemoveTarget holds exactly one skill', async () => {
+    const { screen, store } = await renderDialog()
+    const { setCliRemoveTarget } =
+      await import('../../redux/slices/skillsSlice')
+
+    store.dispatch(setCliRemoveTarget(['brainstorming' as SkillName]))
+
+    await expect
+      .element(
+        screen.getByRole('dialog', { name: /Remove CLI-managed Skill/i }),
+      )
+      .toBeInTheDocument()
+    // Singular title wins over plural — the dialog must not say "Skills".
+    expect(
+      screen
+        .getByRole('dialog', { name: /Remove CLI-managed Skills/i })
+        .query(),
+    ).toBeNull()
+  })
+
+  it('opens with plural title when cliRemoveTarget holds multiple skills', async () => {
+    const { screen, store } = await renderDialog()
+    const { setCliRemoveTarget } =
+      await import('../../redux/slices/skillsSlice')
+
+    store.dispatch(
+      setCliRemoveTarget([
+        'brainstorming' as SkillName,
+        'theme-generator' as SkillName,
+        'code-review' as SkillName,
+      ]),
+    )
+
+    await expect
+      .element(
+        screen.getByRole('dialog', { name: /Remove CLI-managed Skills/i }),
+      )
+      .toBeInTheDocument()
+    // Count rendered into the description body
+    await expect.element(screen.getByText(/3/)).toBeInTheDocument()
+  })
+})
+
+describe('DeleteCliSkillDialog confirm — happy path', () => {
+  it('dispatches cliRemoveSelectedSkills and fires the success toast on all-removed result', async () => {
+    const { screen, store } = await renderDialog()
+    const { setCliRemoveTarget } =
+      await import('../../redux/slices/skillsSlice')
+    const allRemoved: CliRemoveSkillsResult = {
+      items: [{ skillName: 'brainstorming' as SkillName, outcome: 'removed' }],
+    }
+    mockSkillsCliRemoveBatch.mockResolvedValue(allRemoved)
+
+    store.dispatch(setCliRemoveTarget(['brainstorming' as SkillName]))
+    await screen.getByRole('button', { name: /^Remove$/ }).click()
+
+    // Poll until the IPC mock has been called — the dialog's confirm handler
+    // awaits the thunk which in turn awaits the IPC promise.
+    await expect.poll(() => mockSkillsCliRemoveBatch.mock.calls.length).toBe(1)
+    expect(mockSkillsCliRemoveBatch.mock.calls[0][0]).toEqual({
+      items: [{ skillName: 'brainstorming' }],
+    })
+
+    await expect.poll(() => toastSuccess.mock.calls.length).toBe(1)
+    // Single-item success surfaces the name ("Removed brainstorming").
+    expect(toastSuccess.mock.calls[0][0]).toBe('Removed brainstorming')
+
+    // Dialog closes after confirm (cliRemoveTarget cleared via setCliRemoveTarget(null))
+    await expect
+      .poll(() =>
+        screen
+          .getByRole('dialog', { name: /Remove CLI-managed Skill/i })
+          .query(),
+      )
+      .toBeNull()
+  })
+
+  it('surfaces the failure toast when every batch item errors', async () => {
+    const { screen, store } = await renderDialog()
+    const { setCliRemoveTarget } =
+      await import('../../redux/slices/skillsSlice')
+    const allFailed: CliRemoveSkillsResult = {
+      items: [
+        {
+          skillName: 'brainstorming' as SkillName,
+          outcome: 'error',
+          error: { message: 'Skill not found in lock file', code: 1 },
+        },
+      ],
+    }
+    mockSkillsCliRemoveBatch.mockResolvedValue(allFailed)
+
+    store.dispatch(setCliRemoveTarget(['brainstorming' as SkillName]))
+    await screen.getByRole('button', { name: /^Remove$/ }).click()
+
+    await expect.poll(() => mockSkillsCliRemoveBatch.mock.calls.length).toBe(1)
+    // Single-item error surfaces "Failed to remove {name}" — asserting the
+    // exact toast copy ensures sanitisation of the CLI error message still
+    // flows through the batch toast helper.
+    await expect.poll(() => toastError.mock.calls.length).toBe(1)
+    expect(toastError.mock.calls[0][0]).toBe('Failed to remove brainstorming')
+  })
+
+  it('fires Batch CLI remove failed toast when the thunk itself rejects', async () => {
+    const { screen, store } = await renderDialog()
+    const { setCliRemoveTarget } =
+      await import('../../redux/slices/skillsSlice')
+    // IPC rejection (transport-level, not per-item error) routes to the
+    // thunk's rejected branch — `toast.error` fires with the thunk error
+    // rather than the batch-result toast helper.
+    mockSkillsCliRemoveBatch.mockRejectedValue(new Error('IPC channel closed'))
+
+    store.dispatch(
+      setCliRemoveTarget([
+        'brainstorming' as SkillName,
+        'code-review' as SkillName,
+      ]),
+    )
+    await screen.getByRole('button', { name: /^Remove$/ }).click()
+
+    await expect.poll(() => mockSkillsCliRemoveBatch.mock.calls.length).toBe(1)
+    await expect.poll(() => toastError.mock.calls.length).toBe(1)
+    // Batch copy wins because the target was length-2
+    expect(toastError.mock.calls[0][0]).toBe('Batch CLI remove failed')
+  })
+})
+
+describe('DeleteCliSkillDialog confirm — batch path', () => {
+  it('dispatches removeBatch with every queued skill name', async () => {
+    const { screen, store } = await renderDialog()
+    const { setCliRemoveTarget } =
+      await import('../../redux/slices/skillsSlice')
+    const partial: CliRemoveSkillsResult = {
+      items: [
+        { skillName: 'brainstorming' as SkillName, outcome: 'removed' },
+        { skillName: 'theme-generator' as SkillName, outcome: 'removed' },
+        {
+          skillName: 'code-review' as SkillName,
+          outcome: 'error',
+          error: { message: 'Skill not found', code: 1 },
+        },
+      ],
+    }
+    mockSkillsCliRemoveBatch.mockResolvedValue(partial)
+
+    store.dispatch(
+      setCliRemoveTarget([
+        'brainstorming' as SkillName,
+        'theme-generator' as SkillName,
+        'code-review' as SkillName,
+      ]),
+    )
+    await screen.getByRole('button', { name: /^Remove$/ }).click()
+
+    await expect.poll(() => mockSkillsCliRemoveBatch.mock.calls.length).toBe(1)
+    // All three names forwarded in order. Order matters: the CLI processes
+    // them serially and the toast's "N of M" math assumes the server honoured
+    // the array shape the thunk produced.
+    expect(mockSkillsCliRemoveBatch.mock.calls[0][0]).toEqual({
+      items: [
+        { skillName: 'brainstorming' },
+        { skillName: 'theme-generator' },
+        { skillName: 'code-review' },
+      ],
+    })
+    // Partial-success path → warning toast, not success or error
+    await expect.poll(() => toastWarning.mock.calls.length).toBe(1)
+    expect(toastWarning.mock.calls[0][0]).toBe('Removed 2, failed 1')
+  })
+})
+
+describe('DeleteCliSkillDialog close guards', () => {
+  it('clicking Cancel while idle closes the dialog', async () => {
+    const { screen, store } = await renderDialog()
+    const { setCliRemoveTarget } =
+      await import('../../redux/slices/skillsSlice')
+
+    store.dispatch(setCliRemoveTarget(['brainstorming' as SkillName]))
+    await expect.element(screen.getByRole('dialog')).toBeInTheDocument()
+
+    await screen.getByRole('button', { name: /Cancel/ }).click()
+
+    // Cancel path clears `cliRemoveTarget` → dialog unmounts.
+    await expect.poll(() => screen.getByRole('dialog').query()).toBeNull()
+    expect(store.getState().skills.cliRemoveTarget).toBeNull()
+    // IPC never fired — Cancel is a pure-UI action.
+    expect(mockSkillsCliRemoveBatch).not.toHaveBeenCalled()
+  })
+
+  it('Cancel button is disabled while bulkCliRemoving is true (prevents double-dismiss)', async () => {
+    const { screen, store } = await renderDialog()
+    const { setCliRemoveTarget, cliRemoveSelectedSkills } =
+      await import('../../redux/slices/skillsSlice')
+
+    // Hold the IPC promise open so the thunk stays in .pending — this is
+    // exactly the state in which Cancel must be disabled. Without the hold,
+    // the promise resolves before the assertion runs and the dialog closes.
+    let resolveIpc: (value: CliRemoveSkillsResult) => void = () => {}
+    mockSkillsCliRemoveBatch.mockReturnValue(
+      new Promise<CliRemoveSkillsResult>((resolve) => {
+        resolveIpc = resolve
+      }),
+    )
+
+    store.dispatch(setCliRemoveTarget(['brainstorming' as SkillName]))
+    // Fire the thunk via the store directly so we can assert the interim
+    // state without races against a click handler.
+    const pending = store.dispatch(
+      cliRemoveSelectedSkills(['brainstorming' as SkillName]),
+    )
+
+    // `.pending` flip is synchronous after dispatch
+    expect(store.getState().skills.bulkCliRemoving).toBe(true)
+
+    const cancelButton = screen.getByRole('button', { name: /Cancel/ })
+    await expect.element(cancelButton).toBeDisabled()
+
+    // Resolve and wait — the afterEach would otherwise leak an unresolved
+    // promise across the reused Chromium page.
+    resolveIpc({ items: [] })
+    await pending
+  })
+})

--- a/src/renderer/src/components/skills/DeleteCliSkillDialog.tsx
+++ b/src/renderer/src/components/skills/DeleteCliSkillDialog.tsx
@@ -1,0 +1,106 @@
+import React from 'react'
+import { toast } from 'sonner'
+
+import { useAppDispatch, useAppSelector } from '../../redux/hooks'
+import {
+  cliRemoveSelectedSkills,
+  selectBulkCliRemoving,
+  selectCliRemoveTarget,
+  setCliRemoveTarget,
+} from '../../redux/slices/skillsSlice'
+import { refreshAllData } from '../../redux/thunks'
+import { settleCliRemoveBatch } from '../../utils/bulkOpVisuals'
+import { DestructiveConfirmDialog } from '../shared/DestructiveConfirmDialog'
+
+/**
+ * Confirmation dialog for CLI-managed skill removal
+ * (deregister from `~/.agents/.skill-lock.json` via `npx skills remove`).
+ *
+ * Subscribes to `state.skills.cliRemoveTarget` — dispatching
+ * `setCliRemoveTarget([name])` (single) or `setCliRemoveTarget([...names])`
+ * (batch) opens the dialog. Fires the matching thunk on confirm and refreshes
+ * all data on settle, then clears the target.
+ *
+ * No undo: CLI remove is immediate and irreversible (the dialog IS the
+ * safety net). Failures surface per-item via toast.
+ */
+export const DeleteCliSkillDialog = React.memo(
+  function DeleteCliSkillDialog(): React.ReactElement {
+    const dispatch = useAppDispatch()
+    const target = useAppSelector(selectCliRemoveTarget)
+    const removing = useAppSelector(selectBulkCliRemoving)
+
+    const count = target?.length ?? 0
+    const isBatch = count > 1
+    const firstName = target?.[0] ?? ''
+    const subject = isBatch ? (
+      <>
+        <strong>{count}</strong> skills
+      </>
+    ) : (
+      <strong>{firstName}</strong>
+    )
+
+    const handleClose = (): void => {
+      if (!removing) {
+        dispatch(setCliRemoveTarget(null))
+      }
+    }
+
+    const handleConfirm = async (): Promise<void> => {
+      if (!target || target.length === 0) return
+
+      // Single and batch paths both go through `cliRemoveSelectedSkills` —
+      // the batch thunk correctly handles length-1 arrays, and
+      // `toastCliRemoveBatchResult` surfaces the skill name when the batch
+      // had exactly one successful item. Collapsing the two branches kept
+      // the dialog honest: every remove is a batch from the main process's
+      // point of view.
+      try {
+        const result = await dispatch(cliRemoveSelectedSkills(target))
+        if (cliRemoveSelectedSkills.fulfilled.match(result)) {
+          settleCliRemoveBatch(result.payload)
+        } else {
+          toast.error(
+            isBatch ? 'Batch CLI remove failed' : 'CLI remove failed',
+            { description: result.error?.message ?? 'Unexpected error' },
+          )
+        }
+      } finally {
+        // `settleCliRemoveBatch` fans out via CustomEvent dispatch + toast —
+        // if either throws synchronously the dialog would otherwise stay
+        // mounted on a stale target. The finally guarantees the target is
+        // always cleared so the dialog cannot reopen on ghost data.
+        refreshAllData(dispatch)
+        dispatch(setCliRemoveTarget(null))
+      }
+    }
+
+    return (
+      <DestructiveConfirmDialog
+        open={!!target && count > 0}
+        onClose={handleClose}
+        onConfirm={handleConfirm}
+        loading={removing}
+        title={
+          isBatch ? 'Remove CLI-managed Skills' : 'Remove CLI-managed Skill'
+        }
+        description={
+          <>
+            Deregister {subject} from{' '}
+            <code className="text-xs">~/.agents/.skill-lock.json</code>?
+            <br />
+            <span className="text-muted-foreground mt-2 block">
+              This runs <code className="text-xs">npx skills remove</code> and
+              cannot be undone. The skill folder and lock-file entry will be
+              permanently removed.
+            </span>
+          </>
+        }
+        confirmLabel="Remove"
+        loadingLabel="Removing..."
+        iconVariant="warning"
+      />
+    )
+  },
+)

--- a/src/renderer/src/components/skills/SelectionToolbar.tsx
+++ b/src/renderer/src/components/skills/SelectionToolbar.tsx
@@ -13,6 +13,7 @@ import {
 import {
   clearSelection,
   selectAll,
+  selectBulkCliRemoving,
   selectBulkDeleting,
   selectBulkProgress,
   selectBulkUnlinking,
@@ -69,6 +70,7 @@ export const SelectionToolbar = React.memo(function SelectionToolbar({
   const bulkSelectMode = useAppSelector(selectBulkSelectMode)
   const bulkDeleting = useAppSelector(selectBulkDeleting)
   const bulkUnlinking = useAppSelector(selectBulkUnlinking)
+  const bulkCliRemoving = useAppSelector(selectBulkCliRemoving)
   const bulkProgress = useAppSelector(selectBulkProgress)
 
   // Belt-and-suspenders: the listener middleware already clears selection on
@@ -86,7 +88,11 @@ export const SelectionToolbar = React.memo(function SelectionToolbar({
     visibleCount: visibleSelectedCount,
     agentDisplayName,
   })
-  const isBusy = bulkDeleting || bulkUnlinking
+  // OR bulkCliRemoving too — the CLI batch loop spawns npx serially
+  // (~600ms–2s each) with no per-item progress, so without this the user
+  // could double-click and fire a second batch while the first is still
+  // running against the shared `.skill-lock.json` file.
+  const isBusy = bulkDeleting || bulkUnlinking || bulkCliRemoving
 
   const showProgress =
     bulkProgress !== null && bulkProgress.total >= BULK_PROGRESS_THRESHOLD

--- a/src/renderer/src/components/skills/SkillItem.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillItem.browser.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import type { Skill, SkillName } from '../../../../shared/types'
+import { repositoryId } from '../../../../shared/types'
 import { TooltipProvider } from '../ui/tooltip'
 
 const mockGetAll = vi.fn()
@@ -144,5 +145,117 @@ describe('SkillItem bulk-select checkbox visibility', () => {
     // Poll until the checkbox unmounts — exit dispatch is sync but the
     // re-render that removes the node happens on the next commit cycle.
     await expect.poll(() => screen.getByRole('checkbox').query()).toBeNull()
+  })
+})
+
+describe('SkillItem delete button — CLI vs plain routing', () => {
+  // The X button in global view is the fork where `isCliManagedSkill(skill)`
+  // decides whether the row enters the CLI remove dialog (irreversible) or
+  // the shared trash+undo flow. Getting this wrong orphans `.skill-lock.json`
+  // entries, so the branch is worth pinning down with explicit assertions.
+
+  it('aria-label reads "Remove {name} via skills CLI" for a CLI-managed skill', async () => {
+    const { screen } = await renderSkillItem(
+      makeSkill({
+        name: 'brainstorming' as SkillName,
+        // `source` set → isCliManagedSkill → CLI path
+        source: repositoryId('vercel-labs/agent-skills'),
+      }),
+    )
+
+    await expect
+      .element(
+        screen.getByRole('button', {
+          name: /Remove brainstorming via skills CLI/i,
+        }),
+      )
+      .toBeInTheDocument()
+  })
+
+  it('aria-label reads "Delete {name}" for a plain (non-CLI) skill', async () => {
+    const { screen } = await renderSkillItem(
+      makeSkill({ name: 'local-skill' as SkillName }),
+    )
+
+    await expect
+      .element(screen.getByRole('button', { name: /^Delete local-skill$/i }))
+      .toBeInTheDocument()
+  })
+
+  it('clicking the X on a CLI skill dispatches setCliRemoveTarget([name])', async () => {
+    const { screen, store } = await renderSkillItem(
+      makeSkill({
+        name: 'brainstorming' as SkillName,
+        source: repositoryId('vercel-labs/agent-skills'),
+      }),
+    )
+
+    await screen
+      .getByRole('button', { name: /Remove brainstorming via skills CLI/i })
+      .click()
+
+    // CLI path → cliRemoveTarget is set, bulkConfirm stays null. Asserting
+    // both guards against future regressions where the handler accidentally
+    // dispatches into the trash flow as well.
+    expect(store.getState().skills.cliRemoveTarget).toEqual(['brainstorming'])
+    expect(store.getState().ui.bulkConfirm).toBeNull()
+  })
+
+  it('clicking the X on a plain skill opens bulkConfirm (trash + undo path)', async () => {
+    const { screen, store } = await renderSkillItem(
+      makeSkill({ name: 'local-skill' as SkillName }),
+    )
+
+    await screen.getByRole('button', { name: /^Delete local-skill$/i }).click()
+
+    // Plain path → bulkConfirm surfaces the trash+undo dialog, cliRemoveTarget
+    // stays null. The payload shape must also match what BulkConfirmDialog
+    // expects (kind='delete', no agent).
+    const confirm = store.getState().ui.bulkConfirm
+    expect(confirm).toEqual({
+      kind: 'delete',
+      skillNames: ['local-skill'],
+      agentId: null,
+      agentName: null,
+    })
+    expect(store.getState().skills.cliRemoveTarget).toBeNull()
+  })
+
+  it('X button click does not trigger inspector selection (stopPropagation)', async () => {
+    const { screen, store } = await renderSkillItem(
+      makeSkill({ name: 'brainstorming' as SkillName }),
+    )
+
+    await screen
+      .getByRole('button', { name: /^Delete brainstorming$/i })
+      .click()
+
+    // If propagation leaked, the Card's onClick would fire `selectSkill(skill)`
+    // and the inspector pane would open on the very skill we're deleting — an
+    // obvious UX sin. The handler calls `e.stopPropagation()` specifically to
+    // prevent this.
+    expect(store.getState().skills.selectedSkill).toBeNull()
+  })
+})
+
+describe('SkillItem bulk-select checkbox stopPropagation', () => {
+  // The checkbox wrapper `<label>` and the Checkbox itself both need to stop
+  // propagation, otherwise Card's onClick (which toggles the Inspector pane)
+  // fires alongside the toggle — a click on the checkbox would both tick AND
+  // flip selectedSkill, which is never what the user wants.
+
+  it('toggling the checkbox does not set selectedSkill', async () => {
+    const { screen, store } = await renderSkillItem(
+      makeSkill({ name: 'task' as SkillName }),
+    )
+    const { enterBulkSelectMode } = await import('../../redux/slices/uiSlice')
+
+    store.dispatch(enterBulkSelectMode())
+    await screen.getByRole('checkbox', { name: /Select task/i }).click()
+
+    // Checkbox tick → selection updated in the skills slice, Inspector stays
+    // closed. If stopPropagation regressed, selectedSkill would be set here.
+    expect(store.getState().skills.selectedSkillNames).toEqual(['task'])
+    expect(store.getState().skills.selectedSkill).toBeNull()
   })
 })

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -13,7 +13,7 @@ import type { Skill, SkillName } from '../../../../shared/types'
 import { cn } from '../../lib/utils'
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
 import {
-  selectInFlightDeleteNamesSet,
+  selectAnyInFlightRemovalSet,
   selectSelectedSkillNamesSet,
   selectVisibleSkillNames,
 } from '../../redux/selectors'
@@ -26,12 +26,17 @@ import {
   selectRange,
   selectSelectionAnchor,
   selectSkill,
+  setCliRemoveTarget,
   setSkillToAddSymlinks,
   setSkillToCopy,
   setSkillToUnlink,
   toggleSelection,
 } from '../../redux/slices/skillsSlice'
-import { selectBulkSelectMode } from '../../redux/slices/uiSlice'
+import {
+  selectBulkSelectMode,
+  setBulkConfirm,
+} from '../../redux/slices/uiSlice'
+import { BULK_ITEM_FAILED_EVENT } from '../../utils/bulkOpVisuals'
 import { StatusBadge } from '../status/StatusBadge'
 import { Button } from '../ui/button'
 import { Card, CardContent } from '../ui/card'
@@ -45,13 +50,13 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 
 import { canBookmarkSkill, skillToBookmarkData } from './bookmarkHelpers'
-import { computeRangeSelection } from './bulkDeleteHelpers'
+import { computeRangeSelection, isCliManagedSkill } from './bulkDeleteHelpers'
 import { getSkillItemVisibility } from './skillItemHelpers'
 import { SourceLink } from './SourceLink'
 
 // Strongly-type the `skills:bulkItemFailed` CustomEvent so the cast inside
 // handleFailEvent is compile-checked instead of a freeform `as CustomEvent<…>`.
-// The dispatch site lives in MainContent.flashFailedRows.
+// The dispatch site lives in utils/bulkOpVisuals.ts.
 declare global {
   interface WindowEventMap {
     'skills:bulkItemFailed': CustomEvent<{ skillName: SkillName }>
@@ -88,12 +93,12 @@ export const SkillItem = React.memo(function SkillItem({
   const showBookmark = canBookmarkSkill(skill)
 
   const selectedNamesSet = useAppSelector(selectSelectedSkillNamesSet)
-  const inFlightDeleteSet = useAppSelector(selectInFlightDeleteNamesSet)
+  const inFlightRemovalSet = useAppSelector(selectAnyInFlightRemovalSet)
   const selectionAnchor = useAppSelector(selectSelectionAnchor)
   const visibleNames = useAppSelector(selectVisibleSkillNames)
   const bulkSelectMode = useAppSelector(selectBulkSelectMode)
   const isTicked = selectedNamesSet.has(skill.name)
-  const isInFlight = inFlightDeleteSet.has(skill.name)
+  const isInFlight = inFlightRemovalSet.has(skill.name)
 
   const validSymlinks = useMemo(
     () => skill.symlinks.filter((s) => s.status === 'valid'),
@@ -118,11 +123,14 @@ export const SkillItem = React.memo(function SkillItem({
     showAddButton,
     showUnlinkButton,
     showCopyButton,
+    showDeleteButton,
     isLinked,
     isLocalSkill,
     selectedAgentSymlink,
     selectedLocalSkillInfo,
   } = getSkillItemVisibility(selectedAgentId, skill.symlinks)
+
+  const isCliManaged = isCliManagedSkill(skill)
 
   // Get selected agent name for tooltip
   const selectedAgentName =
@@ -139,6 +147,28 @@ export const SkillItem = React.memo(function SkillItem({
   const handleAddClick = (e: React.MouseEvent): void => {
     e.stopPropagation()
     dispatch(setSkillToAddSymlinks(skill))
+  }
+
+  /**
+   * Global-view per-row delete. Routes CLI-managed skills to the CLI remove
+   * dialog (no undo — the dialog is the safety net) and plain skills to the
+   * shared bulk-confirm dialog (which cascades into the trash+undo flow on
+   * confirm). Splitting here keeps SkillItem free of thunk/toast code.
+   */
+  const handleDeleteClick = (e: React.MouseEvent): void => {
+    e.stopPropagation()
+    if (isCliManaged) {
+      dispatch(setCliRemoveTarget([skill.name]))
+      return
+    }
+    dispatch(
+      setBulkConfirm({
+        kind: 'delete',
+        skillNames: [skill.name],
+        agentId: null,
+        agentName: null,
+      }),
+    )
   }
 
   const handleToggleBookmark = (e: React.MouseEvent): void => {
@@ -235,7 +265,7 @@ export const SkillItem = React.memo(function SkillItem({
     // Typed via the `WindowEventMap` augmentation above, so `event.detail` is
     // known to carry `{ skillName }` without a cast.
     const handleFailEvent = (
-      event: WindowEventMap['skills:bulkItemFailed'],
+      event: WindowEventMap[typeof BULK_ITEM_FAILED_EVENT],
     ): void => {
       if (event.detail.skillName !== skill.name) return
       setDidPartialFail(true)
@@ -244,9 +274,9 @@ export const SkillItem = React.memo(function SkillItem({
         setDidPartialFail(false)
       }, PARTIAL_FAIL_FLASH_MS)
     }
-    window.addEventListener('skills:bulkItemFailed', handleFailEvent)
+    window.addEventListener(BULK_ITEM_FAILED_EVENT, handleFailEvent)
     return () => {
-      window.removeEventListener('skills:bulkItemFailed', handleFailEvent)
+      window.removeEventListener(BULK_ITEM_FAILED_EVENT, handleFailEvent)
     }
   }, [skill.name])
 
@@ -279,8 +309,7 @@ export const SkillItem = React.memo(function SkillItem({
           onContextMenu={handleContextMenu}
         >
           {/* X button — agent-view only (unlink or delete a local skill from
-              the selected agent). Global-view delete lives on the bulk
-              SelectionToolbar. Apple HIG 44×44 hit area via min-h/min-w. */}
+              the selected agent). Apple HIG 44×44 hit area via min-h/min-w. */}
           {showUnlinkButton && (
             <Tooltip>
               <TooltipTrigger asChild>
@@ -305,6 +334,34 @@ export const SkillItem = React.memo(function SkillItem({
             </Tooltip>
           )}
 
+          {/* X button — global-view only (delete entire skill).
+              Routes to CLI remove when lock-file-tracked, else to the shared
+              bulk-confirm dialog which cascades to trash + undo toast.
+              Same visual corner as showUnlinkButton; they're mutually
+              exclusive because `!selectedAgentId` gates showDeleteButton. */}
+          {showDeleteButton && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={handleDeleteClick}
+                  aria-label={
+                    isCliManaged
+                      ? `Remove ${skill.name} via skills CLI`
+                      : `Delete ${skill.name}`
+                  }
+                  data-testid={`skill-delete-${skill.name}`}
+                  className="absolute top-0 right-0 min-h-[44px] min-w-[44px] flex items-center justify-center rounded-md hover:bg-destructive/10 text-muted-foreground hover:text-destructive z-10 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="left">
+                {isCliManaged ? 'Remove (CLI)' : 'Delete'}
+              </TooltipContent>
+            </Tooltip>
+          )}
+
           {/* Bookmark toggle — only for skills with repo source.
               Positioned to the left of the X button with a 44×44 hit area. */}
           {showBookmark && (
@@ -320,8 +377,12 @@ export const SkillItem = React.memo(function SkillItem({
                   }
                   className={cn(
                     'absolute top-0 min-h-[44px] min-w-[44px] flex items-center justify-center rounded-md z-10 transition-opacity',
-                    // Right-align: slide the bookmark left of the X when both are visible.
-                    showUnlinkButton ? 'right-11' : 'right-0',
+                    // Right-align: slide the bookmark left of the X when an
+                    // X button (unlink in agent view, delete in global view)
+                    // shares the top-right corner.
+                    showUnlinkButton || showDeleteButton
+                      ? 'right-11'
+                      : 'right-0',
                     isBookmarked
                       ? 'text-primary'
                       : 'text-muted-foreground hover:text-foreground opacity-0 group-hover:opacity-100 focus-visible:opacity-100',
@@ -344,7 +405,9 @@ export const SkillItem = React.memo(function SkillItem({
             className={cn(
               'p-4',
               // Reserve right space for the X/bookmark buttons when shown.
-              showUnlinkButton || showBookmark ? 'pr-14' : 'pr-4',
+              showUnlinkButton || showDeleteButton || showBookmark
+                ? 'pr-14'
+                : 'pr-4',
             )}
           >
             <div className="flex items-start gap-3">

--- a/src/renderer/src/components/skills/bulkDeleteCopy.tsx
+++ b/src/renderer/src/components/skills/bulkDeleteCopy.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+
+import { pluralize } from '../../utils/pluralize'
+
+/**
+ * Render the DialogDescription body for the bulk-delete confirm dialog.
+ *
+ * Three branches, driven by how many CLI-managed skills are in the batch:
+ *  - `cliCount === 0`      → all-trash copy (reversible for 15s)
+ *  - `cliCount === total`  → all-CLI copy (irreversible via `npx skills remove`)
+ *  - otherwise             → mixed copy with per-bucket counts
+ *
+ * Extracted out of the JSX so the dialog render stays readable and so the
+ * three-branch logic is testable without mounting the full MainContent tree.
+ *
+ * @param cliCount - CLI-managed skills in the pending batch (from `selectBulkCliCount`)
+ * @param totalCount - Total skills in the pending batch
+ * @returns React node to drop into `<DialogDescription>`
+ * @example
+ * <DialogDescription>
+ *   {renderBulkDeleteDescription({ cliCount: 0, totalCount: 3 })}
+ * </DialogDescription>
+ */
+export const renderBulkDeleteDescription = ({
+  cliCount,
+  totalCount,
+}: {
+  cliCount: number
+  totalCount: number
+}): React.ReactNode => {
+  if (cliCount === 0) {
+    return 'This moves the skills to the app trash and removes every symlink pointing to them. You can restore within 15 seconds from the notification.'
+  }
+
+  if (cliCount === totalCount) {
+    return (
+      <>
+        These skills are CLI-managed and will be deregistered via{' '}
+        <code className="text-xs">npx skills remove</code>. This cannot be
+        undone.
+      </>
+    )
+  }
+
+  const trashCount = totalCount - cliCount
+  return (
+    <>
+      {trashCount} will move to the app trash (restorable for 15s).{' '}
+      <strong>{cliCount}</strong> CLI-managed {pluralize(cliCount, 'skill')}{' '}
+      will run <code className="text-xs">npx skills remove</code> and cannot be
+      undone.
+    </>
+  )
+}

--- a/src/renderer/src/components/skills/bulkDeleteCopy.tsx
+++ b/src/renderer/src/components/skills/bulkDeleteCopy.tsx
@@ -29,13 +29,14 @@ export const renderBulkDeleteDescription = ({
   totalCount: number
 }): React.ReactNode => {
   if (cliCount === 0) {
-    return 'This moves the skills to the app trash and removes every symlink pointing to them. You can restore within 15 seconds from the notification.'
+    return `This moves the ${pluralize(totalCount, 'skill')} to the app trash and removes every symlink pointing to ${pluralize(totalCount, 'it', 'them')}. You can restore within 15 seconds from the notification.`
   }
 
   if (cliCount === totalCount) {
     return (
       <>
-        These skills are CLI-managed and will be deregistered via{' '}
+        {pluralize(cliCount, 'This skill is', 'These skills are')} CLI-managed
+        and will be deregistered via{' '}
         <code className="text-xs">npx skills remove</code>. This cannot be
         undone.
       </>
@@ -45,10 +46,10 @@ export const renderBulkDeleteDescription = ({
   const trashCount = totalCount - cliCount
   return (
     <>
-      {trashCount} will move to the app trash (restorable for 15s).{' '}
-      <strong>{cliCount}</strong> CLI-managed {pluralize(cliCount, 'skill')}{' '}
-      will run <code className="text-xs">npx skills remove</code> and cannot be
-      undone.
+      {trashCount} {pluralize(trashCount, 'skill')} will move to the app trash
+      (restorable for 15s). <strong>{cliCount}</strong> CLI-managed{' '}
+      {pluralize(cliCount, 'skill')} will run{' '}
+      <code className="text-xs">npx skills remove</code> and cannot be undone.
     </>
   )
 }

--- a/src/renderer/src/components/skills/bulkDeleteHelpers.test.ts
+++ b/src/renderer/src/components/skills/bulkDeleteHelpers.test.ts
@@ -4,6 +4,8 @@ import type {
   AgentId,
   BulkDeleteResult,
   BulkUnlinkResult,
+  RepositoryId,
+  Skill,
   SkillName,
 } from '../../../../shared/types'
 import { tombstoneId } from '../../../../shared/types'
@@ -13,6 +15,8 @@ import {
   formatCascadeSummary,
   formatUnlinkSummary,
   getToolbarState,
+  isCliManagedSkill,
+  partitionSkillsForDelete,
 } from './bulkDeleteHelpers'
 
 describe('getToolbarState', () => {
@@ -273,5 +277,123 @@ describe('computeRangeSelection', () => {
 
   it('handles the first and last items correctly', () => {
     expect(computeRangeSelection('alpha', 'zebra', visible)).toEqual(visible)
+  })
+})
+
+describe('partitionSkillsForDelete', () => {
+  // Keep fixture authoring small: only `name` and `source` drive the bucket
+  // decision; the other Skill fields are cast over with `as Skill`.
+  const mkSkill = (name: string, source?: string): Skill =>
+    ({
+      name: name as SkillName,
+      source:
+        source !== undefined ? (source as unknown as RepositoryId) : undefined,
+    }) as Skill
+
+  it('routes skills with a `source` field into cliNames', () => {
+    const items = [
+      mkSkill('task'),
+      mkSkill('brainstorming', 'vercel-labs/agent-skills'),
+    ]
+    const result = partitionSkillsForDelete(
+      ['task', 'brainstorming'] as SkillName[],
+      items,
+    )
+    expect(result).toEqual({
+      cliNames: ['brainstorming'],
+      plainNames: ['task'],
+    })
+  })
+
+  it('routes skills without a `source` field into plainNames', () => {
+    const items = [mkSkill('task'), mkSkill('theme')]
+    const result = partitionSkillsForDelete(
+      ['task', 'theme'] as SkillName[],
+      items,
+    )
+    expect(result).toEqual({
+      cliNames: [],
+      plainNames: ['task', 'theme'],
+    })
+  })
+
+  it('puts stale selection entries (not in items) into plainNames', () => {
+    const items = [mkSkill('task', 'vercel-labs/agent-skills')]
+    // Ghost name "removed" is not in items at all.
+    const result = partitionSkillsForDelete(
+      ['task', 'removed'] as SkillName[],
+      items,
+    )
+    expect(result.cliNames).toEqual(['task'])
+    expect(result.plainNames).toEqual(['removed'])
+  })
+
+  it('preserves selection order per bucket', () => {
+    const items = [
+      mkSkill('a'),
+      mkSkill('b', 'owner/repo'),
+      mkSkill('c'),
+      mkSkill('d', 'owner/repo'),
+    ]
+    const result = partitionSkillsForDelete(
+      ['d', 'a', 'c', 'b'] as SkillName[],
+      items,
+    )
+    // Relative order within each bucket must mirror input order.
+    expect(result.cliNames).toEqual(['d', 'b'])
+    expect(result.plainNames).toEqual(['a', 'c'])
+  })
+
+  it('handles empty selection', () => {
+    const items = [mkSkill('task')]
+    const result = partitionSkillsForDelete([] as SkillName[], items)
+    expect(result).toEqual({ cliNames: [], plainNames: [] })
+  })
+
+  it("preserves duplicate names in the same bucket (dedup is the caller's job)", () => {
+    // Duplicate selections should not be silently deduplicated here — the
+    // partition contract is "union equals input" (see docstring). Dedup
+    // would hide a real selection bug in callers upstream.
+    const items = [mkSkill('task', 'owner/repo'), mkSkill('theme')]
+    const result = partitionSkillsForDelete(
+      ['task', 'task', 'theme', 'theme'] as SkillName[],
+      items,
+    )
+    expect(result.cliNames).toEqual(['task', 'task'])
+    expect(result.plainNames).toEqual(['theme', 'theme'])
+  })
+
+  it('treats a falsy source (empty string) as CLI-managed since source is present', () => {
+    // `isCliManagedSkill` keys on `source !== undefined`, not truthiness —
+    // an empty-string source is still a lock-file entry (e.g. a local-only
+    // CLI install with no remote repo). Routing it to plainNames would
+    // leak a stale lock entry. See isCliManagedSkill docstring.
+    const items = [mkSkill('task', '')]
+    const result = partitionSkillsForDelete(['task'] as SkillName[], items)
+    expect(result.cliNames).toEqual(['task'])
+    expect(result.plainNames).toEqual([])
+  })
+})
+
+describe('isCliManagedSkill', () => {
+  const mkSkill = (source: string | undefined): Skill =>
+    ({
+      name: 'task' as SkillName,
+      source:
+        source === undefined ? undefined : (source as unknown as RepositoryId),
+    }) as Skill
+
+  it('returns true when source is a non-empty repository id', () => {
+    expect(isCliManagedSkill(mkSkill('vercel-labs/agent-skills'))).toBe(true)
+  })
+
+  it('returns true for an empty-string source (source field present)', () => {
+    // `source = ''` still means the skill was registered via `npx skills add`
+    // with an empty repo field. Must NOT fall through to plainNames.
+    expect(isCliManagedSkill(mkSkill(''))).toBe(true)
+  })
+
+  it('returns false when source is undefined', () => {
+    expect(isCliManagedSkill(mkSkill(undefined))).toBe(false)
   })
 })

--- a/src/renderer/src/components/skills/bulkDeleteHelpers.ts
+++ b/src/renderer/src/components/skills/bulkDeleteHelpers.ts
@@ -6,6 +6,7 @@ import type {
   BulkDeleteResult,
   BulkUnlinkItemResult,
   BulkUnlinkResult,
+  Skill,
   SkillName,
 } from '../../../../shared/types'
 import { pluralize } from '../../utils/pluralize'
@@ -23,6 +24,24 @@ import { pluralize } from '../../utils/pluralize'
  */
 export type ToolbarView = 'global' | 'agent'
 export type ToolbarCountKind = 'single' | 'multi'
+
+/**
+ * Single source of truth for "is this skill registered in
+ * `~/.agents/.skill-lock.json`?" — true when `source` is set, which the main
+ * process writes only for skills installed via `npx skills add`.
+ *
+ * Callers use this to pick the right delete path: CLI-managed skills go
+ * through `cliRemoveSelectedSkills` so the lock file is rewritten, plain
+ * skills go through the trash + UndoToast pipeline. Getting this branch
+ * wrong leaves ghost lock entries that haunt the Installed badge.
+ *
+ * @param skill - Any Skill record from `state.skills.items`
+ * @returns true when the skill is CLI-tracked, false for plain skills
+ * @example
+ * const isCliManaged = isCliManagedSkill(skill)
+ */
+export const isCliManagedSkill = (skill: Skill): boolean =>
+  skill.source !== undefined
 
 export interface ToolbarStateInput {
   view: ToolbarView
@@ -211,6 +230,53 @@ export const formatUnlinkSummary = (
  * computeRangeSelection('removed', 'zebra', ['alpha','zebra'])
  * // => ['zebra']
  */
+/**
+ * Split a set of selected skill names into two buckets based on whether each
+ * skill is tracked in `~/.agents/.skill-lock.json` (i.e. has a `source` field).
+ *
+ * Used by the bulk-delete confirm dialog in global view so the renderer can
+ * fire `deleteSelectedSkills` for plain folders AND `cliRemoveSelectedSkills`
+ * for lock-file-tracked ones in the same operation. Filesystem-only delete
+ * on a CLI-tracked skill would leave a stale lock entry, which eventually
+ * surfaces as a phantom install.
+ *
+ * Names not found in `items` (stale selection after a refetch) fall into the
+ * `plainNames` bucket so the downstream thunk's own reconciliation
+ * (`reconcileByLiveNames`) drops them cleanly.
+ *
+ * @param selectedNames - Names ticked by the user (already visible-filtered).
+ * @param items - `state.skills.items` to look up the `source` field.
+ * @returns Two arrays — CLI-managed names and regular names. Union equals input (order preserved per bucket).
+ * @example
+ * partitionSkillsForDelete(['task', 'brainstorming'], [
+ *   { name: 'task', source: undefined, ... },
+ *   { name: 'brainstorming', source: 'vercel-labs/agent-skills' as ..., ... },
+ * ])
+ * // => { cliNames: ['brainstorming'], plainNames: ['task'] }
+ */
+export const partitionSkillsForDelete = (
+  selectedNames: SkillName[],
+  items: readonly Skill[],
+): { cliNames: SkillName[]; plainNames: SkillName[] } => {
+  // Index items once to avoid O(N*M) lookup when partitioning a large batch.
+  const skillByName = new Map(items.map((skill) => [skill.name, skill]))
+  const cliNames: SkillName[] = []
+  const plainNames: SkillName[] = []
+
+  for (const name of selectedNames) {
+    const skill = skillByName.get(name)
+    // Skills not in the live set — treat as plain so the trash thunk's
+    // `reconcileByLiveNames` filters them out without a CLI round-trip.
+    if (skill !== undefined && isCliManagedSkill(skill)) {
+      cliNames.push(name)
+    } else {
+      plainNames.push(name)
+    }
+  }
+
+  return { cliNames, plainNames }
+}
+
 export const computeRangeSelection = (
   anchorName: SkillName | null,
   targetName: SkillName,

--- a/src/renderer/src/redux/selectors.ts
+++ b/src/renderer/src/redux/selectors.ts
@@ -190,6 +190,13 @@ export const selectInFlightCliRemoveNamesSet = createSelector(
   (names): ReadonlySet<SkillName> => new Set(names),
 )
 
+// Shared empty Set sentinel — returned by every selector that short-circuits
+// on the "no in-flight work" idle case. Hoisted above the first selector that
+// references it so the binding is initialized before any module-time selector
+// evaluation (avoids the TDZ ReferenceError if `createSelector` ever probes
+// its transform eagerly, and removes the reader hazard of a forward reference).
+const EMPTY_SKILL_NAME_SET: ReadonlySet<SkillName> = new Set()
+
 /**
  * Union of `inFlightDeleteNames` and `inFlightCliRemoveNames` — either kind
  * of removal fades the row identically, so SkillItem only needs one Set. One
@@ -216,8 +223,6 @@ export const selectAnyInFlightRemovalSet = createSelector(
     return union
   },
 )
-
-const EMPTY_SKILL_NAME_SET: ReadonlySet<SkillName> = new Set()
 
 /**
  * Memoized Set wrapper around `selectedSkillNames` — used by the checkbox in

--- a/src/renderer/src/redux/selectors.ts
+++ b/src/renderer/src/redux/selectors.ts
@@ -1,14 +1,17 @@
 import { createSelector } from '@reduxjs/toolkit'
 
 import type { SkillName } from '../../../shared/types'
+import { partitionSkillsForDelete } from '../components/skills/bulkDeleteHelpers'
 
 import { selectBookmarkItems } from './slices/bookmarkSlice'
 import {
+  selectInFlightCliRemoveNames,
   selectInFlightDeleteNames,
   selectSelectedSkillNames,
   selectSkillsItems,
 } from './slices/skillsSlice'
 import {
+  selectBulkConfirm,
   selectSearchQuery,
   selectSelectedAgentId,
   selectSkillTypeFilter,
@@ -176,6 +179,47 @@ export const selectInFlightDeleteNamesSet = createSelector(
 )
 
 /**
+ * Memoized Set wrapper around `inFlightCliRemoveNames` — parallel to
+ * `selectInFlightDeleteNamesSet` for the CLI-remove flow. SkillItem OR's
+ * the two sets to decide row fade, so a CLI spawn fades the row the same
+ * as a trash delete.
+ * @returns ReadonlySet<SkillName>
+ */
+export const selectInFlightCliRemoveNamesSet = createSelector(
+  [selectInFlightCliRemoveNames],
+  (names): ReadonlySet<SkillName> => new Set(names),
+)
+
+/**
+ * Union of `inFlightDeleteNames` and `inFlightCliRemoveNames` — either kind
+ * of removal fades the row identically, so SkillItem only needs one Set. One
+ * subscription per row vs two halves the useSyncExternalStore work across
+ * virtualized lists during a large batch.
+ *
+ * Kept as a separate selector (rather than replacing the two underlying ones)
+ * because the reducers still read them individually for narrow state clears.
+ * @returns ReadonlySet<SkillName>
+ * @example
+ * const inFlight = useAppSelector(selectAnyInFlightRemovalSet)
+ * const isFading = inFlight.has(skill.name)
+ */
+export const selectAnyInFlightRemovalSet = createSelector(
+  [selectInFlightDeleteNames, selectInFlightCliRemoveNames],
+  (deleteNames, cliNames): ReadonlySet<SkillName> => {
+    // Short-circuit when neither set has entries — avoids one allocation on
+    // every unrelated re-render in the common idle case.
+    if (deleteNames.length === 0 && cliNames.length === 0) {
+      return EMPTY_SKILL_NAME_SET
+    }
+    const union = new Set<SkillName>(deleteNames)
+    for (const name of cliNames) union.add(name)
+    return union
+  },
+)
+
+const EMPTY_SKILL_NAME_SET: ReadonlySet<SkillName> = new Set()
+
+/**
  * Memoized Set wrapper around `selectedSkillNames` — used by the checkbox in
  * SkillItem to determine its ticked state without scanning the array per row.
  * @returns ReadonlySet<SkillName>
@@ -183,4 +227,24 @@ export const selectInFlightDeleteNamesSet = createSelector(
 export const selectSelectedSkillNamesSet = createSelector(
   [selectSelectedSkillNames],
   (names): ReadonlySet<SkillName> => new Set(names),
+)
+
+/**
+ * Count of CLI-managed skills inside the pending bulk-delete confirmation.
+ * Drives the confirm-dialog warning copy: zero = trash-only language,
+ * >0 = append the no-undo warning so the user sees part of the batch is
+ * irreversible.
+ *
+ * Moved from MainContent's useMemo into Redux so the partition only re-runs
+ * when `bulkConfirm` or `items` actually changes — not on every component
+ * render triggered by unrelated slices.
+ * @returns number — CLI-managed count, or 0 when no bulk-delete confirm is open
+ */
+export const selectBulkCliCount = createSelector(
+  [selectBulkConfirm, selectSkillsItems],
+  (bulkConfirm, items): number => {
+    if (!bulkConfirm || bulkConfirm.kind !== 'delete') return 0
+    return partitionSkillsForDelete(bulkConfirm.skillNames, items).cliNames
+      .length
+  },
 )

--- a/src/renderer/src/redux/slices/skillsSlice.test.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.test.ts
@@ -5,12 +5,14 @@ import type {
   AgentId,
   BulkDeleteResult,
   BulkUnlinkResult,
+  CliRemoveSkillsResult,
   RestoreDeletedSkillResult,
   Skill,
+  SkillName,
   SymlinkInfo,
   TombstoneId,
 } from '../../../../shared/types'
-import { tombstoneId } from '../../../../shared/types'
+import { repositoryId, tombstoneId } from '../../../../shared/types'
 
 const mockGetAll = vi.fn()
 const mockUnlinkFromAgent = vi.fn()
@@ -20,6 +22,7 @@ const mockDeleteSkills = vi.fn()
 const mockUnlinkManyFromAgent = vi.fn()
 const mockRestoreDeletedSkill = vi.fn()
 const mockOnDeleteProgress = vi.fn()
+const mockSkillsCliRemoveBatch = vi.fn()
 
 vi.stubGlobal('window', {
   electron: {
@@ -32,6 +35,9 @@ vi.stubGlobal('window', {
       unlinkManyFromAgent: mockUnlinkManyFromAgent,
       restoreDeletedSkill: mockRestoreDeletedSkill,
       onDeleteProgress: mockOnDeleteProgress,
+    },
+    skillsCli: {
+      removeBatch: mockSkillsCliRemoveBatch,
     },
   },
 })
@@ -73,6 +79,24 @@ const thirdSkill: Skill = {
   ...sampleSkill,
   name: 'browser',
   path: '/home/user/.agents/skills/browser',
+}
+
+/**
+ * Sample CLI-managed skill. `source` is what `isCliManagedSkill` keys on —
+ * main process writes this field only for skills installed via
+ * `npx skills add` (see skillScanner.ts lock-file join).
+ */
+const cliSkill: Skill = {
+  ...sampleSkill,
+  name: 'brainstorming',
+  path: '/home/user/.agents/skills/brainstorming',
+  source: repositoryId('vercel-labs/agent-skills'),
+}
+
+const cliSkillSecond: Skill = {
+  ...cliSkill,
+  name: 'code-review',
+  path: '/home/user/.agents/skills/code-review',
 }
 
 /** Sample symlink info */
@@ -686,5 +710,170 @@ describe('skillsSlice undoLastBulkDelete thunk', () => {
       expect(action.payload[0].result.error.message).toBe('Disk full')
     }
     expect(store.getState().skills.error).toBeNull()
+  })
+
+  // --- setCliRemoveTarget (sync reducer) ---
+  it('setCliRemoveTarget opens the confirm dialog with a single name', async () => {
+    const { setCliRemoveTarget } = await import('./skillsSlice')
+    const store = await createTestStore()
+    store.dispatch(setCliRemoveTarget(['brainstorming' as SkillName]))
+    expect(store.getState().skills.cliRemoveTarget).toEqual(['brainstorming'])
+  })
+
+  it('setCliRemoveTarget with null clears the dialog', async () => {
+    const { setCliRemoveTarget } = await import('./skillsSlice')
+    const store = await createTestStore()
+    store.dispatch(setCliRemoveTarget(['brainstorming' as SkillName]))
+    store.dispatch(setCliRemoveTarget(null))
+    expect(store.getState().skills.cliRemoveTarget).toBeNull()
+  })
+
+  // --- cliRemoveSelectedSkills thunk ---
+  it('cliRemoveSelectedSkills.pending seeds inFlightCliRemoveNames and flips bulkCliRemoving', async () => {
+    // Hold the IPC call pending so we can inspect .pending state before settle.
+    let resolveRemove!: (value: CliRemoveSkillsResult) => void
+    mockSkillsCliRemoveBatch.mockReturnValue(
+      new Promise<CliRemoveSkillsResult>((r) => {
+        resolveRemove = r
+      }),
+    )
+
+    const store = await createTestStore()
+    await seedItems(store, [cliSkill, cliSkillSecond])
+
+    const { cliRemoveSelectedSkills } = await import('./skillsSlice')
+    const promise = store.dispatch(
+      cliRemoveSelectedSkills([cliSkill.name, cliSkillSecond.name]),
+    )
+
+    const pending = store.getState().skills
+    expect(pending.bulkCliRemoving).toBe(true)
+    expect(pending.inFlightCliRemoveNames).toEqual([
+      cliSkill.name,
+      cliSkillSecond.name,
+    ])
+    expect(pending.error).toBeNull()
+
+    resolveRemove({
+      items: [
+        { skillName: cliSkill.name, outcome: 'removed' },
+        { skillName: cliSkillSecond.name, outcome: 'removed' },
+      ],
+    })
+    await promise
+  })
+
+  it('cliRemoveSelectedSkills.pending reconciles ghost names against live items', async () => {
+    mockSkillsCliRemoveBatch.mockResolvedValue({
+      items: [{ skillName: cliSkill.name, outcome: 'removed' }],
+    } satisfies CliRemoveSkillsResult)
+
+    const store = await createTestStore()
+    // Only one of the two requested names is live; the other is a ghost from
+    // a stale selection. reconcileByLiveNames should drop it from the in-flight
+    // fade set so SkillItem never paints a fade on a row that does not exist.
+    await seedItems(store, [cliSkill])
+
+    const { cliRemoveSelectedSkills } = await import('./skillsSlice')
+    const promise = store.dispatch(
+      cliRemoveSelectedSkills([cliSkill.name, 'ghost-skill' as SkillName]),
+    )
+
+    const pending = store.getState().skills
+    expect(pending.inFlightCliRemoveNames).toEqual([cliSkill.name])
+    await promise
+  })
+
+  it('cliRemoveSelectedSkills.fulfilled narrows selection to only removed items, keeps failures', async () => {
+    // Batch with one success, one error — failures should remain selected for
+    // retry; only successful removals should drop out of selectedSkillNames.
+    mockSkillsCliRemoveBatch.mockResolvedValue({
+      items: [
+        { skillName: cliSkill.name, outcome: 'removed' },
+        {
+          skillName: cliSkillSecond.name,
+          outcome: 'error',
+          error: { message: 'Skill not found', code: 1 },
+        },
+      ],
+    } satisfies CliRemoveSkillsResult)
+
+    const store = await createTestStore()
+    await seedItems(store, [cliSkill, cliSkillSecond])
+
+    const { cliRemoveSelectedSkills, selectAll } = await import('./skillsSlice')
+    store.dispatch(selectAll([cliSkill.name, cliSkillSecond.name]))
+
+    await store.dispatch(
+      cliRemoveSelectedSkills([cliSkill.name, cliSkillSecond.name]),
+    )
+
+    const state = store.getState().skills
+    expect(state.selectedSkillNames).toEqual([cliSkillSecond.name])
+    expect(state.bulkCliRemoving).toBe(false)
+    expect(state.inFlightCliRemoveNames).toEqual([])
+    expect(state.bulkProgress).toBeNull()
+  })
+
+  it('cliRemoveSelectedSkills.fulfilled clears selectionAnchor when anchor was removed', async () => {
+    mockSkillsCliRemoveBatch.mockResolvedValue({
+      items: [{ skillName: cliSkill.name, outcome: 'removed' }],
+    } satisfies CliRemoveSkillsResult)
+
+    const store = await createTestStore()
+    await seedItems(store, [cliSkill, cliSkillSecond])
+
+    // selectAll sets anchor to the LAST payload entry, so ordering matters:
+    // we want the anchor to be `cliSkill` (the one about to be removed).
+    const { cliRemoveSelectedSkills, selectAll } = await import('./skillsSlice')
+    store.dispatch(selectAll([cliSkillSecond.name, cliSkill.name]))
+    expect(store.getState().skills.selectionAnchor).toBe(cliSkill.name)
+
+    await store.dispatch(cliRemoveSelectedSkills([cliSkill.name]))
+
+    // Anchor removed → anchor must be nulled; without this, Shift+click would
+    // compute a range from a ghost origin.
+    expect(store.getState().skills.selectionAnchor).toBeNull()
+    // Other selection survives since it was not in this batch.
+    expect(store.getState().skills.selectedSkillNames).toEqual([
+      cliSkillSecond.name,
+    ])
+  })
+
+  it('cliRemoveSelectedSkills.fulfilled clears Inspector when its target was removed', async () => {
+    mockSkillsCliRemoveBatch.mockResolvedValue({
+      items: [{ skillName: cliSkill.name, outcome: 'removed' }],
+    } satisfies CliRemoveSkillsResult)
+
+    const store = await createTestStore()
+    await seedItems(store, [cliSkill])
+
+    const { cliRemoveSelectedSkills, selectSkill } =
+      await import('./skillsSlice')
+    store.dispatch(selectSkill(cliSkill))
+    expect(store.getState().skills.selectedSkill).not.toBeNull()
+
+    await store.dispatch(cliRemoveSelectedSkills([cliSkill.name]))
+
+    // CLI remove is irreversible — leaving the Inspector on a permanently
+    // gone skill would be worse than the trash-flow Inspector (which at
+    // least has undo). See reducer comment.
+    expect(store.getState().skills.selectedSkill).toBeNull()
+  })
+
+  it('cliRemoveSelectedSkills.rejected clears in-flight fade and surfaces error', async () => {
+    mockSkillsCliRemoveBatch.mockRejectedValue(new Error('IPC channel closed'))
+
+    const store = await createTestStore()
+    await seedItems(store, [cliSkill])
+
+    const { cliRemoveSelectedSkills } = await import('./skillsSlice')
+    await store.dispatch(cliRemoveSelectedSkills([cliSkill.name]))
+
+    const state = store.getState().skills
+    expect(state.bulkCliRemoving).toBe(false)
+    expect(state.inFlightCliRemoveNames).toEqual([])
+    expect(state.bulkProgress).toBeNull()
+    expect(state.error).toBe('IPC channel closed')
   })
 })

--- a/src/renderer/src/redux/slices/skillsSlice.test.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.test.ts
@@ -711,8 +711,13 @@ describe('skillsSlice undoLastBulkDelete thunk', () => {
     }
     expect(store.getState().skills.error).toBeNull()
   })
+})
 
-  // --- setCliRemoveTarget (sync reducer) ---
+describe('skillsSlice setCliRemoveTarget (sync reducer)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
   it('setCliRemoveTarget opens the confirm dialog with a single name', async () => {
     const { setCliRemoveTarget } = await import('./skillsSlice')
     const store = await createTestStore()
@@ -727,8 +732,13 @@ describe('skillsSlice undoLastBulkDelete thunk', () => {
     store.dispatch(setCliRemoveTarget(null))
     expect(store.getState().skills.cliRemoveTarget).toBeNull()
   })
+})
 
-  // --- cliRemoveSelectedSkills thunk ---
+describe('skillsSlice cliRemoveSelectedSkills thunk', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
   it('cliRemoveSelectedSkills.pending seeds inFlightCliRemoveNames and flips bulkCliRemoving', async () => {
     // Hold the IPC call pending so we can inspect .pending state before settle.
     let resolveRemove!: (value: CliRemoveSkillsResult) => void

--- a/src/renderer/src/redux/slices/skillsSlice.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.ts
@@ -553,11 +553,16 @@ const skillsSlice = createSlice({
         state.error = null
       })
       .addCase(cliRemoveSelectedSkills.fulfilled, (state, action) => {
-        if (state.inFlightCliRemoveNames.length !== 0) {
-          state.inFlightCliRemoveNames = []
-        }
+        state.inFlightCliRemoveNames = []
         state.bulkCliRemoving = false
         state.bulkProgress = null
+        // Defensive clear: `DeleteCliSkillDialog` already calls
+        // `setCliRemoveTarget(null)` in its finally block, but if that dialog
+        // unmounts mid-flight (route change, component error boundary trip)
+        // the finally never runs and the target sticks until the next user
+        // action. Clearing here makes the cleanup invariant hold regardless
+        // of who dispatched the thunk.
+        state.cliRemoveTarget = null
         const removedNames = new Set(
           action.payload.items
             .filter((item) => item.outcome === 'removed')
@@ -583,9 +588,7 @@ const skillsSlice = createSlice({
         }
       })
       .addCase(cliRemoveSelectedSkills.rejected, (state, action) => {
-        if (state.inFlightCliRemoveNames.length !== 0) {
-          state.inFlightCliRemoveNames = []
-        }
+        state.inFlightCliRemoveNames = []
         state.bulkCliRemoving = false
         state.bulkProgress = null
         state.error = action.error.message ?? 'Bulk CLI remove failed'

--- a/src/renderer/src/redux/slices/skillsSlice.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.ts
@@ -6,6 +6,7 @@ import type {
   AgentId,
   BulkDeleteResult,
   BulkUnlinkResult,
+  CliRemoveSkillsResult,
   RestoreDeletedSkillResult,
   Skill,
   SkillName,
@@ -62,6 +63,16 @@ interface SkillsState {
   bulkUnlinking: boolean
   /** Progress counter emitted by main for batches with total >= 10. */
   bulkProgress: { current: number; total: number } | null
+  /** Names currently in-flight for CLI remove (row fades while present). */
+  inFlightCliRemoveNames: SkillName[]
+  /** true while a single or batch CLI remove thunk is between .pending and settled. */
+  bulkCliRemoving: boolean
+  /**
+   * Skills queued for CLI remove confirmation. Unified array for both
+   * single-row X click (length 1) and batch toolbar (length N) so one
+   * dialog serves both entry points.
+   */
+  cliRemoveTarget: SkillName[] | null
 }
 
 const initialState: SkillsState = {
@@ -82,6 +93,9 @@ const initialState: SkillsState = {
   bulkDeleting: false,
   bulkUnlinking: false,
   bulkProgress: null,
+  inFlightCliRemoveNames: [],
+  bulkCliRemoving: false,
+  cliRemoveTarget: null,
 }
 
 /**
@@ -231,6 +245,32 @@ export const unlinkSelectedFromAgent = createAsyncThunk<
 })
 
 /**
+ * Deregister every selected CLI-managed skill in a single batch. Main spawns
+ * `npx skills remove` serially per item (parallel spawns would race the
+ * shared lock file).
+ *
+ * Single-item dialog paths pass an array of length 1 — the toast helper
+ * (`toastCliRemoveBatchResult`) surfaces the individual skill name when
+ * exactly one item succeeded, so collapsing the two thunks preserved UX.
+ *
+ * `.pending` intersects the passed names with `state.items` — same reconcile
+ * pattern as `deleteSelectedSkills` — so a late refetch between click and
+ * dispatch cannot trigger a CLI call on a ghost skill.
+ * @param selectedNames - CLI-managed names to remove (caller partitions).
+ * @returns CliRemoveSkillsResult with per-item outcome
+ * @example
+ * await dispatch(cliRemoveSelectedSkills(['theme-generator', 'brainstorming']))
+ */
+export const cliRemoveSelectedSkills = createAsyncThunk<
+  CliRemoveSkillsResult,
+  SkillName[]
+>('skills/cliRemoveSelected', async (selectedNames) => {
+  return window.electron.skillsCli.removeBatch({
+    items: selectedNames.map((skillName) => ({ skillName })),
+  })
+})
+
+/**
  * Restore the last batch of tombstoned deletes by calling the main-process
  * trashService once per tombstone. Runs serially because each call may fail
  * independently (collision, trash already evicted). Aggregates the results
@@ -360,6 +400,13 @@ const skillsSlice = createSlice({
       action: PayloadAction<{ current: number; total: number } | null>,
     ) => {
       state.bulkProgress = action.payload
+    },
+    /**
+     * Queue a CLI-managed skill (or batch) for removal confirmation.
+     * Pass `null` to dismiss the dialog without acting.
+     */
+    setCliRemoveTarget: (state, action: PayloadAction<SkillName[] | null>) => {
+      state.cliRemoveTarget = action.payload
     },
   },
   extraReducers: (builder) => {
@@ -494,6 +541,55 @@ const skillsSlice = createSlice({
       .addCase(undoLastBulkDelete.rejected, (state, action) => {
         state.error = action.error.message ?? 'Undo failed'
       })
+      // CLI remove (batch, length 1..N) — mirror delete-batch reducers:
+      // narrow selection to successfully-removed items, keep failures selected
+      // for retry, reconcile anchor the same way.
+      .addCase(cliRemoveSelectedSkills.pending, (state, action) => {
+        state.inFlightCliRemoveNames = reconcileByLiveNames(
+          state.items,
+          action.meta.arg,
+        )
+        state.bulkCliRemoving = true
+        state.error = null
+      })
+      .addCase(cliRemoveSelectedSkills.fulfilled, (state, action) => {
+        if (state.inFlightCliRemoveNames.length !== 0) {
+          state.inFlightCliRemoveNames = []
+        }
+        state.bulkCliRemoving = false
+        state.bulkProgress = null
+        const removedNames = new Set(
+          action.payload.items
+            .filter((item) => item.outcome === 'removed')
+            .map((item) => item.skillName),
+        )
+        // Clear the Inspector when its target was in this batch — CLI remove
+        // is irreversible, so keeping the pane on a permanently-gone skill
+        // would be worse UX than the trash flow (which at least has undo).
+        if (
+          state.selectedSkill !== null &&
+          removedNames.has(state.selectedSkill.name)
+        ) {
+          state.selectedSkill = null
+        }
+        state.selectedSkillNames = state.selectedSkillNames.filter(
+          (name) => !removedNames.has(name),
+        )
+        const anchorWasRemoved =
+          state.selectionAnchor !== null &&
+          removedNames.has(state.selectionAnchor)
+        if (state.selectedSkillNames.length === 0 || anchorWasRemoved) {
+          state.selectionAnchor = null
+        }
+      })
+      .addCase(cliRemoveSelectedSkills.rejected, (state, action) => {
+        if (state.inFlightCliRemoveNames.length !== 0) {
+          state.inFlightCliRemoveNames = []
+        }
+        state.bulkCliRemoving = false
+        state.bulkProgress = null
+        state.error = action.error.message ?? 'Bulk CLI remove failed'
+      })
   },
 })
 
@@ -507,6 +603,7 @@ export const {
   selectAll,
   clearSelection,
   setBulkProgress,
+  setCliRemoveTarget,
 } = skillsSlice.actions
 export default skillsSlice.reducer
 
@@ -547,3 +644,9 @@ export const selectBulkUnlinking = (state: RootState): boolean =>
 export const selectBulkProgress = (
   state: RootState,
 ): { current: number; total: number } | null => state.skills.bulkProgress
+export const selectInFlightCliRemoveNames = (state: RootState): SkillName[] =>
+  state.skills.inFlightCliRemoveNames
+export const selectBulkCliRemoving = (state: RootState): boolean =>
+  state.skills.bulkCliRemoving
+export const selectCliRemoveTarget = (state: RootState): SkillName[] | null =>
+  state.skills.cliRemoveTarget

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -13,6 +13,10 @@ import type {
   InstallOptions,
   CliCommandResult,
   InstallProgress,
+  CliRemoveSkillOptions,
+  CliRemoveSkillResult,
+  CliRemoveSkillsOptions,
+  CliRemoveSkillsResult,
   UnlinkFromAgentOptions,
   UnlinkResult,
   RemoveAllFromAgentOptions,
@@ -104,6 +108,12 @@ declare global {
         onProgress: (
           callback: (progress: InstallProgress) => void,
         ) => () => void
+        remove: (
+          options: CliRemoveSkillOptions,
+        ) => Promise<CliRemoveSkillResult>
+        removeBatch: (
+          options: CliRemoveSkillsOptions,
+        ) => Promise<CliRemoveSkillsResult>
       }
       marketplace: {
         leaderboard: (options: {

--- a/src/renderer/src/utils/bulkOpVisuals.ts
+++ b/src/renderer/src/utils/bulkOpVisuals.ts
@@ -1,0 +1,54 @@
+import type { CliRemoveSkillsResult, SkillName } from '../../../shared/types'
+
+import { toastCliRemoveBatchResult } from './cliRemoveToast'
+
+/**
+ * Name of the DOM CustomEvent fired when a per-row bulk operation fails.
+ * `SkillItem` rows subscribe and flash a red left edge for 3s. Exported so
+ * tests and listeners reference the same string (no stringly-typed drift).
+ */
+export const BULK_ITEM_FAILED_EVENT = 'skills:bulkItemFailed' as const
+
+/**
+ * Fire `skills:bulkItemFailed` for each failed row in a bulk op. The `SkillItem`
+ * rows listen and flash a red left edge for 3s. Uses a DOM CustomEvent instead
+ * of Redux state because the failure highlight is transient and per-row — piping
+ * it through the store would cause a render cascade for a 3-second visual.
+ *
+ * @param failedNames - SkillNames that errored in the last batch
+ * @example
+ * flashFailedRows(failedNames)
+ */
+export const flashFailedRows = (failedNames: SkillName[]): void => {
+  for (const skillName of failedNames) {
+    window.dispatchEvent(
+      new CustomEvent<{ skillName: SkillName }>(BULK_ITEM_FAILED_EVENT, {
+        detail: { skillName },
+      }),
+    )
+  }
+}
+
+/**
+ * Shared settle handler for CLI remove batches. Flashes every failed row and
+ * surfaces the aggregate summary toast in one call so both entry points
+ * (`DeleteCliSkillDialog` confirm path and `MainContent.handleConfirmBulk`
+ * mixed-delete path) give users identical visual + textual feedback.
+ *
+ * Without this, only the mixed-delete path flashed rows and the dialog path
+ * went silent — so a user double-clicking "Remove" saw a toast but no
+ * per-row hint about which skills actually failed.
+ *
+ * @param payload - CliRemoveSkillsResult from the fulfilled thunk
+ * @example
+ * if (cliRemoveSelectedSkills.fulfilled.match(result)) {
+ *   settleCliRemoveBatch(result.payload)
+ * }
+ */
+export const settleCliRemoveBatch = (payload: CliRemoveSkillsResult): void => {
+  const failedNames = payload.items
+    .filter((item) => item.outcome === 'error')
+    .map((item) => item.skillName)
+  flashFailedRows(failedNames)
+  toastCliRemoveBatchResult(payload)
+}

--- a/src/renderer/src/utils/cliRemoveToast.test.ts
+++ b/src/renderer/src/utils/cliRemoveToast.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { CliRemoveSkillsResult, SkillName } from '../../../shared/types'
+
+import { toastCliRemoveBatchResult } from './cliRemoveToast'
+
+/**
+ * sonner's toast module is the one side-effect we care about. Spy on each
+ * branch (success/error/warning) separately so a test can assert the exact
+ * shape of the call — toast library API drift would surface here first.
+ */
+const toastSuccess = vi.fn()
+const toastError = vi.fn()
+const toastWarning = vi.fn()
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccess(...args),
+    error: (...args: unknown[]) => toastError(...args),
+    warning: (...args: unknown[]) => toastWarning(...args),
+  },
+}))
+
+describe('toastCliRemoveBatchResult', () => {
+  beforeEach(() => {
+    toastSuccess.mockReset()
+    toastError.mockReset()
+    toastWarning.mockReset()
+  })
+
+  it('emits a name-specific success toast for a single successful item', () => {
+    // Single-item case surfaces the name so the user sees what they removed.
+    // The DeleteCliSkillDialog confirm path always dispatches a length-1 batch.
+    const result: CliRemoveSkillsResult = {
+      items: [{ skillName: 'brainstorming' as SkillName, outcome: 'removed' }],
+    }
+
+    toastCliRemoveBatchResult(result)
+
+    expect(toastSuccess).toHaveBeenCalledTimes(1)
+    expect(toastSuccess).toHaveBeenCalledWith('Removed brainstorming', {
+      description: 'Deregistered from ~/.agents/.skill-lock.json',
+    })
+    expect(toastError).not.toHaveBeenCalled()
+    expect(toastWarning).not.toHaveBeenCalled()
+  })
+
+  it('emits a count-only success toast for an all-successful multi-item batch', () => {
+    const result: CliRemoveSkillsResult = {
+      items: [
+        { skillName: 'brainstorming' as SkillName, outcome: 'removed' },
+        { skillName: 'theme-generator' as SkillName, outcome: 'removed' },
+        { skillName: 'code-review' as SkillName, outcome: 'removed' },
+      ],
+    }
+
+    toastCliRemoveBatchResult(result)
+
+    expect(toastSuccess).toHaveBeenCalledWith('Removed 3 skills', {
+      description: 'Deregistered from ~/.agents/.skill-lock.json',
+    })
+  })
+
+  it('emits a name-specific error toast with the actual error message for a single failure', () => {
+    // All-failed single-item case surfaces both the name AND the error so the
+    // user does not have to dig through devtools to learn what went wrong.
+    const result: CliRemoveSkillsResult = {
+      items: [
+        {
+          skillName: 'brainstorming' as SkillName,
+          outcome: 'error',
+          error: { message: 'Skill not found in lock file', code: 1 },
+        },
+      ],
+    }
+
+    toastCliRemoveBatchResult(result)
+
+    expect(toastError).toHaveBeenCalledWith('Failed to remove brainstorming', {
+      description: 'Skill not found in lock file',
+    })
+    expect(toastSuccess).not.toHaveBeenCalled()
+  })
+
+  it('emits a generic error toast for an all-failed multi-item batch', () => {
+    const result: CliRemoveSkillsResult = {
+      items: [
+        {
+          skillName: 'a' as SkillName,
+          outcome: 'error',
+          error: { message: 'E1', code: 1 },
+        },
+        {
+          skillName: 'b' as SkillName,
+          outcome: 'error',
+          error: { message: 'E2', code: 1 },
+        },
+      ],
+    }
+
+    toastCliRemoveBatchResult(result)
+
+    expect(toastError).toHaveBeenCalledWith('Failed to remove skills', {
+      description: '2 of 2 failed',
+    })
+  })
+
+  it('emits a warning toast for a partial-success batch', () => {
+    const result: CliRemoveSkillsResult = {
+      items: [
+        { skillName: 'a' as SkillName, outcome: 'removed' },
+        { skillName: 'b' as SkillName, outcome: 'removed' },
+        {
+          skillName: 'c' as SkillName,
+          outcome: 'error',
+          error: { message: 'Skill not found', code: 1 },
+        },
+      ],
+    }
+
+    toastCliRemoveBatchResult(result)
+
+    expect(toastWarning).toHaveBeenCalledWith('Removed 2, failed 1', {
+      description: 'Some skills could not be deregistered',
+    })
+    expect(toastSuccess).not.toHaveBeenCalled()
+    expect(toastError).not.toHaveBeenCalled()
+  })
+
+  it('pluralizes "skill" correctly for the 1-success case in a count-only path', () => {
+    // Rare in practice (batch thunks of length 1 already hit the name-specific
+    // branch), but the pluralize guard should still produce grammatical output.
+    // This covers the path where `removed === 1` via a hypothetical batch
+    // with everything-successful but only one entry — identical to the first
+    // test, double-asserted with singular `skill` wording.
+    const result: CliRemoveSkillsResult = {
+      items: [{ skillName: 'solo' as SkillName, outcome: 'removed' }],
+    }
+
+    toastCliRemoveBatchResult(result)
+
+    // Name-aware branch wins for length-1, so we get the name, not "1 skill".
+    expect(toastSuccess).toHaveBeenCalledWith('Removed solo', {
+      description: 'Deregistered from ~/.agents/.skill-lock.json',
+    })
+  })
+})

--- a/src/renderer/src/utils/cliRemoveToast.ts
+++ b/src/renderer/src/utils/cliRemoveToast.ts
@@ -1,0 +1,59 @@
+import { toast } from 'sonner'
+
+import type { CliRemoveSkillsResult } from '../../../shared/types'
+
+import { pluralize } from './pluralize'
+
+/**
+ * Per-item outcome summary for a CLI remove batch. Collapses the
+ * success / partial / all-failed three-branch toast that was duplicated
+ * between `DeleteCliSkillDialog` (confirm dialog path) and
+ * `MainContent.handleConfirmBulk` (mixed bulk-delete path).
+ *
+ * @example
+ * const result = await dispatch(cliRemoveSelectedSkills(names))
+ * if (cliRemoveSelectedSkills.fulfilled.match(result)) {
+ *   toastCliRemoveBatchResult(result.payload)
+ * }
+ */
+export function toastCliRemoveBatchResult(result: CliRemoveSkillsResult): void {
+  const total = result.items.length
+  const removedItems = result.items.filter((i) => i.outcome === 'removed')
+  const removed = removedItems.length
+  const failed = total - removed
+
+  if (failed === 0) {
+    // Preserve the name-specific toast for the single-item path (the dialog
+    // confirm flow dispatches a batch of length 1). Batch toasts that happen
+    // to succeed with a single item are rare in practice but would also read
+    // better with the name — so we key on length, not on caller.
+    const title =
+      removed === 1
+        ? `Removed ${removedItems[0].skillName}`
+        : `Removed ${removed} ${pluralize(removed, 'skill')}`
+    toast.success(title, {
+      description: 'Deregistered from ~/.agents/.skill-lock.json',
+    })
+    return
+  }
+
+  if (removed === 0) {
+    // All-failed single-item case: surface the skill name and actual error
+    // so the user sees what happened without digging through devtools.
+    if (total === 1 && result.items[0].outcome === 'error') {
+      const only = result.items[0]
+      toast.error(`Failed to remove ${only.skillName}`, {
+        description: only.error.message,
+      })
+      return
+    }
+    toast.error('Failed to remove skills', {
+      description: `${failed} of ${total} failed`,
+    })
+    return
+  }
+
+  toast.warning(`Removed ${removed}, failed ${failed}`, {
+    description: 'Some skills could not be deregistered',
+  })
+}

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -21,6 +21,9 @@ export const IPC_CHANNELS = {
   SKILLS_CLI_INSTALL: 'skills:cli:install',
   SKILLS_CLI_CANCEL: 'skills:cli:cancel',
   SKILLS_CLI_PROGRESS: 'skills:cli:progress',
+  // Skills CLI remove (deregister from ~/.agents/.skill-lock.json)
+  SKILLS_CLI_REMOVE: 'skills:cli:remove',
+  SKILLS_CLI_REMOVE_BATCH: 'skills:cli:removeBatch',
 
   // Marketplace Leaderboard
   MARKETPLACE_LEADERBOARD: 'marketplace:leaderboard',

--- a/src/shared/ipc-contract.test.ts
+++ b/src/shared/ipc-contract.test.ts
@@ -24,6 +24,8 @@ describe('IPC contract alignment', () => {
       [IPC_CHANNELS.SKILLS_CLI_SEARCH]: true,
       [IPC_CHANNELS.SKILLS_CLI_INSTALL]: true,
       [IPC_CHANNELS.SKILLS_CLI_CANCEL]: true,
+      [IPC_CHANNELS.SKILLS_CLI_REMOVE]: true,
+      [IPC_CHANNELS.SKILLS_CLI_REMOVE_BATCH]: true,
       [IPC_CHANNELS.MARKETPLACE_LEADERBOARD]: true,
       [IPC_CHANNELS.SYNC_PREVIEW]: true,
       [IPC_CHANNELS.SYNC_EXECUTE]: true,
@@ -38,7 +40,7 @@ describe('IPC contract alignment', () => {
     // IPC channel (input validation, authz scope, side-effect blast radius).
     // The `satisfies` clause above is a structural guard; this length check is
     // the trip-wire that forces a human PR diff when a channel is added.
-    expect(Object.keys(invokeMapping)).toHaveLength(24)
+    expect(Object.keys(invokeMapping)).toHaveLength(26)
   })
 
   it('all IPC_CHANNELS event values are valid event contract keys', () => {

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -4,6 +4,10 @@ import type {
   BulkDeleteResult,
   BulkUnlinkResult,
   CliCommandResult,
+  CliRemoveSkillOptions,
+  CliRemoveSkillResult,
+  CliRemoveSkillsOptions,
+  CliRemoveSkillsResult,
   CopyToAgentsOptions,
   CopyToAgentsResult,
   CreateSymlinksOptions,
@@ -91,6 +95,14 @@ export interface IpcInvokeContract {
   'skills:cli:search': { args: [SearchQuery]; result: SkillSearchResult[] }
   'skills:cli:install': { args: [InstallOptions]; result: CliCommandResult }
   'skills:cli:cancel': { args: []; result: void }
+  'skills:cli:remove': {
+    args: [CliRemoveSkillOptions]
+    result: CliRemoveSkillResult
+  }
+  'skills:cli:removeBatch': {
+    args: [CliRemoveSkillsOptions]
+    result: CliRemoveSkillsResult
+  }
   'marketplace:leaderboard': {
     args: [{ filter: RankingFilter }]
     result: SkillSearchResult[]

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -689,6 +689,59 @@ export interface BulkUnlinkResult {
 }
 
 /**
+ * IPC argument for `skills:cli:remove` — deregister a single skill from the
+ * global lock file (`~/.agents/.skill-lock.json`) via `npx skills remove
+ * <name> --global --yes`. The UI routes here when `skill.source` is truthy
+ * so the CLI stays in sync; non-CLI skills go through moveToTrash instead.
+ * @example { skillName: 'brainstorming' }
+ */
+export interface CliRemoveSkillOptions {
+  /** Skill to deregister. Must match a key in `~/.agents/.skill-lock.json`. @example "brainstorming" */
+  skillName: SkillName
+}
+
+/**
+ * Result from `skills:cli:remove`. Discriminated on `outcome` so an error
+ * branch never carries a spurious "removed" claim. The CLI is irreversible —
+ * successful removes have no undo token.
+ * @example { skillName: 'brainstorming', outcome: 'removed' }
+ * @example { skillName: 'brainstorming', outcome: 'error', error: { message: 'skills: not found', code: 1 } }
+ */
+export type CliRemoveSkillResult =
+  | { skillName: SkillName; outcome: 'removed' }
+  | {
+      skillName: SkillName
+      outcome: 'error'
+      error: { message: string; code?: number | null }
+    }
+
+/**
+ * IPC argument for `skills:cli:removeBatch` — deregister N skills in sequence.
+ * CLI invocations are serial by design: concurrent writers to the lock file
+ * would race. Bulk mixed-mode flows (CLI + trash) live in the renderer;
+ * this IPC owns only the CLI half.
+ * @example { items: [{ skillName: 'brainstorming' }, { skillName: 'frontend-design' }] }
+ */
+export interface CliRemoveSkillsOptions {
+  /** Skills to deregister, in user-selection order. */
+  items: Array<{ skillName: SkillName }>
+}
+
+/**
+ * Batch CLI remove result. The batch handler is currently silent during the
+ * serial spawn loop (no progress events) — the UI shows only the generic
+ * `bulkCliRemoving` spinner via `SelectionToolbar`. A 10-item batch takes
+ * ~6–20s of npx cold-starts; if that becomes a UX problem, add progress
+ * emission to `skillsCli.ts:SKILLS_CLI_REMOVE_BATCH` and wire it through
+ * `setBulkProgress` the way `SKILLS_CLI_INSTALL` already does.
+ * @example { items: [{ skillName: 'brainstorming', outcome: 'removed' }] }
+ */
+export interface CliRemoveSkillsResult {
+  /** Per-item outcome, index-aligned with the input `items` array. */
+  items: CliRemoveSkillResult[]
+}
+
+/**
  * IPC argument for `skills:restoreDeletedSkill` — undo a single tombstoned delete.
  * Main validates the `tombstoneId` against `tombstoneIdSchema` before touching the filesystem.
  * @example { tombstoneId: '1729180800000-theme-generator-a1b2c3d4' }


### PR DESCRIPTION
## Summary

- Adds `skills:cli:remove` + `skills:cli:removeBatch` IPC channels backed by `skillsCliService.remove()` (spawns `npx skills remove <name> --global -y`, serial batch, shell:false, ANSI + homedir-scrubbed errors)
- New `DeleteCliSkillDialog` + `cliRemoveSelectedSkills` thunk + `setCliRemoveTarget` reducer route CLI-managed skills through an irreversible (no-undo) confirmation; plain skills stay on the trash+undo path
- `MainContent.handleConfirmBulk` now partitions the selection via `partitionSkillsForDelete` and runs CLI-first-awaited → trash-second so tombstone ids never point at CLI-removed ghosts
- SkillItem X button, aria labels, and SelectionToolbar `isBusy` all route via `isCliManagedSkill(skill)` — screen-reader users get "Remove X via skills CLI" vs "Delete X" distinction

## Pre-Landing Review

Three specialist passes on the diff:

| Specialist | Verdict | Issues landed | Issues deferred |
|---|---|---|---|
| Backend security | approve-with-followups | `.max(100)` DoS cap on `skills:cli:removeBatch` | 30s spawn timeout (follow-up) |
| React correctness | approve-with-followups | `try/finally` in `DeleteCliSkillDialog.handleConfirm` against orphan `cliRemoveTarget` | Selector/perf nits (non-blocking) |
| Adversarial red-team | approve-with-followups | (see Known Limitations) | cross-feature timing issues |

All must-land findings are fixed on this branch before push.

## Test Coverage

Coverage audit (subagent) ran before the fixes: **82% (36/44 paths)** — PASS against the default 80% gate.

After this PR, two new boundary tests were added for the `.max(100)` DoS cap, bringing total test count to **696 passing across 45 files** (`pnpm test`, 1.61s).

Gaps noted for future hardening (all non-blocking):
- `BULK_PROGRESS_THRESHOLD` emit path in `skillsCli.ts` batch handler
- `removeSkillViaCli` `validatePath` defense branch (Zod already covers at first layer)
- `selectBulkCliCount` selector direct test (covered transitively)
- `flashFailedRows` `CustomEvent` fan-out
- `renderBulkDeleteDescription` mixed branch snapshot
- `SelectionToolbar.isBusy` OR-chain with `bulkCliRemoving`
- `MainContent` CLI thunk rejection toast path
- `MainContent` `DialogDescription` rendering with mixed copy

## Plan Completion

The plan file `~/.gstack/projects/laststance-skills-desktop/ceo-plans/2026-04-17-bulk-delete-skills.md` describes the trash/tombstone bulk-delete feature that **already shipped in PR #80 (`b389a23`)**. This branch is a distinct follow-up — deregistering `~/.agents/.skill-lock.json`-tracked skills via `npx skills remove`. Plan-vs-branch divergence is intentional; no blockers.

## Verification Results

- `pnpm typecheck` — clean
- `pnpm test` — 45 files / 696 tests pass / 1.61s
- `pnpm lint` — clean
- Bisectable: 3 commits (`feat(ipc)` → `feat(ui)` → `docs(spec)`), each independently useful

## Documentation

- `SPEC.md:154` — updated `Uninstall skill` row from "CLI / no in-app button" to the shipped reality (in-app X + bulk-delete, CLI-managed path irreversible, plain path trash+undo)
- `README.md`, `AGENTS.md`, `website/src/**`, `docs/` scanned — no factual contradictions found, no edits

## Known Limitations (follow-up issues worth opening)

1. `skillsCliService.currentProcess` is module-singleton — triggering install-cancel UI while a batch CLI remove is in flight would kill the remove spawn. Install cancel UI is not reachable while the Radix `modal=true` confirm dialog is open, so this is latent, not active — still worth a scope-per-operation refactor
2. `bulkProgress` slot is shared between CLI and trash batches — mixed-batch flicker between "k of total_cli" and "k of total_plain". Visual only, data integrity intact
3. No `AbortController` / spawn timeout — a hung `npx` (DNS timeout, registry outage) freezes the batch. Add `{ timeout: 30_000 }` in follow-up
4. `app.on('before-quit', () => skillsCliService.cancel())` not wired — Cmd-Q during a batch can leave a zombie npx and a half-written `.skill-lock.json`. Add in follow-up
5. Screen-reader users get no progress announcement — `aria-live` region missing on the confirm dialog while `bulkCliRemoving` is true

## Test Plan

- [x] Install a CLI-managed skill via marketplace, confirm X button now opens `DeleteCliSkillDialog` (no undo) instead of trash dialog
- [x] Select mixed CLI + plain skills in bulk mode, confirm bulk dialog shows merged copy with no-undo warning
- [x] Confirm screen reader reads "Remove brainstorming via skills CLI" vs "Delete local-skill"
- [x] Click X on a CLI skill, confirm the dialog, confirm `npx skills remove` runs and the skill disappears from UI and from `~/.agents/.skill-lock.json`
- [x] Partial failure: remove a mix where one CLI call fails (simulate by deleting `~/.agents/.skill-lock.json` first) — toast should surface the failing name, successful ones stay removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to remove CLI-installed skills with permanent deregistration
  * Implemented differentiated delete flows: CLI-managed skills are irreversibly removed, while app-installed skills go to trash with 15-second undo window
  * Added progress reporting for bulk CLI skill removals
  * Enhanced delete confirmation dialogs with skill-type-specific messaging

* **Documentation**
  * Updated specification to clarify uninstall behavior for CLI vs app-installed skills

<!-- end of auto-generated comment: release notes by coderabbit.ai -->