### PR TITLE
feat: batch-aware CLI remove cancel + timeout/busy hardening

### DIFF
--- a/src/main/ipc/skillsCli.ts
+++ b/src/main/ipc/skillsCli.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path'
 
-import { BrowserWindow } from 'electron'
+import { BrowserWindow, type IpcMainInvokeEvent } from 'electron'
 
 import { BULK_PROGRESS_THRESHOLD } from '../../shared/constants'
 import { IPC_CHANNELS } from '../../shared/ipc-channels'
@@ -9,6 +9,7 @@ import type {
   CliRemoveSkillsResult,
   InstallProgress,
 } from '../../shared/types'
+import { CLI_REMOVE_BUSY_CODE } from '../../shared/types'
 import { SOURCE_DIR } from '../constants'
 import { validatePath } from '../services/pathValidation'
 import { skillsCliService } from '../services/skillsCliService'
@@ -44,7 +45,9 @@ export function registerSkillsCliHandlers(): void {
   })
 
   typedHandle(IPC_CHANNELS.SKILLS_CLI_CANCEL, () => {
-    skillsCliService.cancel()
+    // Shared cancel endpoint: marketplace install and CLI remove batch both
+    // call this channel. requestBatchCancel() also kills running children.
+    skillsCliService.requestBatchCancel()
   })
 
   /**
@@ -70,27 +73,45 @@ export function registerSkillsCliHandlers(): void {
    * @returns CliRemoveSkillsResult with per-item discriminated outcome
    */
   typedHandle(IPC_CHANNELS.SKILLS_CLI_REMOVE_BATCH, async (event, options) => {
+    if (skillsCliService.isBusy()) {
+      return buildBusyBatchResult(
+        options.items.map(({ skillName }) => skillName),
+      )
+    }
+
+    skillsCliService.resetBatchCancelRequest()
+
     const total = options.items.length
     const emitProgress = total >= BULK_PROGRESS_THRESHOLD
     const results: CliRemoveSkillResult[] = []
 
-    for (const [itemIndex, { skillName }] of options.items.entries()) {
-      results.push(await removeSkillViaCli(skillName))
-      if (emitProgress) {
-        // Mirror the SKILLS_CLI_INSTALL guard (lines 30-35): a renderer closed
-        // mid-batch (6-20s per PR) would otherwise throw on typedSend because
-        // webContents is destroyed but event.sender still holds a reference.
-        const win = BrowserWindow.fromWebContents(event.sender)
-        if (win && !win.isDestroyed()) {
-          typedSend(event.sender, IPC_CHANNELS.SKILLS_DELETE_PROGRESS, {
-            current: itemIndex + 1,
-            total,
-          })
+    try {
+      for (const [itemIndex, { skillName }] of options.items.entries()) {
+        if (skillsCliService.isBatchCancelRequested()) {
+          results.push({ skillName, outcome: 'cancelled' })
+        } else {
+          const removeResult = await removeSkillViaCli(skillName)
+          // User cancellation can kill the currently-running child. Normalize
+          // that in-flight item to `cancelled` so renderer summaries align
+          // with user intent instead of showing a synthetic process error.
+          if (
+            skillsCliService.isBatchCancelRequested() &&
+            removeResult.outcome === 'error'
+          ) {
+            results.push({ skillName, outcome: 'cancelled' })
+          } else {
+            results.push(removeResult)
+          }
+        }
+        if (emitProgress) {
+          sendDeleteProgressIfWindowAlive(event, itemIndex + 1, total)
         }
       }
-    }
 
-    return { items: results } satisfies CliRemoveSkillsResult
+      return { items: results } satisfies CliRemoveSkillsResult
+    } finally {
+      skillsCliService.resetBatchCancelRequest()
+    }
   })
 }
 
@@ -112,4 +133,47 @@ async function removeSkillViaCli(
     }
   }
   return skillsCliService.remove(skillName)
