### PR TITLE
fix(scanner): surface orphan symlinks (#127)

### DIFF
--- a/e2e/spec/regression.e2e.ts
+++ b/e2e/spec/regression.e2e.ts
@@ -478,3 +478,171 @@ test('removeAllFromAgent refusal still fires when SOURCE_DIR itself is a symlink
   expect(lstatSync(cursorAgentPath).isSymbolicLink()).toBe(true)
   expect(readdirSync(realSourceDir).sort()).toEqual(realSourceContentsBefore)
 })
+
+/**
+ * Issue #127 — `scanSkills` must surface broken symlinks whose source skill
+ * no longer exists in `~/.agents/skills/` as synthetic `Skill` records with
+ * `isOrphan: true`. Pre-fix the scanner walked SOURCE_DIR only, so a dangling
+ * link in an agent dir (typically left behind when the user `rm -rf`'d a
+ * source skill outside the app, or when an upstream marketplace skill was
+ * removed) was silently dropped from `state.skills.items`. Users would see
+ * filesystem garbage that the app pretended did not exist — no row to click,
+ * no way to clean up.
+ *
+ * Post-fix `scanOrphanSymlinks` runs alongside the source/local scans and
+ * collapses each orphan name into one Skill row whose per-agent `symlinks[]`
+ * marks affected agents as `'broken'` and the rest as `'missing'`. The
+ * renderer reads `isOrphan` directly off the record (`skillItemHelpers.ts`)
+ * to gate the delete/unlink buttons — operating against a phantom source
+ * would otherwise dispatch IPC calls that fail mid-flight.
+ *
+ * Setup avoids depending on the snapshot's azure-* layout: we stage a
+ * fresh dangling symlink under `~/.codeium/windsurf/skills/`. Windsurf is
+ * non-universal (its `scanDir` is `.codeium/windsurf`, not the universal
+ * SOURCE_DIR), so the orphan scanner finds it via its own `agent.path`
+ * walk rather than via the shared SOURCE_DIR readdir that universal
+ * agents collapse into.
+ *
+ * Three load-bearing assertions:
+ *   1. Orphan record EXISTS in `state.skills.items` — pre-fix this row
+ *      would be missing entirely, which is the actual regression.
+ *   2. `isOrphan: true` and `isSource: false` — the renderer's gate flags.
+ *   3. Per-agent symlink row contract — windsurf is `'broken'`, every other
+ *      agent is `'missing'`. A regression that mass-flagged every agent
+ *      slot would silently break the renderer's broken-vs-missing badge
+ *      logic without surfacing in a sourced-skill assertion.
+ *
+ * Negative control on a real source (azure-ai) in the same store state
+ * confirms the orphan flag did NOT broaden across all rows — the previous
+ * three assertions alone could pass while every row got `isOrphan: true`.
+ */
+test('scanSkills surfaces broken symlinks as orphan skills (regression #127)', async ({
+  appWindow,
+  isolatedHome,
+}) => {
+  await waitForInitialScan(appWindow)
+
+  // Stage the orphan condition: a non-universal agent dir containing a
+  // dangling symlink whose target source has never existed (equivalent to
+  // a user-driven `rm -rf ~/.agents/skills/<name>` after install). The
+  // `phantom-` prefix isolates this fixture from any name the snapshot's
+  // azure-* install could ever produce, so a future global-setup change
+  // cannot collide with the test by accident.
+  const orphanSkillName = 'phantom-orphan-fixture'
+  const windsurfSkillsDir = join(isolatedHome, '.codeium', 'windsurf', 'skills')
+  mkdirSync(windsurfSkillsDir, { recursive: true })
+
+  // Target intentionally absent — `checkSymlinkTargetFromKnownLink` resolves
+  // a dangling link to status `'broken'`, which is what `scanOrphanSymlinks`
+  // filters on.
+  const phantomSourcePath = join(
+    isolatedHome,
+    '.agents',
+    'skills',
+    orphanSkillName,
+  )
+  const orphanLinkPath = join(windsurfSkillsDir, orphanSkillName)
+  symlinkSync(phantomSourcePath, orphanLinkPath)
+
+  // FS sanity — the staged shape must be a real symlink with an absent
+  // target. `existsSync` follows symlinks so a broken link reads as `false`;
+  // `lstatSync` does NOT follow, so it confirms the symlink itself is real.
+  expect(lstatSync(orphanLinkPath).isSymbolicLink()).toBe(true)
+  expect(existsSync(phantomSourcePath)).toBe(false)
+  expect(existsSync(orphanLinkPath)).toBe(false)
+
+  await refreshSkillsState(appWindow)
+
+  interface OrphanSkillSnapshot {
+    name: string
+    isOrphan: boolean
+    isSource: boolean
+    description: string
+    symlinks: SymlinkSnapshot[]
+  }
+
+  const orphanRecord = await getStoreState(
+    appWindow,
+    (state): OrphanSkillSnapshot | null => {
+      const root = state as {
+        skills: { items: OrphanSkillSnapshot[] }
+      }
+      return (
+        root.skills.items.find(
+          (skill) => skill.name === 'phantom-orphan-fixture',
+        ) ?? null
+      )
+    },
+  )
+
+  expect(
+    orphanRecord,
+    'orphan skill must surface in state.skills.items — pre-fix bug indicator (the entire row was being silently dropped)',
+  ).not.toBeNull()
+  if (!orphanRecord) return
+
+  // KEY — Skill.isOrphan is the single flag the renderer reads to suppress
+  // the delete/unlink buttons in `getSkillItemVisibility`. A regression
+  // that flipped this back to `false` for orphans would re-introduce the
+  // confusing UX where users click "delete" against a phantom source path
+  // and watch the IPC fail mid-flight.
+  expect(orphanRecord.isOrphan).toBe(true)
+  expect(orphanRecord.isSource).toBe(false)
+  expect(orphanRecord.description).toBe(
+    'Orphan symlink — source skill no longer exists',
+  )
+
+  // The windsurf row must reflect our staged broken symlink. A regression
+  // in Phase 2's `findIndex` / slot-assignment block would land here as
+  // `'missing'` instead of `'broken'`.
+  const windsurfRow = orphanRecord.symlinks.find(
+    (symlink) => symlink.agentId === 'windsurf',
+  )
+  expect(
+    windsurfRow,
+    'windsurf row must be present — every AGENTS entry gets a slot, including agents without a broken link',
+  ).toBeDefined()
+  expect(windsurfRow?.status).toBe('broken')
+  expect(windsurfRow?.isLocal).toBe(false)
+
+  // Agents without a staged broken link must register as 'missing' — NOT
+  // 'broken'. A regression that marked every agent slot as broken (e.g.
+  // by inverting the slot-found check) would silently flip 'missing' to
+  // 'broken' across the whole symlinks[] array.
+  const claudeRow = orphanRecord.symlinks.find(
+    (symlink) => symlink.agentId === 'claude-code',
+  )
+  expect(claudeRow?.status).toBe('missing')
+
+  // Negative control — a real source skill (azure-ai) MUST NOT be flagged
+  // as orphan. A regression that broadened the orphan branch (e.g. moving
+  // `isOrphan: true` outside the orphan-scan block in scanSkills.ts) would
+  // pass the orphan-row assertions above but flip every source skill into
+  // `isOrphan: true`, hiding their delete/unlink buttons across the UI.
+  // The file-level `test.beforeEach` already skips this entire suite when
+  // the snapshot is offline, so azure-ai is guaranteed to be installed.
+  // `getStoreState` re-evaluates the selector inside the renderer via
+  // `Function.toString`, so closure-scope identifiers like `AZURE_AI_NAME`
+  // would resolve to `undefined` at runtime. Inline the literal — same
+  // pattern delete.e2e.ts uses for `'azure-ai'` in azureSnapshotSelector.
+  const azureRecord = await getStoreState(
+    appWindow,
+    (state): { isOrphan: boolean; isSource: boolean } | null => {
+      const root = state as {
+        skills: {
+          items: Array<{ name: string; isOrphan: boolean; isSource: boolean }>
+        }
+      }
+      const azure = root.skills.items.find((skill) => skill.name === 'azure-ai')
+      return azure
+        ? { isOrphan: azure.isOrphan, isSource: azure.isSource }
+        : null
+    },
+  )
+  expect(
+    azureRecord,
+    'azure-ai (real source) must remain in skills.items alongside the orphan',
+  ).not.toBeNull()
+  expect(azureRecord?.isOrphan).toBe(false)
+  expect(azureRecord?.isSource).toBe(true)
+})

