### PR TITLE
chore(e2e): apply CodeRabbit nitpick fixes deferred from PR #113

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ pnpm test:e2e
 
 E2E specs live in `e2e/spec/*.e2e.ts`. The suite uses `cp -al` hardlink snapshots so each test starts from a fresh, populated `~/.agents/skills/` without re-running the skills CLI installer (~50 ms reset). CI runs on `macos-latest` (`.github/workflows/e2e.yml`); failures upload `playwright-report/` and `test-results/` as artifacts (traces + videos retained on failure).
 
+> **⚠️ Hardlink caveat for spec authors.** Hardlinked files share inodes
+> across every working HOME, so in-place edits (`writeFileSync` over an
+> existing `SKILL.md`, `appendFileSync`, etc.) corrupt the snapshot for
+> every subsequent test. Safe ops only: `unlink`, `rmdir`, `mkdir` +
+> `writeFile` of NEW paths. See `e2e/fixtures/isolated-home.ts:44-50`
+> for the canonical safe-ops list.
+
 ### Build
 
 ```bash

--- a/e2e/helpers/redux.ts
+++ b/e2e/helpers/redux.ts
@@ -1,9 +1,28 @@
 import type { Page } from '@playwright/test'
 
 /**
+ * Action type that the `skillsSlice` `fetchAll` thunk dispatches on success.
+ *
+ * This is duplicated from `src/renderer/src/store/skillsSlice.ts` because
+ * `helpers/*` runs in the Playwright Node context — it cannot import the
+ * renderer bundle. Keeping the literal in one place (here) gives `grep`-able
+ * coupling: if the slice ever renames the thunk, the only spot a stale
+ * literal lingers is this constant.
+ *
+ * @see refreshSkillsState for the consumer.
+ */
+const SKILLS_FETCH_ALL_FULFILLED_TYPE = 'skills/fetchAll/fulfilled'
+
+/**
  * Read a slice of the renderer's Redux store via `page.evaluate`.
  * Throws on the test side (not the renderer) when the store isn't exposed,
  * which usually means the bundle was built without `E2E_BUILD=1`.
+ *
+ * Selector errors are wrapped with the source string + the failing message
+ * so a TypeError like `Cannot read properties of undefined (reading 'items')`
+ * surfaces alongside the actual selector body in the test failure output.
+ * Without this wrapping the error lands as a generic Playwright eval failure
+ * and the spec author has to re-derive which selector blew up.
  *
  * @example
  * const tab = await getStoreState(page, (state: any) => state.ui.activeTab)
@@ -23,10 +42,67 @@ export async function getStoreState<T>(
       const fn = new Function('state', `return (${selectorSrc})(state)`) as (
         state: unknown,
       ) => unknown
-      return fn(store.getState())
+      try {
+        return fn(store.getState())
+      } catch (selectorError) {
+        const errorMessage =
+          selectorError instanceof Error
+            ? selectorError.message
+            : String(selectorError)
+        throw new Error(
+          `getStoreState selector threw: ${errorMessage}\nselector source:\n${selectorSrc}`,
+        )
+      }
     },
     { selectorSrc: selector.toString() },
   ) as Promise<T>
+}
+
+/**
+ * Read the refreshed symlink status for `skillName` against `agentId` directly
+ * from the renderer store. Used by Phase-2 specs after `refreshSkillsState` to
+ * confirm an IPC-driven mutation (copy / unlink) propagated correctly.
+ *
+ * Returns `undefined` when the skill is not present in the store OR the agent
+ * has no symlink entry — both shapes are legitimate inputs depending on test
+ * setup, so the caller should compare against the expected literal
+ * (`'valid' | 'broken' | 'missing' | undefined`) rather than `?.toBe('valid')`.
+ *
+ * Closure-capture rules apply (see `getStoreState` doc): both `skillName` and
+ * `agentId` are passed via the second `evaluate` argument — module-level
+ * constants in the caller would be erased by `Function.toString`.
+ *
+ * @example
+ * const status = await getRefreshedSymlinkStatus(appWindow, 'azure-ai', 'cursor')
+ * expect(status).toBe('valid')
+ */
+export async function getRefreshedSymlinkStatus(
+  page: Page,
+  skillName: string,
+  agentId: string,
+): Promise<string | undefined> {
+  return page.evaluate(
+    ({ skillNameLiteral, agentIdLiteral }) => {
+      const store = window.__store__ ?? window.__store
+      const state = store?.getState() as
+        | {
+            skills?: {
+              items?: Array<{
+                name: string
+                symlinks?: Array<{ agentId: string; status: string }>
+              }>
+            }
+          }
+        | undefined
+      const skill = state?.skills?.items?.find(
+        (item) => item.name === skillNameLiteral,
+      )
+      return skill?.symlinks?.find(
+        (symlink) => symlink.agentId === agentIdLiteral,
+      )?.status
+    },
+    { skillNameLiteral: skillName, agentIdLiteral: agentId },
+  )
 }
 
 /**
@@ -124,22 +200,27 @@ export async function clearIpcEvents(page: Page): Promise<void> {
  * do not push back into the renderer store on their own.
  *
  * Internally calls `skills:getAll` and dispatches a synthetic
- * `skills/fetchAll/fulfilled` action so the slice's existing reducer applies
- * the payload — equivalent in effect to dispatching the `fetchSkills` thunk.
+ * `SKILLS_FETCH_ALL_FULFILLED_TYPE` action so the slice's existing reducer
+ * applies the payload — equivalent in effect to dispatching the `fetchSkills`
+ * thunk. The action type literal is centralized at the top of this file so
+ * future renames in `skillsSlice` only need to update one place.
  */
 export async function refreshSkillsState(page: Page): Promise<void> {
-  await page.evaluate(async () => {
-    const skills = await window.electron.skills.getAll()
-    const store = window.__store__ ?? window.__store
-    if (!store) {
-      throw new Error(
-        'window.__store__ is not exposed. Did you build with E2E_BUILD=1?',
-      )
-    }
-    store.dispatch({
-      type: 'skills/fetchAll/fulfilled',
-      payload: skills,
-      meta: { requestId: 'e2e-refresh', requestStatus: 'fulfilled' },
-    })
-  })
+  await page.evaluate(
+    async ({ actionType }) => {
+      const skills = await window.electron.skills.getAll()
+      const store = window.__store__ ?? window.__store
+      if (!store) {
+        throw new Error(
+          'window.__store__ is not exposed. Did you build with E2E_BUILD=1?',
+        )
+      }
+      store.dispatch({
+        type: actionType,
+        payload: skills,
+        meta: { requestId: 'e2e-refresh', requestStatus: 'fulfilled' },
+      })
+    },
+    { actionType: SKILLS_FETCH_ALL_FULFILLED_TYPE },
+  )
 }

