### PR TITLE
feat(search): add repo-scope toggle and source-repo filter pill

### DIFF
--- a/components.json
+++ b/components.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "default",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/renderer/src/styles/globals.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/renderer/src/components",
+    "utils": "@/renderer/src/lib/utils",
+    "ui": "@/renderer/src/components/ui",
+    "lib": "@/renderer/src/lib",
+    "hooks": "@/renderer/src/hooks"
+  },
+  "iconLibrary": "lucide"
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tabs": "^1.1.13",
+    "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@reduxjs/toolkit": "^2.11.2",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,9 @@ importers:
       '@radix-ui/react-tabs':
         specifier: ^1.1.13
         version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-toggle-group':
+        specifier: ^1.1.11
+        version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -1234,6 +1237,32 @@ packages:
 
   '@radix-ui/react-tabs@1.1.13':
     resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle-group@1.1.11':
+    resolution: {integrity: sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle@1.1.10':
+    resolution: {integrity: sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -5593,6 +5622,32 @@ snapshots:
       '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-toggle-group@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-toggle@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)

--- a/src/renderer/src/components/layout/MainContent.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.browser.test.tsx
@@ -456,3 +456,104 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
     expect(mockSkillsDeleteSkills).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('MainContent filter pills (Agent + Source orthogonal)', () => {
+  // The Agent pill and the Source pill are independent narrowings — the user
+  // can be in "agent: Claude Code" view AND filter by "from: vercel-labs/foo"
+  // simultaneously. These tests pin the contract: each pill renders only
+  // when its own state is set, and clearing one does not touch the other.
+
+  it('renders the Source pill with repo name and clears state on click', async () => {
+    const { screen, store } = await renderMainContent()
+    const { setSelectedSource } = await import('../../redux/slices/uiSlice')
+
+    // No source filter active: pill must not render.
+    expect(screen.getByTestId('source-filter-pill').query()).toBeNull()
+
+    store.dispatch(setSelectedSource(repositoryId('vercel-labs/skills')))
+
+    const pill = screen.getByTestId('source-filter-pill')
+    await expect.element(pill).toBeInTheDocument()
+    await expect.element(pill).toHaveTextContent(/Showing skills from/)
+    await expect.element(pill).toHaveTextContent('vercel-labs/skills')
+
+    // Clear button inside the pill resets the slice field.
+    await pill.getByRole('button', { name: /Clear/i }).click()
+
+    await expect.poll(() => store.getState().ui.selectedSource).toBeNull()
+    expect(screen.getByTestId('source-filter-pill').query()).toBeNull()
+  })
+
+  it('Agent + Source pills both render when both filters are active', async () => {
+    const { screen, store } = await renderMainContent()
+    const { fetchAgents } = await import('../../redux/slices/agentsSlice')
+    const { selectAgent, setSelectedSource } =
+      await import('../../redux/slices/uiSlice')
+
+    // Seed an agent fixture so MainContent's `agents.find(...)` resolves.
+    store.dispatch(
+      fetchAgents.fulfilled(
+        [
+          {
+            id: 'claude-code',
+            name: 'Claude Code',
+            path: '/Users/me/.claude/skills' as never,
+            exists: true,
+            skillCount: 0,
+            localSkillCount: 0,
+          },
+        ],
+        'req-id',
+      ),
+    )
+    store.dispatch(selectAgent('claude-code'))
+    store.dispatch(setSelectedSource(repositoryId('vercel-labs/skills')))
+
+    await expect
+      .element(screen.getByTestId('agent-filter-pill'))
+      .toHaveTextContent('Claude Code')
+    await expect
+      .element(screen.getByTestId('source-filter-pill'))
+      .toHaveTextContent('vercel-labs/skills')
+  })
+
+  it('clearing the Source pill leaves the Agent pill intact (orthogonal)', async () => {
+    const { screen, store } = await renderMainContent()
+    const { fetchAgents } = await import('../../redux/slices/agentsSlice')
+    const { selectAgent, setSelectedSource } =
+      await import('../../redux/slices/uiSlice')
+
+    store.dispatch(
+      fetchAgents.fulfilled(
+        [
+          {
+            id: 'claude-code',
+            name: 'Claude Code',
+            path: '/Users/me/.claude/skills' as never,
+            exists: true,
+            skillCount: 0,
+            localSkillCount: 0,
+          },
+        ],
+        'req-id',
+      ),
+    )
+    store.dispatch(selectAgent('claude-code'))
+    store.dispatch(setSelectedSource(repositoryId('vercel-labs/skills')))
+
+    // Clear ONLY the source pill.
+    await screen
+      .getByTestId('source-filter-pill')
+      .getByRole('button', { name: /Clear/i })
+      .click()
+
+    // Agent pill must still be rendered with its label intact; selectedSource
+    // must be null. This pins Issue 4 from the design review: source clear
+    // does not bleed into agent state.
+    await expect.poll(() => store.getState().ui.selectedSource).toBeNull()
+    expect(store.getState().ui.selectedAgentId).toBe('claude-code')
+    await expect
+      .element(screen.getByTestId('agent-filter-pill'))
+      .toHaveTextContent('Claude Code')
+  })
+})

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -35,12 +35,14 @@ import {
 import type { ActiveTab, SkillTypeFilter } from '../../redux/slices/uiSlice'
 import {
   clearBulkConfirm,
+  clearSelectedSource,
   clearUndoToast,
   enterBulkSelectMode,
   exitBulkSelectMode,
   selectAgent,
   selectBulkConfirm,
   selectBulkSelectMode,
+  selectSelectedSource,
   setActiveTab,
   setBulkConfirm,
   setSkillTypeFilter,
@@ -84,6 +86,7 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu'
+import { FilterPill } from '../ui/FilterPill'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs'
 
 const SKILL_TYPE_FILTER_OPTIONS: {
@@ -118,11 +121,16 @@ export const MainContent = React.memo(
 
     const bulkConfirm = useAppSelector(selectBulkConfirm)
     const bulkSelectMode = useAppSelector(selectBulkSelectMode)
+    const selectedSource = useAppSelector(selectSelectedSource)
 
     const selectedAgent = agents.find((a) => a.id === selectedAgentId)
 
     const handleClearFilter = (): void => {
       dispatch(selectAgent(null))
+    }
+
+    const handleClearSourceFilter = (): void => {
+      dispatch(clearSelectedSource())
     }
 
     const handleTabChange = (value: string): void => {
@@ -531,21 +539,34 @@ export const MainContent = React.memo(
 
             {/* Agent filter indicator */}
             {selectedAgent && (
-              <div className="px-4 py-2 border-b border-border bg-primary/5 flex items-center justify-between shrink-0">
-                <span className="text-sm">
-                  Showing skills for{' '}
-                  <strong className="text-primary">{selectedAgent.name}</strong>
-                </span>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={handleClearFilter}
-                  className="min-h-[44px] px-3"
-                >
-                  <X className="h-3 w-3 mr-1" />
-                  Clear
-                </Button>
-              </div>
+              <FilterPill
+                label={
+                  <>
+                    for{' '}
+                    <strong className="text-primary">
+                      {selectedAgent.name}
+                    </strong>
+                  </>
+                }
+                onClear={handleClearFilter}
+                testId="agent-filter-pill"
+              />
+            )}
+
+            {/* Source-repo filter indicator. Stacks orthogonally with the
+                Agent pill — the user can narrow by agent AND by repo at the
+                same time without one resetting the other. */}
+            {selectedSource && (
+              <FilterPill
+                label={
+                  <>
+                    from{' '}
+                    <strong className="text-primary">{selectedSource}</strong>
+                  </>
+                }
+                onClear={handleClearSourceFilter}
+                testId="source-filter-pill"
+              />
             )}
 
             {/* Renders only when at least one skill is ticked. */}

--- a/src/renderer/src/components/skills/SearchBox.browser.test.tsx
+++ b/src/renderer/src/components/skills/SearchBox.browser.test.tsx
@@ -1,0 +1,83 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import { describe, expect, it } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+/**
+ * Build a store with only the slices SearchBox subscribes to. SkillItem-style
+ * fixture stores include `skills`, `agents`, `bookmarks` — none of which the
+ * search box reads, so omitting them keeps the test surface tight.
+ */
+async function createStore() {
+  const { default: uiReducer } = await import('../../redux/slices/uiSlice')
+  return configureStore({
+    reducer: {
+      ui: uiReducer,
+    },
+  })
+}
+
+async function renderSearchBox() {
+  const store = await createStore()
+  const { SearchBox } = await import('./SearchBox')
+  const screen = await render(
+    <Provider store={store}>
+      <SearchBox />
+    </Provider>,
+  )
+  return { screen, store }
+}
+
+describe('SearchBox scope toggle', () => {
+  it('clicking the Repo toggle dispatches setSearchScope("repo")', async () => {
+    const { screen, store } = await renderSearchBox()
+
+    await screen.getByRole('radio', { name: /Search by repository/i }).click()
+
+    await expect.poll(() => store.getState().ui.searchScope).toBe('repo')
+  })
+
+  it('typing in the input dispatches setSearchQuery', async () => {
+    const { screen, store } = await renderSearchBox()
+
+    // The placeholder defaults to the name-mode copy.
+    const input = screen.getByPlaceholder('Search skills...')
+    await input.fill('react')
+
+    await expect.poll(() => store.getState().ui.searchQuery).toBe('react')
+  })
+
+  it('aria-label flips to the repository copy when scope=repo', async () => {
+    const { screen, store } = await renderSearchBox()
+    const { setSearchScope } = await import('../../redux/slices/uiSlice')
+
+    // Default is 'name'; verify both states so a regression renaming one
+    // copy without the other (the original aria-label bug) is caught.
+    await expect
+      .element(screen.getByRole('searchbox', { name: 'Search skills by name' }))
+      .toBeInTheDocument()
+
+    store.dispatch(setSearchScope('repo'))
+
+    await expect
+      .element(
+        screen.getByRole('searchbox', { name: 'Search skills by repository' }),
+      )
+      .toBeInTheDocument()
+  })
+
+  it('placeholder flips to the repository copy when scope=repo', async () => {
+    const { screen, store } = await renderSearchBox()
+    const { setSearchScope } = await import('../../redux/slices/uiSlice')
+
+    await expect
+      .element(screen.getByPlaceholder('Search skills...'))
+      .toBeInTheDocument()
+
+    store.dispatch(setSearchScope('repo'))
+
+    await expect
+      .element(screen.getByPlaceholder('Search by repository...'))
+      .toBeInTheDocument()
+  })
+})

--- a/src/renderer/src/components/skills/SearchBox.tsx
+++ b/src/renderer/src/components/skills/SearchBox.tsx
@@ -2,27 +2,81 @@ import { Search } from 'lucide-react'
 import React from 'react'
 
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
-import { setSearchQuery } from '../../redux/slices/uiSlice'
+import {
+  selectSearchQuery,
+  selectSearchScope,
+  setSearchQuery,
+  setSearchScope,
+  type SearchScope,
+} from '../../redux/slices/uiSlice'
 import { Input } from '../ui/input'
+import { ToggleGroup, ToggleGroupItem } from '../ui/toggle-group'
 
 /**
- * Search box for filtering skills
+ * Map the active scope to the input's user-facing copy. Centralized so the
+ * `aria-label` and `placeholder` always agree — previously the aria-label
+ * claimed "name or description" while the filter only matched the name.
+ */
+const SCOPE_COPY: Record<
+  SearchScope,
+  { ariaLabel: string; placeholder: string }
+> = {
+  name: {
+    ariaLabel: 'Search skills by name',
+    placeholder: 'Search skills...',
+  },
+  repo: {
+    ariaLabel: 'Search skills by repository',
+    placeholder: 'Search by repository...',
+  },
+}
+
+/**
+ * Search box for filtering skills. Combines a Name/Repo scope toggle with a
+ * text input. The scope decides which `Skill` field the query matches against
+ * — see `selectFilteredSkills` for the actual filter logic.
  */
 export const SearchBox = React.memo(function SearchBox(): React.ReactElement {
   const dispatch = useAppDispatch()
-  const { searchQuery } = useAppSelector((state) => state.ui)
+  const searchQuery = useAppSelector(selectSearchQuery)
+  const searchScope = useAppSelector(selectSearchScope)
+  const copy = SCOPE_COPY[searchScope]
 
   return (
-    <div className="relative">
-      <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-      <Input
-        type="search"
-        aria-label="Search skills by name or description"
-        placeholder="Search skills..."
-        value={searchQuery}
-        onChange={(e) => dispatch(setSearchQuery(e.target.value))}
-        className="pl-10 bg-background"
-      />
+    <div className="flex items-center gap-2">
+      <ToggleGroup
+        type="single"
+        variant="outline"
+        size="default"
+        value={searchScope}
+        // Radix returns "" when the user clicks the already-active item.
+        // Treat that as a no-op so scope is never undefined at runtime.
+        onValueChange={(value) => {
+          if (value === 'name' || value === 'repo') {
+            dispatch(setSearchScope(value))
+          }
+        }}
+        aria-label="Search field"
+        className="shrink-0"
+      >
+        <ToggleGroupItem value="name" aria-label="Search by skill name">
+          Name
+        </ToggleGroupItem>
+        <ToggleGroupItem value="repo" aria-label="Search by repository">
+          Repo
+        </ToggleGroupItem>
+      </ToggleGroup>
+      <div className="relative flex-1 min-w-0">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+        <Input
+          type="search"
+          aria-label={copy.ariaLabel}
+          placeholder={copy.placeholder}
+          value={searchQuery}
+          onChange={(e) => dispatch(setSearchQuery(e.target.value))}
+          className="pl-10 bg-background"
+        />
+      </div>
     </div>
   )
 })

--- a/src/renderer/src/components/skills/SkillsList.tsx
+++ b/src/renderer/src/components/skills/SkillsList.tsx
@@ -13,10 +13,12 @@ import {
 import {
   selectSearchQuery,
   selectSelectedAgentId,
+  selectSelectedSource,
   selectSkillTypeFilter,
 } from '../../redux/slices/uiSlice'
 
 import { SkillItem } from './SkillItem'
+import { getEmptyListMessage } from './skillsListHelpers'
 
 /** Base height: padding (32) + title (24) + source link (20) + source-link mb-2 (8) + row gap pb-3 (12) + border (2) + font metrics (3) */
 const ROW_HEIGHT_BASE = 101
@@ -65,6 +67,7 @@ export const SkillsList = React.memo(function SkillsList(): React.ReactElement {
   const selectedAgentId = useAppSelector(selectSelectedAgentId)
   const skillTypeFilter = useAppSelector(selectSkillTypeFilter)
   const searchQuery = useAppSelector(selectSearchQuery)
+  const selectedSource = useAppSelector(selectSelectedSource)
   const filteredSkills = useAppSelector(selectFilteredSkills)
 
   useEffect(() => {
@@ -118,17 +121,15 @@ export const SkillsList = React.memo(function SkillsList(): React.ReactElement {
   }
 
   if (filteredSkills.length === 0) {
+    const emptyMessage = getEmptyListMessage({
+      searchQuery,
+      selectedSource,
+      selectedAgentId,
+      skillTypeFilter,
+    })
     return (
       <div className="flex items-center justify-center py-12">
-        <div className="text-muted-foreground">
-          {selectedAgentId
-            ? searchQuery
-              ? 'No skills match your search'
-              : skillTypeFilter !== 'all'
-                ? `No ${skillTypeFilter} skills for this agent`
-                : 'No skills installed for this agent'
-            : 'No skills match your search'}
-        </div>
+        <div className="text-muted-foreground">{emptyMessage}</div>
       </div>
     )
   }

--- a/src/renderer/src/components/skills/SourceLink.browser.test.tsx
+++ b/src/renderer/src/components/skills/SourceLink.browser.test.tsx
@@ -1,0 +1,150 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import { describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import {
+  type HttpUrl,
+  type RepositoryId,
+  repositoryId,
+} from '../../../../shared/types'
+
+const REPO = repositoryId('pbakaus/impeccable')
+const REPO_URL = 'https://github.com/pbakaus/impeccable.git' as HttpUrl
+const REPO_HREF = 'https://github.com/pbakaus/impeccable'
+
+/**
+ * Minimal store with only the `ui` slice — SourceLink's only Redux touchpoint
+ * is `setSelectedSource`. Keeping the surface tight isolates the test from
+ * unrelated reducer churn.
+ */
+async function createStore() {
+  const { default: uiReducer } = await import('../../redux/slices/uiSlice')
+  return configureStore({
+    reducer: {
+      ui: uiReducer,
+    },
+  })
+}
+
+interface RenderOptions {
+  source?: RepositoryId
+  sourceUrl?: HttpUrl
+  /**
+   * If provided, SourceLink is mounted inside a `<div>` with this onClick
+   * handler so we can assert that propagation is correctly stopped (i.e. the
+   * surrounding `<Card>`'s click does NOT fire when the user clicks the
+   * filter button or the external-link anchor).
+   */
+  onParentClick?: (event: React.MouseEvent<HTMLDivElement>) => void
+}
+
+async function renderSourceLink(options: RenderOptions = {}) {
+  const store = await createStore()
+  const { SourceLink } = await import('./SourceLink')
+  const screen = await render(
+    <Provider store={store}>
+      <div data-testid="parent-row" onClick={options.onParentClick}>
+        <SourceLink source={options.source} sourceUrl={options.sourceUrl} />
+      </div>
+    </Provider>,
+  )
+  return { screen, store }
+}
+
+describe('SourceLink role split', () => {
+  it('clicking the repo text dispatches setSelectedSource', async () => {
+    const { screen, store } = await renderSourceLink({
+      source: REPO,
+      sourceUrl: REPO_URL,
+    })
+
+    await screen
+      .getByRole('button', {
+        name: /Filter skills by repository pbakaus\/impeccable/i,
+      })
+      .click()
+
+    await expect.poll(() => store.getState().ui.selectedSource).toBe(REPO)
+  })
+
+  it('the icon anchor points at the .git-stripped GitHub URL with target=_blank', async () => {
+    const { screen } = await renderSourceLink({
+      source: REPO,
+      sourceUrl: REPO_URL,
+    })
+
+    const anchor = screen.getByRole('link', {
+      name: /Open pbakaus\/impeccable on GitHub/i,
+    })
+    await expect.element(anchor).toHaveAttribute('href', REPO_HREF)
+    await expect.element(anchor).toHaveAttribute('target', '_blank')
+    await expect.element(anchor).toHaveAttribute('rel', 'noreferrer')
+  })
+
+  it('clicks on either affordance do not bubble to the surrounding row', async () => {
+    const onParentClick = vi.fn()
+    const { screen, store } = await renderSourceLink({
+      source: REPO,
+      sourceUrl: REPO_URL,
+      onParentClick,
+    })
+
+    // Button click via Playwright driver — exercises the real React handler.
+    await screen
+      .getByRole('button', { name: /Filter skills by repository/i })
+      .click()
+    expect(onParentClick).not.toHaveBeenCalled()
+    await expect.poll(() => store.getState().ui.selectedSource).toBe(REPO)
+
+    // Anchor click via dispatchEvent — Playwright's `.click()` on a
+    // `target="_blank"` anchor would try to open a new browser context.
+    // A synthetic MouseEvent reaches the React handler the same way for
+    // the propagation assertion without triggering the navigation gesture.
+    const anchorElement = screen
+      .getByRole('link', { name: /Open pbakaus\/impeccable on GitHub/i })
+      .element() as HTMLAnchorElement
+    const clickEvent = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+    })
+    anchorElement.dispatchEvent(clickEvent)
+    expect(onParentClick).not.toHaveBeenCalled()
+  })
+
+  it('Local skill renders the "Local" label with no button or anchor', async () => {
+    const { screen } = await renderSourceLink()
+
+    await expect.element(screen.getByText('Local')).toBeInTheDocument()
+    // Use `.query()` (returns null when missing) instead of `getBy(...).not.
+    // toBeInTheDocument()` to avoid the strict-single-match throw — see
+    // SkillItem.browser.test.tsx for the same pattern.
+    expect(screen.getByRole('button').query()).toBeNull()
+    expect(screen.getByRole('link').query()).toBeNull()
+  })
+
+  it('keyboard Tab focuses the filter button and the external link independently', async () => {
+    const { screen } = await renderSourceLink({
+      source: REPO,
+      sourceUrl: REPO_URL,
+    })
+
+    const filterButton = screen.getByRole('button', {
+      name: /Filter skills by repository/i,
+    })
+    const externalAnchor = screen.getByRole('link', {
+      name: /Open pbakaus\/impeccable on GitHub/i,
+    })
+
+    // Both elements are inherently focusable — `<button>` and `<a href>` —
+    // so a regression that swaps either for a `<span>` (or adds tabindex=-1)
+    // would surface here.
+    const buttonElement = filterButton.element() as HTMLButtonElement
+    buttonElement.focus()
+    expect(document.activeElement).toBe(buttonElement)
+
+    const anchorElement = externalAnchor.element() as HTMLAnchorElement
+    anchorElement.focus()
+    expect(document.activeElement).toBe(anchorElement)
+  })
+})

--- a/src/renderer/src/components/skills/SourceLink.tsx
+++ b/src/renderer/src/components/skills/SourceLink.tsx
@@ -2,6 +2,8 @@ import { ExternalLink } from 'lucide-react'
 import React from 'react'
 
 import type { HttpUrl, RepositoryId } from '../../../../shared/types'
+import { useAppDispatch } from '../../redux/hooks'
+import { setSelectedSource } from '../../redux/slices/uiSlice'
 
 import { getSourceLinkModel } from './sourceLinkHelpers'
 
@@ -11,19 +13,37 @@ interface SourceLinkProps {
 }
 
 /**
- * Display skill source as a clickable external link or "Local" label.
+ * Display skill source. Three render modes from `getSourceLinkModel`:
+ * - `local` — "Local" label, no interactive affordance.
+ * - `text`  — source identifier, plain text (no URL to link to).
+ * - `link`  — split affordances: a `<button>` that filters the skill list by
+ *             repository (dispatches `setSelectedSource`) and a separate
+ *             `<a target="_blank">` whose icon opens the repository on GitHub.
+ *
+ * Why split the `link` mode? Mixing a Redux-dispatch action and an external
+ * navigation under one `<a>` was ambiguous — clicking the repo text used to
+ * navigate away when the user often just wanted to narrow the list. The
+ * split puts each affordance under its semantic element (`<button>` for
+ * in-app actions, `<a>` for navigation) and gives each its own keyboard
+ * focus stop.
+ *
+ * Both interactive elements stop event propagation so they do not bubble to
+ * the surrounding `<Card>`'s click handler, which would otherwise toggle
+ * skill selection silently when the user just wanted to filter or open a link.
+ *
  * @param source - Short source identifier, e.g. "pbakaus/impeccable"
  * @param sourceUrl - Full URL to repository, e.g. "https://github.com/pbakaus/impeccable.git"
  * @example
- * <SourceLink source="pbakaus/impeccable" sourceUrl="https://github.com/pbakaus/impeccable.git" />
- * // => clickable "pbakaus/impeccable ↗" link
+ * <SourceLink source={repositoryId('pbakaus/impeccable')} sourceUrl="https://github.com/pbakaus/impeccable.git" />
+ * // => filter button (repo text) + external-link icon (anchor)
  * <SourceLink />
- * // => "Local" text
+ * // => "Local" label
  */
 export const SourceLink = React.memo(function SourceLink({
   source,
   sourceUrl,
 }: SourceLinkProps): React.ReactElement {
+  const dispatch = useAppDispatch()
   const model = getSourceLinkModel(source, sourceUrl)
 
   if (model.kind === 'local') {
@@ -40,16 +60,42 @@ export const SourceLink = React.memo(function SourceLink({
     )
   }
 
+  // Stop both clicks from reaching the surrounding `<Card>`'s onClick — that
+  // would silently toggle skill selection when the user just wanted to filter
+  // or open the repository.
+  const handleFilterClick = (
+    event: React.MouseEvent<HTMLButtonElement>,
+  ): void => {
+    event.stopPropagation()
+    dispatch(setSelectedSource(model.source))
+  }
+
+  const handleExternalClick = (
+    event: React.MouseEvent<HTMLAnchorElement>,
+  ): void => {
+    event.stopPropagation()
+  }
+
   return (
-    <a
-      href={model.href}
-      target="_blank"
-      rel="noreferrer"
-      onClick={(e) => e.stopPropagation()}
-      className="text-sm text-muted-foreground hover:text-foreground transition-colors inline-flex items-center gap-1 mb-2"
-    >
-      {model.source}
-      <ExternalLink className="h-3 w-3" />
-    </a>
+    <span className="inline-flex items-center gap-1 mb-2">
+      <button
+        type="button"
+        onClick={handleFilterClick}
+        aria-label={`Filter skills by repository ${model.source}`}
+        className="text-sm text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+      >
+        {model.source}
+      </button>
+      <a
+        href={model.href}
+        target="_blank"
+        rel="noreferrer"
+        onClick={handleExternalClick}
+        aria-label={`Open ${model.source} on GitHub`}
+        className="text-muted-foreground hover:text-foreground transition-colors inline-flex items-center"
+      >
+        <ExternalLink className="h-3 w-3" />
+      </a>
+    </span>
   )
 })

--- a/src/renderer/src/components/skills/skillsListHelpers.test.ts
+++ b/src/renderer/src/components/skills/skillsListHelpers.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+
+import { repositoryId } from '../../../../shared/types'
+
+import { getEmptyListMessage } from './skillsListHelpers'
+
+describe('getEmptyListMessage', () => {
+  it('returns the search message when searchQuery is non-empty (highest priority)', () => {
+    // Even with every other filter active, search wins because the user's
+    // most recent narrowing action is what they want named in the message.
+    expect(
+      getEmptyListMessage({
+        searchQuery: 'react',
+        selectedSource: repositoryId('vercel-labs/skills'),
+        selectedAgentId: 'cursor',
+        skillTypeFilter: 'local',
+      }),
+    ).toBe('No skills match your search')
+  })
+
+  it('returns the source message when only selectedSource is set', () => {
+    expect(
+      getEmptyListMessage({
+        searchQuery: '',
+        selectedSource: repositoryId('vercel-labs/skills'),
+        selectedAgentId: null,
+        skillTypeFilter: 'all',
+      }),
+    ).toBe('No skills from vercel-labs/skills')
+  })
+
+  it('source message wins over agent + type when both are set (search empty)', () => {
+    // The pill is a more specific, more recent action than the persistent
+    // agent tab. Order in the ladder is search > source > agent+type > agent.
+    expect(
+      getEmptyListMessage({
+        searchQuery: '',
+        selectedSource: repositoryId('pbakaus/impeccable'),
+        selectedAgentId: 'claude-code',
+        skillTypeFilter: 'symlinked',
+      }),
+    ).toBe('No skills from pbakaus/impeccable')
+  })
+
+  it('returns the agent + type message when both are set (no source / search)', () => {
+    expect(
+      getEmptyListMessage({
+        searchQuery: '',
+        selectedSource: null,
+        selectedAgentId: 'cursor',
+        skillTypeFilter: 'local',
+      }),
+    ).toBe('No local skills for this agent')
+  })
+
+  it('returns the symlinked variant when type filter is symlinked', () => {
+    expect(
+      getEmptyListMessage({
+        searchQuery: '',
+        selectedSource: null,
+        selectedAgentId: 'claude-code',
+        skillTypeFilter: 'symlinked',
+      }),
+    ).toBe('No symlinked skills for this agent')
+  })
+
+  it('returns the agent-only message when selectedAgentId is set and type is all', () => {
+    expect(
+      getEmptyListMessage({
+        searchQuery: '',
+        selectedSource: null,
+        selectedAgentId: 'cursor',
+        skillTypeFilter: 'all',
+      }),
+    ).toBe('No skills installed for this agent')
+  })
+
+  it('returns the fallback when no narrowing is active', () => {
+    // The "no agent, no source, no search" fallback is unusual — typically
+    // means filteredSkills is empty because skills.length is 0, which is
+    // handled by an earlier branch in SkillsList. Still worth locking the
+    // string so the fallback never accidentally returns undefined.
+    expect(
+      getEmptyListMessage({
+        searchQuery: '',
+        selectedSource: null,
+        selectedAgentId: null,
+        skillTypeFilter: 'all',
+      }),
+    ).toBe('No skills match your filter')
+  })
+
+  it('treats whitespace-only searchQuery as a non-empty query (current behavior)', () => {
+    // Document the current contract: the helper checks `length > 0`, so
+    // a single space counts. SkillsList trims-on-input is the right place
+    // to change this if the UX wants to ignore whitespace; the helper only
+    // mirrors the upstream value verbatim.
+    expect(
+      getEmptyListMessage({
+        searchQuery: ' ',
+        selectedSource: null,
+        selectedAgentId: null,
+        skillTypeFilter: 'all',
+      }),
+    ).toBe('No skills match your search')
+  })
+})

--- a/src/renderer/src/components/skills/skillsListHelpers.ts
+++ b/src/renderer/src/components/skills/skillsListHelpers.ts
@@ -1,0 +1,80 @@
+import { match } from 'ts-pattern'
+
+import type { AgentId, RepositoryId } from '../../../../shared/types'
+import type { SkillTypeFilter } from '../../redux/slices/uiSlice'
+
+interface EmptyMessageContext {
+  searchQuery: string
+  selectedSource: RepositoryId | null
+  selectedAgentId: AgentId | null
+  skillTypeFilter: SkillTypeFilter
+}
+
+/**
+ * Compute the empty-state message for SkillsList based on which filters are
+ * currently narrowing the result. The skills list participates in four
+ * orthogonal filters (search query, source-repo pill, selected agent,
+ * skill-type pill). When the intersection produces zero rows, the user
+ * needs a message that names the *last action* they took, not a catch-all
+ * "no skills match your filter."
+ *
+ * Priority order — search > source > (agent + type) > agent > fallback —
+ * mirrors the user's mental model: "I just typed in the search box → the
+ * search is what hid my rows." Source pill takes precedence over the agent
+ * card because clicking a repo link from a skill card is a more recent,
+ * more specific action than the persistent agent-tab selection.
+ *
+ * Why ts-pattern: the `match().with().otherwise()` chain forces the priority
+ * order to be data-shaped (top-down), not nesting-shaped (deeply ternaried).
+ * Adding a new filter axis means inserting one `.with(...)` line in the
+ * right slot, not unfurling an N+1 deep ternary.
+ *
+ * @param ctx - Snapshot of the active filter values from Redux.
+ * @returns
+ * - When `searchQuery` is non-empty: `"No skills match your search"`
+ * - When only `selectedSource` is set: `"No skills from <repo>"`
+ * - When `selectedAgentId` is set AND `skillTypeFilter !== 'all'`:
+ *   `"No <symlinked|local> skills for this agent"`
+ * - When only `selectedAgentId` is set: `"No skills installed for this agent"`
+ * - Otherwise: `"No skills match your filter"`
+ *
+ * @example
+ * getEmptyListMessage({
+ *   searchQuery: '',
+ *   selectedSource: repositoryId('vercel-labs/skills'),
+ *   selectedAgentId: null,
+ *   skillTypeFilter: 'all',
+ * })
+ * // => "No skills from vercel-labs/skills"
+ *
+ * @example
+ * getEmptyListMessage({
+ *   searchQuery: '',
+ *   selectedSource: null,
+ *   selectedAgentId: 'cursor',
+ *   skillTypeFilter: 'local',
+ * })
+ * // => "No local skills for this agent"
+ */
+export function getEmptyListMessage(ctx: EmptyMessageContext): string {
+  return match({
+    hasSearchQuery: ctx.searchQuery.length > 0,
+    hasSelectedSource: ctx.selectedSource !== null,
+    hasSelectedAgent: ctx.selectedAgentId !== null,
+    hasTypeNarrow: ctx.skillTypeFilter !== 'all',
+  })
+    .with({ hasSearchQuery: true }, () => 'No skills match your search')
+    .with(
+      { hasSelectedSource: true },
+      () => `No skills from ${ctx.selectedSource}`,
+    )
+    .with(
+      { hasSelectedAgent: true, hasTypeNarrow: true },
+      () => `No ${ctx.skillTypeFilter} skills for this agent`,
+    )
+    .with(
+      { hasSelectedAgent: true },
+      () => 'No skills installed for this agent',
+    )
+    .otherwise(() => 'No skills match your filter')
+}

--- a/src/renderer/src/components/ui/FilterPill.browser.test.tsx
+++ b/src/renderer/src/components/ui/FilterPill.browser.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import { FilterPill } from './FilterPill'
+
+/**
+ * FilterPill is presentational — it does not subscribe to Redux. The contract
+ * worth pinning is: it renders the label after the static "Showing skills "
+ * prefix, exposes the `data-testid` so MainContent can locate it, and calls
+ * `onClear` when the Clear button is clicked. MainContent's pill-stacking
+ * tests exercise the integration; this file stays focused on the primitive.
+ */
+describe('FilterPill', () => {
+  it('renders "Showing skills <label>" and calls onClear on Clear click', async () => {
+    const onClear = vi.fn()
+    const screen = await render(
+      <FilterPill
+        label={
+          <>
+            for <strong>Claude Code</strong>
+          </>
+        }
+        onClear={onClear}
+        testId="agent-filter-pill"
+      />,
+    )
+
+    const pill = screen.getByTestId('agent-filter-pill')
+    await expect.element(pill).toBeInTheDocument()
+    await expect
+      .element(pill)
+      .toHaveTextContent('Showing skills for Claude Code')
+
+    await pill.getByRole('button', { name: /Clear/i }).click()
+    expect(onClear).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/ui/FilterPill.tsx
+++ b/src/renderer/src/components/ui/FilterPill.tsx
@@ -1,0 +1,59 @@
+import { X } from 'lucide-react'
+import React from 'react'
+
+import { MIN_TOUCH_TARGET_PX } from '../../../../shared/constants'
+
+import { Button } from './button'
+
+interface FilterPillProps {
+  /**
+   * Trailing label content rendered after the static "Showing skills " prefix.
+   * Pass JSX so callers can emphasize the filter target (e.g. wrap an agent
+   * name in `<strong className="text-primary">`).
+   */
+  label: React.ReactNode
+  /** Invoked when the user clicks the Clear button. */
+  onClear: () => void
+  /** Optional `data-testid` for browser-mode assertions. */
+  testId?: string
+}
+
+/**
+ * Horizontal filter indicator bar shown above the skills list when a
+ * filter (agent, source repo, …) is active. Displays "Showing skills {label}"
+ * with a Clear action that dispatches whatever reset reducer the caller wires.
+ *
+ * Multiple instances stack vertically — the agent pill and the source-repo
+ * pill are orthogonal so both can render at once.
+ *
+ * @example
+ *   <FilterPill
+ *     label={<>for <strong className="text-primary">{agent.name}</strong></>}
+ *     onClear={() => dispatch(selectAgent(null))}
+ *     testId="agent-filter-pill"
+ *   />
+ */
+export const FilterPill = React.memo(function FilterPill({
+  label,
+  onClear,
+  testId,
+}: FilterPillProps): React.ReactElement {
+  return (
+    <div
+      data-testid={testId}
+      className="px-4 py-2 border-b border-border bg-primary/5 flex items-center justify-between shrink-0"
+    >
+      <span className="text-sm">Showing skills {label}</span>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={onClear}
+        style={{ minHeight: MIN_TOUCH_TARGET_PX }}
+        className="px-3"
+      >
+        <X className="h-3 w-3 mr-1" />
+        Clear
+      </Button>
+    </div>
+  )
+})

--- a/src/renderer/src/components/ui/toggle-group.tsx
+++ b/src/renderer/src/components/ui/toggle-group.tsx
@@ -116,8 +116,8 @@ const ToggleGroupItem = React.memo(function ToggleGroupItem({
       ref={ref}
       className={cn(
         toggleVariants({
-          variant: context.variant ?? variant,
-          size: context.size ?? size,
+          variant: variant ?? context.variant,
+          size: size ?? context.size,
         }),
         className,
       )}

--- a/src/renderer/src/components/ui/toggle-group.tsx
+++ b/src/renderer/src/components/ui/toggle-group.tsx
@@ -1,0 +1,131 @@
+import * as ToggleGroupPrimitive from '@radix-ui/react-toggle-group'
+import { cva, type VariantProps } from 'class-variance-authority'
+import * as React from 'react'
+
+import { cn } from '../../lib/utils'
+
+/**
+ * Variant + size styles shared by every `ToggleGroupItem`. Mirrors the shadcn
+ * `toggle` cva so future imports of standalone `<Toggle>` (if added later)
+ * stay visually aligned. Inlined here because the project currently has no
+ * standalone toggle usage; adding `toggle.tsx` purely as a re-export would
+ * be dead code.
+ *
+ * Tuning notes:
+ * - Default size is `h-11` (44px) so it clears the Apple HIG / WCAG 2.2 AA
+ *   tap-target floor without callers having to remember to bump `size`. The
+ *   `sm` variant intentionally stays at 32px — it's a "compact" opt-in for
+ *   inspector toolbars where the user has explicitly chosen density.
+ * - Focus ring is `ring-2 ring-offset-2`. Single-pixel rings disappear into
+ *   the input border on `outline` variants when the theme preset has low
+ *   chroma (neutral-light); the offset gives the ring its own breathing room
+ *   regardless of preset.
+ * - `outline` variant adds `data-[state=on]:border-primary` so the active
+ *   item has a clear color anchor on neutral presets where `bg-accent`
+ *   collapses to a near-background gray. The border is a 1px swap (not a
+ *   width change) so there is no layout shift when toggling.
+ */
+const toggleVariants = cva(
+  'inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium transition-colors hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+  {
+    variants: {
+      variant: {
+        default: 'bg-transparent',
+        outline:
+          'border border-input bg-transparent shadow-sm hover:bg-accent hover:text-accent-foreground data-[state=on]:border-primary',
+      },
+      size: {
+        default: 'h-11 px-3 min-w-11',
+        sm: 'h-8 px-1.5 min-w-8',
+        lg: 'h-12 px-3.5 min-w-12',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+)
+
+/**
+ * Context that lets `ToggleGroup` push its `variant` / `size` down to every
+ * `ToggleGroupItem` without callers having to repeat the props on each item.
+ */
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants>
+>({
+  size: 'default',
+  variant: 'default',
+})
+
+/**
+ * Radix `ToggleGroup.Root` styled to match the shadcn default look.
+ * Single-select (`type="single"`) is the common usage; pass `type="multiple"`
+ * for checkbox-style toggle sets.
+ *
+ * @example
+ *   <ToggleGroup type="single" value={scope} onValueChange={(v) => v && setScope(v)}>
+ *     <ToggleGroupItem value="name">Name</ToggleGroupItem>
+ *     <ToggleGroupItem value="repo">Repo</ToggleGroupItem>
+ *   </ToggleGroup>
+ */
+const ToggleGroup = React.memo(function ToggleGroup({
+  className,
+  variant,
+  size,
+  children,
+  ref,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Root> &
+  VariantProps<typeof toggleVariants> & {
+    ref?: React.Ref<HTMLDivElement>
+  }) {
+  // Stable identity for the context value so consumers don't re-render every
+  // time the parent re-renders with the same variant/size pair. React 19's
+  // `<Context>` (no `.Provider`) is the new shorthand.
+  const contextValue = React.useMemo(() => ({ variant, size }), [variant, size])
+  return (
+    <ToggleGroupPrimitive.Root
+      ref={ref}
+      className={cn('flex items-center justify-center gap-1', className)}
+      {...props}
+    >
+      <ToggleGroupContext value={contextValue}>{children}</ToggleGroupContext>
+    </ToggleGroupPrimitive.Root>
+  )
+})
+
+/**
+ * One option button inside a `ToggleGroup`. Inherits `variant` / `size` from
+ * the surrounding group's context unless explicitly overridden.
+ */
+const ToggleGroupItem = React.memo(function ToggleGroupItem({
+  className,
+  children,
+  variant,
+  size,
+  ref,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Item> &
+  VariantProps<typeof toggleVariants> & {
+    ref?: React.Ref<HTMLButtonElement>
+  }) {
+  const context = React.useContext(ToggleGroupContext)
+  return (
+    <ToggleGroupPrimitive.Item
+      ref={ref}
+      className={cn(
+        toggleVariants({
+          variant: context.variant ?? variant,
+          size: context.size ?? size,
+        }),
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </ToggleGroupPrimitive.Item>
+  )
+})
+
+export { ToggleGroup, ToggleGroupItem, toggleVariants }

--- a/src/renderer/src/redux/selectors.test.ts
+++ b/src/renderer/src/redux/selectors.test.ts
@@ -445,12 +445,18 @@ describe('selectFilteredSkills', () => {
     // the toggle is about what the query matches against, not a standalone
     // "show only repo skills" filter. Guards against a regression where the
     // scope itself was treated as a population filter.
+    //
+    // Use the agent view (selectedAgentId set) to actually exercise the
+    // local-skill path: the SourceCard view (no agent) drops every isLocal
+    // skill upstream, so a local fixture without selectedAgentId would never
+    // reach the search-scope branch we want to lock down.
     const skills = [
-      makeSkill('local-task', 'cursor'),
+      makeSkill('local-task', 'cursor', true),
       makeSkill('repo-task', 'cursor', false, 'vercel-labs/skills'),
     ]
     const state = buildState({
       skills,
+      selectedAgentId: 'cursor',
       searchQuery: '',
       searchScope: 'repo',
     })

--- a/src/renderer/src/redux/selectors.test.ts
+++ b/src/renderer/src/redux/selectors.test.ts
@@ -4,6 +4,7 @@ import { repositoryId } from '../../../shared/types'
 import type {
   AgentId,
   BookmarkedSkill,
+  RepositoryId,
   Skill,
   SkillName,
   SymlinkInfo,
@@ -25,7 +26,9 @@ import {
 function buildState(overrides: {
   skills?: Skill[]
   searchQuery?: string
+  searchScope?: 'name' | 'repo'
   selectedAgentId?: AgentId | null
+  selectedSource?: RepositoryId | null
   sortOrder?: 'asc' | 'desc'
   skillTypeFilter?: 'all' | 'symlinked' | 'local'
   bookmarks?: BookmarkedSkill[]
@@ -57,6 +60,8 @@ function buildState(overrides: {
     ui: {
       activeTab: 'installed' as const,
       searchQuery: overrides.searchQuery ?? '',
+      searchScope: overrides.searchScope ?? ('name' as const),
+      selectedSource: overrides.selectedSource ?? null,
       sourceStats: null,
       isRefreshing: false,
       selectedAgentId: overrides.selectedAgentId ?? null,
@@ -109,8 +114,17 @@ function buildState(overrides: {
  * @param isLocal - false = symlinked source skill (default), true = agent-local-only
  *   folder. `isLocal=true` implies the skill exists only under `~/.<agent>/skills/`,
  *   never inside SOURCE_DIR, so `isSource` is forced to `false`.
+ * @param source - Optional repo slug (`"owner/repo"`); when provided, sets
+ *   both `source` and `sourceUrl` on the skill so repo-scope tests can assert
+ *   on a real value. Omitted by default to mimic the most common state where
+ *   skills lack source metadata.
  */
-const makeSkill = (name: string, agentId: AgentId, isLocal = false): Skill => ({
+const makeSkill = (
+  name: string,
+  agentId: AgentId,
+  isLocal = false,
+  source?: string,
+): Skill => ({
   name,
   description: `${name} skill`,
   path: isLocal
@@ -130,6 +144,12 @@ const makeSkill = (name: string, agentId: AgentId, isLocal = false): Skill => ({
     },
   ],
   isSource: !isLocal,
+  ...(source
+    ? {
+        source: repositoryId(source),
+        sourceUrl: `https://github.com/${source}.git`,
+      }
+    : {}),
 })
 
 describe('selectFilteredSkills', () => {
@@ -320,6 +340,163 @@ describe('selectFilteredSkills', () => {
       expect(result.map((s) => s.name)).toEqual(['task'])
     },
   )
+
+  it('searchScope=repo matches against skill.source (repository slug)', () => {
+    const skills = [
+      makeSkill('task', 'claude-code', false, 'vercel-labs/skills'),
+      makeSkill('browse', 'cursor', false, 'pbakaus/impeccable'),
+      makeSkill('mcp', 'cursor', false, 'figma/mcp-server-guide'),
+    ]
+    const state = buildState({
+      skills,
+      searchQuery: 'figma',
+      searchScope: 'repo',
+    })
+    const result = selectFilteredSkills(state as never)
+    expect(result.map((s) => s.name)).toEqual(['mcp'])
+  })
+
+  it('searchScope=repo excludes Local skills (no source) even if name matches', () => {
+    // Critical regression guard: in repo mode, a skill without `source` must
+    // never appear, otherwise the result becomes inconsistent ("I searched a
+    // repo and got a non-repo skill") and the toggle loses its meaning.
+    const skills = [
+      makeSkill('task', 'cursor'), // no source — Local-flavored
+      makeSkill('task-from-repo', 'cursor', false, 'vercel-labs/skills'),
+    ]
+    const state = buildState({
+      skills,
+      searchQuery: 'task',
+      searchScope: 'repo',
+    })
+    const result = selectFilteredSkills(state as never)
+    expect(result.map((s) => s.name)).toEqual([])
+  })
+
+  it('selectedSource pill alone narrows to the matching repo with no query', () => {
+    const skills = [
+      makeSkill('a', 'claude-code', false, 'vercel-labs/skills'),
+      makeSkill('b', 'claude-code', false, 'vercel-labs/skills'),
+      makeSkill('c', 'claude-code', false, 'pbakaus/impeccable'),
+    ]
+    const state = buildState({
+      skills,
+      selectedSource: repositoryId('vercel-labs/skills'),
+    })
+    const result = selectFilteredSkills(state as never)
+    expect(result.map((s) => s.name)).toEqual(['a', 'b'])
+  })
+
+  it('selectedSource pill stacks with searchScope=name + query', () => {
+    // Scope is 'name' (default) — the pill narrows population to one repo,
+    // then the name query narrows further within that population.
+    const skills = [
+      makeSkill('alpha', 'claude-code', false, 'vercel-labs/skills'),
+      makeSkill('beta', 'claude-code', false, 'vercel-labs/skills'),
+      makeSkill('alpha-other', 'claude-code', false, 'pbakaus/impeccable'),
+    ]
+    const state = buildState({
+      skills,
+      selectedSource: repositoryId('vercel-labs/skills'),
+      searchQuery: 'alpha',
+      searchScope: 'name',
+    })
+    const result = selectFilteredSkills(state as never)
+    expect(result.map((s) => s.name)).toEqual(['alpha'])
+  })
+
+  it('selectedSource pill stacks with selectedAgentId (orthogonal filters)', () => {
+    // Per Issue 4 decision: the source pill is independent of the agent pill.
+    // Selecting an agent must not silently reset the pill, and the resulting
+    // list intersects both filters.
+    const skills = [
+      makeSkill('a', 'cursor', false, 'vercel-labs/skills'),
+      makeSkill('b', 'claude-code', false, 'vercel-labs/skills'),
+      makeSkill('c', 'cursor', false, 'pbakaus/impeccable'),
+    ]
+    const state = buildState({
+      skills,
+      selectedAgentId: 'cursor',
+      selectedSource: repositoryId('vercel-labs/skills'),
+    })
+    const result = selectFilteredSkills(state as never)
+    expect(result.map((s) => s.name)).toEqual(['a'])
+  })
+
+  it('searchScope=name preserves the original name-match behavior', () => {
+    // Regression guard: explicitly setting scope='name' must behave identically
+    // to the pre-feature default so the toggle round-trips cleanly.
+    const skills = [
+      makeSkill('task', 'claude-code', false, 'vercel-labs/skills'),
+      makeSkill('browse', 'cursor', false, 'vercel-labs/skills'),
+    ]
+    const state = buildState({
+      skills,
+      searchQuery: 'task',
+      searchScope: 'name',
+    })
+    const result = selectFilteredSkills(state as never)
+    expect(result.map((s) => s.name)).toEqual(['task'])
+  })
+
+  it('searchScope=repo with empty query does not exclude Local skills', () => {
+    // The repo-scope filter only kicks in when there's a non-empty query.
+    // An empty query in repo scope must still surface Local skills, because
+    // the toggle is about what the query matches against, not a standalone
+    // "show only repo skills" filter. Guards against a regression where the
+    // scope itself was treated as a population filter.
+    const skills = [
+      makeSkill('local-task', 'cursor'),
+      makeSkill('repo-task', 'cursor', false, 'vercel-labs/skills'),
+    ]
+    const state = buildState({
+      skills,
+      searchQuery: '',
+      searchScope: 'repo',
+    })
+    const result = selectFilteredSkills(state as never)
+    // Both surface — agent filter narrows to cursor, neither query nor
+    // scope are doing any filtering work with an empty query.
+    expect(result.map((s) => s.name)).toEqual(['local-task', 'repo-task'])
+  })
+
+  it('selectedSource pill stacks with searchScope=repo + matching query', () => {
+    // Three-way compound: pill narrows to one repo, scope=repo searches
+    // within source strings, query matches that source — confirms the
+    // filters compose without short-circuiting each other (per Issue 4).
+    const skills = [
+      makeSkill('a', 'claude-code', false, 'vercel-labs/skills'),
+      makeSkill('b', 'claude-code', false, 'vercel-labs/skills'),
+      makeSkill('c', 'claude-code', false, 'pbakaus/impeccable'),
+    ]
+    const state = buildState({
+      skills,
+      selectedSource: repositoryId('vercel-labs/skills'),
+      searchQuery: 'vercel',
+      searchScope: 'repo',
+    })
+    const result = selectFilteredSkills(state as never)
+    expect(result.map((s) => s.name)).toEqual(['a', 'b'])
+  })
+
+  it('selectedSource pill + searchScope=repo with non-matching query returns empty', () => {
+    // Edge case: the pill says "in vercel-labs/skills" but the user types
+    // 'figma' in repo scope. The compound filter must return empty — the
+    // pill-narrowed population doesn't have a source matching 'figma',
+    // so neither pill nor scope can produce a hit on its own.
+    const skills = [
+      makeSkill('a', 'claude-code', false, 'vercel-labs/skills'),
+      makeSkill('b', 'claude-code', false, 'figma/mcp-server-guide'),
+    ]
+    const state = buildState({
+      skills,
+      selectedSource: repositoryId('vercel-labs/skills'),
+      searchQuery: 'figma',
+      searchScope: 'repo',
+    })
+    const result = selectFilteredSkills(state as never)
+    expect(result.map((s) => s.name)).toEqual([])
+  })
 
   it('is memoized (returns same reference for same inputs)', () => {
     const skills = [makeSkill('task', 'claude-code')]

--- a/src/renderer/src/redux/selectors.ts
+++ b/src/renderer/src/redux/selectors.ts
@@ -1,4 +1,5 @@
 import { createSelector } from '@reduxjs/toolkit'
+import { match } from 'ts-pattern'
 
 import type { SkillName } from '../../../shared/types'
 
@@ -10,14 +11,29 @@ import {
 } from './slices/skillsSlice'
 import {
   selectSearchQuery,
+  selectSearchScope,
   selectSelectedAgentId,
+  selectSelectedSource,
   selectSkillTypeFilter,
   selectSortOrder,
 } from './slices/uiSlice'
 
 /**
  * Memoized selector for filtered and sorted skills list.
- * Applies agent filter, skill type filter, search query, and name sort.
+ * Applies (in order): agent filter, skill type filter, source-repo pill,
+ * scope-aware search query, and name sort.
+ *
+ * Search scope rules:
+ * - `'name'` — case-insensitive substring match against `skill.name` (the
+ *   original behavior; preserved when no toggle is wired).
+ * - `'repo'` — case-insensitive substring match against `skill.source`. Skills
+ *   with no `source` (Local-only skills) are excluded in this mode because
+ *   they have no repo string to match.
+ *
+ * The source pill (`selectedSource`) is an exact-match filter applied
+ * independently of the scope so users can stack "in repo X" with "name
+ * containing Y".
+ *
  * @returns Filtered + sorted skills array
  * @example
  * const filteredSkills = useAppSelector(selectFilteredSkills)
@@ -26,11 +42,21 @@ export const selectFilteredSkills = createSelector(
   [
     selectSkillsItems,
     selectSearchQuery,
+    selectSearchScope,
     selectSelectedAgentId,
+    selectSelectedSource,
     selectSortOrder,
     selectSkillTypeFilter,
   ],
-  (skills, searchQuery, selectedAgentId, sortOrder, skillTypeFilter) => {
+  (
+    skills,
+    searchQuery,
+    searchScope,
+    selectedAgentId,
+    selectedSource,
+    sortOrder,
+    skillTypeFilter,
+  ) => {
     let result = skills
 
     // Filter by selected agent (and optionally by skill type), or — when no
@@ -54,12 +80,28 @@ export const selectFilteredSkills = createSelector(
       result = result.filter((skill) => skill.isSource)
     }
 
-    // Filter by search query (name only)
+    // Source-repo filter pill — exact match. Local skills (source undefined)
+    // can never match a non-null pill value, so they drop out implicitly.
+    if (selectedSource) {
+      result = result.filter((skill) => skill.source === selectedSource)
+    }
+
+    // Scope-aware search. ts-pattern + .exhaustive() makes adding a new
+    // SearchScope a compile-time failure here, not a silent fall-through to
+    // the name branch (the failure mode of the previous if/else).
     if (searchQuery) {
       const query = searchQuery.toLowerCase()
-      result = result.filter((skill) =>
-        skill.name.toLowerCase().includes(query),
-      )
+      result = match(searchScope)
+        .with('repo', () =>
+          // Local skills have no `source`; in repo mode they cannot match.
+          result.filter((skill) =>
+            skill.source ? skill.source.toLowerCase().includes(query) : false,
+          ),
+        )
+        .with('name', () =>
+          result.filter((skill) => skill.name.toLowerCase().includes(query)),
+        )
+        .exhaustive()
     }
 
     // Sort by name

--- a/src/renderer/src/redux/slices/uiSlice.ts
+++ b/src/renderer/src/redux/slices/uiSlice.ts
@@ -6,6 +6,7 @@ import type {
   AgentName,
   BookmarkedSkill,
   IsoTimestamp,
+  RepositoryId,
   SearchQuery,
   SkillName,
   SourceStats,
@@ -25,6 +26,13 @@ export type BookmarkForDetail = BookmarkedSkill & { isInstalled: boolean }
 export type SortOrder = 'asc' | 'desc'
 export type SkillTypeFilter = 'all' | 'symlinked' | 'local'
 export type ActiveTab = 'installed' | 'marketplace'
+/**
+ * Which field the search box matches against.
+ * - `'name'` — matches `Skill.name` (default; previous behavior).
+ * - `'repo'` — matches `Skill.source` (e.g. `"vercel-labs/skills"`).
+ *   Local skills with no `source` are excluded from results in this mode.
+ */
+export type SearchScope = 'name' | 'repo'
 
 /**
  * Shape used by the sonner-rendered UndoToast for bulk delete/unlink.
@@ -68,6 +76,17 @@ interface UiState {
   /** Active main content tab */
   activeTab: ActiveTab
   searchQuery: SearchQuery
+  /**
+   * Which Skill field `searchQuery` matches against. Toggle in `SearchBox`.
+   * Persists across agent changes — scope is a query intent, not list state.
+   */
+  searchScope: SearchScope
+  /**
+   * Repository filter pill. Set when the user clicks a SourceLink text;
+   * cleared from the FilterPill's "Clear" button. Orthogonal to the agent
+   * filter — both can be active simultaneously (skills in agent X from repo Y).
+   */
+  selectedSource: RepositoryId | null
   sourceStats: SourceStats | null
   isRefreshing: boolean
   /** Currently selected agent filter (null = global/all-agents view). */
@@ -109,6 +128,8 @@ interface UiState {
 const initialState: UiState = {
   activeTab: 'installed',
   searchQuery: '',
+  searchScope: 'name',
+  selectedSource: null,
   sourceStats: null,
   isRefreshing: false,
   selectedAgentId: null,
@@ -174,6 +195,30 @@ const uiSlice = createSlice({
     },
     setSearchQuery: (state, action: PayloadAction<SearchQuery>) => {
       state.searchQuery = action.payload
+    },
+    /**
+     * Toggle which Skill field the search query matches.
+     * Does not clear `searchQuery` or `selectedSource` — the user is
+     * narrowing intent, not abandoning the in-progress search.
+     */
+    setSearchScope: (state, action: PayloadAction<SearchScope>) => {
+      state.searchScope = action.payload
+    },
+    /**
+     * Activate the repository filter pill. Dispatched when the user clicks
+     * a SourceLink's repo text on a skill row. Independent of the agent
+     * pill — both can render simultaneously.
+     */
+    setSelectedSource: (state, action: PayloadAction<RepositoryId>) => {
+      state.selectedSource = action.payload
+    },
+    /**
+     * Dismiss the repository filter pill. Wired to the FilterPill's "Clear"
+     * button. Does not touch `searchScope` or `searchQuery` — those remain
+     * as the user left them.
+     */
+    clearSelectedSource: (state) => {
+      state.selectedSource = null
     },
     setRefreshing: (state, action: PayloadAction<boolean>) => {
       state.isRefreshing = action.payload
@@ -325,6 +370,9 @@ const uiSlice = createSlice({
 export const {
   setActiveTab,
   setSearchQuery,
+  setSearchScope,
+  setSelectedSource,
+  clearSelectedSource,
   setRefreshing,
   selectAgent,
   toggleSortOrder,
@@ -347,6 +395,10 @@ export const selectActiveTab = (state: RootState): ActiveTab =>
   state.ui.activeTab
 export const selectSearchQuery = (state: RootState): SearchQuery =>
   state.ui.searchQuery
+export const selectSearchScope = (state: RootState): SearchScope =>
+  state.ui.searchScope
+export const selectSelectedSource = (state: RootState): RepositoryId | null =>
+  state.ui.selectedSource
 export const selectSelectedAgentId = (state: RootState): AgentId | null =>
   state.ui.selectedAgentId
 export const selectSourceStats = (state: RootState): SourceStats | null =>

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -637,3 +637,19 @@ export const UNDO_WINDOW_MS = 15_000
  * gate must read the same threshold.
  */
 export const BULK_PROGRESS_THRESHOLD = 10
+
+/**
+ * Minimum tap-target size (px) for interactive elements. Floor set by both
+ * Apple HIG (44×44 pt) and WCAG 2.2 AA (target size 24 CSS px minimum, 44
+ * recommended) — keeping a single source of truth here means adding a new
+ * pill / toggle / icon button can grep for the constant rather than
+ * scatter `min-h-[44px]` arbitrary-values across components.
+ *
+ * Imported via inline `style={{ minHeight: MIN_TOUCH_TARGET_PX }}` rather
+ * than a Tailwind arbitrary value because the constant is the contract;
+ * the className is just a delivery mechanism.
+ *
+ * @example
+ * <Button style={{ minHeight: MIN_TOUCH_TARGET_PX }}>Clear</Button>
+ */
+export const MIN_TOUCH_TARGET_PX = 44

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -57,6 +57,11 @@ export default defineConfig({
             'react/jsx-runtime',
             'react-redux',
             '@reduxjs/toolkit',
+            // Radix's controllable-state hook runs `useState` against whatever
+            // React it sees first. If Vite bundles toggle-group lazily it grabs
+            // a stale React copy and `useState` returns undefined → render
+            // crash. Listing the package here forces it into the shared chunk.
+            '@radix-ui/react-toggle-group',
           ],
         },
         test: {


### PR DESCRIPTION
## Summary

- **Repo-scope search toggle** — Name/Repo `ToggleGroup` next to the search input. When set to `repo`, the query matches against `skill.source` instead of `skill.name`; Local skills (no source) drop out so the toggle never silently misnames its scope.
- **Source-repo filter pill on each card** — `SourceLink` now splits its single anchor into a `<button>` (dispatches `setSelectedSource` to filter the list) and an `<a target="_blank">` (opens GitHub). Each affordance gets its own focus stop and stop-propagation guard so card selection no longer fires when the user just wanted to filter or open the repo.
- **Empty-state ladder** — Extracted `getEmptyListMessage` with priority `search > source > agent+type > agent > fallback`, replacing a 4-deep nested ternary that silently returned "match your search" for source-pill empties.

## Verification

- `pnpm typecheck` ✓
- `pnpm test` ✓ (822 passing)
- `pnpm lint` ✓
- Manual: searched for `figma`, `vercel`, both empty in repo scope; clicked source-pill on a card, list narrowed; cleared via FilterPill; toggled scope mid-query — copy stays consistent.

## Review-driven refinements (post-initial implementation)

- `ToggleGroup` default size bumped `h-9 → h-11` (44px Apple HIG / WCAG 2.2 AA tap target). Focus ring `ring-1 → ring-2 ring-offset-2` so it stays visible on neutral OKLCH presets. `data-[state=on]:border-primary` on outline variant gives the active item a color anchor when `bg-accent` collapses to near-background gray on neutral presets — 1px border-color swap, no layout shift.
- `MIN_TOUCH_TARGET_PX = 44` extracted to `src/shared/constants.ts`; `FilterPill` consumes via inline style.
- `selectFilteredSkills` and `getEmptyListMessage` use `ts-pattern` + `.exhaustive()` — adding a third `SearchScope` is now a compile-time failure rather than a silent fall-through.
- New compound selector tests covering scope=repo + selectedSource + searchQuery.
- New `skillsListHelpers.test.ts` locks all five empty-state ladder tiers.

## Test plan

- [ ] CI passes (typecheck, lint, vitest run including browser mode)
- [ ] CodeRabbit review actioned via `/coderabbit-resolver`
- [ ] Manual smoke in dev build: scope toggle copy, repo filter pill click, external-link icon opens GitHub, empty-state messages for each tier
- [ ] Visual check on neutral-light and neutral-dark presets — active toggle and focus ring both visible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * リポジトリによるスキルフィルタリング機能を追加
  * スキル名またはリポジトリ名での検索に対応
  * フィルタピルコンポーネントを実装（エージェント・ソースフィルタを独立して表示可能）

* **テスト**
  * 新しいコンポーネントおよび機能のテストカバレッジを拡充

<!-- end of auto-generated comment: release notes by coderabbit.ai -->