--- a/src/main/services/skillScanner.test.ts
+++ b/src/main/services/skillScanner.test.ts
@@ -260,4 +260,63 @@ describe('scanSkills orphan symlink surfacing (issue #127)', () => {
     expect(skills[0].name).toBe('theme-generator')
     expect(skills[0].isSource).toBe(true)
   })
+
+  it('merges orphan broken slots into a same-named local skill (regression for #127 follow-up)', async () => {
+    // Cursor has a real folder named "frontend-design" → local skill.
+    // Codex has a broken symlink with the same name → source missing, orphan.
+    // Naive first-wins (which the original merge used) would keep only the
+    // local record and silently drop codex's broken status — recreating the
+    // visibility hole this PR's main fix addressed.
+    readdirMock.mockImplementation(async (path: string) => {
+      if (path === '/mock/source/skills') return []
+      if (path === '/mock/agents/cursor/skills') {
+        return [
+          createDirent('frontend-design', {
+            isDirectory: true,
+            isSymbolicLink: false,
+          }),
+        ]
+      }
+      if (path === '/mock/agents/codex/skills') {
+        return [
+          createDirent('frontend-design', {
+            isDirectory: false,
+            isSymbolicLink: true,
+          }),
+        ]
+      }
+      return []
+    })
+    accessMock.mockImplementation(async (path: string) => {
+      if (path === '/mock/agents/cursor/skills/frontend-design/SKILL.md') return
+      throw new Error(`ENOENT: ${path}`)
+    })
+    statMock.mockImplementation(async (path: string) => {
+      if (path === '/mock/agents/cursor/skills/frontend-design/SKILL.md') {
+        return { isFile: () => true }
+      }
+      throw new Error(`ENOENT: ${path}`)
+    })
+    checkSymlinkTargetFromKnownLinkMock.mockImplementation(
+      async (linkPath: string) => {
+        if (linkPath === '/mock/agents/codex/skills/frontend-design')
+          return 'broken'
+        return 'missing'
+      },
+    )
+
+    const { scanSkills } = await import('./skillScanner')
+    const skills = await scanSkills()
+
+    expect(skills).toHaveLength(1)
+    const merged = skills[0]
+    expect(merged.name).toBe('frontend-design')
+    const cursor = merged.symlinks.find((s) => s.agentId === 'cursor')
+    const codex = merged.symlinks.find((s) => s.agentId === 'codex')
+    expect(cursor).toMatchObject({ status: 'valid', isLocal: true })
+    expect(codex).toMatchObject({ status: 'broken', isLocal: false })
+    // Once a real local folder is present, the merged record is no longer an
+    // orphan — the UI delete button must remain reachable.
+    expect(merged.isOrphan).toBe(false)
+  })
 })

--- a/src/main/services/skillScanner.test.ts
+++ b/src/main/services/skillScanner.test.ts
@@ -53,15 +53,20 @@ vi.mock('./metadataParser', () => ({
   }),
 }))
 
