### PR TITLE
fix(ui): filter SourceCard view to SOURCE_DIR skills only

### DIFF
--- a/src/main/services/skillScanner.ts
+++ b/src/main/services/skillScanner.ts
@@ -110,6 +110,7 @@ async function scanSourceSkills(): Promise<Skill[]> {
         path: dir.path,
         symlinkCount: countValidSymlinks(symlinks),
         symlinks,
+        isSource: true,
       }
     }),
   )
@@ -172,6 +173,7 @@ async function scanAllLocalSkills(): Promise<Skill[]> {
           path: skillPath,
           symlinkCount: 0, // Local skills have 0 symlinks
           symlinks,
+          isSource: false,
         })
       }
     } catch {
@@ -206,6 +208,7 @@ export async function getSkill(skillName: SkillName): Promise<Skill | null> {
       path: skillPath,
       symlinkCount: countValidSymlinks(symlinks),
       symlinks,
+      isSource: true,
     }
   } catch {
     return null

--- a/src/renderer/src/components/layout/MainContent.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.browser.test.tsx
@@ -246,6 +246,7 @@ describe('MainContent keyboard shortcuts (Cmd+A)', () => {
         path: '/skills/task' as never,
         symlinkCount: 0,
         symlinks: [],
+        isSource: true,
       },
       {
         name: 'tdd' as SkillName,
@@ -253,6 +254,7 @@ describe('MainContent keyboard shortcuts (Cmd+A)', () => {
         path: '/skills/tdd' as never,
         symlinkCount: 0,
         symlinks: [],
+        isSource: true,
       },
     ]
 
@@ -386,6 +388,7 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
       path: `/home/user/.agents/skills/${name}` as Skill['path'],
       symlinkCount: 0,
       symlinks: [],
+      isSource: true,
       ...(cliTracked
         ? { source: repositoryId('vercel-labs/agent-skills') }
         : {}),

--- a/src/renderer/src/components/skills/AddSymlinkModal.browser.test.tsx
+++ b/src/renderer/src/components/skills/AddSymlinkModal.browser.test.tsx
@@ -60,6 +60,7 @@ function makeSkill(overrides: Partial<Skill> = {}): Skill {
     path: '/home/user/.agents/skills/task',
     symlinkCount: 0,
     symlinks: [],
+    isSource: true,
     ...overrides,
   }
 }

--- a/src/renderer/src/components/skills/CopyToAgentsModal.browser.test.tsx
+++ b/src/renderer/src/components/skills/CopyToAgentsModal.browser.test.tsx
@@ -59,6 +59,7 @@ function makeSkill(symlinks: SymlinkInfo[]): Skill {
     path: '/home/user/.agents/skills/task',
     symlinkCount: symlinks.length,
     symlinks,
+    isSource: true,
   }
 }
 

--- a/src/renderer/src/components/skills/SkillItem.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillItem.browser.test.tsx
@@ -39,6 +39,7 @@ function makeSkill(overrides: Partial<Skill> = {}): Skill {
     path: '/home/user/.agents/skills/task' as Skill['path'],
     symlinkCount: 0,
     symlinks: [],
+    isSource: true,
     ...overrides,
   }
 }

--- a/src/renderer/src/components/skills/bookmarkHelpers.test.ts
+++ b/src/renderer/src/components/skills/bookmarkHelpers.test.ts
@@ -19,6 +19,7 @@ function makeSkill(overrides: Partial<Skill> = {}): Skill {
     path: '/home/user/.agents/skills/test-skill',
     symlinkCount: 0,
     symlinks: [],
+    isSource: true,
     ...overrides,
   }
 }

