### PR TITLE
fix(sidebar): pin width with shrink-0 and tighten agent item gap

### DIFF
--- a/src/renderer/src/components/layout/Sidebar.tsx
+++ b/src/renderer/src/components/layout/Sidebar.tsx
@@ -21,7 +21,7 @@ export const Sidebar = React.memo(function Sidebar(): React.ReactElement {
   return (
     <aside
       aria-label="Agent sidebar"
-      className="w-[240px] border-r border-border bg-card flex flex-col"
+      className="w-[240px] shrink-0 border-r border-border bg-card flex flex-col"
     >
       <SidebarHeader />
       <Separator />

--- a/src/renderer/src/components/sidebar/AgentItem.tsx
+++ b/src/renderer/src/components/sidebar/AgentItem.tsx
@@ -106,7 +106,7 @@ export const AgentItem = React.memo(function AgentItem({
               type="button"
               aria-label={`Filter skills by ${agent.name}${skillCountText ? ` (${skillCountText})` : ''}`}
               className={cn(
-                'flex w-full items-center justify-between min-h-[44px] py-1.5 px-2 rounded-md transition-colors border-l-4 border-l-transparent text-left',
+                'flex w-full items-center gap-2 min-h-[44px] py-1.5 px-2 rounded-md transition-colors border-l-4 border-l-transparent text-left',
                 agent.exists && 'cursor-pointer hover:bg-muted/50',
                 isSelected && 'border-l-primary bg-primary/10',
               )}
@@ -115,14 +115,14 @@ export const AgentItem = React.memo(function AgentItem({
             >
               <span
                 className={cn(
-                  'text-sm truncate',
+                  'text-sm truncate min-w-0',
                   !agent.exists && 'text-muted-foreground/70',
                 )}
               >
                 {agent.name}
               </span>
               {skillCountText && (
-                <span className="text-xs text-muted-foreground whitespace-nowrap ml-2">
+                <span className="text-xs text-muted-foreground whitespace-nowrap">
                   {skillCountText}
                 </span>
               )}


### PR DESCRIPTION
## Summary

- **Sidebar overlap fix**: `w-[240px]` alone was not enough — Tailwind sets only `width`, leaving the default `flex-shrink: 1`. The right-side `react-resizable-panels` `Group flex-1` could squeeze the sidebar below 240px, making the main panel visually overlap it. Added `shrink-0` to lock the width.
- **AgentItem spacing fix**: `justify-between` pushed the agent name to the far left and the skill count to the far right, leaving a large dead space. Replaced with `flex gap-2` for tight, consistent 8px spacing. Added `min-w-0` to the name `<span>` so `truncate` still produces ellipsis on long agent names; removed redundant `ml-2` from the count `<span>`.

## Test plan

- [ ] Run `pnpm dev`, confirm the 240px sidebar stays put when resizing the window or dragging the Main/Detail separator
- [ ] Confirm short agent names (e.g. `claude`) sit close to the `N linked` count instead of being slammed to opposite ends
- [ ] Confirm long agent names truncate with ellipsis and don't push the skill count off-card
- [ ] Confirm the agent item still hits the 44px tap target and the active border-l accent renders correctly
- [ ] `pnpm typecheck` and `pnpm lint` pass (already verified locally)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * サイドバーのレイアウト動作を改善し、指定幅を適切に維持
  * エージェントアイテムの表示を最適化し、テキストの折り返しが正しく機能するよう調整

<!-- end of auto-generated comment: release notes by coderabbit.ai -->