+const checkSymlinkTargetFromKnownLinkMock = vi.fn()
+
 vi.mock('./symlinkChecker', () => ({
   checkSkillSymlinks: vi.fn(async () => []),
   countValidSymlinks: vi.fn(() => 0),
+  checkSymlinkTargetFromKnownLink: checkSymlinkTargetFromKnownLinkMock,
 }))
 
 describe('scanSkills local skill aggregation', () => {
   beforeEach(() => {
     readdirMock.mockReset()
     accessMock.mockReset()
+    checkSymlinkTargetFromKnownLinkMock.mockReset()
+    checkSymlinkTargetFromKnownLinkMock.mockResolvedValue('missing')
 
     readdirMock.mockImplementation(async (path: string) => {
       if (path === '/mock/source/skills') {
@@ -128,5 +133,131 @@ describe('scanSkills local skill aggregation', () => {
 
     expect(codex).toMatchObject({ status: 'valid', isLocal: true })
     expect(cursor).toMatchObject({ status: 'valid', isLocal: true })
+  })
+})
+
+describe('scanSkills orphan symlink surfacing (issue #127)', () => {
+  beforeEach(() => {
+    readdirMock.mockReset()
+    accessMock.mockReset()
+    statMock.mockReset()
+    checkSymlinkTargetFromKnownLinkMock.mockReset()
+  })
+
+  it('surfaces broken symlinks whose source is missing as orphan Skill records', async () => {
+    // Source dir empty; codex has 1 broken symlink "connect-chrome".
+    readdirMock.mockImplementation(async (path: string) => {
+      if (path === '/mock/source/skills') return []
+      if (path === '/mock/agents/codex/skills') {
+        return [
+          createDirent('connect-chrome', {
+            isDirectory: false,
+            isSymbolicLink: true,
+          }),
+        ]
+      }
+      return []
+    })
+    accessMock.mockRejectedValue(new Error('ENOENT'))
+    statMock.mockRejectedValue(new Error('ENOENT'))
+    checkSymlinkTargetFromKnownLinkMock.mockImplementation(
+      async (linkPath: string) => {
+        if (linkPath === '/mock/agents/codex/skills/connect-chrome')
+          return 'broken'
+        return 'missing'
+      },
+    )
+
+    const { scanSkills } = await import('./skillScanner')
+    const skills = await scanSkills()
+
+    expect(skills).toHaveLength(1)
+    const orphan = skills[0]
+    expect(orphan.name).toBe('connect-chrome')
+    expect(orphan.isSource).toBe(false)
+    expect(orphan.description).toBe(
+      'Orphan symlink — source skill no longer exists',
+    )
+
+    const codex = orphan.symlinks.find((s) => s.agentId === 'codex')
+    const cursor = orphan.symlinks.find((s) => s.agentId === 'cursor')
+    expect(codex).toMatchObject({ status: 'broken', isLocal: false })
+    expect(cursor).toMatchObject({ status: 'missing', isLocal: false })
+  })
+
+  it('collapses the same broken name across multiple agents into one orphan record', async () => {
+    readdirMock.mockImplementation(async (path: string) => {
+      if (path === '/mock/source/skills') return []
+      if (
+        path === '/mock/agents/codex/skills' ||
+        path === '/mock/agents/cursor/skills'
+      ) {
+        return [
+          createDirent('connect-chrome', {
+            isDirectory: false,
+            isSymbolicLink: true,
+          }),
+        ]
+      }
+      return []
+    })
+    accessMock.mockRejectedValue(new Error('ENOENT'))
+    statMock.mockRejectedValue(new Error('ENOENT'))
+    checkSymlinkTargetFromKnownLinkMock.mockResolvedValue('broken')
+
+    const { scanSkills } = await import('./skillScanner')
+    const skills = await scanSkills()
+
+    expect(skills).toHaveLength(1)
+    const orphan = skills[0]
+    const codex = orphan.symlinks.find((s) => s.agentId === 'codex')
+    const cursor = orphan.symlinks.find((s) => s.agentId === 'cursor')
+    expect(codex?.status).toBe('broken')
+    expect(cursor?.status).toBe('broken')
+  })
+
+  it('does NOT create orphan record when name matches a live source skill', async () => {
+    // Source has "theme-generator". Codex has a broken "theme-generator"
+    // symlink — broken status belongs in the source skill's symlinks[], not
+    // in a separate orphan record.
+    readdirMock.mockImplementation(async (path: string) => {
+      if (path === '/mock/source/skills') {
+        return [
+          createDirent('theme-generator', {
+            isDirectory: true,
+            isSymbolicLink: false,
+          }),
+        ]
+      }
+      if (path === '/mock/agents/codex/skills') {
+        return [
+          createDirent('theme-generator', {
+            isDirectory: false,
+            isSymbolicLink: true,
+          }),
+        ]
+      }
+      return []
+    })
+    // SKILL.md exists for the live source skill.
+    accessMock.mockImplementation(async (path: string) => {
+      if (path === '/mock/source/skills/theme-generator/SKILL.md') return
+      throw new Error(`ENOENT: ${path}`)
+    })
+    statMock.mockImplementation(async (path: string) => {
+      if (path === '/mock/source/skills/theme-generator/SKILL.md') {
+        return { isFile: () => true }
+      }
+      throw new Error(`ENOENT: ${path}`)
+    })
+    checkSymlinkTargetFromKnownLinkMock.mockResolvedValue('broken')
+
+    const { scanSkills } = await import('./skillScanner')
+    const skills = await scanSkills()
+
+    // Exactly one record — the live source skill, no separate orphan.
+    expect(skills).toHaveLength(1)
+    expect(skills[0].name).toBe('theme-generator')
+    expect(skills[0].isSource).toBe(true)
   })
 })

--- a/src/main/services/skillScanner.ts
+++ b/src/main/services/skillScanner.ts
@@ -5,19 +5,23 @@ import { join } from 'path'
 import { formatBytes } from '../../shared/fileTypes'
 import { repositoryId } from '../../shared/types'
 import type {
+  AbsolutePath,
   HttpUrl,
   RepositoryId,
   Skill,
   SkillName,
   SourceStats,
-  SymlinkInfo,
 } from '../../shared/types'
 import { AGENTS, SOURCE_DIR } from '../constants'
 
 import { listValidSourceSkillDirs } from './dirScanner'
 import { parseSkillMetadata } from './metadataParser'
 import { isValidSkillDir } from './skillValidation'
-import { checkSkillSymlinks, countValidSymlinks } from './symlinkChecker'
+import {
+  checkSkillSymlinks,
+  checkSymlinkTargetFromKnownLink,
+  countValidSymlinks,
+} from './symlinkChecker'
 
 /**
  * Entry from ~/.agents/.skill-lock.json
@@ -58,25 +62,45 @@ async function readSkillLock(): Promise<Map<SkillName, SkillLockEntry>> {
 }
 
 /**
- * Scan ~/.agents/skills/ and return all installed skills (source + local)
+ * Scan ~/.agents/skills/ and return all installed skills (source + local + orphan)
+ *
+ * Orphan symlinks (broken symlinks in agent dirs whose source skill no longer
+ * exists) are surfaced as `Skill` records with `isSource:false` and per-agent
+ * `symlinks[].status:'broken'`. Without this, broken-symlink data never enters
+ * the renderer and `HealthWidget` reports 100% even when agents have dangling
+ * links — see issue #127.
+ *
+ * Dedup precedence: source > local > orphan. A name that exists as a source
+ * skill never becomes an orphan record (broken agent links for live source
+ * skills are already represented inside `Skill.symlinks`).
+ *
  * @returns Array of Skill objects with symlink info
  * @example
  * scanSkills()
  * // => [{ name: 'theme-generator', symlinkCount: 3, ... }]
  */
 export async function scanSkills(): Promise<Skill[]> {
-  // Scan source skills, local skills, and lock file in parallel
-  const [sourceSkills, localSkills, lockEntries] = await Promise.all([
-    scanSourceSkills(),
-    scanAllLocalSkills(),
-    readSkillLock(),
-  ])
+  // Orphan scan needs sourceNames to skip live sources, so it chains off
+  // sourceSkills via .then() instead of awaiting separately — that lets it
+  // overlap with scanAllLocalSkills and readSkillLock in the same Promise.all.
+  const sourceSkillsPromise = scanSourceSkills()
+  const orphanSkillsPromise = sourceSkillsPromise.then(async (src) =>
+    scanOrphanSymlinks(new Set(src.map((s) => s.name))),
+  )
+  const [sourceSkills, localSkills, lockEntries, orphanSkills] =
+    await Promise.all([
+      sourceSkillsPromise,
+      scanAllLocalSkills(),
+      readSkillLock(),
+      orphanSkillsPromise,
+    ])
 
-  // Merge: local skills that don't exist in source
-  const sourceNames = new Set(sourceSkills.map((s) => s.name))
-  const uniqueLocalSkills = localSkills.filter((s) => !sourceNames.has(s.name))
-
-  const allSkills = [...sourceSkills, ...uniqueLocalSkills]
+  // Merge precedence: source > local > orphan (first-wins by name).
+  const byName = new Map<SkillName, Skill>()
+  for (const skill of [...sourceSkills, ...localSkills, ...orphanSkills]) {
+    if (!byName.has(skill.name)) byName.set(skill.name, skill)
+  }
+  const allSkills = Array.from(byName.values())
 
   // Attach source info from lock file
   for (const skill of allSkills) {
@@ -111,6 +135,7 @@ async function scanSourceSkills(): Promise<Skill[]> {
         symlinkCount: countValidSymlinks(symlinks),
         symlinks,
         isSource: true,
+        isOrphan: false,
       }
     }),
   )
@@ -119,65 +144,160 @@ async function scanSourceSkills(): Promise<Skill[]> {
 }
 
 /**
- * Scan all agent directories for local skills (real folders, not symlinks)
- * @returns Array of local skills with their agent associations
+ * Scan all agent directories for orphan symlinks — broken symlinks whose target
+ * source skill no longer exists in `~/.agents/skills/`.
+ *
+ * Each orphan name collapses into a single `Skill` record whose `symlinks[]`
+ * marks every affected agent as `'broken'` and the rest as `'missing'`. Names
+ * that already exist as source skills are skipped — broken symlinks for live
+ * sources are represented inside the source skill's own `symlinks[]`.
+ *
+ * @param sourceNames - Names of source skills to exclude from orphan scan
+ * @returns Array of orphan skills with `isSource:false` and broken symlink info
+ * @example
+ * scanOrphanSymlinks(new Set(['theme-generator']))
+ * // => [{ name: 'connect-chrome', isSource: false, symlinks: [{ status: 'broken', ... }] }]
  */
-async function scanAllLocalSkills(): Promise<Skill[]> {
-  const localSkillsByName = new Map<string, Skill>()
-
-  for (const agent of AGENTS) {
-    try {
-      const entries = await readdir(agent.path, { withFileTypes: true })
-      // Get directories that are NOT symlinks and don't start with '.'
-      const localDirs = entries.filter(
-        (e) =>
-          e.isDirectory() && !e.isSymbolicLink() && !e.name.startsWith('.'),
-      )
-
-      for (const dir of localDirs) {
-        const skillPath = join(agent.path, dir.name)
-        const isValid = await isValidSkillDir(skillPath)
-        if (!isValid) continue
-
-        const metadata = await parseSkillMetadata(skillPath)
-        const existing = localSkillsByName.get(metadata.name)
-
-        if (existing) {
-          const symlinkIndex = existing.symlinks.findIndex(
-            (s) => s.agentId === agent.id,
+async function scanOrphanSymlinks(
+  sourceNames: Set<SkillName>,
+): Promise<Skill[]> {
+  // Phase 1 — collect (agent, name, linkPath) tuples for every broken symlink
+  // across all AGENTS in parallel. `entry.isSymbolicLink()` already proved
+  // these are symlinks, so the fast-path checker skips the redundant lstat.
+  const brokenLinks = (
+    await Promise.all(
+      AGENTS.map(async (agent) => {
+        try {
+          const entries = await readdir(agent.path, { withFileTypes: true })
+          const candidates = entries.filter(
+            (entry) => entry.isSymbolicLink() && !sourceNames.has(entry.name),
           )
-          if (symlinkIndex >= 0) {
-            existing.symlinks[symlinkIndex] = {
-              ...existing.symlinks[symlinkIndex],
-              status: 'valid',
-              linkPath: join(agent.path, dir.name),
-              isLocal: true,
-            }
-          }
-          continue
+          const statuses = await Promise.all(
+            candidates.map(async (link) => {
+              const linkPath = join(agent.path, link.name) as AbsolutePath
+              const status = await checkSymlinkTargetFromKnownLink(linkPath)
+              return { agent, name: link.name, linkPath, status }
+            }),
+          )
+          return statuses.filter((s) => s.status === 'broken')
+        } catch {
+          return []
         }
+      }),
+    )
+  ).flat()
 
-        // Initialize local skill with agent-specific status map.
-        const symlinks: SymlinkInfo[] = AGENTS.map((a) => ({
+  // Phase 2 — group by name; first sighting builds the full per-agent
+  // template (every agent 'missing'), subsequent sightings flip that agent's
+  // slot to 'broken'. Single branch, no existing/new split.
+  const orphansByName = new Map<SkillName, Skill>()
+  for (const { agent, name, linkPath } of brokenLinks) {
+    let skill = orphansByName.get(name)
+    if (!skill) {
+      skill = {
+        name,
+        description: 'Orphan symlink — source skill no longer exists',
+        path: linkPath,
+        symlinkCount: 0,
+        symlinks: AGENTS.map((a) => ({
           agentId: a.id,
           agentName: a.name,
-          status: a.id === agent.id ? 'valid' : ('missing' as const),
-          targetPath: '',
-          linkPath: join(a.path, dir.name),
-          isLocal: a.id === agent.id,
-        }))
-
-        localSkillsByName.set(metadata.name, {
-          name: metadata.name,
-          description: metadata.description,
-          path: skillPath,
-          symlinkCount: 0, // Local skills have 0 symlinks
-          symlinks,
-          isSource: false,
-        })
+          status: 'missing',
+          linkPath: join(a.path, name) as AbsolutePath,
+          isLocal: false,
+        })),
+        isSource: false,
+        isOrphan: true,
       }
-    } catch {
-      // Agent directory doesn't exist, skip
+      orphansByName.set(name, skill)
+    }
+    const slot = skill.symlinks.findIndex((s) => s.agentId === agent.id)
+    if (slot >= 0) {
+      skill.symlinks[slot] = {
+        ...skill.symlinks[slot],
+        status: 'broken',
+        linkPath,
+      }
+    }
+  }
+
+  return Array.from(orphansByName.values())
+}
+
+/**
+ * Scan all agent directories for local skills (real folders, not symlinks).
+ *
+ * Mirrors {@link scanOrphanSymlinks}: Phase 1 fans out across every agent in
+ * parallel collecting `(agent, skillPath, metadata)` tuples; Phase 2 groups
+ * by skill name with first-sighting-creates / later-sightings-update logic
+ * — no existing/new branch split, no per-agent sequential I/O.
+ *
+ * @returns Array of local skills with their per-agent presence map
+ */
+async function scanAllLocalSkills(): Promise<Skill[]> {
+  // Phase 1 — for each agent, list real directories (not symlinks, not
+  // dotfiles), validate them in parallel, and parse metadata only for the
+  // ones that pass validation. Each successful tuple carries the bits Phase 2
+  // needs to update the per-agent slot for that skill.
+  const localHits = (
+    await Promise.all(
+      AGENTS.map(async (agent) => {
+        try {
+          const entries = await readdir(agent.path, { withFileTypes: true })
+          const candidates = entries.filter(
+            (e) =>
+              e.isDirectory() && !e.isSymbolicLink() && !e.name.startsWith('.'),
+          )
+          const validated = await Promise.all(
+            candidates.map(async (dir) => {
+              const skillPath = join(agent.path, dir.name) as AbsolutePath
+              if (!(await isValidSkillDir(skillPath))) return null
+              const metadata = await parseSkillMetadata(skillPath)
+              return { agent, dirName: dir.name, skillPath, metadata }
+            }),
+          )
+          return validated.filter(
+            (item): item is NonNullable<typeof item> => item !== null,
+          )
+        } catch {
+          return []
+        }
+      }),
+    )
+  ).flat()
+
+  // Phase 2 — group by skill name. First sighting builds the full per-agent
+  // template (every agent 'missing'); every sighting (including the first)
+  // then flips its own agent slot to a valid local entry. Single branch.
+  const localSkillsByName = new Map<SkillName, Skill>()
+  for (const { agent, dirName, skillPath, metadata } of localHits) {
+    let skill = localSkillsByName.get(metadata.name)
+    if (!skill) {
+      skill = {
+        name: metadata.name,
+        description: metadata.description,
+        path: skillPath,
+        symlinkCount: 0, // Local skills have 0 symlinks
+        symlinks: AGENTS.map((a) => ({
+          agentId: a.id,
+          agentName: a.name,
+          status: 'missing',
+          linkPath: join(a.path, dirName) as AbsolutePath,
+          isLocal: false,
+        })),
+        isSource: false,
+        isOrphan: false,
+      }
+      localSkillsByName.set(metadata.name, skill)
+    }
+    const slot = skill.symlinks.findIndex((s) => s.agentId === agent.id)
+    if (slot >= 0) {
+      skill.symlinks[slot] = {
+        ...skill.symlinks[slot],
+        status: 'valid',
+        linkPath: join(agent.path, dirName) as AbsolutePath,
+        isLocal: true,
+      }
     }
   }
 
@@ -209,6 +329,7 @@ export async function getSkill(skillName: SkillName): Promise<Skill | null> {
       symlinkCount: countValidSymlinks(symlinks),
       symlinks,
       isSource: true,
+      isOrphan: false,
     }
   } catch {
     return null

--- a/src/main/services/skillScanner.ts
+++ b/src/main/services/skillScanner.ts
@@ -95,10 +95,34 @@ export async function scanSkills(): Promise<Skill[]> {
       orphanSkillsPromise,
     ])
 
-  // Merge precedence: source > local > orphan (first-wins by name).
+  // Merge precedence: source > local > orphan (first record's metadata wins).
+  // Naive first-wins discards later records entirely — but a `local + orphan`
+  // collision (real folder in agent A, broken symlink in agent B for the
+  // same name) needs the orphan's broken slots merged into the local record,
+  // otherwise the broken state silently disappears from the UI (issue #127's
+  // failure mode resurfaces). Same agent slot can't legitimately have both
+  // 'valid+local' and 'broken' (a path is either a directory or a symlink),
+  // so per-slot non-missing-wins is conflict-free.
   const byName = new Map<SkillName, Skill>()
   for (const skill of [...sourceSkills, ...localSkills, ...orphanSkills]) {
-    if (!byName.has(skill.name)) byName.set(skill.name, skill)
+    const existing = byName.get(skill.name)
+    if (!existing) {
+      byName.set(skill.name, skill)
+      continue
+    }
+    for (let i = 0; i < existing.symlinks.length; i++) {
+      if (
+        existing.symlinks[i].status === 'missing' &&
+        skill.symlinks[i].status !== 'missing'
+      ) {
+        existing.symlinks[i] = skill.symlinks[i]
+      }
+    }
+    existing.symlinkCount = countValidSymlinks(existing.symlinks)
+    // Once a real source or local folder is present, the skill is no longer
+    // an orphan in the UI sense — only treat as orphan if every contributing
+    // record agreed.
+    existing.isOrphan = existing.isOrphan && skill.isOrphan
   }
   const allSkills = Array.from(byName.values())
 

--- a/src/main/services/symlinkChecker.test.ts
+++ b/src/main/services/symlinkChecker.test.ts
@@ -187,7 +187,7 @@ describe('checkSkillSymlinks', () => {
     expect(claude.status).toBe('broken')
     expect(claude.targetPath).toBe('/mock/source/skills/deleted-target')
     expect(cursor.status).toBe('missing')
-    expect(cursor.targetPath).toBe('')
+    expect(cursor.targetPath).toBeUndefined()
   })
 
   it('returns valid with populated targetPath for valid symlinks', async () => {
@@ -220,7 +220,7 @@ describe('checkSkillSymlinks', () => {
     for (const r of results) {
       expect(r.status).toBe('valid')
       expect(r.isLocal).toBe(true)
-      expect(r.targetPath).toBe('')
+      expect(r.targetPath).toBeUndefined()
     }
   })
 
@@ -234,7 +234,7 @@ describe('checkSkillSymlinks', () => {
     for (const r of results) {
       expect(r.status).toBe('missing')
       expect(r.isLocal).toBe(false)
-      expect(r.targetPath).toBe('')
+      expect(r.targetPath).toBeUndefined()
     }
   })
 

--- a/src/main/services/symlinkChecker.test.ts
+++ b/src/main/services/symlinkChecker.test.ts
@@ -254,6 +254,11 @@ describe('checkSkillSymlinks', () => {
     for (const r of results) {
       expect(r.status).toBe('valid')
       expect(r.isLocal).toBe(false)
+      // targetPath must be the absolute-resolved string, not the raw readlink
+      // value. AbsolutePath is a branded string type; leaking the relative
+      // form here would silently violate the type contract for callers.
+      expect(r.targetPath).not.toBe(relativeTarget)
+      expect(r.targetPath).toMatch(/^\//)
     }
 
     // Verify access was called with resolved absolute paths, not raw relative

--- a/src/main/services/symlinkChecker.ts
+++ b/src/main/services/symlinkChecker.ts
@@ -92,10 +92,15 @@ export async function checkSkillSymlinks(
       // Only symlinks (not local folders, not missing entries) have a target
       // worth recording. Read it lazily and tolerate failures so a flaky
       // readlink doesn't poison the whole scan.
+      // readlink() returns the raw stored target string — relative when the
+      // symlink was created with a relative target (`ln -s ../foo bar`). The
+      // `AbsolutePath` contract requires an absolute path, so resolve it
+      // against the symlink's parent directory, mirroring checkSymlinkStatus.
       let targetPath: AbsolutePath | undefined
       if (status !== 'missing' && !isLocal) {
         try {
-          targetPath = (await readlink(linkPath)) as AbsolutePath
+          const target = await readlink(linkPath)
+          targetPath = resolve(dirname(linkPath), target) as AbsolutePath
         } catch {
           // Leave undefined — the link disappeared between lstat and readlink
         }

--- a/src/main/services/symlinkChecker.ts
+++ b/src/main/services/symlinkChecker.ts
@@ -86,15 +86,18 @@ export async function checkSkillSymlinks(
 ): Promise<SymlinkInfo[]> {
   const results = await Promise.all(
     AGENTS.map(async (agent) => {
-      const linkPath = join(agent.path, skillName)
+      const linkPath = join(agent.path, skillName) as AbsolutePath
       const { status, isLocal } = await checkLinkOrLocal(linkPath)
 
-      let targetPath = ''
+      // Only symlinks (not local folders, not missing entries) have a target
+      // worth recording. Read it lazily and tolerate failures so a flaky
+      // readlink doesn't poison the whole scan.
+      let targetPath: AbsolutePath | undefined
       if (status !== 'missing' && !isLocal) {
         try {
-          targetPath = await readlink(linkPath)
+          targetPath = (await readlink(linkPath)) as AbsolutePath
         } catch {
-          // Could not read link target
+          // Leave undefined — the link disappeared between lstat and readlink
         }
       }
 
@@ -131,18 +134,50 @@ export async function checkSymlinkStatus(
       return 'missing'
     }
 
-    // Check if target exists
-    // resolve() handles both absolute and relative targets correctly
-    const target = await readlink(linkPath)
-    const resolvedTarget = resolve(dirname(linkPath), target)
-    try {
-      await access(resolvedTarget)
-      return 'valid'
-    } catch {
-      return 'broken'
-    }
+    return await resolveSymlinkTarget(linkPath)
   } catch {
     return 'missing'
+  }
+}
+
+/**
+ * Fast-path of {@link checkSymlinkStatus} for callers that already proved the
+ * path is a symbolic link (e.g. via `Dirent.isSymbolicLink()` from `readdir`).
+ * Skips the redundant `lstat` syscall — saves one I/O per orphan candidate
+ * across all agent dirs during a full scan.
+ *
+ * @param linkPath - Path that is known (by the caller) to be a symbolic link
+ * @returns 'valid' if target exists, 'broken' if dangling, 'missing' if the
+ * link itself disappeared between the readdir snapshot and the lookup
+ * @example
+ * // Inside a readdir loop where entry.isSymbolicLink() === true:
+ * await checkSymlinkTargetFromKnownLink(join(dir, entry.name))
+ */
+export async function checkSymlinkTargetFromKnownLink(
+  linkPath: AbsolutePath,
+): Promise<SymlinkStatus> {
+  try {
+    return await resolveSymlinkTarget(linkPath)
+  } catch {
+    return 'missing'
+  }
+}
+
+/**
+ * Shared core: read the symlink, resolve it relative to its own directory
+ * (handles both absolute and relative targets), then probe for existence.
+ * Centralizing this makes the slow-path and fast-path identical in meaning.
+ */
+async function resolveSymlinkTarget(
+  linkPath: AbsolutePath,
+): Promise<SymlinkStatus> {
+  const target = await readlink(linkPath)
+  const resolvedTarget = resolve(dirname(linkPath), target)
+  try {
+    await access(resolvedTarget)
+    return 'valid'
+  } catch {
+    return 'broken'
   }
 }
 

--- a/src/renderer/src/components/layout/MainContent.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.browser.test.tsx
@@ -247,6 +247,7 @@ describe('MainContent keyboard shortcuts (Cmd+A)', () => {
         symlinkCount: 0,
         symlinks: [],
         isSource: true,
+        isOrphan: false,
       },
       {
         name: 'tdd' as SkillName,
@@ -255,6 +256,7 @@ describe('MainContent keyboard shortcuts (Cmd+A)', () => {
         symlinkCount: 0,
         symlinks: [],
         isSource: true,
+        isOrphan: false,
       },
     ]
 
@@ -389,6 +391,7 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
       symlinkCount: 0,
       symlinks: [],
       isSource: true,
+      isOrphan: false,
       ...(cliTracked
         ? { source: repositoryId('vercel-labs/agent-skills') }
         : {}),

--- a/src/renderer/src/components/skills/AddSymlinkModal.browser.test.tsx
+++ b/src/renderer/src/components/skills/AddSymlinkModal.browser.test.tsx
@@ -61,6 +61,7 @@ function makeSkill(overrides: Partial<Skill> = {}): Skill {
     symlinkCount: 0,
     symlinks: [],
     isSource: true,
+    isOrphan: false,
     ...overrides,
   }
 }

--- a/src/renderer/src/components/skills/CopyToAgentsModal.browser.test.tsx
+++ b/src/renderer/src/components/skills/CopyToAgentsModal.browser.test.tsx
@@ -60,6 +60,7 @@ function makeSkill(symlinks: SymlinkInfo[]): Skill {
     symlinkCount: symlinks.length,
     symlinks,
     isSource: true,
+    isOrphan: false,
   }
 }
 

--- a/src/renderer/src/components/skills/SkillItem.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillItem.browser.test.tsx
@@ -40,6 +40,7 @@ function makeSkill(overrides: Partial<Skill> = {}): Skill {
     symlinkCount: 0,
     symlinks: [],
     isSource: true,
+    isOrphan: false,
     ...overrides,
   }
 }

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -130,7 +130,7 @@ export const SkillItem = React.memo(function SkillItem({
     selectedAgentSymlink,
     selectedLocalSkillInfo,
     showGStackBadge,
-  } = getSkillItemVisibility(selectedAgentId, skill.symlinks)
+  } = getSkillItemVisibility(selectedAgentId, skill)
 
   // Get selected agent name for tooltip
   const selectedAgentName =

--- a/src/renderer/src/components/skills/bookmarkHelpers.test.ts
+++ b/src/renderer/src/components/skills/bookmarkHelpers.test.ts
@@ -20,6 +20,7 @@ function makeSkill(overrides: Partial<Skill> = {}): Skill {
     symlinkCount: 0,
     symlinks: [],
     isSource: true,
+    isOrphan: false,
     ...overrides,
   }
 }

--- a/src/renderer/src/components/skills/skillItemHelpers.test.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import type { AgentId, SymlinkInfo } from '../../../../shared/types'
+import type {
+  AbsolutePath,
+  AgentId,
+  Skill,
+  SymlinkInfo,
+} from '../../../../shared/types'
 
 import { getSkillItemVisibility } from './skillItemHelpers'
 
@@ -13,17 +18,38 @@ function makeSymlink(
   return {
     agentName: 'Test Agent' as SymlinkInfo['agentName'],
     status: 'valid',
-    targetPath: '/target',
-    linkPath: '/link',
+    targetPath: '/target' as AbsolutePath,
+    linkPath: '/link' as AbsolutePath,
     isLocal: false,
     ...overrides,
+  }
+}
+
+/**
+ * Bundle a list of symlinks into the minimal `Skill` shape that
+ * {@link getSkillItemVisibility} reads. `isOrphan` is auto-derived from the
+ * symlinks (every entry broken/missing AND no local copy = orphan), matching
+ * what `scanOrphanSymlinks` would set in production. Override when a test
+ * needs to assert the inverse.
+ */
+function makeSkill(
+  symlinks: SymlinkInfo[],
+  overrides?: Partial<Pick<Skill, 'isOrphan'>>,
+): Pick<Skill, 'symlinks' | 'isOrphan'> {
+  const derivedOrphan =
+    symlinks.length > 0 &&
+    symlinks.some((s) => s.status === 'broken') &&
+    !symlinks.some((s) => s.status === 'valid' || s.isLocal)
+  return {
+    symlinks,
+    isOrphan: overrides?.isOrphan ?? derivedOrphan,
   }
 }
 
 describe('getSkillItemVisibility', () => {
   describe('global view (no agent selected)', () => {
     it('shows delete and add buttons, hides unlink', () => {
-      const result = getSkillItemVisibility(null, [])
+      const result = getSkillItemVisibility(null, makeSkill([]))
 
       expect(result.showDeleteButton).toBe(true)
       expect(result.showAddButton).toBe(true)
@@ -35,7 +61,7 @@ describe('getSkillItemVisibility', () => {
 
     it('shows delete and add even when symlinks exist', () => {
       const symlinks = [makeSymlink({ agentId: 'cursor' })]
-      const result = getSkillItemVisibility(null, symlinks)
+      const result = getSkillItemVisibility(null, makeSkill(symlinks))
 
       expect(result.showDeleteButton).toBe(true)
       expect(result.showAddButton).toBe(true)
@@ -45,7 +71,7 @@ describe('getSkillItemVisibility', () => {
 
   describe('agent filtered view (agent selected)', () => {
     it('hides delete button and keeps add hidden when selected agent has no skill', () => {
-      const result = getSkillItemVisibility('cursor', [])
+      const result = getSkillItemVisibility('cursor', makeSkill([]))
 
       expect(result.showDeleteButton).toBe(false)
       expect(result.showAddButton).toBe(false)
@@ -55,7 +81,7 @@ describe('getSkillItemVisibility', () => {
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: false }),
       ]
-      const result = getSkillItemVisibility('cursor', symlinks)
+      const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
 
       expect(result.showAddButton).toBe(true)
     })
@@ -64,7 +90,7 @@ describe('getSkillItemVisibility', () => {
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: true }),
       ]
-      const result = getSkillItemVisibility('cursor', symlinks)
+      const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
 
       expect(result.showAddButton).toBe(true)
     })
@@ -73,18 +99,36 @@ describe('getSkillItemVisibility', () => {
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: false }),
       ]
-      const result = getSkillItemVisibility('cursor', symlinks)
+      const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
 
       expect(result.showUnlinkButton).toBe(true)
       expect(result.isLinked).toBe(true)
       expect(result.selectedAgentSymlink).toBe(symlinks[0])
     })
 
-    it('shows unlink button for broken symlink (but isLinked is false)', () => {
+    it('hides unlink button for orphan-only broken symlink (no usable copy anywhere)', () => {
+      // A skill whose every entry is broken/missing has no source — issue #127
+      // Option B fix routes orphans to a separate cleanup flow (#71), so the
+      // existing X button must not surface (its IPC handlers don't support
+      // orphan removal cleanly).
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'broken', isLocal: false }),
       ]
-      const result = getSkillItemVisibility('cursor', symlinks)
+      const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
+
+      expect(result.showUnlinkButton).toBe(false)
+      expect(result.isLinked).toBe(false)
+    })
+
+    it('still shows unlink for broken symlink when another agent has a valid copy', () => {
+      // Live source skill with one healthy and one broken agent link — the
+      // orphan guard must NOT trigger here. Removing the broken link is safe
+      // and meaningful because the source still exists.
+      const symlinks = [
+        makeSymlink({ agentId: 'cursor', status: 'broken', isLocal: false }),
+        makeSymlink({ agentId: 'codex', status: 'valid', isLocal: false }),
+      ]
+      const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
 
       expect(result.showUnlinkButton).toBe(true)
       expect(result.isLinked).toBe(false)
@@ -94,7 +138,7 @@ describe('getSkillItemVisibility', () => {
       const symlinks = [
         makeSymlink({ agentId: 'codex', status: 'valid', isLocal: false }),
       ]
-      const result = getSkillItemVisibility('cursor', symlinks)
+      const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
 
       expect(result.showUnlinkButton).toBe(false)
       expect(result.selectedAgentSymlink).toBeNull()
@@ -104,7 +148,7 @@ describe('getSkillItemVisibility', () => {
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: true }),
       ]
-      const result = getSkillItemVisibility('cursor', symlinks)
+      const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
 
       expect(result.showUnlinkButton).toBe(true)
       expect(result.selectedAgentSymlink).toBeNull()
@@ -115,7 +159,7 @@ describe('getSkillItemVisibility', () => {
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: true }),
       ]
-      const result = getSkillItemVisibility('cursor', symlinks)
+      const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
 
       expect(result.isLocalSkill).toBe(true)
       expect(result.isLinked).toBe(false)
@@ -126,7 +170,7 @@ describe('getSkillItemVisibility', () => {
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: false }),
       ]
-      const result = getSkillItemVisibility('cursor', symlinks)
+      const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
 
       expect(result.isLocalSkill).toBe(false)
       expect(result.isLinked).toBe(true)
@@ -137,7 +181,7 @@ describe('getSkillItemVisibility', () => {
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: true }),
       ]
-      const result = getSkillItemVisibility(null, symlinks)
+      const result = getSkillItemVisibility(null, makeSkill(symlinks))
 
       expect(result.isLocalSkill).toBe(false)
       expect(result.selectedLocalSkillInfo).toBeNull()
@@ -147,7 +191,7 @@ describe('getSkillItemVisibility', () => {
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'missing', isLocal: false }),
       ]
-      const result = getSkillItemVisibility('cursor', symlinks)
+      const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
 
       expect(result.showUnlinkButton).toBe(false)
     })
@@ -158,7 +202,7 @@ describe('getSkillItemVisibility', () => {
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: false }),
       ]
-      const result = getSkillItemVisibility(null, symlinks)
+      const result = getSkillItemVisibility(null, makeSkill(symlinks))
       expect(result.showCopyButton).toBe(false)
     })
 
@@ -166,7 +210,7 @@ describe('getSkillItemVisibility', () => {
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: false }),
       ]
-      const result = getSkillItemVisibility('codex', symlinks)
+      const result = getSkillItemVisibility('codex', makeSkill(symlinks))
       expect(result.showCopyButton).toBe(false)
     })
 
@@ -174,7 +218,7 @@ describe('getSkillItemVisibility', () => {
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: false }),
       ]
-      const result = getSkillItemVisibility('cursor', symlinks)
+      const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
       expect(result.showCopyButton).toBe(true)
     })
 
@@ -182,7 +226,7 @@ describe('getSkillItemVisibility', () => {
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: true }),
       ]
-      const result = getSkillItemVisibility('cursor', symlinks)
+      const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
       expect(result.showCopyButton).toBe(true)
     })
 
@@ -190,7 +234,7 @@ describe('getSkillItemVisibility', () => {
       const symlinks = [
         makeSymlink({ agentId: 'codex', status: 'valid', isLocal: false }),
       ]
-      const result = getSkillItemVisibility('cursor', symlinks)
+      const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
       expect(result.showCopyButton).toBe(false)
     })
   })
@@ -207,7 +251,7 @@ describe('getSkillItemVisibility', () => {
         }),
       ]
 
-      const result = getSkillItemVisibility('claude-code', symlinks)
+      const result = getSkillItemVisibility('claude-code', makeSkill(symlinks))
       expect(result.showGStackBadge).toBe(true)
     })
 
@@ -222,7 +266,7 @@ describe('getSkillItemVisibility', () => {
         }),
       ]
 
-      const result = getSkillItemVisibility('codex', symlinks)
+      const result = getSkillItemVisibility('codex', makeSkill(symlinks))
       expect(result.showGStackBadge).toBe(true)
     })
 
@@ -236,7 +280,7 @@ describe('getSkillItemVisibility', () => {
         }),
       ]
 
