### PR TITLE
feat(settings): Settings window with cross-window state sync

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -43,6 +43,7 @@ export default defineConfig({
       rollupOptions: {
         input: {
           index: resolve(__dirname, 'src/renderer/index.html'),
+          settings: resolve(__dirname, 'src/renderer/settings/index.html'),
         },
       },
     },

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,6 @@
 import { join } from 'path'
 
-import { app, shell, BrowserWindow, Menu, nativeImage, session } from 'electron'
+import { app, BrowserWindow, Menu, nativeImage, session } from 'electron'
 
 import { isAllowedSkillsUrl } from '../shared/marketplaceUrlPolicy'
 
@@ -9,6 +9,8 @@ import { loadSettings } from './services/settings'
 import { createOrFocusSettingsWindow } from './services/settingsWindow'
 import { startupCleanup as runTrashStartupCleanup } from './services/trashService'
 import { initAutoUpdater } from './updater'
+import { attachExternalLinkHandler } from './utils/attachExternalLinkHandler'
+import { getSecureWebPreferences } from './utils/secureWebPreferences'
 
 process.on('unhandledRejection', (reason, promise) => {
   console.error('Unhandled Rejection at:', promise, 'reason:', reason)
@@ -34,10 +36,9 @@ function createWindow(): void {
     titleBarStyle: 'hiddenInset',
     trafficLightPosition: { x: 16, y: 16 },
     webPreferences: {
-      preload: join(__dirname, '../preload/index.js'),
-      sandbox: true,
-      contextIsolation: true,
-      nodeIntegration: false,
+      ...getSecureWebPreferences(),
+      // Main-window-only: <webview> is used by the marketplace tab to
+      // embed skills.sh; Settings window doesn't need it.
       webviewTag: true,
     },
   })
@@ -72,17 +73,7 @@ function createWindow(): void {
     },
   )
 
-  window.webContents.setWindowOpenHandler((details) => {
-    try {
-      const url = new URL(details.url)
-      if (['http:', 'https:'].includes(url.protocol)) {
-        shell.openExternal(details.url)
-      }
-    } catch {
-      // Invalid URL, ignore
-    }
-    return { action: 'deny' }
-  })
+  attachExternalLinkHandler(window)
 
   // Enforce Content Security Policy in production builds.
   // Use file: and app: schemes explicitly since 'self' may not reliably match file:// origins.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -218,9 +218,13 @@ app.whenReady().then(async () => {
 
   // Hydrate settings cache before any window opens so the first
   // `settings:get` from the renderer returns persisted values rather
-  // than racing the disk read. Fire-and-forget; loadSettings swallows
-  // its own errors and falls back to defaults.
-  void loadSettings()
+  // than racing the disk read. Must be awaited: `getSettings()`
+  // populates cache with `DEFAULT_SETTINGS` on first call when cache is
+  // still null, and the later `loadSettings()` resolution does not
+  // broadcast `settings:changed`, so a fast renderer mount would lock
+  // in defaults until the user manually flips a setting. loadSettings
+  // swallows its own errors and falls back to defaults internally.
+  await loadSettings()
 
   // Sweep orphan trash entries older than 24h. Fire-and-forget: errors per
   // entry are caught + logged inside trashService; we never block startup.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,6 +5,8 @@ import { app, shell, BrowserWindow, Menu, nativeImage, session } from 'electron'
 import { isAllowedSkillsUrl } from '../shared/marketplaceUrlPolicy'
 
 import { registerAllHandlers } from './ipc/handlers'
+import { loadSettings } from './services/settings'
+import { createOrFocusSettingsWindow } from './services/settingsWindow'
 import { startupCleanup as runTrashStartupCleanup } from './services/trashService'
 import { initAutoUpdater } from './updater'
 
@@ -12,8 +14,17 @@ process.on('unhandledRejection', (reason, promise) => {
   console.error('Unhandled Rejection at:', promise, 'reason:', reason)
 })
 
+/**
+ * Module-scoped reference to the main window so `app.activate` can
+ * recreate it specifically when the user has closed only the main
+ * window (Settings may still be open). Pre-fix the activate handler
+ * checked `getAllWindows().length === 0`, which was wrong: a Settings
+ * window stays a window and would have prevented main from re-opening.
+ */
+let mainWindow: BrowserWindow | null = null
+
 function createWindow(): void {
-  const mainWindow = new BrowserWindow({
+  const window = new BrowserWindow({
     width: 1200,
     height: 800,
     minWidth: 800,
@@ -30,10 +41,15 @@ function createWindow(): void {
       webviewTag: true,
     },
   })
+  mainWindow = window
 
-  mainWindow.on('ready-to-show', () => {
-    mainWindow.maximize()
-    mainWindow.show()
+  window.on('closed', () => {
+    mainWindow = null
+  })
+
+  window.on('ready-to-show', () => {
+    window.maximize()
+    window.show()
   })
 
   /** Enforce safe webview options before attachment (Electron security recommendation).
@@ -42,7 +58,7 @@ function createWindow(): void {
    * @param webPreferences - Hardened to disable node integration
    * @param params - Contains the src URL to validate
    */
-  mainWindow.webContents.on(
+  window.webContents.on(
     'will-attach-webview',
     (event, webPreferences, params) => {
       if (!isAllowedSkillsUrl(params.src)) {
@@ -56,7 +72,7 @@ function createWindow(): void {
     },
   )
 
-  mainWindow.webContents.setWindowOpenHandler((details) => {
+  window.webContents.setWindowOpenHandler((details) => {
     try {
       const url = new URL(details.url)
       if (['http:', 'https:'].includes(url.protocol)) {
@@ -85,9 +101,9 @@ function createWindow(): void {
 
   // HMR for renderer based on electron-vite cli
   if (!app.isPackaged && process.env['ELECTRON_RENDERER_URL']) {
-    mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL'])
+    window.loadURL(process.env['ELECTRON_RENDERER_URL'])
   } else {
-    mainWindow.loadFile(join(__dirname, '../renderer/index.html'))
+    window.loadFile(join(__dirname, '../renderer/index.html'))
   }
 }
 
@@ -154,6 +170,14 @@ function createMenu(): void {
       submenu: [
         { role: 'about' },
         { type: 'separator' },
+        {
+          label: 'Settings…',
+          accelerator: 'Cmd+,',
+          click: (): void => {
+            createOrFocusSettingsWindow()
+          },
+        },
+        { type: 'separator' },
         { role: 'hide' },
         { role: 'hideOthers' },
         { role: 'unhide' },
@@ -197,9 +221,15 @@ function createMenu(): void {
   Menu.setApplicationMenu(menu)
 }
 
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
   // Register IPC handlers before creating window
   registerAllHandlers()
+
+  // Hydrate settings cache before any window opens so the first
+  // `settings:get` from the renderer returns persisted values rather
+  // than racing the disk read. Fire-and-forget; loadSettings swallows
+  // its own errors and falls back to defaults.
+  void loadSettings()
 
   // Sweep orphan trash entries older than 24h. Fire-and-forget: errors per
   // entry are caught + logged inside trashService; we never block startup.
@@ -217,8 +247,12 @@ app.whenReady().then(() => {
     initAutoUpdater()
   }
 
+  // Recreate ONLY the main window if it has been closed — the Settings
+  // window may still be open, so checking `getAllWindows().length === 0`
+  // would incorrectly leave a Settings-only state without a main window
+  // when the user clicks the dock icon.
   app.on('activate', () => {
-    if (BrowserWindow.getAllWindows().length === 0) createWindow()
+    if (mainWindow === null || mainWindow.isDestroyed()) createWindow()
   })
 })
 

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -1,6 +1,7 @@
 import { registerAgentsHandlers } from './agents'
 import { registerFilesHandlers } from './files'
 import { registerLeaderboardHandlers } from './leaderboard'
+import { registerSettingsHandlers } from './settings'
 import { registerShellHandlers } from './shell'
 import { registerSkillsHandlers } from './skills'
 import { registerSkillsCliHandlers } from './skillsCli'
@@ -22,4 +23,5 @@ export function registerAllHandlers(): void {
   registerUpdateHandlers()
   registerSyncHandlers()
   registerShellHandlers()
+  registerSettingsHandlers()
 }

--- a/src/main/ipc/ipc-schemas.ts
+++ b/src/main/ipc/ipc-schemas.ts
@@ -229,4 +229,16 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
         message: 'Only http(s) URLs are allowed',
       }),
   ]),
+
+  // Settings — partial<Settings> with explicit allowed keys/values.
+  // Matches src/shared/settings.ts; widening that schema must widen
+  // this one too. Defense-in-depth so a compromised renderer cannot write
+  // arbitrary JSON into settings.json.
+  'settings:set': z.tuple([
+    z
+      .object({
+        defaultSkillTab: z.enum(['files', 'info']).optional(),
+      })
+      .strict(),
+  ]),
 }

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -1,0 +1,35 @@
+import { IPC_CHANNELS } from '../../shared/ipc-channels'
+import { getSettings, saveSettings } from '../services/settings'
+import { createOrFocusSettingsWindow } from '../services/settingsWindow'
+
+import { typedHandle } from './typedHandle'
+import { broadcastTypedEvent } from './typedSend'
+
+/**
+ * Wires the IPC surface for the Settings window:
+ *  - `settings:open`         opens (or focuses) the Settings BrowserWindow.
+ *  - `settings:get`          returns the in-memory cache so renderers can
+ *                            hydrate their Redux slice on mount.
+ *  - `settings:set`          merges a partial update, persists to JSON,
+ *                            and broadcasts `settings:changed` so every
+ *                            open window converges (no stale state across
+ *                            the main window and Settings window).
+ *
+ * The broadcast is what eliminates the dual-Redux race we'd see if
+ * persistence lived in localStorage and both windows wrote to the same
+ * key — the main process is the single source of truth and renderers
+ * are pure caches.
+ */
+export function registerSettingsHandlers(): void {
+  typedHandle(IPC_CHANNELS.SETTINGS_OPEN, () => {
+    createOrFocusSettingsWindow()
+  })
+
+  typedHandle(IPC_CHANNELS.SETTINGS_GET, () => getSettings())
+
+  typedHandle(IPC_CHANNELS.SETTINGS_SET, async (_event, partial) => {
+    const next = await saveSettings(partial)
+    broadcastTypedEvent(IPC_CHANNELS.SETTINGS_CHANGED, next)
+    return next
+  })
+}

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -28,8 +28,15 @@ export function registerSettingsHandlers(): void {
   typedHandle(IPC_CHANNELS.SETTINGS_GET, () => getSettings())
 
   typedHandle(IPC_CHANNELS.SETTINGS_SET, async (_event, partial) => {
+    const before = getSettings()
     const next = await saveSettings(partial)
-    broadcastTypedEvent(IPC_CHANNELS.SETTINGS_CHANGED, next)
+    // `saveSettings` returns the same reference when nothing actually
+    // changed (shallow-compare guard inside the service). Skip the
+    // broadcast in that case so we don't fan out a no-op `settings:changed`
+    // and trigger a redundant Redux replace in every open window.
+    if (next !== before) {
+      broadcastTypedEvent(IPC_CHANNELS.SETTINGS_CHANGED, next)
+    }
     return next
   })
 }

--- a/src/main/ipc/typedSend.ts
+++ b/src/main/ipc/typedSend.ts
@@ -40,6 +40,11 @@ export function broadcastTypedEvent<C extends IpcEventChannel>(
   ...args: IpcEventContract[C] extends void ? [] : [IpcEventContract[C]]
 ): void {
   for (const win of BrowserWindow.getAllWindows()) {
+    // Skip torn-down windows mid-loop. `getAllWindows()` may include a
+    // window whose `webContents` is already destroyed (e.g. a Settings
+    // window whose `closed` event fired between the iteration start and
+    // here) — `webContents.send` on a destroyed view throws.
+    if (win.isDestroyed() || win.webContents.isDestroyed()) continue
     typedSend(win.webContents, channel, ...args)
   }
 }

--- a/src/main/ipc/typedSend.ts
+++ b/src/main/ipc/typedSend.ts
@@ -1,4 +1,4 @@
-import type { WebContents } from 'electron'
+import { BrowserWindow, type WebContents } from 'electron'
 
 import type {
   IpcEventChannel,
@@ -21,4 +21,25 @@ export function typedSend<C extends IpcEventChannel>(
   ...args: IpcEventContract[C] extends void ? [] : [IpcEventContract[C]]
 ): void {
   webContents.send(channel, ...args)
+}
+
+/**
+ * Broadcast a typed event to every open BrowserWindow. Used by the
+ * updater and the settings service to fan out state changes so the
+ * main window and Settings window both stay in sync.
+ *
+ * Lifted out of `updater.ts` so multiple subsystems can reuse it without
+ * each redefining its own `for (...) typedSend(...)` loop.
+ * @param channel - Event channel name (key of IpcEventContract)
+ * @param args - Payload matching the contract (omit for void channels)
+ * @example
+ * broadcastTypedEvent('settings:changed', { defaultSkillTab: 'info' })
+ */
+export function broadcastTypedEvent<C extends IpcEventChannel>(
+  channel: C,
+  ...args: IpcEventContract[C] extends void ? [] : [IpcEventContract[C]]
+): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    typedSend(win.webContents, channel, ...args)
+  }
 }

--- a/src/main/services/settings.ts
+++ b/src/main/services/settings.ts
@@ -1,0 +1,100 @@
+import { promises as fs } from 'fs'
+import { join } from 'path'
+
+import { app } from 'electron'
+
+import {
+  DEFAULT_SETTINGS,
+  SettingsSchema,
+  type Settings,
+} from '../../shared/settings'
+
+/**
+ * In-memory cache of settings. Populated by `loadSettings()` at app
+ * boot and re-populated on every `saveSettings()`. Renderers receive a
+ * snapshot via `settings:get` and a stream of updates via the
+ * `settings:changed` broadcast event — they never read this file
+ * directly.
+ */
+let cache: Settings | null = null
+
+/**
+ * Resolves the on-disk path for `settings.json`. Lazy because
+ * `app.getPath('userData')` is only valid after `app.whenReady()`; calling
+ * this at module-load time crashes Electron in tests.
+ * @returns Absolute path to the settings file
+ * @example
+ * settingsFilePath() // => '/Users/me/Library/Application Support/skills-desktop/settings.json'
+ */
+function settingsFilePath(): string {
+  return join(app.getPath('userData'), 'settings.json')
+}
+
+/**
+ * Reads `settings.json` from disk and validates it with Zod. On any
+ * failure (missing file, malformed JSON, schema mismatch) the defaults
+ * are returned — settings are non-critical, never block startup, and
+ * the next `saveSettings()` will write a clean file.
+ * @returns Validated settings (or defaults on any error)
+ * @example
+ * await loadSettings() // => { defaultSkillTab: 'files' }
+ */
+export async function loadSettings(): Promise<Settings> {
+  try {
+    const raw = await fs.readFile(settingsFilePath(), 'utf8')
+    const parsed = JSON.parse(raw)
+    const validated = SettingsSchema.parse(parsed)
+    cache = validated
+    return validated
+  } catch (err) {
+    // ENOENT (first launch) is expected; other errors get logged so
+    // a corrupt file is visible in the dev console without blocking.
+    const code = (err as NodeJS.ErrnoException).code
+    if (code !== 'ENOENT') {
+      console.warn('[settings] failed to load, using defaults:', err)
+    }
+    cache = { ...DEFAULT_SETTINGS }
+    return cache
+  }
+}
+
+/**
+ * Returns the in-memory settings snapshot. Lazy-loads on first call so
+ * IPC handlers can `getSettings()` without awaiting.
+ * @returns The cached settings (or defaults if `loadSettings` was never called)
+ * @example
+ * getSettings() // => { defaultSkillTab: 'files' }
+ */
+export function getSettings(): Settings {
+  if (cache === null) {
+    cache = { ...DEFAULT_SETTINGS }
+  }
+  return cache
+}
+
+/**
+ * Merges `partial` over the current settings and writes the result
+ * atomically (temp file + rename) so a crash mid-write cannot corrupt
+ * the file. The merged value is validated with Zod before disk write —
+ * an invalid `partial` rejects the whole call.
+ * @param partial - Subset of fields to overwrite
+ * @returns
+ * - On success: the new full Settings object (also updates the cache)
+ * - On Zod failure: throws — caller should surface the message
+ * @example
+ * await saveSettings({ defaultSkillTab: 'info' })
+ * // => { defaultSkillTab: 'info' }
+ */
+export async function saveSettings(
+  partial: Partial<Settings>,
+): Promise<Settings> {
+  const merged = SettingsSchema.parse({ ...getSettings(), ...partial })
+  const target = settingsFilePath()
+  const tempPath = `${target}.tmp`
+  // Ensure userData dir exists — first run on a fresh profile may lack it.
+  await fs.mkdir(app.getPath('userData'), { recursive: true })
+  await fs.writeFile(tempPath, JSON.stringify(merged, null, 2), 'utf8')
+  await fs.rename(tempPath, target)
+  cache = merged
+  return merged
+}

--- a/src/main/services/settings.ts
+++ b/src/main/services/settings.ts
@@ -88,7 +88,17 @@ export function getSettings(): Settings {
 export async function saveSettings(
   partial: Partial<Settings>,
 ): Promise<Settings> {
-  const merged = SettingsSchema.parse({ ...getSettings(), ...partial })
+  const current = getSettings()
+  const merged = SettingsSchema.parse({ ...current, ...partial })
+  // Shallow-compare guard: when nothing actually changed (e.g. tapping
+  // the already-active radio), short-circuit before disk write so
+  // `ipc/settings.ts` can also skip the broadcast — no fan-out, no
+  // redundant Redux replace in every open window. Safe today because
+  // `Settings` is a flat object; revisit if a nested field lands.
+  const isUnchanged = (Object.keys(merged) as Array<keyof Settings>).every(
+    (key) => merged[key] === current[key],
+  )
+  if (isUnchanged) return current
   const target = settingsFilePath()
   const tempPath = `${target}.tmp`
   // Ensure userData dir exists — first run on a fresh profile may lack it.

--- a/src/main/services/settingsWindow.ts
+++ b/src/main/services/settingsWindow.ts
@@ -1,6 +1,9 @@
 import { join } from 'path'
 
-import { app, BrowserWindow, shell } from 'electron'
+import { app, BrowserWindow } from 'electron'
+
+import { attachExternalLinkHandler } from '../utils/attachExternalLinkHandler'
+import { getSecureWebPreferences } from '../utils/secureWebPreferences'
 
 /**
  * Single-instance reference to the Settings window. Held at module scope
@@ -40,27 +43,12 @@ export function createOrFocusSettingsWindow(): void {
     maximizable: false,
     fullscreenable: false,
     backgroundColor: '#0A0F1C',
-    webPreferences: {
-      preload: join(__dirname, '../preload/index.js'),
-      sandbox: true,
-      contextIsolation: true,
-      nodeIntegration: false,
-    },
+    webPreferences: getSecureWebPreferences(),
   })
 
   // External-link routing: keeps About-tab anchor tags out of an in-app
   // BrowserWindow. Mirrors the main-window pattern in src/main/index.ts.
-  window.webContents.setWindowOpenHandler((details) => {
-    try {
-      const url = new URL(details.url)
-      if (['http:', 'https:'].includes(url.protocol)) {
-        shell.openExternal(details.url)
-      }
-    } catch {
-      // Invalid URL, ignore
-    }
-    return { action: 'deny' }
-  })
+  attachExternalLinkHandler(window)
 
   window.on('ready-to-show', () => {
     window.show()

--- a/src/main/services/settingsWindow.ts
+++ b/src/main/services/settingsWindow.ts
@@ -1,0 +1,83 @@
+import { join } from 'path'
+
+import { app, BrowserWindow, shell } from 'electron'
+
+/**
+ * Single-instance reference to the Settings window. Held at module scope
+ * so subsequent `createOrFocusSettingsWindow()` calls (App menu Cmd+, or
+ * sidebar gear icon) focus the existing window instead of spawning a
+ * second one. Cleared on `'closed'`.
+ */
+let settingsWindow: BrowserWindow | null = null
+
+/**
+ * Open (or focus, if already open) the Settings window. Loads the
+ * separate `settings/index.html` Rollup entry — see
+ * `electron.vite.config.ts` for the multi-entry config.
+ *
+ * Window chrome: standard macOS title bar (NOT hidden-inset like the
+ * main window) so the title "Settings" reads naturally; not minimizable,
+ * maximizable, or fullscreen-able to match Inkdrop's pattern.
+ * @example
+ * // Wired into the App menu and the sidebar gear icon button.
+ * createOrFocusSettingsWindow()
+ */
+export function createOrFocusSettingsWindow(): void {
+  if (settingsWindow !== null && !settingsWindow.isDestroyed()) {
+    if (settingsWindow.isMinimized()) settingsWindow.restore()
+    settingsWindow.focus()
+    return
+  }
+
+  const window = new BrowserWindow({
+    width: 800,
+    height: 600,
+    minWidth: 600,
+    minHeight: 400,
+    show: false,
+    title: 'Settings',
+    minimizable: false,
+    maximizable: false,
+    fullscreenable: false,
+    backgroundColor: '#0A0F1C',
+    webPreferences: {
+      preload: join(__dirname, '../preload/index.js'),
+      sandbox: true,
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  })
+
+  // External-link routing: keeps About-tab anchor tags out of an in-app
+  // BrowserWindow. Mirrors the main-window pattern in src/main/index.ts.
+  window.webContents.setWindowOpenHandler((details) => {
+    try {
+      const url = new URL(details.url)
+      if (['http:', 'https:'].includes(url.protocol)) {
+        shell.openExternal(details.url)
+      }
+    } catch {
+      // Invalid URL, ignore
+    }
+    return { action: 'deny' }
+  })
+
+  window.on('ready-to-show', () => {
+    window.show()
+  })
+
+  window.on('closed', () => {
+    settingsWindow = null
+  })
+
+  // Dev: hot-reload via electron-vite renderer URL with explicit hash.
+  // Prod: load the bundled HTML file directly.
+  const rendererUrl = process.env['ELECTRON_RENDERER_URL']
+  if (!app.isPackaged && rendererUrl) {
+    window.loadURL(`${rendererUrl}/settings/index.html`)
+  } else {
+    window.loadFile(join(__dirname, '../renderer/settings/index.html'))
+  }
+
+  settingsWindow = window
+}

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -1,26 +1,9 @@
-import { BrowserWindow } from 'electron'
 import { autoUpdater } from 'electron-updater'
 
 import { IPC_CHANNELS } from '../shared/ipc-channels'
-import type { IpcEventChannel, IpcEventContract } from '../shared/ipc-contract'
 import { semanticVersion } from '../shared/types'
 
-import { typedSend } from './ipc/typedSend'
-
-/**
- * Send typed event to all renderer windows
- * @param channel - Event channel name
- * @param args - Payload matching the contract
- */
-function broadcastEvent<C extends IpcEventChannel>(
-  channel: C,
-  ...args: IpcEventContract[C] extends void ? [] : [IpcEventContract[C]]
-): void {
-  const windows = BrowserWindow.getAllWindows()
-  for (const win of windows) {
-    typedSend(win.webContents, channel, ...args)
-  }
-}
+import { broadcastTypedEvent as broadcastEvent } from './ipc/typedSend'
 
 /**
  * Initialize auto updater with IPC-based UI notifications

--- a/src/main/utils/attachExternalLinkHandler.ts
+++ b/src/main/utils/attachExternalLinkHandler.ts
@@ -1,0 +1,30 @@
+import { type BrowserWindow, shell } from 'electron'
+
+/**
+ * Route any `window.open()` / target="_blank" anchor click out of the
+ * given BrowserWindow into the OS default browser via `shell.openExternal`.
+ * Denies non-http(s) schemes (e.g. `javascript:`, `file:`) so a malicious
+ * marketplace listing or About-tab content cannot pivot through this hook
+ * to navigate the embedding window.
+ *
+ * Mirrors the pattern recommended by Electron's security docs and is
+ * applied to every window we create — main window plus Settings window —
+ * so external link behavior is consistent across surfaces.
+ * @param window - BrowserWindow whose webContents should hand off external links to the OS.
+ * @example
+ * const window = new BrowserWindow({ ... })
+ * attachExternalLinkHandler(window)
+ */
+export function attachExternalLinkHandler(window: BrowserWindow): void {
+  window.webContents.setWindowOpenHandler((details) => {
+    try {
+      const url = new URL(details.url)
+      if (['http:', 'https:'].includes(url.protocol)) {
+        shell.openExternal(details.url)
+      }
+    } catch {
+      // Invalid URL, ignore
+    }
+    return { action: 'deny' }
+  })
+}

--- a/src/main/utils/secureWebPreferences.ts
+++ b/src/main/utils/secureWebPreferences.ts
@@ -1,0 +1,25 @@
+import { join } from 'path'
+
+import type { WebPreferences } from 'electron'
+
+/**
+ * Hardened `webPreferences` shared by every BrowserWindow we create
+ * (main window + Settings window). Centralizing this keeps the security
+ * baseline (`sandbox` + `contextIsolation` + `nodeIntegration: false`)
+ * impossible to silently weaken in only one window.
+ *
+ * Returned as a function — not a frozen constant — because
+ * `app.getPath`/`__dirname` resolution is only valid at main-process
+ * runtime; evaluating at module-load time crashes Electron under tests.
+ * @returns A `WebPreferences` object suitable for passing into a `new BrowserWindow({ webPreferences })`.
+ * @example
+ * new BrowserWindow({ webPreferences: getSecureWebPreferences() })
+ */
+export function getSecureWebPreferences(): WebPreferences {
+  return {
+    preload: join(__dirname, '../preload/index.js'),
+    sandbox: true,
+    contextIsolation: true,
+    nodeIntegration: false,
+  }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,6 +1,7 @@
 import { contextBridge } from 'electron'
 
 import { IPC_CHANNELS } from '../shared/ipc-channels'
+import type { Settings } from '../shared/settings'
 import type {
   AbsolutePath,
   CopyToAgentsOptions,
@@ -114,6 +115,18 @@ contextBridge.exposeInMainWorld('electron', {
     preview: async () => typedInvoke('sync:preview'),
     execute: async (options: SyncExecuteOptions) =>
       typedInvoke('sync:execute', options),
+  },
+  // Settings — main process holds the JSON source of truth at
+  // userData/settings.json; renderers cache via Redux and converge via
+  // the `settings:changed` broadcast event. `open` opens (or focuses)
+  // the dedicated Settings BrowserWindow (App menu Cmd+, and sidebar
+  // gear icon both route here).
+  settings: {
+    open: async () => typedInvoke('settings:open'),
+    get: async () => typedInvoke('settings:get'),
+    set: async (partial: Partial<Settings>) =>
+      typedInvoke('settings:set', partial),
+    onChanged: createIpcListener<Settings>(IPC_CHANNELS.SETTINGS_CHANGED),
   },
 })
 

--- a/src/renderer/settings/SettingsApp.tsx
+++ b/src/renderer/settings/SettingsApp.tsx
@@ -18,31 +18,29 @@ import { AutoUpdates } from './sections/AutoUpdates'
 import { General } from './sections/General'
 import { Keybindings } from './sections/Keybindings'
 
-type Section =
-  | 'general'
-  | 'appearance'
-  | 'autoUpdates'
-  | 'keybindings'
-  | 'about'
-
-interface NavItem {
-  id: Section
-  label: string
-  icon: React.ComponentType<{ className?: string }>
-}
-
 /**
  * Static nav definition. Keep order = visual order so the array is also the
  * tab order — no separate ordering layer to maintain. Lucide icons match the
  * sidebar's existing iconography (single-stroke, 16×16 default).
+ *
+ * `as const satisfies …` keeps `id` literal-typed (so `Section` below can be
+ * a strict union) while still validating the shape of every entry. Adding a
+ * new section here automatically widens `Section` — no second list to
+ * maintain.
  */
-const NAV_ITEMS: readonly NavItem[] = [
+const NAV_ITEMS = [
   { id: 'general', label: 'General', icon: SlidersHorizontal },
   { id: 'appearance', label: 'Appearance', icon: Palette },
   { id: 'autoUpdates', label: 'Auto Updates', icon: RefreshCw },
   { id: 'keybindings', label: 'Keybindings', icon: Keyboard },
   { id: 'about', label: 'About', icon: Info },
-] as const
+] as const satisfies ReadonlyArray<{
+  id: string
+  label: string
+  icon: React.ComponentType<{ className?: string }>
+}>
+
+type Section = (typeof NAV_ITEMS)[number]['id']
 
 /**
  * Top-level Settings window component.
@@ -64,7 +62,7 @@ export const SettingsApp = React.memo(
     const [activeSection, setActiveSection] = useState<Section>('general')
 
     return (
-      <div className="flex h-screen bg-background text-foreground">
+      <div className="flex h-screen bg-background text-foreground window-glow">
         <nav
           aria-label="Settings sections"
           className="w-50 shrink-0 border-r border-border bg-sidebar/30 py-4"

--- a/src/renderer/settings/SettingsApp.tsx
+++ b/src/renderer/settings/SettingsApp.tsx
@@ -1,0 +1,111 @@
+import {
+  Info,
+  Keyboard,
+  Palette,
+  RefreshCw,
+  SlidersHorizontal,
+} from 'lucide-react'
+import React, { useState } from 'react'
+import { match } from 'ts-pattern'
+
+import { ScrollArea } from '../src/components/ui/scroll-area'
+import { useSettingsSync } from '../src/hooks/useSettingsSync'
+import { cn } from '../src/lib/utils'
+
+import { About } from './sections/About'
+import { Appearance } from './sections/Appearance'
+import { AutoUpdates } from './sections/AutoUpdates'
+import { General } from './sections/General'
+import { Keybindings } from './sections/Keybindings'
+
+type Section =
+  | 'general'
+  | 'appearance'
+  | 'autoUpdates'
+  | 'keybindings'
+  | 'about'
+
+interface NavItem {
+  id: Section
+  label: string
+  icon: React.ComponentType<{ className?: string }>
+}
+
+/**
+ * Static nav definition. Keep order = visual order so the array is also the
+ * tab order — no separate ordering layer to maintain. Lucide icons match the
+ * sidebar's existing iconography (single-stroke, 16×16 default).
+ */
+const NAV_ITEMS: readonly NavItem[] = [
+  { id: 'general', label: 'General', icon: SlidersHorizontal },
+  { id: 'appearance', label: 'Appearance', icon: Palette },
+  { id: 'autoUpdates', label: 'Auto Updates', icon: RefreshCw },
+  { id: 'keybindings', label: 'Keybindings', icon: Keyboard },
+  { id: 'about', label: 'About', icon: Info },
+] as const
+
+/**
+ * Top-level Settings window component.
+ *
+ * Layout: 200px left nav rail + scrollable right pane (Inkdrop-style).
+ * The active-section state is local — Settings is a single window that
+ * doesn't deep-link to specific sections (yet), so persisting selection
+ * across opens isn't worth the IPC round-trip.
+ *
+ * `useSettingsSync()` runs once on mount: pulls a snapshot via
+ * `settings:get`, then subscribes to `settings:changed` so a save in
+ * the main window propagates here without polling. Same hook the main
+ * window uses — single source of truth for sync logic.
+ */
+export const SettingsApp = React.memo(
+  function SettingsApp(): React.ReactElement {
+    useSettingsSync()
+
+    const [activeSection, setActiveSection] = useState<Section>('general')
+
+    return (
+      <div className="flex h-screen bg-background text-foreground">
+        <nav
+          aria-label="Settings sections"
+          className="w-50 shrink-0 border-r border-border bg-sidebar/30 py-4"
+        >
+          <ul className="flex flex-col gap-0.5 px-2">
+            {NAV_ITEMS.map((item) => {
+              const Icon = item.icon
+              const isActive = activeSection === item.id
+              return (
+                <li key={item.id}>
+                  <button
+                    type="button"
+                    aria-current={isActive ? 'page' : undefined}
+                    onClick={() => setActiveSection(item.id)}
+                    className={cn(
+                      'flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                      isActive
+                        ? 'bg-accent text-accent-foreground'
+                        : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground',
+                    )}
+                  >
+                    <Icon className="h-4 w-4" />
+                    <span>{item.label}</span>
+                  </button>
+                </li>
+              )
+            })}
+          </ul>
+        </nav>
+        <ScrollArea className="flex-1">
+          <div className="px-8 py-6">
+            {match(activeSection)
+              .with('general', () => <General />)
+              .with('appearance', () => <Appearance />)
+              .with('autoUpdates', () => <AutoUpdates />)
+              .with('keybindings', () => <Keybindings />)
+              .with('about', () => <About />)
+              .exhaustive()}
+          </div>
+        </ScrollArea>
+      </div>
+    )
+  },
+)

--- a/src/renderer/settings/index.html
+++ b/src/renderer/settings/index.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Settings</title>
+    <script>
+      // Theme pre-hydration bootstrap. Mirrors src/renderer/index.html so the
+      // Settings window picks up the user's persisted theme (mode + preset)
+      // before React mounts, avoiding a neutral-dark flash. Settings does NOT
+      // expose theme controls, so we only READ from localStorage; live updates
+      // from the main window are not propagated here (theme changes require
+      // closing and reopening Settings).
+      //
+      // Magic literals duplicated from constants.ts; bootstrap.test.ts
+      // guards against drift:
+      //   'skills-desktop-state' → PERSIST_STORAGE_KEY
+      //   0.16                   → COLOR_PRESET_CHROMA
+      ;(function () {
+        try {
+          var raw = localStorage.getItem('skills-desktop-state')
+          if (!raw) return
+          var parsed = JSON.parse(raw)
+          var t = parsed && parsed.state && parsed.state.theme
+          if (!t || typeof t !== 'object') return
+          var html = document.documentElement
+          if (typeof t.hue === 'number') {
+            html.style.setProperty('--theme-hue', String(t.hue))
+          }
+          if (typeof t.chroma === 'number') {
+            html.style.setProperty('--theme-chroma', String(t.chroma))
+          } else if (t.presetType === 'color') {
+            html.style.setProperty('--theme-chroma', '0.16')
+          } else if (t.presetType === 'neutral') {
+            html.style.setProperty('--theme-chroma', '0')
+          }
+          if (t.mode === 'light') {
+            html.classList.remove('dark')
+            html.classList.add('light')
+          } else if (t.mode === 'dark') {
+            html.classList.add('dark')
+            html.classList.remove('light')
+          }
+        } catch (_err) {
+          // Malformed storage — fall back to default .dark
+        }
+      })()
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/src/renderer/settings/main.tsx
+++ b/src/renderer/settings/main.tsx
@@ -1,0 +1,44 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { Provider } from 'react-redux'
+
+import { ErrorBoundary } from '../src/components/ErrorBoundary'
+import { TooltipProvider } from '../src/components/ui/tooltip'
+import { store } from '../src/redux/store'
+import '../src/styles/globals.css'
+
+import { SettingsApp } from './SettingsApp'
+
+/**
+ * Settings BrowserWindow entry. Loaded from `src/renderer/settings/index.html`,
+ * which is registered as a second Rollup input in `electron.vite.config.ts`.
+ *
+ * Shares the main window's Redux store directly. The Settings UI only
+ * touches the `settings` slice — every other slice (skills, agents,
+ * ui, theme, etc.) is harmless ballast in this window: `useSettingsSync`
+ * keeps `settings` aligned across windows via IPC, and the
+ * redux-storage-middleware `slices` array (`theme | bookmarks | dashboard`)
+ * intentionally excludes `settings`, so there's no dual-write race
+ * with the main window even though both processes hold the same store
+ * shape. Rationale: a single source of truth eliminates the slim-store
+ * vs full-store divergence that previously required parallel selector
+ * typing.
+ *
+ * Provider chain order matters:
+ *   StrictMode → ErrorBoundary → Provider → TooltipProvider → SettingsApp
+ * Same shape as the main window's `main.tsx`. ErrorBoundary sits OUTSIDE
+ * Provider so a render crash in any section still shows the recovery UI
+ * with a working Reload button (the button calls `window.location.reload()`,
+ * which doesn't depend on Redux).
+ */
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <ErrorBoundary>
+      <Provider store={store}>
+        <TooltipProvider delayDuration={200}>
+          <SettingsApp />
+        </TooltipProvider>
+      </Provider>
+    </ErrorBoundary>
+  </StrictMode>,
+)

--- a/src/renderer/settings/sections/About.tsx
+++ b/src/renderer/settings/sections/About.tsx
@@ -54,9 +54,14 @@ function statusLabel(status: CheckStatus): string {
  *    `setWindowOpenHandler` routes them to the system browser via
  *    `shell.openExternal` (see feedback_external_links memory).
  *
- * Note: in dev, `window.electron.update` may be undefined (the updater
- * only initializes in production builds). The button is rendered
- * disabled in that case so the click doesn't silently no-op.
+ * Note: in dev, `window.electron.update` is always exposed by preload
+ * but `initAutoUpdater()` only runs when `app.isPackaged`. A click
+ * therefore fires `update:check` into a process with no autoUpdater
+ * listeners, so no `update:checking` / `update:not-available` event
+ * comes back and the button gets stuck on "Checking…". Accepted as
+ * dev-only cosmetic noise — gating would require plumbing
+ * `app.isPackaged` through a Vite `define` or extra IPC, which costs
+ * more in dev/prod branching than it saves.
  */
 export const About = React.memo(function About(): React.ReactElement {
   const updateApi = window.electron.update

--- a/src/renderer/settings/sections/About.tsx
+++ b/src/renderer/settings/sections/About.tsx
@@ -1,0 +1,165 @@
+import { ExternalLink } from 'lucide-react'
+import React, { useEffect, useState } from 'react'
+import { match } from 'ts-pattern'
+
+import { SKILLS_DESKTOP_REPOSITORY_URL } from '../../../shared/constants'
+import { Button } from '../../src/components/ui/button'
+import { Separator } from '../../src/components/ui/separator'
+
+import { SectionFrame } from './SectionFrame'
+
+const RELEASES_URL = `${SKILLS_DESKTOP_REPOSITORY_URL}/releases`
+const LICENSE_URL = 'https://opensource.org/licenses/MIT'
+
+type CheckStatus =
+  | { kind: 'idle' }
+  | { kind: 'checking' }
+  | { kind: 'up-to-date' }
+  | { kind: 'available'; version: string }
+  | { kind: 'error'; message: string }
+
+/**
+ * Inline status text shown under the "Check for Updates" button.
+ *
+ * Settings subscribes to the same updater events the main window listens
+ * for (via `window.electron.update.*`). We need local state because the
+ * Settings store does NOT include the `update` slice — keeping that
+ * slice main-window-only avoids a second update Redux pipeline that
+ * would only differ from the existing one to drive a four-line status
+ * line.
+ */
+function statusLabel(status: CheckStatus): string {
+  return match(status)
+    .with({ kind: 'idle' }, () => '')
+    .with({ kind: 'checking' }, () => 'Checking for updates…')
+    .with({ kind: 'up-to-date' }, () => 'Skills Desktop is up to date.')
+    .with(
+      { kind: 'available' },
+      ({ version }) => `Update available: v${version}. See the main window.`,
+    )
+    .with({ kind: 'error' }, ({ message }) => `Update check failed: ${message}`)
+    .exhaustive()
+}
+
+/**
+ * About pane.
+ *
+ * Real surfaces (v0.15.0):
+ *  - App version from `__APP_VERSION__` (Vite define injecting
+ *    `package.json#version`).
+ *  - "Check for Updates" calls the existing `update:check` IPC and
+ *    listens for the `update:checking` / `update:not-available` /
+ *    `update:available` / `update:error` events to render inline status.
+ *  - Repo / Releases / MIT links use native `<a target="_blank">` so
+ *    `setWindowOpenHandler` routes them to the system browser via
+ *    `shell.openExternal` (see feedback_external_links memory).
+ *
+ * Note: in dev, `window.electron.update` may be undefined (the updater
+ * only initializes in production builds). The button is rendered
+ * disabled in that case so the click doesn't silently no-op.
+ */
+export const About = React.memo(function About(): React.ReactElement {
+  const updateApi = window.electron.update
+  const isUpdaterAvailable = Boolean(updateApi)
+  const [checkStatus, setCheckStatus] = useState<CheckStatus>({ kind: 'idle' })
+
+  useEffect(() => {
+    if (!updateApi) return
+    const cleanups = [
+      updateApi.onChecking(() => setCheckStatus({ kind: 'checking' })),
+      updateApi.onAvailable((info) =>
+        setCheckStatus({ kind: 'available', version: info.version }),
+      ),
+      updateApi.onNotAvailable(() => setCheckStatus({ kind: 'up-to-date' })),
+      updateApi.onError((error) =>
+        setCheckStatus({ kind: 'error', message: error.message }),
+      ),
+    ]
+    return () => {
+      cleanups.forEach((cleanup) => cleanup())
+    }
+  }, [updateApi])
+
+  const handleCheckForUpdates = (): void => {
+    if (!updateApi) return
+    setCheckStatus({ kind: 'checking' })
+    void updateApi.check()
+  }
+
+  const status = statusLabel(checkStatus)
+
+  return (
+    <SectionFrame title="About">
+      <div className="flex flex-col items-start gap-1">
+        <h2 className="text-lg font-semibold">Skills Desktop</h2>
+        <p className="text-sm text-muted-foreground">
+          Version {__APP_VERSION__}
+        </p>
+      </div>
+
+      <div className="flex flex-col items-start gap-2">
+        <Button
+          type="button"
+          variant="default"
+          size="sm"
+          onClick={handleCheckForUpdates}
+          disabled={!isUpdaterAvailable || checkStatus.kind === 'checking'}
+        >
+          Check for Updates
+        </Button>
+        {!isUpdaterAvailable && (
+          <p className="text-xs text-muted-foreground">
+            Auto-updates are disabled in development builds.
+          </p>
+        )}
+        {status && (
+          <p
+            className="text-xs text-muted-foreground"
+            role="status"
+            aria-live="polite"
+          >
+            {status}
+          </p>
+        )}
+      </div>
+
+      <Separator />
+
+      <ul className="flex flex-col gap-2 text-sm">
+        <li>
+          <a
+            href={SKILLS_DESKTOP_REPOSITORY_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-muted-foreground hover:text-foreground"
+          >
+            <span>GitHub repository</span>
+            <ExternalLink className="h-3 w-3" />
+          </a>
+        </li>
+        <li>
+          <a
+            href={RELEASES_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-muted-foreground hover:text-foreground"
+          >
+            <span>Releases</span>
+            <ExternalLink className="h-3 w-3" />
+          </a>
+        </li>
+        <li>
+          <a
+            href={LICENSE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-muted-foreground hover:text-foreground"
+          >
+            <span>License (MIT)</span>
+            <ExternalLink className="h-3 w-3" />
+          </a>
+        </li>
+      </ul>
+    </SectionFrame>
+  )
+})

--- a/src/renderer/settings/sections/Appearance.tsx
+++ b/src/renderer/settings/sections/Appearance.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+
+import { Checkbox } from '../../src/components/ui/checkbox'
+import {
+  ToggleGroup,
+  ToggleGroupItem,
+} from '../../src/components/ui/toggle-group'
+
+import { MockControl, SectionFrame, SectionRow } from './SectionFrame'
+
+/**
+ * Appearance pane — visual stub for v0.15.0.
+ *
+ * The shadcn theme presets are real and live in the main window, but
+ * the user-facing density / compact-mode knobs are not yet wired to
+ * Tailwind density variables. Shipping disabled controls (with a
+ * "Coming in a future release" hover tooltip) here lets the Settings
+ * shell preview the future shape without misleading users into
+ * thinking the toggles do something today.
+ */
+export const Appearance = React.memo(function Appearance(): React.ReactElement {
+  return (
+    <SectionFrame
+      title="Appearance"
+      description="Density and visual options for the main window."
+    >
+      <SectionRow
+        label="Density"
+        description="How tightly rows pack in skill and marketplace lists."
+      >
+        <MockControl>
+          <ToggleGroup
+            type="single"
+            variant="outline"
+            size="sm"
+            value="comfortable"
+            disabled
+            aria-label="Density"
+            className="pointer-events-none"
+          >
+            <ToggleGroupItem value="comfortable" disabled>
+              Comfortable
+            </ToggleGroupItem>
+            <ToggleGroupItem value="compact" disabled>
+              Compact
+            </ToggleGroupItem>
+          </ToggleGroup>
+        </MockControl>
+      </SectionRow>
+      <SectionRow
+        label="Compact mode"
+        description="Tighter padding across panels for smaller displays."
+      >
+        <MockControl>
+          <label className="flex items-center gap-2 text-sm">
+            <Checkbox disabled />
+            <span>Use compact spacing</span>
+          </label>
+        </MockControl>
+      </SectionRow>
+    </SectionFrame>
+  )
+})

--- a/src/renderer/settings/sections/AutoUpdates.tsx
+++ b/src/renderer/settings/sections/AutoUpdates.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+
+import { Checkbox } from '../../src/components/ui/checkbox'
+
+import { MockControl, SectionFrame, SectionRow } from './SectionFrame'
+
+/**
+ * Auto Updates pane — visual stub for v0.15.0.
+ *
+ * Real updater behavior (auto-download, install-on-quit) is owned by
+ * `electron-updater` in `src/main/updater.ts`. Wiring user-facing
+ * toggles requires propagating values into that module's runtime
+ * config (`autoUpdater.autoDownload`, `allowPrerelease`). That
+ * roundtrip is out of scope for the v0.15.0 Settings shell — see the
+ * "Out of scope" list in the plan. The "Check for Updates" trigger
+ * lives in the About pane and IS wired to the real updater.
+ */
+export const AutoUpdates = React.memo(
+  function AutoUpdates(): React.ReactElement {
+    return (
+      <SectionFrame
+        title="Auto Updates"
+        description="Control how Skills Desktop fetches new releases."
+      >
+        <SectionRow
+          label="Auto-download updates"
+          description="Download in the background when a new version ships."
+        >
+          <MockControl>
+            <label className="flex items-center gap-2 text-sm">
+              <Checkbox disabled />
+              <span>Download updates automatically</span>
+            </label>
+          </MockControl>
+        </SectionRow>
+        <SectionRow
+          label="Beta channel"
+          description="Receive pre-release builds before stable promotion."
+        >
+          <MockControl>
+            <label className="flex items-center gap-2 text-sm">
+              <Checkbox disabled />
+              <span>Opt into beta releases</span>
+            </label>
+          </MockControl>
+        </SectionRow>
+      </SectionFrame>
+    )
+  },
+)

--- a/src/renderer/settings/sections/General.tsx
+++ b/src/renderer/settings/sections/General.tsx
@@ -1,0 +1,97 @@
+import { Files, Info } from 'lucide-react'
+import React from 'react'
+
+import type { Settings } from '../../../shared/settings'
+import {
+  ToggleGroup,
+  ToggleGroupItem,
+} from '../../src/components/ui/toggle-group'
+import { useAppDispatch, useAppSelector } from '../../src/redux/hooks'
+import { setSettings } from '../../src/redux/slices/settingsSlice'
+
+import { SectionFrame, SectionRow } from './SectionFrame'
+
+/**
+ * Default tab values mirror the `Settings['defaultSkillTab']` union.
+ * Both this control and `SkillDetail`'s tab buttons write to the same
+ * settings field — the most recently chosen tab is the default on next
+ * app open.
+ */
+const DEFAULT_TAB_OPTIONS: ReadonlyArray<{
+  value: Settings['defaultSkillTab']
+  label: string
+  icon: React.ComponentType<{ className?: string }>
+}> = [
+  { value: 'files', label: 'Files', icon: Files },
+  { value: 'info', label: 'Info', icon: Info },
+]
+
+/**
+ * General settings pane.
+ *
+ * Currently ships the single real setting in the v0.15.0 Settings shell:
+ * "Default tab when opening a skill". Other knobs (e.g. compact density,
+ * auto-collapse) belong here in future PRs once their behavior is wired.
+ *
+ * Dispatch flow on change:
+ *  1. Dispatch `setSettings` locally for instant UI feedback (no
+ *     waiting on IPC for the radio to highlight).
+ *  2. Fire `settings:set` IPC. Main writes the JSON atomically and
+ *     broadcasts `settings:changed` back to every window including
+ *     this one — the listener dispatches `setSettings` a second time
+ *     with the same payload (idempotent replace).
+ *
+ * The optimistic local dispatch is safe because IPC to the same process
+ * doesn't fail in practice; if main throws, the cache stays stale until
+ * the next broadcast or window reload, which is acceptable for a
+ * non-critical setting.
+ */
+export const General = React.memo(function General(): React.ReactElement {
+  const dispatch = useAppDispatch()
+  const settings = useAppSelector((state) => state.settings)
+
+  const handleDefaultTabChange = (nextValue: string): void => {
+    if (nextValue !== 'files' && nextValue !== 'info') return
+    const nextSettings: Settings = {
+      ...settings,
+      defaultSkillTab: nextValue,
+    }
+    dispatch(setSettings(nextSettings))
+    void window.electron.settings.set({ defaultSkillTab: nextValue })
+  }
+
+  return (
+    <SectionFrame
+      title="General"
+      description="Behavior knobs that apply across the app."
+    >
+      <SectionRow
+        label="Default tab when opening a skill"
+        description="Which tab the right pane lands on when you select a skill."
+      >
+        <ToggleGroup
+          type="single"
+          variant="outline"
+          size="sm"
+          value={settings.defaultSkillTab}
+          onValueChange={handleDefaultTabChange}
+          aria-label="Default tab when opening a skill"
+        >
+          {DEFAULT_TAB_OPTIONS.map((option) => {
+            const Icon = option.icon
+            return (
+              <ToggleGroupItem
+                key={option.value}
+                value={option.value}
+                aria-label={option.label}
+              >
+                <Icon className="h-3.5 w-3.5" />
+                <span>{option.label}</span>
+              </ToggleGroupItem>
+            )
+          })}
+        </ToggleGroup>
+      </SectionRow>
+    </SectionFrame>
+  )
+})

--- a/src/renderer/settings/sections/General.tsx
+++ b/src/renderer/settings/sections/General.tsx
@@ -6,8 +6,8 @@ import {
   ToggleGroup,
   ToggleGroupItem,
 } from '../../src/components/ui/toggle-group'
-import { useAppDispatch, useAppSelector } from '../../src/redux/hooks'
-import { setSettings } from '../../src/redux/slices/settingsSlice'
+import { useUpdateSettings } from '../../src/hooks/useUpdateSettings'
+import { useAppSelector } from '../../src/redux/hooks'
 
 import { SectionFrame, SectionRow } from './SectionFrame'
 
@@ -47,17 +47,12 @@ const DEFAULT_TAB_OPTIONS: ReadonlyArray<{
  * non-critical setting.
  */
 export const General = React.memo(function General(): React.ReactElement {
-  const dispatch = useAppDispatch()
   const settings = useAppSelector((state) => state.settings)
+  const updateSettings = useUpdateSettings()
 
   const handleDefaultTabChange = (nextValue: string): void => {
     if (nextValue !== 'files' && nextValue !== 'info') return
-    const nextSettings: Settings = {
-      ...settings,
-      defaultSkillTab: nextValue,
-    }
-    dispatch(setSettings(nextSettings))
-    void window.electron.settings.set({ defaultSkillTab: nextValue })
+    updateSettings({ defaultSkillTab: nextValue })
   }
 
   return (

--- a/src/renderer/settings/sections/Keybindings.tsx
+++ b/src/renderer/settings/sections/Keybindings.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+
+import { KEYBINDINGS } from '../../../shared/constants'
+
+import { SectionFrame } from './SectionFrame'
+
+/**
+ * Keybindings pane — read-only list for v0.15.0.
+ *
+ * The list is sourced from the canonical `KEYBINDINGS` constant in
+ * `src/shared/constants.ts` so adding or renaming a menu accelerator
+ * in `src/main/index.ts` only requires updating one place. Editing
+ * shortcuts is intentionally out of scope until users ask — a real
+ * editor would need conflict detection, a per-os table for the modifier
+ * glyphs, and a way to flush updates to the menu's `accelerator` field.
+ */
+export const Keybindings = React.memo(
+  function Keybindings(): React.ReactElement {
+    return (
+      <SectionFrame
+        title="Keybindings"
+        description="Keyboard shortcuts wired into the app menu. Read-only for now."
+      >
+        <div className="rounded-md border border-border bg-card/40">
+          <ul className="divide-y divide-border">
+            {KEYBINDINGS.map((binding) => (
+              <li
+                key={binding.id}
+                className="flex items-center justify-between gap-4 px-4 py-2.5"
+              >
+                <span className="text-sm">{binding.action}</span>
+                <kbd className="rounded border border-border bg-muted px-2 py-0.5 font-mono text-xs text-muted-foreground">
+                  {binding.display}
+                </kbd>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </SectionFrame>
+    )
+  },
+)

--- a/src/renderer/settings/sections/SectionFrame.tsx
+++ b/src/renderer/settings/sections/SectionFrame.tsx
@@ -1,0 +1,111 @@
+import React from 'react'
+
+import { Separator } from '../../src/components/ui/separator'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '../../src/components/ui/tooltip'
+
+interface SectionFrameProps {
+  title: string
+  description?: string
+  children: React.ReactNode
+}
+
+/**
+ * Shared chrome around each Settings pane: title, optional one-line
+ * description, separator, and a vertical-rhythm wrapper for the rows.
+ *
+ * Lifting this avoids 5× duplication of header markup and means future
+ * design tweaks (heading scale, separator spacing, max-width) happen in
+ * one place. Kept inside `sections/` because it only exists to serve
+ * pane content — exposing it from `components/ui` would invite reuse in
+ * places where the sizing is wrong.
+ */
+export const SectionFrame = React.memo(function SectionFrame({
+  title,
+  description,
+  children,
+}: SectionFrameProps): React.ReactElement {
+  return (
+    <section className="max-w-2xl">
+      <header className="mb-2">
+        <h1 className="text-xl font-semibold tracking-tight">{title}</h1>
+        {description && (
+          <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+        )}
+      </header>
+      <Separator className="my-4" />
+      <div className="flex flex-col gap-6">{children}</div>
+    </section>
+  )
+})
+
+interface SectionRowProps {
+  label: string
+  description?: string
+  children: React.ReactNode
+}
+
+/**
+ * One labeled control row inside a SectionFrame.
+ *
+ * Layout: stacked label/description on the left, control on the right.
+ * Stack instead of side-by-side because Settings sections often have
+ * long descriptions that would force the control off-screen on the
+ * 800px-wide window. Vertical rhythm reads like Inkdrop / Linear / VS
+ * Code's Settings UI.
+ */
+export const SectionRow = React.memo(function SectionRow({
+  label,
+  description,
+  children,
+}: SectionRowProps): React.ReactElement {
+  return (
+    <div className="flex flex-col gap-2">
+      <div>
+        <div className="text-sm font-medium">{label}</div>
+        {description && (
+          <p className="mt-0.5 text-xs text-muted-foreground">{description}</p>
+        )}
+      </div>
+      <div>{children}</div>
+    </div>
+  )
+})
+
+interface MockControlProps {
+  children: React.ReactNode
+}
+
+/**
+ * Wraps a disabled control + its label with a "Coming in a future
+ * release" tooltip. Used by the Appearance / Auto Updates panes to
+ * communicate that the controls are visual stubs.
+ *
+ * Why a wrapper, not the control itself: Radix Tooltip's
+ * `TooltipTrigger asChild` forwards events to its child, but a
+ * disabled `<button>` / `<input>` does not fire pointer events. The
+ * tooltip would silently not show. Wrapping in a focusable `<div>`
+ * captures hover/focus so the tooltip works while the inner control
+ * stays unambiguously disabled (50% opacity, cursor-not-allowed).
+ */
+export const MockControl = React.memo(function MockControl({
+  children,
+}: MockControlProps): React.ReactElement {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div
+          tabIndex={0}
+          aria-disabled="true"
+          className="inline-flex w-fit cursor-not-allowed items-center gap-3 rounded-md opacity-60"
+        >
+          {children}
+        </div>
+      </TooltipTrigger>
+      <TooltipContent side="top">Coming in a future release</TooltipContent>
+    </Tooltip>
+  )
+})

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -8,6 +8,7 @@ import { Sidebar } from './components/layout/Sidebar'
 import { TooltipProvider } from './components/ui/tooltip'
 import { UpdateToast } from './components/UpdateToast'
 import { useReleaseNotesToast } from './hooks/useReleaseNotesToast'
+import { useSettingsSync } from './hooks/useSettingsSync'
 import { useUpdateNotification } from './hooks/useUpdateNotification'
 import { useAppSelector } from './redux/hooks'
 
@@ -70,6 +71,10 @@ const toasterStyle = {
 const App = React.memo(function App(): React.ReactElement {
   // Subscribe to auto-update IPC events
   useUpdateNotification()
+
+  // Hydrate the settings slice from the main-process JSON store and
+  // subscribe to cross-window changes broadcast by `settings:set`.
+  useSettingsSync()
 
   // After auto-update + restart, fire a one-shot "What's new" toast on the
   // first launch of the new version with a link to the GitHub release notes.

--- a/src/renderer/src/components/dashboard/widgets/QuickActionsWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/QuickActionsWidget.tsx
@@ -75,7 +75,7 @@ const ActionTile = React.memo(function ActionTile({
  *   - Open Marketplace: flips the main tab so the user lands on search.
  *   - Reset Layout: restores the default 4-page dashboard arrangement,
  *     preserving `welcomeDismissed` so reset is a "layout" thing, not a
- *     "preferences wipe".
+ *     "settings wipe".
  *
  * Spinning icons on Sync and Refresh mirror the status bar indicators so
  * the user sees activity without having to look elsewhere.

--- a/src/renderer/src/components/sidebar/SidebarFooter.tsx
+++ b/src/renderer/src/components/sidebar/SidebarFooter.tsx
@@ -1,27 +1,52 @@
-import { ExternalLink } from 'lucide-react'
+import { ExternalLink, Settings } from 'lucide-react'
 import React from 'react'
+
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 
 const SKILLS_REGISTRY_URL = 'https://skills.sh/'
 
 /**
- * Sidebar footer with external link to skills.sh registry
- * Opens URL in system default browser via Electron shell API
+ * Sidebar footer hosting two affordances:
+ *  - the existing skills.sh marketplace link (opens in default browser)
+ *  - a gear icon that opens the Settings window via IPC, mirroring the
+ *    App menu's `Settings… ⌘,` item (Inkdrop-style dual-route open).
+ *
+ * Layout: skills.sh link is centered; gear is anchored to the right so
+ * the link still reads as the primary footer affordance and the gear
+ * stays out of the way until the user reaches for it.
  */
 export const SidebarFooter = React.memo(
   function SidebarFooter(): React.ReactElement {
-    const handleClick = (): void => {
+    const handleSkillsLinkClick = (): void => {
       window.electron.shell.openExternal(SKILLS_REGISTRY_URL)
     }
 
+    const handleSettingsClick = (): void => {
+      void window.electron.settings.open()
+    }
+
     return (
-      <div className="border-t border-border px-6 py-4">
+      <div className="border-t border-border px-6 py-3 flex items-center">
         <button
-          onClick={handleClick}
-          className="flex items-center justify-center gap-1.5 w-full text-xs font-medium font-mono text-muted-foreground hover:text-primary transition-colors"
+          onClick={handleSkillsLinkClick}
+          className="flex flex-1 items-center justify-center gap-1.5 text-xs font-medium font-mono text-muted-foreground hover:text-primary transition-colors"
         >
           <span>skills.sh</span>
           <ExternalLink className="h-3 w-3" />
         </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-label="Open settings"
+              onClick={handleSettingsClick}
+              className="no-drag inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
+            >
+              <Settings className="h-3.5 w-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="top">Settings (⌘,)</TooltipContent>
+        </Tooltip>
       </div>
     )
   },

--- a/src/renderer/src/components/skills/SkillDetail.tsx
+++ b/src/renderer/src/components/skills/SkillDetail.tsx
@@ -2,9 +2,9 @@ import React, { Activity } from 'react'
 
 import type { Settings } from '../../../../shared/settings'
 import type { Skill, SymlinkInfo } from '../../../../shared/types'
+import { useUpdateSettings } from '../../hooks/useUpdateSettings'
 import { cn } from '../../lib/utils'
-import { useAppDispatch, useAppSelector } from '../../redux/hooks'
-import { setSettings } from '../../redux/slices/settingsSlice'
+import { useAppSelector } from '../../redux/hooks'
 import type { LocationViewModel } from '../../utils/getLocationViewModel'
 import { getLocationViewModel } from '../../utils/getLocationViewModel'
 import { SymlinkStatus } from '../status/SymlinkStatus'
@@ -30,20 +30,15 @@ interface SkillDetailProps {
 export const SkillDetail = React.memo(function SkillDetail({
   skill,
 }: SkillDetailProps): React.ReactElement {
-  const dispatch = useAppDispatch()
   const settings = useAppSelector((state) => state.settings)
   const activeTab = settings.defaultSkillTab
   const { items: agents } = useAppSelector((state) => state.agents)
   const selectedAgentId = useAppSelector((state) => state.ui.selectedAgentId)
+  const updateSettings = useUpdateSettings()
 
   const handleTabChange = (nextTab: Settings['defaultSkillTab']): void => {
     if (nextTab === activeTab) return
-    const nextSettings: Settings = {
-      ...settings,
-      defaultSkillTab: nextTab,
-    }
-    dispatch(setSettings(nextSettings))
-    void window.electron.settings.set({ defaultSkillTab: nextTab })
+    updateSettings({ defaultSkillTab: nextTab })
   }
 
   // Filter symlinks to only show detected agents (exists: true)

--- a/src/renderer/src/components/skills/SkillDetail.tsx
+++ b/src/renderer/src/components/skills/SkillDetail.tsx
@@ -1,8 +1,10 @@
-import React, { Activity, useState } from 'react'
+import React, { Activity } from 'react'
 
+import type { Settings } from '../../../../shared/settings'
 import type { Skill, SymlinkInfo } from '../../../../shared/types'
 import { cn } from '../../lib/utils'
-import { useAppSelector } from '../../redux/hooks'
+import { useAppDispatch, useAppSelector } from '../../redux/hooks'
+import { setSettings } from '../../redux/slices/settingsSlice'
 import type { LocationViewModel } from '../../utils/getLocationViewModel'
 import { getLocationViewModel } from '../../utils/getLocationViewModel'
 import { SymlinkStatus } from '../status/SymlinkStatus'
@@ -15,17 +17,34 @@ interface SkillDetailProps {
   skill: Skill
 }
 
-type TabType = 'info' | 'code'
-
 /**
- * Detailed view of a selected skill with tabs
+ * Detailed view of a selected skill with tabs.
+ *
+ * The active tab is read from the persisted `settings.defaultSkillTab`
+ * (single source of truth, owned by the main process). Tapping a tab
+ * dispatches `setSettings` for instant UI feedback and fires a
+ * `settings:set` IPC so the choice is durable across sessions and
+ * synchronised with the Settings window — both surfaces edit the exact
+ * same field. This means "last used tab is the default tab" by design.
  */
 export const SkillDetail = React.memo(function SkillDetail({
   skill,
 }: SkillDetailProps): React.ReactElement {
-  const [activeTab, setActiveTab] = useState<TabType>('code')
+  const dispatch = useAppDispatch()
+  const settings = useAppSelector((state) => state.settings)
+  const activeTab = settings.defaultSkillTab
   const { items: agents } = useAppSelector((state) => state.agents)
   const selectedAgentId = useAppSelector((state) => state.ui.selectedAgentId)
+
+  const handleTabChange = (nextTab: Settings['defaultSkillTab']): void => {
+    if (nextTab === activeTab) return
+    const nextSettings: Settings = {
+      ...settings,
+      defaultSkillTab: nextTab,
+    }
+    dispatch(setSettings(nextSettings))
+    void window.electron.settings.set({ defaultSkillTab: nextTab })
+  }
 
   // Filter symlinks to only show detected agents (exists: true)
   const detectedAgentIds = new Set(
@@ -58,11 +77,11 @@ export const SkillDetail = React.memo(function SkillDetail({
       <div className="flex border-b border-border">
         <button
           type="button"
-          aria-pressed={activeTab === 'code'}
-          onClick={() => setActiveTab('code')}
+          aria-pressed={activeTab === 'files'}
+          onClick={() => handleTabChange('files')}
           className={cn(
             'px-4 py-2 text-sm font-medium border-b-2 -mb-[1px] transition-colors',
-            activeTab === 'code'
+            activeTab === 'files'
               ? 'text-primary border-primary'
               : 'text-muted-foreground border-transparent hover:text-foreground',
           )}
@@ -72,7 +91,7 @@ export const SkillDetail = React.memo(function SkillDetail({
         <button
           type="button"
           aria-pressed={activeTab === 'info'}
-          onClick={() => setActiveTab('info')}
+          onClick={() => handleTabChange('info')}
           className={cn(
             'px-4 py-2 text-sm font-medium border-b-2 -mb-[1px] transition-colors',
             activeTab === 'info'
@@ -88,7 +107,7 @@ export const SkillDetail = React.memo(function SkillDetail({
           position, selected file tab — survives toggling between Files
           and Info. See react-rules.md "<Activity> - State Preservation". */}
       <div className="flex-1 min-h-0 relative">
-        <Activity mode={activeTab === 'code' ? 'visible' : 'hidden'}>
+        <Activity mode={activeTab === 'files' ? 'visible' : 'hidden'}>
           <CodePreview skillPath={skill.path} />
         </Activity>
         <Activity mode={activeTab === 'info' ? 'visible' : 'hidden'}>

--- a/src/renderer/src/hooks/useSettingsSync.ts
+++ b/src/renderer/src/hooks/useSettingsSync.ts
@@ -1,0 +1,52 @@
+import { useEffect } from 'react'
+
+import { useAppDispatch } from '../redux/hooks'
+import { setSettings } from '../redux/slices/settingsSlice'
+
+/**
+ * Subscribes the Redux settings slice to the main-process JSON store.
+ *
+ * Two-step contract:
+ *   1. On mount: pull a snapshot via `settings:get` and hydrate the
+ *      slice. This races initial paint deliberately — components reading
+ *      `defaultSkillTab` get the persisted value before they need it.
+ *   2. While mounted: subscribe to `settings:changed` so a save in
+ *      the Settings window propagates to the main window (and vice
+ *      versa) without either side polling.
+ *
+ * The unsubscribe is returned from `onChanged` so React's cleanup runs it
+ * automatically on unmount; nothing leaks when the component tears down.
+ *
+ * Reused by both renderer entry points — main window (mounted in
+ * `App.tsx`) and Settings window (mounted in `SettingsApp.tsx`) — so
+ * either route into the same source of truth without duplicate hooks.
+ * @example
+ * function App() {
+ *   useSettingsSync()
+ *   return <Layout />
+ * }
+ */
+export function useSettingsSync(): void {
+  const dispatch = useAppDispatch()
+
+  useEffect(() => {
+    let isCancelled = false
+
+    void window.electron.settings.get().then((nextSettings) => {
+      // Guard against the rare case where the component unmounts
+      // between the IPC call and its resolution — dispatch on an
+      // unmounted store is harmless but the cleanup contract is
+      // clearer when we explicitly skip the late write.
+      if (!isCancelled) dispatch(setSettings(nextSettings))
+    })
+
+    const unsubscribe = window.electron.settings.onChanged((nextSettings) => {
+      dispatch(setSettings(nextSettings))
+    })
+
+    return () => {
+      isCancelled = true
+      unsubscribe()
+    }
+  }, [dispatch])
+}

--- a/src/renderer/src/hooks/useUpdateSettings.ts
+++ b/src/renderer/src/hooks/useUpdateSettings.ts
@@ -1,0 +1,43 @@
+import { useCallback } from 'react'
+
+import type { Settings } from '../../../shared/settings'
+import { useAppDispatch, useAppSelector } from '../redux/hooks'
+import { setSettings } from '../redux/slices/settingsSlice'
+
+/**
+ * Encapsulates the optimistic-dispatch + IPC-write pair used whenever
+ * the renderer mutates a settings field. Two separate components
+ * (Settings → General, main-window → SkillDetail) edit the same
+ * `defaultSkillTab` field and were carrying near-identical handlers;
+ * this hook is the single home for the pattern so future settings
+ * additions don't have to re-derive the merge order.
+ *
+ * Flow on call:
+ *  1. Dispatch `setSettings(merged)` locally so the UI reflects the
+ *     change without waiting on an IPC round-trip.
+ *  2. Fire `settings:set` to the main process. Main writes the JSON
+ *     atomically and then broadcasts `settings:changed` back to every
+ *     window (including this one), where `useSettingsSync` dispatches
+ *     `setSettings` a second time — idempotent replace.
+ *
+ * The optimistic dispatch is safe because in-process Electron IPC
+ * doesn't fail in practice; if main throws on validation the cache
+ * stays out of sync until the next broadcast or window reload, which
+ * is acceptable for non-critical settings.
+ * @returns A stable function that takes a partial Settings update and applies it locally + remotely.
+ * @example
+ * const updateSettings = useUpdateSettings()
+ * updateSettings({ defaultSkillTab: 'info' })
+ */
+export function useUpdateSettings(): (partial: Partial<Settings>) => void {
+  const dispatch = useAppDispatch()
+  const settings = useAppSelector((state) => state.settings)
+
+  return useCallback(
+    (partial: Partial<Settings>): void => {
+      dispatch(setSettings({ ...settings, ...partial }))
+      void window.electron.settings.set(partial)
+    },
+    [dispatch, settings],
+  )
+}

--- a/src/renderer/src/redux/slices/dashboardSlice.test.ts
+++ b/src/renderer/src/redux/slices/dashboardSlice.test.ts
@@ -235,7 +235,7 @@ describe('dashboardSlice', () => {
       store.dispatch(dismissWelcome())
       expect(store.getState().dashboard.welcomeDismissed).toBe(true)
 
-      // Reset wipes arrangements but must preserve dismissal preference.
+      // Reset wipes arrangements but must preserve dismissal state.
       store.dispatch(resetToDefaults())
       expect(store.getState().dashboard.welcomeDismissed).toBe(true)
     })

--- a/src/renderer/src/redux/slices/dashboardSlice.ts
+++ b/src/renderer/src/redux/slices/dashboardSlice.ts
@@ -249,7 +249,7 @@ const dashboardSlice = createSlice({
       state.currentPageId = pages[0]?.id ?? null
       state.isEditMode = false
       state.initialized = true
-      // welcomeDismissed intentionally preserved — reset layout, not preferences.
+      // welcomeDismissed intentionally preserved — reset layout, not user settings.
     },
   },
 })

--- a/src/renderer/src/redux/slices/settingsSlice.ts
+++ b/src/renderer/src/redux/slices/settingsSlice.ts
@@ -1,0 +1,34 @@
+import type { PayloadAction } from '@reduxjs/toolkit'
+import { createSlice } from '@reduxjs/toolkit'
+
+import { DEFAULT_SETTINGS, type Settings } from '../../../../shared/settings'
+
+/**
+ * Renderer-side cache of the user settings owned by the main process.
+ *
+ * Source of truth lives at `app.getPath('userData')/settings.json`;
+ * this slice mirrors that JSON so React components can read it
+ * synchronously. Hydration + cross-window sync flows through the
+ * `useSettingsSync` hook — components must NOT call
+ * `window.electron.settings.get()` directly.
+ *
+ * The slice intentionally exposes only an idempotent `setSettings`
+ * replacement (not per-field reducers). Local field updates dispatched
+ * from a Settings section UI happen via the same action after the
+ * `settings:set` IPC roundtrip resolves, keeping cache and disk in
+ * lockstep.
+ *
+ * NOT included in `redux-storage-middleware` slices array — persistence
+ * is owned by main, so layering localStorage on top would create a
+ * dual-write race.
+ */
+const settingsSlice = createSlice({
+  name: 'settings',
+  initialState: DEFAULT_SETTINGS,
+  reducers: {
+    setSettings: (_state, action: PayloadAction<Settings>) => action.payload,
+  },
+})
+
+export const { setSettings } = settingsSlice.actions
+export default settingsSlice.reducer

--- a/src/renderer/src/redux/store.ts
+++ b/src/renderer/src/redux/store.ts
@@ -13,6 +13,7 @@ import agentsReducer from './slices/agentsSlice'
 import bookmarkReducer from './slices/bookmarkSlice'
 import dashboardReducer from './slices/dashboardSlice'
 import marketplaceReducer from './slices/marketplaceSlice'
+import settingsReducer from './slices/settingsSlice'
 import skillsReducer from './slices/skillsSlice'
 import themeReducer from './slices/themeSlice'
 import uiReducer from './slices/uiSlice'
@@ -27,6 +28,12 @@ const rootReducer = combineReducers({
   update: updateReducer,
   marketplace: marketplaceReducer,
   dashboard: dashboardReducer,
+  // Mirrors main-process settings.json. Intentionally NOT listed in
+  // the redux-storage-middleware `slices` array — persistence is owned
+  // by main, so layering localStorage here would create a dual-write race.
+  // Both the Settings window (General → Default tab) and the main window
+  // (SkillDetail tab buttons) read and write `defaultSkillTab` here.
+  settings: settingsReducer,
 })
 
 type RootReducerState = ReturnType<typeof rootReducer>

--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -166,7 +166,7 @@
   }
 }
 
-/* Respect user motion preferences */
+/* Respect the user's reduced-motion accessibility setting */
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -1,3 +1,4 @@
+import type { Settings } from '../../../shared/settings'
 import type {
   Skill,
   Agent,
@@ -113,6 +114,12 @@ declare global {
       sync: {
         preview: () => Promise<SyncPreviewResult>
         execute: (options: SyncExecuteOptions) => Promise<SyncExecuteResult>
+      }
+      settings: {
+        open: () => Promise<void>
+        get: () => Promise<Settings>
+        set: (partial: Partial<Settings>) => Promise<Settings>
+        onChanged: (callback: (settings: Settings) => void) => () => void
       }
     }
   }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -653,3 +653,30 @@ export const BULK_PROGRESS_THRESHOLD = 10
  * <Button style={{ minHeight: MIN_TOUCH_TARGET_PX }}>Clear</Button>
  */
 export const MIN_TOUCH_TARGET_PX = 44
+
+/**
+ * Keyboard shortcuts surfaced read-only in the Settings window's
+ * `Keybindings` section. Anything that is actually wired in
+ * `src/main/index.ts` (menu accelerators) or via Electron defaults belongs
+ * here so the section reflects truth — adding a shortcut to the menu but
+ * forgetting to update this list is the failure mode to avoid.
+ *
+ * `display` is the visual representation (with macOS modifier glyphs); a
+ * future custom-keybindings editor would key off `id`.
+ */
+export const KEYBINDINGS = [
+  { id: 'settings:open', action: 'Open settings', display: '⌘,' },
+  { id: 'window:close', action: 'Close window', display: '⌘W' },
+  { id: 'window:minimize', action: 'Minimize window', display: '⌘M' },
+  { id: 'app:quit', action: 'Quit Skills Desktop', display: '⌘Q' },
+  { id: 'view:reload', action: 'Reload', display: '⌘R' },
+  {
+    id: 'view:toggle-fullscreen',
+    action: 'Toggle full screen',
+    display: '⌃⌘F',
+  },
+] as const satisfies readonly {
+  id: string
+  action: string
+  display: string
+}[]

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -54,6 +54,12 @@ export const IPC_CHANNELS = {
   UPDATE_PROGRESS: 'update:progress',
   UPDATE_DOWNLOADED: 'update:downloaded',
   UPDATE_ERROR: 'update:error',
+
+  // Settings window
+  SETTINGS_OPEN: 'settings:open',
+  SETTINGS_GET: 'settings:get',
+  SETTINGS_SET: 'settings:set',
+  SETTINGS_CHANGED: 'settings:changed',
 } as const
 
 export type IpcChannel = (typeof IPC_CHANNELS)[keyof typeof IPC_CHANNELS]

--- a/src/shared/ipc-contract.test.ts
+++ b/src/shared/ipc-contract.test.ts
@@ -31,6 +31,9 @@ describe('IPC contract alignment', () => {
       [IPC_CHANNELS.UPDATE_INSTALL]: true,
       [IPC_CHANNELS.UPDATE_CHECK]: true,
       [IPC_CHANNELS.SHELL_OPEN_EXTERNAL]: true,
+      [IPC_CHANNELS.SETTINGS_OPEN]: true,
+      [IPC_CHANNELS.SETTINGS_GET]: true,
+      [IPC_CHANNELS.SETTINGS_SET]: true,
     } as const satisfies Record<keyof IpcInvokeContract, true>
 
     // Runtime assertion: mapping covers exactly the contract keys.
@@ -38,7 +41,7 @@ describe('IPC contract alignment', () => {
     // IPC channel (input validation, authz scope, side-effect blast radius).
     // The `satisfies` clause above is a structural guard; this length check is
     // the trip-wire that forces a human PR diff when a channel is added.
-    expect(Object.keys(invokeMapping)).toHaveLength(24)
+    expect(Object.keys(invokeMapping)).toHaveLength(27)
   })
 
   it('all IPC_CHANNELS event values are valid event contract keys', () => {
@@ -52,9 +55,10 @@ describe('IPC contract alignment', () => {
       [IPC_CHANNELS.UPDATE_PROGRESS]: true,
       [IPC_CHANNELS.UPDATE_DOWNLOADED]: true,
       [IPC_CHANNELS.UPDATE_ERROR]: true,
+      [IPC_CHANNELS.SETTINGS_CHANGED]: true,
     } as const satisfies Record<keyof IpcEventContract, true>
 
     // Runtime assertion: mapping covers exactly the contract keys
-    expect(Object.keys(eventMapping)).toHaveLength(8)
+    expect(Object.keys(eventMapping)).toHaveLength(9)
   })
 })

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -1,3 +1,4 @@
+import type { Settings } from './settings'
 import type {
   AbsolutePath,
   Agent,
@@ -101,6 +102,9 @@ export interface IpcInvokeContract {
   'update:install': { args: []; result: void }
   'update:check': { args: []; result: void }
   'shell:openExternal': { args: [HttpUrl]; result: void }
+  'settings:open': { args: []; result: void }
+  'settings:get': { args: []; result: Settings }
+  'settings:set': { args: [Partial<Settings>]; result: Settings }
 }
 
 /**
@@ -121,6 +125,7 @@ export interface IpcEventContract {
   'update:progress': DownloadProgress
   'update:downloaded': UpdateInfo
   'update:error': { message: string }
+  'settings:changed': Settings
 }
 
 export type IpcInvokeChannel = keyof IpcInvokeContract

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod'
+
+/**
+ * User setting for the right-pane skill detail tab. Both the Settings
+ * window's General section and the SkillDetail tab buttons read and write
+ * this same field — last-used tab becomes the default tab next time the
+ * app opens.
+ * @example 'files' → Files tab; 'info' → Info tab
+ */
+export const SettingsSchema = z.object({
+  defaultSkillTab: z.enum(['files', 'info']).default('files'),
+})
+
+/**
+ * App-wide user settings persisted by the main process at
+ * `app.getPath('userData')/settings.json`. Renderers cache this in
+ * Redux but never write directly — see `src/main/services/settings.ts`
+ * and the `settings:get` / `settings:set` IPC handlers.
+ */
+export type Settings = z.infer<typeof SettingsSchema>
+
+/**
+ * Default settings used when `settings.json` is missing or fails
+ * Zod validation. Kept here (not derived from `.parse({})`) so the
+ * defaults are visible to both main and renderer without instantiating
+ * Zod at module-load time.
+ */
+export const DEFAULT_SETTINGS: Settings = {
+  defaultSkillTab: 'files',
+}


### PR DESCRIPTION
## Summary

- 専用の Settings BrowserWindow (Inkdrop 風 5 セクション: General / Appearance / Auto Updates / Keybindings / About) を追加。サイドバーのギアと App メニュー `Settings… ⌘,` が同じウィンドウに収束。
- 永続化レイヤーを `userData/settings.json` に集約し、main プロセスを単一の source of truth に。renderer は Redux + `settings:changed` ブロードキャストでキャッシュとして同期するだけ。
- `window.electron.settings.{open,get,set,onChanged}` の単一ネームスペースに統合。`broadcastTypedEvent` を `updater.ts` から切り出して再利用。
- 既存の `SkillDetail` のタブ状態を `settings.defaultSkillTab` に格上げし、メインウィンドウと Settings → General の両方が同じフィールドを編集する形に。
- Codex のレビューで見つかった起動時 race を修正 (`await loadSettings()` で最初の `settings:get` がデフォルトを掴むのを防ぐ)。

#122 #123 #124 の足場。

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 822/822
- [x] `pnpm test:e2e` — 26/26 (43.8s, ローカル macOS)
- [x] dev 実機: メインウィンドウでタブ切替 → `~/Library/Application Support/skills-desktop/settings.json` 生成
- [x] dev 実機: Settings → General → Default tab トグル → SkillDetail と即同期
- [x] `/review` (Claude) + `/codex review` の両方を通過 (Codex 指摘 P2 修正済み, P3 は dev-only のため別タスク)