### PR TITLE
Add Skills宝 to related resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ src/
 
 - [Skills CLI](https://github.com/vercel-labs/skills) - Install skills via CLI
 - [Skills Registry](https://skills.sh) - Browse available skills
+- [Skills宝](https://skilery.com) - Chinese search and install hub for skills
 - [Agent Skills Spec](https://agentskills.io) - Skills specification
 
 ## License


### PR DESCRIPTION
Adds Skills宝 as a Chinese-language search and install hub for skills. The repo already points users toward the Skills CLI and Skills Registry, so this keeps the related resources section aligned with its discovery workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * README の関連セクションに新しい外部リファレンス「Skills宝」を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->