-      const result = getSkillItemVisibility(null, symlinks)
+      const result = getSkillItemVisibility(null, makeSkill(symlinks))
       expect(result.showGStackBadge).toBe(false)
     })
 
@@ -251,8 +295,41 @@ describe('getSkillItemVisibility', () => {
         }),
       ]
 
-      const result = getSkillItemVisibility('gemini-cli', symlinks)
+      const result = getSkillItemVisibility('gemini-cli', makeSkill(symlinks))
       expect(result.showGStackBadge).toBe(false)
+    })
+  })
+
+  describe('orphan skill guard (issue #127)', () => {
+    it('hides global delete button for orphan-only skill', () => {
+      // Source removed, broken symlinks across two agents, no real folders.
+      const symlinks = [
+        makeSymlink({ agentId: 'cursor', status: 'broken', isLocal: false }),
+        makeSymlink({ agentId: 'codex', status: 'broken', isLocal: false }),
+      ]
+      const result = getSkillItemVisibility(null, makeSkill(symlinks))
+
+      expect(result.showDeleteButton).toBe(false)
+    })
+
+    it('keeps global delete button visible when at least one agent has a valid copy', () => {
+      const symlinks = [
+        makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: false }),
+        makeSymlink({ agentId: 'codex', status: 'broken', isLocal: false }),
+      ]
+      const result = getSkillItemVisibility(null, makeSkill(symlinks))
+
+      expect(result.showDeleteButton).toBe(true)
+    })
+
+    it('keeps global delete button visible when at least one agent has a local copy', () => {
+      const symlinks = [
+        makeSymlink({ agentId: 'cursor', status: 'broken', isLocal: false }),
+        makeSymlink({ agentId: 'codex', status: 'valid', isLocal: true }),
+      ]
+      const result = getSkillItemVisibility(null, makeSkill(symlinks))
+
+      expect(result.showDeleteButton).toBe(true)
     })
   })
 