+}
+
+/**
+ * Build an all-error batch result for reject-on-busy policy.
+ * @param skillNames - Requested skill names in dispatch order
+ * @returns Per-item busy errors preserving order for deterministic UI mapping
+ */
+function buildBusyBatchResult(
+  skillNames: CliRemoveSkillResult['skillName'][],
+): CliRemoveSkillsResult {
+  return {
+    items: skillNames.map((skillName) => ({
+      skillName,
+      outcome: 'error',
+      error: {
+        message: 'Another CLI operation is already in progress',
+        code: CLI_REMOVE_BUSY_CODE,
+      },
+    })),
+  }
+}
+
+/**
+ * Emit `skills:deleteProgress` only while the renderer window is still alive.
+ * @param event - IPC invoke event carrying sender webContents
+ * @param current - 1-based processed item index
+ * @param total - Total items in the current batch
+ */
+function sendDeleteProgressIfWindowAlive(
+  event: IpcMainInvokeEvent,
+  current: number,
+  total: number,
+): void {
+  // Mirror the SKILLS_CLI_INSTALL guard: a renderer closed mid-batch would
+  // otherwise throw on typedSend because webContents is destroyed but
+  // event.sender still holds a stale reference.
+  const win = BrowserWindow.fromWebContents(event.sender)
+  if (win && !win.isDestroyed()) {
+    typedSend(event.sender, IPC_CHANNELS.SKILLS_DELETE_PROGRESS, {
+      current,
+      total,
+    })
+  }
 }

