### PR TITLE
test(e2e): cover Phase-2 sub-cases for copy/delete/bulk-delete

### DIFF
--- a/e2e/spec/bulk-delete.e2e.ts
+++ b/e2e/spec/bulk-delete.e2e.ts
@@ -3,6 +3,7 @@ import {
   mkdirSync,
   readFileSync,
   readdirSync,
+  rmSync,
   writeFileSync,
 } from 'node:fs'
 import { join } from 'node:path'
@@ -177,4 +178,93 @@ test('bulk deleteSkills at BULK_PROGRESS_THRESHOLD (N=10) emits sequential progr
     entry.includes('-bulk-at-'),
   )
   expect(trashEntries).toHaveLength(10)
+})
+
+/**
+ * Partial-failure boundary — one item in the batch raises `TrashError 'ENOENT'`
+ * (its source dir was wiped out-of-band before the IPC call), the other nine
+ * succeed. Locks in the contract that:
+ *
+ *   1. The serial loop in `SKILLS_DELETE_BATCH` does NOT short-circuit on a
+ *      per-item error — every remaining item still runs.
+ *   2. The failing item produces an `outcome: 'error'` row with a structured
+ *      `error: { message, code: 'ENOENT' }` instead of throwing out of the
+ *      handler.
+ *   3. Progress events still fire for every iteration when N >= threshold.
+ *      A regression that moved the `typedSend` inside the try/catch would
+ *      drop the failing item's tick and the progress stream would only have
+ *      9 events for a 10-item batch.
+ */
+test('bulk deleteSkills with one missing source returns per-item error and continues the batch', async ({
+  appWindow,
+  isolatedHome,
+}) => {
+  const skillNames = preStageDummySkills(isolatedHome, 10, 'bulk-partial')
+  // Pick a middle index so a regression that breaks AFTER the first error
+  // still trips the assertion. Index 0 or N-1 would not catch a partial loop
+  // that aborts as soon as the first error fires.
+  const failingIndex = 5
+  const failingSkillName = skillNames[failingIndex]
+  rmSync(join(isolatedHome, '.agents', 'skills', failingSkillName), {
+    recursive: true,
+    force: true,
+  })
+
+  await waitForInitialScan(appWindow)
+
+  await clearIpcEvents(appWindow)
+
+  const result = await appWindow.evaluate(
+    async (items: Array<{ skillName: string }>) =>
+      window.electron.skills.deleteSkills({ items }),
+    skillNames.map((skillName) => ({ skillName })),
+  )
+
+  expect(result.items).toHaveLength(10)
+
+  // Per-item assertions — exactly one error row at the expected index, every
+  // other row a success. Iterate by index instead of filtering so a regression
+  // that misroutes the error to a different position is caught.
+  for (const [index, item] of result.items.entries()) {
+    if (index === failingIndex) {
+      expect(item.skillName).toBe(failingSkillName)
+      expect(item.outcome).toBe('error')
+      if (item.outcome === 'error') {
+        expect(item.error.code).toBe('ENOENT')
+        expect(item.error.message).toMatch(/Skill not found/)
+      }
+    } else {
+      expect(item.skillName).toBe(skillNames[index])
+      expect(item.outcome).toBe('deleted')
+    }
+  }
+
+  // Progress events — N=10 >= threshold, so the handler must emit one tick per
+  // iteration regardless of per-item success. This is the load-bearing
+  // assertion against a "wrap typedSend in the try block" regression that
+  // would silently drop the failing item's tick.
+  const recordedEvents = await getIpcEvents(appWindow)
+  const progressEvents = recordedEvents
+    .filter((event) => event.channel === 'skills:deleteProgress')
+    .map((event) => event.data as DeleteProgressPayload)
+  expect(progressEvents).toHaveLength(10)
+  expect(progressEvents).toEqual(
+    Array.from({ length: 10 }, (_, index) => ({
+      current: index + 1,
+      total: 10,
+    })),
+  )
+
+  // FS — exactly 9 trash entries (one short of N), and the failing skill has
+  // no entry by name. Ranged includes-check protects against a regression
+  // where the handler creates an empty/half-written tombstone for the failing
+  // item before bailing, which would still match a length-only check.
+  const trashDir = join(isolatedHome, '.agents', '.trash')
+  const trashEntries = readdirSync(trashDir).filter((entry) =>
+    entry.includes('-bulk-partial-'),
+  )
+  expect(trashEntries).toHaveLength(9)
+  expect(
+    trashEntries.some((entry) => entry.includes(`-${failingSkillName}-`)),
+  ).toBe(false)
 })

