### PR TITLE
feat(ui): add release notes link in sidebar + post-update toast

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -7,6 +7,7 @@ import { MainContent } from './components/layout/MainContent'
 import { Sidebar } from './components/layout/Sidebar'
 import { TooltipProvider } from './components/ui/tooltip'
 import { UpdateToast } from './components/UpdateToast'
+import { useReleaseNotesToast } from './hooks/useReleaseNotesToast'
 import { useUpdateNotification } from './hooks/useUpdateNotification'
 import { useAppSelector } from './redux/hooks'
 
@@ -69,6 +70,10 @@ const toasterStyle = {
 const App = React.memo(function App(): React.ReactElement {
   // Subscribe to auto-update IPC events
   useUpdateNotification()
+
+  // After auto-update + restart, fire a one-shot "What's new" toast on the
+  // first launch of the new version with a link to the GitHub release notes.
+  useReleaseNotesToast()
 
   // Drive sonner's theme prop from the persisted redux mode so toasts honor
   // the user's light/dark choice. Pre-fix this was hardcoded `theme="dark"`.

--- a/src/renderer/src/components/sidebar/SidebarHeader.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeader.tsx
@@ -1,12 +1,19 @@
 import React from 'react'
 
+import { getReleaseNotesUrl } from '../../utils/getReleaseNotesUrl'
 import { ThemeSelector } from '../theme/ThemeSelector'
 
 /**
- * Sidebar header with app title and theme selector
+ * Sidebar header with app title and theme selector.
+ *
+ * The version label is a link to the matching GitHub release tag so users
+ * can read the changelog after an auto-update. `target="_blank"` is enough
+ * here — the main process's `setWindowOpenHandler` already routes
+ * `window.open` calls to `shell.openExternal`, so no IPC is required.
  */
 export const SidebarHeader = React.memo(
   function SidebarHeader(): React.ReactElement {
+    const releaseNotesUrl = getReleaseNotesUrl(__APP_VERSION__)
     return (
       <div className="p-4 pt-8 drag-region">
         <div className="flex items-center justify-between no-drag">
@@ -14,7 +21,15 @@ export const SidebarHeader = React.memo(
             <h1 className="font-mono text-lg font-semibold text-primary">
               Skills Desktop
             </h1>
-            <p className="text-xs text-muted-foreground">v{__APP_VERSION__}</p>
+            <a
+              href={releaseNotesUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              title="View release notes on GitHub"
+              className="text-xs text-muted-foreground hover:text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm transition-colors"
+            >
+              v{__APP_VERSION__}
+            </a>
           </div>
           <ThemeSelector />
         </div>

--- a/src/renderer/src/hooks/useReleaseNotesToast.ts
+++ b/src/renderer/src/hooks/useReleaseNotesToast.ts
@@ -1,0 +1,57 @@
+import { useEffect } from 'react'
+import { toast } from 'sonner'
+
+import { RELEASE_NOTES_LAST_SEEN_VERSION_KEY } from '../../../shared/constants'
+import { getReleaseNotesUrl } from '../utils/getReleaseNotesUrl'
+
+/**
+ * Show a one-shot "What's new" toast after the app has been updated to a
+ * version the user hasn't seen yet.
+ *
+ * Detection strategy:
+ * - Read the last-seen version from localStorage on mount.
+ * - If absent → first install, silently store the current version (no toast).
+ * - If present and equal → user already saw notes for this version, no-op.
+ * - If present and different → fire the toast once, then store the current
+ *   version so the next launch is silent.
+ *
+ * Why localStorage instead of Redux: this is a transient first-launch cue,
+ * not app state. Nothing else reads or writes the value, so a slice would
+ * just add ceremony.
+ *
+ * @example
+ * // Inside <App /> root:
+ * useReleaseNotesToast()
+ */
+export function useReleaseNotesToast(): void {
+  useEffect(() => {
+    const currentVersion = __APP_VERSION__
+    const lastSeenVersion = window.localStorage.getItem(
+      RELEASE_NOTES_LAST_SEEN_VERSION_KEY,
+    )
+
+    // Persist the running version unconditionally at the end so future
+    // launches are silent. We compute whether to toast first, then write.
+    const shouldShowToast =
+      lastSeenVersion !== null && lastSeenVersion !== currentVersion
+
+    if (shouldShowToast) {
+      const releaseNotesUrl = getReleaseNotesUrl(currentVersion)
+      toast(`Updated to v${currentVersion}`, {
+        description: 'See what changed in this release.',
+        duration: 8000,
+        action: {
+          label: 'View',
+          onClick: () => {
+            window.open(releaseNotesUrl, '_blank', 'noopener,noreferrer')
+          },
+        },
+      })
+    }
+
+    window.localStorage.setItem(
+      RELEASE_NOTES_LAST_SEEN_VERSION_KEY,
+      currentVersion,
+    )
+  }, [])
+}

--- a/src/renderer/src/hooks/useReleaseNotesToast.ts
+++ b/src/renderer/src/hooks/useReleaseNotesToast.ts
@@ -26,32 +26,39 @@ import { getReleaseNotesUrl } from '../utils/getReleaseNotesUrl'
 export function useReleaseNotesToast(): void {
   useEffect(() => {
     const currentVersion = __APP_VERSION__
-    const lastSeenVersion = window.localStorage.getItem(
-      RELEASE_NOTES_LAST_SEEN_VERSION_KEY,
-    )
 
-    // Persist the running version unconditionally at the end so future
-    // launches are silent. We compute whether to toast first, then write.
-    const shouldShowToast =
-      lastSeenVersion !== null && lastSeenVersion !== currentVersion
+    // localStorage can throw in restricted-storage environments (quota
+    // exhausted, sandbox lockdown, future Electron security tightening).
+    // A failing release-notes cue must never block app startup, so swallow
+    // the error and skip the toast — the cue is best-effort.
+    try {
+      const lastSeenVersion = window.localStorage.getItem(
+        RELEASE_NOTES_LAST_SEEN_VERSION_KEY,
+      )
 
-    if (shouldShowToast) {
-      const releaseNotesUrl = getReleaseNotesUrl(currentVersion)
-      toast(`Updated to v${currentVersion}`, {
-        description: 'See what changed in this release.',
-        duration: 8000,
-        action: {
-          label: 'View',
-          onClick: () => {
-            window.open(releaseNotesUrl, '_blank', 'noopener,noreferrer')
+      const shouldShowToast =
+        lastSeenVersion !== null && lastSeenVersion !== currentVersion
+
+      if (shouldShowToast) {
+        const releaseNotesUrl = getReleaseNotesUrl(currentVersion)
+        toast(`Updated to v${currentVersion}`, {
+          description: 'See what changed in this release.',
+          duration: 8000,
+          action: {
+            label: 'View',
+            onClick: () => {
+              window.open(releaseNotesUrl, '_blank', 'noopener,noreferrer')
+            },
           },
-        },
-      })
-    }
+        })
+      }
 
-    window.localStorage.setItem(
-      RELEASE_NOTES_LAST_SEEN_VERSION_KEY,
-      currentVersion,
-    )
+      window.localStorage.setItem(
+        RELEASE_NOTES_LAST_SEEN_VERSION_KEY,
+        currentVersion,
+      )
+    } catch {
+      // ignored — keep startup resilient
+    }
   }, [])
 }

--- a/src/renderer/src/utils/getReleaseNotesUrl.test.ts
+++ b/src/renderer/src/utils/getReleaseNotesUrl.test.ts
@@ -9,8 +9,8 @@ describe('getReleaseNotesUrl', () => {
     )
   })
 
-  it('does not double up the v-prefix when the input already lacks one', () => {
-    expect(getReleaseNotesUrl('1.0.0')).toBe(
+  it('strips a leading v from the input so the tag never gets a doubled prefix', () => {
+    expect(getReleaseNotesUrl('v1.0.0')).toBe(
       'https://github.com/laststance/skills-desktop/releases/tag/v1.0.0',
     )
   })

--- a/src/renderer/src/utils/getReleaseNotesUrl.test.ts
+++ b/src/renderer/src/utils/getReleaseNotesUrl.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { getReleaseNotesUrl } from './getReleaseNotesUrl'
+
+describe('getReleaseNotesUrl', () => {
+  it('builds the GitHub releases tag URL with a v-prefix', () => {
+    expect(getReleaseNotesUrl('0.13.4')).toBe(
+      'https://github.com/laststance/skills-desktop/releases/tag/v0.13.4',
+    )
+  })
+
+  it('does not double up the v-prefix when the input already lacks one', () => {
+    expect(getReleaseNotesUrl('1.0.0')).toBe(
+      'https://github.com/laststance/skills-desktop/releases/tag/v1.0.0',
+    )
+  })
+})

--- a/src/renderer/src/utils/getReleaseNotesUrl.ts
+++ b/src/renderer/src/utils/getReleaseNotesUrl.ts
@@ -4,13 +4,17 @@ import { SKILLS_DESKTOP_REPOSITORY_URL } from '../../../shared/constants'
  * Build the GitHub release notes URL for a given app version.
  *
  * Tag convention is `v<semver>` (e.g. `v0.13.4`), matching the tags created
- * by `/electron-release` when it runs `gh release create`.
+ * by `/electron-release` when it runs `gh release create`. A leading `v` (or
+ * `V`) on the input is stripped so callers can pass either form without
+ * doubling the prefix.
  *
- * @param version - Semver string without the leading `v` (e.g. `"0.13.4"`).
+ * @param version - Semver string with or without a leading `v` (e.g. `"0.13.4"` or `"v0.13.4"`).
  * @returns Absolute https URL to the GitHub release page for that tag.
  * @example
  * getReleaseNotesUrl('0.13.4')
  * // => 'https://github.com/laststance/skills-desktop/releases/tag/v0.13.4'
+ * getReleaseNotesUrl('v1.0.0')
+ * // => 'https://github.com/laststance/skills-desktop/releases/tag/v1.0.0'
  */
 export const getReleaseNotesUrl = (version: string): string =>
-  `${SKILLS_DESKTOP_REPOSITORY_URL}/releases/tag/v${version}`
+  `${SKILLS_DESKTOP_REPOSITORY_URL}/releases/tag/v${version.replace(/^v/i, '')}`

--- a/src/renderer/src/utils/getReleaseNotesUrl.ts
+++ b/src/renderer/src/utils/getReleaseNotesUrl.ts
@@ -1,0 +1,16 @@
+import { SKILLS_DESKTOP_REPOSITORY_URL } from '../../../shared/constants'
+
+/**
+ * Build the GitHub release notes URL for a given app version.
+ *
+ * Tag convention is `v<semver>` (e.g. `v0.13.4`), matching the tags created
+ * by `/electron-release` when it runs `gh release create`.
+ *
+ * @param version - Semver string without the leading `v` (e.g. `"0.13.4"`).
+ * @returns Absolute https URL to the GitHub release page for that tag.
+ * @example
+ * getReleaseNotesUrl('0.13.4')
+ * // => 'https://github.com/laststance/skills-desktop/releases/tag/v0.13.4'
+ */
+export const getReleaseNotesUrl = (version: string): string =>
+  `${SKILLS_DESKTOP_REPOSITORY_URL}/releases/tag/v${version}`

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -343,6 +343,25 @@ export const GSTACK_BADGE_AGENT_IDS = [
 export const GSTACK_REPOSITORY_URL = 'https://github.com/garrytan/gstack'
 
 /**
+ * Canonical GitHub repository URL for Skills Desktop itself.
+ * Used by the sidebar version link and the post-update "What's new" toast
+ * to deep-link into the matching `/releases/tag/v<version>` page.
+ */
+export const SKILLS_DESKTOP_REPOSITORY_URL =
+  'https://github.com/laststance/skills-desktop'
+
+/**
+ * localStorage key tracking the last app version the user was shown release
+ * notes for. Read on mount; if it differs from the running version (and was
+ * non-null), the post-update toast fires once and the key is updated.
+ *
+ * Why a string here rather than a Redux slice: this is a one-shot UI cue,
+ * not a piece of app state — no other component reads or mutates it.
+ */
+export const RELEASE_NOTES_LAST_SEEN_VERSION_KEY =
+  'skills-desktop:last-seen-version'
+
+/**
  * Agent IDs that use ~/.agents/skills/ directly (no symlinks needed).
  * Derived from skills CLI: agents where skillsDir === '.agents/skills'
  * and showInUniversalList !== false.


### PR DESCRIPTION
## Summary
- **A.** Sidebar version label (`v0.13.4`) is now a clickable external link to the matching GitHub releases tag — users can read the changelog anytime, not just right after an update.
- **B.** After auto-update + restart, a one-shot sonner toast (`Updated to v<x> — See what changed`) fires on the first launch of the new version, with a `View` action that opens the release page. Tracked via a single `localStorage` key; first install is silent so brand-new users aren't shown phantom release notes.
- No new IPC — both paths reuse the existing `setWindowOpenHandler` that maps `window.open` / `target="_blank"` to `shell.openExternal` (per `pattern_external_links_native_anchor`).

Implements the A+B hybrid chosen in `/plan-design-review`: a passive always-available link plus a high-visibility cue at the moment users actually want to know what changed. Modeled after VS Code, Linear, and Warp's update flows.

## Files
- `src/shared/constants.ts` — `SKILLS_DESKTOP_REPOSITORY_URL`, `RELEASE_NOTES_LAST_SEEN_VERSION_KEY`
- `src/renderer/src/utils/getReleaseNotesUrl.ts` (+ test) — pure helper, builds `/releases/tag/v<semver>` URL
- `src/renderer/src/components/sidebar/SidebarHeader.tsx` — version → `<a target="_blank">` with focus-visible ring + hover underline
- `src/renderer/src/hooks/useReleaseNotesToast.ts` — one-shot post-update toast with `null` / `==` / `!=` triage
- `src/renderer/src/App.tsx` — wires `useReleaseNotesToast()`

## Test plan
- [x] `pnpm typecheck` ✅
- [x] `pnpm lint` ✅
- [x] `pnpm test` ✅ — 787 passed (53 files + 1 new with 2 cases)
- [x] Manual QA via `playwright-cli` CDP attach: sidebar `v0.13.4` link confirmed in a11y snapshot pointing to `https://github.com/laststance/skills-desktop/releases/tag/v0.13.4`
- [x] Manual QA: seeded `localStorage["skills-desktop:last-seen-version"]="0.13.0"` → reload → toast appeared, `View` action navigates to GitHub release notes in default browser (verified by maintainer)
- [x] Verified `localStorage` updates to current version after toast, so subsequent launches stay silent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * アプリの更新後に「What's new」通知が一度表示され、リリースノートへのリンクが提供されるようになりました
  * サイドバーのアプリバージョン番号がクリック可能になり、対応するリリースノートページが新しいタブで開きます

<!-- end of auto-generated comment: release notes by coderabbit.ai -->