### PR TITLE
feat(orphan): per-agent cleanup dialog + orphan row surfacing (#71)

### DIFF
--- a/src/main/ipc/ipc-schemas.ts
+++ b/src/main/ipc/ipc-schemas.ts
@@ -214,9 +214,19 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
   ]),
 
   // Sync operations
+  // Optional `agentId` scopes preview/execute to a single agent — used by
+  // the per-agent Cleanup flow surfaced from AgentItem's context menu.
+  'sync:preview': z.tuple([
+    z
+      .object({
+        agentId: nonEmptyString.optional(),
+      })
+      .optional(),
+  ]),
   'sync:execute': z.tuple([
     z.object({
       replaceConflicts: z.array(z.string()),
+      agentId: nonEmptyString.optional(),
     }),
   ]),
 

--- a/src/main/ipc/sync.ts
+++ b/src/main/ipc/sync.ts
@@ -7,8 +7,8 @@ import { typedHandle } from './typedHandle'
  * Register IPC handlers for sync operations
  */
 export function registerSyncHandlers(): void {
-  typedHandle(IPC_CHANNELS.SYNC_PREVIEW, async () => {
-    return syncPreview()
+  typedHandle(IPC_CHANNELS.SYNC_PREVIEW, async (_, options) => {
+    return syncPreview(options)
   })
 
   typedHandle(IPC_CHANNELS.SYNC_EXECUTE, async (_, options) => {

--- a/src/main/services/syncService.test.ts
+++ b/src/main/services/syncService.test.ts
@@ -393,3 +393,119 @@ describe('syncExecute', () => {
     })
   })
 })
+
+/**
+ * Scoped (per-agent) sync — drives the per-agent Cleanup flow surfaced
+ * from AgentItem's right-click "Cleanup missing skills..." menu item.
+ * Both `syncPreview` and `syncExecute` accept an optional `agentId` that
+ * narrows the operation to one agent. The whole-agent global sync flow is
+ * unchanged when `agentId` is omitted (covered by the suites above).
+ */
+describe('scoped sync (per-agent)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    accessMock.mockResolvedValue(undefined)
+    statMock.mockResolvedValue({ isFile: () => true })
+    mkdirMock.mockResolvedValue(undefined)
+    symlinkMock.mockResolvedValue(undefined)
+    rmMock.mockResolvedValue(undefined)
+  })
+
+  it('preview narrows to a single agent and echoes forAgent', async () => {
+    readdirMock.mockImplementation(async (dir: string) => {
+      if (dir === '/mock/source/skills') {
+        return [{ name: 'my-skill', isDirectory: () => true }]
+      }
+      return []
+    })
+    // 'my-skill' already symlinked under cursor; we still expect
+    // totalAgents===1 because the claude row is filtered out entirely.
+    lstatMock.mockResolvedValue(createStats({ isSymbolicLink: true }))
+
+    const { syncPreview } = await import('./syncService')
+    const result = await syncPreview({ agentId: 'cursor' })
+
+    expect(result.totalSkills).toBe(1)
+    expect(result.totalAgents).toBe(1)
+    expect(result.alreadySynced).toBe(1) // 1 skill × 1 agent (filtered)
+    expect(result.forAgent).toBe('cursor')
+  })
+
+  it('preview without agentId omits forAgent', async () => {
+    readdirMock.mockResolvedValue([])
+
+    const { syncPreview } = await import('./syncService')
+    const result = await syncPreview()
+
+    expect(result.forAgent).toBeUndefined()
+    expect(result.totalAgents).toBe(2)
+  })
+
+  it('execute creates symlinks only for the scoped agent', async () => {
+    readdirMock.mockImplementation(async (dir: string) => {
+      if (dir === '/mock/source/skills') {
+        return [{ name: 'new-skill', isDirectory: () => true }]
+      }
+      return []
+    })
+    lstatMock.mockRejectedValue(new Error('ENOENT'))
+
+    const { syncExecute } = await import('./syncService')
+    const result = await syncExecute({
+      replaceConflicts: [],
+      agentId: 'cursor',
+    })
+
+    expect(result.created).toBe(1)
+    expect(result.details).toHaveLength(1)
+    expect(result.details[0]).toMatchObject({
+      skillName: 'new-skill',
+      agentName: 'Cursor',
+      action: 'created',
+    })
+    // Only the cursor symlink call — claude must not be touched.
+    expect(symlinkMock).toHaveBeenCalledTimes(1)
+    expect(symlinkMock).toHaveBeenCalledWith(
+      join('/mock/source/skills', 'new-skill'),
+      join('/mock/agents/cursor/skills', 'new-skill'),
+    )
+    expect(symlinkMock).not.toHaveBeenCalledWith(
+      expect.any(String),
+      join('/mock/agents/claude/skills', 'new-skill'),
+    )
+    expect(mkdirMock).toHaveBeenCalledWith('/mock/agents/cursor/skills', {
+      recursive: true,
+    })
+    expect(mkdirMock).not.toHaveBeenCalledWith(
+      '/mock/agents/claude/skills',
+      expect.anything(),
+    )
+  })
+
+  it('execute with an agentId not in AGENTS is a no-op (no silent fallback to all)', async () => {
+    // Defends against typos AND against an agent that exists in the union
+    // but isn't installed/on-disk in the user's environment. The mocked
+    // AGENTS list above only includes claude-code and cursor; passing
+    // 'codex' (a valid AgentId, not in the mock) reproduces "agent not on
+    // disk" — production filterAgentsByOption returns [] and we expect
+    // zero side effects.
+    readdirMock.mockImplementation(async (dir: string) => {
+      if (dir === '/mock/source/skills') {
+        return [{ name: 'new-skill', isDirectory: () => true }]
+      }
+      return []
+    })
+    lstatMock.mockRejectedValue(new Error('ENOENT'))
+
+    const { syncExecute } = await import('./syncService')
+    const result = await syncExecute({
+      replaceConflicts: [],
+      agentId: 'codex',
+    })
+
+    expect(result.created).toBe(0)
+    expect(result.details).toHaveLength(0)
+    expect(symlinkMock).not.toHaveBeenCalled()
+    expect(mkdirMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/services/syncService.test.ts
+++ b/src/main/services/syncService.test.ts
@@ -508,4 +508,27 @@ describe('scoped sync (per-agent)', () => {
     expect(symlinkMock).not.toHaveBeenCalled()
     expect(mkdirMock).not.toHaveBeenCalled()
   })
+
+  it('preview with an agentId not in AGENTS echoes forAgent and returns zero agents', async () => {
+    // Symmetric counterpart to the syncExecute no-op test above. The
+    // empty-state path of CleanupAgentDialog depends on this branch:
+    // forAgent must round-trip so previewMatchesTarget keeps the dialog
+    // gated, while totalAgents collapses to 0 and lstat is never even
+    // queried because filterAgentsByOption returned [].
+    readdirMock.mockImplementation(async (dir: string) => {
+      if (dir === '/mock/source/skills') {
+        return [{ name: 'any-skill', isDirectory: () => true }]
+      }
+      return []
+    })
+
+    const { syncPreview } = await import('./syncService')
+    const result = await syncPreview({ agentId: 'codex' })
+
+    expect(result.totalAgents).toBe(0)
+    expect(result.toCreate).toBe(0)
+    expect(result.alreadySynced).toBe(0)
+    expect(result.forAgent).toBe('codex')
+    expect(lstatMock).not.toHaveBeenCalled()
+  })
 })

--- a/src/main/services/syncService.ts
+++ b/src/main/services/syncService.ts
@@ -10,6 +10,7 @@ import type {
   SyncConflict,
   SyncExecuteOptions,
   SyncExecuteResult,
+  SyncPreviewOptions,
   SyncPreviewResult,
   SyncResultItem,
 } from '../../shared/types'
@@ -41,15 +42,38 @@ async function getExistingAgents(): Promise<ExistingAgent[]> {
 }
 
 /**
- * Preview sync: detect what would happen without making changes
- * @returns SyncPreviewResult with counts and conflicts
+ * Narrow `getExistingAgents()` to a single agent when `options.agentId` is set.
+ * Lifted out so `syncPreview` and `syncExecute` cannot drift on the filter rule.
+ * Returns `[]` when the requested agent isn't on disk — preview/execute then
+ * short-circuit with empty results rather than silently no-op'ing across all
+ * agents (defends against typos in the agentId arg).
+ */
+function filterAgentsByOption<TAgent extends { id: AgentId }>(
+  agents: TAgent[],
+  agentId: AgentId | undefined,
+): TAgent[] {
+  if (!agentId) return agents
+  return agents.filter((a) => a.id === agentId)
+}
+
+/**
+ * Preview sync: detect what would happen without making changes.
+ * Optionally scoped to a single agent for the per-agent Cleanup flow.
+ * @param options - When `agentId` is set, restricts preview to that one agent.
+ * @returns SyncPreviewResult with counts, conflicts, and (when scoped) `forAgent` echo.
  * @example
  * syncPreview()
  * // => { totalSkills: 5, totalAgents: 3, toCreate: 10, alreadySynced: 5, conflicts: [] }
+ * @example
+ * syncPreview({ agentId: 'cursor' })
+ * // => { totalSkills: 5, totalAgents: 1, toCreate: 4, alreadySynced: 1, conflicts: [], forAgent: 'cursor' }
  */
-export async function syncPreview(): Promise<SyncPreviewResult> {
+export async function syncPreview(
+  options?: SyncPreviewOptions,
+): Promise<SyncPreviewResult> {
   const skills = await listValidSourceSkillDirs()
-  const agents = await getExistingAgents()
+  const allAgents = await getExistingAgents()
+  const agents = filterAgentsByOption(allAgents, options?.agentId)
 
   let toCreate = 0
   let alreadySynced = 0
@@ -86,26 +110,32 @@ export async function syncPreview(): Promise<SyncPreviewResult> {
     toCreate,
     alreadySynced,
     conflicts,
+    ...(options?.agentId ? { forAgent: options.agentId } : {}),
   }
 }
 
 /**
  * Execute sync: create symlinks and optionally replace conflicts.
  * Tracks per-item details for displaying a sync diff after completion.
- * @param options - replaceConflicts: paths to replace with symlinks
+ * Optionally scoped to a single agent for the per-agent Cleanup flow.
+ * @param options - replaceConflicts: paths to replace with symlinks. agentId: restrict to one agent.
  * @returns SyncExecuteResult with counts, per-item details, and errors
  * @example
  * syncExecute({ replaceConflicts: ['/Users/x/.claude/skills/my-skill'] })
  * // => { success: true, created: 10, replaced: 1, skipped: 5, errors: [], details: [...] }
+ * @example
+ * syncExecute({ replaceConflicts: [], agentId: 'cursor' })
+ * // => { success: true, created: 4, replaced: 0, skipped: 1, errors: [], details: [...] }
  */
 export async function syncExecute(
   options: SyncExecuteOptions,
 ): Promise<SyncExecuteResult> {
-  const { replaceConflicts } = options
+  const { replaceConflicts, agentId } = options
   const replaceSet = new Set(replaceConflicts)
 
   const skills = await listValidSourceSkillDirs()
-  const agents = await getExistingAgents()
+  const allAgents = await getExistingAgents()
+  const agents = filterAgentsByOption(allAgents, agentId)
 
   let created = 0
   let replaced = 0

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -18,6 +18,7 @@ import type {
   RestoreDeletedSkillOptions,
   SearchQuery,
   SyncExecuteOptions,
+  SyncPreviewOptions,
   UnlinkFromAgentOptions,
   UnlinkManyFromAgentOptions,
   UpdateInfo,
@@ -112,7 +113,8 @@ contextBridge.exposeInMainWorld('electron', {
   },
   // Sync API
   sync: {
-    preview: async () => typedInvoke('sync:preview'),
+    preview: async (options?: SyncPreviewOptions) =>
+      typedInvoke('sync:preview', options),
     execute: async (options: SyncExecuteOptions) =>
       typedInvoke('sync:execute', options),
   },

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -55,6 +55,7 @@ import { errorToastDescription } from '../../utils/errorToastDescription'
 import { isEditableTarget } from '../../utils/isEditableTarget'
 import { pluralize } from '../../utils/pluralize'
 import { SkillsMarketplace } from '../marketplace'
+import { CleanupAgentDialog } from '../sidebar/CleanupAgentDialog'
 import { SyncConfirmDialog } from '../sidebar/SyncConfirmDialog'
 import { SyncConflictDialog } from '../sidebar/SyncConflictDialog'
 import { SyncResultDialog } from '../sidebar/SyncResultDialog'
@@ -605,6 +606,7 @@ export const MainContent = React.memo(
         <SyncConfirmDialog />
         <SyncConflictDialog />
         <SyncResultDialog />
+        <CleanupAgentDialog />
 
         {/*
           Bulk delete / unlink confirmation. Replaces the old `window.confirm`

--- a/src/renderer/src/components/sidebar/AgentItem.tsx
+++ b/src/renderer/src/components/sidebar/AgentItem.tsx
@@ -1,4 +1,4 @@
-import { Trash2 } from 'lucide-react'
+import { Eraser, Trash2 } from 'lucide-react'
 import React, { useMemo, useState } from 'react'
 
 import { AGENT_DEFINITIONS } from '../../../../shared/constants'
@@ -6,11 +6,12 @@ import type { Agent, AgentId } from '../../../../shared/types'
 import { cn } from '../../lib/utils'
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
 import { setAgentToDelete } from '../../redux/slices/agentsSlice'
-import { selectAgent } from '../../redux/slices/uiSlice'
+import { selectAgent, setCleanupAgentTarget } from '../../redux/slices/uiSlice'
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
@@ -88,6 +89,14 @@ export const AgentItem = React.memo(function AgentItem({
     setContextOpen(false)
   }
 
+  const handleCleanupMissing = (): void => {
+    // Opens `CleanupAgentDialog`. The dialog itself dispatches the scoped
+    // `fetchSyncPreview({ agentId })` once it mounts, so we don't need
+    // to chain it here — keeps the menu handler synchronous.
+    dispatch(setCleanupAgentTarget(agent.id))
+    setContextOpen(false)
+  }
+
   const skillCountText = useMemo(
     () =>
       agent.exists
@@ -136,6 +145,11 @@ export const AgentItem = React.memo(function AgentItem({
           </DropdownMenuTrigger>
         </TooltipTrigger>
         <DropdownMenuContent>
+          <DropdownMenuItem onClick={handleCleanupMissing}>
+            <Eraser className="h-4 w-4 mr-2" />
+            Cleanup missing skills...
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
           <DropdownMenuItem
             onClick={handleDelete}
             className="text-destructive focus:text-destructive"

--- a/src/renderer/src/components/sidebar/CleanupAgentDialog.tsx
+++ b/src/renderer/src/components/sidebar/CleanupAgentDialog.tsx
@@ -60,11 +60,23 @@ export const CleanupAgentDialog = React.memo(
 
     // Trigger the scoped preview as soon as the dialog opens. We re-fetch
     // every time `cleanupAgentTarget` changes so closing-then-reopening on
-    // a different agent doesn't render stale numbers.
+    // a different agent doesn't render stale numbers. If the preview thunk
+    // rejects (IPC failure, missing source dir, etc.) we close the dialog
+    // and surface a toast — otherwise it would hang on the loading spinner
+    // forever with no way to recover.
     useEffect(() => {
-      if (cleanupAgentTarget) {
-        dispatch(fetchSyncPreview({ agentId: cleanupAgentTarget }))
-      }
+      if (!cleanupAgentTarget) return
+
+      dispatch(fetchSyncPreview({ agentId: cleanupAgentTarget })).then(
+        (action) => {
+          if (fetchSyncPreview.rejected.match(action)) {
+            toast.error('Failed to load cleanup preview', {
+              description: errorToastDescription(action),
+            })
+            dispatch(clearCleanupAgentTarget())
+          }
+        },
+      )
     }, [cleanupAgentTarget, dispatch])
 
     if (!cleanupAgentTarget) return null
@@ -101,11 +113,15 @@ export const CleanupAgentDialog = React.memo(
         }),
       )
 
-      // SyncResultDialog renders the per-item diff on success.
       if (executeSyncAction.rejected.match(result)) {
         toast.error('Cleanup failed', {
           description: errorToastDescription(result),
         })
+      } else {
+        // Close this dialog so `SyncResultDialog` (which `executeSyncAction`
+        // already populated via `syncResult`) becomes the sole foreground
+        // surface — otherwise the per-agent dialog stays mounted underneath.
+        dispatch(clearCleanupAgentTarget())
       }
 
       setIsExecuting(false)

--- a/src/renderer/src/components/sidebar/CleanupAgentDialog.tsx
+++ b/src/renderer/src/components/sidebar/CleanupAgentDialog.tsx
@@ -1,0 +1,211 @@
+import { Eraser, Loader2 } from 'lucide-react'
+import React, { useEffect, useState } from 'react'
+import { toast } from 'sonner'
+
+import { AGENT_DEFINITIONS } from '../../../../shared/constants'
+import type { AgentName } from '../../../../shared/types'
+import { useAppDispatch, useAppSelector } from '../../redux/hooks'
+import {
+  clearCleanupAgentTarget,
+  executeSyncAction,
+  fetchSyncPreview,
+  selectCleanupAgentTarget,
+  selectSyncPreview,
+} from '../../redux/slices/uiSlice'
+import { Button } from '../ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog'
+
+/**
+ * Per-agent cleanup dialog.
+ * Opens when the user picks "Cleanup missing skills..." from `AgentItem`'s
+ * right-click menu. Triggers a scoped `fetchSyncPreview({ agentId })`,
+ * shows the resulting `toCreate` count, and on confirm dispatches
+ * `executeSyncAction({ replaceConflicts: [], agentId })` to recreate just
+ * that agent's missing symlinks.
+ *
+ * Why this is separate from `SyncConfirmDialog`:
+ * - Global sync acts across every detected agent. A scoped per-agent run
+ *   shares the IPC plumbing but needs different copy ("Cleanup `<agent>`"
+ *   vs "Sync Skills") and a different mental model (recover one agent vs
+ *   propagate everything).
+ * - The global dialogs gate themselves on `!preview.forAgent` so a scoped
+ *   preview never accidentally opens both surfaces at once.
+ *
+ * Lifecycle:
+ * 1. `setCleanupAgentTarget(agentId)` from AgentItem
+ * 2. This component mounts, dispatches `fetchSyncPreview({ agentId })`
+ * 3. Render the count + Cleanup button once preview lands
+ * 4. On confirm: `executeSyncAction({ agentId })` → `SyncResultDialog`
+ *    takes over to display the per-item diff
+ * 5. `clearCleanupAgentTarget()` resets the slice (also nulls
+ *    `syncPreview` so the global confirm can't latch onto it)
+ */
+export const CleanupAgentDialog = React.memo(
+  function CleanupAgentDialog(): React.ReactElement | null {
+    const dispatch = useAppDispatch()
+    const cleanupAgentTarget = useAppSelector(selectCleanupAgentTarget)
+    const syncPreview = useAppSelector(selectSyncPreview)
+    const isSyncing = useAppSelector((state) => state.ui.isSyncing)
+
+    const [isExecuting, setIsExecuting] = useState(false)
+
+    // Trigger the scoped preview as soon as the dialog opens. We re-fetch
+    // every time `cleanupAgentTarget` changes so closing-then-reopening on
+    // a different agent doesn't render stale numbers.
+    useEffect(() => {
+      if (cleanupAgentTarget) {
+        dispatch(fetchSyncPreview({ agentId: cleanupAgentTarget }))
+      }
+    }, [cleanupAgentTarget, dispatch])
+
+    if (!cleanupAgentTarget) return null
+
+    // Stale-preview guard: only trust the preview when its `forAgent`
+    // matches the currently-targeted agent. Defends against the race
+    // where a global preview lands while a scoped fetch is in flight.
+    const previewMatchesTarget =
+      syncPreview?.forAgent === cleanupAgentTarget ? syncPreview : null
+
+    const agentName: AgentName | undefined = AGENT_DEFINITIONS.find(
+      (a) => a.id === cleanupAgentTarget,
+    )?.name
+
+    const conflictCount = previewMatchesTarget?.conflicts.length ?? 0
+    const missingCount = previewMatchesTarget?.toCreate ?? 0
+    const alreadySyncedCount = previewMatchesTarget?.alreadySynced ?? 0
+    const hasWork = missingCount > 0
+    const isLoadingPreview = !previewMatchesTarget
+
+    const handleClose = (): void => {
+      if (!isExecuting) {
+        dispatch(clearCleanupAgentTarget())
+      }
+    }
+
+    const handleCleanup = async (): Promise<void> => {
+      setIsExecuting(true)
+
+      const result = await dispatch(
+        executeSyncAction({
+          replaceConflicts: [],
+          agentId: cleanupAgentTarget,
+        }),
+      )
+
+      // SyncResultDialog renders the per-item diff on success.
+      if (executeSyncAction.rejected.match(result)) {
+        toast.error('Cleanup failed', {
+          description: result.error?.message || 'An unexpected error occurred',
+        })
+      }
+
+      setIsExecuting(false)
+    }
+
+    return (
+      <Dialog open onOpenChange={handleClose}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <div className="flex items-center gap-2">
+              <Eraser className="h-5 w-5 text-primary" />
+              <DialogTitle>
+                Cleanup missing skills{agentName ? ` — ${agentName}` : ''}
+              </DialogTitle>
+            </div>
+            <DialogDescription>
+              Recreate symlinks for skills that exist in your source directory
+              but are missing from {agentName ?? 'this agent'}.
+            </DialogDescription>
+          </DialogHeader>
+
+          {isLoadingPreview ? (
+            <div className="py-6 flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Calculating cleanup plan...
+            </div>
+          ) : (
+            <div className="py-4 space-y-2 text-sm">
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Skills considered</span>
+                <span className="font-medium">
+                  {previewMatchesTarget.totalSkills}
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">
+                  Symlinks to create
+                </span>
+                <span
+                  className={
+                    hasWork ? 'font-medium text-primary' : 'font-medium'
+                  }
+                >
+                  {missingCount}
+                </span>
+              </div>
+              {alreadySyncedCount > 0 && (
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Already linked</span>
+                  <span className="font-medium">{alreadySyncedCount}</span>
+                </div>
+              )}
+              {conflictCount > 0 && (
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">
+                    Conflicts (skipped)
+                  </span>
+                  <span className="font-medium text-amber-500">
+                    {conflictCount}
+                  </span>
+                </div>
+              )}
+              {!hasWork && conflictCount === 0 && (
+                <p className="text-muted-foreground pt-1">
+                  Nothing to clean up — every source skill is already linked.
+                </p>
+              )}
+              {conflictCount > 0 && hasWork && (
+                <p className="text-xs text-muted-foreground pt-1">
+                  Conflicts (real folders blocking a symlink) are not touched by
+                  cleanup. Resolve them from the global Sync flow.
+                </p>
+              )}
+            </div>
+          )}
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={handleClose}
+              disabled={isExecuting}
+            >
+              {hasWork ? 'Cancel' : 'Close'}
+            </Button>
+            {hasWork && (
+              <Button
+                onClick={handleCleanup}
+                disabled={isExecuting || isSyncing}
+              >
+                {isExecuting ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                    Cleaning up...
+                  </>
+                ) : (
+                  `Cleanup ${missingCount} ${missingCount === 1 ? 'skill' : 'skills'}`
+                )}
+              </Button>
+            )}
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    )
+  },
+)

--- a/src/renderer/src/components/sidebar/CleanupAgentDialog.tsx
+++ b/src/renderer/src/components/sidebar/CleanupAgentDialog.tsx
@@ -173,7 +173,7 @@ export const CleanupAgentDialog = React.memo(
                   Nothing to clean up — every source skill is already linked.
                 </p>
               )}
-              {conflictCount > 0 && hasWork && (
+              {conflictCount > 0 && (
                 <p className="text-xs text-muted-foreground pt-1">
                   Conflicts (real folders blocking a symlink) are not touched by
                   cleanup. Resolve them from the global Sync flow.

--- a/src/renderer/src/components/sidebar/CleanupAgentDialog.tsx
+++ b/src/renderer/src/components/sidebar/CleanupAgentDialog.tsx
@@ -12,6 +12,8 @@ import {
   selectCleanupAgentTarget,
   selectSyncPreview,
 } from '../../redux/slices/uiSlice'
+import { errorToastDescription } from '../../utils/errorToastDescription'
+import { pluralize } from '../../utils/pluralize'
 import { Button } from '../ui/button'
 import {
   Dialog,
@@ -102,7 +104,7 @@ export const CleanupAgentDialog = React.memo(
       // SyncResultDialog renders the per-item diff on success.
       if (executeSyncAction.rejected.match(result)) {
         toast.error('Cleanup failed', {
-          description: result.error?.message || 'An unexpected error occurred',
+          description: errorToastDescription(result),
         })
       }
 
@@ -199,7 +201,7 @@ export const CleanupAgentDialog = React.memo(
                     Cleaning up...
                   </>
                 ) : (
-                  `Cleanup ${missingCount} ${missingCount === 1 ? 'skill' : 'skills'}`
+                  `Cleanup ${missingCount} ${pluralize(missingCount, 'skill')}`
                 )}
               </Button>
             )}

--- a/src/renderer/src/components/sidebar/SyncConflictDialog.tsx
+++ b/src/renderer/src/components/sidebar/SyncConflictDialog.tsx
@@ -26,7 +26,10 @@ export const SyncConflictDialog = React.memo(
 
     const conflicts = syncPreview?.conflicts ?? []
     const hasConflicts = conflicts.length > 0
-    const isOpen = hasConflicts && !!syncPreview
+    // Global conflict dialog only — per-agent previews carry `forAgent`
+    // and are owned by `CleanupAgentDialog`. Without this guard a scoped
+    // preview with conflicts would open both dialogs simultaneously.
+    const isOpen = hasConflicts && !!syncPreview && !syncPreview.forAgent
 
     const [selectedPaths, setSelectedPaths] = useState<Set<string>>(new Set())
     const [isExecuting, setIsExecuting] = useState(false)

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -301,6 +301,15 @@ export const SkillItem = React.memo(function SkillItem({
             !didPartialFail &&
               isLocalSkill &&
               'border-l-2 border-l-emerald-400/40',
+            // Orphan accent — surfaces dangling rows that the loosened
+            // selectFilteredSkills now lets through. Mutually exclusive with
+            // isLinked/isLocalSkill by definition (no source dir → no valid
+            // symlinks and no local copy could've kept it from being marked
+            // orphan), so the order below is purely for the partial-fail
+            // override.
+            !didPartialFail &&
+              skill.isOrphan &&
+              'border-l-2 border-l-amber-400/60',
             // In-flight fade while the row is part of an active bulk op.
             isInFlight && 'opacity-50 duration-150',
             // Partial-failure red edge (PARTIAL_FAIL_FLASH_MS).
@@ -443,6 +452,20 @@ export const SkillItem = React.memo(function SkillItem({
                     />
                   )}
                   <span className="truncate">{skill.name}</span>
+                  {/* Orphan badge — paired with the amber left-border so the
+                      row's state is legible even when the user hasn't
+                      noticed the border accent. The plain word "orphan"
+                      keeps it scannable; tooltip explains the action. */}
+                  {skill.isOrphan && (
+                    <span
+                      data-testid={`skill-orphan-badge-${skill.name}`}
+                      className="inline-flex items-center rounded-md border border-amber-400/50 bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-amber-300 shrink-0"
+                      aria-label="Orphan skill — source directory is missing"
+                      title="Source directory is missing — use Cleanup to remove the dangling symlinks"
+                    >
+                      orphan
+                    </span>
+                  )}
                   {/* Add button:
                       - global view => AddSymlinkModal
                       - agent view => CopyToAgentsModal */}

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -458,6 +458,7 @@ export const SkillItem = React.memo(function SkillItem({
                       keeps it scannable; tooltip explains the action. */}
                   {skill.isOrphan && (
                     <span
+                      role="img"
                       data-testid={`skill-orphan-badge-${skill.name}`}
                       className="inline-flex items-center rounded-md border border-amber-400/50 bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-amber-300 shrink-0"
                       aria-label="Orphan skill — source directory is missing"

--- a/src/renderer/src/components/skills/skillItemHelpers.test.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.test.ts
@@ -106,17 +106,20 @@ describe('getSkillItemVisibility', () => {
       expect(result.selectedAgentSymlink).toBe(symlinks[0])
     })
 
-    it('hides unlink button for orphan-only broken symlink (no usable copy anywhere)', () => {
-      // A skill whose every entry is broken/missing has no source — issue #127
-      // Option B fix routes orphans to a separate cleanup flow (#71), so the
-      // existing X button must not surface (its IPC handlers don't support
-      // orphan removal cleanly).
+    it('shows unlink button for orphan-only broken symlink so user can clean it up', () => {
+      // PR #131 (issue #71 PR-2) intentionally surfaces unlink for orphan
+      // rows: removing a dangling symlink at `linkPath` is a safe `rm` op
+      // regardless of whether the target resolves, and it's how the user
+      // sweeps orphans one row at a time without the bulk Cleanup dialog.
+      // Add stays gated separately because re-adding requires a live source.
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'broken', isLocal: false }),
       ]
       const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
 
-      expect(result.showUnlinkButton).toBe(false)
+      expect(result.showUnlinkButton).toBe(true)
+      // isLinked still requires status==='valid'; broken does NOT count as
+      // linked even though it now satisfies showUnlinkButton.
       expect(result.isLinked).toBe(false)
     })
 
@@ -300,16 +303,23 @@ describe('getSkillItemVisibility', () => {
     })
   })
 
-  describe('orphan skill guard (issue #127)', () => {
-    it('hides global delete button for orphan-only skill', () => {
+  describe('orphan skill guard', () => {
+    // PR #131 (issue #71 PR-2) loosens the orphan gate on Delete and Unlink
+    // so users can sweep orphans surfaced by the new amber-border row UI.
+    // Add stays gated because there is no live source to point a new
+    // symlink at. The original #127 hide-everything stance is gone.
+    it('shows global delete button for orphan-only skill so user can sweep the row', () => {
       // Source removed, broken symlinks across two agents, no real folders.
+      // Delete clears all dangling agent symlinks plus the now-empty source
+      // tombstone in one shot — the bulk version of the Cleanup-per-agent
+      // flow.
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'broken', isLocal: false }),
         makeSymlink({ agentId: 'codex', status: 'broken', isLocal: false }),
       ]
       const result = getSkillItemVisibility(null, makeSkill(symlinks))
 
-      expect(result.showDeleteButton).toBe(false)
+      expect(result.showDeleteButton).toBe(true)
     })
 
     it('keeps global delete button visible when at least one agent has a valid copy', () => {
@@ -332,11 +342,10 @@ describe('getSkillItemVisibility', () => {
       expect(result.showDeleteButton).toBe(true)
     })
 
-    it('respects explicit isOrphan override even when symlinks would derive false', () => {
-      // Pins the contract that getSkillItemVisibility reads `isOrphan` straight
-      // off the skill (set by scanOrphanSymlinks in main) instead of
-      // re-deriving it from `symlinks`. A valid symlink would otherwise drive
-      // derivedOrphan=false; the override keeps the orphan path active.
+    it('global Delete is shown regardless of explicit isOrphan override', () => {
+      // After the loosen, Delete is purely a global-view concern (`!selectedAgentId`).
+      // The explicit isOrphan override no longer suppresses it — the override
+      // only steers Add visibility now.
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: false }),
       ]
@@ -344,14 +353,14 @@ describe('getSkillItemVisibility', () => {
         null,
         makeSkill(symlinks, { isOrphan: true }),
       )
-      expect(result.showDeleteButton).toBe(false)
+      expect(result.showDeleteButton).toBe(true)
+      // …and the orphan override DOES still gate Add as designed.
+      expect(result.showAddButton).toBe(false)
     })
 
     it('hides Add button for orphan skill in global view', () => {
-      // Issue #71 PR-1: Add button (which opens AddSymlinkModal /
-      // CopyToAgentsModal) would surface a flow that can only fail when the
-      // source is gone — there is nothing to symlink _to_. Same orphan rule
-      // as Delete and Unlink.
+      // Add (AddSymlinkModal / CopyToAgentsModal) requires a live source
+      // dir to symlink _to_; for orphans the source is gone.
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'broken', isLocal: false }),
         makeSymlink({ agentId: 'codex', status: 'broken', isLocal: false }),
@@ -361,23 +370,22 @@ describe('getSkillItemVisibility', () => {
       expect(result.showAddButton).toBe(false)
     })
 
-    it('hides Add button for orphan skill in agent view even when the agent has a broken symlink', () => {
+    it('hides Add but shows Unlink for orphan skill in agent view', () => {
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'broken', isLocal: false }),
         makeSymlink({ agentId: 'codex', status: 'broken', isLocal: false }),
       ]
       const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
 
-      // Even though `selectedAgentSymlink` is non-null (the broken cursor
-      // entry passes the `valid|broken` filter), the orphan gate wins: there
-      // is no live source to symlink TO, so re-adding makes no sense.
+      // Add stays gated: even though the broken cursor entry passes the
+      // `valid|broken` filter, there is no live source to symlink TO.
       expect(result.showAddButton).toBe(false)
-      // Sibling guards still hold for orphan rows.
-      expect(result.showUnlinkButton).toBe(false)
+      // Unlink is the per-agent cleanup affordance for orphan rows.
+      expect(result.showUnlinkButton).toBe(true)
     })
 
     it('keeps Add button visible when isOrphan is false (non-orphan, valid symlinks)', () => {
-      // Sanity check: the new && !isOrphan term must NOT regress the
+      // Sanity check: the && !isOrphan term must NOT regress the
       // happy path where Add was always available.
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: false }),

--- a/src/renderer/src/components/skills/skillItemHelpers.test.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.test.ts
@@ -382,6 +382,11 @@ describe('getSkillItemVisibility', () => {
       expect(result.showAddButton).toBe(false)
       // Unlink is the per-agent cleanup affordance for orphan rows.
       expect(result.showUnlinkButton).toBe(true)
+      // Copy fans out from the live source skill — same reason Add is
+      // hidden, this must be hidden too. Without this assertion the
+      // context-menu Copy entry leaks through and lands the user in
+      // CopyToAgentsModal with no source to copy from.
+      expect(result.showCopyButton).toBe(false)
     })
 
     it('keeps Add button visible when isOrphan is false (non-orphan, valid symlinks)', () => {

--- a/src/renderer/src/components/skills/skillItemHelpers.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.ts
@@ -76,12 +76,23 @@ function isGStackBundlePath(candidatePath: string): boolean {
  * // => { showDeleteButton: false, showAddButton: true, showUnlinkButton: true, isLinked: true, ... }
  *
  * @example
- * // Orphan skill — both delete and unlink hidden (cleanup flow handled separately)
+ * // Orphan in global view — Delete is shown so the user can sweep the
+ * // dangling skill row; Add is hidden (no live source to point a new
+ * // symlink at).
  * getSkillItemVisibility(null, {
  *   symlinks: [{ agentId: 'cursor', status: 'broken', isLocal: false, ... }],
  *   isOrphan: true,
  * })
- * // => { showDeleteButton: false, showUnlinkButton: false, ... }
+ * // => { showDeleteButton: true, showAddButton: false, showUnlinkButton: false, ... }
+ *
+ * @example
+ * // Orphan in agent view — Unlink is shown so the user can clear the
+ * // dangling agent-side symlink one row at a time. Add stays hidden.
+ * getSkillItemVisibility('cursor', {
+ *   symlinks: [{ agentId: 'cursor', status: 'broken', isLocal: false, ... }],
+ *   isOrphan: true,
+ * })
+ * // => { showDeleteButton: false, showAddButton: false, showUnlinkButton: true, ... }
  */
 export function getSkillItemVisibility(
   selectedAgentId: AgentId | null,
@@ -103,8 +114,8 @@ export function getSkillItemVisibility(
 
   const isLocalSkill = !!selectedLocalSkillInfo
   const hasSkillInSelectedAgent = !!selectedAgentSymlink || isLocalSkill
-  // Orphan handling — see Skill.isOrphan for why the delete/unlink buttons
-  // are gated. Source: scanOrphanSymlinks() in src/main/services/skillScanner.ts.
+  // Orphan handling — see Skill.isOrphan for why the Add button is gated.
+  // Source: scanOrphanSymlinks() in src/main/services/skillScanner.ts.
   const gStackPathCandidates = [
     selectedAgentSymlink?.targetPath ?? '',
     selectedAgentSymlink?.linkPath ?? '',
@@ -117,13 +128,20 @@ export function getSkillItemVisibility(
     isGStackEligibleAgent && gStackPathCandidates.some(isGStackBundlePath)
 
   return {
-    showDeleteButton: !selectedAgentId && !isOrphan,
+    // Delete is the primary cleanup action for orphans in global view —
+    // sweeping the dangling row removes every agent-side symlink at once.
+    // Restored so users have an explicit way to act on what the loosened
+    // selectFilteredSkills now shows them.
+    showDeleteButton: !selectedAgentId,
     // Orphan skills have no live source to symlink _to_, so the Add button
     // (which opens AddSymlinkModal / CopyToAgentsModal) would surface a flow
-    // that can only fail. Hide it for the same reason Delete/Unlink hide:
-    // the source is gone, the row is awaiting cleanup, not action.
+    // that can only fail. Stays gated on `!isOrphan` even after the Delete
+    // and Unlink loosens.
     showAddButton: (!selectedAgentId || hasSkillInSelectedAgent) && !isOrphan,
-    showUnlinkButton: hasSkillInSelectedAgent && !isOrphan,
+    // Unlink is the per-agent cleanup action — drives the right-click
+    // "Cleanup missing skills..." flow's row-level analogue. For orphans
+    // it removes the dangling symlink without touching siblings.
+    showUnlinkButton: hasSkillInSelectedAgent,
     isLinked: !!selectedAgentSymlink && selectedAgentSymlink.status === 'valid',
     isLocalSkill,
     selectedAgentSymlink,

--- a/src/renderer/src/components/skills/skillItemHelpers.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.ts
@@ -146,7 +146,10 @@ export function getSkillItemVisibility(
     isLocalSkill,
     selectedAgentSymlink,
     selectedLocalSkillInfo,
-    showCopyButton: !!selectedAgentId && hasSkillInSelectedAgent,
+    // "Copy to..." opens CopyToAgentsModal which fans out from the live
+    // source skill — for an orphan, that source is gone. Hide the action
+    // for the same reason `showAddButton` is gated on `!isOrphan`.
+    showCopyButton: !!selectedAgentId && hasSkillInSelectedAgent && !isOrphan,
     showGStackBadge,
   }
 }

--- a/src/renderer/src/lib/syncHelpers.ts
+++ b/src/renderer/src/lib/syncHelpers.ts
@@ -12,8 +12,14 @@ import type {
 } from '../../../shared/types'
 
 /**
- * Whether to show the sync confirmation dialog (no-conflict case).
- * Returns true when there are new symlinks to create but no conflicts to resolve.
+ * Whether to show the GLOBAL sync confirmation dialog (no-conflict case).
+ * Returns true when there are new symlinks to create, no conflicts to
+ * resolve, AND the preview is global (not scoped to a single agent).
+ *
+ * Per-agent scoped previews populate `forAgent` and are owned by
+ * `CleanupAgentDialog`; this guard prevents the global dialog from
+ * latching onto them and rendering on top.
+ *
  * @param preview - Sync preview result from the main process, or null if not available
  * @returns true if the confirm dialog should be shown
  * @example
@@ -21,11 +27,13 @@ import type {
  * shouldShowSyncConfirm({ toCreate: 5, conflicts: [] }) // => true
  * shouldShowSyncConfirm({ toCreate: 5, conflicts: [conflict] }) // => false (conflict dialog handles this)
  * shouldShowSyncConfirm({ toCreate: 0, conflicts: [] }) // => false (already synced)
+ * shouldShowSyncConfirm({ toCreate: 5, conflicts: [], forAgent: 'cursor' }) // => false (CleanupAgentDialog owns this)
  */
 export function shouldShowSyncConfirm(
   preview: SyncPreviewResult | null,
 ): boolean {
   if (!preview) return false
+  if (preview.forAgent) return false
   return preview.toCreate > 0 && preview.conflicts.length === 0
 }
 

--- a/src/renderer/src/redux/selectors.test.ts
+++ b/src/renderer/src/redux/selectors.test.ts
@@ -231,7 +231,12 @@ describe('selectFilteredSkills', () => {
     expect(result[0].name).toBe('browse')
   })
 
-  it('excludes skills with broken symlinks for agent filter', () => {
+  it('surfaces broken (orphan) symlinks for agent filter so user can clean them up', () => {
+    // An orphan: source dir vanished, but cursor still has a dangling symlink
+    // pointing at where the source used to live. The per-agent view must
+    // surface this row so the right-click "Cleanup missing skills..." flow
+    // (PR #71) has something to act on. Hiding it would silently strand the
+    // orphan symlink in the agent dir.
     const skill: Skill = {
       name: 'broken-skill',
       description: 'broken',
@@ -244,6 +249,35 @@ describe('selectFilteredSkills', () => {
           linkPath: '/home/user/.cursor/skills/broken-skill',
           targetPath: '/home/user/.agents/skills/broken-skill',
           status: 'broken',
+          isLocal: false,
+        },
+      ],
+      isSource: false,
+      isOrphan: true,
+    }
+    const state = buildState({ skills: [skill], selectedAgentId: 'cursor' })
+    const result = selectFilteredSkills(state as never)
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('broken-skill')
+    expect(result[0].isOrphan).toBe(true)
+  })
+
+  it('excludes "missing" symlink entries from agent filter', () => {
+    // status:'missing' is the scanner's way of representing an agent slot
+    // with NO on-disk symlink at all — there's nothing to surface or clean
+    // up, so it must not pollute the per-agent list.
+    const skill: Skill = {
+      name: 'unlinked-skill',
+      description: 'unlinked',
+      path: '/home/user/.agents/skills/unlinked-skill',
+      symlinkCount: 0,
+      symlinks: [
+        {
+          agentId: 'cursor' as SymlinkInfo['agentId'],
+          agentName: 'Cursor' as SymlinkInfo['agentName'],
+          linkPath: '/home/user/.cursor/skills/unlinked-skill',
+          targetPath: '/home/user/.agents/skills/unlinked-skill',
+          status: 'missing',
           isLocal: false,
         },
       ],

--- a/src/renderer/src/redux/selectors.ts
+++ b/src/renderer/src/redux/selectors.ts
@@ -65,6 +65,13 @@ export const selectFilteredSkills = createSelector(
     // folders (e.g. `~/.claude/skills/<name>` that has no symlink under
     // `~/.agents/skills/`). See "hides agent-local-only skills from the
     // SourceCard view (no agent selected)" test in selectors.test.ts.
+    //
+    // Per-agent surface includes both `valid` and `broken` symlinks so the
+    // user can see and clean up orphans (symlinks whose source dir vanished)
+    // from the agent view — that's the entry point for "Cleanup missing
+    // skills..." driven by AgentItem's right-click menu. `missing` entries
+    // are filtered out because they represent agent slots with no on-disk
+    // symlink at all (nothing to surface or clean up there).
     if (selectedAgentId) {
       const checkType = skillTypeFilter !== 'all'
       const wantLocal = skillTypeFilter === 'local'
@@ -72,7 +79,7 @@ export const selectFilteredSkills = createSelector(
         skill.symlinks.some(
           (s) =>
             s.agentId === selectedAgentId &&
-            s.status === 'valid' &&
+            (s.status === 'valid' || s.status === 'broken') &&
             (!checkType || s.isLocal === wantLocal),
         ),
       )

--- a/src/renderer/src/redux/slices/uiSlice.ts
+++ b/src/renderer/src/redux/slices/uiSlice.ts
@@ -12,6 +12,7 @@ import type {
   SourceStats,
   SyncExecuteOptions,
   SyncExecuteResult,
+  SyncPreviewOptions,
   SyncPreviewResult,
   ToastId,
   TombstoneId,
@@ -123,6 +124,16 @@ interface UiState {
    * the current selection stale (tab, agent, sync op, competing bulk op).
    */
   bulkSelectMode: boolean
+  /**
+   * Agent currently targeted by the per-agent Cleanup dialog (right-click
+   * menu in `AgentItem` → "Cleanup missing skills..."). Null when no
+   * cleanup dialog is open. Distinct from `selectedAgentId` because the
+   * user might cleanup an agent that is NOT the currently filtered list
+   * (e.g. they're viewing all skills globally, then cleanup just `cursor`).
+   * The dialog reads `syncPreview` (which now echoes `forAgent`) to render
+   * agent-scoped counts and conflicts.
+   */
+  cleanupAgentTarget: AgentId | null
 }
 
 const initialState: UiState = {
@@ -143,6 +154,7 @@ const initialState: UiState = {
   undoToast: null,
   bulkConfirm: null,
   bulkSelectMode: false,
+  cleanupAgentTarget: null,
 }
 
 /**
@@ -156,13 +168,22 @@ export const fetchSourceStats = createAsyncThunk(
 )
 
 /**
- * Preview sync: detect conflicts and count operations without executing
- * @returns SyncPreviewResult
+ * Preview sync: detect conflicts and count operations without executing.
+ * When `options.agentId` is provided, narrows the preview to that single
+ * agent — drives the per-agent Cleanup dialog opened from `AgentItem`'s
+ * right-click menu. Without options, runs the global sync preview as
+ * before.
+ * @param options - When `agentId` is set, restricts the preview to that
+ *   agent. Optional; omit for the global preview.
+ * @returns SyncPreviewResult — includes `forAgent` echo when scoped.
+ * @example
+ * dispatch(fetchSyncPreview())                     // global
+ * dispatch(fetchSyncPreview({ agentId: 'cursor' })) // per-agent cleanup
  */
 export const fetchSyncPreview = createAsyncThunk(
   'ui/fetchSyncPreview',
-  async () => {
-    return window.electron.sync.preview()
+  async (options?: SyncPreviewOptions) => {
+    return window.electron.sync.preview(options)
   },
 )
 
@@ -311,6 +332,25 @@ const uiSlice = createSlice({
     exitBulkSelectMode: (state) => {
       state.bulkSelectMode = false
     },
+    /**
+     * Open the per-agent Cleanup dialog targeting `agentId`. Called from
+     * AgentItem's right-click "Cleanup missing skills..." menu item. The
+     * caller is expected to dispatch `fetchSyncPreview({ agentId })`
+     * immediately afterwards so `syncPreview` has scoped counts when the
+     * dialog renders.
+     */
+    setCleanupAgentTarget: (state, action: PayloadAction<AgentId>) => {
+      state.cleanupAgentTarget = action.payload
+    },
+    /**
+     * Close the per-agent Cleanup dialog. Also clears any stale
+     * `syncPreview` to keep the global sync confirm dialog from latching
+     * onto a per-agent preview if the user pivots back to it.
+     */
+    clearCleanupAgentTarget: (state) => {
+      state.cleanupAgentTarget = null
+      state.syncPreview = null
+    },
   },
   extraReducers: (builder) => {
     builder
@@ -387,6 +427,8 @@ export const {
   clearBulkConfirm,
   enterBulkSelectMode,
   exitBulkSelectMode,
+  setCleanupAgentTarget,
+  clearCleanupAgentTarget,
 } = uiSlice.actions
 export default uiSlice.reducer
 
@@ -424,3 +466,13 @@ export const selectBulkConfirm = (state: RootState): BulkConfirmState | null =>
   state.ui.bulkConfirm
 export const selectBulkSelectMode = (state: RootState): boolean =>
   state.ui.bulkSelectMode
+/**
+ * Currently-targeted agent for the per-agent Cleanup dialog. Null when
+ * the dialog is closed. Components subscribe to this to mount/unmount
+ * `CleanupAgentDialog`.
+ * @example
+ * const cleanupTarget = useAppSelector(selectCleanupAgentTarget)
+ * // 'cursor' | null
+ */
+export const selectCleanupAgentTarget = (state: RootState): AgentId | null =>
+  state.ui.cleanupAgentTarget

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -30,6 +30,7 @@ import type {
   CopyToAgentsResult,
   CreateSymlinksOptions,
   CreateSymlinksResult,
+  SyncPreviewOptions,
   SyncPreviewResult,
   SyncExecuteOptions,
   SyncExecuteResult,
@@ -112,7 +113,7 @@ declare global {
         }) => Promise<SkillSearchResult[]>
       }
       sync: {
-        preview: () => Promise<SyncPreviewResult>
+        preview: (options?: SyncPreviewOptions) => Promise<SyncPreviewResult>
         execute: (options: SyncExecuteOptions) => Promise<SyncExecuteResult>
       }
       settings: {

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -98,7 +98,12 @@ export interface IpcInvokeContract {
     result: SkillSearchResult[]
   }
   'sync:preview': {
-    args: [SyncPreviewOptions?]
+    // Always 1-arg (possibly `undefined`) to match the Zod tuple schema —
+    // `z.tuple([...optional()])` accepts `[undefined]` but rejects `[]`.
+    // Preload's `typedInvoke('sync:preview', options)` always forwards the
+    // arg even when `options` is `undefined`, so this contract reflects
+    // reality.
+    args: [SyncPreviewOptions | undefined]
     result: SyncPreviewResult
   }
   'sync:execute': { args: [SyncExecuteOptions]; result: SyncExecuteResult }

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -30,6 +30,7 @@ import type {
   SourceStats,
   SyncExecuteOptions,
   SyncExecuteResult,
+  SyncPreviewOptions,
   SyncPreviewResult,
   UnlinkFromAgentOptions,
   UnlinkManyFromAgentOptions,
@@ -96,7 +97,10 @@ export interface IpcInvokeContract {
     args: [{ filter: RankingFilter }]
     result: SkillSearchResult[]
   }
-  'sync:preview': { args: []; result: SyncPreviewResult }
+  'sync:preview': {
+    args: [SyncPreviewOptions?]
+    result: SyncPreviewResult
+  }
   'sync:execute': { args: [SyncExecuteOptions]; result: SyncExecuteResult }
   'update:download': { args: []; result: void }
   'update:install': { args: []; result: void }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -825,13 +825,28 @@ export interface SyncConflict {
 }
 
 /**
+ * Options for previewing sync, optionally scoped to a single agent.
+ * Nil `agentId` = global preview (every detected agent). Specifying
+ * `agentId` narrows preview to that one agent — used by the per-agent
+ * Cleanup flow so the dialog can show "N skills missing for <agent>"
+ * without surfacing other agents' state.
+ * @example {} // global
+ * @example { agentId: 'cursor' } // scoped
+ */
+export interface SyncPreviewOptions {
+  /** When set, restrict preview to this single agent. */
+  agentId?: AgentId
+}
+
+/**
  * Result from sync preview (dry run).
  * @example { totalSkills: 5, totalAgents: 3, toCreate: 10, alreadySynced: 5, conflicts: [] }
+ * @example { totalSkills: 5, totalAgents: 1, toCreate: 4, alreadySynced: 1, conflicts: [], forAgent: 'cursor' }
  */
 export interface SyncPreviewResult {
   /** Number of source skills considered. @example 5 */
   totalSkills: number
-  /** Number of agents considered. @example 3 */
+  /** Number of agents considered (1 when scoped to one agent). @example 3 */
   totalAgents: number
   /** Symlinks that would be created on execute (excludes conflicts). @example 10 */
   toCreate: number
@@ -839,15 +854,27 @@ export interface SyncPreviewResult {
   alreadySynced: number
   /** Per-agent folders that block creation until the user chooses to replace. */
   conflicts: SyncConflict[]
+  /**
+   * Echoes the `agentId` filter the preview was computed with, if any.
+   * Lets the renderer keep dialog state in sync with the preview that
+   * actually returned (defends against stale dialog after agent switch).
+   */
+  forAgent?: AgentId
 }
 
 /**
  * Options for executing sync with conflict resolution choices.
- * @example { replaceConflicts: ['/Users/me/.claude/skills/my-skill'] }
+ * Optional `agentId` scopes the operation to that single agent — used
+ * by the per-agent Cleanup flow. Nil `agentId` = full sync across every
+ * detected agent (existing behavior).
+ * @example { replaceConflicts: [] } // full sync
+ * @example { replaceConflicts: [], agentId: 'cursor' } // per-agent cleanup
  */
 export interface SyncExecuteOptions {
   /** Absolute paths of conflicting folders the user explicitly opted to replace with symlinks. */
   replaceConflicts: AbsolutePath[]
+  /** When set, restrict execution to this single agent. */
+  agentId?: AgentId
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Issue #71 cleanup UI**: right-click an agent in the sidebar → "Cleanup missing skills..." opens a scoped dialog that previews and recreates that one agent's missing symlinks via the existing sync IPC (extended with optional `agentId`). Apple-HIG ordering: less-destructive Eraser action above destructive Trash2 delete, with separator.
- **PR-2 selector loosen**: `selectFilteredSkills` now surfaces orphan rows (status `valid | broken`) in the per-agent filter view. Orphans get an amber left border + `orphan` badge so they're legible at a glance, and the row's Delete/Unlink gates were relaxed so the user can sweep them without going through the bulk dialog.
- **Dual-dialog isolation**: `SyncPreviewResult.forAgent` is the single scoping primitive. `SyncConflictDialog` and `shouldShowSyncConfirm` both gate on `!forAgent`, so a scoped preview with conflicts cannot accidentally open the global flow on top of `CleanupAgentDialog`.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 93 targeted tests pass (selectors / skillItemHelpers / syncService scoped sync)
- [x] Manual QA via Electron CDP attach (5/5 critical cases PASS — see `qa-reports/electron-2026-05-05-skills-desktop-macOS.md`)
  - [x] TC-001: orphan row amber border + badge in Cursor filter view
  - [x] TC-002: AgentItem right-click menu (Cleanup above Delete, separator)
  - [x] TC-003: scoped preview shows Cursor-only counts (59/0/58/1)
  - [x] TC-004: dual-dialog isolation — only `CleanupAgentDialog` mounts during scoped flow
  - [x] TC-005: empty-state UX (Antigravity fully synced — Cleanup button hidden)
- [ ] Reviewer: spot-check the `forAgent` echo wiring and the `previewMatchesTarget` stale-preview guard

Closes #71.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * エージェント単位の「Cleanup missing skills」ダイアログを追加。対象エージェントのプレビューと個別クリーンアップが可能になりました。
  * サイドバーのエージェント項目に「Cleanup missing skills...」メニューを追加。

* **改善**
  * 同期プレビューと実行がエージェント単位で絞れるように対応。
  * 孤立スキルにバッジと強調表示を追加し、操作ボタンの表示ルールを整理。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->