### PR TITLE
fix: handle local-only skills in moveToTrash

### DIFF
--- a/src/main/ipc/ipc-schemas.ts
+++ b/src/main/ipc/ipc-schemas.ts
@@ -33,6 +33,70 @@ export const tombstoneIdSchema = z
   .string()
   .regex(/^\d+-[^/\\]+-[a-f0-9]{8}$/, 'Invalid tombstone id format')
 
+/** Recorded symlink entry that lived in an agent dir before delete. */
+const symlinkRecordSchema = z.object({
+  agentId: nonEmptyString,
+  linkPath: nonEmptyString,
+  target: nonEmptyString,
+})
+
+/** Recorded local-copy entry — a real (non-symlink) skill folder under an agent dir. */
+const localCopyRecordSchema = z.object({
+  agentId: nonEmptyString,
+  linkPath: nonEmptyString,
+})
+
+/**
+ * Legacy v1 manifest (no kind discriminator — always source-backed).
+ * Read-only path: never written by current code. Normalized to v2 source-backed
+ * via Zod transform so consumers see one shape regardless of on-disk version.
+ * Removable in a future major once the 24h startupCleanup TTL has flushed all
+ * pre-upgrade tombstones.
+ */
+const manifestV1Schema = z
+  .object({
+    schemaVersion: z.literal(1),
+    deletedAt: z.number().int().positive(),
+    skillName: skillNameString,
+    sourcePath: nonEmptyString,
+    symlinks: z.array(symlinkRecordSchema),
+  })
+  .transform((legacy) => ({
+    schemaVersion: 2 as const,
+    kind: 'source-backed' as const,
+    deletedAt: legacy.deletedAt,
+    skillName: legacy.skillName,
+    sourcePath: legacy.sourcePath,
+    symlinks: legacy.symlinks,
+  }))
+
+/**
+ * v2 source-backed manifest — produced when `~/.agents/skills/<name>` is the
+ * authoritative source dir and agent entries are symlinks pointing at it.
+ */
+const manifestV2SourceBackedSchema = z.object({
+  schemaVersion: z.literal(2),
+  kind: z.literal('source-backed'),
+  deletedAt: z.number().int().positive(),
+  skillName: skillNameString,
+  sourcePath: nonEmptyString,
+  symlinks: z.array(symlinkRecordSchema),
+})
+
+/**
+ * v2 local-only manifest — produced when no source dir exists but one or more
+ * agent dirs hold a real (non-symlink) folder for the skill. Each agent folder
+ * is moved to `<entryDir>/local-copies/<agentId>/` and recorded here so
+ * `restore()` can put each copy back exactly where it came from.
+ */
+const manifestV2LocalOnlySchema = z.object({
+  schemaVersion: z.literal(2),
+  kind: z.literal('local-only'),
+  deletedAt: z.number().int().positive(),
+  skillName: skillNameString,
+  localCopies: z.array(localCopyRecordSchema).min(1),
+})
+
 /**
  * Trash manifest schema written on every moveToTrash.
  * Validated via Zod before `trashService.restore()` touches the filesystem
@@ -40,28 +104,35 @@ export const tombstoneIdSchema = z
  * Each `linkPath` is re-validated with `validatePath` against the agent's base
  * directory before any fs op, so an attacker-crafted manifest still cannot point
  * outside the agent's allowed base (defense in depth).
+ *
+ * Discriminated on `kind` after Zod parsing — v1 manifests are normalized to
+ * `{kind: 'source-backed', schemaVersion: 2}` so consumers don't branch on
+ * version separately from kind.
  * @example
+ * // v2 source-backed
  * {
- *   schemaVersion: 1,
+ *   schemaVersion: 2,
+ *   kind: 'source-backed',
  *   deletedAt: 1729180800000,
  *   skillName: 'theme-generator',
  *   sourcePath: '/Users/me/.agents/skills/theme-generator',
  *   symlinks: [{ agentId: 'cursor', linkPath: '/Users/me/.cursor/skills/theme-generator', target: '/Users/me/.agents/skills/theme-generator' }]
  * }
+ * @example
+ * // v2 local-only
+ * {
+ *   schemaVersion: 2,
+ *   kind: 'local-only',
+ *   deletedAt: 1729180800000,
+ *   skillName: 'architecture-decision-records',
+ *   localCopies: [{ agentId: 'claude', linkPath: '/Users/me/.claude/skills/architecture-decision-records' }]
+ * }
  */
-export const manifestSchema = z.object({
-  schemaVersion: z.literal(1),
-  deletedAt: z.number().int().positive(),
-  skillName: skillNameString,
-  sourcePath: nonEmptyString,
-  symlinks: z.array(
-    z.object({
-      agentId: nonEmptyString,
-      linkPath: nonEmptyString,
-      target: nonEmptyString,
-    }),
-  ),
-})
+export const manifestSchema = z.union([
+  manifestV2SourceBackedSchema,
+  manifestV2LocalOnlySchema,
+  manifestV1Schema,
+])
 
 export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
   // File operations — require non-empty path strings

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -16,12 +16,7 @@ import type {
   RestoreDeletedSkillResult,
   SkillName,
 } from '../../shared/types'
-import {
-  AGENTS,
-  findAgentById,
-  isSharedAgentPath,
-  SOURCE_DIR,
-} from '../constants'
+import { AGENTS, findAgentById, isSharedAgentPath } from '../constants'
 import { getAllowedBases, validatePath } from '../services/pathValidation'
 import { scanSkills } from '../services/skillScanner'
 import { moveToTrash, restore, TrashError } from '../services/trashService'
@@ -30,18 +25,6 @@ import { extractErrorMessage } from '../utils/errors'
 
 import { typedHandle } from './typedHandle'
 import { typedSend } from './typedSend'
