### PR TITLE
[codex] support add-modal copy flow and Japanese CodeRabbit locale

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
-language: 'en-US'
+language: 'ja-JP'
 early_access: false
 
 tone_instructions: >

--- a/src/main/ipc/ipc-schemas.test.ts
+++ b/src/main/ipc/ipc-schemas.test.ts
@@ -162,7 +162,7 @@ describe('skillNameString consistency across channels', () => {
         payload.skillPath = '/tmp/x'
         payload.agentIds = ['cursor']
       } else if (channel === 'skills:copyToAgents') {
-        payload.linkPath = '/tmp/x'
+        payload.sourcePath = '/tmp/x'
         payload.targetAgentIds = ['cursor']
       }
       const result = schema.safeParse([payload])

--- a/src/main/ipc/ipc-schemas.ts
+++ b/src/main/ipc/ipc-schemas.ts
@@ -125,7 +125,7 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
   'skills:copyToAgents': z.tuple([
     z.object({
       skillName: skillNameString,
-      linkPath: nonEmptyString,
+      sourcePath: nonEmptyString,
       targetAgentIds: z.array(nonEmptyString).min(1),
     }),
   ]),

--- a/src/main/ipc/skills.copyToAgents.integration.test.ts
+++ b/src/main/ipc/skills.copyToAgents.integration.test.ts
@@ -1,4 +1,13 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readlink,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
@@ -97,5 +106,56 @@ describe('skills:copyToAgents handler', () => {
     await expect(
       readFile(join(copiedSkillPath, 'notes.md'), 'utf-8'),
     ).resolves.toBe('copied payload')
+  })
+
+  it('preserves nested symlinks when copying a source directory', async () => {
+    const sourcePath = join(tempHome, '.agents', 'skills', 'task')
+    await mkdir(join(sourcePath, 'docs'), { recursive: true })
+    await writeFile(
+      join(sourcePath, 'docs', 'guide.md'),
+      'nested guide',
+      'utf-8',
+    )
+    await symlink('./docs/guide.md', join(sourcePath, 'linked-guide.md'))
+
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+
+    const copyToAgentsHandler = getRegisteredHandler('skills:copyToAgents')
+    const result = (await copyToAgentsHandler(
+      {},
+      {
+        skillName: 'task',
+        sourcePath,
+        targetAgentIds: ['cursor'],
+      },
+    )) as {
+      success: boolean
+      copied: number
+      failures: unknown[]
+    }
+
+    expect(result).toEqual({
+      success: true,
+      copied: 1,
+      failures: [],
+    })
+
+    const copiedLinkPath = join(
+      tempHome,
+      '.cursor',
+      'skills',
+      'task',
+      'linked-guide.md',
+    )
+    const copiedLinkStats = await lstat(copiedLinkPath)
+    expect(copiedLinkStats.isSymbolicLink()).toBe(true)
+    await expect(readlink(copiedLinkPath)).resolves.toBe('./docs/guide.md')
+    await expect(
+      readFile(
+        join(tempHome, '.cursor', 'skills', 'task', 'docs', 'guide.md'),
+        'utf-8',
+      ),
+    ).resolves.toBe('nested guide')
   })
 })

--- a/src/main/ipc/skills.copyToAgents.integration.test.ts
+++ b/src/main/ipc/skills.copyToAgents.integration.test.ts
@@ -36,13 +36,25 @@ describe('skills:copyToAgents handler', () => {
     vi.resetModules()
     handleMock.mockReset()
     tempHome = await mkdtemp(join(tmpdir(), 'skills-desktop-copy-'))
-    vi.doMock('os', () => ({
-      homedir: () => tempHome,
-    }))
+    vi.doMock('os', async () => {
+      const actual = await vi.importActual<typeof import('os')>('os')
+      return {
+        ...actual,
+        homedir: () => tempHome,
+      }
+    })
+    vi.doMock('node:os', async () => {
+      const actual = await vi.importActual<typeof import('node:os')>('node:os')
+      return {
+        ...actual,
+        homedir: () => tempHome,
+      }
+    })
   })
 
   afterEach(async () => {
     vi.doUnmock('os')
+    vi.doUnmock('node:os')
     await rm(tempHome, { recursive: true, force: true })
   })
 

--- a/src/main/ipc/skills.copyToAgents.integration.test.ts
+++ b/src/main/ipc/skills.copyToAgents.integration.test.ts
@@ -8,8 +8,9 @@ import {
   symlink,
   writeFile,
 } from 'node:fs/promises'