--- a/e2e/spec/copy.e2e.ts
+++ b/e2e/spec/copy.e2e.ts
@@ -5,6 +5,7 @@ import { test, expect } from '../fixtures/electron-app'
 import {
   clearIpcEvents,
   getIpcEvents,
+  getRefreshedSymlinkStatus,
   getStoreState,
   refreshSkillsState,
   waitForInitialScan,
@@ -146,30 +147,10 @@ test('copyToAgents replicates azure-ai to a missing target agent', async ({
   // missed-refresh regression.
   await refreshSkillsState(appWindow)
 
-  // Closure capture rules: selector source string is re-evaluated, so
-  // `targetSymlink.agentId` must be inlined too (see note above).
-  const targetAgentId = targetSymlink.agentId
-  const refreshedLinkStatus = await appWindow.evaluate(
-    (agentIdLiteral: string) => {
-      const store = window.__store__ ?? window.__store
-      const state = store?.getState() as
-        | {
-            skills?: {
-              items?: Array<{
-                name: string
-                symlinks?: Array<{ agentId: string; status: string }>
-              }>
-            }
-          }
-        | undefined
-      const refreshedAzure = state?.skills?.items?.find(
-        (skill) => skill.name === 'azure-ai',
-      )
-      return refreshedAzure?.symlinks?.find(
-        (symlink) => symlink.agentId === agentIdLiteral,
-      )?.status
-    },
-    targetAgentId,
+  const refreshedLinkStatus = await getRefreshedSymlinkStatus(
+    appWindow,
+    AZURE_AI_NAME,
+    targetSymlink.agentId,
   )
   expect(refreshedLinkStatus).toBe('valid')
 

--- a/e2e/spec/delete.e2e.ts
+++ b/e2e/spec/delete.e2e.ts
@@ -33,6 +33,37 @@ interface SourceBackedManifest {
 const AZURE_AI_NAME = 'azure-ai'
 
 /**
+ * Single snapshot selector for azure-ai used by every test in this file.
+ *
+ * `getStoreState` serializes this function via `Function.prototype.toString`
+ * and re-evaluates it inside the renderer (`new Function('state', ...)`),
+ * so the body must NOT close over outer-scope identifiers — `'azure-ai'`
+ * is inlined as a string literal even though `AZURE_AI_NAME` is in scope
+ * at the call site.
+ *
+ * Promoting this from three inline copies removes the easy mistake of
+ * tweaking one filter and missing the other two when the schema evolves.
+ */
+const azureSnapshotSelector = (state: unknown): AzureSnapshot => {
+  const root = state as {
+    skills: {
+      items: Array<{
+        name: string
+        path: string
+        symlinks: SymlinkSnapshot[]
+      }>
+    }
+  }
+  const azure = root.skills.items.find((skill) => skill.name === 'azure-ai')
+  return {
+    hasAzure: Boolean(azure),
+    sourcePath: azure?.path ?? null,
+    validSymlinks:
+      azure?.symlinks.filter((symlink) => symlink.status === 'valid') ?? [],
+  }
+}
+
+/**
  * Phase-2 spec covering `SKILLS_DELETE` + `SKILLS_RESTORE_DELETED` end-to-end.
  *
  * Two tests, both using the source-backed flow (azure-ai is installed by
@@ -70,27 +101,7 @@ test('deleteSkill moves source-backed skill into trash and unlinks every agent s
     AZURE_AI_NAME,
   )
 
-  // Selector source is re-evaluated in renderer context (see redux.ts:23) so
-  // closures over module-level constants are NOT preserved — `'azure-ai'`
-  // must be inlined as a literal inside the selector body.
-  const initial = await getStoreState(appWindow, (state): AzureSnapshot => {
-    const root = state as {
-      skills: {
-        items: Array<{
-          name: string
-          path: string
-          symlinks: SymlinkSnapshot[]
-        }>
-      }
-    }
-    const azure = root.skills.items.find((skill) => skill.name === 'azure-ai')
-    return {
-      hasAzure: Boolean(azure),
-      sourcePath: azure?.path ?? null,
-      validSymlinks:
-        azure?.symlinks.filter((symlink) => symlink.status === 'valid') ?? [],
-    }
-  })
+  const initial = await getStoreState(appWindow, azureSnapshotSelector)
 
   expect(initial.hasAzure, 'azure-ai should be installed by global-setup').toBe(
     true,
@@ -171,24 +182,7 @@ test('restoreDeletedSkill recovers a source-backed deletion within the undo wind
     AZURE_AI_NAME,
   )
 
-  const initial = await getStoreState(appWindow, (state): AzureSnapshot => {
-    const root = state as {
-      skills: {
-        items: Array<{
-          name: string
-          path: string
-          symlinks: SymlinkSnapshot[]
-        }>
-      }
-    }
-    const azure = root.skills.items.find((skill) => skill.name === 'azure-ai')
-    return {
-      hasAzure: Boolean(azure),
-      sourcePath: azure?.path ?? null,
-      validSymlinks:
-        azure?.symlinks.filter((symlink) => symlink.status === 'valid') ?? [],
-    }
-  })
+  const initial = await getStoreState(appWindow, azureSnapshotSelector)
 
   expect(initial.hasAzure).toBe(true)
   expect(initial.validSymlinks.length).toBeGreaterThan(0)
@@ -244,24 +238,7 @@ test('restoreDeletedSkill recovers a source-backed deletion within the undo wind
   // for the restored agents land on `valid` because the source dir exists
   // and the symlink target resolves.
   await refreshSkillsState(appWindow)
-  const restored = await getStoreState(appWindow, (state): AzureSnapshot => {
-    const root = state as {
-      skills: {
-        items: Array<{
-          name: string
-          path: string
-          symlinks: SymlinkSnapshot[]
-        }>
-      }
-    }
-    const azure = root.skills.items.find((skill) => skill.name === 'azure-ai')
-    return {
-      hasAzure: Boolean(azure),
-      sourcePath: azure?.path ?? null,
-      validSymlinks:
-        azure?.symlinks.filter((symlink) => symlink.status === 'valid') ?? [],
-    }
-  })
+  const restored = await getStoreState(appWindow, azureSnapshotSelector)
 
   expect(restored.hasAzure).toBe(true)
   expect(restored.sourcePath).toBe(expectedSourcePath)

--- a/e2e/spec/regression.e2e.ts
+++ b/e2e/spec/regression.e2e.ts
@@ -11,7 +11,6 @@ import {
 
 interface SymlinkSnapshot {
   agentId: string
-  agentName: string
   status: 'valid' | 'broken' | 'missing'
   isLocal: boolean
   linkPath: string
@@ -94,6 +93,13 @@ test('cline/warp do NOT report universal source skills as their own local skills
   expect(
     existsSync(join(isolatedHome, '.agents', 'skills', AZURE_AI_NAME)),
   ).toBe(true)
+  // Cline/Warp scanDirs may not exist in the snapshot HOME at all — the
+  // skills CLI only creates `~/.cline/skills` and `~/.warp/skills` when an
+  // agent is targeted via `--agent`, and global-setup intentionally does not.
+  // Skipping `readdirSync` when the dir is absent is sound: a non-existent
+  // dir trivially cannot contain `azure-ai`, so the contrapositive of the
+  // assertion still holds. The block runs only when the layout *could*
+  // contain a false-positive.
   const clineDirExists = existsSync(join(isolatedHome, '.cline', 'skills'))
   const warpDirExists = existsSync(join(isolatedHome, '.warp', 'skills'))
   if (clineDirExists) {

--- a/e2e/types.d.ts
+++ b/e2e/types.d.ts
@@ -38,6 +38,15 @@ declare global {
      * Mirrors the relevant shape of `src/renderer/src/types/electron.d.ts`
      * but avoids importing across tsconfig boundaries — only the channels
      * the suite drives are typed here.
+     *
+     * **Non-optional by contract.** The Playwright fixture only launches
+     * builds produced with `E2E_BUILD=1`, and the contextBridge expose
+     * happens unconditionally in `src/preload/index.ts:30`. Marking this
+     * `electron?:` would force every `page.evaluate(... window.electron.X)`
+     * call site to add optional chaining for a guarantee that already
+     * holds — verbose with no diagnostic value. If the bridge ever fails
+     * to mount, the spec fails on the first call with a clear "cannot
+     * read properties of undefined" message that names the channel.
      */
     electron: {
       skills: {


### PR DESCRIPTION
## Summary

Follow-up to #113. Resolves the 8 nitpick threads that were intentionally deferred during the Phase-1 E2E review per the /ship pre-landing audit decision. All changes are pure refactoring — no behavior change, no IPC contract change.

## Threads addressed

| File | Nitpick | Fix |
|------|---------|-----|
| `e2e/fixtures/isolated-home.ts` | #1 — hardlink caveat should be discoverable from README | Add a callout block to README Testing section pointing at `isolated-home.ts:44-50` for the safe-ops list |
| `e2e/helpers/redux.ts:26` | #2 — `new Function()` selector eval has no diagnostic on failure | Wrap eval in `try/catch` that re-throws with source string + original error message |
| `e2e/helpers/redux.ts:145` | #3 — `'skills/fetchAll/fulfilled'` literal couples helper to slice internals | Promote to named constant `SKILLS_FETCH_ALL_FULFILLED_TYPE` with grep-able contract comment |
| `e2e/spec/copy.e2e.ts:152-173` | #4 — inline `appWindow.evaluate` re-implements `getStoreState` pattern | Add `getRefreshedSymlinkStatus(page, skillName, agentId)` helper to `redux.ts`; replace the 22-line inline block with a single helper call |
| `e2e/spec/delete.e2e.ts` | #5 — `AzureSnapshot` selector duplicated 3x | Promote to named `azureSnapshotSelector` const at file top |
| `e2e/spec/regression.e2e.ts:18` | #6 — `agentName` field inconsistent with sibling spec types | Drop `agentName` (was never read); now matches `copy.e2e.ts` and `unlink-agent.e2e.ts` |
| `e2e/spec/regression.e2e.ts:99-112` | #7 — implicit "absent dir ⇒ no azure-ai" assumption is invisible to readers | Add inline explanation above the existence guard |
| `e2e/types.d.ts:42` | #8 — `window.electron` could be optional | Add JSDoc justifying why it stays non-optional (`E2E_BUILD=1` build flag is the contract; optional chaining everywhere would be verbose with no diagnostic gain) |

## Why these were deferred (and why now)

In the original PR I argued for handling these after Phase-2 lands — the rationale being that Phase-2 (bulk IPC assertions, broader spec surface) would clarify which helpers wanted promotion to shared. Re-evaluating: the fixes here are mechanical and don't depend on Phase-2 design. Shipping them now keeps `pnpm test:e2e` cleaner for whoever picks up Phase-2.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test:e2e` (full suite, 12 tests) — all green in 13.2s
- [x] Smoke test passes: `pnpm test:e2e --grep smoke` (1.1s)
- [x] Refactored specs pass: `pnpm test:e2e --grep "copyToAgents|deleteSkill|restoreDeletedSkill"` (3/3 in 7.0s)