--- a/src/renderer/src/redux/selectors.test.ts
+++ b/src/renderer/src/redux/selectors.test.ts
@@ -106,12 +106,16 @@ function buildState(overrides: {
 }
 
 /**
- * @param isLocal - false = symlinked (default), true = local folder
+ * @param isLocal - false = symlinked source skill (default), true = agent-local-only
+ *   folder. `isLocal=true` implies the skill exists only under `~/.<agent>/skills/`,
+ *   never inside SOURCE_DIR, so `isSource` is forced to `false`.
  */
 const makeSkill = (name: string, agentId: AgentId, isLocal = false): Skill => ({
   name,
   description: `${name} skill`,
-  path: `/home/user/.agents/skills/${name}`,
+  path: isLocal
+    ? `/home/user/.${agentId}/skills/${name}`
+    : `/home/user/.agents/skills/${name}`,
   symlinkCount: isLocal ? 0 : 1,
   symlinks: [
     {
@@ -125,16 +129,31 @@ const makeSkill = (name: string, agentId: AgentId, isLocal = false): Skill => ({
       isLocal,
     },
   ],
+  isSource: !isLocal,
 })
 
 describe('selectFilteredSkills', () => {
-  it('returns all skills when no filters active', () => {
+  it('returns all source-dir skills when no agent is selected (SourceCard view)', () => {
     const skills = [
       makeSkill('task', 'claude-code'),
       makeSkill('browse', 'cursor'),
     ]
     const state = buildState({ skills })
     expect(selectFilteredSkills(state as never)).toHaveLength(2)
+  })
+
+  it('hides agent-local-only skills from the SourceCard view (no agent selected)', () => {
+    // Regression: clicking the SourceCard ("~/.agents/skills") used to leak
+    // every claude-/cursor-local skill into the list because the selector
+    // skipped filtering when selectedAgentId was null. Source-only filter
+    // keeps the SourceCard view consistent with its label.
+    const skills = [
+      makeSkill('task', 'claude-code'), // source skill
+      makeSkill('local-only', 'claude-code', true), // agent-local
+    ]
+    const state = buildState({ skills })
+    const result = selectFilteredSkills(state as never)
+    expect(result.map((s) => s.name)).toEqual(['task'])
   })
 
   it('filters by search query (name match)', () => {
@@ -207,6 +226,7 @@ describe('selectFilteredSkills', () => {
           isLocal: false,
         },
       ],
+      isSource: true,
     }
     const state = buildState({ skills: [skill], selectedAgentId: 'cursor' })
     expect(selectFilteredSkills(state as never)).toHaveLength(0)
@@ -285,14 +305,17 @@ describe('selectFilteredSkills', () => {
     expect(result).toHaveLength(0)
   })
 
-  it('skillTypeFilter is ignored in global view (no agent selected)', () => {
+  it('skillTypeFilter is ignored in SourceCard view (no agent selected)', () => {
+    // SourceCard view applies its own source-only filter, so skillTypeFilter
+    // is moot here. `local-task` is hidden because it lives outside SOURCE_DIR,
+    // not because of the symlinked/local filter.
     const skills = [
       makeSkill('task', 'claude-code'),
       makeSkill('local-task', 'cursor', true),
     ]
     const state = buildState({ skills, skillTypeFilter: 'symlinked' })
     const result = selectFilteredSkills(state as never)
-    expect(result.map((s) => s.name)).toEqual(['local-task', 'task'])
+    expect(result.map((s) => s.name)).toEqual(['task'])
   })
 
   it('is memoized (returns same reference for same inputs)', () => {

--- a/src/renderer/src/redux/selectors.test.ts
+++ b/src/renderer/src/redux/selectors.test.ts
@@ -305,18 +305,21 @@ describe('selectFilteredSkills', () => {
     expect(result).toHaveLength(0)
   })
 
-  it('skillTypeFilter is ignored in SourceCard view (no agent selected)', () => {
-    // SourceCard view applies its own source-only filter, so skillTypeFilter
-    // is moot here. `local-task` is hidden because it lives outside SOURCE_DIR,
-    // not because of the symlinked/local filter.
-    const skills = [
-      makeSkill('task', 'claude-code'),
-      makeSkill('local-task', 'cursor', true),
-    ]
-    const state = buildState({ skills, skillTypeFilter: 'symlinked' })
-    const result = selectFilteredSkills(state as never)
-    expect(result.map((s) => s.name)).toEqual(['task'])
-  })
+  it.each(['all', 'symlinked', 'local'] as const)(
+    'skillTypeFilter=%s is ignored in SourceCard view (no agent selected)',
+    (skillTypeFilter) => {
+      // SourceCard view applies its own source-only filter, so skillTypeFilter
+      // is moot here. `local-task` is hidden because it lives outside SOURCE_DIR,
+      // not because of the symlinked/local filter.
+      const skills = [
+        makeSkill('task', 'claude-code'),
+        makeSkill('local-task', 'cursor', true),
+      ]
+      const state = buildState({ skills, skillTypeFilter })
+      const result = selectFilteredSkills(state as never)
+      expect(result.map((s) => s.name)).toEqual(['task'])
+    },
+  )
 
   it('is memoized (returns same reference for same inputs)', () => {
     const skills = [makeSkill('task', 'claude-code')]

--- a/src/renderer/src/redux/selectors.ts
+++ b/src/renderer/src/redux/selectors.ts
@@ -37,7 +37,8 @@ export const selectFilteredSkills = createSelector(
     // agent is selected — narrow to SOURCE_DIR skills so the SourceCard view
     // matches its `~/.agents/skills/` label instead of leaking agent-local
     // folders (e.g. `~/.claude/skills/<name>` that has no symlink under
-    // `~/.agents/skills/`). See `selectSourceSkills` test in selectors.test.ts.
+    // `~/.agents/skills/`). See "hides agent-local-only skills from the
+    // SourceCard view (no agent selected)" test in selectors.test.ts.
     if (selectedAgentId) {
       const checkType = skillTypeFilter !== 'all'
       const wantLocal = skillTypeFilter === 'local'

--- a/src/renderer/src/redux/selectors.ts
+++ b/src/renderer/src/redux/selectors.ts
@@ -33,7 +33,11 @@ export const selectFilteredSkills = createSelector(
   (skills, searchQuery, selectedAgentId, sortOrder, skillTypeFilter) => {
     let result = skills
 
-    // Filter by selected agent (and optionally by skill type)
+    // Filter by selected agent (and optionally by skill type), or — when no
+    // agent is selected — narrow to SOURCE_DIR skills so the SourceCard view
+    // matches its `~/.agents/skills/` label instead of leaking agent-local
+    // folders (e.g. `~/.claude/skills/<name>` that has no symlink under
+    // `~/.agents/skills/`). See `selectSourceSkills` test in selectors.test.ts.
     if (selectedAgentId) {
       const checkType = skillTypeFilter !== 'all'
       const wantLocal = skillTypeFilter === 'local'
@@ -45,6 +49,8 @@ export const selectFilteredSkills = createSelector(
             (!checkType || s.isLocal === wantLocal),
         ),
       )
+    } else {
+      result = result.filter((skill) => skill.isSource)
     }
 
     // Filter by search query (name only)

--- a/src/renderer/src/redux/slices/skillsSlice.test.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.test.ts
@@ -61,6 +61,7 @@ const sampleSkill: Skill = {
       isLocal: false,
     },
   ],
+  isSource: true,
 }
 
 const secondSkill: Skill = {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -155,6 +155,12 @@ export interface Skill {
   symlinkCount: number
   /** Per-agent symlink status entries */
   symlinks: SymlinkInfo[]
+  /**
+   * `true` when the skill lives under SOURCE_DIR (`~/.agents/skills/`); `false`
+   * when it is an agent-local-only directory under `~/.<agent>/skills/`.
+   * Used by the renderer to filter the SourceCard view to source-dir skills only.
+   */
+  isSource: boolean
   /** Short source identifier in owner/repo format. @example "vercel-labs/skills" */
   source?: RepositoryId
   /** Full URL to the source repository. @example "https://github.com/vercel-labs/skills.git" */


### PR DESCRIPTION
## Summary

- **Bug**: SourceCard (the `~/.agents/skills` view shown when no agent is selected) was listing agent-local skills like `benchmark-models` even though that skill only exists under `~/.claude/skills/` and has no entry in `~/.agents/skills/`. The visible directory label and the actual contents disagreed.
- **Root cause**: `selectFilteredSkills` returned every scanned skill when `selectedAgentId === null`. The previous Universal removal (commit `89c601a`) deleted the dead branches but left this "show all" semantic mismatched with SourceCard's label.
- **Fix**: Added an `isSource: boolean` discriminator on the `Skill` type, set by `scanSourceSkills` (`true`) and `scanAllLocalSkills` (`false`) in `skillScanner.ts`. `selectFilteredSkills` now narrows to `skill.isSource` when no agent is selected, so the view matches its `~/.agents/skills/` label.

## Verification

- `pnpm test` — **779/779 passing** (added a regression test in `selectors.test.ts` covering the SourceCard "no agent selected" branch)
- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `playwright-cli` QA: SourceCard view no longer shows `benchmark-models`; selecting Claude Code agent still shows it correctly.

## Files changed

- `src/shared/types.ts` — add `isSource: boolean` to `Skill`
- `src/main/services/skillScanner.ts` — set `isSource` in 3 return paths
- `src/renderer/src/redux/selectors.ts` — narrow no-agent branch to source-only
- 7 test files updated for new required field + 1 new regression test

## Test plan

- [ ] Launch app, confirm SourceCard view ("~/.agents/skills" header) lists only source-dir skills
- [ ] Click Claude Code agent — local-only skills (e.g. `benchmark-models`) still appear there
- [ ] Search/sort/skill-type filter still work as before in agent views
- [ ] Marketplace install + symlink creation flow unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * スキルフィクスチャを更新し、スキル識別プロパティを追加

* **バグ修正**
  * エージェント未選択時にエージェント固有のスキルが表示されないようフィルタリングロジックを改善

<!-- end of auto-generated comment: release notes by coderabbit.ai -->