### PR TITLE
feat: add G-Stack badge and GitHub link to skill cards

### DIFF
--- a/src/renderer/src/components/skills/SkillItem.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillItem.browser.test.tsx
@@ -3,6 +3,7 @@ import { Provider } from 'react-redux'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
+import { GSTACK_REPOSITORY_URL } from '../../../../shared/constants'
 import type { Skill, SkillName } from '../../../../shared/types'
 import { repositoryId } from '../../../../shared/types'
 import { TooltipProvider } from '../ui/tooltip'
@@ -294,6 +295,58 @@ describe('SkillItem Add button routing', () => {
 
     expect(store.getState().skills.skillToAddSymlinks?.name).toBe('task')
     expect(store.getState().skills.skillToCopy).toBeNull()
+  })
+})
+
+describe('SkillItem G-Stack badge', () => {
+  it('shows a G-Stack badge link in supported agent view for gstack-managed skills', async () => {
+    const { screen, store } = await renderSkillItem(
+      makeSkill({
+        symlinks: [
+          {
+            agentId: 'claude-code',
+            agentName: 'Claude Code',
+            status: 'valid',
+            targetPath: '/Users/me/.claude/skills/gstack/task',
+            linkPath: '/Users/me/.claude/skills/task',
+            isLocal: false,
+          },
+        ],
+      }),
+    )
+    const { selectAgent } = await import('../../redux/slices/uiSlice')
+
+    store.dispatch(selectAgent('claude-code'))
+
+    const gstackLink = screen.getByRole('link', { name: /G-Stack/i })
+    await expect.element(gstackLink).toBeInTheDocument()
+    await expect
+      .element(
+        screen.getByRole('link', { name: /Open G-Stack GitHub repository/i }),
+      )
+      .toBeInTheDocument()
+    await expect
+      .element(gstackLink)
+      .toHaveAttribute('href', GSTACK_REPOSITORY_URL)
+  })
+
+  it('hides the G-Stack badge in global view', async () => {
+    const { screen } = await renderSkillItem(
+      makeSkill({
+        symlinks: [
+          {
+            agentId: 'claude-code',
+            agentName: 'Claude Code',
+            status: 'valid',
+            targetPath: '/Users/me/.claude/skills/gstack/task',
+            linkPath: '/Users/me/.claude/skills/task',
+            isLocal: false,
+          },
+        ],
+      }),
+    )
+
+    expect(screen.getByRole('link', { name: /G-Stack/i }).query()).toBeNull()
   })
 })
 

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -2,6 +2,7 @@ import {
   BookmarkCheck,
   BookmarkPlus,
   Copy,
+  ExternalLink,
   FolderDot,
   Link2,
   Plus,
@@ -9,6 +10,7 @@ import {
 } from 'lucide-react'
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 
+import { GSTACK_REPOSITORY_URL } from '../../../../shared/constants'
 import type { Skill, SkillName } from '../../../../shared/types'
 import { cn } from '../../lib/utils'
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
@@ -128,6 +130,7 @@ export const SkillItem = React.memo(function SkillItem({
     isLocalSkill,
     selectedAgentSymlink,
     selectedLocalSkillInfo,
+    showGStackBadge,
   } = getSkillItemVisibility(selectedAgentId, skill.symlinks)
 
   const isCliManaged = isCliManagedSkill(skill)
@@ -466,6 +469,19 @@ export const SkillItem = React.memo(function SkillItem({
                       <Plus className="h-3 w-3 mr-0.5" />
                       Add
                     </Button>
+                  )}
+                  {showGStackBadge && (
+                    <a
+                      href={GSTACK_REPOSITORY_URL}
+                      target="_blank"
+                      rel="noreferrer"
+                      onClick={(e) => e.stopPropagation()}
+                      className="inline-flex items-center gap-1 rounded-md border border-sky-400/40 bg-sky-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-sky-300 transition-colors hover:bg-sky-500/25 shrink-0"
+                      aria-label="Open G-Stack GitHub repository"
+                    >
+                      G-Stack
+                      <ExternalLink className="h-2.5 w-2.5" />
+                    </a>
                   )}
                 </h3>
                 {skill.description && (

--- a/src/renderer/src/components/skills/skillItemHelpers.test.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.test.ts
@@ -195,6 +195,67 @@ describe('getSkillItemVisibility', () => {
     })
   })
 
+  describe('showGStackBadge', () => {
+    it('shows badge for gstack-backed symlink in supported agent view', () => {
+      const symlinks = [
+        makeSymlink({
+          agentId: 'claude-code',
+          targetPath: '/Users/me/.claude/skills/gstack/task',
+          linkPath: '/Users/me/.claude/skills/task',
+          isLocal: false,
+          status: 'valid',
+        }),
+      ]
+
+      const result = getSkillItemVisibility('claude-code', symlinks)
+      expect(result.showGStackBadge).toBe(true)
+    })
+
+    it('shows badge for relative gstack symlink targets', () => {
+      const symlinks = [
+        makeSymlink({
+          agentId: 'codex',
+          targetPath: '../gstack/task',
+          linkPath: '/Users/me/.codex/skills/task',
+          isLocal: false,
+          status: 'valid',
+        }),
+      ]
+
+      const result = getSkillItemVisibility('codex', symlinks)
+      expect(result.showGStackBadge).toBe(true)
+    })
+
+    it('hides badge in global view even when gstack path exists', () => {
+      const symlinks = [
+        makeSymlink({
+          agentId: 'claude-code',
+          targetPath: '/Users/me/.claude/skills/gstack/task',
+          isLocal: false,
+          status: 'valid',
+        }),
+      ]
+
+      const result = getSkillItemVisibility(null, symlinks)
+      expect(result.showGStackBadge).toBe(false)
+    })
+
+    it('hides badge for non-supported agents', () => {
+      const symlinks = [
+        makeSymlink({
+          agentId: 'gemini-cli',
+          targetPath: '/Users/me/.gemini/skills/gstack/task',
+          linkPath: '/Users/me/.gemini/skills/task',
+          isLocal: false,
+          status: 'valid',
+        }),
+      ]
+
+      const result = getSkillItemVisibility('gemini-cli', symlinks)
+      expect(result.showGStackBadge).toBe(false)
+    })
+  })
+
   describe('regression: dual delete buttons', () => {
     it('never shows both delete button and unlink button simultaneously', () => {
       // This was the bug: both X (delete) and Trash (unlink) showed in agent view

--- a/src/renderer/src/components/skills/skillItemHelpers.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.ts
@@ -1,3 +1,4 @@
+import { GSTACK_BADGE_AGENT_IDS } from '../../../../shared/constants'
 import type { AgentId, SymlinkInfo } from '../../../../shared/types'
 
 /**
@@ -25,6 +26,28 @@ export interface SkillItemVisibility {
   selectedLocalSkillInfo: SymlinkInfo | null
   /** Show "Copy to..." context menu — only in agent view (not global, not universal) */
   showCopyButton: boolean
+  /** Show G-Stack source badge/link in selected agent view */
+  showGStackBadge: boolean
+}
+
+/** Path-segment matcher for `.../gstack/...` on both POSIX and Windows paths. */
+const GSTACK_SEGMENT_PATTERN = /(^|[\\/])gstack([\\/]|$)/i
+
+/**
+ * Detect whether a filesystem-like path points to a G-Stack-managed location.
+ * @param candidatePath - Path candidate from symlink target or link path.
+ * @returns
+ * - `true`: Path contains a standalone `gstack` segment.
+ * - `false`: Empty or non-matching path.
+ * @example
+ * isGStackBundlePath('/Users/me/.claude/skills/gstack/skill-a') // => true
+ * @example
+ * isGStackBundlePath('../gstack/skill-a') // => true
+ * @example
+ * isGStackBundlePath('/Users/me/.agents/skills/task') // => false
+ */
+function isGStackBundlePath(candidatePath: string): boolean {
+  return GSTACK_SEGMENT_PATTERN.test(candidatePath)
 }
 
 /**
@@ -67,6 +90,16 @@ export function getSkillItemVisibility(
 
   const isLocalSkill = !!selectedLocalSkillInfo
   const hasSkillInSelectedAgent = !!selectedAgentSymlink || isLocalSkill
+  const gStackPathCandidates = [
+    selectedAgentSymlink?.targetPath ?? '',
+    selectedAgentSymlink?.linkPath ?? '',
+    selectedLocalSkillInfo?.linkPath ?? '',
+  ]
+  const isGStackEligibleAgent =
+    selectedAgentId !== null &&
+    GSTACK_BADGE_AGENT_IDS.some((agentId) => agentId === selectedAgentId)
+  const showGStackBadge =
+    isGStackEligibleAgent && gStackPathCandidates.some(isGStackBundlePath)
 
   return {
     showDeleteButton: !selectedAgentId,
@@ -77,5 +110,6 @@ export function getSkillItemVisibility(
     selectedAgentSymlink,
     selectedLocalSkillInfo,
     showCopyButton: !!selectedAgentId && hasSkillInSelectedAgent,
+    showGStackBadge,
   }
 }

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { AGENT_DEFINITIONS, UNIVERSAL_AGENT_IDS } from './constants'
+import {
+  AGENT_DEFINITIONS,
+  GSTACK_BADGE_AGENT_IDS,
+  GSTACK_REPOSITORY_URL,
+  UNIVERSAL_AGENT_IDS,
+} from './constants'
 
 describe('AGENT_DEFINITIONS', () => {
   it('has unique ids', () => {
@@ -53,5 +58,18 @@ describe('UNIVERSAL_AGENT_IDS', () => {
     expect(UNIVERSAL_AGENT_IDS).toContain('kimi-cli')
     expect(UNIVERSAL_AGENT_IDS).toContain('opencode')
     expect(UNIVERSAL_AGENT_IDS).toContain('warp')
+  })
+})
+
+describe('GSTACK constants', () => {
+  it('gstack badge agent ids are valid AgentIds in AGENT_DEFINITIONS', () => {
+    const allIds = AGENT_DEFINITIONS.map((a) => a.id)
+    for (const id of GSTACK_BADGE_AGENT_IDS) {
+      expect(allIds).toContain(id)
+    }
+  })
+
+  it('gstack repository URL points to the canonical GitHub repository', () => {
+    expect(GSTACK_REPOSITORY_URL).toBe('https://github.com/garrytan/gstack')
   })
 })

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -209,6 +209,23 @@ export type AgentId = (typeof AGENT_DEFINITIONS)[number]['id']
 export type AgentName = (typeof AGENT_DEFINITIONS)[number]['name']
 
 /**
+ * Agent IDs where G-Stack-managed skills may appear in card-level UI.
+ * Currently the team operates G-Stack primarily through Claude Code, with
+ * Codex/Cursor included for forward compatibility.
+ */
+export const GSTACK_BADGE_AGENT_IDS = [
+  'claude-code',
+  'codex',
+  'cursor',
+] as const satisfies readonly AgentId[]
+
+/**
+ * Canonical GitHub repository URL for G-Stack.
+ * Used by the skill-card badge link so users can jump to upstream docs.
+ */
+export const GSTACK_REPOSITORY_URL = 'https://github.com/garrytan/gstack'
+
+/**
  * Agent IDs that use ~/.agents/skills/ directly (no symlinks needed).
  * Derived from skills CLI: agents where skillsDir === '.agents/skills'
  * and showInUniversalList !== false.


### PR DESCRIPTION
## Summary
- add shared G-Stack constants for supported agent IDs and repository URL
- detect G-Stack-managed skills from selected-agent symlink/link paths in SkillItem helpers
- render a G-Stack badge link on skill cards in eligible agent views
- add tests for constants, helper visibility logic, and SkillItem badge rendering

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test

Closes #69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a "G-Stack" badge on skill items that appears when G-Stack-managed resources are detected with supported agents. The badge links to the G-Stack GitHub repository and opens in a new tab.

* **Tests**
  * Expanded test coverage for skill item visibility detection and G-Stack badge rendering behavior across different agent configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->