### PR TITLE
fix(ui): show source and symlink paths separately in Inspector Location

### DIFF
--- a/src/renderer/src/components/layout/Sidebar.tsx
+++ b/src/renderer/src/components/layout/Sidebar.tsx
@@ -12,7 +12,7 @@ import { ScrollArea } from '../ui/scroll-area'
 import { Separator } from '../ui/separator'
 
 /**
- * Left sidebar component (240px width)
+ * Left sidebar component (272px / w-68)
  * Contains app header, source card, and agents list
  */
 export const Sidebar = React.memo(function Sidebar(): React.ReactElement {

--- a/src/renderer/src/components/layout/Sidebar.tsx
+++ b/src/renderer/src/components/layout/Sidebar.tsx
@@ -21,7 +21,7 @@ export const Sidebar = React.memo(function Sidebar(): React.ReactElement {
   return (
     <aside
       aria-label="Agent sidebar"
-      className="w-60 shrink-0 border-r border-border bg-card flex flex-col"
+      className="w-68 shrink-0 border-r border-border bg-card flex flex-col"
     >
       <SidebarHeader />
       <Separator />

--- a/src/renderer/src/components/layout/Sidebar.tsx
+++ b/src/renderer/src/components/layout/Sidebar.tsx
@@ -21,7 +21,7 @@ export const Sidebar = React.memo(function Sidebar(): React.ReactElement {
   return (
     <aside
       aria-label="Agent sidebar"
-      className="w-[240px] shrink-0 border-r border-border bg-card flex flex-col"
+      className="w-60 shrink-0 border-r border-border bg-card flex flex-col"
     >
       <SidebarHeader />
       <Separator />

--- a/src/renderer/src/components/sidebar/BookmarkItem.tsx
+++ b/src/renderer/src/components/sidebar/BookmarkItem.tsx
@@ -51,7 +51,7 @@ export const BookmarkItem = React.memo(function BookmarkItem({
   return (
     <div
       className={cn(
-        'flex w-full items-center justify-between min-h-[44px] py-1.5 px-2 rounded-md transition-colors group cursor-pointer hover:bg-accent/50',
+        'flex w-full items-center justify-between min-h-11 py-1.5 px-2 rounded-md transition-colors group cursor-pointer hover:bg-accent/50',
       )}
       onClick={handleClick}
     >
@@ -71,15 +71,22 @@ export const BookmarkItem = React.memo(function BookmarkItem({
 
       <div className="flex items-center gap-1 ml-2 shrink-0">
         {bookmark.isInstalled ? (
-          <span className="text-xs text-emerald-500 flex items-center gap-0.5">
-            <Check className="h-3 w-3" />
-            Installed
-          </span>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                aria-label="Installed"
+                className="text-emerald-500 flex items-center justify-center min-h-11 min-w-11"
+              >
+                <Check className="h-4 w-4" />
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="left">Installed</TooltipContent>
+          </Tooltip>
         ) : (
           <button
             type="button"
             aria-label={`Install ${bookmark.name}`}
-            className="min-h-[44px] min-w-[44px] flex items-center justify-center text-primary hover:text-primary/80 transition-colors opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
+            className="min-h-11 min-w-11 flex items-center justify-center text-primary hover:text-primary/80 transition-colors opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
             onClick={handleInstall}
             disabled={isInstalling}
           >
@@ -89,7 +96,7 @@ export const BookmarkItem = React.memo(function BookmarkItem({
         <button
           type="button"
           aria-label={`Remove ${bookmark.name} from bookmarks`}
-          className="min-h-[44px] min-w-[44px] flex items-center justify-center text-muted-foreground hover:text-destructive transition-colors opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
+          className="min-h-11 min-w-11 flex items-center justify-center text-muted-foreground hover:text-destructive transition-colors opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
           onClick={handleRemove}
         >
           <X className="h-3.5 w-3.5" />

--- a/src/renderer/src/components/sidebar/BookmarkItem.tsx
+++ b/src/renderer/src/components/sidebar/BookmarkItem.tsx
@@ -48,12 +48,23 @@ export const BookmarkItem = React.memo(function BookmarkItem({
     dispatch(setSelectedBookmarkForDetail(bookmark))
   }
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>): void => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      handleClick()
+    }
+  }
+
   return (
     <div
+      role="button"
+      tabIndex={0}
+      aria-label={`View details for ${bookmark.name}`}
       className={cn(
-        'flex w-full items-center justify-between min-h-11 py-1.5 px-2 rounded-md transition-colors group cursor-pointer hover:bg-accent/50',
+        'flex w-full items-center justify-between min-h-11 py-1.5 px-2 rounded-md transition-colors group cursor-pointer hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
       )}
       onClick={handleClick}
+      onKeyDown={handleKeyDown}
     >
       <Tooltip>
         <TooltipTrigger asChild>

--- a/src/renderer/src/components/sidebar/SourceCard.tsx
+++ b/src/renderer/src/components/sidebar/SourceCard.tsx
@@ -93,7 +93,7 @@ export const SourceCard = React.memo(function SourceCard(): React.ReactElement {
             <Button
               variant="ghost"
               size="sm"
-              className="min-h-[44px] px-2 text-xs font-medium gap-1"
+              className="min-h-11 px-2 text-xs font-medium gap-1"
               onClick={(e) => {
                 e.stopPropagation()
                 handleSync()

--- a/src/renderer/src/components/skills/SkillDetail.tsx
+++ b/src/renderer/src/components/skills/SkillDetail.tsx
@@ -23,6 +23,7 @@ export const SkillDetail = React.memo(function SkillDetail({
 }: SkillDetailProps): React.ReactElement {
   const [activeTab, setActiveTab] = useState<TabType>('code')
   const { items: agents } = useAppSelector((state) => state.agents)
+  const selectedAgentId = useAppSelector((state) => state.ui.selectedAgentId)
 
   // Filter symlinks to only show detected agents (exists: true)
   const detectedAgentIds = new Set(
@@ -31,6 +32,18 @@ export const SkillDetail = React.memo(function SkillDetail({
   const filteredSymlinks = skill.symlinks.filter((s) =>
     detectedAgentIds.has(s.agentId),
   )
+
+  // When a specific agent is selected and that agent's link points to a
+  // different path than the skill's actual location, show both Source and
+  // Symlink so the user isn't confused by seeing ~/.agents/skills while
+  // looking at e.g. OpenClaw.
+  const selectedSymlink = selectedAgentId
+    ? skill.symlinks.find((s) => s.agentId === selectedAgentId)
+    : undefined
+  const symlinkPath =
+    selectedSymlink && selectedSymlink.linkPath !== skill.path
+      ? selectedSymlink.linkPath
+      : undefined
 
   const validCount = filteredSymlinks.filter((s) => s.status === 'valid').length
   const brokenCount = filteredSymlinks.filter(
@@ -92,6 +105,7 @@ export const SkillDetail = React.memo(function SkillDetail({
             filteredSymlinks={filteredSymlinks}
             validCount={validCount}
             brokenCount={brokenCount}
+            symlinkPath={symlinkPath}
           />
         </Activity>
       </div>
@@ -104,6 +118,7 @@ interface InfoViewProps {
   filteredSymlinks: SymlinkInfo[]
   validCount: number
   brokenCount: number
+  symlinkPath?: string
 }
 
 const InfoView = React.memo(function InfoView({
@@ -111,6 +126,7 @@ const InfoView = React.memo(function InfoView({
   filteredSymlinks,
   validCount,
   brokenCount,
+  symlinkPath,
 }: InfoViewProps): React.ReactElement {
   return (
     <div className="p-4 overflow-auto h-full">
@@ -146,9 +162,28 @@ const InfoView = React.memo(function InfoView({
         <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wider mb-2">
           Location
         </h3>
-        <code className="text-xs bg-muted px-2 py-1 rounded break-all">
-          {skill.path}
-        </code>
+        {symlinkPath ? (
+          <div className="space-y-2">
+            <div>
+              <div className="text-xs text-muted-foreground mb-1">
+                Source Files
+              </div>
+              <code className="text-xs bg-muted px-2 py-1 rounded break-all inline-block max-w-full">
+                {skill.path}
+              </code>
+            </div>
+            <div>
+              <div className="text-xs text-muted-foreground mb-1">Symlink</div>
+              <code className="text-xs bg-muted px-2 py-1 rounded break-all inline-block max-w-full">
+                {symlinkPath}
+              </code>
+            </div>
+          </div>
+        ) : (
+          <code className="text-xs bg-muted px-2 py-1 rounded break-all">
+            {skill.path}
+          </code>
+        )}
       </div>
     </div>
   )

--- a/src/renderer/src/components/skills/SkillDetail.tsx
+++ b/src/renderer/src/components/skills/SkillDetail.tsx
@@ -3,6 +3,8 @@ import React, { Activity, useState } from 'react'
 import type { Skill, SymlinkInfo } from '../../../../shared/types'
 import { cn } from '../../lib/utils'
 import { useAppSelector } from '../../redux/hooks'
+import type { LocationViewModel } from '../../utils/getLocationViewModel'
+import { getLocationViewModel } from '../../utils/getLocationViewModel'
 import { SymlinkStatus } from '../status/SymlinkStatus'
 import { Separator } from '../ui/separator'
 
@@ -33,17 +35,7 @@ export const SkillDetail = React.memo(function SkillDetail({
     detectedAgentIds.has(s.agentId),
   )
 
-  // When a specific agent is selected and that agent's link points to a
-  // different path than the skill's actual location, show both Source and
-  // Symlink so the user isn't confused by seeing ~/.agents/skills while
-  // looking at e.g. OpenClaw.
-  const selectedSymlink = selectedAgentId
-    ? skill.symlinks.find((s) => s.agentId === selectedAgentId)
-    : undefined
-  const symlinkPath =
-    selectedSymlink && selectedSymlink.linkPath !== skill.path
-      ? selectedSymlink.linkPath
-      : undefined
+  const locationView = getLocationViewModel(skill, selectedAgentId)
 
   const validCount = filteredSymlinks.filter((s) => s.status === 'valid').length
   const brokenCount = filteredSymlinks.filter(
@@ -105,7 +97,7 @@ export const SkillDetail = React.memo(function SkillDetail({
             filteredSymlinks={filteredSymlinks}
             validCount={validCount}
             brokenCount={brokenCount}
-            symlinkPath={symlinkPath}
+            location={locationView}
           />
         </Activity>
       </div>
@@ -118,7 +110,7 @@ interface InfoViewProps {
   filteredSymlinks: SymlinkInfo[]
   validCount: number
   brokenCount: number
-  symlinkPath?: string
+  location: LocationViewModel
 }
 
 const InfoView = React.memo(function InfoView({
@@ -126,7 +118,7 @@ const InfoView = React.memo(function InfoView({
   filteredSymlinks,
   validCount,
   brokenCount,
-  symlinkPath,
+  location,
 }: InfoViewProps): React.ReactElement {
   return (
     <div className="p-4 overflow-auto h-full">
@@ -162,26 +154,26 @@ const InfoView = React.memo(function InfoView({
         <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wider mb-2">
           Location
         </h3>
-        {symlinkPath ? (
+        {location.symlinkPath ? (
           <div className="space-y-2">
             <div>
               <div className="text-xs text-muted-foreground mb-1">
                 Source Files
               </div>
               <code className="text-xs bg-muted px-2 py-1 rounded break-all inline-block max-w-full">
-                {skill.path}
+                {location.sourcePath}
               </code>
             </div>
             <div>
               <div className="text-xs text-muted-foreground mb-1">Symlink</div>
               <code className="text-xs bg-muted px-2 py-1 rounded break-all inline-block max-w-full">
-                {symlinkPath}
+                {location.symlinkPath}
               </code>
             </div>
           </div>
         ) : (
-          <code className="text-xs bg-muted px-2 py-1 rounded break-all">
-            {skill.path}
+          <code className="text-xs bg-muted px-2 py-1 rounded break-all inline-block max-w-full">
+            {location.sourcePath}
           </code>
         )}
       </div>

--- a/src/renderer/src/components/theme/ThemeSelector.tsx
+++ b/src/renderer/src/components/theme/ThemeSelector.tsx
@@ -158,7 +158,7 @@ export const ThemeSelector = React.memo(function ThemeSelector(): ReactElement {
                 key={name}
                 type="button"
                 onClick={() => handleSelectPreset(name)}
-                className="min-h-[44px] min-w-[44px] flex items-center justify-center"
+                className="min-h-11 min-w-11 flex items-center justify-center"
                 title={config.label}
                 aria-label={`Select ${config.label} theme`}
                 aria-pressed={isSelected}

--- a/src/renderer/src/components/ui/separator.tsx
+++ b/src/renderer/src/components/ui/separator.tsx
@@ -10,7 +10,7 @@ const Separator = React.memo(function Separator({
   ref,
   ...props
 }: React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root> & {
-  ref?: React.Ref<React.ElementRef<typeof SeparatorPrimitive.Root>>
+  ref?: React.ComponentPropsWithRef<typeof SeparatorPrimitive.Root>['ref']
 }) {
   return (
     <SeparatorPrimitive.Root
@@ -19,7 +19,7 @@ const Separator = React.memo(function Separator({
       orientation={orientation}
       className={cn(
         'shrink-0 bg-border',
-        orientation === 'horizontal' ? 'h-[1px] w-full' : 'h-full w-[1px]',
+        orientation === 'horizontal' ? 'h-px w-full' : 'h-full w-px',
         className,
       )}
       {...props}

--- a/src/renderer/src/utils/getLocationViewModel.test.ts
+++ b/src/renderer/src/utils/getLocationViewModel.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+
+import type { AgentId, Skill, SymlinkInfo } from '../../../shared/types'
+
+import { getLocationViewModel } from './getLocationViewModel'
+
+const makeSymlink = (
+  agentId: AgentId,
+  linkPath: SymlinkInfo['linkPath'],
+  targetPath: SymlinkInfo['targetPath'],
+  isLocal = false,
+): SymlinkInfo => ({
+  agentId,
+  agentName: agentId as SymlinkInfo['agentName'],
+  status: 'valid',
+  targetPath,
+  linkPath,
+  isLocal,
+})
+
+const makeSkill = (
+  path: Skill['path'],
+  symlinks: SymlinkInfo[],
+  isSource = true,
+): Skill => ({
+  name: 'foo',
+  description: 'foo skill',
+  path,
+  symlinkCount: symlinks.filter((s) => s.status === 'valid').length,
+  symlinks,
+  isSource,
+})
+
+describe('getLocationViewModel', () => {
+  it('omits symlinkPath when no agent is selected', () => {
+    const skill = makeSkill('/u/me/.agents/skills/foo', [
+      makeSymlink(
+        'opencode',
+        '/u/me/.opencode/skills/foo',
+        '/u/me/.agents/skills/foo',
+      ),
+    ])
+
+    expect(getLocationViewModel(skill, null)).toEqual({
+      sourcePath: '/u/me/.agents/skills/foo',
+      symlinkPath: undefined,
+    })
+  })
+
+  it('omits symlinkPath when the selected agent has no symlink for this skill', () => {
+    const skill = makeSkill('/u/me/.agents/skills/foo', [
+      makeSymlink(
+        'opencode',
+        '/u/me/.opencode/skills/foo',
+        '/u/me/.agents/skills/foo',
+      ),
+    ])
+
+    expect(getLocationViewModel(skill, 'cursor')).toEqual({
+      sourcePath: '/u/me/.agents/skills/foo',
+      symlinkPath: undefined,
+    })
+  })
+
+  it('omits symlinkPath for a local skill where linkPath equals skill.path', () => {
+    const skill = makeSkill(
+      '/u/me/.cursor/skills/foo',
+      [
+        makeSymlink(
+          'cursor',
+          '/u/me/.cursor/skills/foo',
+          '/u/me/.cursor/skills/foo',
+          true,
+        ),
+      ],
+      false,
+    )
+
+    expect(getLocationViewModel(skill, 'cursor')).toEqual({
+      sourcePath: '/u/me/.cursor/skills/foo',
+      symlinkPath: undefined,
+    })
+  })
+
+  it('returns symlinkPath when the selected agent links to a different path', () => {
+    const skill = makeSkill('/u/me/.agents/skills/foo', [
+      makeSymlink(
+        'opencode',
+        '/u/me/.opencode/skills/foo',
+        '/u/me/.agents/skills/foo',
+      ),
+      makeSymlink(
+        'claude-code',
+        '/u/me/.claude/skills/foo',
+        '/u/me/.agents/skills/foo',
+      ),
+    ])
+
+    expect(getLocationViewModel(skill, 'opencode')).toEqual({
+      sourcePath: '/u/me/.agents/skills/foo',
+      symlinkPath: '/u/me/.opencode/skills/foo',
+    })
+  })
+})

--- a/src/renderer/src/utils/getLocationViewModel.ts
+++ b/src/renderer/src/utils/getLocationViewModel.ts
@@ -1,0 +1,65 @@
+import type { AgentId, Skill, SymlinkInfo } from '../../../shared/types'
+
+/**
+ * View-model for the Inspector's "Location" section.
+ *
+ * - `sourcePath`: where the skill files actually live on disk.
+ * - `symlinkPath`: the agent's link path, only set when a specific agent is
+ *   selected AND that agent's link points to a different location than the
+ *   source. When undefined, the Inspector renders a single line; otherwise
+ *   it renders both Source Files and Symlink rows.
+ */
+export interface LocationViewModel {
+  sourcePath: Skill['path']
+  symlinkPath?: SymlinkInfo['linkPath']
+}
+
+/**
+ * Compute the Location view-model for the Inspector.
+ *
+ * A universal skill (e.g. `~/.agents/skills/foo`) is symlinked into each
+ * agent's skills dir. When the user selects a specific agent in the sidebar,
+ * the Inspector should show both the source path and the agent's symlink
+ * path, so seeing `~/.agents/skills/...` while looking at OpenClaw is no
+ * longer confusing.
+ *
+ * @param skill - The skill being inspected.
+ * @param selectedAgentId - The currently selected agent in the sidebar, or null when no agent is selected.
+ * @returns
+ * - `sourcePath` is always `skill.path`.
+ * - `symlinkPath` is set only when an agent is selected, that agent has a symlink for this skill, and the symlink path differs from the source path.
+ * - Otherwise `symlinkPath` is undefined and the Inspector renders a single-line layout.
+ * @example
+ * // Universal skill viewed under OpenClaw → two-line layout
+ * getLocationViewModel(
+ *   { path: '/u/me/.agents/skills/foo', symlinks: [{ agentId: 'opencode', linkPath: '/u/me/.opencode/skills/foo', ... }] },
+ *   'opencode',
+ * )
+ * // => { sourcePath: '/u/me/.agents/skills/foo', symlinkPath: '/u/me/.opencode/skills/foo' }
+ *
+ * // No agent selected → single-line layout
+ * getLocationViewModel(skill, null)
+ * // => { sourcePath: skill.path, symlinkPath: undefined }
+ *
+ * // Local skill (link path equals source path) → single-line layout
+ * getLocationViewModel(
+ *   { path: '/u/me/.cursor/skills/foo', symlinks: [{ agentId: 'cursor', linkPath: '/u/me/.cursor/skills/foo', ... }] },
+ *   'cursor',
+ * )
+ * // => { sourcePath: '/u/me/.cursor/skills/foo', symlinkPath: undefined }
+ */
+export function getLocationViewModel(
+  skill: Skill,
+  selectedAgentId: AgentId | null,
+): LocationViewModel {
+  const selectedSymlink = selectedAgentId
+    ? skill.symlinks.find((s) => s.agentId === selectedAgentId)
+    : undefined
+  return {
+    sourcePath: skill.path,
+    symlinkPath:
+      selectedSymlink && selectedSymlink.linkPath !== skill.path
+        ? selectedSymlink.linkPath
+        : undefined,
+  }
+}


### PR DESCRIPTION
## Summary

- Inspector の `Location` で、特定 agent 選択時にその agent の `linkPath` と実体パスが異なる場合は `Source Files` / `Symlink` の2段表記に切替
- Universal skill (`~/.agents/skills/...`) を例えば OpenClaw で見ているときに「なぜ ~/.agents/skills が表示されるのか」という混乱を解消
- ついでに code タグを `inline-block max-w-full` にして背景がコンテンツ幅にフィットするよう調整

## 含まれる先行コミット

ローカル `main` に未 push で残っていた以下も同梱:
- `ad7206b` Sidebar / BookmarkItem スタイル更新 (Installed バッジをアイコン化)
- `ca5ea0c` Sidebar 幅 `w-60 → w-68` で Installed バッジ表示幅を確保

## Test plan

- [x] `pnpm typecheck`
- [ ] サイドバーで特定 agent (例: Claude Code) を選択 → universal skill (例: coderabbit-resolver) を選び `Info` タブで `Source Files` / `Symlink` が2段表示されることを確認
- [ ] サイドバーで agent 未選択の状態 → 1段表示 (現状維持) を確認
- [ ] ローカル skill (`~/.<agent>/skills/...` 直下) では1段表示 (Source と Symlink が同一なため) を確認
- [ ] 長いパスでも `break-all` で折り返し、背景がパネルからはみ出ないこと

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Style**
  * サイドバーの幅を調整しました。
  * ブックマークアイテムおよびテーマセレクターのボタンサイズを統一しました。
  * 同期ボタンおよびセパレーターコンポーネントのサイズ指定を最適化しました。

* **Features**
  * ブックマークの「インストール済み」ステータスをツールチップアイコンで表示するようにしました。
  * スキル詳細ビューでシムリンク情報を表示できるようにしました。

* **Bug Fixes**
  * セパレーターコンポーネントの参照型を修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->