--- a/e2e/spec/copy.e2e.ts
+++ b/e2e/spec/copy.e2e.ts
@@ -328,18 +328,59 @@ test('copyToAgents reports per-target Already exists and continues with the rest
   const sourceMarker = `# ${skillName}\n\nfresh source for partial-failure test\n`
   writeFileSync(join(sourcePath, 'SKILL.md'), sourceMarker)
 
+  await waitForInitialScan(appWindow)
+
+  // Pick two agents with distinct, non-shared scan dirs straight from the
+  // running store. Hardcoding `cursor` / `gemini-cli` would couple this test
+  // to AGENT_DEFINITIONS by name; the contract being verified is the
+  // collision *policy*, not the survival of any particular agent in the
+  // catalog. Filtering on `seenPaths` also sidesteps the IRON RULE shared
+  // scanDirs (amp / kimi-cli / replit on .config/agents/skills) — picking
+  // two agents that share a path would let the second mkdirSync see the
+  // first's collision and break the asymmetric setup.
+  const agentSelection = await getStoreState(appWindow, (state) => {
+    const root = state as {
+      agents: { items: Array<{ id: string; name: string; path: string }> }
+    }
+    const seenPaths = new Set<string>()
+    const uniques: Array<{ id: string; path: string }> = []
+    for (const agent of root.agents.items) {
+      if (seenPaths.has(agent.path)) continue
+      seenPaths.add(agent.path)
+      uniques.push({ id: agent.id, path: agent.path })
+      if (uniques.length === 2) break
+    }
+    return {
+      occupiedAgentId: uniques[0]?.id ?? null,
+      occupiedAgentPath: uniques[0]?.path ?? null,
+      freeAgentId: uniques[1]?.id ?? null,
+      freeAgentPath: uniques[1]?.path ?? null,
+    }
+  })
+
+  expect(agentSelection.occupiedAgentId).toBeTruthy()
+  expect(agentSelection.occupiedAgentPath).toBeTruthy()
+  expect(agentSelection.freeAgentId).toBeTruthy()
+  expect(agentSelection.freeAgentPath).toBeTruthy()
+  if (
+    !agentSelection.occupiedAgentId ||
+    !agentSelection.occupiedAgentPath ||
+    !agentSelection.freeAgentId ||
+    !agentSelection.freeAgentPath
+  ) {
+    return
+  }
+  const { occupiedAgentId, occupiedAgentPath, freeAgentId, freeAgentPath } =
+    agentSelection
+
   // Pre-occupy ONE target. The handler's `lstat(destPath)` will succeed and
   // push 'Already exists'. A real-but-different file in the destination is
   // the strongest signal: if the handler ever switches to overwrite, the
   // sentinel content disappears and the assertion below catches it.
-  const occupiedAgentId = 'cursor'
-  const freeAgentId = 'gemini-cli'
-  const occupiedAgentPath = join(isolatedHome, '.cursor', 'skills', skillName)
-  mkdirSync(occupiedAgentPath, { recursive: true })
+  const occupiedSkillDir = join(occupiedAgentPath, skillName)
+  mkdirSync(occupiedSkillDir, { recursive: true })
   const sentinelContent = `# pre-existing\nDO NOT OVERWRITE — collision sentinel.\n`
-  writeFileSync(join(occupiedAgentPath, 'SKILL.md'), sentinelContent)
-
-  await waitForInitialScan(appWindow)
+  writeFileSync(join(occupiedSkillDir, 'SKILL.md'), sentinelContent)
 
   const ipcResult = await appWindow.evaluate(
     async (args: {
@@ -363,7 +404,7 @@ test('copyToAgents reports per-target Already exists and continues with the rest
   // FS — sentinel survived (collision did NOT overwrite). Read the bytes
   // back so a regression that swaps `lstat` for `cp -f` shows up as a
   // content mismatch instead of a length-only check.
-  expect(readFileSync(join(occupiedAgentPath, 'SKILL.md'), 'utf-8')).toBe(
+  expect(readFileSync(join(occupiedSkillDir, 'SKILL.md'), 'utf-8')).toBe(
     sentinelContent,
   )
 
@@ -371,7 +412,7 @@ test('copyToAgents reports per-target Already exists and continues with the rest
   // the sentinel. This is the load-bearing "loop continues" assertion: a
   // regression that aborts the loop on first failure would leave the free
   // agent's path untouched.
-  const freeAgentDestPath = join(isolatedHome, '.gemini', 'skills', skillName)
+  const freeAgentDestPath = join(freeAgentPath, skillName)
   expect(existsSync(freeAgentDestPath)).toBe(true)
   expect(readFileSync(join(freeAgentDestPath, 'SKILL.md'), 'utf-8')).toBe(
     sourceMarker,
@@ -442,6 +483,14 @@ test('copyToAgents UI-driven modal copies via dispatch + checkbox click', async 
   ) {
     return
   }
+  const targetLinkPath = modalSelection.targetLinkPath
+
+  // Pre-condition the FS state. If a snapshot reset ever leaves stale bytes
+  // at this path, the post-click existence check would be a false positive
+  // — a "test passed" outcome that doesn't prove the click chain reached
+  // `fs.cp` at all. Asserting non-existence up front converts that mode
+  // into a loud failure right at the boundary.
+  expect(existsSync(targetLinkPath)).toBe(false)
 
   // Drive Redux. `selectedAgentId` is set first because the modal's
   // `targetAgents` memo depends on it; toggling order would briefly render
@@ -486,21 +535,13 @@ test('copyToAgents UI-driven modal copies via dispatch + checkbox click', async 
     .getByRole('button', { name: /^Copy to \d+ agent\(s\)$/ })
     .click()
 
-  // Wait for the thunk to settle. `copying` flips true on dispatch and back
-  // to false on fulfilled/rejected; polling the slice avoids guessing how
-  // long fs.cp takes for the azure-ai tree.
-  await appWindow.waitForFunction(
-    () => {
-      const store = window.__store__ ?? window.__store
-      const state = store?.getState() as { skills?: { copying?: boolean } }
-      return state?.skills?.copying === false
-    },
-    undefined,
-    { timeout: 10_000 },
-  )
-
-  // FS — the target's linkPath now exists. Existence is the smallest proxy
-  // that the click chain reached the IPC handler; the symlink-vs-directory
-  // contract is already covered by the local-copy variant above.
-  expect(existsSync(modalSelection.targetLinkPath)).toBe(true)
+  // Poll the FS directly. `state.skills.copying` flips false on both initial
+  // mount AND fulfillment, so a Redux poll can pass before the click chain
+  // ever reaches `fs.cp` — masking a regression where the dispatch never
+  // fires. FS existence is the smallest signal the IPC handler completed
+  // end-to-end. The symlink-vs-directory contract is already covered by the
+  // local-copy variant above, so existence is enough here.
+  await expect
+    .poll(() => existsSync(targetLinkPath), { timeout: 10_000 })
+    .toBe(true)
 })

--- a/e2e/spec/copy.e2e.ts
+++ b/e2e/spec/copy.e2e.ts
@@ -1,4 +1,11 @@
-import { existsSync, lstatSync, realpathSync } from 'node:fs'
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  writeFileSync,
+} from 'node:fs'
 import { join } from 'node:path'
 
 import { test, expect } from '../fixtures/electron-app'
@@ -54,8 +61,8 @@ const AZURE_AI_NAME = 'azure-ai'
  *   3. Renderer state (post-refresh `state.skills.items` reflects the new
  *      `valid` symlink for the target agent)
  *
- * Phase-2 follow-up specs will add a UI-driven variant that walks the modal
- * to cover the click handlers (TODO).
+ * UI-driven coverage of the modal interactions lives at the bottom of this
+ * file (`copyToAgents UI-driven modal …`).
  */
 test('copyToAgents replicates azure-ai to a missing target agent', async ({
   appWindow,
@@ -162,4 +169,338 @@ test('copyToAgents replicates azure-ai to a missing target agent', async ({
   expect(
     recordedEvents.filter((event) => event.channel === 'skills:copyToAgents'),
   ).toEqual([])
+})
+
+/**
+ * Symlink-source branch of the IPC handler — when `sourcePath` itself is a
+ * symlink, the handler must:
+ *
+ *   1. `readlink` to get the raw target.
+ *   2. Resolve it against `dirname(sourcePath)` (so relative links don't get
+ *      rooted at cwd).
+ *   3. Validate the resolved target via `validatePath(... getAllowedBases())`.
+ *   4. `fs.symlink(symlinkTarget, destPath)` — i.e., replicate the link, NOT
+ *      copy the underlying directory tree.
+ *
+ * The existing top-of-file test exercises the directory branch via the source
+ * dir at `~/.agents/skills/azure-ai`. Here we pass a per-agent symlink (e.g.,
+ * `~/.codex/skills/azure-ai`) as `sourcePath` so the lstat lands on a symlink
+ * and the alternate code path runs.
+ *
+ * KEY assertion is `lstat(targetLink).isSymbolicLink()` — a regression that
+ * collapsed both branches into `fs.cp` would create a real directory at the
+ * target instead of a symlink, and the test would catch it before the broken
+ * "deleting the target deletes the source" UX shipped.
+ */
+test('copyToAgents replicates a symlink source verbatim (local-copy variant)', async ({
+  appWindow,
+  isolatedHome,
+}) => {
+  await waitForInitialScan(appWindow)
+
+  const expectedSourceDir = join(
+    isolatedHome,
+    '.agents',
+    'skills',
+    AZURE_AI_NAME,
+  )
+
+  // Pick the first valid-and-non-local symlink as the source linkPath, and
+  // the first missing-and-non-local symlink as the target. Both lookups
+  // re-evaluate inside the renderer, so 'azure-ai' must stay a string literal.
+  const linkSelection = await getStoreState(appWindow, (state) => {
+    const root = state as {
+      skills: {
+        items: Array<{
+          name: string
+          path: string
+          symlinks: SymlinkSnapshot[]
+        }>
+      }
+    }
+    const azure = root.skills.items.find((skill) => skill.name === 'azure-ai')
+    const validLink = azure?.symlinks.find(
+      (symlink) => symlink.status === 'valid' && !symlink.isLocal,
+    )
+    const missingLink = azure?.symlinks.find(
+      (symlink) => symlink.status === 'missing' && !symlink.isLocal,
+    )
+    return {
+      sourceLinkPath: validLink?.linkPath ?? null,
+      sourceAgentId: validLink?.agentId ?? null,
+      targetLinkPath: missingLink?.linkPath ?? null,
+      targetAgentId: missingLink?.agentId ?? null,
+    }
+  })
+
+  expect(
+    linkSelection.sourceLinkPath,
+    'expected at least one agent with azure-ai linked — global-setup contract',
+  ).toBeTruthy()
+  expect(
+    linkSelection.targetLinkPath,
+    'expected at least one agent without azure-ai linked — global-setup contract',
+  ).toBeTruthy()
+  if (
+    !linkSelection.sourceLinkPath ||
+    !linkSelection.targetLinkPath ||
+    !linkSelection.targetAgentId
+  ) {
+    return
+  }
+
+  // Sanity — the source we're about to feed to the IPC really is a symlink
+  // on disk. If global-setup ever switches to physical copies for these
+  // agents, this test must be revisited (the directory branch already has
+  // coverage above).
+  expect(lstatSync(linkSelection.sourceLinkPath).isSymbolicLink()).toBe(true)
+
+  await clearIpcEvents(appWindow)
+
+  const ipcResult = await appWindow.evaluate(
+    async (args: {
+      skillName: string
+      sourcePath: string
+      targetAgentIds: string[]
+    }) => window.electron.skills.copyToAgents(args),
+    {
+      skillName: AZURE_AI_NAME,
+      sourcePath: linkSelection.sourceLinkPath,
+      targetAgentIds: [linkSelection.targetAgentId],
+    },
+  )
+
+  expect(ipcResult.success).toBe(true)
+  expect(ipcResult.copied).toBe(1)
+  expect(ipcResult.failures).toEqual([])
+
+  // FS — the target must be a symlink (NOT a directory). A regression that
+  // collapsed both branches into `fs.cp` would surface here as
+  // `isSymbolicLink() === false`.
+  expect(existsSync(linkSelection.targetLinkPath)).toBe(true)
+  const targetStat = lstatSync(linkSelection.targetLinkPath)
+  expect(targetStat.isSymbolicLink()).toBe(true)
+
+  // Realpath round-trip — the new symlink must canonicalize to the same
+  // location as the universal source dir. This confirms the readlink ->
+  // resolve(dirname, raw) -> fs.symlink(target, dest) chain produced a
+  // working link, not a dangling one.
+  expect(realpathSync.native(linkSelection.targetLinkPath)).toBe(
+    realpathSync.native(expectedSourceDir),
+  )
+
+  await refreshSkillsState(appWindow)
+  const refreshedStatus = await getRefreshedSymlinkStatus(
+    appWindow,
+    AZURE_AI_NAME,
+    linkSelection.targetAgentId,
+  )
+  expect(refreshedStatus).toBe('valid')
+})
+
+/**
+ * Per-target collision policy — when one of the requested target agents
+ * already owns an entry at `<agent.path>/<skillName>`, the IPC handler MUST:
+ *
+ *   1. Push a `{ agentId, error: 'Already exists' }` row into `failures`.
+ *   2. NOT overwrite the existing entry (no `fs.cp` against an occupied path).
+ *   3. Continue the loop — every other target still gets copied.
+ *   4. Return `success: false` because `failures.length > 0`, with `copied`
+ *      reflecting only the successful targets.
+ *
+ * No rollback contract is exercised here on purpose — the handler does not
+ * clean up successful copies when a sibling fails. This test locks that in:
+ * a future "rollback all on partial failure" change would flip the success
+ * count and the FS shape, and the assertions below would catch it.
+ *
+ * Source is a fresh dummy dir created procedurally so the snapshot's azure-*
+ * link topology is irrelevant to the assertion.
+ */
+test('copyToAgents reports per-target Already exists and continues with the rest (no rollback)', async ({
+  appWindow,
+  isolatedHome,
+}) => {
+  // Brand-new skill name so no agent in the snapshot has it linked. Avoids
+  // dependency on global-setup's --global link set.
+  const skillName = 'copy-partial'
+  const sourcePath = join(isolatedHome, '.agents', 'skills', skillName)
+  mkdirSync(sourcePath, { recursive: true })
+  const sourceMarker = `# ${skillName}\n\nfresh source for partial-failure test\n`
+  writeFileSync(join(sourcePath, 'SKILL.md'), sourceMarker)
+
+  // Pre-occupy ONE target. The handler's `lstat(destPath)` will succeed and
+  // push 'Already exists'. A real-but-different file in the destination is
+  // the strongest signal: if the handler ever switches to overwrite, the
+  // sentinel content disappears and the assertion below catches it.
+  const occupiedAgentId = 'cursor'
+  const freeAgentId = 'gemini-cli'
+  const occupiedAgentPath = join(isolatedHome, '.cursor', 'skills', skillName)
+  mkdirSync(occupiedAgentPath, { recursive: true })
+  const sentinelContent = `# pre-existing\nDO NOT OVERWRITE — collision sentinel.\n`
+  writeFileSync(join(occupiedAgentPath, 'SKILL.md'), sentinelContent)
+
+  await waitForInitialScan(appWindow)
+
+  const ipcResult = await appWindow.evaluate(
+    async (args: {
+      skillName: string
+      sourcePath: string
+      targetAgentIds: string[]
+    }) => window.electron.skills.copyToAgents(args),
+    {
+      skillName,
+      sourcePath,
+      targetAgentIds: [occupiedAgentId, freeAgentId],
+    },
+  )
+
+  expect(ipcResult.success).toBe(false)
+  expect(ipcResult.copied).toBe(1)
+  expect(ipcResult.failures).toEqual([
+    { agentId: occupiedAgentId, error: 'Already exists' },
+  ])
+
+  // FS — sentinel survived (collision did NOT overwrite). Read the bytes
+  // back so a regression that swaps `lstat` for `cp -f` shows up as a
+  // content mismatch instead of a length-only check.
+  expect(readFileSync(join(occupiedAgentPath, 'SKILL.md'), 'utf-8')).toBe(
+    sentinelContent,
+  )
+
+  // FS — the free agent's destPath was created with the source content, NOT
+  // the sentinel. This is the load-bearing "loop continues" assertion: a
+  // regression that aborts the loop on first failure would leave the free
+  // agent's path untouched.
+  const freeAgentDestPath = join(isolatedHome, '.gemini', 'skills', skillName)
+  expect(existsSync(freeAgentDestPath)).toBe(true)
+  expect(readFileSync(join(freeAgentDestPath, 'SKILL.md'), 'utf-8')).toBe(
+    sourceMarker,
+  )
+})
+
+/**
+ * UI-driven coverage of `CopyToAgentsModal`. The earlier tests in this file
+ * drive the IPC directly; this one walks the click path the user actually
+ * takes:
+ *
+ *   1. Set `state.ui.selectedAgentId` so the modal can derive `sourcePath`
+ *      from `skillToCopy.symlinks[selectedAgentId].linkPath`.
+ *   2. Dispatch `skills/setSkillToCopy` with the azure-ai snapshot — this is
+ *      what the right-click "Copy to..." menu item dispatches in production.
+ *   3. Tick the target agent's checkbox by `aria-label` (mirrors the modal's
+ *      `<Checkbox aria-label={agent.name} />`).
+ *   4. Click the primary "Copy to N agent(s)" button.
+ *   5. Wait for `state.skills.copying === false` to know the IPC settled.
+ *
+ * The IPC contract is already covered above, so this test only verifies the
+ * UI wiring: the modal must mount, the checkbox toggle must update Redux,
+ * and the primary button must fire the `copyToAgents` thunk. Filesystem
+ * existence is the simplest proxy that the whole click chain reached `fs.cp`.
+ */
+test('copyToAgents UI-driven modal copies via dispatch + checkbox click', async ({
+  appWindow,
+}) => {
+  await waitForInitialScan(appWindow)
+
+  // Locate a valid source agent (provides linkPath the modal needs) plus a
+  // missing-symlink target agent (so the copy can succeed without colliding).
+  // Both agent ids and the target's display name are returned because the
+  // checkbox's aria-label is the human name (e.g., "Goose"), not the id.
+  const modalSelection = await getStoreState(appWindow, (state) => {
+    const root = state as {
+      skills: {
+        items: Array<{ name: string; symlinks: SymlinkSnapshot[] }>
+      }
+      agents: { items: Array<{ id: string; name: string }> }
+    }
+    const azure = root.skills.items.find((skill) => skill.name === 'azure-ai')
+    const validSymlink = azure?.symlinks.find(
+      (symlink) => symlink.status === 'valid' && !symlink.isLocal,
+    )
+    const targetSymlink = azure?.symlinks.find(
+      (symlink) => symlink.status === 'missing' && !symlink.isLocal,
+    )
+    const targetAgent = root.agents.items.find(
+      (agent) => agent.id === targetSymlink?.agentId,
+    )
+    return {
+      sourceAgentId: validSymlink?.agentId ?? null,
+      targetAgentId: targetSymlink?.agentId ?? null,
+      targetAgentName: targetAgent?.name ?? null,
+      targetLinkPath: targetSymlink?.linkPath ?? null,
+    }
+  })
+
+  expect(modalSelection.sourceAgentId).toBeTruthy()
+  expect(modalSelection.targetAgentId).toBeTruthy()
+  expect(modalSelection.targetAgentName).toBeTruthy()
+  expect(modalSelection.targetLinkPath).toBeTruthy()
+  if (
+    !modalSelection.sourceAgentId ||
+    !modalSelection.targetAgentName ||
+    !modalSelection.targetLinkPath
+  ) {
+    return
+  }
+
+  // Drive Redux. `selectedAgentId` is set first because the modal's
+  // `targetAgents` memo depends on it; toggling order would briefly render
+  // an empty list. Action types are inlined string literals — these
+  // dispatches re-evaluate inside the renderer where slice-imported action
+  // creators are out of scope.
+  await appWindow.evaluate((sourceAgentId: string) => {
+    const store = window.__store__ ?? window.__store
+    store?.dispatch({ type: 'ui/selectAgent', payload: sourceAgentId })
+  }, modalSelection.sourceAgentId)
+
+  await appWindow.evaluate(() => {
+    const store = window.__store__ ?? window.__store
+    const state = store?.getState() as {
+      skills?: { items?: Array<{ name: string }> }
+    }
+    const azure = state?.skills?.items?.find(
+      (skill) => skill.name === 'azure-ai',
+    )
+    if (azure) {
+      store?.dispatch({ type: 'skills/setSkillToCopy', payload: azure })
+    }
+  })
+
+  // Modal mount — the DialogTitle text is the most stable signal that the
+  // dialog is open and rendered. Roles also work but the title is unique
+  // and more readable in failure output.
+  await appWindow.getByRole('heading', { name: 'Copy to Agents' }).waitFor({
+    state: 'visible',
+    timeout: 5_000,
+  })
+
+  // Tick the target agent's checkbox. aria-label is the agent's display
+  // name (see CopyToAgentsModal.tsx:165 — `<Checkbox aria-label={agent.name} />`).
+  await appWindow
+    .getByRole('checkbox', { name: modalSelection.targetAgentName })
+    .check()
+
+  // Primary button label is dynamic ("Copy to 1 agent(s)"). Match the prefix
+  // so the test stays robust to copy-tweaks of the count parenthetical.
+  await appWindow
+    .getByRole('button', { name: /^Copy to \d+ agent\(s\)$/ })
+    .click()
+
+  // Wait for the thunk to settle. `copying` flips true on dispatch and back
+  // to false on fulfilled/rejected; polling the slice avoids guessing how
+  // long fs.cp takes for the azure-ai tree.
+  await appWindow.waitForFunction(
+    () => {
+      const store = window.__store__ ?? window.__store
+      const state = store?.getState() as { skills?: { copying?: boolean } }
+      return state?.skills?.copying === false
+    },
+    undefined,
+    { timeout: 10_000 },
+  )
+
+  // FS — the target's linkPath now exists. Existence is the smallest proxy
+  // that the click chain reached the IPC handler; the symlink-vs-directory
+  // contract is already covered by the local-copy variant above.
+  expect(existsSync(modalSelection.targetLinkPath)).toBe(true)
 })

--- a/e2e/spec/delete.e2e.ts
+++ b/e2e/spec/delete.e2e.ts
@@ -364,16 +364,18 @@ test('deleteSkill moves a local-only skill into trash with kind="local-only" man
  *   1. The entry dir is removed from `.trash/`.
  *   2. The internal `evictTimers` map drops the id (idempotent next call).
  *
- * This test waits real time (`UNDO_WINDOW_MS + 1500ms` buffer) instead of
- * mocking timers because:
+ * This test polls the FS in real time (deadline `UNDO_WINDOW_MS + 10s`)
+ * instead of mocking timers because:
  *   - The timer lives in the main process; the renderer's clock is irrelevant.
  *   - The test helpers `__clearEvictTimersForTests` cancel timers WITHOUT
  *     firing them, so they prove the absence of leaks but NOT that the
  *     scheduled callback evicts correctly.
  *   - Real-time wait is the only way to exercise the production code path.
  *
- * Test budget: setup (~3s) + 15s wait + 2s buffer ~= 20s. Bumping the
- * per-test timeout to 45s leaves headroom for macOS CI variance.
+ * Test budget: setup (~3s) + 15s wait + up to 10s poll deadline ~= 25-28s on
+ * the slow path. Bumping the per-test timeout to 45s leaves headroom for
+ * macOS CI variance. Happy path returns as soon as `existsSync(entryDir)`
+ * flips false (typically within ~100ms of UNDO_WINDOW_MS firing).
  */
 test('source-backed delete entry is auto-evicted after UNDO_WINDOW_MS', async ({
   appWindow,
@@ -416,22 +418,22 @@ test('source-backed delete entry is auto-evicted after UNDO_WINDOW_MS', async ({
   expect(existsSync(entryDir)).toBe(true)
   expect(existsSync(expectedSourcePath)).toBe(false)
 
-  // Wait the full undo window plus a small buffer for the async fs.rm in
-  // `evict()` to complete. The 1.5s buffer matches what other Electron
-  // suites use for "post-timer fs settle" assertions.
-  await new Promise((resolveSleep) =>
-    setTimeout(resolveSleep, UNDO_WINDOW_MS_FOR_TEST + 1_500),
-  )
-
-  // KEY assertion — the entire entry is gone. A regression that:
-  //   - never schedules the timer → entry persists indefinitely (this fails)
-  //   - clears the timer without calling evict → same (this fails)
-  //   - evict throws on a partial dir → entry partially remains (this also
-  //     fails because `existsSync(entryDir)` would still be true)
-  expect(
-    existsSync(entryDir),
-    `expected ${entryDir} to be evicted after ${UNDO_WINDOW_MS_FOR_TEST}ms`,
-  ).toBe(false)
+  // KEY assertion — the entire entry is gone. A bounded poll instead of a
+  // fixed sleep: the happy path returns as soon as eviction lands (under
+  // load CI macOS runners can take an extra few hundred ms after the timer
+  // fires), and the deadline still bounds wall time at UNDO_WINDOW_MS + 10s.
+  //
+  // Regression coverage stays the same:
+  //   - never schedules the timer → entry persists, poll times out
+  //   - clears the timer without calling evict → same
+  //   - evict throws on a partial dir → entry partially remains, poll
+  //     times out because existsSync(entryDir) stays true
+  await expect
+    .poll(() => existsSync(entryDir), {
+      timeout: UNDO_WINDOW_MS_FOR_TEST + 10_000,
+      intervals: [250, 500, 1_000],
+    })
+    .toBe(false)
 
   // Source dir stays gone post-eviction — eviction is meant to delete the
   // staged copy, NOT resurrect the original. A regression that mistakenly

--- a/e2e/spec/delete.e2e.ts
+++ b/e2e/spec/delete.e2e.ts
@@ -1,4 +1,11 @@
-import { existsSync, lstatSync, readFileSync, readdirSync } from 'node:fs'
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from 'node:fs'
 import { join } from 'node:path'
 
 import { test, expect } from '../fixtures/electron-app'
@@ -7,6 +14,16 @@ import {
   refreshSkillsState,
   waitForInitialScan,
 } from '../helpers/redux'
+
+/**
+ * Mirrors `UNDO_WINDOW_MS` in `src/shared/constants.ts`. Duplicated here
+ * (rather than imported) because the e2e suite has its own tsconfig and
+ * import budget — adding a renderer/main barrel just for one constant
+ * outweighs the upkeep cost of this comment. If the production constant
+ * ever drifts, the 15s-timer test below fails immediately with a clear
+ * "expected entry to be evicted, still present" assertion.
+ */
+const UNDO_WINDOW_MS_FOR_TEST = 15_000
 
 interface SymlinkSnapshot {
   agentId: string
@@ -82,10 +99,8 @@ const azureSnapshotSelector = (state: unknown): AzureSnapshot => {
  * restore test below recovers the id by reading the on-disk trash dir, which
  * is a legitimate test-only seam (the renderer does not perform this lookup).
  *
- * TODO Phase-2 follow-up: cover the local-only delete branch (skills that
- * exist as real folders in agent dirs with no `~/.agents/skills/<name>`
- * source). That path exercises `moveLocalOnlyToTrash` + `restoreLocalOnly`
- * which is independently bisectable from the source-backed flow.
+ * Local-only branch coverage (`moveLocalOnlyToTrash`) and the 15s undo-window
+ * eviction live in dedicated tests below the source-backed pair.
  */
 
 test('deleteSkill moves source-backed skill into trash and unlinks every agent symlink', async ({
@@ -245,4 +260,181 @@ test('restoreDeletedSkill recovers a source-backed deletion within the undo wind
   expect(
     restored.validSymlinks.map((symlink) => symlink.agentId).sort(),
   ).toEqual(initial.validSymlinks.map((symlink) => symlink.agentId).sort())
+})
+
+interface LocalOnlyManifest {
+  schemaVersion: 2
+  kind: 'local-only'
+  deletedAt: number
+  skillName: string
+  localCopies: Array<{ agentId: string; linkPath: string }>
+}
+
+/**
+ * Local-only delete branch — exercises the second arm of `moveToTrash`'s
+ * dispatcher in `trashService.ts:265-273`. Source dir at
+ * `~/.agents/skills/<name>` is intentionally absent; the skill exists ONLY
+ * as a real folder under one or more agent dirs. The handler must:
+ *
+ *   1. Probe `~/.agents/skills/<name>` → ENOENT, NOT throw.
+ *   2. `scanLocalCopies(skillName)` finds the real folder(s).
+ *   3. `moveLocalOnlyToTrash` renames each into `<entryDir>/local-copies/<agentId>`.
+ *   4. Manifest is written with `kind: 'local-only'` (not `'source-backed'`).
+ *
+ * Codex is chosen over claude/cursor because the QA Safety contract in
+ * CLAUDE.md flags those two as the user's live working sets — even though
+ * this test runs under an isolated tempdir HOME, picking codex keeps the
+ * pattern consistent with the spirit of the rule for any human reviewer.
+ *
+ * The renderer-side scanSkills surfaces local-only skills with `isLocal: true`
+ * symlink rows, so a post-delete `state.skills.items` lookup is the canonical
+ * way to confirm the entry vanished — same shape as the source-backed test.
+ */
+test('deleteSkill moves a local-only skill into trash with kind="local-only" manifest', async ({
+  appWindow,
+  isolatedHome,
+}) => {
+  const skillName = 'local-only-skill'
+  const codexAgentDir = join(isolatedHome, '.codex', 'skills', skillName)
+  mkdirSync(codexAgentDir, { recursive: true })
+  const localOnlyContent = `# ${skillName}\n\nlocal-only fixture for delete.e2e.ts\n`
+  writeFileSync(join(codexAgentDir, 'SKILL.md'), localOnlyContent)
+
+  // Sanity — confirm the source dir branch will NOT trigger. If a future
+  // refactor of the snapshot ever pre-creates this name as source-backed,
+  // moveToTrash takes the wrong path and the manifest below ends up
+  // 'source-backed'. Failing fast here gives a clearer signal than a
+  // downstream JSON shape mismatch.
+  expect(
+    existsSync(join(isolatedHome, '.agents', 'skills', skillName)),
+    'local-only test requires the source dir to be absent',
+  ).toBe(false)
+
+  await waitForInitialScan(appWindow)
+
+  const ipcResult = await appWindow.evaluate(
+    async (name: string) =>
+      window.electron.skills.deleteSkill({ skillName: name }),
+    skillName,
+  )
+
+  expect(ipcResult.success).toBe(true)
+  // The local-only return reuses `symlinksRemoved` to mean "agent folders
+  // moved" — see trashService.ts:660-664. One agent staged, so 1.
+  expect(ipcResult.symlinksRemoved).toBe(1)
+  expect(ipcResult.cascadeAgents).toEqual(['codex'])
+
+  // FS — codex's real folder is gone (renamed into trash).
+  expect(existsSync(codexAgentDir)).toBe(false)
+
+  // FS — trash entry has the local-copies/<agentId>/ shape, NOT a source/
+  // subdirectory. Catching this discriminator at the FS layer is what makes
+  // the test independently bisectable from the source-backed flow.
+  const trashDir = join(isolatedHome, '.agents', '.trash')
+  const trashEntries = readdirSync(trashDir).filter((entry) =>
+    entry.includes(`-${skillName}-`),
+  )
+  expect(trashEntries).toHaveLength(1)
+  const entryDir = join(trashDir, trashEntries[0])
+  expect(existsSync(join(entryDir, 'local-copies', 'codex'))).toBe(true)
+  expect(existsSync(join(entryDir, 'local-copies', 'codex', 'SKILL.md'))).toBe(
+    true,
+  )
+  expect(existsSync(join(entryDir, 'source'))).toBe(false)
+
+  // Manifest kind is the canonical discriminator the restore path branches
+  // on (`restoreLocalOnly` vs the source-backed restore). A regression that
+  // wrote 'source-backed' here would silently break the undo flow.
+  const manifest = JSON.parse(
+    readFileSync(join(entryDir, 'manifest.json'), 'utf-8'),
+  ) as LocalOnlyManifest
+  expect(manifest.schemaVersion).toBe(2)
+  expect(manifest.kind).toBe('local-only')
+  expect(manifest.skillName).toBe(skillName)
+  expect(manifest.localCopies).toHaveLength(1)
+  expect(manifest.localCopies[0].agentId).toBe('codex')
+  expect(manifest.localCopies[0].linkPath).toBe(codexAgentDir)
+})
+
+/**
+ * Undo-window TTL eviction — `moveToTrash` schedules `setTimeout(evict,
+ * UNDO_WINDOW_MS)` after staging the entry (see `trashService.ts:484-487` for
+ * source-backed and `:648-651` for local-only). After the timer fires:
+ *
+ *   1. The entry dir is removed from `.trash/`.
+ *   2. The internal `evictTimers` map drops the id (idempotent next call).
+ *
+ * This test waits real time (`UNDO_WINDOW_MS + 1500ms` buffer) instead of
+ * mocking timers because:
+ *   - The timer lives in the main process; the renderer's clock is irrelevant.
+ *   - The test helpers `__clearEvictTimersForTests` cancel timers WITHOUT
+ *     firing them, so they prove the absence of leaks but NOT that the
+ *     scheduled callback evicts correctly.
+ *   - Real-time wait is the only way to exercise the production code path.
+ *
+ * Test budget: setup (~3s) + 15s wait + 2s buffer ~= 20s. Bumping the
+ * per-test timeout to 45s leaves headroom for macOS CI variance.
+ */
+test('source-backed delete entry is auto-evicted after UNDO_WINDOW_MS', async ({
+  appWindow,
+  isolatedHome,
+}) => {
+  test.setTimeout(45_000)
+
+  await waitForInitialScan(appWindow)
+
+  const expectedSourcePath = join(
+    isolatedHome,
+    '.agents',
+    'skills',
+    AZURE_AI_NAME,
+  )
+
+  const initial = await getStoreState(appWindow, azureSnapshotSelector)
+  expect(initial.hasAzure).toBe(true)
+
+  const deleteResult = await appWindow.evaluate(
+    async (skillName: string) =>
+      window.electron.skills.deleteSkill({ skillName }),
+    AZURE_AI_NAME,
+  )
+  expect(deleteResult.success).toBe(true)
+
+  // Locate the staged entry by name pattern. Single match expected because
+  // we just deleted exactly one azure-ai entry into a fresh isolated HOME.
+  const trashDir = join(isolatedHome, '.agents', '.trash')
+  const trashEntries = readdirSync(trashDir).filter((entry) =>
+    entry.includes(`-${AZURE_AI_NAME}-`),
+  )
+  expect(trashEntries).toHaveLength(1)
+  const tombstoneIdValue = trashEntries[0]
+  const entryDir = join(trashDir, tombstoneIdValue)
+
+  // Pre-eviction sanity — the entry exists right after the IPC settles. If
+  // this fails, `moveToTrash` is dropping the staged dir before the timer
+  // even runs (a different bug than the one this test is hunting).
+  expect(existsSync(entryDir)).toBe(true)
+  expect(existsSync(expectedSourcePath)).toBe(false)
+
+  // Wait the full undo window plus a small buffer for the async fs.rm in
+  // `evict()` to complete. The 1.5s buffer matches what other Electron
+  // suites use for "post-timer fs settle" assertions.
+  await new Promise((resolveSleep) =>
+    setTimeout(resolveSleep, UNDO_WINDOW_MS_FOR_TEST + 1_500),
+  )
+
+  // KEY assertion — the entire entry is gone. A regression that:
+  //   - never schedules the timer → entry persists indefinitely (this fails)
+  //   - clears the timer without calling evict → same (this fails)
+  //   - evict throws on a partial dir → entry partially remains (this also
+  //     fails because `existsSync(entryDir)` would still be true)
+  expect(
+    existsSync(entryDir),
+    `expected ${entryDir} to be evicted after ${UNDO_WINDOW_MS_FOR_TEST}ms`,
+  ).toBe(false)
+
+  // Source dir stays gone post-eviction — eviction is meant to delete the
+  // staged copy, NOT resurrect the original. A regression that mistakenly
+  // restored on TTL expiry would surface here as `existsSync === true`.
+  expect(existsSync(expectedSourcePath)).toBe(false)
 })


### PR DESCRIPTION
## Summary

Closes #116. Fills the six deferred Phase-2 sub-cases left as `TODO Phase-2 follow-up:` comments after PR #113, so the production IPC branches that were only guarded by unit/integration tests now have an E2E safety net before release.

- **copy.e2e.ts (+3)** — local-copy variant (symlink replication asserted via `lstat` + `realpath`), partial-failure (one target pre-occupied returns `Already exists` while the other completes; sentinel preserved), UI-driven modal (dispatches `selectAgent` + `setSkillToCopy`, walks `CopyToAgentsModal` via aria-label + dynamic Copy button)
- **delete.e2e.ts (+2)** — local-only delete (manifest `kind: 'local-only'`, layout uses `local-copies/<agentId>/`), 15s undo timer (real-time wait of `UNDO_WINDOW_MS + 1.5s`; per-test timeout bumped to 45s)
- **bulk-delete.e2e.ts (+1)** — partial-failure variant (N=10 with one source removed yields one `ENOENT` error row at failing index, nine `deleted` rows elsewhere; loop does NOT short-circuit — ten progress events still fire)

`+631 / -8` across three spec files; no new helpers/fixtures (existing patterns suffice).

## Acceptance criteria from #116

- [x] `e2e/spec/copy.e2e.ts` に local-copy + partial-failure rollback + UI-driven の 3ケース追加
- [x] `e2e/spec/delete.e2e.ts` に 15s undo timer + local-only delete branch の 2ケース追加
- [x] `e2e/spec/bulk-delete.e2e.ts` に partial-failure variant 1ケース追加
- [x] 該当 spec ファイル内の `TODO Phase-2 follow-up:` コメントを削除
- [x] `pnpm test:e2e` で全テストパス
- [x] `pnpm typecheck` / `pnpm lint` パス

## Test plan

- [x] `pnpm test:e2e` — 18/18 pass (35.2s; undo-timer test 17.2s — 15s real-time wait + buffer)
- [x] `pnpm test` — 792/792 pass (no regressions in unit/browser lanes)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [ ] CI green on this PR

## Notes

- The 15s undo-timer test waits in real time rather than mocking `setTimeout` because the timer lives in the main process — main-process timers are not addressable from the test process via the existing CDP-attach surface. Cost: +15s of wall time per run, gated to a single test. If the wait becomes a CI bottleneck, the natural follow-up is to expose a debug IPC that shrinks `TRASH_TTL_MS` for E2E builds (`__E2E_BUILD__` already exists as a Vite `define`).
- Partial-failure tests intentionally exercise post-error continuation (the serial `for...of` loop must not short-circuit) — that is the single most likely regression vector if the per-item `try/catch` is ever refactored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * 複数スキル削除時のエラーハンドリング検証テストを追加しました
  * スキルのコピー機能に関して、シンボリックリンク保持、競合処理、UI操作の検証テストを追加しました
  * スキル削除機能に関して、ローカルオンリー削除とトラッシュの自動削除機能の検証テストを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->