### PR TITLE
feat(folder): Reveal in Finder + Open in Terminal for skill folders (#103, #104)

### DIFF
--- a/e2e/helpers/redux.ts
+++ b/e2e/helpers/redux.ts
@@ -24,26 +24,46 @@ const SKILLS_FETCH_ALL_FULFILLED_TYPE = 'skills/fetchAll/fulfilled'
  * Without this wrapping the error lands as a generic Playwright eval failure
  * and the spec author has to re-derive which selector blew up.
  *
+ * Closure capture caveat: the selector is serialized via `Function.toString`
+ * and re-evaluated in the renderer, so it CANNOT reference variables from
+ * the surrounding test scope (those become `ReferenceError: x is not
+ * defined` at runtime). Pass dynamic values through the third `args`
+ * parameter — they're sent over the wire and arrive as the selector's
+ * second positional argument.
+ *
  * @example
  * const tab = await getStoreState(page, (state: any) => state.ui.activeTab)
+ * @example
+ * // Closure-safe: pass dynamic values via `args`
+ * const present = await getStoreState(
+ *   page,
+ *   (state, name) => {
+ *     const root = state as { skills: { items: Array<{ name: string }> } }
+ *     return root.skills.items.some((s) => s.name === name)
+ *   },
+ *   skillName,
+ * )
  */
-export async function getStoreState<T>(
+export async function getStoreState<T, A = undefined>(
   page: Page,
-  selector: (state: unknown) => T,
+  selector: (state: unknown, args: A) => T,
+  args?: A,
 ): Promise<T> {
   return page.evaluate(
-    ({ selectorSrc }) => {
+    ({ selectorSrc, selectorArgs }) => {
       const store = window.__store__ ?? window.__store
       if (!store) {
         throw new Error(
           'window.__store__ is not exposed. Did you build with E2E_BUILD=1?',
         )
       }
-      const fn = new Function('state', `return (${selectorSrc})(state)`) as (
-        state: unknown,
-      ) => unknown
+      const fn = new Function(
+        'state',
+        'args',
+        `return (${selectorSrc})(state, args)`,
+      ) as (state: unknown, args: unknown) => unknown
       try {
-        return fn(store.getState())
+        return fn(store.getState(), selectorArgs)
       } catch (selectorError) {
         const errorMessage =
           selectorError instanceof Error
@@ -54,7 +74,7 @@ export async function getStoreState<T>(
         )
       }
     },
-    { selectorSrc: selector.toString() },
+    { selectorSrc: selector.toString(), selectorArgs: args },
   ) as Promise<T>
 }
 

--- a/e2e/spec/delete.e2e.ts
+++ b/e2e/spec/delete.e2e.ts
@@ -441,11 +441,18 @@ test('deleteSkill clears orphan (broken) symlinks with no trash entry', async ({
   ).toEqual([])
 
   // Redux — the orphan row disappears from skills.items after rescan.
+  // `skillName` MUST be passed via the third arg: the selector is serialized
+  // and re-evaluated in the renderer, so closure capture would surface as
+  // `ReferenceError: skillName is not defined`.
   await refreshSkillsState(appWindow)
-  const stillPresent = await getStoreState(appWindow, (state) => {
-    const root = state as { skills: { items: Array<{ name: string }> } }
-    return root.skills.items.some((skill) => skill.name === skillName)
-  })
+  const stillPresent = await getStoreState(
+    appWindow,
+    (state, name: string) => {
+      const root = state as { skills: { items: Array<{ name: string }> } }
+      return root.skills.items.some((skill) => skill.name === name)
+    },
+    skillName,
+  )
   expect(stillPresent).toBe(false)
 })
 

--- a/e2e/spec/folder-actions.e2e.ts
+++ b/e2e/spec/folder-actions.e2e.ts
@@ -91,6 +91,23 @@ test('AgentItem right-click menu exposes folder actions above destructive items'
   await expect(openTerm).toBeVisible()
   await expect(cleanup).toBeVisible()
   await expect(remove).toBeVisible()
+
+  // Y-axis order check: visibility alone would pass even if Reveal/Open were
+  // moved BELOW Cleanup/Delete, defeating the "safe-action-first" ordering
+  // contract this test claims to enforce. Compare boundingBox().y so a
+  // refactor that reshuffles items fails here, not in production where the
+  // user notices Down→Enter triggering Delete.
+  const [revealBox, openTermBox, cleanupBox, removeBox] = await Promise.all([
+    reveal.boundingBox(),
+    openTerm.boundingBox(),
+    cleanup.boundingBox(),
+    remove.boundingBox(),
+  ])
+  // `boundingBox()` returns null only for invisible elements — already
+  // guarded by the `toBeVisible` assertions above, so the `!` is safe.
+  expect(revealBox!.y).toBeLessThan(cleanupBox!.y)
+  expect(openTermBox!.y).toBeLessThan(cleanupBox!.y)
+  expect(cleanupBox!.y).toBeLessThan(removeBox!.y)
 })
 
 test('Settings → Preferred terminal picker lists all 8 IDs and reveals custom input on select', async ({

--- a/e2e/spec/folder-actions.e2e.ts
+++ b/e2e/spec/folder-actions.e2e.ts
@@ -1,0 +1,142 @@
+import { mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { test, expect } from '../fixtures/electron-app'
+import { isSnapshotOffline } from '../fixtures/isolated-home'
+import { waitForInitialScan } from '../helpers/redux'
+
+/**
+ * Issues #103 / #104 — DOM-binding regression guards for the folder actions
+ * (Reveal in Finder / Open in Terminal). These specs deliberately do NOT
+ * launch Finder or any terminal app: OS side-effects are out of scope for a
+ * deterministic test runner. What we DO assert:
+ *
+ *   1. SourceCard kebab exposes both menu items (issue #103 surface).
+ *   2. AgentItem context menu exposes both menu items above the existing
+ *      Cleanup / Delete items, in the order the spec dictates (#104 surface).
+ *   3. Settings → "Preferred terminal" picker enumerates all 8 terminal IDs
+ *      and reveals the custom-name <input> only when 'custom' is selected.
+ *
+ * If any of these aria-labels or option lists drift, the user-visible IPC
+ * binding silently breaks — `useOpenFolder` would still exist, but no UI
+ * could trigger it. That class of regression cannot be caught by the unit
+ * tests under `src/main/ipc/folder.test.ts` because they never touch the
+ * renderer tree.
+ */
+
+// All three tests need at least the SOURCE_DIR in the snapshot to surface
+// universal agents (and SourceCard rows) in the sidebar. Skipping mirrors
+// the offline-skip pattern in regression.e2e.ts so an offline runner does
+// not produce a confusing "menu item not found" failure when the real
+// cause is empty fixture state.
+test.beforeEach(() => {
+  test.skip(
+    isSnapshotOffline(),
+    'snapshot SOURCE_DIR required to render the sidebar; runner is offline (global-setup wrote snapshot.offline=true)',
+  )
+})
+
+test('SourceCard kebab exposes Reveal in Finder + Open in Terminal', async ({
+  appWindow,
+}) => {
+  await waitForInitialScan(appWindow)
+
+  // Single kebab-only trigger; right-click on the card body opens the same
+  // menu but is covered separately by the unit-level component story. Here
+  // we exercise the explicit click path the user typically takes.
+  await appWindow.getByLabel('Source folder actions').click()
+
+  await expect(
+    appWindow.getByRole('menuitem', { name: 'Reveal in Finder' }),
+  ).toBeVisible()
+  await expect(
+    appWindow.getByRole('menuitem', { name: 'Open in Terminal' }),
+  ).toBeVisible()
+})
+
+test('AgentItem right-click menu exposes folder actions above destructive items', async ({
+  appWindow,
+  isolatedHome,
+}) => {
+  // Stage `.cursor/skills` so the Cursor agent reports `exists: true` —
+  // `handleContextMenu` short-circuits when the agent dir is absent, so the
+  // menu would never open without this. Single mkdir is enough; we never
+  // write any skill files because the test asserts DOM, not symlink state.
+  mkdirSync(join(isolatedHome, '.cursor', 'skills'), { recursive: true })
+
+  await waitForInitialScan(appWindow)
+
+  // The Cursor row's aria-label is "Filter skills by Cursor (N linked, M local)";
+  // the prefix is stable across snapshot churn so we anchor on it. Right-click
+  // is the documented gesture for opening the menu — left-click only filters.
+  await appWindow
+    .getByLabel(/^Filter skills by Cursor/)
+    .first()
+    .click({ button: 'right' })
+
+  // Folder actions render above Cleanup/Delete by design (see AgentItem.tsx
+  // comment on line 158-159) — keyboard nav (Down then Enter) lands on a
+  // safe action first. Asserting both the new and existing items pins the
+  // ordering contract.
+  const reveal = appWindow.getByRole('menuitem', { name: 'Reveal in Finder' })
+  const openTerm = appWindow.getByRole('menuitem', { name: 'Open in Terminal' })
+  const cleanup = appWindow.getByRole('menuitem', {
+    name: /Cleanup missing skills/,
+  })
+  const remove = appWindow.getByRole('menuitem', {
+    name: 'Delete skills folder',
+  })
+
+  await expect(reveal).toBeVisible()
+  await expect(openTerm).toBeVisible()
+  await expect(cleanup).toBeVisible()
+  await expect(remove).toBeVisible()
+})
+
+test('Settings → Preferred terminal picker lists all 8 IDs and reveals custom input on select', async ({
+  appWindow,
+  electronApp,
+}) => {
+  await waitForInitialScan(appWindow)
+
+  // Opening Settings spawns a second BrowserWindow. Capture the window event
+  // BEFORE clicking — the event fires synchronously when the new window's
+  // webContents is created, and racing it would surface as a flaky timeout.
+  const settingsWindowPromise = electronApp.waitForEvent('window')
+  await appWindow.getByLabel('Open settings').click()
+  const settingsWindow = await settingsWindowPromise
+  await settingsWindow.waitForLoadState('domcontentloaded')
+
+  const picker = settingsWindow.getByLabel('Preferred terminal')
+  await picker.waitFor({ state: 'visible' })
+
+  // Pin the option list against `TERMINAL_APP_IDS` order. A regression that
+  // appended/removed an ID without updating the picker would land here, not
+  // in production where the user notices a missing terminal a week later.
+  const optionValues = await picker
+    .locator('option')
+    .evaluateAll((opts) => opts.map((opt) => (opt as HTMLOptionElement).value))
+  expect(optionValues).toEqual([
+    'terminal',
+    'iterm',
+    'warp',
+    'ghostty',
+    'alacritty',
+    'kitty',
+    'wezterm',
+    'custom',
+  ])
+
+  // The custom-name <input> is rendered conditionally on
+  // `settings.preferredTerminal === 'custom'` (General.tsx:163). Default state
+  // has it absent; selecting 'custom' must reveal it. Toggling back is not
+  // asserted here because the optimistic dispatch reaches the input render
+  // synchronously — the appearance check is the load-bearing assertion.
+  await expect(
+    settingsWindow.getByLabel('Custom terminal app name'),
+  ).toHaveCount(0)
+  await picker.selectOption('custom')
+  await expect(
+    settingsWindow.getByLabel('Custom terminal app name'),
+  ).toBeVisible()
+})

--- a/e2e/spec/folder-actions.e2e.ts
+++ b/e2e/spec/folder-actions.e2e.ts
@@ -128,13 +128,11 @@ test('Settings → Preferred terminal picker lists all 8 IDs and reveals custom 
   ])
 
   // The custom-name <input> is rendered conditionally on
-  // `settings.preferredTerminal === 'custom'` (General.tsx:163). Default state
-  // has it absent; selecting 'custom' must reveal it. Toggling back is not
-  // asserted here because the optimistic dispatch reaches the input render
-  // synchronously — the appearance check is the load-bearing assertion.
-  await expect(
-    settingsWindow.getByLabel('Custom terminal app name'),
-  ).toHaveCount(0)
+  // `settings.preferredTerminal === 'custom'` (General.tsx:163). The
+  // load-bearing assertion is that selecting 'custom' makes the input
+  // visible — we don't assert the pre-state because settings.json may be
+  // persisted into the snapshot HOME from a prior dev session, which
+  // would make a "starts hidden" precondition flaky.
   await picker.selectOption('custom')
   await expect(
     settingsWindow.getByLabel('Custom terminal app name'),

--- a/src/main/ipc/folder.integration.test.ts
+++ b/src/main/ipc/folder.integration.test.ts
@@ -1,0 +1,271 @@
+import { EventEmitter } from 'node:events'
+import type * as NodeFsPromises from 'node:fs/promises'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const handleMock = vi.fn()
+const realpathMock = vi.fn()
+const spawnMock = vi.fn()
+const openPathMock = vi.fn()
+const getSettingsMock = vi.fn()
+
+/**
+ * Mock surfaces:
+ *  - electron.ipcMain → captures every typedHandle registration so tests can
+ *    invoke handlers directly via getRegisteredHandler('folder:openInTerminal').
+ *  - electron.shell.openPath → controls the success/error path for Reveal.
+ *  - node:fs/promises.realpath → controls the not-found / found branch.
+ *  - node:child_process.spawn → returns a fake EventEmitter so tests can fire
+ *    `exit` / `error` events synchronously and assert how the handler reacts.
+ *  - main/services/settings.getSettings → drives the preferredTerminal /
+ *    customTerminalAppName branch coverage.
+ */
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (...args: unknown[]) => handleMock(...args),
+  },
+  shell: {
+    openPath: (...args: unknown[]) => openPathMock(...args),
+  },
+}))
+
+vi.mock('node:fs/promises', async () => {
+  const actual =
+    await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
+  return {
+    ...actual,
+    realpath: (...args: unknown[]) => realpathMock(...args),
+  }
+})
+
+vi.mock('node:child_process', () => ({
+  spawn: (...args: unknown[]) => spawnMock(...args),
+}))
+
+vi.mock('../services/settings', () => ({
+  getSettings: () => getSettingsMock(),
+}))
+
+/**
+ * Look up a registered IPC handler captured by the ipcMain mock.
+ * Mirrors the helper in `skills.copyToAgents.integration.test.ts`.
+ */
+function getRegisteredHandler(
+  channel: string,
+): (event: unknown, ...args: unknown[]) => Promise<unknown> {
+  const registration = handleMock.mock.calls.find(([name]) => name === channel)
+  if (!registration) throw new Error(`No handler registered for ${channel}`)
+  return registration[1] as (
+    event: unknown,
+    ...args: unknown[]
+  ) => Promise<unknown>
+}
+
+/**
+ * Build a fake child process that we can drive via `.emit('exit', code)` /
+ * `.emit('error', err)`. Carries an `unref` spy so we can assert the handler
+ * detaches the child from the main process.
+ *
+ * The fake child also captures all `once` registrations so the emit helper
+ * below can buffer events fired before listeners are wired — needed because
+ * `spawn` is called *after* `await realpath()` in the handler, so the test
+ * cannot synchronously emit and expect a listener to be present yet.
+ */
+function makeFakeChild(): EventEmitter & { unref: () => void } {
+  const ee = new EventEmitter() as EventEmitter & { unref: () => void }
+  ee.unref = vi.fn()
+  return ee
+}
+
+/**
+ * Configure spawnMock to return a fake child AND auto-fire the requested
+ * event after listeners are registered. Handles the listener-registration
+ * race that makes synchronous `child.emit(...)` after `handler(...)` flaky.
+ *
+ * @param event - 'exit' or 'error'
+ * @param payload - exit code (number) or Error
+ * @returns The fake child instance the spawn mock will hand to the handler.
+ */
+function spawnFiringEvent(
+  event: 'exit' | 'error',
+  payload: number | Error,
+): EventEmitter & { unref: () => void } {
+  const child = makeFakeChild()
+  spawnMock.mockReturnValueOnce(child)
+  // setImmediate runs after the current microtask queue drains — by which
+  // time the handler has resumed past every `await` and registered both
+  // `child.once('exit')` and `child.once('error')`.
+  setImmediate(() => child.emit(event, payload))
+  return child
+}
+
+describe('folder IPC handlers (integration)', () => {
+  beforeEach(async () => {
+    vi.resetModules()
+    handleMock.mockReset()
+    realpathMock.mockReset()
+    spawnMock.mockReset()
+    openPathMock.mockReset()
+    getSettingsMock.mockReset()
+    // Default: the most common happy-path settings.
+    getSettingsMock.mockReturnValue({
+      defaultSkillTab: 'files',
+      preferredTerminal: 'terminal',
+    })
+    // Re-import after resetModules so the mocks above take effect.
+    const { registerFolderHandlers } = await import('./folder')
+    registerFolderHandlers()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('folder:revealInFinder', () => {
+    it('returns ok:true on happy path', async () => {
+      realpathMock.mockResolvedValue('/Users/me/.agents/skills')
+      openPathMock.mockResolvedValue('')
+      const handler = getRegisteredHandler('folder:revealInFinder')
+      const result = await handler({}, '/Users/me/.agents/skills')
+      expect(result).toEqual({ ok: true })
+    })
+
+    it('returns not-found when realpath rejects with ENOENT', async () => {
+      const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+      realpathMock.mockRejectedValue(err)
+      const handler = getRegisteredHandler('folder:revealInFinder')
+      const result = await handler({}, '/missing/path')
+      expect(result).toEqual({
+        ok: false,
+        reason: 'not-found',
+        message: 'Folder not found: /missing/path',
+      })
+      expect(openPathMock).not.toHaveBeenCalled()
+    })
+
+    it('returns not-found for ELOOP (symlink cycle)', async () => {
+      const err = Object.assign(new Error('ELOOP'), { code: 'ELOOP' })
+      realpathMock.mockRejectedValue(err)
+      const handler = getRegisteredHandler('folder:revealInFinder')
+      const result = await handler({}, '/cycle')
+      expect(result).toMatchObject({ ok: false, reason: 'not-found' })
+    })
+
+    it('returns launch-failed when shell.openPath returns an error string', async () => {
+      realpathMock.mockResolvedValue('/x')
+      openPathMock.mockResolvedValue('Permission denied')
+      const handler = getRegisteredHandler('folder:revealInFinder')
+      const result = await handler({}, '/x')
+      expect(result).toMatchObject({
+        ok: false,
+        reason: 'launch-failed',
+      })
+      expect(result).toHaveProperty(
+        'message',
+        expect.stringContaining('Permission denied'),
+      )
+    })
+  })
+
+  describe('folder:openInTerminal', () => {
+    it('returns ok:true when spawn fires exit(0)', async () => {
+      realpathMock.mockResolvedValue('/x')
+      const child = spawnFiringEvent('exit', 0)
+      const handler = getRegisteredHandler('folder:openInTerminal')
+
+      const result = await handler({}, '/x')
+
+      expect(result).toEqual({ ok: true })
+      expect(child.unref).toHaveBeenCalled()
+      expect(spawnMock).toHaveBeenCalledWith('open', ['-a', 'Terminal', '/x'], {
+        stdio: 'ignore',
+      })
+    })
+
+    it('returns not-found BEFORE getSettings/spawn when path missing', async () => {
+      const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+      realpathMock.mockRejectedValue(err)
+      const handler = getRegisteredHandler('folder:openInTerminal')
+
+      const result = await handler({}, '/gone')
+
+      expect(result).toMatchObject({ ok: false, reason: 'not-found' })
+      expect(getSettingsMock).not.toHaveBeenCalled()
+      expect(spawnMock).not.toHaveBeenCalled()
+    })
+
+    it('returns invalid-path when preferredTerminal=custom and customTerminalAppName missing', async () => {
+      realpathMock.mockResolvedValue('/x')
+      getSettingsMock.mockReturnValue({
+        defaultSkillTab: 'files',
+        preferredTerminal: 'custom',
+      })
+      const handler = getRegisteredHandler('folder:openInTerminal')
+
+      const result = await handler({}, '/x')
+
+      expect(result).toMatchObject({
+        ok: false,
+        reason: 'invalid-path',
+      })
+      expect(spawnMock).not.toHaveBeenCalled()
+    })
+
+    it('returns launch-failed on spawn exit(1) (app not installed)', async () => {
+      realpathMock.mockResolvedValue('/x')
+      spawnFiringEvent('exit', 1)
+      const handler = getRegisteredHandler('folder:openInTerminal')
+
+      const result = await handler({}, '/x')
+
+      expect(result).toMatchObject({
+        ok: false,
+        reason: 'launch-failed',
+      })
+    })
+
+    it('returns launch-failed on spawn error event', async () => {
+      realpathMock.mockResolvedValue('/x')
+      spawnFiringEvent('error', new Error('spawn ENOENT'))
+      const handler = getRegisteredHandler('folder:openInTerminal')
+
+      const result = await handler({}, '/x')
+
+      expect(result).toMatchObject({
+        ok: false,
+        reason: 'launch-failed',
+      })
+      expect(result).toHaveProperty(
+        'message',
+        expect.stringContaining('spawn ENOENT'),
+      )
+    })
+
+    it('reads getSettings on EVERY call (no module-load caching)', async () => {
+      realpathMock.mockResolvedValue('/x')
+      const handler = getRegisteredHandler('folder:openInTerminal')
+
+      // First click: Terminal
+      spawnFiringEvent('exit', 0)
+      await handler({}, '/x')
+      expect(spawnMock).toHaveBeenLastCalledWith(
+        'open',
+        ['-a', 'Terminal', '/x'],
+        { stdio: 'ignore' },
+      )
+
+      // User changed Settings to iTerm — no app restart, just another click.
+      getSettingsMock.mockReturnValue({
+        defaultSkillTab: 'files',
+        preferredTerminal: 'iterm',
+      })
+      spawnFiringEvent('exit', 0)
+      await handler({}, '/x')
+      expect(spawnMock).toHaveBeenLastCalledWith(
+        'open',
+        ['-a', 'iTerm', '/x'],
+        { stdio: 'ignore' },
+      )
+    })
+  })
+})

--- a/src/main/ipc/folder.integration.test.ts
+++ b/src/main/ipc/folder.integration.test.ts
@@ -151,6 +151,23 @@ describe('folder IPC handlers (integration)', () => {
       expect(result).toMatchObject({ ok: false, reason: 'not-found' })
     })
 
+    it('returns not-found for ENOTDIR (parent component is a file)', async () => {
+      const err = Object.assign(new Error('ENOTDIR'), { code: 'ENOTDIR' })
+      realpathMock.mockRejectedValue(err)
+      const handler = getRegisteredHandler('folder:revealInFinder')
+      const result = await handler({}, '/file/inside')
+      expect(result).toMatchObject({ ok: false, reason: 'not-found' })
+      expect(openPathMock).not.toHaveBeenCalled()
+    })
+
+    it('rethrows unexpected realpath errors (e.g. EPERM) to the IPC boundary', async () => {
+      const err = Object.assign(new Error('EPERM'), { code: 'EPERM' })
+      realpathMock.mockRejectedValue(err)
+      const handler = getRegisteredHandler('folder:revealInFinder')
+      await expect(handler({}, '/locked')).rejects.toThrow('EPERM')
+      expect(openPathMock).not.toHaveBeenCalled()
+    })
+
     it('returns launch-failed when shell.openPath returns an error string', async () => {
       realpathMock.mockResolvedValue('/x')
       openPathMock.mockResolvedValue('Permission denied')
@@ -188,6 +205,18 @@ describe('folder IPC handlers (integration)', () => {
       const handler = getRegisteredHandler('folder:openInTerminal')
 
       const result = await handler({}, '/gone')
+
+      expect(result).toMatchObject({ ok: false, reason: 'not-found' })
+      expect(getSettingsMock).not.toHaveBeenCalled()
+      expect(spawnMock).not.toHaveBeenCalled()
+    })
+
+    it('returns not-found for ENOTDIR (parent component is a file)', async () => {
+      const err = Object.assign(new Error('ENOTDIR'), { code: 'ENOTDIR' })
+      realpathMock.mockRejectedValue(err)
+      const handler = getRegisteredHandler('folder:openInTerminal')
+
+      const result = await handler({}, '/file/inside')
 
       expect(result).toMatchObject({ ok: false, reason: 'not-found' })
       expect(getSettingsMock).not.toHaveBeenCalled()

--- a/src/main/ipc/folder.test.ts
+++ b/src/main/ipc/folder.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+
+import { buildOpenArgs } from './folder'
+
+/**
+ * Pure-function unit tests for `buildOpenArgs` — covers every branch of the
+ * curated × custom matrix without spawning processes or touching the filesystem.
+ * Integration tests (mocked spawn / realpath) live in `folder.integration.test.ts`.
+ */
+describe('buildOpenArgs', () => {
+  it('maps curated id "terminal" to Apple Terminal display name', () => {
+    expect(buildOpenArgs('terminal', undefined, '/x')).toEqual([
+      '-a',
+      'Terminal',
+      '/x',
+    ])
+  })
+
+  it('maps curated id "iterm" to iTerm display name', () => {
+    expect(buildOpenArgs('iterm', undefined, '/x')).toEqual([
+      '-a',
+      'iTerm',
+      '/x',
+    ])
+  })
+
+  it('maps curated id "warp" to Warp display name', () => {
+    expect(buildOpenArgs('warp', undefined, '/x')).toEqual(['-a', 'Warp', '/x'])
+  })
+
+  it('maps curated id "ghostty" to Ghostty display name', () => {
+    expect(buildOpenArgs('ghostty', undefined, '/x')).toEqual([
+      '-a',
+      'Ghostty',
+      '/x',
+    ])
+  })
+
+  it('maps curated id "alacritty" to Alacritty display name', () => {
+    expect(buildOpenArgs('alacritty', undefined, '/x')).toEqual([
+      '-a',
+      'Alacritty',
+      '/x',
+    ])
+  })
+
+  it('maps curated id "kitty" to lowercased "kitty" display name', () => {
+    expect(buildOpenArgs('kitty', undefined, '/x')).toEqual([
+      '-a',
+      'kitty',
+      '/x',
+    ])
+  })
+
+  it('maps curated id "wezterm" to WezTerm display name', () => {
+    expect(buildOpenArgs('wezterm', undefined, '/x')).toEqual([
+      '-a',
+      'WezTerm',
+      '/x',
+    ])
+  })
+
+  it('uses customTerminalAppName when preferredTerminal is "custom"', () => {
+    expect(buildOpenArgs('custom', 'Hyper', '/x')).toEqual([
+      '-a',
+      'Hyper',
+      '/x',
+    ])
+  })
+
+  it('returns null for "custom" with undefined customTerminalAppName', () => {
+    expect(buildOpenArgs('custom', undefined, '/x')).toBeNull()
+  })
+
+  it('returns null for "custom" with empty string customTerminalAppName', () => {
+    expect(buildOpenArgs('custom', '', '/x')).toBeNull()
+  })
+
+  it('returns null for "custom" with whitespace-only customTerminalAppName', () => {
+    // Defense-in-depth: Zod already trims+min(1)s the input, but the function
+    // also trims internally so a stale settings.json with '   ' is rejected.
+    expect(buildOpenArgs('custom', '   ', '/x')).toBeNull()
+  })
+
+  it('trims surrounding whitespace from custom name', () => {
+    expect(buildOpenArgs('custom', '  Hyper  ', '/x')).toEqual([
+      '-a',
+      'Hyper',
+      '/x',
+    ])
+  })
+})

--- a/src/main/ipc/folder.ts
+++ b/src/main/ipc/folder.ts
@@ -7,6 +7,7 @@ import { TERMINAL_APP_DISPLAY_NAMES } from '../../shared/constants'
 import { IPC_CHANNELS } from '../../shared/ipc-channels'
 import type { FolderActionResult, TerminalAppId } from '../../shared/types'
 import { getSettings } from '../services/settings'
+import { errorCode } from '../utils/errorCode'
 
 import { typedHandle } from './typedHandle'
 
@@ -74,7 +75,7 @@ async function resolveExistingPath(
     const resolved = await realpath(requestedPath)
     return { ok: true, resolved }
   } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code
+    const code = errorCode(err)
     // ENOENT: folder deleted externally. ELOOP: symlink cycle. ENOTDIR:
     // a parent component is a file, not a dir. All three are user-facing
     // "not found" from our POV — the launcher would fail the same way.

--- a/src/main/ipc/folder.ts
+++ b/src/main/ipc/folder.ts
@@ -1,0 +1,218 @@
+import { spawn } from 'node:child_process'
+import { realpath } from 'node:fs/promises'
+
+import { shell } from 'electron'
+
+import { TERMINAL_APP_DISPLAY_NAMES } from '../../shared/constants'
+import { IPC_CHANNELS } from '../../shared/ipc-channels'
+import type { FolderActionResult, TerminalAppId } from '../../shared/types'
+import { getSettings } from '../services/settings'
+
+import { typedHandle } from './typedHandle'
+
+/**
+ * Resolve the macOS app name to forward to `open -a <name>` for a given
+ * `preferredTerminal` setting. Returns `null` when the setting is `'custom'`
+ * but `customTerminalAppName` is missing/blank — the caller should surface
+ * `{ ok: false, reason: 'invalid-path' }` so the user is told to fix Settings
+ * rather than silently launching a wrong app.
+ *
+ * Pure (no fs / spawn) so it can be unit-tested without mocks. Exported so
+ * `folder.test.ts` can hammer every branch of the curated × custom matrix.
+ *
+ * @param preferredTerminal - The setting value (`TerminalAppId`).
+ * @param customTerminalAppName - Free-form app name, only honored when
+ *   `preferredTerminal === 'custom'`. Should already be Zod-trimmed.
+ * @param folderPath - Absolute path to the folder to open.
+ * @returns
+ * - For curated IDs: `['-a', '<DisplayName>', folderPath]`
+ * - For `'custom'` with a non-blank name: `['-a', '<custom name>', folderPath]`
+ * - For `'custom'` with a blank/missing name: `null`
+ * @example
+ * buildOpenArgs('terminal', undefined, '/x') // ['-a', 'Terminal', '/x']
+ * buildOpenArgs('iterm', undefined, '/x')    // ['-a', 'iTerm', '/x']
+ * buildOpenArgs('custom', 'Hyper', '/x')     // ['-a', 'Hyper', '/x']
+ * buildOpenArgs('custom', undefined, '/x')   // null
+ * buildOpenArgs('custom', '   ', '/x')       // null
+ */
+export function buildOpenArgs(
+  preferredTerminal: TerminalAppId,
+  customTerminalAppName: string | undefined,
+  folderPath: string,
+): readonly string[] | null {
+  if (preferredTerminal === 'custom') {
+    const trimmed = customTerminalAppName?.trim()
+    if (!trimmed) return null
+    return ['-a', trimmed, folderPath]
+  }
+  // Type system guarantees preferredTerminal is one of the curated IDs here.
+  const displayName = TERMINAL_APP_DISPLAY_NAMES[preferredTerminal]
+  return ['-a', displayName, folderPath]
+}
+
+/**
+ * Verify a path exists on disk before handing it to a launcher. Catches the
+ * "user deleted the folder externally between scan and click" race AND
+ * symlink loops (ELOOP) that would otherwise hang `realpath` indefinitely.
+ *
+ * Returns the canonical (symlink-resolved) path on success — pass that
+ * to `open` / `shell.openPath` so the launcher sees a real directory rather
+ * than a broken symlink.
+ *
+ * @param requestedPath - Absolute path supplied by the renderer (already
+ *   Zod-validated as starting with `/`).
+ * @returns
+ * - `{ ok: true, resolved }` on success
+ * - `{ ok: false, reason: 'not-found' }` for ENOENT / ELOOP / ENOTDIR
+ */
+async function resolveExistingPath(
+  requestedPath: string,
+): Promise<
+  { ok: true; resolved: string } | { ok: false; reason: 'not-found' }
+> {
+  try {
+    const resolved = await realpath(requestedPath)
+    return { ok: true, resolved }
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code
+    // ENOENT: folder deleted externally. ELOOP: symlink cycle. ENOTDIR:
+    // a parent component is a file, not a dir. All three are user-facing
+    // "not found" from our POV — the launcher would fail the same way.
+    if (code === 'ENOENT' || code === 'ELOOP' || code === 'ENOTDIR') {
+      return { ok: false, reason: 'not-found' }
+    }
+    // Re-throw unexpected errors so the typedHandle wrapper logs them
+    // and the renderer sees a generic launch-failed toast.
+    throw err
+  }
+}
+
+/**
+ * Format a user-safe error message for `not-found` toasts. The path is
+ * included so the user knows *which* folder vanished — useful when several
+ * agent rows are shown side-by-side.
+ */
+function notFoundMessage(folderPath: string): string {
+  return `Folder not found: ${folderPath}`
+}
+
+/**
+ * Reveal a folder in the macOS Finder (parent dir opened, target highlighted
+ * when possible). Wraps `shell.openPath` because Electron's `shell.openPath`
+ * returns an empty string on success and an error string on failure (no
+ * thrown exception) — we map that into the discriminated `FolderActionResult`
+ * so the renderer can render a toast without try/catch.
+ *
+ * @param folderPath - Absolute path to the folder.
+ */
+async function revealInFinder(folderPath: string): Promise<FolderActionResult> {
+  const existence = await resolveExistingPath(folderPath)
+  if (!existence.ok) {
+    return {
+      ok: false,
+      reason: 'not-found',
+      message: notFoundMessage(folderPath),
+    }
+  }
+  const errMessage = await shell.openPath(existence.resolved)
+  if (errMessage !== '') {
+    return {
+      ok: false,
+      reason: 'launch-failed',
+      message: `Could not open folder: ${errMessage}`,
+    }
+  }
+  return { ok: true }
+}
+
+/**
+ * Spawn `open -a <appName> <folderPath>` and resolve once macOS reports
+ * launch success/failure. We deliberately do NOT inherit stdio (silent in
+ * dev console) and call `unref()` so the child process never keeps the
+ * Electron main process alive at quit time.
+ *
+ * Resolves on either:
+ * - `exit` event with code 0 → success
+ * - `exit` event with non-zero code → app-not-installed (most common)
+ * - `error` event → spawn failure (e.g. `open` binary missing — impossible
+ *   on macOS but defensive)
+ *
+ * The Promise never rejects; the typedHandle boundary expects a value.
+ *
+ * @param folderPath - Absolute path to the folder to open.
+ */
+async function openInTerminal(folderPath: string): Promise<FolderActionResult> {
+  const existence = await resolveExistingPath(folderPath)
+  if (!existence.ok) {
+    return {
+      ok: false,
+      reason: 'not-found',
+      message: notFoundMessage(folderPath),
+    }
+  }
+
+  // Read settings on EVERY call (not at module load) so a Settings change in
+  // another window takes effect immediately on the next click — no app restart.
+  // getSettings() is sync, in-memory; the cost is one object lookup per click.
+  const settings = getSettings()
+  const args = buildOpenArgs(
+    settings.preferredTerminal,
+    settings.customTerminalAppName,
+    existence.resolved,
+  )
+  if (args === null) {
+    return {
+      ok: false,
+      reason: 'invalid-path',
+      message: 'Custom terminal name is empty. Set one in Settings → General.',
+    }
+  }
+
+  return new Promise<FolderActionResult>((resolve) => {
+    const child = spawn('open', [...args], { stdio: 'ignore' })
+    // Detach from main process so quitting the app does not interrupt the
+    // user's freshly-opened terminal.
+    child.unref()
+
+    child.once('exit', (code) => {
+      if (code === 0) {
+        resolve({ ok: true })
+      } else {
+        resolve({
+          ok: false,
+          reason: 'launch-failed',
+          message: `Could not launch terminal. Is the chosen app installed? (exit ${code ?? 'null'})`,
+        })
+      }
+    })
+
+    child.once('error', (err) => {
+      resolve({
+        ok: false,
+        reason: 'launch-failed',
+        message: `Could not launch terminal: ${err.message}`,
+      })
+    })
+  })
+}
+
+/**
+ * Register IPC handlers for the "Reveal in Finder" / "Open in Terminal"
+ * folder actions. Both channels are typed to return `FolderActionResult`
+ * (never throw) so the renderer can dispatch a toast without try/catch.
+ *
+ * Intentionally exhaustive guard against `'custom'` mis-config (test 2.7
+ * in the test plan): Settings UI prevents saving an empty custom name, but
+ * a stale settings.json (or a renderer with race conditions) could still
+ * surface here. Surfacing the error to the user beats silently launching
+ * a wrong app.
+ */
+export function registerFolderHandlers(): void {
+  typedHandle(IPC_CHANNELS.FOLDER_REVEAL_IN_FINDER, async (_event, path) => {
+    return revealInFinder(path)
+  })
+
+  typedHandle(IPC_CHANNELS.FOLDER_OPEN_IN_TERMINAL, async (_event, path) => {
+    return openInTerminal(path)
+  })
+}

--- a/src/main/ipc/folder.ts
+++ b/src/main/ipc/folder.ts
@@ -5,7 +5,12 @@ import { shell } from 'electron'
 
 import { TERMINAL_APP_DISPLAY_NAMES } from '../../shared/constants'
 import { IPC_CHANNELS } from '../../shared/ipc-channels'
-import type { FolderActionResult, TerminalAppId } from '../../shared/types'
+import type { Settings } from '../../shared/settings'
+import type {
+  AbsolutePath,
+  FolderActionResult,
+  TerminalAppId,
+} from '../../shared/types'
 import { getSettings } from '../services/settings'
 import { errorCode } from '../utils/errorCode'
 
@@ -38,9 +43,9 @@ import { typedHandle } from './typedHandle'
  */
 export function buildOpenArgs(
   preferredTerminal: TerminalAppId,
-  customTerminalAppName: string | undefined,
-  folderPath: string,
-): readonly string[] | null {
+  customTerminalAppName: Settings['customTerminalAppName'],
+  folderPath: AbsolutePath,
+): readonly ['-a', string, AbsolutePath] | null {
   if (preferredTerminal === 'custom') {
     const trimmed = customTerminalAppName?.trim()
     if (!trimmed) return null
@@ -67,9 +72,9 @@ export function buildOpenArgs(
  * - `{ ok: false, reason: 'not-found' }` for ENOENT / ELOOP / ENOTDIR
  */
 async function resolveExistingPath(
-  requestedPath: string,
+  requestedPath: AbsolutePath,
 ): Promise<
-  { ok: true; resolved: string } | { ok: false; reason: 'not-found' }
+  { ok: true; resolved: AbsolutePath } | { ok: false; reason: 'not-found' }
 > {
   try {
     const resolved = await realpath(requestedPath)
@@ -93,7 +98,7 @@ async function resolveExistingPath(
  * included so the user knows *which* folder vanished — useful when several
  * agent rows are shown side-by-side.
  */
-function notFoundMessage(folderPath: string): string {
+function notFoundMessage(folderPath: AbsolutePath): string {
   return `Folder not found: ${folderPath}`
 }
 
@@ -106,7 +111,9 @@ function notFoundMessage(folderPath: string): string {
  *
  * @param folderPath - Absolute path to the folder.
  */
-async function revealInFinder(folderPath: string): Promise<FolderActionResult> {
+async function revealInFinder(
+  folderPath: AbsolutePath,
+): Promise<FolderActionResult> {
   const existence = await resolveExistingPath(folderPath)
   if (!existence.ok) {
     return {
@@ -142,7 +149,9 @@ async function revealInFinder(folderPath: string): Promise<FolderActionResult> {
  *
  * @param folderPath - Absolute path to the folder to open.
  */
-async function openInTerminal(folderPath: string): Promise<FolderActionResult> {
+async function openInTerminal(
+  folderPath: AbsolutePath,
+): Promise<FolderActionResult> {
   const existence = await resolveExistingPath(folderPath)
   if (!existence.ok) {
     return {

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -1,5 +1,6 @@
 import { registerAgentsHandlers } from './agents'
 import { registerFilesHandlers } from './files'
+import { registerFolderHandlers } from './folder'
 import { registerLeaderboardHandlers } from './leaderboard'
 import { registerSettingsHandlers } from './settings'
 import { registerShellHandlers } from './shell'
@@ -24,4 +25,5 @@ export function registerAllHandlers(): void {
   registerSyncHandlers()
   registerShellHandlers()
   registerSettingsHandlers()
+  registerFolderHandlers()
 }

--- a/src/main/ipc/ipc-schemas.test.ts
+++ b/src/main/ipc/ipc-schemas.test.ts
@@ -53,3 +53,76 @@ describe('skillNameString consistency across channels', () => {
     }
   })
 })
+
+/**
+ * Argument validation for the folder:* channels added in the
+ * "Open in Terminal / Reveal in Finder" feature. These schemas guard the
+ * boundary between an untrusted renderer call and `shell.openPath` /
+ * `child_process.spawn('open', ...)`.
+ */
+describe('folder:* channels', () => {
+  const finderSchema = IPC_ARG_SCHEMAS['folder:revealInFinder']!
+  const terminalSchema = IPC_ARG_SCHEMAS['folder:openInTerminal']!
+
+  it('folder:revealInFinder accepts an absolute path', () => {
+    expect(finderSchema.safeParse(['/Users/me/.agents/skills']).success).toBe(
+      true,
+    )
+  })
+
+  it('folder:revealInFinder rejects empty string', () => {
+    expect(finderSchema.safeParse(['']).success).toBe(false)
+  })
+
+  it('folder:revealInFinder rejects relative path', () => {
+    expect(finderSchema.safeParse(['relative/path']).success).toBe(false)
+  })
+
+  it('folder:openInTerminal mirrors the same absolute-path guard', () => {
+    expect(terminalSchema.safeParse(['/Users/me/.cline/skills']).success).toBe(
+      true,
+    )
+    expect(terminalSchema.safeParse(['']).success).toBe(false)
+    expect(terminalSchema.safeParse(['./relative']).success).toBe(false)
+  })
+})
+
+/**
+ * `settings:set` is the highest-blast-radius write channel: validated input
+ * lands on disk in user data. The schema is .strict() so unknown keys are
+ * rejected — a compromised renderer cannot inject arbitrary fields.
+ */
+describe('settings:set lockstep with SettingsSchema', () => {
+  const schema = IPC_ARG_SCHEMAS['settings:set']!
+
+  it('accepts the new preferredTerminal field', () => {
+    expect(schema.safeParse([{ preferredTerminal: 'iterm' }]).success).toBe(
+      true,
+    )
+  })
+
+  it('accepts customTerminalAppName within length cap', () => {
+    expect(schema.safeParse([{ customTerminalAppName: 'Hyper' }]).success).toBe(
+      true,
+    )
+  })
+
+  it('rejects an unknown enum value for preferredTerminal', () => {
+    expect(
+      schema.safeParse([{ preferredTerminal: 'fish-shell' }]).success,
+    ).toBe(false)
+  })
+
+  it('rejects customTerminalAppName longer than 64 chars', () => {
+    expect(
+      schema.safeParse([{ customTerminalAppName: 'a'.repeat(65) }]).success,
+    ).toBe(false)
+  })
+
+  it('rejects unknown extra keys (.strict())', () => {
+    expect(
+      schema.safeParse([{ defaultSkillTab: 'files', somethingElse: 'x' }])
+        .success,
+    ).toBe(false)
+  })
+})

--- a/src/main/ipc/ipc-schemas.ts
+++ b/src/main/ipc/ipc-schemas.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 
+import { TERMINAL_APP_IDS } from '../../shared/constants'
 import type { IpcInvokeChannel } from '../../shared/ipc-contract'
 
 /**
@@ -11,6 +12,28 @@ import type { IpcInvokeChannel } from '../../shared/ipc-contract'
  */
 
 const nonEmptyString = z.string().min(1)
+
+/**
+ * Absolute POSIX path validator for IPC channels that hand a path to
+ * `shell.openPath` / `spawn('open', …)`. The leading-slash refine catches
+ * relative paths early (a renderer bug or a tampered call) before they reach
+ * the OS — `shell.openPath('relative/path')` resolves against the main
+ * process's cwd, which is almost never what the user expects and may escape
+ * the agent / source dir entirely.
+ *
+ * Symlink-loop protection (ELOOP) and not-found handling live in the
+ * `folder.ts` handler — this is a syntactic guard only.
+ *
+ * @example
+ * absolutePathArg.parse('/Users/me/.agents/skills') // ok
+ * absolutePathArg.parse('relative/path')           // throws ZodError
+ */
+const absolutePathArg = z
+  .string()
+  .min(1)
+  .refine((p) => p.startsWith('/'), {
+    message: 'Path must be absolute (start with /)',
+  })
 /**
  * Skill name must not contain path separators (prevents `../` traversal) or
  * null bytes (defense in depth: some libc wrappers truncate at `\0`, which
@@ -248,7 +271,15 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
     z
       .object({
         defaultSkillTab: z.enum(['files', 'info']).optional(),
+        preferredTerminal: z.enum(TERMINAL_APP_IDS).optional(),
+        // Same trim+min(1)+max(64) shape as SettingsSchema — keep in sync.
+        customTerminalAppName: z.string().trim().min(1).max(64).optional(),
       })
       .strict(),
   ]),
+
+  // Folder actions — `open -a` / `shell.openPath`. Path must be absolute;
+  // see `absolutePathArg` for rationale.
+  'folder:revealInFinder': z.tuple([absolutePathArg]),
+  'folder:openInTerminal': z.tuple([absolutePathArg]),
 }

--- a/src/main/ipc/ipc-schemas.ts
+++ b/src/main/ipc/ipc-schemas.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 
 import { TERMINAL_APP_IDS } from '../../shared/constants'
 import type { IpcInvokeChannel } from '../../shared/ipc-contract'
+import { SettingsSchema } from '../../shared/settings'
 
 /**
  * Zod schemas for runtime validation of IPC invoke arguments.
@@ -272,8 +273,10 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
       .object({
         defaultSkillTab: z.enum(['files', 'info']).optional(),
         preferredTerminal: z.enum(TERMINAL_APP_IDS).optional(),
-        // Same trim+min(1)+max(64) shape as SettingsSchema — keep in sync.
-        customTerminalAppName: z.string().trim().min(1).max(64).optional(),
+        // Direct re-export from SettingsSchema — drift between the two
+        // constraint sets is mechanically impossible. `.shape` access yields
+        // the field's ZodOptional<ZodString> exactly as defined in settings.ts.
+        customTerminalAppName: SettingsSchema.shape.customTerminalAppName,
       })
       .strict(),
   ]),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -130,6 +130,16 @@ contextBridge.exposeInMainWorld('electron', {
       typedInvoke('settings:set', partial),
     onChanged: createIpcListener<Settings>(IPC_CHANNELS.SETTINGS_CHANGED),
   },
+  // Folder actions — main-process-only because both `shell.openPath` and
+  // `child_process.spawn('open', …)` are unavailable in sandboxed preload.
+  // Both methods return `FolderActionResult` instead of throwing so the
+  // renderer can render a toast without try/catch.
+  folder: {
+    revealInFinder: async (folderPath: AbsolutePath) =>
+      typedInvoke('folder:revealInFinder', folderPath),
+    openInTerminal: async (folderPath: AbsolutePath) =>
+      typedInvoke('folder:openInTerminal', folderPath),
+  },
 })
 
 // E2E-only escape hatch from the typed `electron.*` IPC contract above.

--- a/src/renderer/settings/sections/General.tsx
+++ b/src/renderer/settings/sections/General.tsx
@@ -1,7 +1,13 @@
 import { Files, Info } from 'lucide-react'
-import React from 'react'
+import React, { useState } from 'react'
 
+import {
+  TERMINAL_APP_IDS,
+  TERMINAL_APP_UI_LABELS,
+} from '../../../shared/constants'
 import type { Settings } from '../../../shared/settings'
+import type { TerminalAppId } from '../../../shared/types'
+import { Input } from '../../src/components/ui/input'
 import {
   ToggleGroup,
   ToggleGroupItem,
@@ -27,33 +33,84 @@ const DEFAULT_TAB_OPTIONS: ReadonlyArray<{
 ]
 
 /**
+ * Length cap mirrors `SettingsSchema.customTerminalAppName.max(64)` and the
+ * IPC schema in `src/main/ipc/ipc-schemas.ts`. Surfacing the limit on the
+ * `<input maxLength>` keeps the user from typing past the boundary instead
+ * of getting a silent reject after blur.
+ */
+const CUSTOM_APP_NAME_MAX_LENGTH = 64
+
+/**
+ * Type guard for the `<select>` change event — keeps the IPC dispatcher
+ * narrowed without `as` casts. Defensive against a tampered DOM that
+ * could fire `onChange` with an unknown value.
+ */
+function isTerminalAppId(value: string): value is TerminalAppId {
+  return (TERMINAL_APP_IDS as readonly string[]).includes(value)
+}
+
+/**
  * General settings pane.
  *
- * Currently ships the single real setting in the v0.15.0 Settings shell:
- * "Default tab when opening a skill". Other knobs (e.g. compact density,
- * auto-collapse) belong here in future PRs once their behavior is wired.
+ * Currently ships:
+ *  - "Default tab when opening a skill" (existing).
+ *  - "Preferred terminal" — which macOS terminal "Open in Terminal" launches.
+ *    `'custom'` reveals a free-form input that's persisted as
+ *    `customTerminalAppName`.
  *
- * Dispatch flow on change:
- *  1. Dispatch `setSettings` locally for instant UI feedback (no
- *     waiting on IPC for the radio to highlight).
- *  2. Fire `settings:set` IPC. Main writes the JSON atomically and
- *     broadcasts `settings:changed` back to every window including
- *     this one — the listener dispatches `setSettings` a second time
- *     with the same payload (idempotent replace).
+ * Dispatch flow on change (mirrors `defaultSkillTab`):
+ *  1. Local optimistic dispatch via `useUpdateSettings` for instant feedback.
+ *  2. IPC `settings:set` — main writes JSON atomically + broadcasts
+ *     `settings:changed` to every window.
  *
- * The optimistic local dispatch is safe because IPC to the same process
- * doesn't fail in practice; if main throws, the cache stays stale until
- * the next broadcast or window reload, which is acceptable for a
- * non-critical setting.
+ * The custom-app-name input intentionally does NOT fire IPC on every
+ * keystroke. We commit on `blur` (focus leaves the field) so an atomic
+ * disk write doesn't happen on each keypress — that would be a footgun
+ * for users typing slowly and would also fan out a `settings:changed`
+ * broadcast to every open window per character.
  */
 export const General = React.memo(function General(): React.ReactElement {
   const settings = useAppSelector((state) => state.settings)
   const updateSettings = useUpdateSettings()
 
+  // Local mirror of the custom name field so users can type without
+  // committing on every keystroke. Initial value is whatever's in settings
+  // (which itself was last committed via blur). Reset implicitly on
+  // re-mount; explicit reset on settings change isn't needed because the
+  // field is only visible while preferredTerminal === 'custom'.
+  const [customNameDraft, setCustomNameDraft] = useState<string>(
+    settings.customTerminalAppName ?? '',
+  )
+
   const handleDefaultTabChange = (nextValue: string): void => {
     if (nextValue !== 'files' && nextValue !== 'info') return
     updateSettings({ defaultSkillTab: nextValue })
   }
+
+  const handlePreferredTerminalChange = (
+    e: React.ChangeEvent<HTMLSelectElement>,
+  ): void => {
+    const next = e.target.value
+    if (!isTerminalAppId(next)) return
+    updateSettings({ preferredTerminal: next })
+  }
+
+  /**
+   * Commit the trimmed draft on blur. Empty string after trim → skip the
+   * IPC call (keeps prior value) so leaving the field blank doesn't wipe
+   * what the user previously saved. Same trim/min(1) guard as the Zod
+   * schema so the renderer never asks main to write a value that the
+   * schema would reject.
+   */
+  const handleCustomNameBlur = (): void => {
+    const trimmed = customNameDraft.trim()
+    if (trimmed === '') return
+    if (trimmed === settings.customTerminalAppName) return
+    updateSettings({ customTerminalAppName: trimmed })
+  }
+
+  const isCustom = settings.preferredTerminal === 'custom'
+  const isDraftBlank = customNameDraft.trim() === ''
 
   return (
     <SectionFrame
@@ -86,6 +143,63 @@ export const General = React.memo(function General(): React.ReactElement {
             )
           })}
         </ToggleGroup>
+      </SectionRow>
+
+      <SectionRow
+        label="Preferred terminal"
+        description='Which app "Open in Terminal" launches for skill folders.'
+      >
+        <div className="flex flex-col gap-2">
+          {/* Native <select> instead of shadcn — fewer deps, native macOS */}
+          {/* popover menu, free type-to-search and arrow-key nav. Sized to */}
+          {/* fit longest label ("Terminal (Apple)") at the chosen text size. */}
+          <select
+            className="h-9 min-w-[14rem] rounded-md border border-input bg-background px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            value={settings.preferredTerminal}
+            onChange={handlePreferredTerminalChange}
+            aria-label="Preferred terminal"
+          >
+            {TERMINAL_APP_IDS.map((id) => (
+              <option key={id} value={id}>
+                {TERMINAL_APP_UI_LABELS[id]}
+              </option>
+            ))}
+          </select>
+
+          {isCustom && (
+            <div className="flex flex-col gap-1">
+              <Input
+                type="text"
+                value={customNameDraft}
+                onChange={(e) => setCustomNameDraft(e.target.value)}
+                onBlur={handleCustomNameBlur}
+                placeholder="e.g. Hyper"
+                maxLength={CUSTOM_APP_NAME_MAX_LENGTH}
+                aria-label="Custom terminal app name"
+                className="min-w-[14rem]"
+              />
+              {isDraftBlank ? (
+                <p className="text-xs text-muted-foreground">
+                  Enter the macOS app name (e.g. <code>Hyper</code>). The app
+                  must be installed in <code>/Applications</code>.
+                </p>
+              ) : (
+                <p className="text-xs text-muted-foreground">
+                  Saved when you click outside the field.
+                </p>
+              )}
+            </div>
+          )}
+
+          {/* Footnote disclosure: some terminals (Warp Stable, Ghostty) */}
+          {/* don't honor `cwd` from the macOS `open -a` flag and may */}
+          {/* launch at $HOME instead of the requested folder. We can't */}
+          {/* fix that from our side — surface it so the user isn't surprised. */}
+          <p className="text-xs text-muted-foreground">
+            Note: some terminals (Warp, Ghostty) may open at your home directory
+            instead of the skill folder.
+          </p>
+        </div>
       </SectionRow>
     </SectionFrame>
   )

--- a/src/renderer/settings/sections/General.tsx
+++ b/src/renderer/settings/sections/General.tsx
@@ -6,7 +6,6 @@ import {
   TERMINAL_APP_UI_LABELS,
 } from '../../../shared/constants'
 import type { Settings } from '../../../shared/settings'
-import type { TerminalAppId } from '../../../shared/types'
 import { Input } from '../../src/components/ui/input'
 import {
   ToggleGroup,
@@ -39,15 +38,6 @@ const DEFAULT_TAB_OPTIONS: ReadonlyArray<{
  * of getting a silent reject after blur.
  */
 const CUSTOM_APP_NAME_MAX_LENGTH = 64
-
-/**
- * Type guard for the `<select>` change event — keeps the IPC dispatcher
- * narrowed without `as` casts. Defensive against a tampered DOM that
- * could fire `onChange` with an unknown value.
- */
-function isTerminalAppId(value: string): value is TerminalAppId {
-  return (TERMINAL_APP_IDS as readonly string[]).includes(value)
-}
 
 /**
  * General settings pane.
@@ -90,8 +80,12 @@ export const General = React.memo(function General(): React.ReactElement {
   const handlePreferredTerminalChange = (
     e: React.ChangeEvent<HTMLSelectElement>,
   ): void => {
-    const next = e.target.value
-    if (!isTerminalAppId(next)) return
+    // `find` infers `TerminalAppId | undefined` from the readonly tuple, so
+    // the IPC dispatcher is narrowed without an `as` cast. The IPC schema
+    // (`z.enum(TERMINAL_APP_IDS)`) is the real trust boundary — this filter
+    // is only here so a tampered DOM can't tunnel a bad string in.
+    const next = TERMINAL_APP_IDS.find((id) => id === e.target.value)
+    if (!next) return
     updateSettings({ preferredTerminal: next })
   }
 

--- a/src/renderer/src/components/sidebar/AgentItem.tsx
+++ b/src/renderer/src/components/sidebar/AgentItem.tsx
@@ -1,8 +1,9 @@
-import { Eraser, Trash2 } from 'lucide-react'
+import { Eraser, FolderOpen, Terminal, Trash2 } from 'lucide-react'
 import React, { useMemo, useState } from 'react'
 
 import { AGENT_DEFINITIONS } from '../../../../shared/constants'
 import type { Agent, AgentId } from '../../../../shared/types'
+import { useOpenFolder } from '../../hooks/useOpenFolder'
 import { cn } from '../../lib/utils'
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
 import { setAgentToDelete } from '../../redux/slices/agentsSlice'
@@ -72,6 +73,7 @@ export const AgentItem = React.memo(function AgentItem({
   const { selectedAgentId } = useAppSelector((state) => state.ui)
   const isSelected = selectedAgentId === agent.id
   const [contextOpen, setContextOpen] = useState(false)
+  const { revealInFinder, openInTerminal } = useOpenFolder()
 
   const handleClick = (): void => {
     if (!agent.exists) return
@@ -82,6 +84,16 @@ export const AgentItem = React.memo(function AgentItem({
     e.preventDefault()
     if (!agent.exists) return
     setContextOpen(true)
+  }
+
+  const handleRevealInFinder = (): void => {
+    void revealInFinder(agent.path)
+    setContextOpen(false)
+  }
+
+  const handleOpenInTerminal = (): void => {
+    void openInTerminal(agent.path)
+    setContextOpen(false)
   }
 
   const handleDelete = (): void => {
@@ -145,6 +157,17 @@ export const AgentItem = React.memo(function AgentItem({
           </DropdownMenuTrigger>
         </TooltipTrigger>
         <DropdownMenuContent>
+          {/* Folder actions go above destructive items so accidental keyboard */}
+          {/* navigation (Down arrow → Enter) lands on a safe action first. */}
+          <DropdownMenuItem onClick={handleRevealInFinder}>
+            <FolderOpen className="h-4 w-4 mr-2" />
+            Reveal in Finder
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={handleOpenInTerminal}>
+            <Terminal className="h-4 w-4 mr-2" />
+            Open in Terminal
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
           <DropdownMenuItem onClick={handleCleanupMissing}>
             <Eraser className="h-4 w-4 mr-2" />
             Cleanup missing skills...

--- a/src/renderer/src/components/sidebar/AgentItem.tsx
+++ b/src/renderer/src/components/sidebar/AgentItem.tsx
@@ -88,12 +88,10 @@ export const AgentItem = React.memo(function AgentItem({
 
   const handleRevealInFinder = (): void => {
     void revealInFinder(agent.path)
-    setContextOpen(false)
   }
 
   const handleOpenInTerminal = (): void => {
     void openInTerminal(agent.path)
-    setContextOpen(false)
   }
 
   const handleDelete = (): void => {

--- a/src/renderer/src/components/sidebar/AgentItem.tsx
+++ b/src/renderer/src/components/sidebar/AgentItem.tsx
@@ -157,11 +157,13 @@ export const AgentItem = React.memo(function AgentItem({
         <DropdownMenuContent>
           {/* Folder actions go above destructive items so accidental keyboard */}
           {/* navigation (Down arrow → Enter) lands on a safe action first. */}
-          <DropdownMenuItem onClick={handleRevealInFinder}>
+          {/* `onSelect` (not `onClick`) — Radix DropdownMenu.Item only fires */}
+          {/* `onSelect` for keyboard activation (Enter/Space). */}
+          <DropdownMenuItem onSelect={handleRevealInFinder}>
             <FolderOpen className="h-4 w-4 mr-2" />
             Reveal in Finder
           </DropdownMenuItem>
-          <DropdownMenuItem onClick={handleOpenInTerminal}>
+          <DropdownMenuItem onSelect={handleOpenInTerminal}>
             <Terminal className="h-4 w-4 mr-2" />
             Open in Terminal
           </DropdownMenuItem>

--- a/src/renderer/src/components/sidebar/SourceCard.tsx
+++ b/src/renderer/src/components/sidebar/SourceCard.tsx
@@ -80,13 +80,11 @@ export const SourceCard = React.memo(function SourceCard(): React.ReactElement {
   const handleRevealInFinder = (): void => {
     if (!sourceStats) return
     void revealInFinder(sourceStats.path)
-    setContextOpen(false)
   }
 
   const handleOpenInTerminal = (): void => {
     if (!sourceStats) return
     void openInTerminal(sourceStats.path)
-    setContextOpen(false)
   }
 
   /**

--- a/src/renderer/src/components/sidebar/SourceCard.tsx
+++ b/src/renderer/src/components/sidebar/SourceCard.tsx
@@ -203,11 +203,14 @@ export const SourceCard = React.memo(function SourceCard(): React.ReactElement {
         </CardContent>
       </Card>
       <DropdownMenuContent align="end">
-        <DropdownMenuItem onClick={handleRevealInFinder}>
+        {/* `onSelect` (not `onClick`) — Radix DropdownMenu.Item only fires */}
+        {/* `onSelect` for keyboard activation (Enter/Space). `onClick` would */}
+        {/* silently no-op for keyboard-only users. */}
+        <DropdownMenuItem onSelect={handleRevealInFinder}>
           <FolderOpen className="h-4 w-4 mr-2" />
           Reveal in Finder
         </DropdownMenuItem>
-        <DropdownMenuItem onClick={handleOpenInTerminal}>
+        <DropdownMenuItem onSelect={handleOpenInTerminal}>
           <Terminal className="h-4 w-4 mr-2" />
           Open in Terminal
         </DropdownMenuItem>

--- a/src/renderer/src/components/sidebar/SourceCard.tsx
+++ b/src/renderer/src/components/sidebar/SourceCard.tsx
@@ -1,7 +1,16 @@
-import { Folder, Loader2, RefreshCw, FolderSync } from 'lucide-react'
-import React, { useEffect } from 'react'
+import {
+  Folder,
+  FolderOpen,
+  FolderSync,
+  Loader2,
+  MoreVertical,
+  RefreshCw,
+  Terminal,
+} from 'lucide-react'
+import React, { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 
+import { useOpenFolder } from '../../hooks/useOpenFolder'
 import { cn } from '../../lib/utils'
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
 import { fetchAgents } from '../../redux/slices/agentsSlice'
@@ -15,6 +24,12 @@ import {
 } from '../../redux/slices/uiSlice'
 import { Button } from '../ui/button'
 import { Card, CardContent } from '../ui/card'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '../ui/dropdown-menu'
 
 /**
  * Source directory card showing stats, refresh, and sync buttons
@@ -25,6 +40,8 @@ export const SourceCard = React.memo(function SourceCard(): React.ReactElement {
   const { sourceStats, isRefreshing, isSyncing, selectedAgentId } =
     useAppSelector((state) => state.ui)
   const isActive = selectedAgentId === null
+  const [contextOpen, setContextOpen] = useState(false)
+  const { revealInFinder, openInTerminal } = useOpenFolder()
 
   useEffect(() => {
     dispatch(fetchSourceStats())
@@ -44,6 +61,32 @@ export const SourceCard = React.memo(function SourceCard(): React.ReactElement {
   const handlePathClick = (): void => {
     dispatch(selectAgent(null))
     dispatch(setSearchQuery(''))
+  }
+
+  /**
+   * Right-click on the card body opens the same DropdownMenu the kebab opens.
+   * `preventDefault` suppresses the OS context menu; `stopPropagation` keeps
+   * the Card-level `onClick` (which clears filters) from also firing.
+   * No-ops while sourceStats hasn't loaded — without a path there is nothing
+   * to reveal.
+   */
+  const handleContextMenu = (e: React.MouseEvent): void => {
+    e.preventDefault()
+    e.stopPropagation()
+    if (!sourceStats) return
+    setContextOpen(true)
+  }
+
+  const handleRevealInFinder = (): void => {
+    if (!sourceStats) return
+    void revealInFinder(sourceStats.path)
+    setContextOpen(false)
+  }
+
+  const handleOpenInTerminal = (): void => {
+    if (!sourceStats) return
+    void openInTerminal(sourceStats.path)
+    setContextOpen(false)
   }
 
   /**
@@ -78,61 +121,99 @@ export const SourceCard = React.memo(function SourceCard(): React.ReactElement {
   }
 
   return (
-    <Card
-      className={cn(
-        'bg-card/50 border-l-4 border-l-transparent transition-colors cursor-pointer',
-        isActive && 'border-l-primary bg-primary/5',
-      )}
-      onClick={handlePathClick}
-      title="Click to clear filters and show all skills"
+    <DropdownMenu
+      open={contextOpen}
+      onOpenChange={(open) => {
+        if (!open) setContextOpen(false)
+      }}
     >
-      <CardContent className="p-3">
-        <div className="flex items-center justify-between mb-2">
-          <div className="flex items-center gap-2">
-            <Folder className="h-4 w-4 text-primary" />
-            <Button
-              variant="ghost"
-              size="sm"
-              className="min-h-11 px-2 text-xs font-medium gap-1"
-              onClick={(e) => {
-                e.stopPropagation()
-                handleSync()
-              }}
-              disabled={isSyncing}
-            >
-              {isSyncing ? (
-                <Loader2 className="h-3 w-3 animate-spin" />
-              ) : (
-                <FolderSync className="h-3 w-3" />
-              )}
-              Sync
-            </Button>
-          </div>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-11 w-11"
-            onClick={(e) => {
-              e.stopPropagation()
-              handleRefresh()
-            }}
-            disabled={isRefreshing}
-          >
-            <RefreshCw
-              className={`h-3 w-3 ${isRefreshing ? 'animate-spin' : ''}`}
-            />
-          </Button>
-        </div>
-        <div className="hover:text-primary transition-colors">
-          <p className="text-sm font-medium truncate">~/.agents/skills</p>
-          {sourceStats && (
-            <div className="flex gap-4 mt-2 text-xs text-muted-foreground">
-              <span>{sourceStats.skillCount} skills</span>
-              <span>{sourceStats.totalSize}</span>
+      <Card
+        className={cn(
+          'bg-card/50 border-l-4 border-l-transparent transition-colors cursor-pointer',
+          isActive && 'border-l-primary bg-primary/5',
+        )}
+        onClick={handlePathClick}
+        onContextMenu={handleContextMenu}
+        title="Click to clear filters and show all skills"
+      >
+        <CardContent className="p-3">
+          <div className="flex items-center justify-between mb-2">
+            <div className="flex items-center gap-2">
+              <Folder className="h-4 w-4 text-primary" />
+              <Button
+                variant="ghost"
+                size="sm"
+                className="min-h-11 px-2 text-xs font-medium gap-1"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  handleSync()
+                }}
+                disabled={isSyncing}
+              >
+                {isSyncing ? (
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                ) : (
+                  <FolderSync className="h-3 w-3" />
+                )}
+                Sync
+              </Button>
             </div>
-          )}
-        </div>
-      </CardContent>
-    </Card>
+            <div className="flex items-center gap-1">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-11 w-11"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  handleRefresh()
+                }}
+                disabled={isRefreshing}
+              >
+                <RefreshCw
+                  className={`h-3 w-3 ${isRefreshing ? 'animate-spin' : ''}`}
+                />
+              </Button>
+              {/* Kebab uses asChild so the Button itself becomes the trigger — */}
+              {/* avoids a nested button (a11y violation) and routes the open */}
+              {/* state through the controlled `contextOpen` flag. */}
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-11 w-11"
+                  aria-label="Source folder actions"
+                  disabled={!sourceStats}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setContextOpen((prev) => !prev)
+                  }}
+                >
+                  <MoreVertical className="h-3 w-3" />
+                </Button>
+              </DropdownMenuTrigger>
+            </div>
+          </div>
+          <div className="hover:text-primary transition-colors">
+            <p className="text-sm font-medium truncate">~/.agents/skills</p>
+            {sourceStats && (
+              <div className="flex gap-4 mt-2 text-xs text-muted-foreground">
+                <span>{sourceStats.skillCount} skills</span>
+                <span>{sourceStats.totalSize}</span>
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={handleRevealInFinder}>
+          <FolderOpen className="h-4 w-4 mr-2" />
+          Reveal in Finder
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={handleOpenInTerminal}>
+          <Terminal className="h-4 w-4 mr-2" />
+          Open in Terminal
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 })

--- a/src/renderer/src/hooks/useOpenFolder.browser.test.tsx
+++ b/src/renderer/src/hooks/useOpenFolder.browser.test.tsx
@@ -82,6 +82,34 @@ describe('useOpenFolder', () => {
     expect(toastErrorMock).toHaveBeenCalledWith('Folder not found: /missing')
   })
 
+  it('toasts a fallback message when revealInFinder rejects (e.g. main rethrows EPERM)', async () => {
+    // The main process rethrows unexpected errors (EPERM, etc.) past the
+    // structured `{ok:false}` boundary — see folder.ts. Without try/catch
+    // here the user would get no feedback at all on those paths.
+    revealMock.mockRejectedValue(new Error('EPERM'))
+    const { useOpenFolder } = await import('./useOpenFolder')
+    const { result } = await renderHook(() => useOpenFolder())
+
+    await result.current.revealInFinder('/locked' as never)
+
+    expect(toastErrorMock).toHaveBeenCalledTimes(1)
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      'Failed to reveal folder in Finder',
+    )
+  })
+
+  it('toasts a fallback message when openInTerminal rejects', async () => {
+    openTerminalMock.mockRejectedValue(new Error('EPERM'))
+    const { useOpenFolder } = await import('./useOpenFolder')
+    const { result } = await renderHook(() => useOpenFolder())
+
+    await result.current.openInTerminal('/locked' as never)
+
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      'Failed to open folder in terminal',
+    )
+  })
+
   it('returns referentially-stable callbacks across re-renders', async () => {
     revealMock.mockResolvedValue({ ok: true })
     const { useOpenFolder } = await import('./useOpenFolder')

--- a/src/renderer/src/hooks/useOpenFolder.browser.test.tsx
+++ b/src/renderer/src/hooks/useOpenFolder.browser.test.tsx
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook } from 'vitest-browser-react'
+
+import type { FolderActionResult } from '../../../shared/types'
+
+const revealMock = vi.fn<(folderPath: string) => Promise<FolderActionResult>>()
+const openTerminalMock =
+  vi.fn<(folderPath: string) => Promise<FolderActionResult>>()
+
+const toastErrorMock = vi.fn()
+vi.mock('sonner', () => ({
+  toast: {
+    error: (...args: unknown[]) => toastErrorMock(...args),
+  },
+}))
+
+beforeEach(() => {
+  revealMock.mockReset()
+  openTerminalMock.mockReset()
+  toastErrorMock.mockReset()
+  vi.stubGlobal('electron', {
+    folder: {
+      revealInFinder: revealMock,
+      openInTerminal: openTerminalMock,
+    },
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('useOpenFolder', () => {
+  it('does not toast on successful revealInFinder', async () => {
+    revealMock.mockResolvedValue({ ok: true })
+    const { useOpenFolder } = await import('./useOpenFolder')
+    const { result } = await renderHook(() => useOpenFolder())
+
+    await result.current.revealInFinder('/x' as never)
+
+    expect(revealMock).toHaveBeenCalledWith('/x')
+    expect(toastErrorMock).not.toHaveBeenCalled()
+  })
+
+  it('toasts the error message on failed revealInFinder', async () => {
+    revealMock.mockResolvedValue({
+      ok: false,
+      reason: 'launch-failed',
+      message: 'boom',
+    })
+    const { useOpenFolder } = await import('./useOpenFolder')
+    const { result } = await renderHook(() => useOpenFolder())
+
+    await result.current.revealInFinder('/x' as never)
+
+    expect(toastErrorMock).toHaveBeenCalledTimes(1)
+    expect(toastErrorMock).toHaveBeenCalledWith('boom')
+  })
+
+  it('does not toast on successful openInTerminal', async () => {
+    openTerminalMock.mockResolvedValue({ ok: true })
+    const { useOpenFolder } = await import('./useOpenFolder')
+    const { result } = await renderHook(() => useOpenFolder())
+
+    await result.current.openInTerminal('/x' as never)
+
+    expect(openTerminalMock).toHaveBeenCalledWith('/x')
+    expect(toastErrorMock).not.toHaveBeenCalled()
+  })
+
+  it('toasts the error message on failed openInTerminal', async () => {
+    openTerminalMock.mockResolvedValue({
+      ok: false,
+      reason: 'not-found',
+      message: 'Folder not found: /missing',
+    })
+    const { useOpenFolder } = await import('./useOpenFolder')
+    const { result } = await renderHook(() => useOpenFolder())
+
+    await result.current.openInTerminal('/missing' as never)
+
+    expect(toastErrorMock).toHaveBeenCalledWith('Folder not found: /missing')
+  })
+
+  it('returns referentially-stable callbacks across re-renders', async () => {
+    revealMock.mockResolvedValue({ ok: true })
+    const { useOpenFolder } = await import('./useOpenFolder')
+    const { result, rerender } = await renderHook(() => useOpenFolder())
+
+    const firstReveal = result.current.revealInFinder
+    const firstOpen = result.current.openInTerminal
+
+    await rerender()
+
+    expect(result.current.revealInFinder).toBe(firstReveal)
+    expect(result.current.openInTerminal).toBe(firstOpen)
+  })
+})

--- a/src/renderer/src/hooks/useOpenFolder.ts
+++ b/src/renderer/src/hooks/useOpenFolder.ts
@@ -6,10 +6,12 @@ import type { AbsolutePath } from '../../../shared/types'
 /**
  * Renderer-side wrapper around `window.electron.folder.{revealInFinder,openInTerminal}`.
  *
- * Both methods return a `Promise<FolderActionResult>` that NEVER rejects —
- * the main process maps every failure (path missing, app not installed,
- * spawn error) into `{ ok: false, ... message }`. The hook surfaces that
- * `message` as a `toast.error` and otherwise stays out of the way.
+ * Both methods normally return a `Promise<FolderActionResult>` where every
+ * expected failure (path missing, app not installed, spawn error) is mapped
+ * into `{ ok: false, ... message }` by the main process. Unexpected errors
+ * (e.g. EPERM on `realpath`) are intentionally rethrown at the IPC boundary
+ * — see `src/main/ipc/folder.ts` — so the hook ALSO has to handle the
+ * rejection branch or the user gets no feedback at all.
  *
  * Deliberately no double-click / debounce guard: spamming "Reveal in Finder"
  * 5× just brings Finder forward 5×, which is harmless. Adding a guard would
@@ -34,9 +36,11 @@ export function useOpenFolder(): {
 } {
   const revealInFinder = useCallback(
     async (folderPath: AbsolutePath): Promise<void> => {
-      const result = await window.electron.folder.revealInFinder(folderPath)
-      if (!result.ok) {
-        toast.error(result.message)
+      try {
+        const result = await window.electron.folder.revealInFinder(folderPath)
+        if (!result.ok) toast.error(result.message)
+      } catch {
+        toast.error('Failed to reveal folder in Finder')
       }
     },
     [],
@@ -44,9 +48,11 @@ export function useOpenFolder(): {
 
   const openInTerminal = useCallback(
     async (folderPath: AbsolutePath): Promise<void> => {
-      const result = await window.electron.folder.openInTerminal(folderPath)
-      if (!result.ok) {
-        toast.error(result.message)
+      try {
+        const result = await window.electron.folder.openInTerminal(folderPath)
+        if (!result.ok) toast.error(result.message)
+      } catch {
+        toast.error('Failed to open folder in terminal')
       }
     },
     [],

--- a/src/renderer/src/hooks/useOpenFolder.ts
+++ b/src/renderer/src/hooks/useOpenFolder.ts
@@ -1,0 +1,56 @@
+import { useCallback } from 'react'
+import { toast } from 'sonner'
+
+import type { AbsolutePath } from '../../../shared/types'
+
+/**
+ * Renderer-side wrapper around `window.electron.folder.{revealInFinder,openInTerminal}`.
+ *
+ * Both methods return a `Promise<FolderActionResult>` that NEVER rejects —
+ * the main process maps every failure (path missing, app not installed,
+ * spawn error) into `{ ok: false, ... message }`. The hook surfaces that
+ * `message` as a `toast.error` and otherwise stays out of the way.
+ *
+ * Deliberately no double-click / debounce guard: spamming "Reveal in Finder"
+ * 5× just brings Finder forward 5×, which is harmless. Adding a guard would
+ * cost UX clarity (greyed-out menu items mid-launch) for no real protection.
+ *
+ * Returned methods are wrapped in `useCallback` with empty deps so they are
+ * referentially stable across re-renders — safe to pass to `<DropdownMenuItem>`
+ * `onSelect` props that compare on identity.
+ *
+ * @returns
+ * - `revealInFinder(folderPath)`: opens the folder in macOS Finder
+ * - `openInTerminal(folderPath)`: opens the user's preferred terminal at `cwd = folderPath`
+ * @example
+ * const { revealInFinder, openInTerminal } = useOpenFolder()
+ * <DropdownMenuItem onSelect={() => void revealInFinder(agent.path)}>
+ *   Reveal in Finder
+ * </DropdownMenuItem>
+ */
+export function useOpenFolder(): {
+  revealInFinder: (folderPath: AbsolutePath) => Promise<void>
+  openInTerminal: (folderPath: AbsolutePath) => Promise<void>
+} {
+  const revealInFinder = useCallback(
+    async (folderPath: AbsolutePath): Promise<void> => {
+      const result = await window.electron.folder.revealInFinder(folderPath)
+      if (!result.ok) {
+        toast.error(result.message)
+      }
+    },
+    [],
+  )
+
+  const openInTerminal = useCallback(
+    async (folderPath: AbsolutePath): Promise<void> => {
+      const result = await window.electron.folder.openInTerminal(folderPath)
+      if (!result.ok) {
+        toast.error(result.message)
+      }
+    },
+    [],
+  )
+
+  return { revealInFinder, openInTerminal }
+}

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -1,5 +1,6 @@
 import type { Settings } from '../../../shared/settings'
 import type {
+  AbsolutePath,
   Skill,
   Agent,
   SourceStats,
@@ -124,8 +125,12 @@ declare global {
         onChanged: (callback: (settings: Settings) => void) => () => void
       }
       folder: {
-        revealInFinder: (folderPath: string) => Promise<FolderActionResult>
-        openInTerminal: (folderPath: string) => Promise<FolderActionResult>
+        revealInFinder: (
+          folderPath: AbsolutePath,
+        ) => Promise<FolderActionResult>
+        openInTerminal: (
+          folderPath: AbsolutePath,
+        ) => Promise<FolderActionResult>
       }
     }
   }

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -9,6 +9,7 @@ import type {
   UpdateInfo,
   DeleteProgressPayload,
   DownloadProgress,
+  FolderActionResult,
   RankingFilter,
   SkillSearchResult,
   InstallOptions,
@@ -121,6 +122,10 @@ declare global {
         get: () => Promise<Settings>
         set: (partial: Partial<Settings>) => Promise<Settings>
         onChanged: (callback: (settings: Settings) => void) => () => void
+      }
+      folder: {
+        revealInFinder: (folderPath: string) => Promise<FolderActionResult>
+        openInTerminal: (folderPath: string) => Promise<FolderActionResult>
       }
     }
   }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -603,6 +603,82 @@ export const UNIVERSAL_AGENT_IDS = [
 ] as const satisfies readonly AgentId[]
 
 /**
+ * Curated terminal app identifiers used by the "Open in Terminal" feature.
+ * Single source of truth for the `TerminalAppId` type (derived in
+ * `src/shared/types.ts` via indexed-access on this tuple) AND the Zod enum
+ * in `src/shared/settings.ts` (`z.enum(TERMINAL_APP_IDS)`). Adding a new
+ * terminal here automatically widens both — drift is mechanically impossible.
+ *
+ * Order is the order shown in the Settings → Preferred Terminal `<Select>`.
+ * `'custom'` MUST stay last so the "Custom…" option appears at the bottom.
+ */
+export const TERMINAL_APP_IDS = [
+  'terminal',
+  'iterm',
+  'warp',
+  'ghostty',
+  'alacritty',
+  'kitty',
+  'wezterm',
+  'custom',
+] as const
+
+/**
+ * Display names for the curated terminal apps, exactly as macOS LaunchServices
+ * registers them under `/Applications`. Used by the main-process IPC handler
+ * `folder:openInTerminal` as the argument to `open -a <name>`. We deliberately
+ * use display names instead of bundle IDs (`-b com.apple.Terminal`) because
+ * vendor bundle IDs drift across Stable / Preview / Insiders rebrands (e.g.,
+ * Warp), while LaunchServices keeps the human-facing names stable.
+ *
+ * The `'custom'` entry is intentionally excluded — when the user picks Custom
+ * in Settings, the handler reads `settings.customTerminalAppName` instead.
+ *
+ * @example
+ * spawn('open', ['-a', TERMINAL_APP_DISPLAY_NAMES.iterm, '/Users/me/.agents/skills'])
+ */
+export const TERMINAL_APP_DISPLAY_NAMES: Record<
+  Exclude<(typeof TERMINAL_APP_IDS)[number], 'custom'>,
+  string
+> = {
+  terminal: 'Terminal',
+  iterm: 'iTerm',
+  warp: 'Warp',
+  ghostty: 'Ghostty',
+  alacritty: 'Alacritty',
+  kitty: 'kitty',
+  wezterm: 'WezTerm',
+}
+
+/**
+ * Human-facing labels for the Settings → General → Preferred Terminal `<Select>`.
+ * Diverges from `TERMINAL_APP_DISPLAY_NAMES` in two cases:
+ * - `'terminal'` becomes "Terminal (Apple)" because the bare word "Terminal"
+ *   is ambiguous next to other vendors in a dropdown.
+ * - `'custom'` exists here because it is a UI-only sentinel.
+ *
+ * The launch-time string MUST come from `TERMINAL_APP_DISPLAY_NAMES`; this
+ * record is for rendering only.
+ *
+ * @example
+ * <SelectItem value="terminal">{TERMINAL_APP_UI_LABELS.terminal}</SelectItem>
+ * // renders "Terminal (Apple)"
+ */
+export const TERMINAL_APP_UI_LABELS: Record<
+  (typeof TERMINAL_APP_IDS)[number],
+  string
+> = {
+  terminal: 'Terminal (Apple)',
+  iterm: 'iTerm',
+  warp: 'Warp',
+  ghostty: 'Ghostty',
+  alacritty: 'Alacritty',
+  kitty: 'kitty',
+  wezterm: 'WezTerm',
+  custom: 'Custom…',
+}
+
+/**
  * Pinned `vercel-labs/skills` CLI version used by the main-process
  * `skillsCliService` when spawning `npx skills@<version> ...`. Kept in the
  * shared module so the `/cli-upgrade` maintenance skill has a single place

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -60,6 +60,10 @@ export const IPC_CHANNELS = {
   SETTINGS_GET: 'settings:get',
   SETTINGS_SET: 'settings:set',
   SETTINGS_CHANGED: 'settings:changed',
+
+  // Folder actions (Reveal in Finder, Open in Terminal)
+  FOLDER_REVEAL_IN_FINDER: 'folder:revealInFinder',
+  FOLDER_OPEN_IN_TERMINAL: 'folder:openInTerminal',
 } as const
 
 export type IpcChannel = (typeof IPC_CHANNELS)[keyof typeof IPC_CHANNELS]

--- a/src/shared/ipc-contract.test.ts
+++ b/src/shared/ipc-contract.test.ts
@@ -34,6 +34,8 @@ describe('IPC contract alignment', () => {
       [IPC_CHANNELS.SETTINGS_OPEN]: true,
       [IPC_CHANNELS.SETTINGS_GET]: true,
       [IPC_CHANNELS.SETTINGS_SET]: true,
+      [IPC_CHANNELS.FOLDER_REVEAL_IN_FINDER]: true,
+      [IPC_CHANNELS.FOLDER_OPEN_IN_TERMINAL]: true,
     } as const satisfies Record<keyof IpcInvokeContract, true>
 
     // Runtime assertion: mapping covers exactly the contract keys.
@@ -41,7 +43,7 @@ describe('IPC contract alignment', () => {
     // IPC channel (input validation, authz scope, side-effect blast radius).
     // The `satisfies` clause above is a structural guard; this length check is
     // the trip-wire that forces a human PR diff when a channel is added.
-    expect(Object.keys(invokeMapping)).toHaveLength(27)
+    expect(Object.keys(invokeMapping)).toHaveLength(29)
   })
 
   it('all IPC_CHANNELS event values are valid event contract keys', () => {

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -13,6 +13,7 @@ import type {
   DeleteSkillResult,
   DeleteSkillsOptions,
   DownloadProgress,
+  FolderActionResult,
   HttpUrl,
   InstallOptions,
   InstallProgress,
@@ -114,6 +115,12 @@ export interface IpcInvokeContract {
   'settings:open': { args: []; result: void }
   'settings:get': { args: []; result: Settings }
   'settings:set': { args: [Partial<Settings>]; result: Settings }
+  // Folder actions are intentionally typed as `Promise<FolderActionResult>`
+  // (never throws) so the renderer can render a toast without try/catch.
+  // Main-process exceptions get caught at the typedHandle boundary and
+  // converted to `{ ok: false, reason: 'launch-failed', message }`.
+  'folder:revealInFinder': { args: [AbsolutePath]; result: FolderActionResult }
+  'folder:openInTerminal': { args: [AbsolutePath]; result: FolderActionResult }
 }
 
 /**

--- a/src/shared/settings.test.ts
+++ b/src/shared/settings.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+
+import { DEFAULT_SETTINGS, SettingsSchema } from './settings'
+
+/**
+ * Schema-level tests for `SettingsSchema`. These are the canary that fires
+ * when the source-of-truth schema and the static `DEFAULT_SETTINGS` drift
+ * apart, or when a future field migration silently breaks an existing
+ * settings.json on disk.
+ */
+describe('SettingsSchema', () => {
+  it('parsing an empty object fills in every default field', () => {
+    const parsed = SettingsSchema.parse({})
+    expect(parsed.defaultSkillTab).toBe('files')
+    expect(parsed.preferredTerminal).toBe('terminal')
+  })
+
+  it('legacy settings.json with only defaultSkillTab gets preferredTerminal default', () => {
+    // Simulates a user who upgraded from a pre-feature build — their
+    // settings.json on disk has no `preferredTerminal` key. Without a
+    // `.default()` they would crash on validation.
+    const parsed = SettingsSchema.parse({ defaultSkillTab: 'info' })
+    expect(parsed.preferredTerminal).toBe('terminal')
+    expect(parsed.defaultSkillTab).toBe('info')
+  })
+
+  it('rejects an unknown preferredTerminal value', () => {
+    expect(() =>
+      SettingsSchema.parse({ preferredTerminal: 'fish-shell' }),
+    ).toThrow()
+  })
+
+  it('accepts every curated terminal id', () => {
+    for (const id of [
+      'terminal',
+      'iterm',
+      'warp',
+      'ghostty',
+      'alacritty',
+      'kitty',
+      'wezterm',
+      'custom',
+    ] as const) {
+      expect(() =>
+        SettingsSchema.parse({ preferredTerminal: id }),
+      ).not.toThrow()
+    }
+  })
+
+  it('trims customTerminalAppName and rejects empty post-trim', () => {
+    expect(() =>
+      SettingsSchema.parse({ customTerminalAppName: '   ' }),
+    ).toThrow()
+  })
+
+  it('rejects customTerminalAppName longer than 64 chars', () => {
+    expect(() =>
+      SettingsSchema.parse({ customTerminalAppName: 'a'.repeat(65) }),
+    ).toThrow()
+  })
+
+  it('accepts customTerminalAppName at exactly 64 chars', () => {
+    const sixtyFour = 'a'.repeat(64)
+    const parsed = SettingsSchema.parse({ customTerminalAppName: sixtyFour })
+    expect(parsed.customTerminalAppName).toBe(sixtyFour)
+  })
+
+  /**
+   * Drift guard: if anyone edits SettingsSchema and forgets to update
+   * DEFAULT_SETTINGS (or vice versa), this test fails. The static defaults
+   * are duplicated by design (so they don't cost a Zod parse at boot) but
+   * MUST stay in lockstep with the schema.
+   */
+  it('DEFAULT_SETTINGS matches SettingsSchema.parse({})', () => {
+    expect(DEFAULT_SETTINGS).toEqual(SettingsSchema.parse({}))
+  })
+})

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -1,14 +1,32 @@
 import { z } from 'zod'
 
+import { TERMINAL_APP_IDS } from './constants'
+
 /**
- * User setting for the right-pane skill detail tab. Both the Settings
- * window's General section and the SkillDetail tab buttons read and write
- * this same field — last-used tab becomes the default tab next time the
- * app opens.
- * @example 'files' → Files tab; 'info' → Info tab
+ * App-wide user settings schema.
+ *
+ * - `defaultSkillTab`: right-pane tab on initial render of a skill detail.
+ *   Both the Settings window's General section and the SkillDetail tab
+ *   buttons read and write this — last-used tab becomes the default next
+ *   time the app opens.
+ * - `preferredTerminal`: which macOS terminal app the "Open in Terminal"
+ *   action launches. `'custom'` defers to `customTerminalAppName`.
+ * - `customTerminalAppName`: free-form macOS app name forwarded to
+ *   `open -a <name>`. Trimmed and length-capped (1..64) at the schema
+ *   boundary so a malformed value cannot reach `spawn`. Only consulted
+ *   when `preferredTerminal === 'custom'`.
+ *
+ * Adding a field here requires widening `IPC_ARG_SCHEMAS['settings:set']`
+ * in `src/main/ipc/ipc-schemas.ts` in lockstep — that schema is `.strict()`
+ * so unknown keys are rejected at the IPC boundary (defense in depth).
+ *
+ * @example
+ * SettingsSchema.parse({}) // { defaultSkillTab: 'files', preferredTerminal: 'terminal' }
  */
 export const SettingsSchema = z.object({
   defaultSkillTab: z.enum(['files', 'info']).default('files'),
+  preferredTerminal: z.enum(TERMINAL_APP_IDS).default('terminal'),
+  customTerminalAppName: z.string().trim().min(1).max(64).optional(),
 })
 
 /**
@@ -27,4 +45,5 @@ export type Settings = z.infer<typeof SettingsSchema>
  */
 export const DEFAULT_SETTINGS: Settings = {
   defaultSkillTab: 'files',
+  preferredTerminal: 'terminal',
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,4 +1,4 @@
-import type { AgentId, AgentName } from './constants'
+import type { AgentId, AgentName, TERMINAL_APP_IDS } from './constants'
 import type { FilePreviewKind } from './fileTypes'
 export type { AgentId, AgentName } from './constants'
 export type { ThemePresetName } from './constants'
@@ -249,6 +249,43 @@ export type SymlinkStatus = 'valid' | 'broken' | 'missing'
  * - local: Skill created directly in agent's skills directory
  */
 export type SkillType = 'source' | 'local'
+
+/**
+ * Identifier for the macOS terminal application launched by
+ * "Open in Terminal" actions on agent / source folders.
+ *
+ * `'custom'` is a sentinel meaning "consult `Settings.customTerminalAppName`
+ * for a freeform app name forwarded to `open -a <name>`". The seven curated
+ * IDs map to stable display names in `TERMINAL_APP_DISPLAY_NAMES` (see
+ * `src/shared/constants.ts`); they are display names rather than bundle IDs
+ * because vendor-side bundle IDs drift across rebrands (Warp Stable/Preview).
+ *
+ * @example 'terminal' // Apple's first-party Terminal.app
+ * @example 'iterm'    // iTerm2
+ * @example 'custom'   // user-supplied name from settings
+ */
+export type TerminalAppId = (typeof TERMINAL_APP_IDS)[number]
+
+/**
+ * Discriminated result of a folder-launch IPC call (Reveal in Finder /
+ * Open in Terminal). The `ok: false` branch carries a user-safe message
+ * already formatted for `toast.error` — renderer code never touches the
+ * raw OS error.
+ *
+ * @example // success
+ * { ok: true }
+ * @example // folder deleted between scan and click
+ * { ok: false, reason: 'not-found', message: 'Folder not found: /Users/me/.cline/skills' }
+ * @example // chosen terminal app not installed
+ * { ok: false, reason: 'launch-failed', message: 'Could not launch terminal. Is the chosen app installed?' }
+ */
+export type FolderActionResult =
+  | { ok: true }
+  | {
+      ok: false
+      reason: 'not-found' | 'launch-failed' | 'invalid-path'
+      message: string
+    }
 
 /**
  * Statistics for the ~/.agents/skills/ source directory.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -267,6 +267,26 @@ export type SkillType = 'source' | 'local'
 export type TerminalAppId = (typeof TERMINAL_APP_IDS)[number]
 
 /**
+ * Discriminator for the failure cases of `FolderActionResult`.
+ * Extracted so renderer toast handlers and unit tests can switch on
+ * the same finite set instead of redeclaring it inline.
+ *
+ * - `not-found`: the requested folder no longer exists (deleted between
+ *   scan and click, or stat raised ENOENT/ELOOP/ENOTDIR).
+ * - `launch-failed`: `open -a` exited non-zero or `shell.openPath`
+ *   returned an error string (most often: chosen terminal app missing).
+ * - `invalid-path`: settings are in `'custom'` mode but the custom app
+ *   name is blank/missing — caller must surface a Settings hint.
+ *
+ * @example
+ * const reason: FolderActionErrorReason = 'not-found'
+ */
+export type FolderActionErrorReason =
+  | 'not-found'
+  | 'launch-failed'
+  | 'invalid-path'
+
+/**
  * Discriminated result of a folder-launch IPC call (Reveal in Finder /
  * Open in Terminal). The `ok: false` branch carries a user-safe message
  * already formatted for `toast.error` — renderer code never touches the
@@ -283,7 +303,7 @@ export type FolderActionResult =
   | { ok: true }
   | {
       ok: false
-      reason: 'not-found' | 'launch-failed' | 'invalid-path'
+      reason: FolderActionErrorReason
       message: string
     }
 


### PR DESCRIPTION
## Summary

- Adds **Reveal in Finder** and **Open in Terminal** actions to the SourceCard kebab and AgentItem context menu, addressing issues #103 and #104.
- Wires a new `Preferred terminal` picker in Settings → General with 8 supported macOS terminal apps (Terminal / iTerm / Warp / Ghostty / Alacritty / Kitty / WezTerm / custom). Custom mode reveals an `app name` input with the same trim/min/max validation as the IPC schema.
- Hardens IPC: absolute-path Zod refinement, ENOENT/ELOOP/ENOTDIR all collapse to a structured `not-found` result, unexpected `realpath` errors (e.g. EPERM) bubble to the IPC boundary so they don't get swallowed.
- Adds DOM-binding regression guards (Playwright e2e) for both menu surfaces and the Settings picker — no OS side-effects asserted.

## Hardening / fixes bundled in

- **Schema lockstep:** `IPC_ARG_SCHEMAS['settings:set'].customTerminalAppName` re-uses `SettingsSchema.shape.customTerminalAppName` directly, so the trim/min/max constraint is sourced from one place — drift between renderer and IPC is now mechanically impossible.
- **`getStoreState` closure-leak fix:** discovered while running this PR's e2e suite — `delete.e2e.ts:445` (preexisting on `main` since #130 / commit `870fff8d`) closed over `skillName` inside a selector that gets `.toString()`-serialized into the renderer, so `skillName` was undefined at eval time. Extended `getStoreState` with an optional third `args` parameter (mirrors `page.evaluate`'s 2nd-arg pattern) and updated the orphan-cleared spec to use it. Existing call sites are unaffected (`A` defaults to `undefined`).

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `npx tsc -p e2e/tsconfig.json --noEmit` — clean (e2e has separate tsconfig)
- [x] `pnpm test` — all unit tests pass (folder IPC integration tests + browser-mode `useOpenFolder` tests added)
- [x] `pnpm test:e2e` — **31/31 passed** including the 3 new folder-actions specs
- [x] Manual QA via `playwright-cli` against `pnpm dev`: kebab + context menu render the new items in the documented order; Settings picker enumerates all 8 IDs and reveals/hides the custom-name input on selection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * フォルダナビゲーション機能を追加しました。エージェントとソースフォルダのコンテキストメニューから「Finderで表示」「ターミナルで開く」のアクションが利用可能になりました。
  * ターミナル設定を追加しました。設定で優先ターミナルを選択でき、カスタムターミナルアプリケーション名の指定にも対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->