-import { join } from 'node:path'
+import type * as NodeOs from 'node:os'
 import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -46,14 +47,14 @@ describe('skills:copyToAgents handler', () => {
     handleMock.mockReset()
     tempHome = await mkdtemp(join(tmpdir(), 'skills-desktop-copy-'))
     vi.doMock('os', async () => {
-      const actual = await vi.importActual<typeof import('os')>('os')
+      const actual = await vi.importActual<typeof NodeOs>('os')
       return {
         ...actual,
         homedir: () => tempHome,
       }
     })
     vi.doMock('node:os', async () => {
-      const actual = await vi.importActual<typeof import('node:os')>('node:os')
+      const actual = await vi.importActual<typeof NodeOs>('node:os')
       return {
         ...actual,
         homedir: () => tempHome,

--- a/src/main/ipc/skills.copyToAgents.test.ts
+++ b/src/main/ipc/skills.copyToAgents.test.ts
@@ -1,0 +1,89 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const handleMock = vi.fn()
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (...args: unknown[]) => handleMock(...args),
+  },
+}))
+
+/**
+ * Look up a registered IPC handler by channel name.
+ * @param channel - IPC invoke channel to find.
+ * @returns Registered handler function.
+ * @example
+ * const handler = getRegisteredHandler('skills:copyToAgents')
+ */
+function getRegisteredHandler(
+  channel: string,
+): (...args: unknown[]) => unknown {
+  const registration = handleMock.mock.calls.find(([name]) => name === channel)
+  if (!registration) {
+    throw new Error(`No handler registered for ${channel}`)
+  }
+  return registration[1] as (...args: unknown[]) => unknown
+}
+
+describe('skills:copyToAgents handler', () => {
+  let tempHome = ''
+
+  beforeEach(async () => {
+    vi.resetModules()
+    handleMock.mockReset()
+    tempHome = await mkdtemp(join(tmpdir(), 'skills-desktop-copy-'))
+    vi.doMock('os', () => ({
+      homedir: () => tempHome,
+    }))
+  })
+
+  afterEach(async () => {
+    vi.doUnmock('os')
+    await rm(tempHome, { recursive: true, force: true })
+  })
+
+  it('accepts a source skill directory path and copies it into the target agent dir', async () => {
+    const sourcePath = join(tempHome, '.agents', 'skills', 'task')
+    await mkdir(sourcePath, { recursive: true })
+    await writeFile(
+      join(sourcePath, 'SKILL.md'),
+      '---\nname: task\ndescription: Task\n---\n',
+    )
+    await writeFile(join(sourcePath, 'notes.md'), 'copied payload')
+
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+
+    const copyToAgentsHandler = getRegisteredHandler('skills:copyToAgents')
+    const result = (await copyToAgentsHandler(
+      {},
+      {
+        skillName: 'task',
+        sourcePath,
+        targetAgentIds: ['cursor'],
+      },
+    )) as {
+      success: boolean
+      copied: number
+      failures: unknown[]
+    }
+
+    expect(result).toEqual({
+      success: true,
+      copied: 1,
+      failures: [],
+    })
+
+    const copiedSkillPath = join(tempHome, '.cursor', 'skills', 'task')
+    await expect(
+      readFile(join(copiedSkillPath, 'SKILL.md'), 'utf-8'),
+    ).resolves.toContain('name: task')
+    await expect(
+      readFile(join(copiedSkillPath, 'notes.md'), 'utf-8'),
+    ).resolves.toBe('copied payload')
+  })
+})

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -442,7 +442,7 @@ export function registerSkillsHandlers(): void {
   /**
    * Copy a skill source into other agents.
    * Symlinked sources → create symlink pointing to same resolved target.
-   * Directory sources → physical copy (`fs.cp(..., { recursive: true })`).
+   * Directory sources → physical copy while preserving nested symlinks.
    * @param options - skillName, sourcePath, targetAgentIds
    * @returns CopyToAgentsResult with copied count and per-agent failures
    * @example
@@ -539,7 +539,10 @@ export function registerSkillsHandlers(): void {
         if (isSymlink) {
           await fs.symlink(symlinkTarget, destPath)
         } else {
-          await fs.cp(sourcePath, destPath, { recursive: true })
+          await fs.cp(sourcePath, destPath, {
+            recursive: true,
+            verbatimSymlinks: true,
+          })
         }
         copied++
       } catch (error) {

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -440,18 +440,18 @@ export function registerSkillsHandlers(): void {
   })
 
   /**
-   * Copy a skill from one agent to other agents.
-   * Symlinked skills → create symlink pointing to same source.
-   * Local skills → physical copy (fs.cp recursive).
-   * @param options - skillName, linkPath (source), targetAgentIds
+   * Copy a skill source into other agents.
+   * Symlinked sources → create symlink pointing to same resolved target.
+   * Directory sources → physical copy (`fs.cp(..., { recursive: true })`).
+   * @param options - skillName, sourcePath, targetAgentIds
    * @returns CopyToAgentsResult with copied count and per-agent failures
    * @example
-   * // Symlink: creates symlink in target agent pointing to same source
-   * // Local: copies folder recursively to target agent
+   * // Symlink source: creates symlink in target agent pointing to same source
+   * // Directory source: copies folder recursively to target agent
    */
   typedHandle(IPC_CHANNELS.SKILLS_COPY_TO_AGENTS, async (_, options) => {
-    const { skillName, linkPath, targetAgentIds } = options
-    validatePath(linkPath, getAllowedBases())
+    const { skillName, sourcePath, targetAgentIds } = options
+    validatePath(sourcePath, getAllowedBases())
     let copied = 0
     const failures: Array<{
       agentId: (typeof targetAgentIds)[number]
@@ -465,18 +465,18 @@ export function registerSkillsHandlers(): void {
     let isSymlink = false
     let symlinkTarget = ''
     try {
-      const stats = await fs.lstat(linkPath)
+      const stats = await fs.lstat(sourcePath)
       const detectionOutcome = await match({
         isSymlink: stats.isSymbolicLink(),
         isDirectory: stats.isDirectory(),
       })
         .with({ isSymlink: true }, async () => {
           // `readlink` returns the raw target, which can be relative to the
-          // symlink's own directory. Resolve it against `dirname(linkPath)`
+          // symlink's own directory. Resolve it against `dirname(sourcePath)`
           // so validation and replication see an absolute filesystem path
           // rather than a cwd-relative string.
-          const rawTarget = await fs.readlink(linkPath)
-          const resolvedTarget = resolve(dirname(linkPath), rawTarget)
+          const rawTarget = await fs.readlink(sourcePath)
+          const resolvedTarget = resolve(dirname(sourcePath), rawTarget)
           // Validate the resolved symlink target is within allowed bases.
           // After the CREATE_SYMLINKS fix, symlinks may legitimately point at
           // either SOURCE_DIR (source skills) or another agent's dir (local
@@ -539,7 +539,7 @@ export function registerSkillsHandlers(): void {
         if (isSymlink) {
           await fs.symlink(symlinkTarget, destPath)
         } else {
-          await fs.cp(linkPath, destPath, { recursive: true })
+          await fs.cp(sourcePath, destPath, { recursive: true })
         }
         copied++
       } catch (error) {

--- a/src/renderer/src/components/skills/AddSymlinkModal.browser.test.tsx
+++ b/src/renderer/src/components/skills/AddSymlinkModal.browser.test.tsx
@@ -1,0 +1,331 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import type { Agent, AgentId, Skill, SkillName } from '../../../../shared/types'
+
+const mockCreateSymlinks = vi.fn()
+const mockCopyToAgents = vi.fn()
+const mockGetAll = vi.fn()
+const mockAgentsGetAll = vi.fn()
+const mockSourceGetStats = vi.fn()
+const mockOnDeleteProgress = vi.fn(() => () => {})
+
+const toastSuccess = vi.fn()
+const toastError = vi.fn()
+const toastWarning = vi.fn()
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccess(...args),
+    error: (...args: unknown[]) => toastError(...args),
+    warning: (...args: unknown[]) => toastWarning(...args),
+  },
+}))
+
+/**
+ * Build a minimal agent fixture for modal-selection tests.
+ * @param overrides - Partial agent overrides.
+ * @returns Complete Agent object.
+ * @example
+ * makeAgent({ id: 'cursor', name: 'Cursor' })
+ */
+function makeAgent(
+  overrides: Partial<Agent> & Pick<Agent, 'id' | 'name'>,
+): Agent {
+  const { id, name, ...rest } = overrides
+  return {
+    id,
+    name,
+    path: `/home/user/.${id}/skills`,
+    exists: true,
+    skillCount: 0,
+    localSkillCount: 0,
+    ...rest,
+  }
+}
+
+/**
+ * Build a minimal global-skill fixture for Add modal tests.
+ * @param overrides - Partial skill overrides.
+ * @returns Complete Skill object.
+ * @example
+ * makeSkill({ name: 'task' as SkillName })
+ */
+function makeSkill(overrides: Partial<Skill> = {}): Skill {
+  return {
+    name: 'task' as SkillName,
+    description: 'Task management skill',
+    path: '/home/user/.agents/skills/task',
+    symlinkCount: 0,
+    symlinks: [],
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  mockCreateSymlinks.mockReset()
+  mockCopyToAgents.mockReset()
+  mockGetAll.mockReset()
+  mockAgentsGetAll.mockReset()
+  mockSourceGetStats.mockReset()
+  toastSuccess.mockReset()
+  toastError.mockReset()
+  toastWarning.mockReset()
+
+  mockGetAll.mockResolvedValue([])
+  mockAgentsGetAll.mockResolvedValue([])
+  mockSourceGetStats.mockResolvedValue(null)
+
+  vi.stubGlobal('electron', {
+    skills: {
+      createSymlinks: mockCreateSymlinks,
+      copyToAgents: mockCopyToAgents,
+      getAll: mockGetAll,
+      onDeleteProgress: mockOnDeleteProgress,
+    },
+    agents: {
+      getAll: mockAgentsGetAll,
+    },
+    source: {
+      getStats: mockSourceGetStats,
+    },
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+/**
+ * Build a real reducer store so modal tests exercise actual thunk/reducer wiring.
+ * @returns Redux store with only the slices the modal and refresh thunks need.
+ */
+async function createStore() {
+  const { default: skillsReducer } =
+    await import('../../redux/slices/skillsSlice')
+  const { default: agentsReducer } =
+    await import('../../redux/slices/agentsSlice')
+  const { default: uiReducer } = await import('../../redux/slices/uiSlice')
+
+  return configureStore({
+    reducer: {
+      skills: skillsReducer,
+      agents: agentsReducer,
+      ui: uiReducer,
+    },
+  })
+}
+
+/**
+ * Render the Add modal and seed agent rows through the real fetch thunk.
+ * @param options.skill - Skill to open the modal with.
+ * @param options.agents - Agent rows returned by the mocked IPC bridge.
+ * @returns Render handle and Redux store.
+ */
+async function renderModal(options: { skill: Skill; agents: Agent[] }) {
+  const { skill, agents } = options
+  const store = await createStore()
+  const { AddSymlinkModal } = await import('./AddSymlinkModal')
+  const { fetchAgents } = await import('../../redux/slices/agentsSlice')
+  const { setSkillToAddSymlinks } =
+    await import('../../redux/slices/skillsSlice')
+
+  mockAgentsGetAll.mockResolvedValue(agents)
+
+  const screen = await render(
+    <Provider store={store}>
+      <AddSymlinkModal />
+    </Provider>,
+  )
+
+  await store.dispatch(fetchAgents())
+  store.dispatch(setSkillToAddSymlinks(skill))
+
+  await expect
+    .element(screen.getByRole('dialog', { name: /Add Symlink/i }))
+    .toBeInTheDocument()
+
+  return { screen, store }
+}
+
+describe('AddSymlinkModal actions', () => {
+  it('renders both Add Symlink and Copy Skill files actions', async () => {
+    const { screen } = await renderModal({
+      skill: makeSkill(),
+      agents: [makeAgent({ id: 'codex', name: 'Codex' })],
+    })
+
+    await expect
+      .element(screen.getByRole('button', { name: /^Add Symlink$/i }))
+      .toBeInTheDocument()
+    await expect
+      .element(screen.getByRole('button', { name: /Copy Skill files/i }))
+      .toBeInTheDocument()
+  })
+
+  it('dispatches createSymlinks with the existing skill path when Add Symlink is clicked', async () => {
+    mockCreateSymlinks.mockResolvedValue({
+      success: true,
+      created: 1,
+      failures: [],
+    })
+
+    const { screen } = await renderModal({
+      skill: makeSkill(),
+      agents: [makeAgent({ id: 'codex', name: 'Codex' })],
+    })
+
+    await screen.getByRole('checkbox', { name: /Codex/i }).click()
+    await screen.getByRole('button', { name: /^Add Symlink$/i }).click()
+
+    await expect.poll(() => mockCreateSymlinks.mock.calls.length).toBe(1)
+    expect(mockCreateSymlinks.mock.calls[0][0]).toEqual({
+      skillName: 'task',
+      skillPath: '/home/user/.agents/skills/task',
+      agentIds: ['codex'],
+    })
+  })
+
+  it('dispatches copyToAgents with sourcePath when Copy Skill files is clicked', async () => {
+    mockCopyToAgents.mockResolvedValue({
+      success: true,
+      copied: 1,
+      failures: [],
+    })
+
+    const { screen } = await renderModal({
+      skill: makeSkill(),
+      agents: [makeAgent({ id: 'codex', name: 'Codex' })],
+    })
+
+    await screen.getByRole('checkbox', { name: /Codex/i }).click()
+    await screen.getByRole('button', { name: /Copy Skill files/i }).click()
+
+    await expect.poll(() => mockCopyToAgents.mock.calls.length).toBe(1)
+    expect(mockCopyToAgents.mock.calls[0][0]).toEqual({
+      skillName: 'task',
+      sourcePath: '/home/user/.agents/skills/task',
+      targetAgentIds: ['codex'],
+    })
+  })
+})
+
+describe('AddSymlinkModal occupied-agent states', () => {
+  it('disables linked, local, and broken destinations with their reason labels', async () => {
+    const skill = makeSkill({
+      symlinks: [
+        {
+          agentId: 'claude-code',
+          agentName: 'Claude Code',
+          status: 'valid',
+          targetPath: '/home/user/.agents/skills/task',
+          linkPath: '/home/user/.claude/skills/task',
+          isLocal: false,
+        },
+        {
+          agentId: 'cursor',
+          agentName: 'Cursor',
+          status: 'valid',
+          targetPath: '',
+          linkPath: '/home/user/.cursor/skills/task',
+          isLocal: true,
+        },
+        {
+          agentId: 'warp',
+          agentName: 'Warp',
+          status: 'broken',
+          targetPath: '/home/user/.agents/skills/task',
+          linkPath: '/home/user/.warp/skills/task',
+          isLocal: false,
+        },
+      ],
+    })
+
+    const { screen } = await renderModal({
+      skill,
+      agents: [
+        makeAgent({ id: 'claude-code', name: 'Claude Code' }),
+        makeAgent({ id: 'cursor', name: 'Cursor' }),
+        makeAgent({ id: 'warp', name: 'Warp' }),
+        makeAgent({ id: 'codex', name: 'Codex' }),
+      ],
+    })
+
+    await expect
+      .element(screen.getByRole('checkbox', { name: /Claude Code/i }))
+      .toBeDisabled()
+    await expect
+      .element(screen.getByRole('checkbox', { name: /Cursor/i }))
+      .toBeDisabled()
+    await expect
+      .element(screen.getByRole('checkbox', { name: /Warp/i }))
+      .toBeDisabled()
+    await expect.element(screen.getByText(/linked/i)).toBeInTheDocument()
+    await expect.element(screen.getByText(/local/i)).toBeInTheDocument()
+    await expect
+      .element(screen.getByText(/already exists/i))
+      .toBeInTheDocument()
+    await expect
+      .element(screen.getByRole('checkbox', { name: /Codex/i }))
+      .toBeEnabled()
+  })
+})
+
+describe('AddSymlinkModal busy state', () => {
+  it('keeps the modal open and disables both actions while adding symlinks', async () => {
+    const skill = makeSkill()
+    const { screen, store } = await renderModal({
+      skill,
+      agents: [makeAgent({ id: 'codex', name: 'Codex' })],
+    })
+
+    const { createSymlinks } = await import('../../redux/slices/skillsSlice')
+    store.dispatch(
+      createSymlinks.pending('adding-request', {
+        skill,
+        agentIds: ['codex' as AgentId],
+      }),
+    )
+
+    await expect
+      .element(screen.getByRole('button', { name: /Adding/i }))
+      .toBeDisabled()
+    await expect
+      .element(screen.getByRole('button', { name: /Copy Skill files/i }))
+      .toBeDisabled()
+
+    await screen.getByRole('button', { name: /^Close$/i }).click()
+
+    expect(store.getState().skills.skillToAddSymlinks?.name).toBe('task')
+  })
+
+  it('keeps the modal open and disables both actions while copying files', async () => {
+    const skill = makeSkill()
+    const { screen, store } = await renderModal({
+      skill,
+      agents: [makeAgent({ id: 'codex', name: 'Codex' })],
+    })
+
+    const { copyToAgents } = await import('../../redux/slices/skillsSlice')
+    store.dispatch(
+      copyToAgents.pending('copying-request', {
+        skill,
+        sourcePath: skill.path,
+        agentIds: ['codex' as AgentId],
+      }),
+    )
+
+    await expect
+      .element(screen.getByRole('button', { name: /^Add Symlink$/i }))
+      .toBeDisabled()
+    await expect
+      .element(screen.getByRole('button', { name: /Copying/i }))
+      .toBeDisabled()
+
+    await screen.getByRole('button', { name: /^Close$/i }).click()
+
+    expect(store.getState().skills.skillToAddSymlinks?.name).toBe('task')
+  })
+})

--- a/src/renderer/src/components/skills/AddSymlinkModal.browser.test.tsx
+++ b/src/renderer/src/components/skills/AddSymlinkModal.browser.test.tsx
@@ -144,7 +144,7 @@ async function renderModal(options: { skill: Skill; agents: Agent[] }) {
   store.dispatch(setSkillToAddSymlinks(skill))
 
   await expect
-    .element(screen.getByRole('dialog', { name: /Add Symlink/i }))
+    .element(screen.getByRole('dialog', { name: /Add Skill to Agents/i }))
     .toBeInTheDocument()
 
   return { screen, store }
@@ -209,6 +209,54 @@ describe('AddSymlinkModal actions', () => {
       sourcePath: '/home/user/.agents/skills/task',
       targetAgentIds: ['codex'],
     })
+  })
+
+  it('shows a warning toast when copying succeeds only for some agents', async () => {
+    mockCopyToAgents.mockResolvedValue({
+      success: false,
+      copied: 1,
+      failures: [{ agentId: 'cursor', error: 'Already exists' }],
+    })
+
+    const { screen } = await renderModal({
+      skill: makeSkill(),
+      agents: [makeAgent({ id: 'codex', name: 'Codex' })],
+    })
+
+    await screen.getByRole('checkbox', { name: /Codex/i }).click()
+    await screen.getByRole('button', { name: /Copy Skill files/i }).click()
+
+    await expect.poll(() => toastWarning.mock.calls.length).toBe(1)
+    expect(toastSuccess).not.toHaveBeenCalled()
+  })
+
+  it('clears selected agents when the modal closes externally and reopens', async () => {
+    const firstSkill = makeSkill({ name: 'task' as SkillName })
+    const secondSkill = makeSkill({
+      name: 'review' as SkillName,
+      path: '/home/user/.agents/skills/review',
+    })
+    const { screen, store } = await renderModal({
+      skill: firstSkill,
+      agents: [makeAgent({ id: 'codex', name: 'Codex' })],
+    })
+    const { setSkillToAddSymlinks } =
+      await import('../../redux/slices/skillsSlice')
+
+    await screen.getByRole('checkbox', { name: /Codex/i }).click()
+    await expect
+      .element(screen.getByRole('checkbox', { name: /Codex/i }))
+      .toBeChecked()
+
+    store.dispatch(setSkillToAddSymlinks(null))
+    store.dispatch(setSkillToAddSymlinks(secondSkill))
+
+    await expect
+      .element(screen.getByRole('dialog', { name: /Add Skill to Agents/i }))
+      .toBeInTheDocument()
+    await expect
+      .element(screen.getByRole('checkbox', { name: /Codex/i }))
+      .not.toBeChecked()
   })
 })
 

--- a/src/renderer/src/components/skills/AddSymlinkModal.browser.test.tsx
+++ b/src/renderer/src/components/skills/AddSymlinkModal.browser.test.tsx
@@ -310,9 +310,15 @@ describe('AddSymlinkModal occupied-agent states', () => {
     await expect
       .element(screen.getByRole('checkbox', { name: /Warp/i }))
       .toBeDisabled()
-    await expect.element(screen.getByText(/linked/i)).toBeInTheDocument()
-    await expect.element(screen.getByText(/local/i)).toBeInTheDocument()
-    await expect.element(screen.getByText(/broken link/i)).toBeInTheDocument()
+    await expect
+      .element(screen.getByText('linked', { exact: true }))
+      .toBeInTheDocument()
+    await expect
+      .element(screen.getByText('local', { exact: true }))
+      .toBeInTheDocument()
+    await expect
+      .element(screen.getByText('broken link', { exact: true }))
+      .toBeInTheDocument()
     await expect
       .element(screen.getByRole('checkbox', { name: /Codex/i }))
       .toBeEnabled()
@@ -344,6 +350,9 @@ describe('AddSymlinkModal busy state', () => {
 
     await screen.getByRole('button', { name: /^Close$/i }).click()
 
+    await expect
+      .element(screen.getByRole('dialog', { name: /Add Skill to Agents/i }))
+      .toBeInTheDocument()
     expect(store.getState().skills.skillToAddSymlinks?.name).toBe('task')
   })
 
@@ -372,6 +381,9 @@ describe('AddSymlinkModal busy state', () => {
 
     await screen.getByRole('button', { name: /^Close$/i }).click()
 
+    await expect
+      .element(screen.getByRole('dialog', { name: /Add Skill to Agents/i }))
+      .toBeInTheDocument()
     expect(store.getState().skills.skillToAddSymlinks?.name).toBe('task')
   })
 })

--- a/src/renderer/src/components/skills/AddSymlinkModal.browser.test.tsx
+++ b/src/renderer/src/components/skills/AddSymlinkModal.browser.test.tsx
@@ -264,9 +264,7 @@ describe('AddSymlinkModal occupied-agent states', () => {
       .toBeDisabled()
     await expect.element(screen.getByText(/linked/i)).toBeInTheDocument()
     await expect.element(screen.getByText(/local/i)).toBeInTheDocument()
-    await expect
-      .element(screen.getByText(/already exists/i))
-      .toBeInTheDocument()
+    await expect.element(screen.getByText(/broken link/i)).toBeInTheDocument()
     await expect
       .element(screen.getByRole('checkbox', { name: /Codex/i }))
       .toBeEnabled()

--- a/src/renderer/src/components/skills/AddSymlinkModal.tsx
+++ b/src/renderer/src/components/skills/AddSymlinkModal.tsx
@@ -1,4 +1,4 @@
-import { Loader2, Plus } from 'lucide-react'
+import { Copy, Loader2, Plus } from 'lucide-react'
 import React, { useMemo, useState } from 'react'
 import { toast } from 'sonner'
 
@@ -6,6 +6,7 @@ import type { AgentId } from '../../../../shared/types'
 import { cn } from '../../lib/utils'
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
 import {
+  copyToAgents,
   createSymlinks,
   setSkillToAddSymlinks,
 } from '../../redux/slices/skillsSlice'
@@ -21,16 +22,21 @@ import {
   DialogTitle,
 } from '../ui/dialog'
 
-import { getTargetAgentsForSelection } from './agentSelectionHelpers'
+import {
+  getOccupiedAgentReasonById,
+  getOccupiedAgentReasonLabel,
+  getTargetAgentsForSelection,
+} from './agentSelectionHelpers'
+import type { OccupiedAgentReason } from './agentSelectionHelpers'
 
 /**
- * Modal for selecting agents to add skill symlinks to
- * Shows agent checkboxes with already-linked agents disabled
+ * Modal for selecting agents to add a skill to from global view.
+ * Offers both symlink creation and physical file-copy actions.
  */
 export const AddSymlinkModal = React.memo(
   function AddSymlinkModal(): React.ReactElement {
     const dispatch = useAppDispatch()
-    const { skillToAddSymlinks, addingSymlinks } = useAppSelector(
+    const { skillToAddSymlinks, addingSymlinks, copying } = useAppSelector(
       (state) => state.skills,
     )
     const { items: agents } = useAppSelector((state) => state.agents)
@@ -42,24 +48,22 @@ export const AddSymlinkModal = React.memo(
       [agents],
     )
 
-    const alreadyLinkedAgentIds = useMemo(() => {
-      if (!skillToAddSymlinks) return new Set<AgentId>()
-      return new Set(
-        skillToAddSymlinks.symlinks
-          .filter((s) => s.status === 'valid')
-          .map((s) => s.agentId),
-      )
+    const occupiedAgentReasonById = useMemo(() => {
+      if (!skillToAddSymlinks) return new Map<AgentId, OccupiedAgentReason>()
+      return getOccupiedAgentReasonById(skillToAddSymlinks.symlinks)
     }, [skillToAddSymlinks])
 
+    const isSubmitting = addingSymlinks || copying
+
     const handleClose = (): void => {
-      if (!addingSymlinks) {
+      if (!isSubmitting) {
         dispatch(setSkillToAddSymlinks(null))
         setSelectedAgents([])
       }
     }
 
     const handleAgentToggle = (agentId: AgentId): void => {
-      if (alreadyLinkedAgentIds.has(agentId)) return
+      if (occupiedAgentReasonById.has(agentId)) return
       setSelectedAgents((prev) =>
         prev.includes(agentId)
           ? prev.filter((id) => id !== agentId)
@@ -89,6 +93,29 @@ export const AddSymlinkModal = React.memo(
       refreshAllData(dispatch)
     }
 
+    const handleCopySkillFiles = async (): Promise<void> => {
+      if (!skillToAddSymlinks || selectedAgents.length === 0) return
+
+      const result = await dispatch(
+        copyToAgents({
+          skill: skillToAddSymlinks,
+          sourcePath: skillToAddSymlinks.path,
+          agentIds: selectedAgents,
+        }),
+      )
+
+      if (copyToAgents.fulfilled.match(result)) {
+        toast.success(`Copied to ${result.payload.copied} agent(s)`, {
+          description: `${skillToAddSymlinks.name} copied successfully`,
+        })
+      } else {
+        toast.error('Failed to copy skill', {
+          description: result.error?.message || 'An unexpected error occurred',
+        })
+      }
+      refreshAllData(dispatch)
+    }
+
     const hasNewSelections = selectedAgents.length > 0
 
     return (
@@ -100,8 +127,8 @@ export const AddSymlinkModal = React.memo(
               <DialogTitle>Add Symlink</DialogTitle>
             </div>
             <DialogDescription>
-              Select agents to link <strong>{skillToAddSymlinks?.name}</strong>{' '}
-              to
+              Select agents to link or copy{' '}
+              <strong>{skillToAddSymlinks?.name}</strong> to
             </DialogDescription>
           </DialogHeader>
 
@@ -109,44 +136,53 @@ export const AddSymlinkModal = React.memo(
             <h4 className="text-sm font-medium mb-3">Select Agents</h4>
             <div className="max-h-[240px] overflow-y-auto rounded-md border p-2 space-y-1">
               {targetAgents.map((agent) => {
-                const isAlreadyLinked = alreadyLinkedAgentIds.has(agent.id)
+                const occupiedReason = occupiedAgentReasonById.get(agent.id)
+                const isOccupied = occupiedReason !== undefined
+                const checkboxId = `add-agent-${agent.id}`
                 return (
-                  <label
+                  <div
                     key={agent.id}
                     className={cn(
                       'flex items-center gap-3 p-2 rounded-md',
-                      isAlreadyLinked
+                      isOccupied
                         ? 'opacity-50 cursor-not-allowed'
                         : 'hover:bg-muted cursor-pointer',
                     )}
                   >
                     <Checkbox
-                      checked={
-                        isAlreadyLinked || selectedAgents.includes(agent.id)
-                      }
+                      id={checkboxId}
+                      checked={isOccupied || selectedAgents.includes(agent.id)}
                       onCheckedChange={() => handleAgentToggle(agent.id)}
-                      disabled={addingSymlinks || isAlreadyLinked}
+                      disabled={isSubmitting || isOccupied}
                     />
-                    <span className="text-sm">
+                    <label
+                      htmlFor={checkboxId}
+                      className={cn(
+                        'text-sm',
+                        isOccupied || isSubmitting
+                          ? 'cursor-not-allowed'
+                          : 'cursor-pointer',
+                      )}
+                    >
                       {agent.name}
                       {!agent.exists && (
                         <span className="text-xs text-muted-foreground ml-2">
                           not installed
                         </span>
                       )}
-                      {isAlreadyLinked && (
+                      {isOccupied && (
                         <span className="text-xs text-muted-foreground ml-2">
-                          (linked)
+                          {getOccupiedAgentReasonLabel(occupiedReason!)}
                         </span>
                       )}
-                    </span>
-                  </label>
+                    </label>
+                  </div>
                 )
               })}
             </div>
             {!hasNewSelections && (
               <p className="text-sm text-muted-foreground mt-2">
-                Select at least one new agent
+                Select at least one available agent
               </p>
             )}
           </div>
@@ -155,13 +191,30 @@ export const AddSymlinkModal = React.memo(
             <Button
               variant="outline"
               onClick={handleClose}
-              disabled={addingSymlinks}
+              disabled={isSubmitting}
             >
               Cancel
             </Button>
             <Button
+              variant="outline"
+              onClick={handleCopySkillFiles}
+              disabled={isSubmitting || !hasNewSelections}
+            >
+              {copying ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                  Copying...
+                </>
+              ) : (
+                <>
+                  <Copy className="h-4 w-4 mr-2" />
+                  Copy Skill files
+                </>
+              )}
+            </Button>
+            <Button
               onClick={handleAddSymlinks}
-              disabled={addingSymlinks || !hasNewSelections}
+              disabled={isSubmitting || !hasNewSelections}
             >
               {addingSymlinks ? (
                 <>

--- a/src/renderer/src/components/skills/AddSymlinkModal.tsx
+++ b/src/renderer/src/components/skills/AddSymlinkModal.tsx
@@ -1,5 +1,5 @@
 import { Copy, Loader2, Plus } from 'lucide-react'
-import React, { useMemo, useState } from 'react'
+import React, { useMemo } from 'react'
 import { toast } from 'sonner'
 
 import type { AgentId } from '../../../../shared/types'
@@ -9,6 +9,7 @@ import {
   copyToAgents,
   createSymlinks,
   setSkillToAddSymlinks,
+  toggleAddAgentSelection,
 } from '../../redux/slices/skillsSlice'
 import { refreshAllData } from '../../redux/thunks'
 import { Button } from '../ui/button'
@@ -36,12 +37,9 @@ import type { OccupiedAgentReason } from './agentSelectionHelpers'
 export const AddSymlinkModal = React.memo(
   function AddSymlinkModal(): React.ReactElement {
     const dispatch = useAppDispatch()
-    const { skillToAddSymlinks, addingSymlinks, copying } = useAppSelector(
-      (state) => state.skills,
-    )
+    const { skillToAddSymlinks, selectedAddAgentIds, addingSymlinks, copying } =
+      useAppSelector((state) => state.skills)
     const { items: agents } = useAppSelector((state) => state.agents)
-
-    const [selectedAgents, setSelectedAgents] = useState<AgentId[]>([])
 
     const targetAgents = useMemo(
       () => getTargetAgentsForSelection(agents),
@@ -58,24 +56,22 @@ export const AddSymlinkModal = React.memo(
     const handleClose = (): void => {
       if (!isSubmitting) {
         dispatch(setSkillToAddSymlinks(null))
-        setSelectedAgents([])
       }
     }
 
     const handleAgentToggle = (agentId: AgentId): void => {
       if (occupiedAgentReasonById.has(agentId)) return
-      setSelectedAgents((prev) =>
-        prev.includes(agentId)
-          ? prev.filter((id) => id !== agentId)
-          : [...prev, agentId],
-      )
+      dispatch(toggleAddAgentSelection(agentId))
     }
 
     const handleAddSymlinks = async (): Promise<void> => {
-      if (!skillToAddSymlinks || selectedAgents.length === 0) return
+      if (!skillToAddSymlinks || selectedAddAgentIds.length === 0) return
 
       const result = await dispatch(
-        createSymlinks({ skill: skillToAddSymlinks, agentIds: selectedAgents }),
+        createSymlinks({
+          skill: skillToAddSymlinks,
+          agentIds: selectedAddAgentIds,
+        }),
       )
 
       if (createSymlinks.fulfilled.match(result)) {
@@ -94,20 +90,31 @@ export const AddSymlinkModal = React.memo(
     }
 
     const handleCopySkillFiles = async (): Promise<void> => {
-      if (!skillToAddSymlinks || selectedAgents.length === 0) return
+      if (!skillToAddSymlinks || selectedAddAgentIds.length === 0) return
 
       const result = await dispatch(
         copyToAgents({
           skill: skillToAddSymlinks,
           sourcePath: skillToAddSymlinks.path,
-          agentIds: selectedAgents,
+          agentIds: selectedAddAgentIds,
         }),
       )
 
       if (copyToAgents.fulfilled.match(result)) {
-        toast.success(`Copied to ${result.payload.copied} agent(s)`, {
-          description: `${skillToAddSymlinks.name} copied successfully`,
-        })
+        if (result.payload.failures.length > 0) {
+          toast.warning(
+            `Copied to ${result.payload.copied} agent(s), ${result.payload.failures.length} failed`,
+            {
+              description: result.payload.failures
+                .map((failure) => `${failure.agentId}: ${failure.error}`)
+                .join(', '),
+            },
+          )
+        } else {
+          toast.success(`Copied to ${result.payload.copied} agent(s)`, {
+            description: `${skillToAddSymlinks.name} copied successfully`,
+          })
+        }
       } else {
         toast.error('Failed to copy skill', {
           description: result.error?.message || 'An unexpected error occurred',
@@ -116,15 +123,18 @@ export const AddSymlinkModal = React.memo(
       refreshAllData(dispatch)
     }
 
-    const hasNewSelections = selectedAgents.length > 0
+    const hasNewSelections = selectedAddAgentIds.length > 0
 
     return (
-      <Dialog open={!!skillToAddSymlinks} onOpenChange={handleClose}>
+      <Dialog
+        open={!!skillToAddSymlinks}
+        onOpenChange={(open) => !open && handleClose()}
+      >
         <DialogContent className="max-w-md">
           <DialogHeader>
             <div className="flex items-center gap-2">
               <Plus className="h-5 w-5 text-primary" />
-              <DialogTitle>Add Symlink</DialogTitle>
+              <DialogTitle>Add Skill to Agents</DialogTitle>
             </div>
             <DialogDescription>
               Select agents to link or copy{' '}
@@ -148,15 +158,23 @@ export const AddSymlinkModal = React.memo(
                         ? 'opacity-50 cursor-not-allowed'
                         : 'hover:bg-muted cursor-pointer',
                     )}
+                    onClick={() =>
+                      !isOccupied &&
+                      !isSubmitting &&
+                      handleAgentToggle(agent.id)
+                    }
                   >
                     <Checkbox
                       id={checkboxId}
-                      checked={isOccupied || selectedAgents.includes(agent.id)}
+                      aria-label={agent.name}
+                      checked={
+                        isOccupied || selectedAddAgentIds.includes(agent.id)
+                      }
+                      onClick={(event) => event.stopPropagation()}
                       onCheckedChange={() => handleAgentToggle(agent.id)}
                       disabled={isSubmitting || isOccupied}
                     />
-                    <label
-                      htmlFor={checkboxId}
+                    <div
                       className={cn(
                         'text-sm',
                         isOccupied || isSubmitting
@@ -170,12 +188,12 @@ export const AddSymlinkModal = React.memo(
                           not installed
                         </span>
                       )}
-                      {isOccupied && (
+                      {isOccupied && occupiedReason && (
                         <span className="text-xs text-muted-foreground ml-2">
-                          {getOccupiedAgentReasonLabel(occupiedReason!)}
+                          {getOccupiedAgentReasonLabel(occupiedReason)}
                         </span>
                       )}
-                    </label>
+                    </div>
                   </div>
                 )
               })}

--- a/src/renderer/src/components/skills/CopyToAgentsModal.browser.test.tsx
+++ b/src/renderer/src/components/skills/CopyToAgentsModal.browser.test.tsx
@@ -1,0 +1,173 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import type {
+  Agent,
+  Skill,
+  SkillName,
+  SymlinkInfo,
+} from '../../../../shared/types'
+
+const mockCopyToAgents = vi.fn()
+const mockGetAll = vi.fn()
+const mockAgentsGetAll = vi.fn()
+const mockOnDeleteProgress = vi.fn(() => () => {})
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+  },
+}))
+
+/**
+ * Build a minimal agent fixture for Copy modal tests.
+ * @param overrides - Partial agent overrides.
+ * @returns Complete Agent object.
+ * @example
+ * makeAgent({ id: 'cursor', name: 'Cursor' })
+ */
+function makeAgent(
+  overrides: Partial<Agent> & Pick<Agent, 'id' | 'name'>,
+): Agent {
+  const { id, name, ...rest } = overrides
+  return {
+    id,
+    name,
+    path: `/home/user/.${id}/skills`,
+    exists: true,
+    skillCount: 0,
+    localSkillCount: 0,
+    ...rest,
+  }
+}
+
+/**
+ * Build a minimal skill fixture for Copy modal tests.
+ * @param symlinks - Source/target entries attached to the skill.
+ * @returns Complete Skill object.
+ * @example
+ * makeSkill([])
+ */
+function makeSkill(symlinks: SymlinkInfo[]): Skill {
+  return {
+    name: 'task' as SkillName,
+    description: 'Task management skill',
+    path: '/home/user/.agents/skills/task',
+    symlinkCount: symlinks.length,
+    symlinks,
+  }
+}
+
+beforeEach(() => {
+  mockCopyToAgents.mockReset()
+  mockGetAll.mockReset()
+  mockAgentsGetAll.mockReset()
+
+  mockGetAll.mockResolvedValue([])
+  mockAgentsGetAll.mockResolvedValue([])
+
+  vi.stubGlobal('electron', {
+    skills: {
+      copyToAgents: mockCopyToAgents,
+      getAll: mockGetAll,
+      onDeleteProgress: mockOnDeleteProgress,
+    },
+    agents: {
+      getAll: mockAgentsGetAll,
+    },
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+/**
+ * Render the Copy modal with a real reducer store.
+ * @param options.skill - Skill opened in the modal.
+ * @param options.agents - Agent rows returned by the mocked IPC bridge.
+ * @param options.selectedAgentId - Current Agent View source agent.
+ * @returns Render handle and Redux store.
+ */
+async function renderModal(options: {
+  skill: Skill
+  agents: Agent[]
+  selectedAgentId: Agent['id']
+}) {
+  const { skill, agents, selectedAgentId } = options
+  const { default: skillsReducer } =
+    await import('../../redux/slices/skillsSlice')
+  const { default: agentsReducer } =
+    await import('../../redux/slices/agentsSlice')
+  const { default: uiReducer } = await import('../../redux/slices/uiSlice')
+  const { CopyToAgentsModal } = await import('./CopyToAgentsModal')
+  const { fetchAgents } = await import('../../redux/slices/agentsSlice')
+  const { setSkillToCopy } = await import('../../redux/slices/skillsSlice')
+  const { selectAgent } = await import('../../redux/slices/uiSlice')
+
+  const store = configureStore({
+    reducer: {
+      skills: skillsReducer,
+      agents: agentsReducer,
+      ui: uiReducer,
+    },
+  })
+
+  mockAgentsGetAll.mockResolvedValue(agents)
+
+  const screen = await render(
+    <Provider store={store}>
+      <CopyToAgentsModal />
+    </Provider>,
+  )
+
+  await store.dispatch(fetchAgents())
+  store.dispatch(selectAgent(selectedAgentId))
+  store.dispatch(setSkillToCopy(skill))
+
+  await expect
+    .element(screen.getByRole('dialog', { name: /Copy to Agents/i }))
+    .toBeInTheDocument()
+
+  return { screen, store }
+}
+
+describe('CopyToAgentsModal source guards', () => {
+  it('disables copy actions when the selected source is a broken symlink', async () => {
+    const skill = makeSkill([
+      {
+        agentId: 'claude-code',
+        agentName: 'Claude Code',
+        status: 'broken',
+        targetPath: '/home/user/.agents/skills/task',
+        linkPath: '/home/user/.claude/skills/task',
+        isLocal: false,
+      },
+    ])
+
+    const { screen } = await renderModal({
+      skill,
+      agents: [
+        makeAgent({ id: 'claude-code', name: 'Claude Code' }),
+        makeAgent({ id: 'cursor', name: 'Cursor' }),
+      ],
+      selectedAgentId: 'claude-code',
+    })
+
+    await expect
+      .element(screen.getByText(/selected source is unavailable/i))
+      .toBeInTheDocument()
+    await expect
+      .element(screen.getByRole('checkbox', { name: /Cursor/i }))
+      .toBeDisabled()
+    await expect
+      .element(screen.getByRole('button', { name: /Copy to 0 agent\(s\)/i }))
+      .toBeDisabled()
+
+    expect(mockCopyToAgents).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/skills/CopyToAgentsModal.tsx
+++ b/src/renderer/src/components/skills/CopyToAgentsModal.tsx
@@ -63,8 +63,11 @@ export const CopyToAgentsModal = React.memo(
       const symlink = skillToCopy.symlinks.find(
         (s) => s.agentId === selectedAgentId,
       )
-      return symlink?.linkPath ?? null
+      if (!symlink) return null
+      if (!symlink.isLocal && symlink.status !== 'valid') return null
+      return symlink.linkPath
     }, [skillToCopy, selectedAgentId])
+    const isSourceUnavailable = sourcePath === null
 
     const handleClose = (): void => {
       if (!copying) {
@@ -146,24 +149,28 @@ export const CopyToAgentsModal = React.memo(
                 <div
                   key={agent.id}
                   className={`flex items-center gap-3 p-2 rounded-md transition-colors ${
-                    alreadyExists
+                    alreadyExists || isSourceUnavailable
                       ? 'opacity-50 cursor-not-allowed'
                       : 'hover:bg-accent cursor-pointer'
                   }`}
                   onClick={() =>
-                    !alreadyExists && !copying && handleAgentToggle(agent.id)
+                    !alreadyExists &&
+                    !copying &&
+                    !isSourceUnavailable &&
+                    handleAgentToggle(agent.id)
                   }
                 >
                   <Checkbox
                     id={checkboxId}
+                    aria-label={agent.name}
                     checked={alreadyExists || selectedAgents.includes(agent.id)}
-                    disabled={alreadyExists || copying}
+                    disabled={alreadyExists || copying || isSourceUnavailable}
+                    onClick={(event) => event.stopPropagation()}
                     onCheckedChange={() => handleAgentToggle(agent.id)}
                   />
-                  <label
-                    htmlFor={checkboxId}
+                  <div
                     className={
-                      alreadyExists || copying
+                      alreadyExists || copying || isSourceUnavailable
                         ? 'text-sm cursor-not-allowed'
                         : 'text-sm cursor-pointer'
                     }
@@ -174,16 +181,22 @@ export const CopyToAgentsModal = React.memo(
                         not installed
                       </span>
                     )}
-                    {alreadyExists && (
+                    {alreadyExists && occupiedReason && (
                       <span className="text-xs text-muted-foreground ml-2">
-                        {getOccupiedAgentReasonLabel(occupiedReason!)}
+                        {getOccupiedAgentReasonLabel(occupiedReason)}
                       </span>
                     )}
-                  </label>
+                  </div>
                 </div>
               )
             })}
           </div>
+          {isSourceUnavailable && (
+            <p className="text-sm text-muted-foreground">
+              The selected source is unavailable. Choose a valid or local skill
+              before copying.
+            </p>
+          )}
 
           <DialogFooter>
             <Button variant="outline" onClick={handleClose} disabled={copying}>
@@ -191,7 +204,7 @@ export const CopyToAgentsModal = React.memo(
             </Button>
             <Button
               onClick={handleCopy}
-              disabled={!hasNewSelections || copying}
+              disabled={!hasNewSelections || copying || isSourceUnavailable}
             >
               {copying && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
               {copying

--- a/src/renderer/src/components/skills/CopyToAgentsModal.tsx
+++ b/src/renderer/src/components/skills/CopyToAgentsModal.tsx
@@ -17,10 +17,15 @@ import {
   DialogTitle,
 } from '../ui/dialog'
 
-import { getTargetAgentsForSelection } from './agentSelectionHelpers'
+import {
+  getOccupiedAgentReasonById,
+  getOccupiedAgentReasonLabel,
+  getTargetAgentsForSelection,
+} from './agentSelectionHelpers'
+import type { OccupiedAgentReason } from './agentSelectionHelpers'
 
 /**
- * Modal for selecting target agents when copying a skill from one agent to others.
+ * Modal for selecting target agents when copying a skill source from one agent to others.
  * Triggered by right-click "Copy to..." on a skill card in Agent View.
  * @example
  * <CopyToAgentsModal />
@@ -46,18 +51,14 @@ export const CopyToAgentsModal = React.memo(
       })
     }, [agents, selectedAgentId])
 
-    /** Agent IDs where this skill already exists (valid symlink or local) */
-    const alreadyExistsAgentIds = useMemo(() => {
-      if (!skillToCopy) return new Set<AgentId>()
-      return new Set(
-        skillToCopy.symlinks
-          .filter((s) => s.status === 'valid' || s.isLocal)
-          .map((s) => s.agentId),
-      )
+    /** Agent IDs where this skill already occupies the destination path. */
+    const occupiedAgentReasonById = useMemo(() => {
+      if (!skillToCopy) return new Map<AgentId, OccupiedAgentReason>()
+      return getOccupiedAgentReasonById(skillToCopy.symlinks)
     }, [skillToCopy])
 
-    /** The linkPath of the skill in the source agent */
-    const sourceLinkPath = useMemo(() => {
+    /** The on-disk source entry for the selected agent's copy operation. */
+    const sourcePath = useMemo(() => {
       if (!skillToCopy || !selectedAgentId) return null
       const symlink = skillToCopy.symlinks.find(
         (s) => s.agentId === selectedAgentId,
@@ -73,7 +74,7 @@ export const CopyToAgentsModal = React.memo(
     }
 
     const handleAgentToggle = (agentId: AgentId): void => {
-      if (alreadyExistsAgentIds.has(agentId)) return
+      if (occupiedAgentReasonById.has(agentId)) return
       setSelectedAgents((prev) =>
         prev.includes(agentId)
           ? prev.filter((id) => id !== agentId)
@@ -82,12 +83,12 @@ export const CopyToAgentsModal = React.memo(
     }
 
     const handleCopy = async (): Promise<void> => {
-      if (!skillToCopy || !sourceLinkPath || selectedAgents.length === 0) return
+      if (!skillToCopy || !sourcePath || selectedAgents.length === 0) return
 
       const result = await dispatch(
         copyToAgents({
           skill: skillToCopy,
-          linkPath: sourceLinkPath,
+          sourcePath,
           agentIds: selectedAgents,
         }),
       )
@@ -138,7 +139,8 @@ export const CopyToAgentsModal = React.memo(
 
           <div className="max-h-64 overflow-y-auto space-y-2 py-2">
             {targetAgents.map((agent) => {
-              const alreadyExists = alreadyExistsAgentIds.has(agent.id)
+              const occupiedReason = occupiedAgentReasonById.get(agent.id)
+              const alreadyExists = occupiedReason !== undefined
               const checkboxId = `copy-agent-${agent.id}`
               return (
                 <div
@@ -160,7 +162,11 @@ export const CopyToAgentsModal = React.memo(
                   />
                   <label
                     htmlFor={checkboxId}
-                    className="text-sm cursor-pointer"
+                    className={
+                      alreadyExists || copying
+                        ? 'text-sm cursor-not-allowed'
+                        : 'text-sm cursor-pointer'
+                    }
                   >
                     {agent.name}
                     {!agent.exists && (
@@ -170,7 +176,7 @@ export const CopyToAgentsModal = React.memo(
                     )}
                     {alreadyExists && (
                       <span className="text-xs text-muted-foreground ml-2">
-                        already exists
+                        {getOccupiedAgentReasonLabel(occupiedReason!)}
                       </span>
                     )}
                   </label>

--- a/src/renderer/src/components/skills/agentSelectionHelpers.ts
+++ b/src/renderer/src/components/skills/agentSelectionHelpers.ts
@@ -1,4 +1,18 @@
-import type { Agent, AgentId } from '../../../../shared/types'
+import type { Agent, AgentId, SymlinkInfo } from '../../../../shared/types'
+
+/**
+ * Why an agent row is unavailable as a destination in Add/Copy flows.
+ * - `linked`: a valid symlink already exists
+ * - `local`: a real directory already exists in the agent's skills dir
+ * - `already-exists`: some other occupied entry exists (for example a broken symlink)
+ */
+export type OccupiedAgentReason = 'linked' | 'local' | 'already-exists'
+
+const OCCUPIED_AGENT_REASON_LABELS: Record<OccupiedAgentReason, string> = {
+  linked: 'linked',
+  local: 'local',
+  'already-exists': 'already exists',
+}
 
 /**
  * Returns target-agent candidates for Add/Copy modals.
@@ -36,4 +50,78 @@ export function getTargetAgentsForSelection(
   const notInstalledAgents = filteredAgents.filter((agent) => !agent.exists)
 
   return [...installedAgents, ...notInstalledAgents]
+}
+
+/**
+ * Collapse per-agent skill state into one occupancy reason map for selection UIs.
+ * Any existing destination entry should block Add/Copy because the main-process
+ * filesystem operations would otherwise fail with `EEXIST`.
+ *
+ * @param symlinks - Per-agent skill state from the scanned Skill model.
+ * @returns AgentId -> occupied reason for every blocked destination.
+ * @example
+ * getOccupiedAgentReasonById([
+ *   { agentId: 'cursor', status: 'valid', isLocal: false } as SymlinkInfo,
+ *   { agentId: 'codex', status: 'broken', isLocal: false } as SymlinkInfo,
+ * ])
+ * // => Map { 'cursor' => 'linked', 'codex' => 'already-exists' }
+ */
+export function getOccupiedAgentReasonById(
+  symlinks: SymlinkInfo[],
+): Map<AgentId, OccupiedAgentReason> {
+  const occupiedAgentReasonById = new Map<AgentId, OccupiedAgentReason>()
+
+  for (const symlink of symlinks) {
+    const occupiedReason = getOccupiedAgentReason(symlink)
+    if (occupiedReason) {
+      occupiedAgentReasonById.set(symlink.agentId, occupiedReason)
+    }
+  }
+
+  return occupiedAgentReasonById
+}
+
+/**
+ * Convert an occupied-agent reason into the UI label shown beside the agent name.
+ * @param occupiedReason - Reason the destination is unavailable.
+ * @returns Human-readable status text for the modal row.
+ * @example
+ * getOccupiedAgentReasonLabel('linked') // => "linked"
+ * @example
+ * getOccupiedAgentReasonLabel('already-exists') // => "already exists"
+ */
+export function getOccupiedAgentReasonLabel(
+  occupiedReason: OccupiedAgentReason,
+): string {
+  return OCCUPIED_AGENT_REASON_LABELS[occupiedReason]
+}
+
+/**
+ * Determine whether a single symlink row means the destination path is occupied.
+ * @param symlink - One agent's relationship to the current skill.
+ * @returns
+ * - `linked`: valid symlink already present
+ * - `local`: local skill directory already present
+ * - `already-exists`: broken symlink still occupies the destination path
+ * - `null`: destination is free (`missing`)
+ * @example
+ * getOccupiedAgentReason({ status: 'broken', isLocal: false } as SymlinkInfo)
+ * // => "already-exists"
+ */
+function getOccupiedAgentReason(
+  symlink: SymlinkInfo,
+): OccupiedAgentReason | null {
+  if (symlink.isLocal) {
+    return 'local'
+  }
+
+  if (symlink.status === 'valid') {
+    return 'linked'
+  }
+
+  if (symlink.status === 'broken') {
+    return 'already-exists'
+  }
+
+  return null
 }

--- a/src/renderer/src/components/skills/agentSelectionHelpers.ts
+++ b/src/renderer/src/components/skills/agentSelectionHelpers.ts
@@ -4,13 +4,19 @@ import type { Agent, AgentId, SymlinkInfo } from '../../../../shared/types'
  * Why an agent row is unavailable as a destination in Add/Copy flows.
  * - `linked`: a valid symlink already exists
  * - `local`: a real directory already exists in the agent's skills dir
- * - `already-exists`: some other occupied entry exists (for example a broken symlink)
+ * - `broken`: a broken symlink occupies the destination path
+ * - `already-exists`: some other occupied entry exists
  */
-export type OccupiedAgentReason = 'linked' | 'local' | 'already-exists'
+export type OccupiedAgentReason =
+  | 'linked'
+  | 'local'
+  | 'broken'
+  | 'already-exists'
 
 const OCCUPIED_AGENT_REASON_LABELS: Record<OccupiedAgentReason, string> = {
   linked: 'linked',
   local: 'local',
+  broken: 'broken link',
   'already-exists': 'already exists',
 }
 
@@ -64,7 +70,7 @@ export function getTargetAgentsForSelection(
  *   { agentId: 'cursor', status: 'valid', isLocal: false } as SymlinkInfo,
  *   { agentId: 'codex', status: 'broken', isLocal: false } as SymlinkInfo,
  * ])
- * // => Map { 'cursor' => 'linked', 'codex' => 'already-exists' }
+ * // => Map { 'cursor' => 'linked', 'codex' => 'broken' }
  */
 export function getOccupiedAgentReasonById(
   symlinks: SymlinkInfo[],
@@ -102,11 +108,11 @@ export function getOccupiedAgentReasonLabel(
  * @returns
  * - `linked`: valid symlink already present
  * - `local`: local skill directory already present
- * - `already-exists`: broken symlink still occupies the destination path
+ * - `broken`: broken symlink still occupies the destination path
  * - `null`: destination is free (`missing`)
  * @example
  * getOccupiedAgentReason({ status: 'broken', isLocal: false } as SymlinkInfo)
- * // => "already-exists"
+ * // => "broken"
  */
 function getOccupiedAgentReason(
   symlink: SymlinkInfo,
@@ -120,7 +126,7 @@ function getOccupiedAgentReason(
   }
 
   if (symlink.status === 'broken') {
-    return 'already-exists'
+    return 'broken'
   }
 
   return null

--- a/src/renderer/src/components/skills/agentSelectionHelpers.ts
+++ b/src/renderer/src/components/skills/agentSelectionHelpers.ts
@@ -5,19 +5,13 @@ import type { Agent, AgentId, SymlinkInfo } from '../../../../shared/types'
  * - `linked`: a valid symlink already exists
  * - `local`: a real directory already exists in the agent's skills dir
  * - `broken`: a broken symlink occupies the destination path
- * - `already-exists`: some other occupied entry exists
  */
-export type OccupiedAgentReason =
-  | 'linked'
-  | 'local'
-  | 'broken'
-  | 'already-exists'
+export type OccupiedAgentReason = 'linked' | 'local' | 'broken'
 
 const OCCUPIED_AGENT_REASON_LABELS: Record<OccupiedAgentReason, string> = {
   linked: 'linked',
   local: 'local',
   broken: 'broken link',
-  'already-exists': 'already exists',
 }
 
 /**
@@ -93,8 +87,6 @@ export function getOccupiedAgentReasonById(
  * @returns Human-readable status text for the modal row.
  * @example
  * getOccupiedAgentReasonLabel('linked') // => "linked"
- * @example
- * getOccupiedAgentReasonLabel('already-exists') // => "already exists"
  */
 export function getOccupiedAgentReasonLabel(
   occupiedReason: OccupiedAgentReason,

--- a/src/renderer/src/redux/slices/skillsSlice.test.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.test.ts
@@ -294,7 +294,7 @@ describe('skillsSlice', () => {
   })
 
   // --- copyToAgents thunk ---
-  it('copyToAgents clears skillToCopy on fulfilled', async () => {
+  it('copyToAgents clears copy-related modal targets on fulfilled', async () => {
     mockCopyToAgents.mockResolvedValue({
       success: true,
       copied: 1,
@@ -302,17 +302,20 @@ describe('skillsSlice', () => {
     })
 
     const store = await createTestStore()
-    const { setSkillToCopy, copyToAgents } = await import('./skillsSlice')
+    const { setSkillToAddSymlinks, setSkillToCopy, copyToAgents } =
+      await import('./skillsSlice')
     store.dispatch(setSkillToCopy(sampleSkill))
+    store.dispatch(setSkillToAddSymlinks(sampleSkill))
     await store.dispatch(
       copyToAgents({
         skill: sampleSkill,
-        linkPath: sampleSymlink.linkPath,
+        sourcePath: sampleSymlink.linkPath,
         agentIds: ['codex' as AgentId],
       }),
     )
 
     expect(store.getState().skills.skillToCopy).toBeNull()
+    expect(store.getState().skills.skillToAddSymlinks).toBeNull()
     expect(store.getState().skills.copying).toBe(false)
   })
 
@@ -328,7 +331,7 @@ describe('skillsSlice', () => {
     await store.dispatch(
       copyToAgents({
         skill: sampleSkill,
-        linkPath: sampleSymlink.linkPath,
+        sourcePath: sampleSymlink.linkPath,
         agentIds: ['codex' as AgentId],
       }),
     )

--- a/src/renderer/src/redux/slices/skillsSlice.test.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.test.ts
@@ -124,6 +124,7 @@ describe('skillsSlice', () => {
     expect(state.selectedSkill).toBeNull()
     expect(state.loading).toBe(false)
     expect(state.error).toBeNull()
+    expect(state.selectedAddAgentIds).toEqual([])
     // v2.4 bulk-select state
     expect(state.selectedSkillNames).toEqual([])
     expect(state.selectionAnchor).toBeNull()
@@ -157,14 +158,30 @@ describe('skillsSlice', () => {
     expect(store.getState().skills.skillToUnlink).toBeNull()
   })
 
-  it('setSkillToAddSymlinks sets and clears pending add', async () => {
-    const { setSkillToAddSymlinks } = await import('./skillsSlice')
+  it('setSkillToAddSymlinks sets and clears pending add and resets modal selections', async () => {
+    const { setSkillToAddSymlinks, toggleAddAgentSelection } =
+      await import('./skillsSlice')
     const store = await createTestStore()
+    store.dispatch(toggleAddAgentSelection('codex' as AgentId))
     store.dispatch(setSkillToAddSymlinks(sampleSkill))
     expect(store.getState().skills.skillToAddSymlinks).toEqual(sampleSkill)
+    expect(store.getState().skills.selectedAddAgentIds).toEqual([])
 
+    store.dispatch(toggleAddAgentSelection('cursor' as AgentId))
     store.dispatch(setSkillToAddSymlinks(null))
     expect(store.getState().skills.skillToAddSymlinks).toBeNull()
+    expect(store.getState().skills.selectedAddAgentIds).toEqual([])
+  })
+
+  it('toggleAddAgentSelection toggles the Add modal agent list', async () => {
+    const { toggleAddAgentSelection } = await import('./skillsSlice')
+    const store = await createTestStore()
+
+    store.dispatch(toggleAddAgentSelection('codex' as AgentId))
+    expect(store.getState().skills.selectedAddAgentIds).toEqual(['codex'])
+
+    store.dispatch(toggleAddAgentSelection('codex' as AgentId))
+    expect(store.getState().skills.selectedAddAgentIds).toEqual([])
   })
 
   it('setSkillToCopy sets and clears pending copy', async () => {
@@ -263,9 +280,10 @@ describe('skillsSlice', () => {
     })
 
     const store = await createTestStore()
-    const { setSkillToAddSymlinks, createSymlinks } =
+    const { setSkillToAddSymlinks, toggleAddAgentSelection, createSymlinks } =
       await import('./skillsSlice')
     store.dispatch(setSkillToAddSymlinks(sampleSkill))
+    store.dispatch(toggleAddAgentSelection('cursor' as AgentId))
     await store.dispatch(
       createSymlinks({
         skill: sampleSkill,
@@ -274,6 +292,7 @@ describe('skillsSlice', () => {
     )
 
     expect(store.getState().skills.skillToAddSymlinks).toBeNull()
+    expect(store.getState().skills.selectedAddAgentIds).toEqual([])
     expect(store.getState().skills.addingSymlinks).toBe(false)
   })
 
@@ -302,10 +321,15 @@ describe('skillsSlice', () => {
     })
 
     const store = await createTestStore()
-    const { setSkillToAddSymlinks, setSkillToCopy, copyToAgents } =
-      await import('./skillsSlice')
+    const {
+      setSkillToAddSymlinks,
+      setSkillToCopy,
+      toggleAddAgentSelection,
+      copyToAgents,
+    } = await import('./skillsSlice')
     store.dispatch(setSkillToCopy(sampleSkill))
     store.dispatch(setSkillToAddSymlinks(sampleSkill))
+    store.dispatch(toggleAddAgentSelection('cursor' as AgentId))
     await store.dispatch(
       copyToAgents({
         skill: sampleSkill,
@@ -316,6 +340,7 @@ describe('skillsSlice', () => {
 
     expect(store.getState().skills.skillToCopy).toBeNull()
     expect(store.getState().skills.skillToAddSymlinks).toBeNull()
+    expect(store.getState().skills.selectedAddAgentIds).toEqual([])
     expect(store.getState().skills.copying).toBe(false)
   })
 

--- a/src/renderer/src/redux/slices/skillsSlice.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.ts
@@ -42,6 +42,8 @@ interface SkillsState {
   unlinking: boolean
   /** Skill targeted by the AddSymlinkModal. */
   skillToAddSymlinks: Skill | null
+  /** Agent IDs checked in the AddSymlinkModal. */
+  selectedAddAgentIds: AgentId[]
   /** true while createSymlinks is in flight. */
   addingSymlinks: boolean
   /** Skill targeted by the CopyToAgentsModal. */
@@ -83,6 +85,7 @@ const initialState: SkillsState = {
   skillToUnlink: null,
   unlinking: false,
   skillToAddSymlinks: null,
+  selectedAddAgentIds: [],
   addingSymlinks: false,
   skillToCopy: null,
   copying: false,
@@ -333,9 +336,28 @@ const skillsSlice = createSlice({
     },
     setSkillToAddSymlinks: (state, action: PayloadAction<Skill | null>) => {
       state.skillToAddSymlinks = action.payload
+      state.selectedAddAgentIds = []
     },
     setSkillToCopy: (state, action: PayloadAction<Skill | null>) => {
       state.skillToCopy = action.payload
+    },
+    /**
+     * Toggle one target agent in the AddSymlinkModal selection.
+     */
+    toggleAddAgentSelection: (state, action: PayloadAction<AgentId>) => {
+      const agentId = action.payload
+      const existingIndex = state.selectedAddAgentIds.indexOf(agentId)
+      if (existingIndex === -1) {
+        state.selectedAddAgentIds.push(agentId)
+        return
+      }
+      state.selectedAddAgentIds.splice(existingIndex, 1)
+    },
+    /**
+     * Clear the AddSymlinkModal agent selection.
+     */
+    clearAddAgentSelection: (state) => {
+      state.selectedAddAgentIds = []
     },
     /**
      * Toggle a single skill in `selectedSkillNames` and update the anchor.
@@ -445,6 +467,7 @@ const skillsSlice = createSlice({
       .addCase(createSymlinks.fulfilled, (state) => {
         state.addingSymlinks = false
         state.skillToAddSymlinks = null
+        state.selectedAddAgentIds = []
       })
       .addCase(createSymlinks.rejected, (state, action) => {
         state.addingSymlinks = false
@@ -458,6 +481,7 @@ const skillsSlice = createSlice({
         state.copying = false
         state.skillToCopy = null
         state.skillToAddSymlinks = null
+        state.selectedAddAgentIds = []
       })
       .addCase(copyToAgents.rejected, (state, action) => {
         state.copying = false
@@ -602,6 +626,8 @@ export const {
   setSkillToUnlink,
   setSkillToAddSymlinks,
   setSkillToCopy,
+  toggleAddAgentSelection,
+  clearAddAgentSelection,
   toggleSelection,
   selectRange,
   selectAll,

--- a/src/renderer/src/redux/slices/skillsSlice.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.ts
@@ -173,21 +173,21 @@ export const createSymlinks = createAsyncThunk(
 )
 
 /**
- * Copy a skill from one agent to other agents
- * @param params - skill, linkPath of source, and target agent IDs
+ * Copy a skill source into other agents.
+ * @param params - skill, sourcePath, and target agent IDs
  * @returns Copied count and failures
  */
 export const copyToAgents = createAsyncThunk(
   'skills/copyToAgents',
   async (params: {
     skill: Skill
-    linkPath: AbsolutePath
+    sourcePath: AbsolutePath
     agentIds: AgentId[]
   }) => {
-    const { skill, linkPath, agentIds } = params
+    const { skill, sourcePath, agentIds } = params
     const result = await window.electron.skills.copyToAgents({
       skillName: skill.name,
-      linkPath,
+      sourcePath,
       targetAgentIds: agentIds,
     })
     if (!result.success && result.copied === 0) {
@@ -457,6 +457,7 @@ const skillsSlice = createSlice({
       .addCase(copyToAgents.fulfilled, (state) => {
         state.copying = false
         state.skillToCopy = null
+        state.skillToAddSymlinks = null
       })
       .addCase(copyToAgents.rejected, (state, action) => {
         state.copying = false

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -819,13 +819,13 @@ export interface CreateSymlinksResult {
  * one agent's directory into other agents (for the "copy for agent
  * collaboration" flow, where symlinks are intentionally NOT used).
  * @example
- * { skillName: 'my-skill', linkPath: '/Users/me/.claude/skills/my-skill', targetAgentIds: ['cursor', 'windsurf'] }
+ * { skillName: 'my-skill', sourcePath: '/Users/me/.claude/skills/my-skill', targetAgentIds: ['cursor', 'windsurf'] }
  */
 export interface CopyToAgentsOptions {
   /** Skill name, used as the destination folder name in each target agent. @example "my-skill" */
   skillName: SkillName
-  /** Absolute path to the source skill in the originating agent's directory. @example "/Users/me/.claude/skills/my-skill" */
-  linkPath: AbsolutePath
+  /** Absolute path to the source entry to replicate. May be a source-directory path or an agent-local symlink/directory path. @example "/Users/me/.claude/skills/my-skill" */
+  sourcePath: AbsolutePath
   /** Agents that should receive a full copy (not a symlink). */
   targetAgentIds: AgentId[]
 }


### PR DESCRIPTION
## Summary
- add a `Copy Skill files` action to the global Add modal alongside `Add Symlink`
- disable occupied agent destinations consistently for linked, local, and broken entries
- switch CodeRabbit review language from English to Japanese

## Why
The Add modal only supported symlink creation, but some agents such as Cursor need physical skill files in their agent-specific skills directory for chat suggestion and discovery flows.

## What Changed
- reused the existing `skills:copyToAgents` IPC flow from the global Add modal
- renamed the internal copy IPC field from `linkPath` to `sourcePath`
- added browser and node tests for the Add modal copy path and source-directory copy handling
- updated `.coderabbit.yaml` to use `ja-JP`

## Impact
- users can choose between symlinking and physical file copies from the global Add modal
- add/copy selection UIs now block destinations that are already occupied by valid links, broken links, or local directories
- CodeRabbit feedback is now configured to come back in Japanese

## Validation
- `pnpm typecheck`
- `pnpm exec vitest run --project node src/main/ipc/ipc-schemas.test.ts src/main/ipc/skills.copyToAgents.test.ts src/renderer/src/redux/slices/skillsSlice.test.ts`
- `pnpm exec vitest run --project browser src/renderer/src/components/skills/AddSymlinkModal.browser.test.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Copy Skill files" action to the skill deployment modal alongside existing "Add Symlink" option
  * Enhanced agent selection with detailed status indicators showing why agents are unavailable (e.g., "linked", "broken", "local")

* **Configuration**
  * Changed interface language setting to Japanese
<!-- end of auto-generated comment: release notes by coderabbit.ai -->