### PR TITLE
feat: allow selecting not-installed agents from skill add/copy modals

### DIFF
--- a/src/renderer/src/components/skills/AddSymlinkModal.tsx
+++ b/src/renderer/src/components/skills/AddSymlinkModal.tsx
@@ -131,7 +131,7 @@ export const AddSymlinkModal = React.memo(
                       {agent.name}
                       {!agent.exists && (
                         <span className="text-xs text-muted-foreground ml-2">
-                          (not installed)
+                          not installed
                         </span>
                       )}
                       {isAlreadyLinked && (

--- a/src/renderer/src/components/skills/AddSymlinkModal.tsx
+++ b/src/renderer/src/components/skills/AddSymlinkModal.tsx
@@ -21,6 +21,8 @@ import {
   DialogTitle,
 } from '../ui/dialog'
 
+import { getTargetAgentsForSelection } from './agentSelectionHelpers'
+
 /**
  * Modal for selecting agents to add skill symlinks to
  * Shows agent checkboxes with already-linked agents disabled
@@ -35,8 +37,8 @@ export const AddSymlinkModal = React.memo(
 
     const [selectedAgents, setSelectedAgents] = useState<AgentId[]>([])
 
-    const existingAgents = useMemo(
-      () => agents.filter((a) => a.exists),
+    const targetAgents = useMemo(
+      () => getTargetAgentsForSelection(agents),
       [agents],
     )
 
@@ -106,7 +108,7 @@ export const AddSymlinkModal = React.memo(
           <div className="py-4">
             <h4 className="text-sm font-medium mb-3">Select Agents</h4>
             <div className="max-h-[240px] overflow-y-auto rounded-md border p-2 space-y-1">
-              {existingAgents.map((agent) => {
+              {targetAgents.map((agent) => {
                 const isAlreadyLinked = alreadyLinkedAgentIds.has(agent.id)
                 return (
                   <label
@@ -127,6 +129,11 @@ export const AddSymlinkModal = React.memo(
                     />
                     <span className="text-sm">
                       {agent.name}
+                      {!agent.exists && (
+                        <span className="text-xs text-muted-foreground ml-2">
+                          (not installed)
+                        </span>
+                      )}
                       {isAlreadyLinked && (
                         <span className="text-xs text-muted-foreground ml-2">
                           (linked)

--- a/src/renderer/src/components/skills/CopyToAgentsModal.tsx
+++ b/src/renderer/src/components/skills/CopyToAgentsModal.tsx
@@ -39,13 +39,12 @@ export const CopyToAgentsModal = React.memo(
       setSelectedAgents([])
     }, [skillToCopy])
 
-    const targetAgents = useMemo(
-      () =>
-        getTargetAgentsForSelection(agents, {
-          excludeAgentId: selectedAgentId,
-        }),
-      [agents, selectedAgentId],
-    )
+    const targetAgents = useMemo(() => {
+      if (!selectedAgentId) return []
+      return getTargetAgentsForSelection(agents, {
+        excludeAgentId: selectedAgentId,
+      })
+    }, [agents, selectedAgentId])
 
     /** Agent IDs where this skill already exists (valid symlink or local) */
     const alreadyExistsAgentIds = useMemo(() => {

--- a/src/renderer/src/components/skills/CopyToAgentsModal.tsx
+++ b/src/renderer/src/components/skills/CopyToAgentsModal.tsx
@@ -17,6 +17,8 @@ import {
   DialogTitle,
 } from '../ui/dialog'
 
+import { getTargetAgentsForSelection } from './agentSelectionHelpers'
+
 /**
  * Modal for selecting target agents when copying a skill from one agent to others.
  * Triggered by right-click "Copy to..." on a skill card in Agent View.
@@ -37,9 +39,12 @@ export const CopyToAgentsModal = React.memo(
       setSelectedAgents([])
     }, [skillToCopy])
 
-    const existingAgents = useMemo(
-      () => agents.filter((a) => a.exists),
-      [agents],
+    const targetAgents = useMemo(
+      () =>
+        getTargetAgentsForSelection(agents, {
+          excludeAgentId: selectedAgentId,
+        }),
+      [agents, selectedAgentId],
     )
 
     /** Agent IDs where this skill already exists (valid symlink or local) */
@@ -133,45 +138,46 @@ export const CopyToAgentsModal = React.memo(
           </DialogHeader>
 
           <div className="max-h-64 overflow-y-auto space-y-2 py-2">
-            {existingAgents
-              .filter((agent) => agent.id !== selectedAgentId)
-              .map((agent) => {
-                const alreadyExists = alreadyExistsAgentIds.has(agent.id)
-                const checkboxId = `copy-agent-${agent.id}`
-                return (
-                  <div
-                    key={agent.id}
-                    className={`flex items-center gap-3 p-2 rounded-md transition-colors ${
-                      alreadyExists
-                        ? 'opacity-50 cursor-not-allowed'
-                        : 'hover:bg-accent cursor-pointer'
-                    }`}
-                    onClick={() =>
-                      !alreadyExists && !copying && handleAgentToggle(agent.id)
-                    }
+            {targetAgents.map((agent) => {
+              const alreadyExists = alreadyExistsAgentIds.has(agent.id)
+              const checkboxId = `copy-agent-${agent.id}`
+              return (
+                <div
+                  key={agent.id}
+                  className={`flex items-center gap-3 p-2 rounded-md transition-colors ${
+                    alreadyExists
+                      ? 'opacity-50 cursor-not-allowed'
+                      : 'hover:bg-accent cursor-pointer'
+                  }`}
+                  onClick={() =>
+                    !alreadyExists && !copying && handleAgentToggle(agent.id)
+                  }
+                >
+                  <Checkbox
+                    id={checkboxId}
+                    checked={alreadyExists || selectedAgents.includes(agent.id)}
+                    disabled={alreadyExists || copying}
+                    onCheckedChange={() => handleAgentToggle(agent.id)}
+                  />
+                  <label
+                    htmlFor={checkboxId}
+                    className="text-sm cursor-pointer"
                   >
-                    <Checkbox
-                      id={checkboxId}
-                      checked={
-                        alreadyExists || selectedAgents.includes(agent.id)
-                      }
-                      disabled={alreadyExists || copying}
-                      onCheckedChange={() => handleAgentToggle(agent.id)}
-                    />
-                    <label
-                      htmlFor={checkboxId}
-                      className="text-sm cursor-pointer"
-                    >
-                      {agent.name}
-                      {alreadyExists && (
-                        <span className="text-xs text-muted-foreground ml-2">
-                          already exists
-                        </span>
-                      )}
-                    </label>
-                  </div>
-                )
-              })}
+                    {agent.name}
+                    {!agent.exists && (
+                      <span className="text-xs text-muted-foreground ml-2">
+                        not installed
+                      </span>
+                    )}
+                    {alreadyExists && (
+                      <span className="text-xs text-muted-foreground ml-2">
+                        already exists
+                      </span>
+                    )}
+                  </label>
+                </div>
+              )
+            })}
           </div>
 
           <DialogFooter>

--- a/src/renderer/src/components/skills/agentSelectionHelpers.test.ts
+++ b/src/renderer/src/components/skills/agentSelectionHelpers.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Agent } from '../../../../shared/types'
+
+import { getTargetAgentsForSelection } from './agentSelectionHelpers'
+
+/**
+ * Creates a minimal Agent object for selection-helper unit tests.
+ * @param overrides - Test-specific fields.
+ * @returns Agent fixture with stable defaults.
+ */
+function makeAgent(overrides: Partial<Agent> & Pick<Agent, 'id'>): Agent {
+  return {
+    id: overrides.id,
+    name: overrides.name ?? ('Agent' as Agent['name']),
+    path: overrides.path ?? ('/tmp/skills' as Agent['path']),
+    exists: overrides.exists ?? true,
+    skillCount: overrides.skillCount ?? 0,
+    localSkillCount: overrides.localSkillCount ?? 0,
+  }
+}
+
+describe('getTargetAgentsForSelection', () => {
+  it('keeps installed agents first and appends not-installed agents', () => {
+    const agents: Agent[] = [
+      makeAgent({ id: 'cursor', exists: true }),
+      makeAgent({ id: 'amp', exists: false }),
+      makeAgent({ id: 'codex', exists: true }),
+      makeAgent({ id: 'augment', exists: false }),
+    ]
+
+    const result = getTargetAgentsForSelection(agents)
+
+    expect(result.map((agent) => agent.id)).toEqual([
+      'cursor',
+      'codex',
+      'amp',
+      'augment',
+    ])
+  })
+
+  it('excludes the source agent when excludeAgentId is provided', () => {
+    const agents: Agent[] = [
+      makeAgent({ id: 'claude-code', exists: true }),
+      makeAgent({ id: 'cursor', exists: true }),
+      makeAgent({ id: 'amp', exists: false }),
+    ]
+
+    const result = getTargetAgentsForSelection(agents, {
+      excludeAgentId: 'claude-code',
+    })
+
+    expect(result.map((agent) => agent.id)).toEqual(['cursor', 'amp'])
+  })
+})

--- a/src/renderer/src/components/skills/agentSelectionHelpers.ts
+++ b/src/renderer/src/components/skills/agentSelectionHelpers.ts
@@ -1,0 +1,39 @@
+import type { Agent, AgentId } from '../../../../shared/types'
+
+/**
+ * Returns target-agent candidates for Add/Copy modals.
+ * Installed agents are listed first for quick access, then not-installed
+ * agents so users can still prepare skills directories ahead of installation.
+ *
+ * @param agents - Full agent list from Redux state.
+ * @param options - Optional filtering options.
+ * @returns
+ * - Agents eligible for selection, ordered as installed -> not installed.
+ *
+ * @example
+ * getTargetAgentsForSelection(
+ *   [
+ *     { id: 'cursor', exists: true } as Agent,
+ *     { id: 'amp', exists: false } as Agent,
+ *   ],
+ * )
+ * // => [cursor, amp]
+ *
+ * @example
+ * getTargetAgentsForSelection(agents, { excludeAgentId: 'claude-code' })
+ * // => all except claude-code
+ */
+export function getTargetAgentsForSelection(
+  agents: Agent[],
+  options: { excludeAgentId?: AgentId | null } = {},
+): Agent[] {
+  const { excludeAgentId = null } = options
+  const filteredAgents =
+    excludeAgentId === null
+      ? agents
+      : agents.filter((agent) => agent.id !== excludeAgentId)
+  const installedAgents = filteredAgents.filter((agent) => agent.exists)
+  const notInstalledAgents = filteredAgents.filter((agent) => !agent.exists)
+
+  return [...installedAgents, ...notInstalledAgents]
+}


### PR DESCRIPTION
## Summary
- include not-installed agents in Add Symlink modal target list
- include not-installed agents in Copy to Agents modal target list (excluding source agent)
- add shared selection helper with tests for ordering and source-agent exclusion

## Verification
- pnpm typecheck
- pnpm lint
- pnpm test src/renderer/src/components/skills/agentSelectionHelpers.test.ts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agent selection modals now display both installed and non-installed agents with clear "(not installed)" labels, improving visibility of all available options.

* **Tests**
  * Added test coverage for agent selection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->