### PR TITLE
feat(orphan): IPC + UI delete pathway for orphan symlinks (#71)

### DIFF
--- a/e2e/spec/delete.e2e.ts
+++ b/e2e/spec/delete.e2e.ts
@@ -4,6 +4,7 @@ import {
   mkdirSync,
   readFileSync,
   readdirSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs'
 import { join } from 'node:path'
@@ -366,6 +367,86 @@ test('deleteSkill moves a local-only skill into trash with kind="local-only" man
   expect(manifest.localCopies).toHaveLength(1)
   expect(manifest.localCopies[0].agentId).toBe('codex')
   expect(manifest.localCopies[0].linkPath).toBe(codexAgentDir)
+})
+
+/**
+ * Orphan-cleared delete branch (issue #71 PR-1) — exercises the third arm of
+ * `moveToTrash`'s dispatcher in `trashService.ts:moveToTrash`. Both the source
+ * dir AND every agent's local copy are absent; the only remaining records are
+ * dangling symlinks. The handler must:
+ *
+ *   1. Probe `~/.agents/skills/<name>` → ENOENT, NOT throw.
+ *   2. `scanLocalCopies` → empty (no real folders anywhere).
+ *   3. `scanOrphanSymlinkPaths` → finds the dangling links.
+ *   4. `clearOrphanSymlinks` unlinks each, returns `kind: 'orphan-cleared'`.
+ *   5. NO trash entry, NO manifest, NO TTL timer — the source is gone, so
+ *      "undo" would only restore broken links.
+ *
+ * The single-delete IPC `SKILLS_DELETE` strips `kind` and `tombstoneId` from
+ * the result (see `src/main/ipc/skills.ts:SKILLS_DELETE`); only the bulk-delete
+ * path discriminates on `outcome`. So this test asserts only the common-shape
+ * fields (`success`, `symlinksRemoved`, `cascadeAgents`) plus the FS invariants
+ * — link gone, trash dir untouched.
+ */
+test('deleteSkill clears orphan (broken) symlinks with no trash entry', async ({
+  appWindow,
+  isolatedHome,
+}) => {
+  const skillName = 'orphan-only-fixture'
+  // Stage a dangling symlink under codex (chosen for the same QA Safety
+  // reason as the local-only test above — avoids touching .claude/.cursor).
+  // Target is a path under SOURCE_DIR that we never create, so `fs.access`
+  // on it returns ENOENT and the orphan scanner picks it up.
+  const codexSkillsDir = join(isolatedHome, '.codex', 'skills')
+  mkdirSync(codexSkillsDir, { recursive: true })
+  const phantomSourcePath = join(isolatedHome, '.agents', 'skills', skillName)
+  const orphanLinkPath = join(codexSkillsDir, skillName)
+  symlinkSync(phantomSourcePath, orphanLinkPath)
+
+  // Sanity — staged shape is a real symlink with an absent target.
+  expect(lstatSync(orphanLinkPath).isSymbolicLink()).toBe(true)
+  expect(existsSync(phantomSourcePath)).toBe(false)
+
+  await waitForInitialScan(appWindow)
+
+  const ipcResult = await appWindow.evaluate(
+    async (name: string) =>
+      window.electron.skills.deleteSkill({ skillName: name }),
+    skillName,
+  )
+
+  expect(ipcResult.success).toBe(true)
+  // Common-shape fields work for both kinds. orphan-cleared returns the
+  // unlinked count and the agents whose links were swept.
+  expect(ipcResult.symlinksRemoved).toBe(1)
+  expect(ipcResult.cascadeAgents).toEqual(['codex'])
+
+  // FS — the dangling symlink itself is gone (lstat throws ENOENT). Using
+  // lstat (not stat) because stat follows symlinks and would have thrown
+  // even before the delete, masking a no-op regression.
+  expect(existsSync(orphanLinkPath)).toBe(false)
+  expect(() => lstatSync(orphanLinkPath)).toThrow()
+
+  // FS — KEY assertion: NO trash entry was written. The orphan branch
+  // deliberately skips manifest/TTL/evict-timer machinery because there
+  // is nothing meaningful to undo. A regression that mistakenly took the
+  // source-backed or local-only path would leave a tombstone here.
+  const trashDir = join(isolatedHome, '.agents', '.trash')
+  const trashEntries = existsSync(trashDir)
+    ? readdirSync(trashDir).filter((entry) => entry.includes(`-${skillName}-`))
+    : []
+  expect(
+    trashEntries,
+    'orphan-cleared must not write a tombstone — there is no source to restore',
+  ).toEqual([])
+
+  // Redux — the orphan row disappears from skills.items after rescan.
+  await refreshSkillsState(appWindow)
+  const stillPresent = await getStoreState(appWindow, (state) => {
+    const root = state as { skills: { items: Array<{ name: string }> } }
+    return root.skills.items.some((skill) => skill.name === skillName)
+  })
+  expect(stillPresent).toBe(false)
 })
 
 /**

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -271,18 +271,26 @@ export function registerSkillsHandlers(): void {
 
       for (const [itemIndex, { skillName }] of items.entries()) {
         try {
-          const {
-            tombstoneId: id,
-            cascadeAgents,
-            symlinksRemoved,
-          } = await moveToTrash(skillName)
-          results.push({
-            skillName,
-            outcome: 'deleted',
-            tombstoneId: id,
-            symlinksRemoved,
-            cascadeAgents,
-          })
+          const moveResult = await moveToTrash(skillName)
+          // Discriminate on `kind` so the renderer can tell apart "this row has
+          // a tombstone, wire it into the Undo toast" from "this row is just a
+          // broken-symlink sweep with no undo path".
+          if (moveResult.kind === 'tombstoned') {
+            results.push({
+              skillName,
+              outcome: 'deleted',
+              tombstoneId: moveResult.tombstoneId,
+              symlinksRemoved: moveResult.symlinksRemoved,
+              cascadeAgents: moveResult.cascadeAgents,
+            })
+          } else {
+            results.push({
+              skillName,
+              outcome: 'orphan-cleared',
+              symlinksRemoved: moveResult.symlinksRemoved,
+              cascadeAgents: moveResult.cascadeAgents,
+            })
+          }
         } catch (error) {
           const message =
             error instanceof TrashError

--- a/src/main/services/trashService.integration.test.ts
+++ b/src/main/services/trashService.integration.test.ts
@@ -1,6 +1,8 @@
 import { mkdtempSync, realpathSync } from 'node:fs'
 import {
+  lstat,
   mkdir,
+  readdir,
   readFile,
   readlink,
   rm,
@@ -20,6 +22,8 @@ import {
   it,
   vi,
 } from 'vitest'
+
+import type { MoveToTrashResult } from './trashService'
 
 // sharedHome is stamped SYNCHRONOUSLY at module load so that the vi.mock
 // factory below captures a defined value by the time `trashService` is
@@ -70,6 +74,28 @@ const trashServicePromise = (async () => {
   const mod = await import('./trashService')
   return mod
 })()
+
+/**
+ * Narrow a `MoveToTrashResult` to the `tombstoned` variant for the rest of the
+ * caller's scope. Every existing test in this file exercises a source-backed
+ * or local-only path, both of which produce `kind: 'tombstoned'`. The new
+ * `'orphan-cleared'` arm (added in PR-1 of issue #71) has its own dedicated
+ * test below — for the legacy tests we just need to assert and continue.
+ *
+ * @param result - Result returned by `moveToTrash` under test
+ * @throws Error if the result is not a tombstoned variant
+ * @example
+ * const deleteResult = await moveToTrash(skillName)
+ * assertTombstoned(deleteResult)
+ * // deleteResult.tombstoneId is now type-safe to access
+ */
+function assertTombstoned(
+  result: MoveToTrashResult,
+): asserts result is Extract<MoveToTrashResult, { kind: 'tombstoned' }> {
+  if (result.kind !== 'tombstoned') {
+    throw new Error(`Expected tombstoned result, got kind=${result.kind}`)
+  }
+}
 
 describe('trashService (integration)', () => {
   beforeAll(async () => {
@@ -144,6 +170,25 @@ describe('trashService (integration)', () => {
     return localPath
   }
 
+  /**
+   * Create a broken symlink in an agent dir: the link is well-formed but its
+   * target — `sharedSourceDir/<name>` — was never created (or was deleted),
+   * so `fs.access(target)` fails with ENOENT. This is exactly the disk shape
+   * the orphan branch of `moveToTrash` is meant to clean up.
+   * @param skillName - Skill name (target basename under SOURCE_DIR)
+   * @param agentBaseDir - Absolute path to the agent's skills dir
+   * @returns Absolute path to the dangling symlink
+   */
+  async function makeBrokenSymlink(
+    skillName: string,
+    agentBaseDir: string,
+  ): Promise<string> {
+    const linkPath = join(agentBaseDir, skillName)
+    const danglingTarget = join(sharedSourceDir, skillName)
+    await symlink(danglingTarget, linkPath)
+    return linkPath
+  }
+
   it('round-trip: moves source and agent symlink into trash, then restores both', async () => {
     const { moveToTrash, restore } = await trashServicePromise
 
@@ -156,6 +201,7 @@ describe('trashService (integration)', () => {
     await stat(linkPath)
 
     const deleteResult = await moveToTrash(skillName)
+    assertTombstoned(deleteResult)
     // With both `os` and `node:os` mocked, `AGENTS` paths resolve under
     // `sharedHome` so the cursor symlink we created above is actually
     // walked, recorded, and unlinked by the cascade. The exact count is
@@ -212,6 +258,7 @@ describe('trashService (integration)', () => {
     const skillName = 'manifest-corrupt-skill'
     await makeSourceSkill(skillName)
     const result = await moveToTrash(skillName)
+    assertTombstoned(result)
 
     // Corrupt the manifest.
     const manifestPath = join(
@@ -236,6 +283,7 @@ describe('trashService (integration)', () => {
     const skillName = 'collision-skill'
     const sourcePath = await makeSourceSkill(skillName)
     const result = await moveToTrash(skillName)
+    assertTombstoned(result)
 
     // Recreate something at the original source path to simulate a reinstall
     // before the user pressed undo.
@@ -272,6 +320,8 @@ describe('trashService (integration)', () => {
         return moveToTrash('race-b')
       })(),
     ])
+    assertTombstoned(a)
+    assertTombstoned(b)
     expect(a.tombstoneId).not.toBe(b.tombstoneId)
   })
 
@@ -282,6 +332,7 @@ describe('trashService (integration)', () => {
     const skillName = 'sweep-recent'
     await makeSourceSkill(skillName)
     const recent = await moveToTrash(skillName)
+    assertTombstoned(recent)
 
     // Planted ancient entry: must be swept.
     // Its basename must still match the trash naming regex (digits-skill-hex8).
@@ -304,6 +355,7 @@ describe('trashService (integration)', () => {
     const skillName = 'evict-then-restore'
     await makeSourceSkill(skillName)
     const result = await moveToTrash(skillName)
+    assertTombstoned(result)
 
     await evict(result.tombstoneId)
     const restoreResult = await restore(result.tombstoneId)
@@ -324,6 +376,7 @@ describe('trashService (integration)', () => {
     const skillName = 'manifest-check'
     const sourcePath = await makeSourceSkill(skillName)
     const result = await moveToTrash(skillName)
+    assertTombstoned(result)
 
     const manifestPath = join(
       sharedTrashDir,
@@ -353,6 +406,7 @@ describe('trashService (integration)', () => {
     const skillName = 'nested-source'
     await makeSourceSkill(skillName)
     const result = await moveToTrash(skillName)
+    assertTombstoned(result)
 
     // The moved source must live under entry/source.
     const trashSourceChild = join(
@@ -384,6 +438,7 @@ describe('trashService (integration)', () => {
     await expect(stat(join(sharedSourceDir, skillName))).rejects.toThrow()
 
     const deleteResult = await moveToTrash(skillName)
+    assertTombstoned(deleteResult)
     expect(deleteResult.cascadeAgents).toContain('claude-code')
     // The local copy is staged under entryDir/local-copies — count it for parity
     // with the source-backed path so the renderer's "skills removed" toast works.
@@ -430,6 +485,7 @@ describe('trashService (integration)', () => {
     const localPath = await makeLocalSkill(skillName, sharedAgentClaude)
 
     const deleteResult = await moveToTrash(skillName)
+    assertTombstoned(deleteResult)
     await expect(stat(localPath)).rejects.toThrow()
 
     const restoreResult = await restore(deleteResult.tombstoneId)
@@ -465,6 +521,7 @@ describe('trashService (integration)', () => {
     const orphanLocal = await makeLocalSkill(skillName, sharedAgentClaude)
 
     const deleteResult = await moveToTrash(skillName)
+    assertTombstoned(deleteResult)
 
     // Source went into trash entry under /source.
     await expect(stat(sourcePath)).rejects.toThrow()
@@ -507,6 +564,76 @@ describe('trashService (integration)', () => {
       cascadeAgents: ['claude-code'],
       symlinksRemoved: 1,
     })
+  })
+
+  // ---------------------------------------------------------------------
+  // Orphan-branch tests (issue #71 PR-1). When the source skill is gone
+  // and no agent has a real local copy, every remaining record is a broken
+  // symlink. moveToTrash sweeps them with no manifest/no undo, returning
+  // `kind: 'orphan-cleared'`. The renderer's bulkDelete summary counts these
+  // as success rows even though they have no `tombstoneId`.
+  // ---------------------------------------------------------------------
+
+  it('moveToTrash: pure orphan returns orphan-cleared and unlinks the dangling symlink', async () => {
+    const { moveToTrash } = await trashServicePromise
+
+    const skillName = 'pure-orphan-skill'
+    const linkPath = await makeBrokenSymlink(skillName, sharedAgentCursor)
+    // Sanity: lstat sees the symlink itself; access on the target fails
+    // (target was never created), confirming the orphan disk shape.
+    const linkStats = await lstat(linkPath)
+    expect(linkStats.isSymbolicLink()).toBe(true)
+
+    const result = await moveToTrash(skillName)
+    expect(result.kind).toBe('orphan-cleared')
+    if (result.kind === 'orphan-cleared') {
+      expect(result.cascadeAgents).toEqual(['cursor'])
+      expect(result.symlinksRemoved).toBe(1)
+    }
+
+    // The symlink itself is gone (lstat throws ENOENT now).
+    await expect(lstat(linkPath)).rejects.toThrow()
+  })
+
+  it('moveToTrash: orphan branch sweeps broken symlinks across multiple agents', async () => {
+    const { moveToTrash } = await trashServicePromise
+
+    const skillName = 'multi-agent-orphan'
+    const cursorLink = await makeBrokenSymlink(skillName, sharedAgentCursor)
+    const claudeLink = await makeBrokenSymlink(skillName, sharedAgentClaude)
+
+    const result = await moveToTrash(skillName)
+    expect(result.kind).toBe('orphan-cleared')
+    if (result.kind === 'orphan-cleared') {
+      expect(result.symlinksRemoved).toBe(2)
+      // Cascade order follows AGENTS table iteration; assert membership rather
+      // than exact order so a future reordering of AGENTS doesn't break this.
+      expect(result.cascadeAgents).toContain('cursor')
+      expect(result.cascadeAgents).toContain('claude-code')
+    }
+
+    await expect(lstat(cursorLink)).rejects.toThrow()
+    await expect(lstat(claudeLink)).rejects.toThrow()
+  })
+
+  it('moveToTrash: orphan branch writes no tombstone (no undo for orphan)', async () => {
+    // The whole point of the orphan-cleared variant: there is nothing
+    // meaningful to restore (resurrected symlinks would still be broken),
+    // so we skip the manifest/TTL/evict timer machinery entirely.
+    const { moveToTrash } = await trashServicePromise
+
+    const skillName = 'orphan-no-tombstone'
+    await makeBrokenSymlink(skillName, sharedAgentCursor)
+
+    const result = await moveToTrash(skillName)
+    expect(result.kind).toBe('orphan-cleared')
+
+    // Trash dir is wiped in afterEach, so any entry here was created by THIS
+    // call. An orphan-cleared run must leave it empty (or the dir absent).
+    const trashEntries = await readdir(sharedTrashDir).catch(
+      () => [] as string[],
+    )
+    expect(trashEntries).toEqual([])
   })
 })
 

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -309,15 +309,28 @@ async function scanOrphanSymlinkPaths(
       await fs.access(resolvedTarget)
       // Target resolves — not orphan. Skip.
       continue
-    } catch {
-      // ENOENT (or any access failure) → treat as broken. The bulk cleanup
-      // path is forgiving: if a permission-denied read makes us mis-classify
-      // a live link as broken, the subsequent `unlink` will also EACCES and
-      // get logged; we never silently delete data we couldn't read.
-      orphans.push({
+    } catch (error) {
+      // Only ENOENT / ENOTDIR confirm "the target is gone". Other codes
+      // (EACCES, EPERM, ELOOP, etc.) mean we couldn't probe the target — the
+      // link might still be live and pointing at real data. Classifying those
+      // as orphan would let the subsequent `unlink` delete a working symlink
+      // a privileged process needs, so we log + skip and leave the entry
+      // for the user to investigate.
+      const code = errorCode(error)
+      if (code === 'ENOENT' || code === 'ENOTDIR') {
+        orphans.push({
+          agentId: agent.id,
+          linkPath: linkPath as AbsolutePath,
+          target,
+        })
+        continue
+      }
+      console.warn('trashService: scanOrphanSymlinkPaths access failed', {
         agentId: agent.id,
-        linkPath: linkPath as AbsolutePath,
-        target,
+        linkPath,
+        resolvedTarget,
+        code,
+        message: extractErrorMessage(error),
       })
     }
   }
@@ -344,6 +357,18 @@ async function clearOrphanSymlinks(
   const startTime = Date.now()
   const cascadeAgents: AgentId[] = []
   let symlinksRemoved = 0
+  /**
+   * Per-orphan unlink errors that did NOT recover via the ENOENT race path.
+   * Collected so we can fail the whole call atomically instead of returning
+   * a `'orphan-cleared'` success while data is still on disk — see why-throw
+   * note below.
+   */
+  const unlinkFailures: Array<{
+    agentId: AgentId
+    linkPath: AbsolutePath
+    code: string | undefined
+    message: string
+  }> = []
 
   for (const orphan of orphans) {
     try {
@@ -359,11 +384,18 @@ async function clearOrphanSymlinks(
         symlinksRemoved++
         continue
       }
+      const message = extractErrorMessage(error)
       console.warn('trashService: clearOrphanSymlinks unlink failed', {
         agentId: orphan.agentId,
         linkPath: orphan.linkPath,
         code,
-        message: extractErrorMessage(error),
+        message,
+      })
+      unlinkFailures.push({
+        agentId: orphan.agentId,
+        linkPath: orphan.linkPath,
+        code,
+        message,
       })
     }
   }
@@ -372,8 +404,23 @@ async function clearOrphanSymlinks(
     skillName,
     orphanCount: orphans.length,
     symlinksRemoved,
+    failureCount: unlinkFailures.length,
     durationMs: Date.now() - startTime,
   })
+
+  // Why throw on partial failure: the renderer (`MainContent.tsx`) treats
+  // `outcome: 'orphan-cleared'` as an unconditional success toast. Returning
+  // success while broken symlinks are still on disk would tell the user "all
+  // gone" while they're still seeing the orphan rows on the next scan — a
+  // trust-eroding lie. Throwing surfaces the failure as `outcome: 'error'`
+  // so the toast and row state stay honest. Successfully unlinked entries
+  // remain unlinked (no rollback) — re-running the delete will skip them via
+  // the ENOENT race path above, so the operation is idempotent.
+  if (unlinkFailures.length > 0) {
+    const firstFailure = unlinkFailures[0]
+    const summary = `Failed to remove ${unlinkFailures.length} of ${orphans.length} orphan ${orphans.length === 1 ? 'symlink' : 'symlinks'} for "${skillName}"`
+    throw new TrashError(summary, firstFailure?.code)
+  }
 
   return {
     kind: 'orphan-cleared',

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -164,6 +164,34 @@ async function rollbackMovedLocalCopies(
 }
 
 /**
+ * Discriminated result from `moveToTrash`.
+ *
+ * - `tombstoned`: source-backed or local-only delete; produces a trash entry +
+ *   manifest + TTL evict timer; renderer can surface an Undo toast that calls
+ *   `restore(tombstoneId)`.
+ * - `orphan-cleared`: every record was a broken symlink whose target source no
+ *   longer exists; cleanup is just a series of `unlink()` calls. No manifest,
+ *   no TTL, no undo — there is nothing meaningful to restore (the resurrected
+ *   symlinks would still be broken).
+ *
+ * Callers must dispatch on `kind` before reading `tombstoneId`. The discriminated
+ * union makes the "no undo" property a compile-time guarantee instead of a
+ * runtime convention.
+ */
+export type MoveToTrashResult =
+  | {
+      kind: 'tombstoned'
+      tombstoneId: TombstoneId
+      cascadeAgents: AgentId[]
+      symlinksRemoved: number
+    }
+  | {
+      kind: 'orphan-cleared'
+      cascadeAgents: AgentId[]
+      symlinksRemoved: number
+    }
+
+/**
  * Walk every configured agent directory and find real (non-symlink) folders
  * matching `skillName`. Used by `moveToTrash` when `~/.agents/skills/<name>`
  * has no source dir but the skill exists as a local copy in one or more agents.
@@ -212,33 +240,186 @@ async function scanLocalCopies(
 }
 
 /**
- * Move a skill into the on-disk trash. The skill may be:
- * - **source-backed**: `~/.agents/skills/<name>` exists; agent entries are
- *   symlinks pointing at it. Move source + unlink every symlink.
- * - **local-only**: no source dir; one or more agents hold the skill as a real
- *   folder. Move every real folder into `<entryDir>/local-copies/<agentId>/`.
+ * Walk every configured agent directory and find broken symlinks matching
+ * `skillName` — i.e. a symlink whose target no longer resolves. Used by
+ * `moveToTrash` when neither a source dir nor any local folder copies exist
+ * (every remaining record is a stranded link).
  *
- * Both flows write a v2 manifest with a `kind` discriminator that `restore()`
- * matches on. TTL eviction is scheduled regardless of kind.
+ * Valid (resolvable) symlinks are deliberately ignored: if they exist we are
+ * not in the orphan branch — `moveSourceBackedToTrash` already covers the
+ * case where any symlink, broken or otherwise, sits next to a live source.
+ *
+ * @param skillName - Validated skill name (no separators)
+ * @returns Per-agent broken-symlink records, ordered by AGENTS iteration
+ * @example
+ * // After `rm -rf ~/.agents/skills/abandoned`, all 14 agents still have
+ * // dangling symlinks. scanOrphanSymlinkPaths('abandoned') returns one
+ * // RecordedSymlink per agent with the broken target preserved for logging.
+ */
+async function scanOrphanSymlinkPaths(
+  skillName: SkillName,
+): Promise<RecordedSymlink[]> {
+  const orphans: RecordedSymlink[] = []
+  for (const agent of AGENTS) {
+    const linkPath = join(agent.path, skillName)
+    // Use getAllowedBases() — validatePath realpath-follows linkPath. A broken
+    // symlink's realpath chase fails, so we fall through to the catch and skip
+    // this agent rather than mis-classify the unverifiable path.
+    try {
+      validatePath(linkPath, getAllowedBases())
+    } catch {
+      continue
+    }
+
+    let stats: Awaited<ReturnType<typeof fs.lstat>>
+    try {
+      stats = await fs.lstat(linkPath)
+    } catch (error) {
+      if (errorCode(error) === 'ENOENT') continue
+      console.warn('trashService: scanOrphanSymlinkPaths lstat failed', {
+        agentId: agent.id,
+        linkPath,
+        code: errorCode(error),
+        message: extractErrorMessage(error),
+      })
+      continue
+    }
+    if (!stats.isSymbolicLink()) continue
+
+    let target: string
+    try {
+      target = await fs.readlink(linkPath)
+    } catch (error) {
+      if (errorCode(error) === 'ENOENT') continue
+      console.warn('trashService: scanOrphanSymlinkPaths readlink failed', {
+        agentId: agent.id,
+        linkPath,
+        code: errorCode(error),
+        message: extractErrorMessage(error),
+      })
+      continue
+    }
+
+    // Probe target. `readlink` returns the verbatim string used at create
+    // time — relative targets must be resolved against the link's own dir.
+    const resolvedTarget = isAbsolute(target)
+      ? target
+      : resolve(dirname(linkPath), target)
+    try {
+      await fs.access(resolvedTarget)
+      // Target resolves — not orphan. Skip.
+      continue
+    } catch {
+      // ENOENT (or any access failure) → treat as broken. The bulk cleanup
+      // path is forgiving: if a permission-denied read makes us mis-classify
+      // a live link as broken, the subsequent `unlink` will also EACCES and
+      // get logged; we never silently delete data we couldn't read.
+      orphans.push({
+        agentId: agent.id,
+        linkPath: linkPath as AbsolutePath,
+        target,
+      })
+    }
+  }
+  return orphans
+}
+
+/**
+ * Orphan path of `moveToTrash`. Removes every broken symlink for `skillName`
+ * across agents. No tombstone, no manifest, no undo — the source is gone, so
+ * resurrecting the broken links would only restore them to "still broken".
+ *
+ * Per-link errors are logged and skipped: bulk cleanup soldiers on so a
+ * single permission-denied agent doesn't strand the rest. The returned
+ * `symlinksRemoved` count reflects only successful unlinks.
+ *
+ * @param skillName - Validated skill name (only used for the info log)
+ * @param orphans - Records produced by `scanOrphanSymlinkPaths`
+ * @returns `kind: 'orphan-cleared'` with cascade list and unlink count
+ */
+async function clearOrphanSymlinks(
+  skillName: SkillName,
+  orphans: RecordedSymlink[],
+): Promise<Extract<MoveToTrashResult, { kind: 'orphan-cleared' }>> {
+  const startTime = Date.now()
+  const cascadeAgents: AgentId[] = []
+  let symlinksRemoved = 0
+
+  for (const orphan of orphans) {
+    try {
+      await fs.unlink(orphan.linkPath)
+      cascadeAgents.push(orphan.agentId)
+      symlinksRemoved++
+    } catch (error) {
+      const code = errorCode(error)
+      if (code === 'ENOENT') {
+        // Race: link disappeared between scan and unlink. The user-visible
+        // outcome ("orphan is gone") is the same, so count it as success.
+        cascadeAgents.push(orphan.agentId)
+        symlinksRemoved++
+        continue
+      }
+      console.warn('trashService: clearOrphanSymlinks unlink failed', {
+        agentId: orphan.agentId,
+        linkPath: orphan.linkPath,
+        code,
+        message: extractErrorMessage(error),
+      })
+    }
+  }
+
+  console.info('trashService: moveToTrash (orphan-cleared)', {
+    skillName,
+    orphanCount: orphans.length,
+    symlinksRemoved,
+    durationMs: Date.now() - startTime,
+  })
+
+  return {
+    kind: 'orphan-cleared',
+    cascadeAgents,
+    symlinksRemoved,
+  }
+}
+
+/**
+ * Move a skill into the on-disk trash. The skill may be in one of three states:
+ *
+ * - **source-backed** (`kind: 'tombstoned'`): `~/.agents/skills/<name>` exists;
+ *   agent entries are symlinks pointing at it. Move source + unlink every
+ *   symlink. Writes a v2 manifest, schedules TTL evict, supports undo.
+ * - **local-only** (`kind: 'tombstoned'`): no source dir; one or more agents
+ *   hold the skill as a real folder. Move every real folder into
+ *   `<entryDir>/local-copies/<agentId>/`. Writes a v2 manifest, supports undo.
+ * - **orphan** (`kind: 'orphan-cleared'`): no source, no local folders, only
+ *   broken symlinks remain. Unlink each broken symlink; no manifest, no
+ *   tombstone, no undo (resurrection would only restore the broken state).
+ *
+ * Dispatch order matters: source > local-only > orphan. A live source covers
+ * its broken peers (they get unlinked in the source-backed walk anyway), so
+ * the orphan branch only fires when nothing else applies.
  *
  * @param skillName - Validated skill name (no path separators, enforced by Zod)
- * @returns Tombstone id + cascadeAgents + symlinksRemoved for the caller's result
- * @throws TrashError when the skill cannot be located in either form, or any
+ * @returns Discriminated `MoveToTrashResult`. Callers MUST switch on `kind`
+ *   before reading `tombstoneId` — orphan-cleared has no tombstone.
+ * @throws TrashError when the skill cannot be located in any form, or any
  *   filesystem op fails non-recoverably mid-move
  * @example
  * // source-backed
  * const result = await moveToTrash('theme-generator')
- * // { tombstoneId: '1729...-theme-generator-a1b2c3d4', cascadeAgents: ['cursor'], symlinksRemoved: 1 }
+ * // { kind: 'tombstoned', tombstoneId: '1729...-theme-generator-a1b2c3d4', cascadeAgents: ['cursor'], symlinksRemoved: 1 }
  * @example
  * // local-only (skill lives in ~/.claude/skills/architecture-decision-records)
  * const result = await moveToTrash('architecture-decision-records')
- * // { tombstoneId: '1729...-architecture-decision-records-...', cascadeAgents: ['claude'], symlinksRemoved: 1 }
+ * // { kind: 'tombstoned', tombstoneId: '1729...-architecture-decision-records-...', cascadeAgents: ['claude'], symlinksRemoved: 1 }
+ * @example
+ * // orphan (source already rm -rf'd, only broken symlinks remain)
+ * const result = await moveToTrash('abandoned-skill')
+ * // { kind: 'orphan-cleared', cascadeAgents: ['cursor', 'codex'], symlinksRemoved: 2 }
  */
-export async function moveToTrash(skillName: SkillName): Promise<{
-  tombstoneId: TombstoneId
-  cascadeAgents: AgentId[]
-  symlinksRemoved: number
-}> {
+export async function moveToTrash(
+  skillName: SkillName,
+): Promise<MoveToTrashResult> {
   // Construct sourcePath from the (Zod-validated) skill name and re-check it
   // against SOURCE_DIR for defense in depth — even though the renderer never
   // passes a path, this keeps the file's invariants self-evident if a future
@@ -267,10 +448,18 @@ export async function moveToTrash(skillName: SkillName): Promise<{
   }
 
   const localCopies = await scanLocalCopies(skillName)
-  if (localCopies.length === 0) {
-    throw new TrashError('Skill not found (already deleted?)', 'ENOENT')
+  if (localCopies.length > 0) {
+    return moveLocalOnlyToTrash(skillName, localCopies)
   }
-  return moveLocalOnlyToTrash(skillName, localCopies)
+
+  // Last-resort branch: nothing real or live exists, but agents may still
+  // have broken symlinks. Sweep them with no manifest/undo (orphan-cleared).
+  const orphans = await scanOrphanSymlinkPaths(skillName)
+  if (orphans.length > 0) {
+    return clearOrphanSymlinks(skillName, orphans)
+  }
+
+  throw new TrashError('Skill not found (already deleted?)', 'ENOENT')
 }
 
 /**
@@ -282,11 +471,7 @@ export async function moveToTrash(skillName: SkillName): Promise<{
 async function moveSourceBackedToTrash(
   skillName: SkillName,
   sourcePath: AbsolutePath,
-): Promise<{
-  tombstoneId: TombstoneId
-  cascadeAgents: AgentId[]
-  symlinksRemoved: number
-}> {
+): Promise<Extract<MoveToTrashResult, { kind: 'tombstoned' }>> {
   const startTime = Date.now()
   await fs.mkdir(TRASH_DIR, { recursive: true, mode: 0o755 })
 
@@ -494,6 +679,7 @@ async function moveSourceBackedToTrash(
   })
 
   return {
+    kind: 'tombstoned',
     tombstoneId: id,
     cascadeAgents: cascadeAgentIds,
     symlinksRemoved: recordedSymlinks.length,
@@ -520,11 +706,7 @@ async function moveSourceBackedToTrash(
 async function moveLocalOnlyToTrash(
   skillName: SkillName,
   localCopies: RecordedLocalCopy[],
-): Promise<{
-  tombstoneId: TombstoneId
-  cascadeAgents: AgentId[]
-  symlinksRemoved: number
-}> {
+): Promise<Extract<MoveToTrashResult, { kind: 'tombstoned' }>> {
   const startTime = Date.now()
   await fs.mkdir(TRASH_DIR, { recursive: true, mode: 0o755 })
 
@@ -658,6 +840,7 @@ async function moveLocalOnlyToTrash(
   })
 
   return {
+    kind: 'tombstoned',
     tombstoneId: id,
     cascadeAgents: moved.map((c) => c.agentId),
     symlinksRemoved: moved.length,

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -335,10 +335,21 @@ export const MainContent = React.memo(
         refreshAllData(dispatch)
 
         if (tombstoneIds.length === 0) {
-          // Every item errored — show a plain error toast, no undo possible.
-          toast.error('Bulk delete failed', {
-            description: formatCascadeSummary(action.payload),
-          })
+          // No tombstones, but the rows still might have succeeded as
+          // `orphan-cleared` (broken-symlink sweeps that have no undo path).
+          // Distinguish all-errored from any-cleared so we don't slap an
+          // "error" title on a row that the user actually wanted swept.
+          const anySuccess = action.payload.items.some(
+            (item) =>
+              item.outcome === 'deleted' || item.outcome === 'orphan-cleared',
+          )
+          if (anySuccess) {
+            toast.success(formatCascadeSummary(action.payload))
+          } else {
+            toast.error('Bulk delete failed', {
+              description: formatCascadeSummary(action.payload),
+            })
+          }
           return
         }
 

--- a/src/renderer/src/components/skills/SkillDetail.tsx
+++ b/src/renderer/src/components/skills/SkillDetail.tsx
@@ -1,3 +1,4 @@
+import { Unlink2 } from 'lucide-react'
 import React, { Activity } from 'react'
 
 import type { Settings } from '../../../../shared/settings'
@@ -100,10 +101,20 @@ export const SkillDetail = React.memo(function SkillDetail({
 
       {/* Tab content: both branches stay mounted so their state — scroll
           position, selected file tab — survives toggling between Files
-          and Info. See react-rules.md "<Activity> - State Preservation". */}
+          and Info. See react-rules.md "<Activity> - State Preservation".
+
+          Orphan note: when `skill.isOrphan` is true the source path is a
+          dead symlink. CodePreview would `lstat(skill.path)` and surface
+          a confusing error, so we swap in OrphanNotice for the Files tab.
+          InfoView still works — it shows the broken symlinks per agent,
+          which is exactly what the user needs to decide on cleanup. */}
       <div className="flex-1 min-h-0 relative">
         <Activity mode={activeTab === 'files' ? 'visible' : 'hidden'}>
-          <CodePreview skillPath={skill.path} />
+          {skill.isOrphan ? (
+            <OrphanNotice />
+          ) : (
+            <CodePreview skillPath={skill.path} />
+          )}
         </Activity>
         <Activity mode={activeTab === 'info' ? 'visible' : 'hidden'}>
           <InfoView
@@ -115,6 +126,27 @@ export const SkillDetail = React.memo(function SkillDetail({
           />
         </Activity>
       </div>
+    </div>
+  )
+})
+
+/**
+ * Files-tab placeholder shown when `skill.isOrphan` is true. The original
+ * `~/.agents/skills/<name>/` directory is gone; only broken symlinks remain
+ * in agent dirs. There is nothing to preview, so we explain the state and
+ * point the user at the Info tab where the per-agent broken list lives.
+ */
+const OrphanNotice = React.memo(function OrphanNotice(): React.ReactElement {
+  return (
+    <div className="flex flex-col items-center justify-center h-full p-6 text-center">
+      <Unlink2 className="size-10 text-amber-400 mb-3" aria-hidden />
+      <h3 className="text-sm font-medium text-foreground mb-1">
+        Source skill is missing
+      </h3>
+      <p className="text-xs text-muted-foreground max-w-xs">
+        The original skill folder no longer exists. Remaining links in agent
+        directories are broken — see the Info tab for which agents are affected.
+      </p>
     </div>
   )
 })

--- a/src/renderer/src/components/skills/UnlinkDialog.tsx
+++ b/src/renderer/src/components/skills/UnlinkDialog.tsx
@@ -74,10 +74,19 @@ function getUnlinkCopy(
     .exhaustive()
 }
 
-/** Compute the variant from the symlink record (single source of truth). */
+/**
+ * Compute the variant from the symlink record (single source of truth).
+ *
+ * `'missing'` is mapped to `'broken'` defensively: both represent "no live
+ * link to remove" (a cleanup operation, not a live unlink). Upstream gating
+ * in `SkillItemHelpers` should prevent `'missing'` from ever reaching this
+ * dialog, but the explicit branch ensures it can never silently fall through
+ * to `'valid'` and surface the wrong "remove live link" copy.
+ */
 function pickVariant(symlink: SymlinkInfo): UnlinkVariant {
   if (symlink.isLocal) return 'local'
-  if (symlink.status === 'broken') return 'broken'
+  if (symlink.status === 'broken' || symlink.status === 'missing')
+    return 'broken'
   return 'valid'
 }
 

--- a/src/renderer/src/components/skills/UnlinkDialog.tsx
+++ b/src/renderer/src/components/skills/UnlinkDialog.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { toast } from 'sonner'
+import { match } from 'ts-pattern'
 
+import type { SymlinkInfo } from '../../../../shared/types'
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
 import {
   setSkillToUnlink,
@@ -10,15 +12,94 @@ import { refreshAllData } from '../../redux/thunks'
 import { DestructiveConfirmDialog } from '../shared/DestructiveConfirmDialog'
 
 /**
+ * Three exhaustive states the dialog has to cover:
+ * - `local`  : real skill folder lives in the agent dir; removal is permanent.
+ * - `broken` : the agent has a dangling symlink to a source that no longer
+ *              exists (orphan); removal is permanent (nothing to restore to).
+ * - `valid`  : a working symlink that can be safely removed (the source dir
+ *              and any other agents' links survive).
+ *
+ * `'missing'` symlinks never reach this dialog — the unlink button is gated
+ * out for them upstream (see SkillItemHelpers).
+ */
+type UnlinkVariant = 'local' | 'broken' | 'valid'
+
+interface UnlinkCopy {
+  title: string
+  detailText: string
+  confirmLabel: string
+  loadingLabel: string
+  successTitle: string
+  successDescription: string
+  errorTitle: string
+}
+
+/** Pure mapper from symlink shape → strings shown in the dialog and toast. */
+function getUnlinkCopy(
+  variant: UnlinkVariant,
+  skillName: string,
+  agentName: string,
+): UnlinkCopy {
+  return match(variant)
+    .with('local', () => ({
+      title: 'Delete from Agent',
+      detailText:
+        'This will permanently delete the local skill folder. This action cannot be undone.',
+      confirmLabel: 'Delete',
+      loadingLabel: 'Deleting...',
+      successTitle: `Deleted from ${agentName}`,
+      successDescription: `${skillName} folder has been deleted from ${agentName}`,
+      errorTitle: 'Failed to delete skill',
+    }))
+    .with('broken', () => ({
+      title: 'Remove Broken Link',
+      detailText:
+        'The original skill source no longer exists, so this cannot be undone.',
+      confirmLabel: 'Remove',
+      loadingLabel: 'Removing...',
+      successTitle: `Cleaned up broken link in ${agentName}`,
+      successDescription: `Broken symlink to ${skillName} removed from ${agentName}`,
+      errorTitle: 'Failed to remove broken link',
+    }))
+    .with('valid', () => ({
+      title: 'Remove from Agent',
+      detailText:
+        'This only removes the link. The skill will remain available for other agents.',
+      confirmLabel: 'Remove',
+      loadingLabel: 'Removing...',
+      successTitle: `Removed from ${agentName}`,
+      successDescription: `${skillName} is no longer linked to ${agentName}`,
+      errorTitle: 'Failed to remove skill',
+    }))
+    .exhaustive()
+}
+
+/** Compute the variant from the symlink record (single source of truth). */
+function pickVariant(symlink: SymlinkInfo): UnlinkVariant {
+  if (symlink.isLocal) return 'local'
+  if (symlink.status === 'broken') return 'broken'
+  return 'valid'
+}
+
+/**
  * Confirmation dialog for removing a skill from the selected agent.
- * Handles both symlink removal and local skill folder deletion.
+ * Handles three states (local folder delete / broken-symlink cleanup / live
+ * symlink unlink) via an exhaustive ts-pattern match — adding a future
+ * variant forces the copy table to be updated at compile time.
  */
 export const UnlinkDialog = React.memo(
   function UnlinkDialog(): React.ReactElement {
     const dispatch = useAppDispatch()
     const { skillToUnlink, unlinking } = useAppSelector((state) => state.skills)
 
-    const isLocal = skillToUnlink?.symlink.isLocal ?? false
+    const variant: UnlinkVariant = skillToUnlink
+      ? pickVariant(skillToUnlink.symlink)
+      : 'valid'
+    const copy = getUnlinkCopy(
+      variant,
+      skillToUnlink?.skill.name ?? '',
+      skillToUnlink?.symlink.agentName ?? '',
+    )
 
     const handleClose = (): void => {
       if (!unlinking) {
@@ -33,24 +114,13 @@ export const UnlinkDialog = React.memo(
       const result = await dispatch(unlinkSkillFromAgent({ skill, symlink }))
 
       if (unlinkSkillFromAgent.fulfilled.match(result)) {
-        toast.success(
-          isLocal
-            ? `Deleted from ${symlink.agentName}`
-            : `Removed from ${symlink.agentName}`,
-          {
-            description: isLocal
-              ? `${skill.name} folder has been deleted from ${symlink.agentName}`
-              : `${skill.name} is no longer linked to ${symlink.agentName}`,
-          },
-        )
+        toast.success(copy.successTitle, {
+          description: copy.successDescription,
+        })
       } else {
-        toast.error(
-          isLocal ? 'Failed to delete skill' : 'Failed to remove skill',
-          {
-            description:
-              result.error?.message || 'An unexpected error occurred',
-          },
-        )
+        toast.error(copy.errorTitle, {
+          description: result.error?.message || 'An unexpected error occurred',
+        })
       }
       // Always refresh after an unlink attempt: success refreshes the list,
       // failure clears any stale `state.skills.error` (via fetchSkills.pending)
@@ -65,22 +135,20 @@ export const UnlinkDialog = React.memo(
         onClose={handleClose}
         onConfirm={handleUnlink}
         loading={unlinking}
-        title={isLocal ? 'Delete from Agent' : 'Remove from Agent'}
+        title={copy.title}
         description={
           <>
-            Are you sure you want to {isLocal ? 'delete' : 'remove'}{' '}
+            Are you sure you want to {copy.confirmLabel.toLowerCase()}{' '}
             <strong>{skillToUnlink?.skill.name}</strong> from{' '}
             <strong>{skillToUnlink?.symlink.agentName}</strong>?
             <br />
             <span className="text-muted-foreground mt-2 block">
-              {isLocal
-                ? 'This will permanently delete the local skill folder. This action cannot be undone.'
-                : 'This only removes the link. The skill will remain available for other agents.'}
+              {copy.detailText}
             </span>
           </>
         }
-        confirmLabel={isLocal ? 'Delete' : 'Remove'}
-        loadingLabel={isLocal ? 'Deleting...' : 'Removing...'}
+        confirmLabel={copy.confirmLabel}
+        loadingLabel={copy.loadingLabel}
         iconVariant="warning"
       />
     )

--- a/src/renderer/src/components/skills/bulkDeleteHelpers.test.ts
+++ b/src/renderer/src/components/skills/bulkDeleteHelpers.test.ts
@@ -196,9 +196,10 @@ describe('formatCascadeSummary', () => {
     )
   })
 
-  it('counts orphan-cleared rows as success and rolls their symlinksRemoved into the cascade tally', () => {
-    // Issue #71 PR-1: orphan-cleared has no tombstoneId (no undo to wire up),
-    // but from the user's POV the broken link "is gone" — same wording.
+  it('keeps orphan-cleared distinct from the Undo-facing "Deleted" phrase', () => {
+    // Issue #71 PR-1: orphan-cleared has no tombstoneId so Undo can't restore
+    // it — therefore the "Deleted N" wording must NOT include it (otherwise
+    // the toast lies about how many rows the user can bring back).
     const result: BulkDeleteResult = {
       items: [
         {
@@ -217,16 +218,17 @@ describe('formatCascadeSummary', () => {
       ],
     }
 
-    // 2 successes, 3 cascaded symlinks (1 + 2). The "K of N" form must NOT
-    // appear: orphan-cleared is success, not error.
+    // 1 truly-deleted (undoable) + 2 orphan symlinks swept (irreversible) +
+    // 1 cascaded symlink from the deleted row. Three independent phrases.
     expect(formatCascadeSummary(result)).toBe(
-      'Deleted 2 skills. 3 symlinks removed.',
+      'Deleted 1 skill. Cleaned up 2 orphan symlinks. 1 symlink removed.',
     )
   })
 
-  it('formats orphan-only batches without any tombstoneId rows', () => {
+  it('reports orphan-only batches without any "Deleted" phrase', () => {
     // The all-orphan case: e.g. user deleted the source first, then bulk
     // selected the broken-symlink rows in agent view to clean them up.
+    // Nothing was tombstoned, so "Deleted" stays out of the message entirely.
     const result: BulkDeleteResult = {
       items: [
         {
@@ -248,12 +250,12 @@ describe('formatCascadeSummary', () => {
       ],
     }
 
-    expect(formatCascadeSummary(result)).toBe(
-      'Deleted 2 skills. 4 symlinks removed.',
-    )
+    expect(formatCascadeSummary(result)).toBe('Cleaned up 4 orphan symlinks.')
   })
 
-  it('treats mixed orphan + error correctly with K-of-N partial form', () => {
+  it('reports mixed orphan + error as separate phrases (no K-of-N form)', () => {
+    // No tombstoned rows means the K-of-N "Deleted X of Y" form has nothing
+    // to attach to; the error count gets its own standalone phrase instead.
     const result: BulkDeleteResult = {
       items: [
         {
@@ -270,9 +272,8 @@ describe('formatCascadeSummary', () => {
       ],
     }
 
-    // 1 of 2 succeeded, 2 symlinks removed by the orphan-cleared row.
     expect(formatCascadeSummary(result)).toBe(
-      'Deleted 1 of 2 skills. 2 symlinks removed.',
+      'Cleaned up 2 orphan symlinks. 1 deletion failed.',
     )
   })
 })

--- a/src/renderer/src/components/skills/bulkDeleteHelpers.test.ts
+++ b/src/renderer/src/components/skills/bulkDeleteHelpers.test.ts
@@ -195,6 +195,86 @@ describe('formatCascadeSummary', () => {
       'Deleted 1 skill. 1 symlink removed.',
     )
   })
+
+  it('counts orphan-cleared rows as success and rolls their symlinksRemoved into the cascade tally', () => {
+    // Issue #71 PR-1: orphan-cleared has no tombstoneId (no undo to wire up),
+    // but from the user's POV the broken link "is gone" — same wording.
+    const result: BulkDeleteResult = {
+      items: [
+        {
+          skillName: 'task',
+          outcome: 'deleted',
+          tombstoneId: tombstoneId('1-task-aaaa'),
+          symlinksRemoved: 1,
+          cascadeAgents: ['cursor' as AgentId],
+        },
+        {
+          skillName: 'abandoned',
+          outcome: 'orphan-cleared',
+          symlinksRemoved: 2,
+          cascadeAgents: ['cursor' as AgentId, 'codex' as AgentId],
+        },
+      ],
+    }
+
+    // 2 successes, 3 cascaded symlinks (1 + 2). The "K of N" form must NOT
+    // appear: orphan-cleared is success, not error.
+    expect(formatCascadeSummary(result)).toBe(
+      'Deleted 2 skills. 3 symlinks removed.',
+    )
+  })
+
+  it('formats orphan-only batches without any tombstoneId rows', () => {
+    // The all-orphan case: e.g. user deleted the source first, then bulk
+    // selected the broken-symlink rows in agent view to clean them up.
+    const result: BulkDeleteResult = {
+      items: [
+        {
+          skillName: 'abandoned-a',
+          outcome: 'orphan-cleared',
+          symlinksRemoved: 1,
+          cascadeAgents: ['cursor' as AgentId],
+        },
+        {
+          skillName: 'abandoned-b',
+          outcome: 'orphan-cleared',
+          symlinksRemoved: 3,
+          cascadeAgents: [
+            'cursor' as AgentId,
+            'codex' as AgentId,
+            'claude-code' as AgentId,
+          ],
+        },
+      ],
+    }
+
+    expect(formatCascadeSummary(result)).toBe(
+      'Deleted 2 skills. 4 symlinks removed.',
+    )
+  })
+
+  it('treats mixed orphan + error correctly with K-of-N partial form', () => {
+    const result: BulkDeleteResult = {
+      items: [
+        {
+          skillName: 'abandoned',
+          outcome: 'orphan-cleared',
+          symlinksRemoved: 2,
+          cascadeAgents: ['cursor' as AgentId, 'codex' as AgentId],
+        },
+        {
+          skillName: 'locked',
+          outcome: 'error',
+          error: { message: 'EACCES', code: 'EACCES' },
+        },
+      ],
+    }
+
+    // 1 of 2 succeeded, 2 symlinks removed by the orphan-cleared row.
+    expect(formatCascadeSummary(result)).toBe(
+      'Deleted 1 of 2 skills. 2 symlinks removed.',
+    )
+  })
 })
 
 describe('formatUnlinkSummary', () => {

--- a/src/renderer/src/components/skills/bulkDeleteHelpers.ts
+++ b/src/renderer/src/components/skills/bulkDeleteHelpers.ts
@@ -113,9 +113,30 @@ export const getToolbarState = ({
 }
 
 /**
+ * Outcomes that count as a successful row in a bulk delete: a real tombstoned
+ * delete (`'deleted'`) or an orphan symlink sweep (`'orphan-cleared'`). Both
+ * carry `symlinksRemoved` and contribute to the user's "things removed" tally;
+ * only the first carries a tombstoneId, so callers that need undo must filter
+ * narrower than this.
+ */
+type BulkDeleteSuccessOutcome = 'deleted' | 'orphan-cleared'
+
+const isBulkDeleteSuccess = (
+  item: BulkDeleteItemResult,
+): item is Extract<
+  BulkDeleteItemResult,
+  { outcome: BulkDeleteSuccessOutcome }
+> => item.outcome === 'deleted' || item.outcome === 'orphan-cleared'
+
+/**
  * Build the summary string shown in the undo toast after a bulk DELETE:
- *  - Counts successful deletes vs errors.
+ *  - Counts successful rows (tombstoned + orphan-cleared) vs errors.
  *  - Aggregates `symlinksRemoved` across every success to surface the cascade.
+ *
+ * Orphan-cleared rows are folded into the success count even though they have
+ * no tombstone — from the user's perspective the broken link "is gone", which
+ * is exactly what bulk delete promises. Undo wiring is the caller's concern;
+ * see `MainContent` where we filter to `outcome === 'deleted'` for the toast.
  *
  * @param result - BulkDeleteResult from the main-process thunk.
  * @returns Human-readable summary for the toast body.
@@ -123,6 +144,13 @@ export const getToolbarState = ({
  * formatCascadeSummary({ items: [
  *   { skillName: 'task', outcome: 'deleted', tombstoneId: '...', symlinksRemoved: 2, cascadeAgents: ['cursor', 'claude-code'] },
  *   { skillName: 'theme', outcome: 'deleted', tombstoneId: '...', symlinksRemoved: 1, cascadeAgents: ['cursor'] },
+ * ] })
+ * // => 'Deleted 2 skills. 3 symlinks removed.'
+ * @example
+ * // With orphan-cleared mixed in:
+ * formatCascadeSummary({ items: [
+ *   { skillName: 'task', outcome: 'deleted', tombstoneId: '...', symlinksRemoved: 1, cascadeAgents: [] },
+ *   { skillName: 'abandoned', outcome: 'orphan-cleared', symlinksRemoved: 2, cascadeAgents: ['cursor', 'codex'] },
  * ] })
  * // => 'Deleted 2 skills. 3 symlinks removed.'
  * @example
@@ -134,21 +162,18 @@ export const getToolbarState = ({
  * // => 'Deleted 1 of 2 skills. 1 symlink removed.'
  */
 export const formatCascadeSummary = (result: BulkDeleteResult): string => {
-  const deletedItems = result.items.filter(
-    (item): item is Extract<BulkDeleteItemResult, { outcome: 'deleted' }> =>
-      item.outcome === 'deleted',
-  )
-  const totalSymlinksRemoved = deletedItems.reduce(
+  const successItems = result.items.filter(isBulkDeleteSuccess)
+  const totalSymlinksRemoved = successItems.reduce(
     (sum, item) => sum + item.symlinksRemoved,
     0,
   )
-  const deletedCount = deletedItems.length
+  const successCount = successItems.length
   const totalCount = result.items.length
-  const hadErrors = deletedCount < totalCount
+  const hadErrors = successCount < totalCount
 
   const skillsPhrase = hadErrors
-    ? `Deleted ${deletedCount} of ${totalCount} ${pluralize(totalCount, 'skill')}.`
-    : `Deleted ${deletedCount} ${pluralize(deletedCount, 'skill')}.`
+    ? `Deleted ${successCount} of ${totalCount} ${pluralize(totalCount, 'skill')}.`
+    : `Deleted ${successCount} ${pluralize(successCount, 'skill')}.`
 
   // Omit the symlink sentence when nothing cascaded (keeps the toast compact).
   const symlinksPhrase =

--- a/src/renderer/src/components/skills/bulkDeleteHelpers.ts
+++ b/src/renderer/src/components/skills/bulkDeleteHelpers.ts
@@ -113,33 +113,25 @@ export const getToolbarState = ({
 }
 
 /**
- * Outcomes that count as a successful row in a bulk delete: a real tombstoned
- * delete (`'deleted'`) or an orphan symlink sweep (`'orphan-cleared'`). Both
- * carry `symlinksRemoved` and contribute to the user's "things removed" tally;
- * only the first carries a tombstoneId, so callers that need undo must filter
- * narrower than this.
- */
-type BulkDeleteSuccessOutcome = 'deleted' | 'orphan-cleared'
-
-const isBulkDeleteSuccess = (
-  item: BulkDeleteItemResult,
-): item is Extract<
-  BulkDeleteItemResult,
-  { outcome: BulkDeleteSuccessOutcome }
-> => item.outcome === 'deleted' || item.outcome === 'orphan-cleared'
-
-/**
- * Build the summary string shown in the undo toast after a bulk DELETE:
- *  - Counts successful rows (tombstoned + orphan-cleared) vs errors.
- *  - Aggregates `symlinksRemoved` across every success to surface the cascade.
+ * Build the summary string shown in the toast body after a bulk DELETE.
  *
- * Orphan-cleared rows are folded into the success count even though they have
- * no tombstone — from the user's perspective the broken link "is gone", which
- * is exactly what bulk delete promises. Undo wiring is the caller's concern;
- * see `MainContent` where we filter to `outcome === 'deleted'` for the toast.
+ * The phrases are deliberately independent so the Undo-facing text only
+ * counts truly restorable rows (`outcome === 'deleted'`):
+ *
+ *  1. **"Deleted N skill(s)"** — tombstoned only. Drives the Undo wording in
+ *     `MainContent`'s undo toast; orphan-cleared rows MUST NOT be folded in
+ *     here, otherwise Undo lies about how many things will come back.
+ *  2. **"Cleaned up M orphan symlinks"** — orphan-cleared rows. Communicated
+ *     as a distinct phrase because there is no undo path; the user should see
+ *     it as a separate, irreversible cleanup.
+ *  3. **"X symlinks removed"** — cascade tally from tombstoned rows ONLY.
+ *     Orphan symlinks are already counted by phrase 2; combining them would
+ *     double-count.
+ *  4. **"Y deletion(s) failed"** — emitted only when there are errors AND no
+ *     tombstoned rows to embed the K-of-N form into.
  *
  * @param result - BulkDeleteResult from the main-process thunk.
- * @returns Human-readable summary for the toast body.
+ * @returns Human-readable summary built from the four phrases above.
  * @example
  * formatCascadeSummary({ items: [
  *   { skillName: 'task', outcome: 'deleted', tombstoneId: '...', symlinksRemoved: 2, cascadeAgents: ['cursor', 'claude-code'] },
@@ -147,41 +139,77 @@ const isBulkDeleteSuccess = (
  * ] })
  * // => 'Deleted 2 skills. 3 symlinks removed.'
  * @example
- * // With orphan-cleared mixed in:
+ * // Mixed deleted + orphan-cleared — orphan stays separate from the Undo count:
  * formatCascadeSummary({ items: [
  *   { skillName: 'task', outcome: 'deleted', tombstoneId: '...', symlinksRemoved: 1, cascadeAgents: [] },
  *   { skillName: 'abandoned', outcome: 'orphan-cleared', symlinksRemoved: 2, cascadeAgents: ['cursor', 'codex'] },
  * ] })
- * // => 'Deleted 2 skills. 3 symlinks removed.'
+ * // => 'Deleted 1 skill. Cleaned up 2 orphan symlinks. 1 symlink removed.'
  * @example
  * // With errors:
  * formatCascadeSummary({ items: [
  *   { skillName: 'task', outcome: 'deleted', tombstoneId: '...', symlinksRemoved: 1, cascadeAgents: [] },
- *   { skillName: 'locked', outcome: 'error', error: { message: 'EACCES' } },
+ *   { skillName: 'locked', outcome: 'error', error: { message: 'EACCES', code: 'EACCES' } },
  * ] })
  * // => 'Deleted 1 of 2 skills. 1 symlink removed.'
  */
 export const formatCascadeSummary = (result: BulkDeleteResult): string => {
-  const successItems = result.items.filter(isBulkDeleteSuccess)
-  const totalSymlinksRemoved = successItems.reduce(
+  const deletedItems = result.items.filter(
+    (item): item is Extract<BulkDeleteItemResult, { outcome: 'deleted' }> =>
+      item.outcome === 'deleted',
+  )
+  const orphanItems = result.items.filter(
+    (
+      item,
+    ): item is Extract<BulkDeleteItemResult, { outcome: 'orphan-cleared' }> =>
+      item.outcome === 'orphan-cleared',
+  )
+  const errorCount = result.items.filter(
+    (item) => item.outcome === 'error',
+  ).length
+
+  const deletedCount = deletedItems.length
+  const tombstonedAttempted = deletedCount + errorCount
+  const tombstonedCascade = deletedItems.reduce(
     (sum, item) => sum + item.symlinksRemoved,
     0,
   )
-  const successCount = successItems.length
-  const totalCount = result.items.length
-  const hadErrors = successCount < totalCount
+  const orphanSymlinks = orphanItems.reduce(
+    (sum, item) => sum + item.symlinksRemoved,
+    0,
+  )
 
-  const skillsPhrase = hadErrors
-    ? `Deleted ${successCount} of ${totalCount} ${pluralize(totalCount, 'skill')}.`
-    : `Deleted ${successCount} ${pluralize(successCount, 'skill')}.`
+  const phrases: string[] = []
 
-  // Omit the symlink sentence when nothing cascaded (keeps the toast compact).
-  const symlinksPhrase =
-    totalSymlinksRemoved > 0
-      ? ` ${totalSymlinksRemoved} ${pluralize(totalSymlinksRemoved, 'symlink')} removed.`
-      : ''
+  // Phrase 1 — tombstoned only. The Undo button restores exactly these rows.
+  if (deletedCount > 0) {
+    phrases.push(
+      errorCount > 0
+        ? `Deleted ${deletedCount} of ${tombstonedAttempted} ${pluralize(tombstonedAttempted, 'skill')}.`
+        : `Deleted ${deletedCount} ${pluralize(deletedCount, 'skill')}.`,
+    )
+  }
 
-  return `${skillsPhrase}${symlinksPhrase}`
+  // Phrase 2 — orphan cleanup, irreversible, kept distinct from deletions.
+  if (orphanSymlinks > 0) {
+    phrases.push(
+      `Cleaned up ${orphanSymlinks} orphan ${pluralize(orphanSymlinks, 'symlink')}.`,
+    )
+  }
+
+  // Phrase 3 — cascade tally from tombstoned only (orphans counted in phrase 2).
+  if (tombstonedCascade > 0) {
+    phrases.push(
+      `${tombstonedCascade} ${pluralize(tombstonedCascade, 'symlink')} removed.`,
+    )
+  }
+
+  // Phrase 4 — standalone error report when no tombstoned row absorbs it.
+  if (deletedCount === 0 && errorCount > 0) {
+    phrases.push(`${errorCount} ${pluralize(errorCount, 'deletion')} failed.`)
+  }
+
+  return phrases.join(' ')
 }
 
 /**

--- a/src/renderer/src/components/skills/skillItemHelpers.test.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.test.ts
@@ -346,6 +346,48 @@ describe('getSkillItemVisibility', () => {
       )
       expect(result.showDeleteButton).toBe(false)
     })
+
+    it('hides Add button for orphan skill in global view', () => {
+      // Issue #71 PR-1: Add button (which opens AddSymlinkModal /
+      // CopyToAgentsModal) would surface a flow that can only fail when the
+      // source is gone — there is nothing to symlink _to_. Same orphan rule
+      // as Delete and Unlink.
+      const symlinks = [
+        makeSymlink({ agentId: 'cursor', status: 'broken', isLocal: false }),
+        makeSymlink({ agentId: 'codex', status: 'broken', isLocal: false }),
+      ]
+      const result = getSkillItemVisibility(null, makeSkill(symlinks))
+
+      expect(result.showAddButton).toBe(false)
+    })
+
+    it('hides Add button for orphan skill in agent view even when the agent has a broken symlink', () => {
+      const symlinks = [
+        makeSymlink({ agentId: 'cursor', status: 'broken', isLocal: false }),
+        makeSymlink({ agentId: 'codex', status: 'broken', isLocal: false }),
+      ]
+      const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
+
+      // Even though `selectedAgentSymlink` is non-null (the broken cursor
+      // entry passes the `valid|broken` filter), the orphan gate wins: there
+      // is no live source to symlink TO, so re-adding makes no sense.
+      expect(result.showAddButton).toBe(false)
+      // Sibling guards still hold for orphan rows.
+      expect(result.showUnlinkButton).toBe(false)
+    })
+
+    it('keeps Add button visible when isOrphan is false (non-orphan, valid symlinks)', () => {
+      // Sanity check: the new && !isOrphan term must NOT regress the
+      // happy path where Add was always available.
+      const symlinks = [
+        makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: false }),
+      ]
+      const globalResult = getSkillItemVisibility(null, makeSkill(symlinks))
+      expect(globalResult.showAddButton).toBe(true)
+
+      const agentResult = getSkillItemVisibility('cursor', makeSkill(symlinks))
+      expect(agentResult.showAddButton).toBe(true)
+    })
   })
 
   describe('regression: dual delete buttons', () => {

--- a/src/renderer/src/components/skills/skillItemHelpers.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.ts
@@ -118,7 +118,11 @@ export function getSkillItemVisibility(
 
   return {
     showDeleteButton: !selectedAgentId && !isOrphan,
-    showAddButton: !selectedAgentId || hasSkillInSelectedAgent,
+    // Orphan skills have no live source to symlink _to_, so the Add button
+    // (which opens AddSymlinkModal / CopyToAgentsModal) would surface a flow
+    // that can only fail. Hide it for the same reason Delete/Unlink hide:
+    // the source is gone, the row is awaiting cleanup, not action.
+    showAddButton: (!selectedAgentId || hasSkillInSelectedAgent) && !isOrphan,
     showUnlinkButton: hasSkillInSelectedAgent && !isOrphan,
     isLinked: !!selectedAgentSymlink && selectedAgentSymlink.status === 'valid',
     isLocalSkill,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -645,7 +645,17 @@ export interface DeleteSkillsOptions {
 /**
  * Per-item result from a batch delete. Discriminated on `outcome` so error items
  * never carry a phantom `tombstoneId` (reviewer CRITICAL-1).
+ *
+ * Three success-or-failure shapes:
+ * - `deleted`: tombstoned (source-backed or local-only). Carries a `tombstoneId`
+ *   the renderer wires into the Undo toast.
+ * - `orphan-cleared`: every record was a broken symlink whose source no longer
+ *   exists. Cleanup is just `unlink()` calls — no tombstone, no undo, because
+ *   resurrecting the broken links is meaningless.
+ * - `error`: the operation failed mid-flight; the renderer flashes the row.
+ *
  * @example { skillName: 'task', outcome: 'deleted', tombstoneId: '1729180800000-task-a1b2c3d4', symlinksRemoved: 3, cascadeAgents: ['cursor'] }
+ * @example { skillName: 'abandoned', outcome: 'orphan-cleared', symlinksRemoved: 2, cascadeAgents: ['cursor', 'codex'] }
  * @example { skillName: 'task', outcome: 'error', error: { message: 'Permission denied', code: 'EACCES' } }
  */
 export type BulkDeleteItemResult =
@@ -653,6 +663,12 @@ export type BulkDeleteItemResult =
       skillName: SkillName
       outcome: 'deleted'
       tombstoneId: TombstoneId
+      symlinksRemoved: number
+      cascadeAgents: AgentId[]
+    }
+  | {
+      skillName: SkillName
+      outcome: 'orphan-cleared'
       symlinksRemoved: number
       cascadeAgents: AgentId[]
     }


### PR DESCRIPTION
## Summary

- Extend `moveToTrash` with a discriminated `MoveToTrashResult` (`tombstoned` vs `orphan-cleared`) so the orphan branch — every record is a broken symlink whose source no longer exists — cleans up via plain `unlink()` calls without writing a tombstone or scheduling TTL eviction. There is nothing meaningful to undo (the resurrected links would still be broken), and the discriminated union makes that a compile-time guarantee.
- Single (`SKILLS_DELETE`) and batch (`SKILLS_DELETE_BATCH`) IPC handlers now dispatch on `kind` and surface either `outcome: 'deleted'` (with `tombstoneId` for the Undo toast) or `outcome: 'orphan-cleared'` (no `tombstoneId`).
- Renderer surfaces:
  - `SkillDetail` adds an `OrphanNotice` on the Files tab and an "Orphan symlink — source skill no longer exists" header for orphan rows.
  - `UnlinkDialog` learns the 3-way variants for broken / local / valid records.
  - `skillItemHelpers` gates Delete / Add / Unlink buttons when `isOrphan`.
  - `bulkDeleteHelpers.formatCascadeSummary` consumes the new `outcome` discriminator.

## Scope of this PR

Backend + IPC + SkillDetail surface only. **Orphan rows are still hidden in the global / agent list views** because `selectFilteredSkills` (`src/renderer/src/redux/selectors.ts:71-81`) filters on `isSource` / `status === 'valid'`. The new orphan delete pathway is reachable via direct IPC and via SkillDetail, but the row that would carry it is not yet rendered. That fix ships separately (see "Follow-up" below).

## QA results

Live filesystem QA against an environment with 35 pre-existing orphans across `~/.codex/`, `~/.junie/`, `~/.openclaw/` (and synthetic fixtures staged in those same safe dirs — `~/.claude/` and `~/.cursor/` were untouched per the project's QA Safety policy):

| TC | Surface | Result |
|----|---------|--------|
| 1 | IPC `skills:deleteSkill` (2-agent orphan) | `{success:true, symlinksRemoved:2, cascadeAgents:["codex","junie"]}` ✅ |
| 2 | Filesystem after TC-1 | both broken symlinks removed ✅ |
| 3 | Trash service after TC-1 | tombstone dir empty (no undo) ✅ |
| 4 | Scanner re-scan | total/orphan counts dropped correctly ✅ |
| 5 | IPC `skills:deleteSkills` bulk (2 orphans, mixed cascade) | per-item `outcome:"orphan-cleared"` with correct cascade ✅ |
| 6 | Filesystem after TC-5 | all 3 broken symlinks removed ✅ |
| 7 | SkillDetail Files tab | `OrphanNotice` "Source skill is missing" rendered ✅ |
| 8 | SkillDetail header | "Orphan symlink — source skill no longer exists" ✅ |
| 9 | SkillDetail Info tab | Codex `broken`, other agents `missing` ✅ |
| 10 | SkillDetail Location | broken-symlink path displayed ✅ |

**10/10 PASS.** Unit + integration + e2e suites: 840/840 passing.

## Follow-up (separate PR)

`selectFilteredSkills` excludes orphans from both views by design today (regression-tested at `src/renderer/src/redux/selectors.test.ts:234`). Until that selector is loosened — or a dedicated "Broken / Orphans" view is added off the dashboard's `Symlink Health` widget — the `getSkillItemVisibility` orphan gate (`skillItemHelpers.ts:120-126`) is correct but unreachable in the list. Will open as PR-2.

## Test plan

- [x] `pnpm typecheck` passes (root + `e2e/tsconfig.json`)
- [x] `pnpm lint` passes
- [x] Unit + integration + e2e suites green (840/840)
- [x] Live-filesystem QA via `playwright-cli` CDP attach: 10/10 cases PASS (table above)
- [x] No tombstone written for orphan branch (verified via empty trash dir after orphan delete)
- [x] `~/.claude/` and `~/.cursor/` untouched (CLAUDE.md QA Safety policy)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
* リンク切れのスキルを直接削除でき、ゴミ箱に記録されなくなりました。

## バグ修正
* 一括削除時に、成功と失敗の区別がより正確に表示されるようになりました。

## UI改善
* リンク切れのスキルに対して、ファイルタブに注釈が表示されるようになりました。
* リンク解除ダイアログが異なるリンク状態に対応し、より適切なメッセージを表示します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->