-
-/**
- * Derive the canonical source path for a skill. Renderer never passes paths
- * for bulk ops — main always re-derives from SOURCE_DIR + skillName. This
- * closes the "renderer-supplied path" trust boundary (security CRITICAL-2).
- * @param skillName - Validated skill name (no path separators, enforced by Zod)
- * @returns Absolute path inside SOURCE_DIR
- * @example deriveSourcePath('task') // '/Users/me/.agents/skills/task'
- */
-function deriveSourcePath(skillName: SkillName): string {
-  return join(SOURCE_DIR, skillName)
-}
 
 /**
  * Unlink or remove a single link-path inside an agent directory. Shared by the
@@ -239,32 +222,16 @@ export function registerSkillsHandlers(): void {
    * Delete a single skill by delegating to trashService so the single-delete
    * path shares the same trash/undo/eviction code as batch delete.
    *
-   * `sourcePath = join(SOURCE_DIR, skillName)` is derived server-side; the
-   * renderer never passes a path (security CRITICAL-2 closed, asymmetry with
-   * the bulk handler resolved).
+   * `moveToTrash(skillName)` derives + validates `sourcePath` internally and
+   * also handles the local-only case (skill lives in agent dirs only with no
+   * `~/.agents/skills/<name>` source). The renderer never passes a path.
    * @param options - { skillName }
    * @returns DeleteSkillResult with symlinksRemoved + cascadeAgents
    */
   typedHandle(IPC_CHANNELS.SKILLS_DELETE, async (_, options) => {
     const { skillName } = options
-    const sourcePath = deriveSourcePath(skillName)
-
     try {
-      validatePath(sourcePath, [SOURCE_DIR])
-    } catch (error) {
-      return {
-        success: false,
-        symlinksRemoved: 0,
-        cascadeAgents: [],
-        error: extractErrorMessage(error),
-      }
-    }
-
-    try {
-      const { cascadeAgents, symlinksRemoved } = await moveToTrash(
-        skillName,
-        sourcePath,
-      )
+      const { cascadeAgents, symlinksRemoved } = await moveToTrash(skillName)
       return {
         success: true,
         symlinksRemoved,
@@ -303,31 +270,12 @@ export function registerSkillsHandlers(): void {
       const results: BulkDeleteItemResult[] = []
 
       for (const [itemIndex, { skillName }] of items.entries()) {
-        const sourcePath = deriveSourcePath(skillName)
-
-        try {
-          validatePath(sourcePath, [SOURCE_DIR])
-        } catch (error) {
-          results.push({
-            skillName,
-            outcome: 'error',
-            error: { message: extractErrorMessage(error) },
-          })
-          if (emitProgress) {
-            typedSend(event.sender, IPC_CHANNELS.SKILLS_DELETE_PROGRESS, {
-              current: itemIndex + 1,
-              total,
-            })
-          }
-          continue
-        }
-
         try {
           const {
             tombstoneId: id,
             cascadeAgents,
             symlinksRemoved,
-          } = await moveToTrash(skillName, sourcePath)
+          } = await moveToTrash(skillName)
           results.push({
             skillName,
             outcome: 'deleted',

--- a/src/main/services/trashService.integration.test.ts
+++ b/src/main/services/trashService.integration.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync } from 'node:fs'
+import { mkdtempSync, realpathSync } from 'node:fs'
 import {
   mkdir,
   readFile,
@@ -27,14 +27,37 @@ import {
 // which raced with vitest's dynamic-import scheduling: on some orderings
 // `trashService`'s top-level `TRASH_DIR = join(homedir(), '.agents', '.trash')`
 // ran while sharedHome was still undefined and blew up inside `join`.
-const sharedHome = mkdtempSync(join(tmpdir(), 'skills-trash-it-'))
+//
+// `realpathSync` canonicalizes the tmp dir up-front: macOS reports
+// `/var/folders/...` from `mkdtempSync` but `realpathSync` resolves it to
+// `/private/var/...`, and `validatePath` (called inside trashService) uses
+// `realpathSync` internally — without canonicalization every constructed
+// path would appear to escape its declared base.
+const sharedHome = realpathSync(mkdtempSync(join(tmpdir(), 'skills-trash-it-')))
 const sharedSourceDir = join(sharedHome, '.agents', 'skills')
 const sharedTrashDir = join(sharedHome, '.agents', '.trash')
 const sharedAgentCursor = join(sharedHome, '.cursor', 'skills')
+const sharedAgentClaude = join(sharedHome, '.claude', 'skills')
 
 vi.mock('node:os', async () => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-imports
   const actual = await vi.importActual<typeof import('node:os')>('node:os')
+  return {
+    ...actual,
+    homedir: () => sharedHome,
+  }
+})
+
+// `../constants` (and therefore the AGENTS table) imports from the bare `'os'`
+// specifier, not `'node:os'`. Without this second mock, AGENT paths still
+// point at the developer's REAL `~/.claude/skills`, `~/.cursor/skills`, etc.
+// at module-init time — meaning `scanLocalCopies` could never see the agent
+// dirs we set up under `sharedHome` and the local-only flow would be
+// untestable from this file. Mock both so both `homedir()` paths resolve
+// here.
+vi.mock('os', async () => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const actual = await vi.importActual<typeof import('os')>('os')
   return {
     ...actual,
     homedir: () => sharedHome,
@@ -52,6 +75,7 @@ describe('trashService (integration)', () => {
   beforeAll(async () => {
     await mkdir(sharedSourceDir, { recursive: true })
     await mkdir(sharedAgentCursor, { recursive: true })
+    await mkdir(sharedAgentClaude, { recursive: true })
   })
 
   afterAll(async () => {
@@ -63,15 +87,18 @@ describe('trashService (integration)', () => {
     __clearEvictTimersForTests()
     // Wipe trash between tests so collisions don't surface.
     await rm(sharedTrashDir, { recursive: true, force: true })
-    // Reset source dir contents for a clean slate.
+    // Reset source + agent dirs for a clean slate. Claude is needed for the
+    // local-only tests; cursor is needed for the source-backed cascade tests.
     try {
       await rm(sharedSourceDir, { recursive: true, force: true })
       await rm(sharedAgentCursor, { recursive: true, force: true })
+      await rm(sharedAgentClaude, { recursive: true, force: true })
     } catch {
       // ignore
     }
     await mkdir(sharedSourceDir, { recursive: true })
     await mkdir(sharedAgentCursor, { recursive: true })
+    await mkdir(sharedAgentClaude, { recursive: true })
   })
 
   /**
@@ -98,6 +125,25 @@ describe('trashService (integration)', () => {
     return linkPath
   }
 
+  /**
+   * Create a local-only skill: a real (non-symlink) directory with SKILL.md
+   * directly inside an agent dir (no `~/.agents/skills/<name>` source). Mirrors
+   * the disk shape that triggered the original "Bulk delete failed - Deleted
+   * 0 of 1 skill" bug for `architecture-decision-records`.
+   * @param skillName - Directory basename
+   * @param agentBaseDir - Absolute path to the agent's skills dir (e.g. sharedAgentClaude)
+   * @returns Absolute folder path
+   */
+  async function makeLocalSkill(
+    skillName: string,
+    agentBaseDir: string,
+  ): Promise<string> {
+    const localPath = join(agentBaseDir, skillName)
+    await mkdir(localPath, { recursive: true })
+    await writeFile(join(localPath, 'SKILL.md'), `# ${skillName}\n`, 'utf-8')
+    return localPath
+  }
+
   it('round-trip: moves source and agent symlink into trash, then restores both', async () => {
     const { moveToTrash, restore } = await trashServicePromise
 
@@ -109,15 +155,14 @@ describe('trashService (integration)', () => {
     await stat(sourcePath)
     await stat(linkPath)
 
-    const deleteResult = await moveToTrash(skillName, sourcePath)
-    // symlinksRemoved is 0 here because `AGENTS` resolves its paths against
-    // the REAL homedir (constants.ts imports happen at top level before our
-    // \`vi.mock('node:os')\` scope can dynamically flip the sharedHome). The
-    // crucial integration invariants — source moved, manifest valid, restore
-    // succeeds — are exercised regardless. Count-level assertions live in the
-    // mocked unit test where AGENTS can be fully controlled.
-    expect(deleteResult.symlinksRemoved).toBeGreaterThanOrEqual(0)
-    expect(deleteResult.cascadeAgents).toBeInstanceOf(Array)
+    const deleteResult = await moveToTrash(skillName)
+    // With both `os` and `node:os` mocked, `AGENTS` paths resolve under
+    // `sharedHome` so the cursor symlink we created above is actually
+    // walked, recorded, and unlinked by the cascade. The exact count is
+    // 1 (only the cursor link exists), but other agent dirs are absent so
+    // their lstat calls return ENOENT and they're silently skipped.
+    expect(deleteResult.symlinksRemoved).toBe(1)
+    expect(deleteResult.cascadeAgents).toContain('cursor')
     // Source is gone from SOURCE_DIR.
     await expect(stat(sourcePath)).rejects.toThrow()
     // Link was removed (or absent).
@@ -131,9 +176,11 @@ describe('trashService (integration)', () => {
     const manifestRaw = await readFile(manifestPath, 'utf-8')
     const manifest = JSON.parse(manifestRaw) as {
       schemaVersion: number
+      kind: string
       skillName: string
     }
-    expect(manifest.schemaVersion).toBe(1)
+    expect(manifest.schemaVersion).toBe(2)
+    expect(manifest.kind).toBe('source-backed')
     expect(manifest.skillName).toBe(skillName)
 
     // Restore it.
@@ -163,8 +210,8 @@ describe('trashService (integration)', () => {
     const { moveToTrash, restore } = await trashServicePromise
 
     const skillName = 'manifest-corrupt-skill'
-    const sourcePath = await makeSourceSkill(skillName)
-    const result = await moveToTrash(skillName, sourcePath)
+    await makeSourceSkill(skillName)
+    const result = await moveToTrash(skillName)
 
     // Corrupt the manifest.
     const manifestPath = join(
@@ -188,7 +235,7 @@ describe('trashService (integration)', () => {
 
     const skillName = 'collision-skill'
     const sourcePath = await makeSourceSkill(skillName)
-    const result = await moveToTrash(skillName, sourcePath)
+    const result = await moveToTrash(skillName)
 
     // Recreate something at the original source path to simulate a reinstall
     // before the user pressed undo.
@@ -202,26 +249,27 @@ describe('trashService (integration)', () => {
     }
   })
 
-  it('moveToTrash aborts cleanly when source does not exist (already deleted)', async () => {
+  it('moveToTrash aborts cleanly when source does not exist and no agent has a local copy', async () => {
     const { moveToTrash } = await trashServicePromise
+    // No source-skill, no agent copy: pure ghost — moveToTrash should reject
+    // with "already deleted". The previous version of this test passed a fake
+    // sourcePath; the new signature derives sourcePath from skillName itself,
+    // so we just verify the missing-everywhere case still surfaces ENOENT.
     const skillName = 'ghost-skill'
-    const fakeSourcePath = join(sharedSourceDir, skillName)
 
-    await expect(moveToTrash(skillName, fakeSourcePath)).rejects.toThrow(
-      /already deleted/i,
-    )
+    await expect(moveToTrash(skillName)).rejects.toThrow(/already deleted/i)
   })
 
   it('produces unique tombstone ids when two calls happen in the same ms', async () => {
     const { moveToTrash } = await trashServicePromise
     const [a, b] = await Promise.all([
       (async () => {
-        const p = await makeSourceSkill('race-a')
-        return moveToTrash('race-a', p)
+        await makeSourceSkill('race-a')
+        return moveToTrash('race-a')
       })(),
       (async () => {
-        const p = await makeSourceSkill('race-b')
-        return moveToTrash('race-b', p)
+        await makeSourceSkill('race-b')
+        return moveToTrash('race-b')
       })(),
     ])
     expect(a.tombstoneId).not.toBe(b.tombstoneId)
@@ -232,8 +280,8 @@ describe('trashService (integration)', () => {
 
     // Fresh entry: should survive the sweep.
     const skillName = 'sweep-recent'
-    const sourcePath = await makeSourceSkill(skillName)
-    const recent = await moveToTrash(skillName, sourcePath)
+    await makeSourceSkill(skillName)
+    const recent = await moveToTrash(skillName)
 
     // Planted ancient entry: must be swept.
     // Its basename must still match the trash naming regex (digits-skill-hex8).
@@ -254,8 +302,8 @@ describe('trashService (integration)', () => {
     const { moveToTrash, evict, restore } = await trashServicePromise
 
     const skillName = 'evict-then-restore'
-    const sourcePath = await makeSourceSkill(skillName)
-    const result = await moveToTrash(skillName, sourcePath)
+    await makeSourceSkill(skillName)
+    const result = await moveToTrash(skillName)
 
     await evict(result.tombstoneId)
     const restoreResult = await restore(result.tombstoneId)
@@ -275,7 +323,7 @@ describe('trashService (integration)', () => {
 
     const skillName = 'manifest-check'
     const sourcePath = await makeSourceSkill(skillName)
-    const result = await moveToTrash(skillName, sourcePath)
+    const result = await moveToTrash(skillName)
 
     const manifestPath = join(
       sharedTrashDir,
@@ -285,12 +333,14 @@ describe('trashService (integration)', () => {
     const raw = await readFile(manifestPath, 'utf-8')
     const manifest = JSON.parse(raw) as {
       schemaVersion: number
+      kind: string
       symlinks: unknown[]
       deletedAt: number
       skillName: string
       sourcePath: string
     }
-    expect(manifest.schemaVersion).toBe(1)
+    expect(manifest.schemaVersion).toBe(2)
+    expect(manifest.kind).toBe('source-backed')
     expect(manifest.skillName).toBe(skillName)
     expect(manifest.sourcePath).toBe(sourcePath)
     expect(Array.isArray(manifest.symlinks)).toBe(true)
@@ -301,8 +351,8 @@ describe('trashService (integration)', () => {
     const { moveToTrash } = await trashServicePromise
 
     const skillName = 'nested-source'
-    const sourcePath = await makeSourceSkill(skillName)
-    const result = await moveToTrash(skillName, sourcePath)
+    await makeSourceSkill(skillName)
+    const result = await moveToTrash(skillName)
 
     // The moved source must live under entry/source.
     const trashSourceChild = join(
@@ -313,6 +363,150 @@ describe('trashService (integration)', () => {
     )
     const moved = await readFile(trashSourceChild, 'utf-8')
     expect(moved).toContain(skillName)
+  })
+
+  // ---------------------------------------------------------------------
+  // Local-only skill tests (regression coverage for the bug where clicking
+  // X on a skill that lived only inside an agent dir — no source — produced
+  // "Bulk delete failed - Deleted 0 of 1 skill". The fix teaches moveToTrash
+  // to detect that case via `scanLocalCopies`, stage each agent folder under
+  // `<entryDir>/local-copies/<agentId>/`, and write a v2 local-only manifest
+  // that `restore()` can put back agent-by-agent.)
+  // ---------------------------------------------------------------------
+
+  it('moveToTrash handles a local-only skill (no source, single agent copy)', async () => {
+    const { moveToTrash } = await trashServicePromise
+
+    const skillName = 'architecture-decision-records'
+    const localPath = await makeLocalSkill(skillName, sharedAgentClaude)
+    // Sanity precondition: real folder, no source dir.
+    await stat(localPath)
+    await expect(stat(join(sharedSourceDir, skillName))).rejects.toThrow()
+
+    const deleteResult = await moveToTrash(skillName)
+    expect(deleteResult.cascadeAgents).toContain('claude-code')
+    // The local copy is staged under entryDir/local-copies — count it for parity
+    // with the source-backed path so the renderer's "skills removed" toast works.
+    expect(deleteResult.symlinksRemoved).toBe(1)
+
+    // The agent folder is gone.
+    await expect(stat(localPath)).rejects.toThrow()
+
+    // The staged copy lives under <entryDir>/local-copies/<agentId>/SKILL.md.
+    const stagedSkill = join(
+      sharedTrashDir,
+      deleteResult.tombstoneId,
+      'local-copies',
+      'claude-code',
+      'SKILL.md',
+    )
+    const stagedContents = await readFile(stagedSkill, 'utf-8')
+    expect(stagedContents).toContain(skillName)
+
+    // Manifest is v2 local-only.
+    const manifestPath = join(
+      sharedTrashDir,
+      deleteResult.tombstoneId,
+      'manifest.json',
+    )
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as {
+      schemaVersion: number
+      kind: string
+      skillName: string
+      localCopies: Array<{ agentId: string; linkPath: string }>
+    }
+    expect(manifest.schemaVersion).toBe(2)
+    expect(manifest.kind).toBe('local-only')
+    expect(manifest.skillName).toBe(skillName)
+    expect(manifest.localCopies).toHaveLength(1)
+    expect(manifest.localCopies[0]?.agentId).toBe('claude-code')
+    expect(manifest.localCopies[0]?.linkPath).toBe(localPath)
+  })
+
+  it('round-trip: deletes a local-only skill and restores it back into the agent dir', async () => {
+    const { moveToTrash, restore } = await trashServicePromise
+
+    const skillName = 'local-round-trip'
+    const localPath = await makeLocalSkill(skillName, sharedAgentClaude)
+
+    const deleteResult = await moveToTrash(skillName)
+    await expect(stat(localPath)).rejects.toThrow()
+
+    const restoreResult = await restore(deleteResult.tombstoneId)
+    expect(restoreResult.outcome).toBe('restored')
+    if (restoreResult.outcome === 'restored') {
+      expect(restoreResult.symlinksRestored).toBe(1)
+      expect(restoreResult.symlinksSkipped).toBe(0)
+    }
+
+    // Folder is back at its original agent path with original contents.
+    const restoredSkill = await readFile(join(localPath, 'SKILL.md'), 'utf-8')
+    expect(restoredSkill).toContain(skillName)
+    // No leftover source dir (local-only restore must not plant SOURCE_DIR/<name>).
+    await expect(stat(join(sharedSourceDir, skillName))).rejects.toThrow()
+    // Trash entry is gone.
+    await expect(
+      stat(join(sharedTrashDir, deleteResult.tombstoneId)),
+    ).rejects.toThrow()
+  })
+
+  it('source-backed flow wins when both source and a local copy exist', async () => {
+    // Disambiguates the dispatch in moveToTrash: if SOURCE_DIR/<name> exists,
+    // we must NOT fall through to local-only even when an agent dir also has
+    // a real folder by the same name (rare but possible, e.g. user manually
+    // copied the source into an agent dir bypassing the symlink workflow).
+    const { moveToTrash } = await trashServicePromise
+
+    const skillName = 'mixed-state-skill'
+    const sourcePath = await makeSourceSkill(skillName)
+    // Plant a real folder under .claude/skills with the same name. The
+    // source-backed cascade walks AGENTS but only touches *symlinks*, so this
+    // local copy must be left alone untouched.
+    const orphanLocal = await makeLocalSkill(skillName, sharedAgentClaude)
+
+    const deleteResult = await moveToTrash(skillName)
+
+    // Source went into trash entry under /source.
+    await expect(stat(sourcePath)).rejects.toThrow()
+    const stagedSource = join(
+      sharedTrashDir,
+      deleteResult.tombstoneId,
+      'source',
+      'SKILL.md',
+    )
+    expect((await readFile(stagedSource, 'utf-8')).length).toBeGreaterThan(0)
+
+    // Manifest is source-backed (NOT local-only).
+    const manifest = JSON.parse(
+      await readFile(
+        join(sharedTrashDir, deleteResult.tombstoneId, 'manifest.json'),
+        'utf-8',
+      ),
+    ) as { kind: string }
+    expect(manifest.kind).toBe('source-backed')
+
+    // Orphan local folder under .claude is untouched — this matches the
+    // documented "leave non-symlink dirs in agent dirs alone" invariant in
+    // moveSourceBackedToTrash. The user can clean it up themselves later.
+    await stat(orphanLocal)
+  })
+
+  it('regression: moveToTrash no longer throws "already deleted" when only an agent-side local folder exists', async () => {
+    // Direct repro of the user-reported bug. Pre-fix, the IPC handler called
+    // moveToTrash with sourcePath = SOURCE_DIR/<name>, which didn't exist for
+    // local-only skills, so the fs.stat probe failed with ENOENT and surfaced
+    // "Skill not found (already deleted?)" even though the skill was clearly
+    // present in .claude/skills. Post-fix, scanLocalCopies finds the agent
+    // folder and dispatches to moveLocalOnlyToTrash.
+    const { moveToTrash } = await trashServicePromise
+
+    const skillName = 'regression-local-only'
+    await makeLocalSkill(skillName, sharedAgentClaude)
+
+    await expect(moveToTrash(skillName)).resolves.toMatchObject({
+      cascadeAgents: ['claude-code'],
+      symlinksRemoved: 1,
+    })
   })
 })
 

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -121,13 +121,21 @@ async function rollbackRemovedSymlinks(
  * agent linkPath. Mirrors `rollbackRemovedSymlinks` for the local-only flow.
  * Errors are logged per copy and the function never throws — the caller is
  * about to surface the original failure and that must not be masked.
+ *
+ * Returns the subset of copies that could NOT be restored. The caller MUST
+ * use this list to decide whether the staged trash entry is still the only
+ * surviving copy of the data: if any restore failed, the staged folder under
+ * `<entryDir>/local-copies/<agentId>/` is the user's only remaining copy and
+ * the entryDir MUST NOT be deleted.
  * @param entryDir - Trash entry root (contains `local-copies/<agentId>/`)
  * @param copies - Local copies that were moved during the failing forward pass
+ * @returns The copies whose restore failed (empty array means full success)
  */
 async function rollbackMovedLocalCopies(
   entryDir: string,
   copies: RecordedLocalCopy[],
-): Promise<void> {
+): Promise<RecordedLocalCopy[]> {
+  const unrestoredCopies: RecordedLocalCopy[] = []
   for (const copy of copies) {
     const stagedPath = join(entryDir, 'local-copies', copy.agentId)
     try {
@@ -149,8 +157,10 @@ async function rollbackMovedLocalCopies(
         code: errorCode(error),
         message: extractErrorMessage(error),
       })
+      unrestoredCopies.push(copy)
     }
   }
+  return unrestoredCopies
 }
 
 /**
@@ -563,11 +573,25 @@ async function moveLocalOnlyToTrash(
         }))
 
       if (recoveryOutcome.kind === 'fatal') {
-        await rollbackMovedLocalCopies(entryDir, moved)
-        await fs.rm(entryDir, { recursive: true, force: true }).catch(() => {
-          // best-effort cleanup
-        })
-        throw recoveryOutcome.error
+        const unrestoredCopies = await rollbackMovedLocalCopies(entryDir, moved)
+        if (unrestoredCopies.length === 0) {
+          // All copies restored — safe to drop the staged entry dir.
+          await fs.rm(entryDir, { recursive: true, force: true }).catch(() => {
+            // best-effort cleanup
+          })
+          throw recoveryOutcome.error
+        }
+        // One or more copies could not be restored. The staged folder under
+        // <entryDir>/local-copies/<agentId>/ is the ONLY remaining copy of
+        // the user's data. Preserve entryDir and surface a recovery hint so
+        // the caller (and ultimately the UI) can guide the user to it.
+        const strandedAgents = unrestoredCopies
+          .map((copy) => copy.agentId)
+          .join(', ')
+        throw new TrashError(
+          `${recoveryOutcome.error.message}; ${unrestoredCopies.length} local copy/copies stranded in ${entryDir}/local-copies (agents: ${strandedAgents})`,
+          recoveryOutcome.error.code,
+        )
       }
       if (recoveryOutcome.kind === 'moved') {
         moved.push(copy)
@@ -597,13 +621,25 @@ async function moveLocalOnlyToTrash(
     const manifestWriteCode = errorCode(manifestWriteError)
     const manifestWriteMessage = extractErrorMessage(manifestWriteError)
 
-    await rollbackMovedLocalCopies(entryDir, moved)
-    await fs.rm(entryDir, { recursive: true, force: true }).catch(() => {
-      // best-effort cleanup
-    })
-
+    const unrestoredCopies = await rollbackMovedLocalCopies(entryDir, moved)
+    if (unrestoredCopies.length === 0) {
+      // All copies restored — safe to drop the staged entry dir.
+      await fs.rm(entryDir, { recursive: true, force: true }).catch(() => {
+        // best-effort cleanup
+      })
+      throw new TrashError(
+        `Failed to write trash manifest: ${manifestWriteMessage}`,
+        manifestWriteCode,
+      )
+    }
+    // Manifest write failed AND rollback could not restore every copy. The
+    // staged folder is the ONLY remaining copy of the user's data — keep
+    // entryDir intact so they can recover manually from local-copies/.
+    const strandedAgents = unrestoredCopies
+      .map((copy) => copy.agentId)
+      .join(', ')
     throw new TrashError(
-      `Failed to write trash manifest: ${manifestWriteMessage}`,
+      `Failed to write trash manifest: ${manifestWriteMessage}; ${unrestoredCopies.length} local copy/copies stranded in ${entryDir}/local-copies (agents: ${strandedAgents})`,
       manifestWriteCode,
     )
   }

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -66,6 +66,16 @@ export interface RecordedSymlink {
 }
 
 /**
+ * Record of a real (non-symlink) skill folder under an agent dir that was
+ * moved into the trash. Used for local-only skills (no `~/.agents/skills/<name>`
+ * source exists; the skill lives directly in one or more agent directories).
+ */
+export interface RecordedLocalCopy {
+  agentId: AgentId
+  linkPath: AbsolutePath
+}
+
+/**
  * Build a unique trash entry name from skillName + current clock + random suffix.
  * `rand8hex` prevents same-ms collisions on fast machines (reviewer iter-2 HIGH-4).
  * @param skillName - Validated skill name (no path separators)
@@ -107,28 +117,159 @@ async function rollbackRemovedSymlinks(
 }
 
 /**
- * Move a skill source directory + its symlinks into the on-disk trash.
- *
- * Lifecycle:
- * 1. `mkdir(TRASH_DIR)` idempotent (fresh-install safe).
- * 2. Generate `entryName = <unix_ms>-<skillName>-<rand8hex>`.
- * 3. Walk agent dirs, read symlinks, record them, unlink each symlink. On any
- *    non-ENOENT unlink failure: abort before rename, no trash entry created,
- *    source stays in place — surfaces as per-item error in caller.
- * 4. `fs.rename(sourcePath, entryDir/source)`. On EXDEV: fall back to `fs.cp` + `fs.rm`.
- * 5. Write `manifest.json` with `schemaVersion:1`.
- * 6. Schedule TTL evict timer keyed in `evictTimers`.
- *
- * @param skillName - Validated skill name (no path separators)
- * @param sourcePath - Absolute path to the skill source directory (already validated)
- * @returns Tombstone id + cascadeAgents + symlinksRemoved for the caller's result
- * @throws Error with user-facing message when unlink fails with non-ENOENT code
- *   or rename/cp fallback cannot move the source
- * @example
- * const result = await moveToTrash('theme-generator', '/Users/me/.agents/skills/theme-generator')
- * // { tombstoneId: '1729180800000-theme-generator-a1b2c3d4', cascadeAgents: ['cursor'], symlinksRemoved: 1 }
+ * Best-effort rename each previously-moved local copy back to its original
+ * agent linkPath. Mirrors `rollbackRemovedSymlinks` for the local-only flow.
+ * Errors are logged per copy and the function never throws — the caller is
+ * about to surface the original failure and that must not be masked.
+ * @param entryDir - Trash entry root (contains `local-copies/<agentId>/`)
+ * @param copies - Local copies that were moved during the failing forward pass
  */
-export async function moveToTrash(
+async function rollbackMovedLocalCopies(
+  entryDir: string,
+  copies: RecordedLocalCopy[],
+): Promise<void> {
+  for (const copy of copies) {
+    const stagedPath = join(entryDir, 'local-copies', copy.agentId)
+    try {
+      await fs.mkdir(dirname(copy.linkPath), { recursive: true })
+      try {
+        await fs.rename(stagedPath, copy.linkPath)
+      } catch (renameError) {
+        if (errorCode(renameError) === 'EXDEV') {
+          await fs.cp(stagedPath, copy.linkPath, { recursive: true })
+          await fs.rm(stagedPath, { recursive: true, force: true })
+        } else {
+          throw renameError
+        }
+      }
+    } catch (error) {
+      console.warn('trashService: rollback local copy failed', {
+        agentId: copy.agentId,
+        linkPath: copy.linkPath,
+        code: errorCode(error),
+        message: extractErrorMessage(error),
+      })
+    }
+  }
+}
+
+/**
+ * Walk every configured agent directory and find real (non-symlink) folders
+ * matching `skillName`. Used by `moveToTrash` when `~/.agents/skills/<name>`
+ * has no source dir but the skill exists as a local copy in one or more agents.
+ *
+ * Symlinks are deliberately ignored here — for local-only delete we only move
+ * real directories. A stray symlink pointing at one of those copies will become
+ * broken after delete and is surfaced by the next scan as a "broken" entry.
+ *
+ * @param skillName - Validated skill name (no separators)
+ * @returns Per-agent local copy records, ordered by AGENTS iteration
+ */
+async function scanLocalCopies(
+  skillName: SkillName,
+): Promise<RecordedLocalCopy[]> {
+  const copies: RecordedLocalCopy[] = []
+  for (const agent of AGENTS) {
+    const linkPath = join(agent.path, skillName)
+    try {
+      // For real directories validation can use [agent.path] specifically —
+      // unlike symlinks, realpath stops at the directory itself, which lives
+      // inside the agent's allowed base.
+      validatePath(linkPath, [agent.path])
+    } catch {
+      continue
+    }
+    let stats: Awaited<ReturnType<typeof fs.lstat>>
+    try {
+      stats = await fs.lstat(linkPath)
+    } catch (error) {
+      if (errorCode(error) === 'ENOENT') continue
+      // Permission error or other — log and skip this agent rather than abort
+      // the whole scan; the user can retry once they've fixed perms.
+      console.warn('trashService: scanLocalCopies lstat failed', {
+        agentId: agent.id,
+        linkPath,
+        code: errorCode(error),
+        message: extractErrorMessage(error),
+      })
+      continue
+    }
+    if (stats.isDirectory() && !stats.isSymbolicLink()) {
+      copies.push({ agentId: agent.id, linkPath: linkPath as AbsolutePath })
+    }
+  }
+  return copies
+}
+
+/**
+ * Move a skill into the on-disk trash. The skill may be:
+ * - **source-backed**: `~/.agents/skills/<name>` exists; agent entries are
+ *   symlinks pointing at it. Move source + unlink every symlink.
+ * - **local-only**: no source dir; one or more agents hold the skill as a real
+ *   folder. Move every real folder into `<entryDir>/local-copies/<agentId>/`.
+ *
+ * Both flows write a v2 manifest with a `kind` discriminator that `restore()`
+ * matches on. TTL eviction is scheduled regardless of kind.
+ *
+ * @param skillName - Validated skill name (no path separators, enforced by Zod)
+ * @returns Tombstone id + cascadeAgents + symlinksRemoved for the caller's result
+ * @throws TrashError when the skill cannot be located in either form, or any
+ *   filesystem op fails non-recoverably mid-move
+ * @example
+ * // source-backed
+ * const result = await moveToTrash('theme-generator')
+ * // { tombstoneId: '1729...-theme-generator-a1b2c3d4', cascadeAgents: ['cursor'], symlinksRemoved: 1 }
+ * @example
+ * // local-only (skill lives in ~/.claude/skills/architecture-decision-records)
+ * const result = await moveToTrash('architecture-decision-records')
+ * // { tombstoneId: '1729...-architecture-decision-records-...', cascadeAgents: ['claude'], symlinksRemoved: 1 }
+ */
+export async function moveToTrash(skillName: SkillName): Promise<{
+  tombstoneId: TombstoneId
+  cascadeAgents: AgentId[]
+  symlinksRemoved: number
+}> {
+  // Construct sourcePath from the (Zod-validated) skill name and re-check it
+  // against SOURCE_DIR for defense in depth — even though the renderer never
+  // passes a path, this keeps the file's invariants self-evident if a future
+  // caller forgets to validate.
+  const sourcePath = join(SOURCE_DIR, skillName) as AbsolutePath
+  validatePath(sourcePath, [SOURCE_DIR])
+
+  // Probe the source dir. If it exists, source-backed flow. Otherwise scan
+  // agent dirs for local copies and dispatch to local-only flow if found.
+  let sourceExists = false
+  try {
+    await fs.stat(sourcePath)
+    sourceExists = true
+  } catch (error) {
+    const code = errorCode(error)
+    if (code !== 'ENOENT') {
+      throw new TrashError(
+        `Failed to inspect skill source: ${extractErrorMessage(error)}`,
+        code,
+      )
+    }
+  }
+
+  if (sourceExists) {
+    return moveSourceBackedToTrash(skillName, sourcePath)
+  }
+
+  const localCopies = await scanLocalCopies(skillName)
+  if (localCopies.length === 0) {
+    throw new TrashError('Skill not found (already deleted?)', 'ENOENT')
+  }
+  return moveLocalOnlyToTrash(skillName, localCopies)
+}
+
+/**
+ * Source-backed path of `moveToTrash`. Walks agent dirs, removes symlinks,
+ * renames the source dir into the entry, writes a v2 source-backed manifest.
+ * Same lifecycle as the original v0.13.x implementation, just gated on the
+ * source-existed branch in the wrapper.
+ */
+async function moveSourceBackedToTrash(
   skillName: SkillName,
   sourcePath: AbsolutePath,
 ): Promise<{
@@ -260,7 +401,8 @@ export async function moveToTrash(
   // restore would be impossible. Roll back (source → original path, re-create
   // symlinks, drop trash entry) before surfacing the error to the caller.
   const manifest = {
-    schemaVersion: 1 as const,
+    schemaVersion: 2 as const,
+    kind: 'source-backed' as const,
     deletedAt: Date.now(),
     skillName,
     sourcePath,
@@ -334,7 +476,7 @@ export async function moveToTrash(
   }, TRASH_TTL_MS)
   evictTimers.set(id, timer)
 
-  console.info('trashService: moveToTrash', {
+  console.info('trashService: moveToTrash (source-backed)', {
     skillName,
     entryName,
     symlinkCount: recordedSymlinks.length,
@@ -345,6 +487,144 @@ export async function moveToTrash(
     tombstoneId: id,
     cascadeAgents: cascadeAgentIds,
     symlinksRemoved: recordedSymlinks.length,
+  }
+}
+
+/**
+ * Local-only path of `moveToTrash`. The skill exists only as real folders
+ * inside one or more agent dirs (no `~/.agents/skills/<name>` source).
+ *
+ * Lifecycle:
+ * 1. `mkdir(<entryDir>/local-copies)` to host the staged folders.
+ * 2. For each `RecordedLocalCopy`, `fs.rename(linkPath → <entryDir>/local-copies/<agentId>)`.
+ *    On EXDEV: cp + rm fallback. On per-copy failure: rollback (rename already-moved
+ *    copies back to their linkPaths) before throwing.
+ * 3. Write v2 local-only manifest. On manifest-write failure: rollback all moved
+ *    copies and drop the entry dir.
+ * 4. Schedule TTL evict timer.
+ *
+ * `cascadeAgents` is the list of agents whose local copies were moved;
+ * `symlinksRemoved` carries the same count for parity with the source-backed
+ * return shape (the renderer treats it as "things removed from agent dirs").
+ */
+async function moveLocalOnlyToTrash(
+  skillName: SkillName,
+  localCopies: RecordedLocalCopy[],
+): Promise<{
+  tombstoneId: TombstoneId
+  cascadeAgents: AgentId[]
+  symlinksRemoved: number
+}> {
+  const startTime = Date.now()
+  await fs.mkdir(TRASH_DIR, { recursive: true, mode: 0o755 })
+
+  const entryName = buildEntryName(skillName)
+  const entryDir = join(TRASH_DIR, entryName)
+  const localCopiesRoot = join(entryDir, 'local-copies')
+  const manifestPath = join(entryDir, 'manifest.json')
+
+  await fs.mkdir(localCopiesRoot, { recursive: true })
+
+  // Move each agent's real folder into <entryDir>/local-copies/<agentId>/.
+  // Track successfully-moved copies so a mid-loop failure can be rolled back.
+  const moved: RecordedLocalCopy[] = []
+  for (const copy of localCopies) {
+    const stagedPath = join(localCopiesRoot, copy.agentId)
+    try {
+      await fs.rename(copy.linkPath, stagedPath)
+      moved.push(copy)
+    } catch (error) {
+      const code = errorCode(error)
+      // EXDEV across volumes — fall back to cp + rm. ENOENT means the copy
+      // disappeared mid-flight (race); skip and continue rather than abort.
+      const recoveryOutcome = await match(code)
+        .with('EXDEV', async () => {
+          try {
+            await fs.cp(copy.linkPath, stagedPath, { recursive: true })
+            await fs.rm(copy.linkPath, { recursive: true, force: true })
+            return { kind: 'moved' as const }
+          } catch (fallbackError) {
+            return {
+              kind: 'fatal' as const,
+              error: new TrashError(
+                `Failed to move local copy (cross-device, agent=${copy.agentId}): ${extractErrorMessage(fallbackError)}`,
+                errorCode(fallbackError),
+              ),
+            }
+          }
+        })
+        .with('ENOENT', async () => ({ kind: 'race-skip' as const }))
+        .otherwise(async () => ({
+          kind: 'fatal' as const,
+          error: new TrashError(
+            `Failed to move local copy (agent=${copy.agentId}): ${extractErrorMessage(error)}`,
+            code,
+          ),
+        }))
+
+      if (recoveryOutcome.kind === 'fatal') {
+        await rollbackMovedLocalCopies(entryDir, moved)
+        await fs.rm(entryDir, { recursive: true, force: true }).catch(() => {
+          // best-effort cleanup
+        })
+        throw recoveryOutcome.error
+      }
+      if (recoveryOutcome.kind === 'moved') {
+        moved.push(copy)
+      }
+      // race-skip: copy vanished, leave moved unchanged.
+    }
+  }
+
+  if (moved.length === 0) {
+    // Every copy raced away — nothing to tombstone.
+    await fs.rm(entryDir, { recursive: true, force: true }).catch(() => {
+      // best-effort cleanup
+    })
+    throw new TrashError('Skill not found (already deleted?)', 'ENOENT')
+  }
+
+  const manifest = {
+    schemaVersion: 2 as const,
+    kind: 'local-only' as const,
+    deletedAt: Date.now(),
+    skillName,
+    localCopies: moved,
+  }
+  try {
+    await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf-8')
+  } catch (manifestWriteError) {
+    const manifestWriteCode = errorCode(manifestWriteError)
+    const manifestWriteMessage = extractErrorMessage(manifestWriteError)
+
+    await rollbackMovedLocalCopies(entryDir, moved)
+    await fs.rm(entryDir, { recursive: true, force: true }).catch(() => {
+      // best-effort cleanup
+    })
+
+    throw new TrashError(
+      `Failed to write trash manifest: ${manifestWriteMessage}`,
+      manifestWriteCode,
+    )
+  }
+
+  const id = tombstoneId(entryName)
+  const timer = setTimeout(() => {
+    void evict(id)
+  }, TRASH_TTL_MS)
+  evictTimers.set(id, timer)
+
+  console.info('trashService: moveToTrash (local-only)', {
+    skillName,
+    entryName,
+    localCopyCount: moved.length,
+    durationMs: Date.now() - startTime,
+  })
+
+  return {
+    tombstoneId: id,
+    cascadeAgents: moved.map((c) => c.agentId),
+    symlinksRemoved: moved.length,
   }
 }
 
@@ -378,14 +658,12 @@ export async function evict(id: TombstoneId): Promise<void> {
  * Preconditions checked in order (first failure is fatal for this item):
  * (a) Entry dir exists.
  * (b) Manifest readable + schema-valid (Zod).
- * (c) Source path free (no collision with a reinstalled skill).
  *
- * Per-symlink: if target is gone (volume unmounted, source moved) OR the
- * agent's linkPath is occupied by something else → skip that symlink only,
- * count in `symlinksSkipped`; keep going with other links.
+ * Dispatches to source-backed or local-only flow based on `manifest.kind`.
+ * Per-record skips (collision, missing target, tampered path) are counted in
+ * `symlinksSkipped`; the operation is reported as `outcome: 'restored'` even
+ * if zero records succeeded — the entry has at least been moved out of trash.
  *
- * On success: rename source back, recreate surviving symlinks, remove trash
- * dir, cancel pending evict timer.
  * @param id - Tombstone id (already validated)
  * @returns RestoreDeletedSkillResult (discriminated union on `outcome`)
  * @example
@@ -397,7 +675,6 @@ export async function restore(
 ): Promise<RestoreDeletedSkillResult> {
   const startTime = Date.now()
   const entryDir = join(TRASH_DIR, id)
-  const entrySourceDir = join(entryDir, 'source')
   const manifestPath = join(entryDir, 'manifest.json')
 
   // (a) Entry exists.
@@ -435,6 +712,39 @@ export async function restore(
     }
   }
 
+  // Dispatch on manifest.kind. Both branches own their own cleanup + timer
+  // cancellation so the wrapper stays a thin router.
+  const result = await match(manifest)
+    .with({ kind: 'source-backed' }, async (m) =>
+      restoreSourceBacked(id, entryDir, m),
+    )
+    .with({ kind: 'local-only' }, async (m) =>
+      restoreLocalOnly(id, entryDir, m),
+    )
+    .exhaustive()
+
+  console.info('trashService: restore', {
+    tombstoneId: id,
+    kind: manifest.kind,
+    durationMs: Date.now() - startTime,
+  })
+
+  return result
+}
+
+/**
+ * Restore a source-backed tombstone: rename `<entryDir>/source` back to its
+ * original `~/.agents/skills/<name>` path, then walk the manifest's recorded
+ * symlinks and recreate each in its agent dir. Per-link skips are counted but
+ * never abort the operation.
+ */
+async function restoreSourceBacked(
+  id: TombstoneId,
+  entryDir: string,
+  manifest: Extract<z.infer<typeof manifestSchema>, { kind: 'source-backed' }>,
+): Promise<RestoreDeletedSkillResult> {
+  const entrySourceDir = join(entryDir, 'source')
+
   // Validate sourcePath is within SOURCE_DIR specifically — skill sources
   // always live there. A tampered manifest could otherwise claim sourcePath
   // is in an agent dir and restore would happily plant the files there.
@@ -449,7 +759,7 @@ export async function restore(
     }
   }
 
-  // (c) Source path free.
+  // Source path free?
   try {
     await fs.stat(manifest.sourcePath)
     return {
@@ -555,26 +865,104 @@ export async function restore(
     }
   }
 
-  // Cleanup: remove trash entry + cancel evict timer.
-  const pendingTimer = evictTimers.get(id)
-  if (pendingTimer) {
-    clearTimeout(pendingTimer)
-    evictTimers.delete(id)
-  }
-  await fs.rm(entryDir, { recursive: true, force: true })
-
-  console.info('trashService: restore', {
-    tombstoneId: id,
-    symlinksRestored,
-    symlinksSkipped,
-    durationMs: Date.now() - startTime,
-  })
+  await finalizeRestore(id, entryDir)
 
   return {
     outcome: 'restored',
     symlinksRestored,
     symlinksSkipped,
   }
+}
+
+/**
+ * Restore a local-only tombstone: for each `localCopies[i]`, rename
+ * `<entryDir>/local-copies/<agentId>/` back to its original `linkPath`.
+ * Per-copy collisions or unknown agents skip cleanly — partial restores are
+ * still reported as `outcome: 'restored'` with `symlinksSkipped > 0`.
+ *
+ * Reuses `symlinksRestored`/`symlinksSkipped` for parity with source-backed
+ * — both fields semantically count "agent-side restorations" regardless of
+ * whether the underlying op was a symlink or a directory rename.
+ */
+async function restoreLocalOnly(
+  id: TombstoneId,
+  entryDir: string,
+  manifest: Extract<z.infer<typeof manifestSchema>, { kind: 'local-only' }>,
+): Promise<RestoreDeletedSkillResult> {
+  let symlinksRestored = 0
+  let symlinksSkipped = 0
+  const localCopiesRoot = join(entryDir, 'local-copies')
+
+  for (const copy of manifest.localCopies) {
+    const agent = AGENTS.find((a) => a.id === copy.agentId)
+    if (!agent) {
+      symlinksSkipped++
+      continue
+    }
+    // Re-validate linkPath stays inside this agent's base. Tampered manifest
+    // could otherwise plant the folder somewhere outside the agent dir.
+    try {
+      validatePath(copy.linkPath, [agent.path])
+    } catch {
+      symlinksSkipped++
+      continue
+    }
+    // linkPath free?
+    try {
+      await fs.lstat(copy.linkPath)
+      // Something already exists at the destination; skip rather than overwrite.
+      symlinksSkipped++
+      continue
+    } catch (error) {
+      if (errorCode(error) !== 'ENOENT') {
+        symlinksSkipped++
+        continue
+      }
+      // ENOENT = free, proceed.
+    }
+    const stagedPath = join(localCopiesRoot, copy.agentId)
+    try {
+      await fs.mkdir(agent.path, { recursive: true })
+      try {
+        await fs.rename(stagedPath, copy.linkPath)
+      } catch (renameError) {
+        if (errorCode(renameError) === 'EXDEV') {
+          await fs.cp(stagedPath, copy.linkPath, { recursive: true })
+          await fs.rm(stagedPath, { recursive: true, force: true })
+        } else {
+          throw renameError
+        }
+      }
+      symlinksRestored++
+    } catch {
+      symlinksSkipped++
+    }
+  }
+
+  await finalizeRestore(id, entryDir)
+
+  return {
+    outcome: 'restored',
+    symlinksRestored,
+    symlinksSkipped,
+  }
+}
+
+/**
+ * Shared restore postlude: cancel pending evict timer + remove the trash entry
+ * directory. Best-effort; called after both source-backed and local-only
+ * restorations succeed past their per-record loop.
+ */
+async function finalizeRestore(
+  id: TombstoneId,
+  entryDir: string,
+): Promise<void> {
+  const pendingTimer = evictTimers.get(id)
+  if (pendingTimer) {
+    clearTimeout(pendingTimer)
+    evictTimers.delete(id)
+  }
+  await fs.rm(entryDir, { recursive: true, force: true })
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes user-reported bug: clicking X on a local-only skill (e.g. `architecture-decision-records`) showed "Bulk delete failed - Deleted 0 of 1 skill". The skill had no `~/.agents/skills/<name>/` source dir — only an agent-side copy under `~/.codex/skills/<name>/` — and `moveToTrash` rejected it before even probing the real on-disk shape.

**Changes:**
- `src/main/ipc/skills.ts` — drop the SOURCE_DIR pre-validation; trashService now dispatches itself.
- `src/main/services/trashService.ts` — add `scanLocalCopies` + local-only branch. `moveToTrash` probes source first, falls through to local-only when only an agent-side folder exists. `restore()` round-trips it back to the original `linkPath`.
- `src/main/ipc/ipc-schemas.ts` — manifest v1 → v2 with `kind: 'source-backed' | 'local-only'` discriminator. Legacy v1 manifests on disk normalize to v2 via Zod `.transform()` (backward compatible — exercised by `trashService.restore.test.ts`).
- `src/main/services/trashService.integration.test.ts` — 4 new tests:
  - `moveToTrash handles a local-only skill` — happy path
  - `round-trip: deletes a local-only skill and restores it back into the agent dir`
  - `source-backed flow wins when both source and a local copy exist` — dispatch precedence
  - `regression: moveToTrash no longer throws "already deleted" when only an agent-side local folder exists` — direct repro

## Test Coverage

778/778 tests pass (52 files). Integration tests cover the exact user-reported failure mode + 3 adjacent cases. Type and lint clean.

## Verification

Live UI verification was attempted via `electron-playwright-cli` but blocked by upstream `playwright` peer-dep mismatch. Workaround via `playwright-cli attach --cdp=http://localhost:9222` was confirmed working but not run end-to-end this session. Service-layer integration tests are the strongest verification short of a manual click-through. See `qa-reports/electron-2026-04-27-skills-desktop-darwin.md` for full QA report. Tracking the tooling migration in #105.

## Test plan
- [x] `pnpm test` — 778/778 pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [ ] Manual UI click-through (deferred — see QA report)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * エージェントのみに存在するスキル（ローカルオンリースキル）の削除・復元機能を追加しました。

* **改善**
  * スキル削除時の処理を最適化し、より安定した削除・復元動作を実現しました。
  * ゴミ箱マニフェスト形式をv2に更新し、複数のスキル配置パターンに対応できるようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->