### PR TITLE
fix(e2e): keep app windows hidden during Playwright runs

### DIFF
--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -46,6 +46,9 @@ export const test = baseTest.extend<ElectronFixtures>({
         ...process.env,
         HOME: isolatedHome,
         E2E_DISABLE_UPDATE: '1',
+        // Default to fully-hidden windows; allow opt-out when the developer
+        // wants to watch the test (e.g. `E2E_BACKGROUND_LAUNCH=0 pnpm test:e2e:headed`).
+        E2E_BACKGROUND_LAUNCH: process.env['E2E_BACKGROUND_LAUNCH'] ?? '1',
       },
     })
     await use(app)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,6 +10,7 @@ import { createOrFocusSettingsWindow } from './services/settingsWindow'
 import { startupCleanup as runTrashStartupCleanup } from './services/trashService'
 import { initAutoUpdater } from './updater'
 import { attachExternalLinkHandler } from './utils/attachExternalLinkHandler'
+import { isE2EBackgroundLaunch } from './utils/e2eEnv'
 import { getSecureWebPreferences } from './utils/secureWebPreferences'
 
 process.on('unhandledRejection', (reason, promise) => {
@@ -24,21 +25,6 @@ process.on('unhandledRejection', (reason, promise) => {
  * window stays a window and would have prevented main from re-opening.
  */
 let mainWindow: BrowserWindow | null = null
-
-/**
- * True when the app was spawned by the Playwright E2E fixture
- * (`e2e/fixtures/electron-app.ts`). When set, the renderer-bearing
- * BrowserWindows are kept fully hidden (no `show()` / `showInactive()` /
- * `maximize()` calls) and the app is hidden from the Dock / Cmd-Tab via
- * `setActivationPolicy('accessory')`. Playwright drives the renderer
- * through `webContents` (loaded as part of the BrowserWindow lifecycle
- * regardless of visibility), so tests don't need a visible window.
- *
- * NOTE: `showInactive()` does NOT hide the window — per Electron docs it
- * shows the window without focusing it. Only skipping `show()` entirely
- * keeps the window off-screen.
- */
-const isE2EBackgroundLaunch = process.env['E2E_BACKGROUND_LAUNCH'] === '1'
 
 function createWindow(): void {
   const window = new BrowserWindow({
@@ -233,6 +219,15 @@ function createMenu(): void {
 }
 
 app.whenReady().then(async () => {
+  // E2E: hide from Dock / Cmd-Tab BEFORE any other init runs. Done first
+  // because `configureAboutPanel()` below calls `app.dock.setIcon()`,
+  // which would briefly flash the Dock icon if the policy is still
+  // `regular`. macOS-only API; guard with platform check to avoid
+  // runtime errors on Linux/Windows CI runners.
+  if (isE2EBackgroundLaunch && process.platform === 'darwin') {
+    app.setActivationPolicy('accessory')
+  }
+
   // Register IPC handlers before creating window
   registerAllHandlers()
 
@@ -253,13 +248,6 @@ app.whenReady().then(async () => {
   // Configure the About panel before the menu wires up `role: 'about'`
   configureAboutPanel()
   createMenu()
-
-  // E2E: hide from Dock / Cmd-Tab so test launches don't disrupt the user.
-  // macOS-only API; guard with platform check to avoid runtime errors on
-  // Linux/Windows CI runners.
-  if (isE2EBackgroundLaunch && process.platform === 'darwin') {
-    app.setActivationPolicy('accessory')
-  }
   createWindow()
 
   // Initialize auto updater in production.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -25,6 +25,21 @@ process.on('unhandledRejection', (reason, promise) => {
  */
 let mainWindow: BrowserWindow | null = null
 
+/**
+ * True when the app was spawned by the Playwright E2E fixture
+ * (`e2e/fixtures/electron-app.ts`). When set, the renderer-bearing
+ * BrowserWindows are kept fully hidden (no `show()` / `showInactive()` /
+ * `maximize()` calls) and the app is hidden from the Dock / Cmd-Tab via
+ * `setActivationPolicy('accessory')`. Playwright drives the renderer
+ * through `webContents` (loaded as part of the BrowserWindow lifecycle
+ * regardless of visibility), so tests don't need a visible window.
+ *
+ * NOTE: `showInactive()` does NOT hide the window — per Electron docs it
+ * shows the window without focusing it. Only skipping `show()` entirely
+ * keeps the window off-screen.
+ */
+const isE2EBackgroundLaunch = process.env['E2E_BACKGROUND_LAUNCH'] === '1'
+
 function createWindow(): void {
   const window = new BrowserWindow({
     width: 1200,
@@ -49,6 +64,11 @@ function createWindow(): void {
   })
 
   window.on('ready-to-show', () => {
+    // E2E: keep the window completely hidden. Skipping both maximize() and
+    // show() prevents the OS from rendering the window at all — Playwright
+    // still drives the renderer through webContents, which is loaded
+    // independently of window visibility.
+    if (isE2EBackgroundLaunch) return
     window.maximize()
     window.show()
   })
@@ -233,6 +253,13 @@ app.whenReady().then(async () => {
   // Configure the About panel before the menu wires up `role: 'about'`
   configureAboutPanel()
   createMenu()
+
+  // E2E: hide from Dock / Cmd-Tab so test launches don't disrupt the user.
+  // macOS-only API; guard with platform check to avoid runtime errors on
+  // Linux/Windows CI runners.
+  if (isE2EBackgroundLaunch && process.platform === 'darwin') {
+    app.setActivationPolicy('accessory')
+  }
   createWindow()
 
   // Initialize auto updater in production.

--- a/src/main/services/settingsWindow.ts
+++ b/src/main/services/settingsWindow.ts
@@ -51,6 +51,10 @@ export function createOrFocusSettingsWindow(): void {
   attachExternalLinkHandler(window)
 
   window.on('ready-to-show', () => {
+    // E2E: never reveal the Settings window — see the comment on
+    // `isE2EBackgroundLaunch` in src/main/index.ts. `showInactive()` would
+    // still display the window; only skipping `show()` keeps it hidden.
+    if (process.env['E2E_BACKGROUND_LAUNCH'] === '1') return
     window.show()
   })
 

--- a/src/main/services/settingsWindow.ts
+++ b/src/main/services/settingsWindow.ts
@@ -3,6 +3,7 @@ import { join } from 'path'
 import { app, BrowserWindow } from 'electron'
 
 import { attachExternalLinkHandler } from '../utils/attachExternalLinkHandler'
+import { isE2EBackgroundLaunch } from '../utils/e2eEnv'
 import { getSecureWebPreferences } from '../utils/secureWebPreferences'
 
 /**
@@ -51,10 +52,9 @@ export function createOrFocusSettingsWindow(): void {
   attachExternalLinkHandler(window)
 
   window.on('ready-to-show', () => {
-    // E2E: never reveal the Settings window — see the comment on
-    // `isE2EBackgroundLaunch` in src/main/index.ts. `showInactive()` would
-    // still display the window; only skipping `show()` keeps it hidden.
-    if (process.env['E2E_BACKGROUND_LAUNCH'] === '1') return
+    // E2E: never reveal the Settings window — see the JSDoc on
+    // `isE2EBackgroundLaunch` in src/main/utils/e2eEnv.ts.
+    if (isE2EBackgroundLaunch) return
     window.show()
   })
 

--- a/src/main/utils/e2eEnv.ts
+++ b/src/main/utils/e2eEnv.ts
@@ -1,0 +1,19 @@
+/**
+ * True when the Electron app was spawned by the Playwright E2E fixture
+ * (`e2e/fixtures/electron-app.ts`), which sets
+ * `E2E_BACKGROUND_LAUNCH=1` by default. Single source of truth shared
+ * by `src/main/index.ts` and `src/main/services/settingsWindow.ts` so a
+ * typo in the env-var key can't silently flip only one call site.
+ *
+ * When set, BrowserWindows are kept fully hidden (no `show()` /
+ * `showInactive()` / `maximize()`) and the app is hidden from the Dock
+ * / Cmd-Tab via `app.setActivationPolicy('accessory')`. Playwright
+ * drives the renderer through `webContents`, which loads regardless of
+ * window visibility, so tests don't need a visible window.
+ *
+ * NOTE: `showInactive()` does NOT hide the window — per Electron docs
+ * it shows the window without focusing it. Only skipping `show()`
+ * entirely keeps the window off-screen.
+ */
+export const isE2EBackgroundLaunch =
+  process.env['E2E_BACKGROUND_LAUNCH'] === '1'


### PR DESCRIPTION
## Summary

- E2E 実行時に Electron ウィンドウが前面に飛び出して macOS の操作 (フォーカス・カーソル) を奪う問題を修正
- `E2E_BACKGROUND_LAUNCH=1` (Playwright fixture のデフォルト) で main / Settings 両ウィンドウの `show()` / `maximize()` を完全スキップし、`app.setActivationPolicy('accessory')` で Dock / Cmd-Tab からも除外
- 開発者がテストを目視確認したい場合は `E2E_BACKGROUND_LAUNCH=0 pnpm test:e2e:headed` で opt-out 可能

## Why not \`showInactive()\`

Electron docs によると `showInactive()` は「ウィンドウを表示するがフォーカスを当てない」だけで、ウィンドウ自体は画面に出ます。`setActivationPolicy('accessory')` も Dock/Cmd-Tab presence のみ消し、ウィンドウの可視性には影響しません。完全に非表示にするには `show()` を呼ばないことが唯一の方法です ([Electron issue #38206](https://github.com/electron/electron/issues/38206) 参照)。

Playwright の `_electron.firstWindow()` は `webContents` のロード完了で解決するため、ウィンドウ非表示でもテストは通常通り走ります。

## Test plan

- [x] \`pnpm typecheck\` — pass
- [x] \`npx tsc -p e2e/tsconfig.json --noEmit\` — pass
- [x] \`pnpm lint\` — pass
- [x] \`pnpm test:e2e\` — 26/26 passed (39.4s)
- [x] 手動確認: E2E 実行中にウィンドウが画面に出ない / Dock に出ない / フォーカスを奪わないこと
- [ ] (regression) \`pnpm dev\` で通常起動はこれまで通り前面表示・Dock 表示されること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * E2Eテスト実行時のアプリケーション動作を改善しました。テスト環境では、メインウィンドウと設定ウィンドウが背景で起動し、表示されなくなります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->