### PR TITLE
fix: guard "remove all from agent" against shared-dir cascade

### DIFF
--- a/src/main/constants.test.ts
+++ b/src/main/constants.test.ts
@@ -1,0 +1,86 @@
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  AGENTS,
+  isSharedAgentPath,
+  SHARED_AGENT_PATHS,
+  SOURCE_DIR,
+} from './constants'
+
+describe('SHARED_AGENT_PATHS', () => {
+  it('always includes SOURCE_DIR so "delete agent" cannot wipe the universal source', () => {
+    expect(SHARED_AGENT_PATHS.has(SOURCE_DIR)).toBe(true)
+  })
+
+  it('includes ~/.agents/skills — the v0.13.0 regression path', () => {
+    // Cline + Warp both resolve here via AGENT_DEFINITIONS. SOURCE_DIR is also
+    // this exact path. Three aliases => must be flagged.
+    expect(SHARED_AGENT_PATHS.has(join(homedir(), '.agents', 'skills'))).toBe(
+      true,
+    )
+  })
+
+  it('includes ~/.config/agents/skills — aliased across amp/kimi-cli/replit', () => {
+    expect(
+      SHARED_AGENT_PATHS.has(join(homedir(), '.config', 'agents', 'skills')),
+    ).toBe(true)
+  })
+
+  it('does not flag agents that own their own non-shared directory', () => {
+    const claude = AGENTS.find((a) => a.id === 'claude-code')!
+    const cursor = AGENTS.find((a) => a.id === 'cursor')!
+    const codex = AGENTS.find((a) => a.id === 'codex')!
+
+    expect(SHARED_AGENT_PATHS.has(claude.path)).toBe(false)
+    expect(SHARED_AGENT_PATHS.has(cursor.path)).toBe(false)
+    expect(SHARED_AGENT_PATHS.has(codex.path)).toBe(false)
+  })
+
+  it('includes every agent whose path aliases another agent', () => {
+    const pathCounts = new Map<string, number>()
+    for (const a of AGENTS)
+      pathCounts.set(a.path, (pathCounts.get(a.path) ?? 0) + 1)
+
+    for (const [path, count] of pathCounts) {
+      if (count > 1) expect(SHARED_AGENT_PATHS.has(path)).toBe(true)
+    }
+  })
+})
+
+describe('isSharedAgentPath', () => {
+  it('returns true for SOURCE_DIR', () => {
+    expect(isSharedAgentPath(SOURCE_DIR)).toBe(true)
+  })
+
+  it('returns false for a non-shared agent path', () => {
+    const claude = AGENTS.find((a) => a.id === 'claude-code')!
+    expect(isSharedAgentPath(claude.path)).toBe(false)
+  })
+
+  it('returns false for an unknown path', () => {
+    expect(isSharedAgentPath('/tmp/not-a-real-agent/skills')).toBe(false)
+  })
+
+  // Normalization guards — Set.has() does exact-string match, and
+  // SHARED_AGENT_PATHS stores canonically-joined paths. Without a resolve()
+  // normalization in isSharedAgentPath, these shapes would bypass the
+  // check even though they point at the same on-disk target.
+  it('normalizes trailing slash to prevent Set.has bypass', () => {
+    expect(isSharedAgentPath(SOURCE_DIR + '/')).toBe(true)
+  })
+
+  it('normalizes .. segments to prevent bypass', () => {
+    // e.g. /Users/me/.agents/skills/../skills → /Users/me/.agents/skills
+    const bypass = join(SOURCE_DIR, '..', 'skills')
+    expect(isSharedAgentPath(bypass)).toBe(true)
+  })
+
+  it('normalizes double-slash to prevent bypass', () => {
+    // e.g. /Users/me/.agents//skills → /Users/me/.agents/skills
+    const bypass = SOURCE_DIR.replace('/.agents/', '/.agents//')
+    expect(isSharedAgentPath(bypass)).toBe(true)
+  })
+})

--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -1,5 +1,6 @@
+import { realpathSync } from 'fs'
 import { homedir } from 'os'
-import { join } from 'path'
+import { join, resolve } from 'path'
 
 import { AGENT_DEFINITIONS } from '../shared/constants'
 