@@ -262,7 +339,7 @@ describe('getSkillItemVisibility', () => {
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: false }),
       ]
-      const result = getSkillItemVisibility('cursor', symlinks)
+      const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
 
       // When agent is selected, delete must be hidden
       expect(result.showDeleteButton).toBe(false)
@@ -279,13 +356,16 @@ describe('getSkillItemVisibility', () => {
       ]
 
       // With agent selected
-      const agentView = getSkillItemVisibility('claude-code', symlinks)
+      const agentView = getSkillItemVisibility(
+        'claude-code',
+        makeSkill(symlinks),
+      )
       expect(agentView.showDeleteButton && agentView.showUnlinkButton).toBe(
         false,
       )
 
       // Without agent selected
-      const globalView = getSkillItemVisibility(null, symlinks)
+      const globalView = getSkillItemVisibility(null, makeSkill(symlinks))
       expect(globalView.showDeleteButton && globalView.showUnlinkButton).toBe(
         false,
       )

--- a/src/renderer/src/components/skills/skillItemHelpers.test.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.test.ts
@@ -331,6 +331,21 @@ describe('getSkillItemVisibility', () => {
 
       expect(result.showDeleteButton).toBe(true)
     })
+
+    it('respects explicit isOrphan override even when symlinks would derive false', () => {
+      // Pins the contract that getSkillItemVisibility reads `isOrphan` straight
+      // off the skill (set by scanOrphanSymlinks in main) instead of
+      // re-deriving it from `symlinks`. A valid symlink would otherwise drive
+      // derivedOrphan=false; the override keeps the orphan path active.
+      const symlinks = [
+        makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: false }),
+      ]
+      const result = getSkillItemVisibility(
+        null,
+        makeSkill(symlinks, { isOrphan: true }),
+      )
+      expect(result.showDeleteButton).toBe(false)
+    })
   })
 
   describe('regression: dual delete buttons', () => {

--- a/src/renderer/src/components/skills/skillItemHelpers.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.ts
@@ -1,5 +1,5 @@
 import { GSTACK_BADGE_AGENT_IDS } from '../../../../shared/constants'
-import type { AgentId, SymlinkInfo } from '../../../../shared/types'
+import type { AgentId, Skill, SymlinkInfo } from '../../../../shared/types'
 
 /**
  * Visibility state for SkillItem action buttons.
@@ -53,28 +53,41 @@ function isGStackBundlePath(candidatePath: string): boolean {
 /**
  * Compute which action buttons to show on a SkillItem card.
  *
+ * Reads `isOrphan` directly off the skill — set by `scanOrphanSymlinks` in
+ * main, where the source-skill existence check actually lives — instead of
+ * re-deriving it from `symlinks`. The renderer no longer needs to know the
+ * orphan rule; it only needs to know how to react to it.
+ *
  * @param selectedAgentId - Currently selected agent filter (null = global view)
- * @param symlinks - Symlink info array for the skill
+ * @param skill - The skill being rendered (only `symlinks` and `isOrphan` are read)
  * @returns Visibility flags for each action button
  *
  * @example
  * // Global view (no agent filter) — show delete & add, hide unlink
- * getSkillItemVisibility(null, []) // => { showDeleteButton: true, showAddButton: true, showUnlinkButton: false, ... }
+ * getSkillItemVisibility(null, { symlinks: [], isOrphan: false })
+ * // => { showDeleteButton: true, showAddButton: true, showUnlinkButton: false, ... }
  *
  * @example
  * // Agent filtered view with valid symlink — show unlink and add, hide delete
- * getSkillItemVisibility('cursor', [{ agentId: 'cursor', status: 'valid', isLocal: false, ... }])
+ * getSkillItemVisibility('cursor', {
+ *   symlinks: [{ agentId: 'cursor', status: 'valid', isLocal: false, ... }],
+ *   isOrphan: false,
+ * })
  * // => { showDeleteButton: false, showAddButton: true, showUnlinkButton: true, isLinked: true, ... }
  *
  * @example
- * // Agent filtered view with local skill — show unlink button for deletion
- * getSkillItemVisibility('cursor', [{ agentId: 'cursor', status: 'valid', isLocal: true, ... }])
- * // => { showDeleteButton: false, showUnlinkButton: true, isLocalSkill: true, selectedLocalSkillInfo: {...}, ... }
+ * // Orphan skill — both delete and unlink hidden (cleanup flow handled separately)
+ * getSkillItemVisibility(null, {
+ *   symlinks: [{ agentId: 'cursor', status: 'broken', isLocal: false, ... }],
+ *   isOrphan: true,
+ * })
+ * // => { showDeleteButton: false, showUnlinkButton: false, ... }
  */
 export function getSkillItemVisibility(
   selectedAgentId: AgentId | null,
-  symlinks: SymlinkInfo[],
+  skill: Pick<Skill, 'symlinks' | 'isOrphan'>,
 ): SkillItemVisibility {
+  const { symlinks, isOrphan } = skill
   const selectedAgentSymlink = selectedAgentId
     ? (symlinks.find(
         (s) =>
@@ -90,6 +103,8 @@ export function getSkillItemVisibility(
 
   const isLocalSkill = !!selectedLocalSkillInfo
   const hasSkillInSelectedAgent = !!selectedAgentSymlink || isLocalSkill
+  // Orphan handling — see Skill.isOrphan for why the delete/unlink buttons
+  // are gated. Source: scanOrphanSymlinks() in src/main/services/skillScanner.ts.
   const gStackPathCandidates = [
     selectedAgentSymlink?.targetPath ?? '',
     selectedAgentSymlink?.linkPath ?? '',
@@ -102,9 +117,9 @@ export function getSkillItemVisibility(
     isGStackEligibleAgent && gStackPathCandidates.some(isGStackBundlePath)
 
   return {
-    showDeleteButton: !selectedAgentId,
+    showDeleteButton: !selectedAgentId && !isOrphan,
     showAddButton: !selectedAgentId || hasSkillInSelectedAgent,
-    showUnlinkButton: hasSkillInSelectedAgent,
+    showUnlinkButton: hasSkillInSelectedAgent && !isOrphan,
     isLinked: !!selectedAgentSymlink && selectedAgentSymlink.status === 'valid',
     isLocalSkill,
     selectedAgentSymlink,

--- a/src/renderer/src/redux/selectors.test.ts
+++ b/src/renderer/src/redux/selectors.test.ts
@@ -144,6 +144,7 @@ const makeSkill = (
     },
   ],
   isSource: !isLocal,
+  isOrphan: false,
   ...(source
     ? {
         source: repositoryId(source),
@@ -247,6 +248,7 @@ describe('selectFilteredSkills', () => {
         },
       ],
       isSource: true,
+      isOrphan: false,
     }
     const state = buildState({ skills: [skill], selectedAgentId: 'cursor' })
     expect(selectFilteredSkills(state as never)).toHaveLength(0)

--- a/src/renderer/src/redux/slices/skillsSlice.test.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.test.ts
@@ -62,6 +62,7 @@ const sampleSkill: Skill = {
     },
   ],
   isSource: true,
+  isOrphan: false,
 }
 
 const secondSkill: Skill = {

--- a/src/renderer/src/utils/getLocationViewModel.test.ts
+++ b/src/renderer/src/utils/getLocationViewModel.test.ts
@@ -29,6 +29,7 @@ const makeSkill = (
   symlinkCount: symlinks.filter((s) => s.status === 'valid').length,
   symlinks,
   isSource,
+  isOrphan: false,
 })
 
 describe('getLocationViewModel', () => {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -161,6 +161,13 @@ export interface Skill {
    * Used by the renderer to filter the SourceCard view to source-dir skills only.
    */
   isSource: boolean
+  /**
+   * `true` when every entry in `symlinks` is broken/missing AND no real local
+   * folder exists for the skill — i.e. the source skill was deleted but agent
+   * symlinks still dangle. Set by `scanOrphanSymlinks`; the renderer reads it
+   * to gate delete/unlink buttons (see issue #127, cleanup flow #71).
+   */
+  isOrphan: boolean
   /** Short source identifier in owner/repo format. @example "vercel-labs/skills" */
   source?: RepositoryId
   /** Full URL to the source repository. @example "https://github.com/vercel-labs/skills.git" */
@@ -215,8 +222,13 @@ export interface SymlinkInfo {
   agentName: AgentName
   /** Current symlink state: valid (linked), broken (dangling), or missing (no link) */
   status: SymlinkStatus
-  /** Where the symlink points to (skill source directory). @example "/Users/me/.agents/skills/tdd-workflow" */
-  targetPath: AbsolutePath
+  /**
+   * Where the symlink points to (skill source directory). Omitted when no
+   * symlink exists for this agent (`status === 'missing'`) or the entry is a
+   * real local folder (`isLocal === true`) — both have no target to record.
+   * @example "/Users/me/.agents/skills/tdd-workflow"
+   */
+  targetPath?: AbsolutePath
   /** Where the symlink lives (in agent's skills dir). @example "/Users/me/.cursor/skills/tdd-workflow" */
   linkPath: AbsolutePath
   /** true = real folder in agent dir (local skill), false = symlink */


### PR DESCRIPTION
## Summary

Closes #127.

- **scanner**: rewrite `scanOrphanSymlinks` so dangling symlinks (whose source skill in `~/.agents/skills/` no longer exists) surface as orphan `Skill` records instead of vanishing. Each affected agent is marked `broken`; other agents stay `missing`. The renderer reads `Skill.isOrphan` directly to gate the delete/unlink buttons rather than re-deriving the rule.
- **types**: add `Skill.isOrphan` and make `SymlinkInfo.targetPath` optional so orphan entries don't lie about a target that no longer resolves.
- **regression test**: new e2e case in `regression.e2e.ts` stages a phantom symlink in `~/.codeium/windsurf/skills`, refreshes state, and asserts the orphan record is surfaced (`isOrphan: true`, `isSource: false`, broken description) plus a negative control on `azure-ai` to make sure normal skills aren't misclassified.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `npx tsc -p e2e/tsconfig.json --noEmit`
- [x] `pnpm test` — 829/829 passing
- [x] `pnpm test:e2e` — 27/27 passing (full suite)
- [x] Targeted regression test passes (`--grep "regression #127"`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * オーファンスキル（ソース削除後もエージェント側にシンボリックリンクが残る状態）の自動検出と表示機能を追加しました

* **バグ修正**
  * オーファンスキルに対する削除・アンリンク操作を無効化しました

* **テスト**
  * オーファンスキル処理の包括的なテストカバレッジを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->