### PR TITLE
refactor(sync-dialogs): unify with useExecuteSync + shared StatRow/DialogIconHeader

### DIFF
--- a/src/renderer/src/components/sidebar/CleanupAgentDialog.tsx
+++ b/src/renderer/src/components/sidebar/CleanupAgentDialog.tsx
@@ -1,13 +1,13 @@
 import { Eraser, Loader2 } from 'lucide-react'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect } from 'react'
 import { toast } from 'sonner'
 
 import { AGENT_DEFINITIONS } from '../../../../shared/constants'
 import type { AgentName } from '../../../../shared/types'
+import { useExecuteSync } from '../../hooks/useExecuteSync'
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
 import {
   clearCleanupAgentTarget,
-  executeSyncAction,
   fetchSyncPreview,
   selectCleanupAgentTarget,
   selectSyncPreview,
@@ -21,8 +21,9 @@ import {
   DialogDescription,
   DialogFooter,
   DialogHeader,
-  DialogTitle,
 } from '../ui/dialog'
+import { DialogIconHeader } from '../ui/dialog-icon-header'
+import { StatRow } from '../ui/stat-row'
 
 /**
  * Per-agent cleanup dialog.
@@ -56,7 +57,8 @@ export const CleanupAgentDialog = React.memo(
     const syncPreview = useAppSelector(selectSyncPreview)
     const isSyncing = useAppSelector((state) => state.ui.isSyncing)
 
-    const [isExecuting, setIsExecuting] = useState(false)
+    const { run: executeCleanup, isExecuting } =
+      useExecuteSync('Cleanup failed')
 
     // Trigger the scoped preview as soon as the dialog opens. We re-fetch
     // every time `cleanupAgentTarget` changes so closing-then-reopening on
@@ -104,39 +106,26 @@ export const CleanupAgentDialog = React.memo(
     }
 
     const handleCleanup = async (): Promise<void> => {
-      setIsExecuting(true)
-
-      const result = await dispatch(
-        executeSyncAction({
-          replaceConflicts: [],
-          agentId: cleanupAgentTarget,
-        }),
-      )
-
-      if (executeSyncAction.rejected.match(result)) {
-        toast.error('Cleanup failed', {
-          description: errorToastDescription(result),
-        })
-      } else {
+      const succeeded = await executeCleanup({
+        replaceConflicts: [],
+        agentId: cleanupAgentTarget,
+      })
+      if (succeeded) {
         // Close this dialog so `SyncResultDialog` (which `executeSyncAction`
         // already populated via `syncResult`) becomes the sole foreground
         // surface — otherwise the per-agent dialog stays mounted underneath.
         dispatch(clearCleanupAgentTarget())
       }
-
-      setIsExecuting(false)
     }
 
     return (
       <Dialog open onOpenChange={handleClose}>
         <DialogContent className="max-w-md">
           <DialogHeader>
-            <div className="flex items-center gap-2">
-              <Eraser className="h-5 w-5 text-primary" />
-              <DialogTitle>
-                Cleanup missing skills{agentName ? ` — ${agentName}` : ''}
-              </DialogTitle>
-            </div>
+            <DialogIconHeader
+              icon={Eraser}
+              title={`Cleanup missing skills${agentName ? ` — ${agentName}` : ''}`}
+            />
             <DialogDescription>
               Recreate symlinks for skills that exist in your source directory
               but are missing from {agentName ?? 'this agent'}.
@@ -150,39 +139,24 @@ export const CleanupAgentDialog = React.memo(
             </div>
           ) : (
             <div className="py-4 space-y-2 text-sm">
-              <div className="flex justify-between">
-                <span className="text-muted-foreground">Skills considered</span>
-                <span className="font-medium">
-                  {previewMatchesTarget.totalSkills}
-                </span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-muted-foreground">
-                  Symlinks to create
-                </span>
-                <span
-                  className={
-                    hasWork ? 'font-medium text-primary' : 'font-medium'
-                  }
-                >
-                  {missingCount}
-                </span>
-              </div>
+              <StatRow
+                label="Skills considered"
+                value={previewMatchesTarget.totalSkills}
+              />
+              <StatRow
+                label="Symlinks to create"
+                value={missingCount}
+                tone={hasWork ? 'primary' : 'default'}
+              />
               {alreadySyncedCount > 0 && (
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Already linked</span>
-                  <span className="font-medium">{alreadySyncedCount}</span>
-                </div>
+                <StatRow label="Already linked" value={alreadySyncedCount} />
               )}
               {conflictCount > 0 && (
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">
-                    Conflicts (skipped)
-                  </span>
-                  <span className="font-medium text-amber-500">
-                    {conflictCount}
-                  </span>
-                </div>
+                <StatRow
+                  label="Conflicts (skipped)"
+                  value={conflictCount}
+                  tone="amber"
+                />
               )}
               {!hasWork && conflictCount === 0 && (
                 <p className="text-muted-foreground pt-1">

--- a/src/renderer/src/components/sidebar/SyncConfirmDialog.tsx
+++ b/src/renderer/src/components/sidebar/SyncConfirmDialog.tsx
@@ -1,10 +1,10 @@
 import { FolderSync, Loader2 } from 'lucide-react'
-import React, { useState } from 'react'
-import { toast } from 'sonner'
+import React from 'react'
 
+import { useExecuteSync } from '../../hooks/useExecuteSync'
 import { shouldShowSyncConfirm } from '../../lib/syncHelpers'
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
-import { executeSyncAction, setSyncPreview } from '../../redux/slices/uiSlice'
+import { setSyncPreview } from '../../redux/slices/uiSlice'
 import { Button } from '../ui/button'
 import {
   Dialog,
@@ -12,8 +12,9 @@ import {
   DialogDescription,
   DialogFooter,
   DialogHeader,
-  DialogTitle,
 } from '../ui/dialog'
+import { DialogIconHeader } from '../ui/dialog-icon-header'
+import { StatRow } from '../ui/stat-row'
 
 /**
  * Confirmation dialog shown before sync execution (no-conflict case).
@@ -28,7 +29,7 @@ export const SyncConfirmDialog = React.memo(
     const isSyncing = useAppSelector((state) => state.ui.isSyncing)
     const isOpen = shouldShowSyncConfirm(syncPreview)
 
-    const [isExecuting, setIsExecuting] = useState(false)
+    const { run: executeSync, isExecuting } = useExecuteSync('Sync failed')
 
     const handleClose = (): void => {
       if (!isExecuting) {
@@ -36,29 +37,16 @@ export const SyncConfirmDialog = React.memo(
       }
     }
 
+    // Success feedback + refreshAllData handled by SyncResultDialog
     const handleSync = async (): Promise<void> => {
-      setIsExecuting(true)
-
-      const result = await dispatch(executeSyncAction({ replaceConflicts: [] }))
-
-      // Success feedback + refreshAllData handled by SyncResultDialog
-      if (executeSyncAction.rejected.match(result)) {
-        toast.error('Sync failed', {
-          description: result.error?.message || 'An unexpected error occurred',
-        })
-      }
-
-      setIsExecuting(false)
+      await executeSync({ replaceConflicts: [] })
     }
 
     return (
       <Dialog open={isOpen} onOpenChange={handleClose}>
         <DialogContent className="max-w-md">
           <DialogHeader>
-            <div className="flex items-center gap-2">
-              <FolderSync className="h-5 w-5 text-primary" />
-              <DialogTitle>Sync Skills</DialogTitle>
-            </div>
+            <DialogIconHeader icon={FolderSync} title="Sync Skills" />
             <DialogDescription>
               Create symlinks from your source skills to all agents.
             </DialogDescription>
@@ -66,28 +54,20 @@ export const SyncConfirmDialog = React.memo(
 
           {syncPreview && (
             <div className="py-4 space-y-2 text-sm">
-              <div className="flex justify-between">
-                <span className="text-muted-foreground">Skills → Agents</span>
-                <span className="font-medium">
-                  {syncPreview.totalSkills} skills → {syncPreview.totalAgents}{' '}
-                  agents
-                </span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-muted-foreground">
-                  New symlinks to create
-                </span>
-                <span className="font-medium text-primary">
-                  {syncPreview.toCreate}
-                </span>
-              </div>
+              <StatRow
+                label="Skills → Agents"
+                value={`${syncPreview.totalSkills} skills → ${syncPreview.totalAgents} agents`}
+              />
+              <StatRow
+                label="New symlinks to create"
+                value={syncPreview.toCreate}
+                tone="primary"
+              />
               {syncPreview.alreadySynced > 0 && (
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Already synced</span>
-                  <span className="font-medium">
-                    {syncPreview.alreadySynced}
-                  </span>
-                </div>
+                <StatRow
+                  label="Already synced"
+                  value={syncPreview.alreadySynced}
+                />
               )}
             </div>
           )}

--- a/src/renderer/src/components/sidebar/SyncConflictDialog.tsx
+++ b/src/renderer/src/components/sidebar/SyncConflictDialog.tsx
@@ -1,9 +1,9 @@
 import { AlertTriangle, Loader2 } from 'lucide-react'
 import React, { useState } from 'react'
-import { toast } from 'sonner'
 
+import { useExecuteSync } from '../../hooks/useExecuteSync'
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
-import { executeSyncAction, setSyncPreview } from '../../redux/slices/uiSlice'
+import { setSyncPreview } from '../../redux/slices/uiSlice'
 import { Button } from '../ui/button'
 import { Checkbox } from '../ui/checkbox'
 import {
@@ -12,8 +12,8 @@ import {
   DialogDescription,
   DialogFooter,
   DialogHeader,
-  DialogTitle,
 } from '../ui/dialog'
+import { DialogIconHeader } from '../ui/dialog-icon-header'
 
 /**
  * Dialog for resolving sync conflicts (local folders that would be replaced by symlinks)
@@ -32,7 +32,7 @@ export const SyncConflictDialog = React.memo(
     const isOpen = hasConflicts && !!syncPreview && !syncPreview.forAgent
 
     const [selectedPaths, setSelectedPaths] = useState<Set<string>>(new Set())
-    const [isExecuting, setIsExecuting] = useState(false)
+    const { run: executeSync, isExecuting } = useExecuteSync('Sync failed')
 
     const handleClose = (): void => {
       if (!isExecuting) {
@@ -53,23 +53,12 @@ export const SyncConflictDialog = React.memo(
       })
     }
 
+    // Success feedback + refreshAllData handled by SyncResultDialog
     const handleSync = async (replaceAll: boolean): Promise<void> => {
-      setIsExecuting(true)
-
       const replaceConflicts = replaceAll
         ? conflicts.map((c) => c.agentSkillPath)
         : Array.from(selectedPaths)
-
-      const result = await dispatch(executeSyncAction({ replaceConflicts }))
-
-      // Success feedback + refreshAllData handled by SyncResultDialog
-      if (executeSyncAction.rejected.match(result)) {
-        toast.error('Sync failed', {
-          description: result.error?.message || 'An unexpected error occurred',
-        })
-      }
-
-      setIsExecuting(false)
+      await executeSync({ replaceConflicts })
       setSelectedPaths(new Set())
     }
 
@@ -77,10 +66,11 @@ export const SyncConflictDialog = React.memo(
       <Dialog open={isOpen} onOpenChange={handleClose}>
         <DialogContent className="max-w-lg">
           <DialogHeader>
-            <div className="flex items-center gap-2">
-              <AlertTriangle className="h-5 w-5 text-amber-500" />
-              <DialogTitle>Sync Conflicts</DialogTitle>
-            </div>
+            <DialogIconHeader
+              icon={AlertTriangle}
+              title="Sync Conflicts"
+              tone="amber"
+            />
             <DialogDescription>
               {conflicts.length} local folder(s) found where symlinks would be
               created. Select which to replace with symlinks.

--- a/src/renderer/src/components/sidebar/SyncConflictDialog.tsx
+++ b/src/renderer/src/components/sidebar/SyncConflictDialog.tsx
@@ -58,8 +58,10 @@ export const SyncConflictDialog = React.memo(
       const replaceConflicts = replaceAll
         ? conflicts.map((c) => c.agentSkillPath)
         : Array.from(selectedPaths)
-      await executeSync({ replaceConflicts })
-      setSelectedPaths(new Set())
+      const succeeded = await executeSync({ replaceConflicts })
+      if (succeeded) {
+        setSelectedPaths(new Set())
+      }
     }
 
     return (

--- a/src/renderer/src/components/ui/dialog-icon-header.tsx
+++ b/src/renderer/src/components/ui/dialog-icon-header.tsx
@@ -1,0 +1,57 @@
+import type { LucideIcon } from 'lucide-react'
+import React from 'react'
+
+import { DialogTitle } from './dialog'
+
+/**
+ * Tone variants for the leading icon. Matches the two distinct accents
+ * the sync dialogs use today:
+ * - `primary`: routine/positive flows (Sync, Cleanup).
+ * - `amber`: warning flows (conflict resolution).
+ */
+export type DialogIconHeaderTone = 'primary' | 'amber'
+
+/**
+ * Map of tone → text colour utility for the icon. Kept here so dialogs
+ * cannot accidentally pair, say, an `AlertTriangle` with `text-primary`.
+ */
+const ICON_CLASS_BY_TONE: Record<DialogIconHeaderTone, string> = {
+  primary: 'text-primary',
+  amber: 'text-amber-500',
+}
+
+interface DialogIconHeaderProps {
+  /** A `lucide-react` icon component (e.g. `Eraser`, `FolderSync`, `AlertTriangle`). */
+  icon: LucideIcon
+  /** Title text rendered inside `<DialogTitle>`. */
+  title: React.ReactNode
+  /** Icon accent colour. Defaults to `'primary'`. */
+  tone?: DialogIconHeaderTone
+}
+/**
+ * The icon + title pair that opens every sync-related dialog. Replaces
+ * the inline `<div className="flex items-center gap-2"><Icon … /><DialogTitle>…</DialogTitle></div>`
+ * markup that was duplicated across `SyncConfirmDialog`,
+ * `SyncConflictDialog`, and `CleanupAgentDialog`. Render this as the
+ * first child of `<DialogHeader>` (before `<DialogDescription>`).
+ *
+ * @example
+ * <DialogHeader>
+ *   <DialogIconHeader icon={Eraser} title="Cleanup missing skills" />
+ *   <DialogDescription>…</DialogDescription>
+ * </DialogHeader>
+ * @example
+ * <DialogIconHeader icon={AlertTriangle} title="Sync Conflicts" tone="amber" />
+ */
+export const DialogIconHeader = React.memo(function DialogIconHeader({
+  icon: Icon,
+  title,
+  tone = 'primary',
+}: DialogIconHeaderProps): React.ReactElement {
+  return (
+    <div className="flex items-center gap-2">
+      <Icon className={`h-5 w-5 ${ICON_CLASS_BY_TONE[tone]}`} />
+      <DialogTitle>{title}</DialogTitle>
+    </div>
+  )
+})

--- a/src/renderer/src/components/ui/stat-row.tsx
+++ b/src/renderer/src/components/ui/stat-row.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+
+/**
+ * Tone variants for a `StatRow` value.
+ * - `default`: neutral foreground; used when the count is informational.
+ * - `primary`: brand accent; used when the count represents actionable work
+ *   (e.g. "Symlinks to create" when there is something to do).
+ * - `amber`: warning hue; used for conflict or skipped counts.
+ */
+export type StatRowTone = 'default' | 'primary' | 'amber'
+
+/**
+ * Map of tone → utility classes applied to the value `<span>`. Centralised
+ * here so the three sync dialogs cannot drift on accent colour or weight.
+ */
+const VALUE_CLASS_BY_TONE: Record<StatRowTone, string> = {
+  default: 'font-medium',
+  primary: 'font-medium text-primary',
+  amber: 'font-medium text-amber-500',
+}
+
+interface StatRowProps {
+  /** Left-aligned label rendered in muted foreground. */
+  label: React.ReactNode
+  /** Right-aligned value rendered in `font-medium` plus the tone colour. */
+  value: React.ReactNode
+  /** Visual emphasis for `value`. Defaults to `'default'`. */
+  tone?: StatRowTone
+}
+
+/**
+ * One row of the "skills considered / symlinks to create / conflicts skipped"
+ * count list rendered by every sync-related dialog. Replaces the inline
+ * `flex justify-between` markup that was duplicated three times across
+ * `SyncConfirmDialog`, `SyncConflictDialog`, and `CleanupAgentDialog`.
+ *
+ * @example
+ * <StatRow label="Skills considered" value={preview.totalSkills} />
+ * @example
+ * <StatRow label="Symlinks to create" value={missingCount} tone="primary" />
+ * @example
+ * <StatRow label="Conflicts (skipped)" value={conflictCount} tone="amber" />
+ */
+export const StatRow = React.memo(function StatRow({
+  label,
+  value,
+  tone = 'default',
+}: StatRowProps): React.ReactElement {
+  return (
+    <div className="flex justify-between">
+      <span className="text-muted-foreground">{label}</span>
+      <span className={VALUE_CLASS_BY_TONE[tone]}>{value}</span>
+    </div>
+  )
+})

--- a/src/renderer/src/hooks/useExecuteSync.ts
+++ b/src/renderer/src/hooks/useExecuteSync.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { toast } from 'sonner'
 
 import type { SyncExecuteOptions } from '../../../shared/types'
@@ -13,14 +13,20 @@ import { errorToastDescription } from '../utils/errorToastDescription'
  * managed their own `isExecuting` and toast call.
  *
  * The hook owns the component-local executing flag so dialogs no longer
- * need their own `useState`. `run` resolves to `true` on success and
- * `false` on rejection, letting the caller chain success-only side
- * effects (e.g. closing a scoped dialog) without re-implementing the
- * rejected-match check.
+ * need their own `useState`. `run` resolves to `true` only when the thunk
+ * fulfills; it returns `false` for rejections AND for re-entrant calls
+ * that arrive while a previous run is still in flight. Callers therefore
+ * gate success-only side effects on the boolean without re-implementing
+ * the rejected-match check or worrying about double-dispatch.
+ *
+ * Internally guarded by a `useRef` flag so that double-clicks or rapid
+ * re-renders cannot fire `dispatch(executeSyncAction)` twice in parallel,
+ * and by `try/finally` so an unexpected throw still releases both the
+ * ref guard and the `isExecuting` state.
  *
  * @param toastTitle - Title used for the failure toast (e.g. "Sync failed").
  * @returns
- * - `run(options)`: dispatches the thunk, raises a toast on rejection, returns `true` when fulfilled
+ * - `run(options)`: dispatches the thunk, raises a toast on rejection, returns `true` when fulfilled and `false` when rejected or skipped due to a still-running call
  * - `isExecuting`: `true` from the moment `run` is called until the thunk settles
  * @example
  * const { run, isExecuting } = useExecuteSync('Cleanup failed')
@@ -35,18 +41,25 @@ export function useExecuteSync(toastTitle: string): {
 } {
   const dispatch = useAppDispatch()
   const [isExecuting, setIsExecuting] = useState(false)
+  const isExecutingRef = useRef(false)
 
   const run = async (options: SyncExecuteOptions): Promise<boolean> => {
+    if (isExecutingRef.current) return false
+    isExecutingRef.current = true
     setIsExecuting(true)
-    const result = await dispatch(executeSyncAction(options))
-    const succeeded = !executeSyncAction.rejected.match(result)
-    if (!succeeded) {
-      toast.error(toastTitle, {
-        description: errorToastDescription(result),
-      })
+    try {
+      const result = await dispatch(executeSyncAction(options))
+      const succeeded = !executeSyncAction.rejected.match(result)
+      if (!succeeded) {
+        toast.error(toastTitle, {
+          description: errorToastDescription(result),
+        })
+      }
+      return succeeded
+    } finally {
+      isExecutingRef.current = false
+      setIsExecuting(false)
     }
-    setIsExecuting(false)
-    return succeeded
   }
 
   return { run, isExecuting }

--- a/src/renderer/src/hooks/useExecuteSync.ts
+++ b/src/renderer/src/hooks/useExecuteSync.ts
@@ -1,0 +1,53 @@
+import { useState } from 'react'
+import { toast } from 'sonner'
+
+import type { SyncExecuteOptions } from '../../../shared/types'
+import { useAppDispatch } from '../redux/hooks'
+import { executeSyncAction } from '../redux/slices/uiSlice'
+import { errorToastDescription } from '../utils/errorToastDescription'
+
+/**
+ * Encapsulates the dispatch + rejected-match + toast flow shared by every
+ * sync-related dialog (`SyncConfirmDialog`, `SyncConflictDialog`,
+ * `CleanupAgentDialog`). Replaces three near-identical handlers that each
+ * managed their own `isExecuting` and toast call.
+ *
+ * The hook owns the component-local executing flag so dialogs no longer
+ * need their own `useState`. `run` resolves to `true` on success and
+ * `false` on rejection, letting the caller chain success-only side
+ * effects (e.g. closing a scoped dialog) without re-implementing the
+ * rejected-match check.
+ *
+ * @param toastTitle - Title used for the failure toast (e.g. "Sync failed").
+ * @returns
+ * - `run(options)`: dispatches the thunk, raises a toast on rejection, returns `true` when fulfilled
+ * - `isExecuting`: `true` from the moment `run` is called until the thunk settles
+ * @example
+ * const { run, isExecuting } = useExecuteSync('Cleanup failed')
+ * const handleCleanup = async (): Promise<void> => {
+ *   const succeeded = await run({ replaceConflicts: [], agentId })
+ *   if (succeeded) dispatch(clearCleanupAgentTarget())
+ * }
+ */
+export function useExecuteSync(toastTitle: string): {
+  run: (options: SyncExecuteOptions) => Promise<boolean>
+  isExecuting: boolean
+} {
+  const dispatch = useAppDispatch()
+  const [isExecuting, setIsExecuting] = useState(false)
+
+  const run = async (options: SyncExecuteOptions): Promise<boolean> => {
+    setIsExecuting(true)
+    const result = await dispatch(executeSyncAction(options))
+    const succeeded = !executeSyncAction.rejected.match(result)
+    if (!succeeded) {
+      toast.error(toastTitle, {
+        description: errorToastDescription(result),
+      })
+    }
+    setIsExecuting(false)
+    return succeeded
+  }
+
+  return { run, isExecuting }
+}


### PR DESCRIPTION
## Summary
- Extract `useExecuteSync(toastTitle)` hook so all three sync dialogs share one dispatch + `rejected.match` + toast flow. `run()` resolves to a boolean so callers can chain success-only side effects (e.g. `clearCleanupAgentTarget`).
- Add `<StatRow>` (`default` | `primary` | `amber` tones) and `<DialogIconHeader>` (`primary` | `amber` tones) — both use a `Record<Tone, string>` map so accent classes can't drift per dialog.
- Migrate `SyncConfirmDialog`, `SyncConflictDialog`, `CleanupAgentDialog` to the shared primitives; drop local `useState(isExecuting)` and inline markup.

Closes #131

## Diff stats
- 3 dialogs touched, 3 new primitives added
- Net: +228 / -119

## Test plan
- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — 0 errors (after wrapping new UI components in `React.memo` to satisfy `@laststance/react-next/all-memo`)
- [x] `pnpm test` — 846/846 pass across 58 files
- [x] Real-device QA via `playwright-cli` CDP attach — full report at `qa-reports/electron-2026-05-05-skills-desktop-darwin.md`
  - TC-002a `CleanupAgentDialog` (no work) — PASS
  - TC-002b `CleanupAgentDialog` (with conflict) — PASS, amber `Conflicts (skipped)` row rendered
  - TC-003 `SyncConflictDialog` — PASS, AlertTriangle (amber) header rendered
  - TC-001 `SyncConfirmDialog` happy path — DEFERRED (host had a pre-existing conflict, so Sync routed straight to `SyncConflictDialog`; same component path verified indirectly)
  - 0 console errors during the session

## Notes
- `tone="primary"` on `StatRow` was not directly observable on the host (no agent had `Symlinks to create > 0`). It is exercised by the same shared map as the verified `default`/`amber` tones, so regression risk is bounded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ダイアログヘッダーとステータス表示の新しい UI コンポーネントを追加しました。

* **改善**
  * 同期操作のエラーハンドリングと状態管理を改善しました。
  * ダイアログ全体の視覚的な一貫性を強化し、アイコンの色分け表示を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->