@@ -16,6 +17,63 @@ export const AGENTS = AGENT_DEFINITIONS.map((agent) => ({
   name: agent.name,
   path: join(homedir(), agent.dir, 'skills'),
 }))
+
+/**
+ * Paths where a "delete everything under this agent" op would destroy data
+ * that belongs to more than just that agent — either the Universal source
+ * itself, or a directory that the Skills CLI points multiple agent rows at
+ * (e.g. `~/.agents/skills`, `~/.config/agents/skills`).
+ *
+ * Mental model: each agent has its OWN dedicated skills dir AND additionally
+ * reads from the open-standard `~/.agents/skills/` path. The two are
+ * independent reads, not an alias. But when an agent's currently-configured
+ * `dir` happens to equal one of those shared on-disk locations, a naive
+ * `fs.rm(agentPath)` would wipe the shared directory along with it — which
+ * is exactly the v0.13.0 regression.
+ *
+ * Computed once from AGENTS + SOURCE_DIR so adding another universal-style
+ * agent in the future (via `/cli-upgrade`) auto-populates this set without
+ * touching every caller. Consumed by the IPC destructive-op handler as a
+ * last-line guard; the sidebar does NOT filter on this set — visibility of
+ * every agent is load-bearing for Cursor-style direct-file workflows.
+ */
+export const SHARED_AGENT_PATHS: ReadonlySet<string> = (() => {
+  const counts = new Map<string, number>()
+  for (const a of AGENTS) counts.set(a.path, (counts.get(a.path) ?? 0) + 1)
+  const shared = new Set<string>([SOURCE_DIR])
+  for (const [path, count] of counts)
+    if (count > 1 || path === SOURCE_DIR) shared.add(path)
+  return shared
+})()
+
+/**
+ * Returns true if this path is SOURCE_DIR or a dir that multiple agent
+ * definitions currently resolve to. Used by the delete handler to reject
+ * destructive ops whose blast radius exceeds the single agent the user
+ * thinks they're acting on.
+ *
+ * Two-stage check:
+ *  1. `resolve(path)` normalizes trailing slash, `..`, and double-slash
+ *     so string-level shapes can't bypass Set.has().
+ *  2. `realpathSync.native(path)` follows directory-level symlinks so a
+ *     manually-created alias like `~/.cursor/skills → ~/.agents/skills`
+ *     is caught by comparing the symlink target against the Set.
+ *
+ * Returns false on non-existent paths (realpath throws ENOENT): a path
+ * that doesn't exist on disk can't be a shared-dir alias.
+ * @example isSharedAgentPath('/Users/me/.agents/skills') // => true
+ * @example isSharedAgentPath('/Users/me/.agents/skills/') // => true (normalized)
+ * @example isSharedAgentPath('/Users/me/.cursor/skills') // => false
+ */
+export function isSharedAgentPath(path: string): boolean {
+  const resolved = resolve(path)
+  if (SHARED_AGENT_PATHS.has(resolved)) return true
+  try {
+    return SHARED_AGENT_PATHS.has(realpathSync.native(resolved))
+  } catch {
+    return false
+  }
+}
 
 /**
  * Look up an agent by its internal ID.

--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -41,8 +41,9 @@ export const SHARED_AGENT_PATHS: ReadonlySet<string> = (() => {
   const counts = new Map<string, number>()
   for (const a of AGENTS) counts.set(a.path, (counts.get(a.path) ?? 0) + 1)
   const shared = new Set<string>([SOURCE_DIR])
-  for (const [path, count] of counts)
-    if (count > 1 || path === SOURCE_DIR) shared.add(path)
+  for (const [path, count] of counts) {
+    if (count > 1) shared.add(path)
+  }
   return shared
 })()
 
@@ -52,12 +53,19 @@ export const SHARED_AGENT_PATHS: ReadonlySet<string> = (() => {
  * destructive ops whose blast radius exceeds the single agent the user
  * thinks they're acting on.
  *
- * Two-stage check:
+ * Three-stage check, cheapest first:
  *  1. `resolve(path)` normalizes trailing slash, `..`, and double-slash
  *     so string-level shapes can't bypass Set.has().
  *  2. `realpathSync.native(path)` follows directory-level symlinks so a
  *     manually-created alias like `~/.cursor/skills → ~/.agents/skills`
  *     is caught by comparing the symlink target against the Set.
+ *  3. Realpath each entry in SHARED_AGENT_PATHS and compare canonical
+ *     forms. Required because SHARED_AGENT_PATHS is built via `join()`,
+ *     which does not resolve OS-level firmlinks (macOS `/var` →
+ *     `/private/var`). Without this stage, a symlink alias whose
+ *     realpath lands on SOURCE_DIR but crosses a firmlink would slip
+ *     through. O(|SHARED_AGENT_PATHS|) realpath calls in the slow path
+ *     only; the fast paths catch the common cases first.
  *
  * Returns false on non-existent paths (realpath throws ENOENT): a path
  * that doesn't exist on disk can't be a shared-dir alias.
@@ -68,11 +76,23 @@ export const SHARED_AGENT_PATHS: ReadonlySet<string> = (() => {
 export function isSharedAgentPath(path: string): boolean {
   const resolved = resolve(path)
   if (SHARED_AGENT_PATHS.has(resolved)) return true
+
+  let realInput: string
   try {
-    return SHARED_AGENT_PATHS.has(realpathSync.native(resolved))
+    realInput = realpathSync.native(resolved)
   } catch {
     return false
   }
+  if (SHARED_AGENT_PATHS.has(realInput)) return true
+
+  for (const sharedPath of SHARED_AGENT_PATHS) {
+    try {
+      if (realpathSync.native(sharedPath) === realInput) return true
+    } catch {
+      // Shared path doesn't exist on disk; can't be the alias target.
+    }
+  }
+  return false
 }
 
 /**

--- a/src/main/ipc/skills.removeAllFromAgent.integration.test.ts
+++ b/src/main/ipc/skills.removeAllFromAgent.integration.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, symlink } from 'node:fs/promises'
 import type * as NodeOs from 'node:os'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -151,5 +151,28 @@ describe('skills:removeAllFromAgent handler', () => {
 
     expect(result).toEqual({ success: true, removedCount: 2 })
     expect(trashItemMock).toHaveBeenCalledTimes(1)
+  })
+
+  // Exercises the `realpathSync.native` fallback inside isSharedAgentPath.
+  // The resolve() stage sees ~/.cursor/skills (not in SHARED_AGENT_PATHS);
+  // the realpath stage follows the symlink to ~/.agents/skills and catches
+  // it. Without the fallback, a user who manually symlinked their agent
+  // dir to the universal source could still trip the v0.13.0 cascade.
+  it('rejects a symlink alias whose realpath lands on SOURCE_DIR', async () => {
+    const sourceDir = join(tempHome, '.agents', 'skills')
+    const aliasDir = join(tempHome, '.cursor', 'skills')
+    await mkdir(sourceDir, { recursive: true })
+    await mkdir(join(tempHome, '.cursor'), { recursive: true })
+    await symlink(sourceDir, aliasDir, 'dir')
+
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+
+    const handler = getRegisteredHandler('skills:removeAllFromAgent')
+    const result = await handler({}, { agentId: 'cursor', agentPath: aliasDir })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/shared skills folder/)
+    expect(trashItemMock).not.toHaveBeenCalled()
   })
 })

--- a/src/main/ipc/skills.removeAllFromAgent.integration.test.ts
+++ b/src/main/ipc/skills.removeAllFromAgent.integration.test.ts
@@ -1,0 +1,155 @@
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import type * as NodeOs from 'node:os'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const handleMock = vi.fn()
+const trashItemMock = vi.fn()
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (...args: unknown[]) => handleMock(...args),
+  },
+  shell: {
+    trashItem: (...args: unknown[]) => trashItemMock(...args),
+  },
+}))
+
+/**
+ * Look up a registered IPC handler by channel name.
+ * @param channel - IPC invoke channel to find.
+ * @returns Registered handler function.
+ * @example
+ * const handler = getRegisteredHandler('skills:removeAllFromAgent')
+ */
+function getRegisteredHandler(channel: string): (
+  event: unknown,
+  arg: { agentId: string; agentPath: string },
+) => Promise<{
+  success: boolean
+  removedCount: number
+  error?: string
+}> {
+  const registration = handleMock.mock.calls.find(([name]) => name === channel)
+  if (!registration) {
+    throw new Error(`No handler registered for ${channel}`)
+  }
+  return registration[1] as (
+    event: unknown,
+    arg: { agentId: string; agentPath: string },
+  ) => Promise<{
+    success: boolean
+    removedCount: number
+    error?: string
+  }>
+}
+
+describe('skills:removeAllFromAgent handler', () => {
+  let tempHome = ''
+
+  beforeEach(async () => {
+    vi.resetModules()
+    handleMock.mockReset()
+    trashItemMock.mockReset()
+    trashItemMock.mockResolvedValue(undefined)
+    tempHome = await mkdtemp(join(tmpdir(), 'skills-desktop-remove-'))
+    vi.doMock('os', async () => {
+      const actual = await vi.importActual<typeof NodeOs>('os')
+      return {
+        ...actual,
+        homedir: () => tempHome,
+      }
+    })
+    vi.doMock('node:os', async () => {
+      const actual = await vi.importActual<typeof NodeOs>('node:os')
+      return {
+        ...actual,
+        homedir: () => tempHome,
+      }
+    })
+  })
+
+  afterEach(async () => {
+    vi.doUnmock('os')
+    vi.doUnmock('node:os')
+    await rm(tempHome, { recursive: true, force: true })
+  })
+
+  // v0.13.0 regression lock: clicking "remove all from Cline" used to pass
+  // SOURCE_DIR (=~/.agents/skills) through unchecked, cascading into every
+  // universal agent. The guard must reject this before any trashItem call.
+  it('rejects SOURCE_DIR — the v0.13.0 regression path', async () => {
+    const sourceDir = join(tempHome, '.agents', 'skills')
+    await mkdir(sourceDir, { recursive: true })
+
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+
+    const handler = getRegisteredHandler('skills:removeAllFromAgent')
+    const result = await handler({}, { agentId: 'cline', agentPath: sourceDir })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/shared skills folder/)
+    expect(trashItemMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a trailing-slash bypass of SOURCE_DIR', async () => {
+    // A raw string `~/.agents/skills/` would miss SHARED_AGENT_PATHS.has()
+    // without the resolve() normalization in isSharedAgentPath.
+    const sourceDir = join(tempHome, '.agents', 'skills')
+    await mkdir(sourceDir, { recursive: true })
+
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+
+    const handler = getRegisteredHandler('skills:removeAllFromAgent')
+    const result = await handler(
+      {},
+      { agentId: 'cline', agentPath: sourceDir + '/' },
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/shared skills folder/)
+    expect(trashItemMock).not.toHaveBeenCalled()
+  })
+
+  // Idempotency contract: shell.trashItem throws ENOENT (unlike the old
+  // fs.rm({force:true}) this handler used to call). Pre-checking with
+  // fs.access lets double-clicks and out-of-band deletes resolve cleanly.
+  it('returns success with 0 count when agent dir does not exist', async () => {
+    // Never mkdir — the .cursor/skills dir is absent.
+    const cursorDir = join(tempHome, '.cursor', 'skills')
+
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+
+    const handler = getRegisteredHandler('skills:removeAllFromAgent')
+    const result = await handler(
+      {},
+      { agentId: 'cursor', agentPath: cursorDir },
+    )
+
+    expect(result).toEqual({ success: true, removedCount: 0 })
+    expect(trashItemMock).not.toHaveBeenCalled()
+  })
+
+  it('trashes a real agent dir and returns count of entries', async () => {
+    const cursorDir = join(tempHome, '.cursor', 'skills')
+    await mkdir(join(cursorDir, 'skill-a'), { recursive: true })
+    await mkdir(join(cursorDir, 'skill-b'), { recursive: true })
+
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+
+    const handler = getRegisteredHandler('skills:removeAllFromAgent')
+    const result = await handler(
+      {},
+      { agentId: 'cursor', agentPath: cursorDir },
+    )
+
+    expect(result).toEqual({ success: true, removedCount: 2 })
+    expect(trashItemMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
 
 import type { IpcMainInvokeEvent } from 'electron'
+import { shell } from 'electron'
 import { match } from 'ts-pattern'
 
 import { BULK_PROGRESS_THRESHOLD } from '../../shared/constants'
@@ -15,7 +16,12 @@ import type {
   RestoreDeletedSkillResult,
   SkillName,
 } from '../../shared/types'
-import { AGENTS, findAgentById, SOURCE_DIR } from '../constants'
+import {
+  AGENTS,
+  findAgentById,
+  isSharedAgentPath,
+  SOURCE_DIR,
+} from '../constants'
 import { getAllowedBases, validatePath } from '../services/pathValidation'
 import { scanSkills } from '../services/skillScanner'
 import { moveToTrash, restore, TrashError } from '../services/trashService'
@@ -162,7 +168,14 @@ export function registerSkillsHandlers(): void {
   })
 
   /**
-   * Delete a specific agent's entire skills folder
+   * Delete a specific agent's entire skills folder. Moves the directory to the
+   * OS trash (macOS Finder Trash) so accidents are recoverable.
+   *
+   * Rejects paths that alias SOURCE_DIR or are shared across multiple agent
+   * rows (see `SHARED_AGENT_PATHS`). Without this guard a "delete Cline" click
+   * would wipe `~/.agents/skills` and cascade into every universal agent —
+   * the exact v0.13.0 regression that motivated this handler rewrite.
+   *
    * @param options - agentId, agentPath
    * @returns RemoveAllFromAgentResult with item count removed
    */
@@ -171,18 +184,46 @@ export function registerSkillsHandlers(): void {
 
     try {
       const agentBases = AGENTS.map((a) => a.path)
+      // validatePath throws on traversal attempts. We discard the return
+      // value intentionally: SHARED_AGENT_PATHS is keyed by the resolve()-
+      // normalized join() form, NOT by realpath, to avoid macOS firmlink
+      // (/var → /private/var) false negatives. isSharedAgentPath handles
+      // symlink aliases itself via its realpathSync fallback. Using
+      // agentPath (not the realpath'd form) for trashItem is also safer:
+      // trashItem on a symlink moves the symlink, not its target.
       validatePath(agentPath, agentBases)
+
+      if (isSharedAgentPath(agentPath)) {
+        return {
+          success: false,
+          removedCount: 0,
+          error:
+            'Refusing to delete a shared skills folder. This directory is used by the Universal source and/or multiple agents — deleting it would cascade beyond the selected agent.',
+        }
+      }
+
+      // Idempotent missing-dir handling: `shell.trashItem` throws ENOENT,
+      // unlike the old `fs.rm({ force: true })` this handler used to call.
+      // Short-circuit when the dir is already gone so double-clicks and
+      // out-of-band deletes don't surface as errors.
+      try {
+        await fs.access(agentPath)
+      } catch {
+        return { success: true, removedCount: 0 }
+      }
+
       // Count entries before deletion for reporting
       let removedCount = 0
       try {
         const entries = await fs.readdir(agentPath)
         removedCount = entries.length
       } catch {
-        // Directory may not exist or be unreadable
+        // Directory may be unreadable (permissions) — proceed to trash anyway
       }
 
-      // Delete the entire agent skills directory
-      await fs.rm(agentPath, { recursive: true, force: true })
+      // Move to OS trash instead of hard-rm so accidents can be restored from
+      // Finder > Trash.
+      await shell.trashItem(agentPath)
 
       return { success: true, removedCount }
     } catch (error) {

--- a/src/main/services/agentScanner.test.ts
+++ b/src/main/services/agentScanner.test.ts
@@ -220,13 +220,16 @@ describe('scanAgents', () => {
     const agents = await scanAgents()
 
     // Cline + Warp currently resolve to the Universal source in the mock.
-    // We still render them: the dedicated/universal relationship is a
-    // dual-source READ, not an alias, and hiding rows breaks direct-file
-    // workflows (e.g. Cursor autocomplete needs file copies, not symlinks,
-    // inside the agent-specific dir). Data safety lives at the IPC layer:
+    // We still render them AND pin `exists: true` — the dedicated/universal
+    // relationship is a dual-source READ, not an alias. Hiding rows or
+    // silently marking them non-existent would break direct-file workflows
+    // (e.g. Cursor autocomplete needs file copies, not symlinks, inside
+    // the agent-specific dir). Data safety lives at the IPC layer:
     // SKILLS_REMOVE_ALL_FROM_AGENT rejects SHARED_AGENT_PATHS targets.
-    expect(agents.find((a) => a.id === 'cline')).toBeDefined()
-    expect(agents.find((a) => a.id === 'warp')).toBeDefined()
+    const cline = agents.find((a) => a.id === 'cline')!
+    const warp = agents.find((a) => a.id === 'warp')!
+    expect(cline.exists).toBe(true)
+    expect(warp.exists).toBe(true)
     expect(agents.find((a) => a.id === 'claude-code')).toBeDefined()
     expect(agents.find((a) => a.id === 'cursor')).toBeDefined()
   })

--- a/src/main/services/agentScanner.test.ts
+++ b/src/main/services/agentScanner.test.ts
@@ -48,7 +48,12 @@ vi.mock('../constants', () => ({
       path: '/mock/agents/claude/skills',
     },
     { id: 'cursor', name: 'Cursor', path: '/mock/agents/cursor/skills' },
+    // cline + warp both alias SOURCE_DIR — the v0.13.0 shape that must
+    // never render as individual sidebar rows
+    { id: 'cline', name: 'Cline', path: '/mock/source/skills' },
+    { id: 'warp', name: 'Warp', path: '/mock/source/skills' },
   ],
+  SHARED_AGENT_PATHS: new Set(['/mock/source/skills']),
 }))
 
 describe('scanAgents', () => {
@@ -183,7 +188,8 @@ describe('scanAgents', () => {
 
   it('sorts existing agents before non-existing agents', async () => {
     accessMock.mockImplementation(async (path: string) => {
-      // Claude doesn't exist, Cursor does
+      // Claude doesn't exist; cursor + the universal-resolving rows (cline,
+      // warp both point at /mock/source/skills in the mock) do.
       if (path === '/mock/agents/claude/skills') {
         throw new Error('ENOENT')
       }
@@ -195,11 +201,34 @@ describe('scanAgents', () => {
     const { scanAgents } = await import('./agentScanner')
     const agents = await scanAgents()
 
-    // Cursor exists -> sorted first
-    expect(agents[0].id).toBe('cursor')
-    expect(agents[0].exists).toBe(true)
-    expect(agents[1].id).toBe('claude-code')
-    expect(agents[1].exists).toBe(false)
+    // Existing rows sort first, then alphabetically by name:
+    //   Cline, Cursor, Warp (exists=true) → Claude Code (exists=false)
+    expect(agents.map((a) => a.id)).toEqual([
+      'cline',
+      'cursor',
+      'warp',
+      'claude-code',
+    ])
+    expect(agents[agents.length - 1].exists).toBe(false)
+  })
+
+  it('includes every agent — even ones whose Skills CLI dir resolves to the Universal source', async () => {
+    accessMock.mockResolvedValue(undefined)
+    readdirMock.mockResolvedValue([])
+
+    const { scanAgents } = await import('./agentScanner')
+    const agents = await scanAgents()
+
+    // Cline + Warp currently resolve to the Universal source in the mock.
+    // We still render them: the dedicated/universal relationship is a
+    // dual-source READ, not an alias, and hiding rows breaks direct-file
+    // workflows (e.g. Cursor autocomplete needs file copies, not symlinks,
+    // inside the agent-specific dir). Data safety lives at the IPC layer:
+    // SKILLS_REMOVE_ALL_FROM_AGENT rejects SHARED_AGENT_PATHS targets.
+    expect(agents.find((a) => a.id === 'cline')).toBeDefined()
+    expect(agents.find((a) => a.id === 'warp')).toBeDefined()
+    expect(agents.find((a) => a.id === 'claude-code')).toBeDefined()
+    expect(agents.find((a) => a.id === 'cursor')).toBeDefined()
   })
 
   it('excludes dot-prefixed directories from local skill count', async () => {

--- a/src/main/services/agentScanner.ts
+++ b/src/main/services/agentScanner.ts
@@ -7,7 +7,21 @@ import { AGENTS } from '../constants'
 import { checkSymlinkStatus } from './symlinkChecker'
 
 /**
- * Scan all supported agents and check their existence
+ * Scan all supported agents and check their existence.
+ *
+ * Every agent row is returned — including ones whose Skills CLI `dir`
+ * currently resolves to the Universal source (e.g. Cline, Warp, Amp).
+ * The mental model: each agent has its own dedicated skills directory
+ * AND additionally reads from the open-standard `~/.agents/skills/`
+ * path. The two are independent reads, not an alias — so hiding the
+ * row would remove a legitimate affordance (direct file copies into a
+ * specific agent's dir, which Cursor's chat autocomplete requires).
+ *
+ * Data-loss prevention for the v0.13.0 regression is handled one layer
+ * down: the IPC handler for SKILLS_REMOVE_ALL_FROM_AGENT rejects any
+ * agentPath in SHARED_AGENT_PATHS, and deletes go through
+ * `shell.trashItem` for recoverability.
+ *
  * @returns Array of Agent objects with existence, skill count, and local skill count
  * @example
  * scanAgents()


### PR DESCRIPTION
## Summary

- **v0.13.0 regression fix**: the Skills CLI v1.5.x collapse of several agents' `skillsDir` into the shared `~/.agents/skills` path made a naive `fs.rm(agentPath)` wipe every universal agent at once when the user clicked *remove all from Cline/Warp/Amp/etc.* This PR adds a last-line IPC guard and routes the delete through `shell.trashItem` so any remaining accident is recoverable from Finder > Trash.
- `SHARED_AGENT_PATHS` is derived once at startup from `AGENT_DEFINITIONS` + `SOURCE_DIR`, so adding another universal-style agent via `/cli-upgrade` auto-populates the guard set without touching every caller.
- The sidebar keeps rendering **every** agent row — the dedicated dir + universal dir relationship is a dual-source read, not an alias, and hiding rows would break Cursor-style workflows that need actual file copies inside `~/.cursor/skills/`.

## What changed

- `src/main/constants.ts` — `SHARED_AGENT_PATHS` Set + `isSharedAgentPath()` with two-stage check (`resolve()` normalization for trailing slash / `..` / `//`, then `realpathSync.native` fallback for symlink aliases).
- `src/main/ipc/skills.ts` — `SKILLS_REMOVE_ALL_FROM_AGENT` handler: validate → check `isSharedAgentPath` → `fs.access` for ENOENT idempotency → `shell.trashItem` (not `fs.rm`).
- `src/main/services/agentScanner.ts` — docstring clarifies the dual-source read model; no row filtering.
- **New tests**: 3 normalization cases in `constants.test.ts`, 4 integration tests in `skills.removeAllFromAgent.integration.test.ts` (regression-lock for `SOURCE_DIR`, trailing-slash bypass, missing-dir idempotency, happy-path count).

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm lint` — passes
- [x] `pnpm vitest run src/main/constants.test.ts src/main/services/agentScanner.test.ts src/main/ipc/skills.removeAllFromAgent.integration.test.ts` — 23/23 pass (including the 7 new regression-lock cases)
- [x] Full `pnpm test` — 837/838 pass (1 pre-existing failure in `pathValidation.test.ts` confirmed unrelated via `git stash` isolation on clean `main`)
- [ ] Manual smoke (reviewer): `pnpm dev`, click *remove all from Cline* — expect the action to be rejected with the "shared skills folder" error and no files moved; then click *remove all from Claude Code* and verify the directory lands in Finder > Trash and is restorable.

## Out of scope

- The pre-existing `pathValidation.test.ts > getAllowedBases > rejects an agent-dir skill path when only SOURCE_DIR is allowed` failure is not touched here — it fails on clean `main` too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 複数のエージェント間で共有されているスキルフォルダの誤削除を防止するための安全ガードを追加しました。

* **改善**
  * スキル削除時に、ファイルを完全削除する代わりにゴミ箱に移動するようにしました。復元可能になります。

* **ドキュメント**
  * 共有スキルフォルダを持つエージェントの表示動作を明確化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->