### PR TITLE
feat(skills): add +Add shortcut in agent view for cross-agent copy

### DIFF
--- a/src/renderer/src/components/skills/SkillItem.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillItem.browser.test.tsx
@@ -238,6 +238,65 @@ describe('SkillItem delete button — CLI vs plain routing', () => {
   })
 })
 
+describe('SkillItem Add button routing', () => {
+  it('shows Add button in agent view when the skill exists in selected agent', async () => {
+    const { screen, store } = await renderSkillItem(
+      makeSkill({
+        symlinks: [
+          {
+            agentId: 'cursor',
+            agentName: 'Cursor',
+            status: 'valid',
+            targetPath: '/home/user/.agents/skills/task',
+            linkPath: '/home/user/.cursor/skills/task',
+            isLocal: false,
+          },
+        ],
+      }),
+    )
+    const { selectAgent } = await import('../../redux/slices/uiSlice')
+
+    store.dispatch(selectAgent('cursor'))
+
+    await expect
+      .element(screen.getByRole('button', { name: /^Add$/i }))
+      .toBeInTheDocument()
+  })
+
+  it('in agent view, Add click opens copy modal target (skillToCopy)', async () => {
+    const { screen, store } = await renderSkillItem(
+      makeSkill({
+        symlinks: [
+          {
+            agentId: 'cursor',
+            agentName: 'Cursor',
+            status: 'valid',
+            targetPath: '/home/user/.agents/skills/task',
+            linkPath: '/home/user/.cursor/skills/task',
+            isLocal: false,
+          },
+        ],
+      }),
+    )
+    const { selectAgent } = await import('../../redux/slices/uiSlice')
+
+    store.dispatch(selectAgent('cursor'))
+    await screen.getByRole('button', { name: /^Add$/i }).click()
+
+    expect(store.getState().skills.skillToCopy?.name).toBe('task')
+    expect(store.getState().skills.skillToAddSymlinks).toBeNull()
+  })
+
+  it('in global view, Add click keeps existing add-symlink routing', async () => {
+    const { screen, store } = await renderSkillItem(makeSkill())
+
+    await screen.getByRole('button', { name: /^Add$/i }).click()
+
+    expect(store.getState().skills.skillToAddSymlinks?.name).toBe('task')
+    expect(store.getState().skills.skillToCopy).toBeNull()
+  })
+})
+
 describe('SkillItem bulk-select checkbox stopPropagation', () => {
   // The checkbox wrapper `<label>` and the Checkbox itself both need to stop
   // propagation, otherwise Card's onClick (which toggles the Inspector pane)

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -146,6 +146,10 @@ export const SkillItem = React.memo(function SkillItem({
 
   const handleAddClick = (e: React.MouseEvent): void => {
     e.stopPropagation()
+    if (selectedAgentId) {
+      dispatch(setSkillToCopy(skill))
+      return
+    }
     dispatch(setSkillToAddSymlinks(skill))
   }
 
@@ -449,7 +453,9 @@ export const SkillItem = React.memo(function SkillItem({
                     />
                   )}
                   <span className="truncate">{skill.name}</span>
-                  {/* Add button - only when viewing all skills (no agent filter) */}
+                  {/* Add button:
+                      - global view => AddSymlinkModal
+                      - agent view => CopyToAgentsModal */}
                   {showAddButton && (
                     <Button
                       variant="ghost"

--- a/src/renderer/src/components/skills/skillItemHelpers.test.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.test.ts
@@ -44,11 +44,29 @@ describe('getSkillItemVisibility', () => {
   })
 
   describe('agent filtered view (agent selected)', () => {
-    it('hides delete and add buttons when agent is selected', () => {
+    it('hides delete button and keeps add hidden when selected agent has no skill', () => {
       const result = getSkillItemVisibility('cursor', [])
 
       expect(result.showDeleteButton).toBe(false)
       expect(result.showAddButton).toBe(false)
+    })
+
+    it('shows add button when selected agent has a valid symlink', () => {
+      const symlinks = [
+        makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: false }),
+      ]
+      const result = getSkillItemVisibility('cursor', symlinks)
+
+      expect(result.showAddButton).toBe(true)
+    })
+
+    it('shows add button when selected agent has a local skill', () => {
+      const symlinks = [
+        makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: true }),
+      ]
+      const result = getSkillItemVisibility('cursor', symlinks)
+
+      expect(result.showAddButton).toBe(true)
     })
 
     it('shows unlink button when valid symlink exists for selected agent', () => {

--- a/src/renderer/src/components/skills/skillItemHelpers.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.ts
@@ -7,7 +7,11 @@ import type { AgentId, SymlinkInfo } from '../../../../shared/types'
 export interface SkillItemVisibility {
   /** Show X button (delete skill entirely) — only in global view */
   showDeleteButton: boolean
-  /** Show Add button (create symlinks) — only in global view */
+  /**
+   * Show Add button.
+   * - global view: opens AddSymlinkModal
+   * - agent view (skill exists in selected agent): opens CopyToAgentsModal
+   */
   showAddButton: boolean
   /** Show Trash icon (unlink symlink or delete local skill from selected agent) */
   showUnlinkButton: boolean
@@ -35,9 +39,9 @@ export interface SkillItemVisibility {
  * getSkillItemVisibility(null, []) // => { showDeleteButton: true, showAddButton: true, showUnlinkButton: false, ... }
  *
  * @example
- * // Agent filtered view with valid symlink — show unlink, hide delete & add
+ * // Agent filtered view with valid symlink — show unlink and add, hide delete
  * getSkillItemVisibility('cursor', [{ agentId: 'cursor', status: 'valid', isLocal: false, ... }])
- * // => { showDeleteButton: false, showAddButton: false, showUnlinkButton: true, isLinked: true, ... }
+ * // => { showDeleteButton: false, showAddButton: true, showUnlinkButton: true, isLinked: true, ... }
  *
  * @example
  * // Agent filtered view with local skill — show unlink button for deletion
@@ -62,16 +66,16 @@ export function getSkillItemVisibility(
     : null
 
   const isLocalSkill = !!selectedLocalSkillInfo
+  const hasSkillInSelectedAgent = !!selectedAgentSymlink || isLocalSkill
 
   return {
     showDeleteButton: !selectedAgentId,
-    showAddButton: !selectedAgentId,
-    showUnlinkButton: !!selectedAgentSymlink || isLocalSkill,
+    showAddButton: !selectedAgentId || hasSkillInSelectedAgent,
+    showUnlinkButton: hasSkillInSelectedAgent,
     isLinked: !!selectedAgentSymlink && selectedAgentSymlink.status === 'valid',
     isLocalSkill,
     selectedAgentSymlink,
     selectedLocalSkillInfo,
-    showCopyButton:
-      !!selectedAgentId && (!!selectedAgentSymlink || isLocalSkill),
+    showCopyButton: !!selectedAgentId && hasSkillInSelectedAgent,
   }
 }


### PR DESCRIPTION
## Summary
- Show + Add on skill cards in agent-filtered view when the skill exists in the selected agent
- Route agent-view + Add to the existing CopyToAgentsModal flow
- Keep global-view + Add behavior unchanged (AddSymlinkModal)
- Keep right-click Copy to... behavior unchanged

## Changes
- skillItemHelpers.ts
  - showAddButton now returns true in agent view when the skill exists for that agent (symlink or local)
  - Updated JSDoc to reflect global vs agent behavior
- SkillItem.tsx
  - handleAddClick now branches:
    - global view -> setSkillToAddSymlinks(skill)
    - agent view -> setSkillToCopy(skill)
- Tests
  - skillItemHelpers.test.ts: added agent-view showAddButton coverage
  - SkillItem.browser.test.tsx: added Add routing tests for agent/global views

## Validation
- Passed: pnpm typecheck
- Passed: pnpm lint
- Passed: pnpm test src/renderer/src/components/skills/skillItemHelpers.test.ts src/renderer/src/components/skills/SkillItem.browser.test.tsx

## QA (Electron + agent-browser)
- Agent tab shows + Add on skill cards
- Agent-view + Add opens Copy to Agents modal
- Local skill copy from Claude Code to Codex works
- Global-view + Add still opens Add Symlink
- Agent-view context menu still shows Copy to...

Evidence (local):
- qa-reports/electron-2026-04-20-agent-tab-add-button-macos/01-agent-view-add-button.png
- qa-reports/electron-2026-04-20-agent-tab-add-button-macos/02-copy-to-agents-modal.png
- qa-reports/electron-2026-04-20-agent-tab-add-button-macos/03-context-menu-copy-to.png

## Note
A full pnpm test run in this environment fails on pre-existing bootstrap.test.ts localStorage setup (localStorage.clear is not a function), unrelated to this change.