--- a/src/main/services/skillsCliService.test.ts
+++ b/src/main/services/skillsCliService.test.ts
@@ -2,7 +2,11 @@ import { EventEmitter } from 'events'
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { SkillName } from '../../shared/types'
+import {
+  CLI_REMOVE_BUSY_CODE,
+  CLI_REMOVE_TIMEOUT_CODE,
+  type SkillName,
+} from '../../shared/types'
 
 /**
  * Fake child process so we can drive stdout/stderr/close from the test.
@@ -54,25 +58,32 @@ function simulateCli({
   stdout = '',
   stderr = '',
   exitCode = 0,
+  autoClose = true,
 }: {
   stdout?: string
   stderr?: string
   exitCode?: number
-}): void {
+  autoClose?: boolean
+}): FakeChildProcess {
   const fake = new FakeChildProcess()
   spawnMock.mockImplementationOnce(() => {
-    // Defer emission until after execCli finishes attaching listeners
-    queueMicrotask(() => {
-      if (stdout) fake.stdout.emit('data', Buffer.from(stdout))
-      if (stderr) fake.stderr.emit('data', Buffer.from(stderr))
-      fake.emit('close', exitCode)
-    })
+    if (autoClose) {
+      // Defer emission until after execCli finishes attaching listeners
+      queueMicrotask(() => {
+        if (stdout) fake.stdout.emit('data', Buffer.from(stdout))
+        if (stderr) fake.stderr.emit('data', Buffer.from(stderr))
+        fake.emit('close', exitCode)
+      })
+    }
     return fake
   })
+  return fake
 }
 
 describe('skillsCliService.remove', () => {
   beforeEach(() => {
+    vi.useRealTimers()
+    vi.resetModules()
     spawnMock.mockReset()
   })
 
@@ -155,6 +166,44 @@ describe('skillsCliService.remove', () => {
     expect(result.error.message).toBe('CLI remove failed')
   })
 
+  it('returns a timeout error code when a CLI child exceeds SPAWN_TIMEOUT_MS', async () => {
+    vi.useFakeTimers()
+    const fake = simulateCli({ autoClose: false })
+
+    const { skillsCliService } = await import('./skillsCliService')
+    const promise = skillsCliService.remove('brainstorming' as SkillName)
+
+    await vi.advanceTimersByTimeAsync(60_000)
+    const result = await promise
+
+    if (result.outcome !== 'error') {
+      throw new Error('Expected error outcome')
+    }
+    expect(result.error.code).toBe(CLI_REMOVE_TIMEOUT_CODE)
+    expect(result.error.message).toBe('CLI command timed out after 60s')
+    expect(fake.kill).toHaveBeenCalledWith('SIGTERM')
+  })
+
+  it('returns a busy error when another CLI remove is already in flight', async () => {
+    const first = simulateCli({ autoClose: false })
+
+    const { skillsCliService } = await import('./skillsCliService')
+    const firstPromise = skillsCliService.remove('first' as SkillName)
+    const secondResult = await skillsCliService.remove('second' as SkillName)
+
+    expect(secondResult).toEqual({
+      skillName: 'second',
+      outcome: 'error',
+      error: {
+        message: 'Another CLI operation is already in progress',
+        code: CLI_REMOVE_BUSY_CODE,
+      },
+    })
+
+    first.emit('close', 0)
+    await firstPromise
+  })
+
   it('invokes spawn with npx skills@<VERSION> remove <name> --global -y', async () => {
     simulateCli({ exitCode: 0 })
 
@@ -170,5 +219,23 @@ describe('skillsCliService.remove', () => {
     expect(command).toBe('npx')
     expect(args[0]).toMatch(/^skills@/)
     expect(args.slice(1)).toEqual(['remove', 'brainstorming', '--global', '-y'])
+  })
+
+  it('kills all running CLI children on cancel()', async () => {
+    const first = simulateCli({ autoClose: false })
+    const second = simulateCli({ autoClose: false })
+
+    const { skillsCliService } = await import('./skillsCliService')
+    const searchA = skillsCliService.search('a')
+    const searchB = skillsCliService.search('b')
+
+    skillsCliService.cancel()
+
+    expect(first.kill).toHaveBeenCalledWith('SIGTERM')
+    expect(second.kill).toHaveBeenCalledWith('SIGTERM')
+
+    first.emit('close', 0)
+    second.emit('close', 0)
+    await Promise.all([searchA, searchB])
   })
 })

--- a/src/main/services/skillsCliService.ts
+++ b/src/main/services/skillsCliService.ts
@@ -5,7 +5,11 @@ import { homedir } from 'os'
 import { match, P } from 'ts-pattern'
 
 import { AGENT_DEFINITIONS, SKILLS_CLI_VERSION } from '../../shared/constants'
-import { repositoryId } from '../../shared/types'
+import {
+  CLI_REMOVE_BUSY_CODE,
+  CLI_REMOVE_TIMEOUT_CODE,
+  repositoryId,
+} from '../../shared/types'
 import type {
   SkillSearchResult,
   InstallOptions,
@@ -35,6 +39,20 @@ const CLI_FLAGS = {
   GLOBAL: '--global',
   YES: '-y',
 } as const
+
+/** Hard timeout per spawned `npx skills ...` child process (60 seconds). */
+const SPAWN_TIMEOUT_MS = 60_000
+/** Signal used for user cancel and timeout kill paths. */
+const PROCESS_KILL_SIGNAL: NodeJS.Signals = 'SIGTERM'
+
+/**
+ * Internal execution payload from `execCli`.
+ * Extends `CliCommandResult` with a timeout sentinel so callers can map
+ * user-facing error copy without overloading `code`.
+ */
+interface CliExecutionResult extends CliCommandResult {
+  timedOut: boolean
+}
 
 /**
  * Remove ANSI escape sequences from a string
@@ -88,7 +106,8 @@ function sanitizeCliMessage(text: string): string {
  * version is imported from shared constants so upgrades happen in one place.
  */
 class SkillsCliService extends EventEmitter {
-  private currentProcess: ChildProcess | null = null
+  private runningProcesses = new Set<ChildProcess>()
+  private batchCancelRequested = false
 
   /**
    * Search for skills using `npx skills find <query>`
@@ -157,6 +176,10 @@ class SkillsCliService extends EventEmitter {
    * // => { skillName: 'brainstorming', outcome: 'removed' }
    */
   async remove(skillName: SkillName): Promise<CliRemoveSkillResult> {
+    if (this.isBusy()) {
+      return this.buildBusyRemoveResult(skillName)
+    }
+
     const result = await this.execCli([
       'remove',
       skillName,
@@ -166,6 +189,17 @@ class SkillsCliService extends EventEmitter {
 
     if (result.success) {
       return { skillName, outcome: 'removed' }
+    }
+
+    if (result.timedOut) {
+      return {
+        skillName,
+        outcome: 'error',
+        error: {
+          message: this.buildTimeoutMessage(),
+          code: CLI_REMOVE_TIMEOUT_CODE,
+        },
+      }
     }
 
     // stderr often has the actionable message (e.g., "Skill not found").
@@ -183,12 +217,42 @@ class SkillsCliService extends EventEmitter {
   }
 
   /**
-   * Cancel the current CLI operation
+   * True when at least one CLI child process is currently running.
+   * Used by IPC handlers to apply reject-on-busy behavior for batch dispatch.
+   */
+  isBusy(): boolean {
+    return this.runningProcesses.size > 0
+  }
+
+  /**
+   * Mark the current batch operation as cancelled and terminate in-flight CLI
+   * children. Remaining items are handled by the batch loop in `skillsCli.ts`.
+   */
+  requestBatchCancel(): void {
+    this.batchCancelRequested = true
+    this.cancel()
+  }
+
+  /**
+   * Clear batch-cancel state before starting a new removeBatch dispatch.
+   */
+  resetBatchCancelRequest(): void {
+    this.batchCancelRequested = false
+  }
+
+  /**
+   * Read-only snapshot of the batch cancel flag for loop checks.
+   */
+  isBatchCancelRequested(): boolean {
+    return this.batchCancelRequested
+  }
+
+  /**
+   * Cancel all currently-running CLI operations.
    */
   cancel(): void {
-    if (this.currentProcess) {
-      this.currentProcess.kill('SIGTERM')
-      this.currentProcess = null
+    for (const proc of this.runningProcesses) {
+      proc.kill(PROCESS_KILL_SIGNAL)
     }
   }
 
@@ -201,17 +265,39 @@ class SkillsCliService extends EventEmitter {
   private async execCli(
     args: string[],
     onOutput?: (data: string) => void,
-  ): Promise<CliCommandResult> {
+  ): Promise<CliExecutionResult> {
     return new Promise((resolve) => {
       let stdout = ''
       let stderr = ''
+      let settled = false
 
       // Use npx to run skills CLI with FORCE_COLOR=0 to disable ANSI colors
       const proc = spawn('npx', [`skills@${SKILLS_CLI_VERSION}`, ...args], {
         env: { ...process.env, FORCE_COLOR: '0' },
       })
 
-      this.currentProcess = proc
+      this.runningProcesses.add(proc)
+
+      const finalize = (result: CliExecutionResult): void => {
+        if (settled) {
+          return
+        }
+        settled = true
+        clearTimeout(timeoutHandle)
+        this.runningProcesses.delete(proc)
+        resolve(result)
+      }
+
+      const timeoutHandle = setTimeout(() => {
+        proc.kill(PROCESS_KILL_SIGNAL)
+        finalize({
+          success: false,
+          stdout,
+          stderr: this.buildTimeoutMessage(),
+          code: null,
+          timedOut: true,
+        })
+      }, SPAWN_TIMEOUT_MS)
 
       proc.stdout?.on('data', (data: Buffer) => {
         const text = data.toString()
@@ -224,25 +310,48 @@ class SkillsCliService extends EventEmitter {
       })
 
       proc.on('close', (code) => {
-        this.currentProcess = null
-        resolve({
+        finalize({
           success: code === 0,
           stdout,
           stderr,
           code,
+          timedOut: false,
         })
       })
 
       proc.on('error', (error) => {
-        this.currentProcess = null
-        resolve({
+        finalize({
           success: false,
           stdout,
           stderr: error.message,
           code: null,
+          timedOut: false,
         })
       })
     })
+  }
+
+  /**
+   * Build the user-facing timeout message using the shared timeout constant.
+   */
+  private buildTimeoutMessage(): string {
+    const timeoutSeconds = Math.floor(SPAWN_TIMEOUT_MS / 1000)
+    return `CLI command timed out after ${timeoutSeconds}s`
+  }
+
+  /**
+   * Build a deterministic busy error so callers can map specific UI copy.
+   * @param skillName - Skill that was requested while another CLI process was active
+   */
+  private buildBusyRemoveResult(skillName: SkillName): CliRemoveSkillResult {
+    return {
+      skillName,
+      outcome: 'error',
+      error: {
+        message: 'Another CLI operation is already in progress',
+        code: CLI_REMOVE_BUSY_CODE,
+      },
+    }
   }
 
   /**

--- a/src/renderer/src/bootstrap.test.ts
+++ b/src/renderer/src/bootstrap.test.ts
@@ -34,6 +34,15 @@ import {
 // instead of a `file:` URL).
 const HTML_PATH = resolve(process.cwd(), 'src/renderer/index.html')
 
+interface StorageMock {
+  clear: () => void
+  getItem: (key: string) => string | null
+  key: (index: number) => string | null
+  readonly length: number
+  removeItem: (key: string) => void
+  setItem: (key: string, value: string) => void
+}
+
 /**
  * Locate the inline bootstrap IIFE by finding the `<script>` block that
  * contains the PERSIST_STORAGE_KEY literal. Anchoring on the marker is
@@ -65,6 +74,52 @@ function loadBootstrapScript(): string {
   return match[1]
 }
 
+/**
+ * Build an isolated in-memory Storage implementation for this test file.
+ * @returns Storage-like object with deterministic get/set/remove/clear behavior.
+ * @example
+ * const storage = createStorageMock()
+ * storage.setItem('k', 'v')
+ * storage.getItem('k') // => 'v'
+ */
+function createStorageMock(): StorageMock {
+  const entries = new Map<string, string>()
+  return {
+    clear: () => {
+      entries.clear()
+    },
+    getItem: (key: string) => entries.get(key) ?? null,
+    key: (index: number) => Array.from(entries.keys())[index] ?? null,
+    get length() {
+      return entries.size
+    },
+    removeItem: (key: string) => {
+      entries.delete(key)
+    },
+    setItem: (key: string, value: string) => {
+      entries.set(key, value)
+    },
+  }
+}
+
+/**
+ * Install a fresh storage mock on the global object so the inline bootstrap
+ * script reads from a predictable storage implementation.
+ * @returns The installed storage mock for direct use in tests.
+ * @example
+ * const storage = installStorageMock()
+ * storage.setItem('x', '1')
+ */
+function installStorageMock(): StorageMock {
+  const storage = createStorageMock()
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: storage,
+    writable: true,
+    configurable: true,
+  })
+  return storage
+}
+
 function runBootstrap(): void {
   const script = loadBootstrapScript()
   // Using `new Function` (not `eval`) keeps the script in its own lexical
@@ -74,6 +129,7 @@ function runBootstrap(): void {
 }
 
 beforeEach(() => {
+  installStorageMock()
   localStorage.clear()
   const root = document.documentElement
   root.style.removeProperty('--theme-hue')

--- a/src/renderer/src/redux/slices/skillsSlice.test.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.test.ts
@@ -871,6 +871,29 @@ describe('skillsSlice cliRemoveSelectedSkills thunk', () => {
     expect(store.getState().skills.selectedSkill).toBeNull()
   })
 
+  it('cliRemoveSelectedSkills.fulfilled keeps cancelled names selected for retry', async () => {
+    mockSkillsCliRemoveBatch.mockResolvedValue({
+      items: [
+        { skillName: cliSkill.name, outcome: 'removed' },
+        { skillName: cliSkillSecond.name, outcome: 'cancelled' },
+      ],
+    } satisfies CliRemoveSkillsResult)
+
+    const store = await createTestStore()
+    await seedItems(store, [cliSkill, cliSkillSecond])
+
+    const { cliRemoveSelectedSkills, selectAll } = await import('./skillsSlice')
+    store.dispatch(selectAll([cliSkill.name, cliSkillSecond.name]))
+
+    await store.dispatch(
+      cliRemoveSelectedSkills([cliSkill.name, cliSkillSecond.name]),
+    )
+
+    expect(store.getState().skills.selectedSkillNames).toEqual([
+      cliSkillSecond.name,
+    ])
+  })
+
   it('cliRemoveSelectedSkills.rejected clears in-flight fade and surfaces error', async () => {
     mockSkillsCliRemoveBatch.mockRejectedValue(new Error('IPC channel closed'))
 

--- a/src/renderer/src/redux/slices/skillsSlice.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.ts
@@ -542,8 +542,8 @@ const skillsSlice = createSlice({
         state.error = action.error.message ?? 'Undo failed'
       })
       // CLI remove (batch, length 1..N) — mirror delete-batch reducers:
-      // narrow selection to successfully-removed items, keep failures selected
-      // for retry, reconcile anchor the same way.
+      // narrow selection to successfully-removed items, keep failures/cancelled
+      // selected for retry, reconcile anchor the same way.
       .addCase(cliRemoveSelectedSkills.pending, (state, action) => {
         state.inFlightCliRemoveNames = reconcileByLiveNames(
           state.items,

--- a/src/renderer/src/utils/cliRemoveToast.test.ts
+++ b/src/renderer/src/utils/cliRemoveToast.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { CliRemoveSkillsResult, SkillName } from '../../../shared/types'
+import {
+  CLI_REMOVE_BUSY_CODE,
+  CLI_REMOVE_TIMEOUT_CODE,
+  type CliRemoveSkillsResult,
+  type SkillName,
+} from '../../../shared/types'
 
 import { toastCliRemoveBatchResult } from './cliRemoveToast'
 
@@ -12,12 +17,14 @@ import { toastCliRemoveBatchResult } from './cliRemoveToast'
 const toastSuccess = vi.fn()
 const toastError = vi.fn()
 const toastWarning = vi.fn()
+const toastInfo = vi.fn()
 
 vi.mock('sonner', () => ({
   toast: {
     success: (...args: unknown[]) => toastSuccess(...args),
     error: (...args: unknown[]) => toastError(...args),
     warning: (...args: unknown[]) => toastWarning(...args),
+    info: (...args: unknown[]) => toastInfo(...args),
   },
 }))
 
@@ -26,6 +33,7 @@ describe('toastCliRemoveBatchResult', () => {
     toastSuccess.mockReset()
     toastError.mockReset()
     toastWarning.mockReset()
+    toastInfo.mockReset()
   })
 
   it('emits a name-specific success toast for a single successful item', () => {
@@ -105,6 +113,47 @@ describe('toastCliRemoveBatchResult', () => {
     })
   })
 
+  it('emits a busy-specific error toast when every failure is CLI_BUSY', () => {
+    const result: CliRemoveSkillsResult = {
+      items: [
+        {
+          skillName: 'a' as SkillName,
+          outcome: 'error',
+          error: { message: 'busy', code: CLI_REMOVE_BUSY_CODE },
+        },
+        {
+          skillName: 'b' as SkillName,
+          outcome: 'error',
+          error: { message: 'busy', code: CLI_REMOVE_BUSY_CODE },
+        },
+      ],
+    }
+
+    toastCliRemoveBatchResult(result)
+
+    expect(toastError).toHaveBeenCalledWith('CLI operation already running', {
+      description: 'Another CLI operation is already in progress.',
+    })
+  })
+
+  it('emits a timeout-specific error toast when every failure is CLI_TIMEOUT', () => {
+    const result: CliRemoveSkillsResult = {
+      items: [
+        {
+          skillName: 'a' as SkillName,
+          outcome: 'error',
+          error: { message: 'timed out', code: CLI_REMOVE_TIMEOUT_CODE },
+        },
+      ],
+    }
+
+    toastCliRemoveBatchResult(result)
+
+    expect(toastError).toHaveBeenCalledWith('CLI remove timed out', {
+      description: 'One or more CLI remove commands exceeded 60 seconds.',
+    })
+  })
+
   it('emits a warning toast for a partial-success batch', () => {
     const result: CliRemoveSkillsResult = {
       items: [
@@ -142,6 +191,37 @@ describe('toastCliRemoveBatchResult', () => {
     // Name-aware branch wins for length-1, so we get the name, not "1 skill".
     expect(toastSuccess).toHaveBeenCalledWith('Removed solo', {
       description: 'Deregistered from ~/.agents/.skill-lock.json',
+    })
+  })
+
+  it('emits an info toast when all remaining items are cancelled', () => {
+    const result: CliRemoveSkillsResult = {
+      items: [
+        { skillName: 'a' as SkillName, outcome: 'cancelled' },
+        { skillName: 'b' as SkillName, outcome: 'cancelled' },
+      ],
+    }
+
+    toastCliRemoveBatchResult(result)
+
+    expect(toastInfo).toHaveBeenCalledWith('Cancelled removing 2 skills')
+    expect(toastSuccess).not.toHaveBeenCalled()
+    expect(toastError).not.toHaveBeenCalled()
+    expect(toastWarning).not.toHaveBeenCalled()
+  })
+
+  it('emits a mixed warning toast when removed and cancelled coexist', () => {
+    const result: CliRemoveSkillsResult = {
+      items: [
+        { skillName: 'a' as SkillName, outcome: 'removed' },
+        { skillName: 'b' as SkillName, outcome: 'cancelled' },
+      ],
+    }
+
+    toastCliRemoveBatchResult(result)
+
+    expect(toastWarning).toHaveBeenCalledWith('Removed 1, cancelled 1', {
+      description: 'Batch was cancelled before all skills were processed',
     })
   })
 })

--- a/src/renderer/src/utils/cliRemoveToast.ts
+++ b/src/renderer/src/utils/cliRemoveToast.ts
@@ -1,6 +1,10 @@
 import { toast } from 'sonner'
 
-import type { CliRemoveSkillsResult } from '../../../shared/types'
+import {
+  CLI_REMOVE_BUSY_CODE,
+  CLI_REMOVE_TIMEOUT_CODE,
+  type CliRemoveSkillsResult,
+} from '../../../shared/types'
 
 import { pluralize } from './pluralize'
 
@@ -19,10 +23,19 @@ import { pluralize } from './pluralize'
 export function toastCliRemoveBatchResult(result: CliRemoveSkillsResult): void {
   const total = result.items.length
   const removedItems = result.items.filter((i) => i.outcome === 'removed')
+  const cancelledItems = result.items.filter((i) => i.outcome === 'cancelled')
+  const errorItems = result.items.filter((i) => i.outcome === 'error')
   const removed = removedItems.length
-  const failed = total - removed
+  const cancelled = cancelledItems.length
+  const failed = errorItems.length
+  const timeoutFailures = errorItems.filter(
+    (item) => item.error.code === CLI_REMOVE_TIMEOUT_CODE,
+  ).length
+  const busyFailures = errorItems.filter(
+    (item) => item.error.code === CLI_REMOVE_BUSY_CODE,
+  ).length
 
-  if (failed === 0) {
+  if (failed === 0 && cancelled === 0) {
     // Preserve the name-specific toast for the single-item path (the dialog
     // confirm flow dispatches a batch of length 1). Batch toasts that happen
     // to succeed with a single item are rare in practice but would also read
@@ -37,19 +50,70 @@ export function toastCliRemoveBatchResult(result: CliRemoveSkillsResult): void {
     return
   }
 
-  if (removed === 0) {
+  if (removed === 0 && cancelled > 0 && failed === 0) {
+    toast.info(
+      `Cancelled removing ${cancelled} ${pluralize(cancelled, 'skill')}`,
+    )
+    return
+  }
+
+  if (removed === 0 && failed > 0) {
+    if (busyFailures === failed) {
+      toast.error('CLI operation already running', {
+        description: 'Another CLI operation is already in progress.',
+      })
+      return
+    }
+
+    if (timeoutFailures === failed) {
+      toast.error('CLI remove timed out', {
+        description: 'One or more CLI remove commands exceeded 60 seconds.',
+      })
+      return
+    }
+
     // All-failed single-item case: surface the skill name and actual error
     // so the user sees what happened without digging through devtools.
-    if (total === 1 && result.items[0].outcome === 'error') {
-      const only = result.items[0]
+    if (total === 1 && errorItems.length === 1) {
+      const only = errorItems[0]
+      const description =
+        only.error.code === CLI_REMOVE_TIMEOUT_CODE
+          ? 'CLI remove timed out. Please try again.'
+          : only.error.code === CLI_REMOVE_BUSY_CODE
+            ? 'Another CLI operation is already in progress.'
+            : only.error.message
       toast.error(`Failed to remove ${only.skillName}`, {
-        description: only.error.message,
+        description,
       })
       return
     }
     toast.error('Failed to remove skills', {
       description: `${failed} of ${total} failed`,
     })
+    return
+  }
+
+  if (removed > 0 && cancelled > 0 && failed === 0) {
+    toast.warning(`Removed ${removed}, cancelled ${cancelled}`, {
+      description: 'Batch was cancelled before all skills were processed',
+    })
+    return
+  }
+
+  if (removed === 0 && cancelled > 0 && failed > 0) {
+    toast.warning(`Cancelled ${cancelled}, failed ${failed}`, {
+      description: 'Some skills failed before cancellation completed',
+    })
+    return
+  }
+
+  if (removed > 0 && cancelled > 0 && failed > 0) {
+    toast.warning(
+      `Removed ${removed}, cancelled ${cancelled}, failed ${failed}`,
+      {
+        description: 'Batch completed with mixed outcomes',
+      },
+    )
     return
   }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -700,19 +700,39 @@ export interface CliRemoveSkillOptions {
   skillName: SkillName
 }
 
+/** Batch remove timeout sentinel code surfaced to renderer to show retry copy. */
+export const CLI_REMOVE_TIMEOUT_CODE = 'CLI_TIMEOUT' as const
+/** Reject-on-busy sentinel code surfaced when another CLI process is active. */
+export const CLI_REMOVE_BUSY_CODE = 'CLI_BUSY' as const
+
+/**
+ * Error code surfaced by CLI remove failures.
+ * - numeric: direct process exit code from `npx skills remove`
+ * - null: child process exited without a numeric code (signal/unknown)
+ * - `CLI_TIMEOUT`: hard timeout exceeded before close
+ * - `CLI_BUSY`: another CLI operation is already running
+ */
+export type CliRemoveErrorCode =
+  | number
+  | null
+  | typeof CLI_REMOVE_TIMEOUT_CODE
+  | typeof CLI_REMOVE_BUSY_CODE
+
 /**
  * Result from `skills:cli:remove`. Discriminated on `outcome` so an error
  * branch never carries a spurious "removed" claim. The CLI is irreversible —
  * successful removes have no undo token.
  * @example { skillName: 'brainstorming', outcome: 'removed' }
  * @example { skillName: 'brainstorming', outcome: 'error', error: { message: 'skills: not found', code: 1 } }
+ * @example { skillName: 'brainstorming', outcome: 'cancelled' }
  */
 export type CliRemoveSkillResult =
   | { skillName: SkillName; outcome: 'removed' }
+  | { skillName: SkillName; outcome: 'cancelled' }
   | {
       skillName: SkillName
       outcome: 'error'
-      error: { message: string; code?: number | null }
+      error: { message: string; code?: CliRemoveErrorCode }
     }
 
 /**
@@ -734,7 +754,10 @@ export interface CliRemoveSkillsOptions {
  * ~6–20s of npx cold-starts; if that becomes a UX problem, add progress
  * emission to `skillsCli.ts:SKILLS_CLI_REMOVE_BATCH` and wire it through
  * `setBulkProgress` the way `SKILLS_CLI_INSTALL` already does.
+ * Cancelled batches keep unprocessed items as `{ outcome: 'cancelled' }`
+ * so renderer can preserve selection for retry.
  * @example { items: [{ skillName: 'brainstorming', outcome: 'removed' }] }
+ * @example { items: [{ skillName: 'task', outcome: 'cancelled' }] }
  */
 export interface CliRemoveSkillsResult {
   /** Per-item outcome, index-aligned with the input `items` array. */


### PR DESCRIPTION
## Summary
- implement batch-aware cancellation for `skills:cli:removeBatch` with explicit `cancelled` outcomes for unprocessed items
- harden `skillsCliService` by replacing single-slot process tracking with `Set<ChildProcess>` and adding per-process timeout handling (60s)
- add reject-on-busy behavior for batch dispatches and propagate structured busy/timeout error codes to renderer toasts
- update renderer handling/tests so cancelled items stay selected for retry and toast copy distinguishes timeout/busy/cancel paths

## Validation
- `pnpm test src/main/services/skillsCliService.test.ts src/renderer/src/utils/cliRemoveToast.test.ts src/renderer/src/redux/slices/skillsSlice.test.ts`
- `pnpm test src/renderer/src/components/skills/DeleteCliSkillDialog.browser.test.tsx src/renderer/src/components/layout/MainContent.browser.test.tsx`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` currently still fails on pre-existing `bootstrap.test.ts` (`localStorage.clear is not a function`) unrelated to this change

Closes #89
Closes #90


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for cancelling skill removal operations and better tracking of cancelled items in batch removals.

* **Bug Fixes**
  * Improved skill removal concurrency handling to prevent simultaneous operations.
  * Added 60-second timeout protection for CLI operations.
  * Enhanced error messages for busy state and timeout scenarios.
  * Fixed cancellation behavior to properly handle mixed removal results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->