### PR TITLE
feat(settings): persist startup window size & always-on devtools shortcut

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ e2e/.snapshot/
 e2e/test-results/
 e2e/playwright-report/
 playwright/.cache/
+.claude/goal.json
+.claude/goal-notes.md

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -50,6 +50,14 @@ function createWindow(): void {
     : { width: DEFAULT_LAUNCH_WIDTH, height: DEFAULT_LAUNCH_HEIGHT }
 
   const window = new BrowserWindow({
+    // `useContentSize` makes `width`/`height` (and `minWidth`/`minHeight`)
+    // describe the content area instead of the outer frame. Required for
+    // exact round-trip with the persisted size: the renderer captures via
+    // `window:getMainBounds` → `getContentBounds()`, so the stored value
+    // is content-area dimensions. Without this flag, restoring would treat
+    // those as outer-frame dimensions and shave off the titlebar (~28px
+    // even with `hiddenInset`) on every save→restore cycle.
+    useContentSize: true,
     width: launchSize.width,
     height: launchSize.height,
     minWidth: 800,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,15 +1,24 @@
 import { join } from 'path'
 
-import { app, BrowserWindow, Menu, nativeImage, session } from 'electron'
+import {
+  app,
+  BrowserWindow,
+  Menu,
+  nativeImage,
+  screen,
+  session,
+} from 'electron'
 
 import { isAllowedSkillsUrl } from '@/shared/marketplaceUrlPolicy'
 
 import { registerAllHandlers } from './ipc/handlers'
-import { loadSettings } from './services/settings'
+import { getMainWindow, setMainWindow } from './services/mainWindowState'
+import { getSettings, loadSettings } from './services/settings'
 import { createOrFocusSettingsWindow } from './services/settingsWindow'
 import { startupCleanup as runTrashStartupCleanup } from './services/trashService'
 import { initAutoUpdater } from './updater'
 import { attachExternalLinkHandler } from './utils/attachExternalLinkHandler'
+import { clampSizeToWorkArea } from './utils/clampSizeToWorkArea'
 import { isE2EBackgroundLaunch } from './utils/e2eEnv'
 import { getSecureWebPreferences } from './utils/secureWebPreferences'
 
@@ -18,18 +27,31 @@ process.on('unhandledRejection', (reason, promise) => {
 })
 
 /**
- * Module-scoped reference to the main window so `app.activate` can
- * recreate it specifically when the user has closed only the main
- * window (Settings may still be open). Pre-fix the activate handler
- * checked `getAllWindows().length === 0`, which was wrong: a Settings
- * window stays a window and would have prevented main from re-opening.
+ * Default launch size used when the user has no persisted `windowSize`
+ * preference. Mirrors the previous hard-coded constructor values; with no
+ * preference the app maximizes on `ready-to-show` so users keep the original
+ * "fills the screen" behavior on first launch.
  */
-let mainWindow: BrowserWindow | null = null
+const DEFAULT_LAUNCH_WIDTH = 1200
+const DEFAULT_LAUNCH_HEIGHT = 800
 
 function createWindow(): void {
+  // Resolve the launch size from settings. `undefined` means the user has
+  // not chosen one — fall back to the default size + `maximize()` on
+  // ready-to-show. When set, we clamp to the current display's work area
+  // so a size saved on a wider monitor doesn't open off-screen on a smaller
+  // one (clamping happens *before* the BrowserWindow is constructed because
+  // Electron applies `width`/`height` literally — there's no built-in clamp).
+  const persistedWindowSize = getSettings().windowSize
+  const primaryWorkArea = screen.getPrimaryDisplay().workAreaSize
+  const hasCustomSize = persistedWindowSize !== undefined
+  const launchSize = hasCustomSize
+    ? clampSizeToWorkArea(persistedWindowSize, primaryWorkArea)
+    : { width: DEFAULT_LAUNCH_WIDTH, height: DEFAULT_LAUNCH_HEIGHT }
+
   const window = new BrowserWindow({
-    width: 1200,
-    height: 800,
+    width: launchSize.width,
+    height: launchSize.height,
     minWidth: 800,
     minHeight: 600,
     show: false,
@@ -43,10 +65,10 @@ function createWindow(): void {
       webviewTag: true,
     },
   })
-  mainWindow = window
+  setMainWindow(window)
 
   window.on('closed', () => {
-    mainWindow = null
+    setMainWindow(null)
   })
 
   window.on('ready-to-show', () => {
@@ -55,7 +77,12 @@ function createWindow(): void {
     // still drives the renderer through webContents, which is loaded
     // independently of window visibility.
     if (isE2EBackgroundLaunch) return
-    window.maximize()
+    // When the user has chosen a custom size in Settings we honor it
+    // verbatim — calling `maximize()` here would override their choice.
+    // No-preference still maximizes (preserves prior launch behavior).
+    if (!hasCustomSize) {
+      window.maximize()
+    }
     window.show()
   })
 
@@ -199,7 +226,13 @@ function createMenu(): void {
       submenu: [
         { role: 'reload' },
         { role: 'forceReload' },
-        ...(app.isPackaged ? [] : [{ role: 'toggleDevTools' as const }]),
+        // `toggleDevTools` carries the default Cmd+Opt+I accelerator and
+        // dispatches to whichever window currently has focus — so the
+        // shortcut works on both the main window and the Settings window
+        // out of the box. Keep this entry available in packaged builds:
+        // power users rely on the standard shortcut to inspect visual
+        // glitches and capture detail for bug reports (issue #123).
+        { role: 'toggleDevTools' },
         { type: 'separator' },
         { role: 'resetZoom' },
         { role: 'zoomIn' },
@@ -260,9 +293,10 @@ app.whenReady().then(async () => {
   // Recreate ONLY the main window if it has been closed — the Settings
   // window may still be open, so checking `getAllWindows().length === 0`
   // would incorrectly leave a Settings-only state without a main window
-  // when the user clicks the dock icon.
+  // when the user clicks the dock icon. `getMainWindow()` already returns
+  // null for both the never-created and post-destroy cases.
   app.on('activate', () => {
-    if (mainWindow === null || mainWindow.isDestroyed()) createWindow()
+    if (getMainWindow() === null) createWindow()
   })
 })
 

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -9,6 +9,7 @@ import { registerSkillsCliHandlers } from './skillsCli'
 import { registerSourceHandlers } from './source'
 import { registerSyncHandlers } from './sync'
 import { registerUpdateHandlers } from './update'
+import { registerWindowHandlers } from './window'
 
 /**
  * Register all IPC handlers for main process
@@ -26,4 +27,5 @@ export function registerAllHandlers(): void {
   registerShellHandlers()
   registerSettingsHandlers()
   registerFolderHandlers()
+  registerWindowHandlers()
 }

--- a/src/main/ipc/ipc-schemas.ts
+++ b/src/main/ipc/ipc-schemas.ts
@@ -277,6 +277,10 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
         // constraint sets is mechanically impossible. `.shape` access yields
         // the field's ZodOptional<ZodString> exactly as defined in settings.ts.
         customTerminalAppName: SettingsSchema.shape.customTerminalAppName,
+        // Same source-of-truth pattern: re-use the schema's own field so
+        // the {min,int} constraints can never drift. `undefined` is how
+        // the Settings UI clears the persisted size back to "use default".
+        windowSize: SettingsSchema.shape.windowSize,
       })
       .strict(),
   ]),

--- a/src/main/ipc/window.ts
+++ b/src/main/ipc/window.ts
@@ -1,0 +1,23 @@
+import { getMainWindow } from '@/main/services/mainWindowState'
+import { IPC_CHANNELS } from '@/shared/ipc-channels'
+
+import { typedHandle } from './typedHandle'
+
+/**
+ * Wires IPC handlers that introspect the main BrowserWindow.
+ *
+ * `window:getMainBounds` returns the live content bounds (CSS pixels,
+ * matching what the renderer's `window.innerWidth/Height` would report) so
+ * the Settings window can capture the user's current size and persist it
+ * to `settings.windowSize`. Returns `null` when the main window is gone
+ * (closed but Settings still open) — the caller treats null as "feature
+ * unavailable" and disables the button.
+ */
+export function registerWindowHandlers(): void {
+  typedHandle(IPC_CHANNELS.WINDOW_GET_MAIN_BOUNDS, () => {
+    const mainWindow = getMainWindow()
+    if (mainWindow === null) return null
+    const bounds = mainWindow.getContentBounds()
+    return { width: bounds.width, height: bounds.height }
+  })
+}

--- a/src/main/services/mainWindowState.ts
+++ b/src/main/services/mainWindowState.ts
@@ -1,0 +1,45 @@
+import type { BrowserWindow } from 'electron'
+
+/**
+ * Shared module-scoped reference to the application's main BrowserWindow.
+ *
+ * Why this lives in its own module: both `src/main/index.ts` (which creates
+ * the window) and IPC handlers (which need to query the window's bounds for
+ * the Settings → "Use current window size" action) need access. A separate
+ * module avoids a circular import between `index.ts` and `ipc/window.ts`.
+ *
+ * Settings window references stay in `settingsWindow.ts` — same single-
+ * instance pattern, kept separate so each module owns one window's lifecycle.
+ *
+ * Always go through `getMainWindow()` rather than the module-local variable
+ * so callers consistently get a `null` back after the window has been
+ * destroyed (Electron leaves a `BrowserWindow` instance behind whose methods
+ * throw post-`destroy()`).
+ */
+let mainWindowRef: BrowserWindow | null = null
+
+/**
+ * Record the freshly-created main window so IPC handlers can query it.
+ * Pass `null` from the window's `'closed'` event so a stale reference
+ * cannot leak across re-creates.
+ * @param window - The newly created main BrowserWindow, or null on close
+ */
+export function setMainWindow(window: BrowserWindow | null): void {
+  mainWindowRef = window
+}
+
+/**
+ * Returns the live main window, or `null` if there is none (never created,
+ * already closed, or destroyed). Callers should treat `null` as "feature
+ * not available right now" rather than an error.
+ * @returns The current main BrowserWindow, or null
+ * @example
+ * const win = getMainWindow()
+ * if (!win) return null
+ * const { width, height } = win.getContentBounds()
+ */
+export function getMainWindow(): BrowserWindow | null {
+  if (mainWindowRef === null) return null
+  if (mainWindowRef.isDestroyed()) return null
+  return mainWindowRef
+}

--- a/src/main/utils/clampSizeToWorkArea.test.ts
+++ b/src/main/utils/clampSizeToWorkArea.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+
+import { clampSizeToWorkArea } from './clampSizeToWorkArea'
+
+describe('clampSizeToWorkArea', () => {
+  it('returns the desired size when it fits inside the work area', () => {
+    expect(
+      clampSizeToWorkArea(
+        { width: 1000, height: 700 },
+        { width: 1440, height: 900 },
+      ),
+    ).toEqual({ width: 1000, height: 700 })
+  })
+
+  it('clamps width when it exceeds the work area', () => {
+    expect(
+      clampSizeToWorkArea(
+        { width: 3000, height: 700 },
+        { width: 1440, height: 900 },
+      ),
+    ).toEqual({ width: 1440, height: 700 })
+  })
+
+  it('clamps height when it exceeds the work area', () => {
+    expect(
+      clampSizeToWorkArea(
+        { width: 1000, height: 2000 },
+        { width: 1440, height: 900 },
+      ),
+    ).toEqual({ width: 1000, height: 900 })
+  })
+
+  it('clamps both dimensions independently', () => {
+    expect(
+      clampSizeToWorkArea(
+        { width: 3000, height: 2000 },
+        { width: 1440, height: 900 },
+      ),
+    ).toEqual({ width: 1440, height: 900 })
+  })
+
+  it('preserves an exact-match size', () => {
+    expect(
+      clampSizeToWorkArea(
+        { width: 1440, height: 900 },
+        { width: 1440, height: 900 },
+      ),
+    ).toEqual({ width: 1440, height: 900 })
+  })
+})

--- a/src/main/utils/clampSizeToWorkArea.ts
+++ b/src/main/utils/clampSizeToWorkArea.ts
@@ -1,0 +1,33 @@
+/**
+ * Clamp a desired window size to a display's usable work area.
+ *
+ * "Work area" excludes the macOS menu bar and Dock — the same region the OS
+ * lets a window cover without going off-screen. We use `screen.getDisplayMatching`
+ * to pick the display the window would actually open on (in practice the
+ * primary display at launch — Electron offers no API for "the display the
+ * cursor is on" before a window exists).
+ *
+ * Why clamp at all: a user may save a size on a wide external monitor and
+ * later launch on a 13" laptop. Without clamping the window would either
+ * open off-screen or get force-shrunk by macOS — both feel broken. Clamping
+ * to `min(saved, workAreaSize)` keeps the window fully visible while
+ * respecting the user's preference whenever the display can fit it.
+ *
+ * @param desired - The size the user persisted in settings
+ * @param workArea - The display's usable size (Display.workAreaSize)
+ * @returns The clamped size — both dimensions ≤ workArea
+ * @example
+ * clampSizeToWorkArea({ width: 3000, height: 2000 }, { width: 1440, height: 900 })
+ * // => { width: 1440, height: 900 }
+ * clampSizeToWorkArea({ width: 1000, height: 700 }, { width: 1440, height: 900 })
+ * // => { width: 1000, height: 700 }
+ */
+export function clampSizeToWorkArea(
+  desired: { width: number; height: number },
+  workArea: { width: number; height: number },
+): { width: number; height: number } {
+  return {
+    width: Math.min(desired.width, workArea.width),
+    height: Math.min(desired.height, workArea.height),
+  }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -140,6 +140,12 @@ contextBridge.exposeInMainWorld('electron', {
     openInTerminal: async (folderPath: AbsolutePath) =>
       typedInvoke('folder:openInTerminal', folderPath),
   },
+  // Main window introspection. `getMainBounds` resolves with `null` when
+  // the main window has been closed (Settings may still be open), letting
+  // the renderer fall back gracefully instead of throwing.
+  window: {
+    getMainBounds: async () => typedInvoke('window:getMainBounds'),
+  },
 })
 
 // E2E-only escape hatch from the typed `electron.*` IPC contract above.

--- a/src/renderer/settings/sections/General.tsx
+++ b/src/renderer/settings/sections/General.tsx
@@ -1,6 +1,7 @@
 import { Files, Info } from 'lucide-react'
 import React, { useState } from 'react'
 
+import { Button } from '@/renderer/src/components/ui/button'
 import { Input } from '@/renderer/src/components/ui/input'
 import {
   ToggleGroup,
@@ -103,6 +104,29 @@ export const General = React.memo(function General(): React.ReactElement {
   const isCustom = settings.preferredTerminal === 'custom'
   const isDraftBlank = customNameDraft.trim() === ''
 
+  /**
+   * Capture the live main-window bounds via IPC and persist them.
+   * `getMainBounds()` resolves to `null` when the main window has been
+   * closed (Settings can outlive it on macOS) — in that case we keep the
+   * existing setting silently rather than overwriting with garbage. The
+   * UI surfaces the unavailability via the `mainWindowAvailable` state
+   * below.
+   */
+  const handleSaveCurrentSize = async (): Promise<void> => {
+    const bounds = await window.electron.window.getMainBounds()
+    if (bounds === null) return
+    updateSettings({ windowSize: bounds })
+  }
+
+  const handleResetWindowSize = (): void => {
+    // `undefined` removes the persisted size; on next launch the main
+    // window falls back to the default 1200×800 + maximize() behavior.
+    updateSettings({ windowSize: undefined })
+  }
+
+  const persistedWindowSize = settings.windowSize
+  const hasCustomWindowSize = persistedWindowSize !== undefined
+
   return (
     <SectionFrame
       title="General"
@@ -189,6 +213,46 @@ export const General = React.memo(function General(): React.ReactElement {
           <p className="text-xs text-muted-foreground">
             Note: some terminals (Warp, Ghostty) may open at your home directory
             instead of the skill folder.
+          </p>
+        </div>
+      </SectionRow>
+
+      <SectionRow
+        label="Startup window size"
+        description="The size the main window opens at on launch. Saved sizes are clamped to the current display so a window saved on a wide monitor never opens off-screen."
+      >
+        <div className="flex flex-col gap-2">
+          <p
+            className="text-sm tabular-nums"
+            aria-label="Current saved startup window size"
+          >
+            {hasCustomWindowSize
+              ? `${persistedWindowSize.width} × ${persistedWindowSize.height} px`
+              : 'Default (maximized on launch)'}
+          </p>
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                void handleSaveCurrentSize()
+              }}
+            >
+              Use current window size
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={handleResetWindowSize}
+              disabled={!hasCustomWindowSize}
+            >
+              Reset to default
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Takes effect the next time you launch the app.
           </p>
         </div>
       </SectionRow>

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -132,6 +132,9 @@ declare global {
           folderPath: AbsolutePath,
         ) => Promise<FolderActionResult>
       }
+      window: {
+        getMainBounds: () => Promise<{ width: number; height: number } | null>
+      }
     }
   }
 }

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -64,6 +64,10 @@ export const IPC_CHANNELS = {
   // Folder actions (Reveal in Finder, Open in Terminal)
   FOLDER_REVEAL_IN_FINDER: 'folder:revealInFinder',
   FOLDER_OPEN_IN_TERMINAL: 'folder:openInTerminal',
+
+  // Main window introspection — used by Settings → "Use current window size"
+  // to capture the live bounds before persisting them as the launch size.
+  WINDOW_GET_MAIN_BOUNDS: 'window:getMainBounds',
 } as const
 
 export type IpcChannel = (typeof IPC_CHANNELS)[keyof typeof IPC_CHANNELS]

--- a/src/shared/ipc-contract.test.ts
+++ b/src/shared/ipc-contract.test.ts
@@ -36,6 +36,7 @@ describe('IPC contract alignment', () => {
       [IPC_CHANNELS.SETTINGS_SET]: true,
       [IPC_CHANNELS.FOLDER_REVEAL_IN_FINDER]: true,
       [IPC_CHANNELS.FOLDER_OPEN_IN_TERMINAL]: true,
+      [IPC_CHANNELS.WINDOW_GET_MAIN_BOUNDS]: true,
     } as const satisfies Record<keyof IpcInvokeContract, true>
 
     // Runtime assertion: mapping covers exactly the contract keys.
@@ -43,7 +44,7 @@ describe('IPC contract alignment', () => {
     // IPC channel (input validation, authz scope, side-effect blast radius).
     // The `satisfies` clause above is a structural guard; this length check is
     // the trip-wire that forces a human PR diff when a channel is added.
-    expect(Object.keys(invokeMapping)).toHaveLength(29)
+    expect(Object.keys(invokeMapping)).toHaveLength(30)
   })
 
   it('all IPC_CHANNELS event values are valid event contract keys', () => {

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -121,6 +121,13 @@ export interface IpcInvokeContract {
   // converted to `{ ok: false, reason: 'launch-failed', message }`.
   'folder:revealInFinder': { args: [AbsolutePath]; result: FolderActionResult }
   'folder:openInTerminal': { args: [AbsolutePath]; result: FolderActionResult }
+  // Returns the *content* bounds of the live main window — `null` when the
+  // window has been closed/destroyed. Settings → "Use current window size"
+  // calls this and writes the result into `settings.windowSize`.
+  'window:getMainBounds': {
+    args: []
+    result: { width: number; height: number } | null
+  }
 }
 
 /**

--- a/src/shared/settings.test.ts
+++ b/src/shared/settings.test.ts
@@ -74,4 +74,31 @@ describe('SettingsSchema', () => {
   it('DEFAULT_SETTINGS matches SettingsSchema.parse({})', () => {
     expect(DEFAULT_SETTINGS).toEqual(SettingsSchema.parse({}))
   })
+
+  it('windowSize is optional and defaults to undefined', () => {
+    const parsed = SettingsSchema.parse({})
+    expect(parsed.windowSize).toBeUndefined()
+  })
+
+  it('accepts a windowSize at the minimum dimension', () => {
+    const parsed = SettingsSchema.parse({
+      windowSize: { width: 400, height: 400 },
+    })
+    expect(parsed.windowSize).toEqual({ width: 400, height: 400 })
+  })
+
+  it('rejects a windowSize below the minimum dimension', () => {
+    expect(() =>
+      SettingsSchema.parse({ windowSize: { width: 399, height: 400 } }),
+    ).toThrow()
+    expect(() =>
+      SettingsSchema.parse({ windowSize: { width: 400, height: 399 } }),
+    ).toThrow()
+  })
+
+  it('rejects a non-integer windowSize', () => {
+    expect(() =>
+      SettingsSchema.parse({ windowSize: { width: 400.5, height: 400 } }),
+    ).toThrow()
+  })
 })

--- a/src/shared/settings.test.ts
+++ b/src/shared/settings.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest'
 
-import { DEFAULT_SETTINGS, SettingsSchema } from './settings'
+import {
+  DEFAULT_SETTINGS,
+  SettingsSchema,
+  WINDOW_SIZE_MIN_DIMENSION,
+} from './settings'
 
 /**
  * Schema-level tests for `SettingsSchema`. These are the canary that fires
@@ -82,23 +86,44 @@ describe('SettingsSchema', () => {
 
   it('accepts a windowSize at the minimum dimension', () => {
     const parsed = SettingsSchema.parse({
-      windowSize: { width: 400, height: 400 },
+      windowSize: {
+        width: WINDOW_SIZE_MIN_DIMENSION,
+        height: WINDOW_SIZE_MIN_DIMENSION,
+      },
     })
-    expect(parsed.windowSize).toEqual({ width: 400, height: 400 })
+    expect(parsed.windowSize).toEqual({
+      width: WINDOW_SIZE_MIN_DIMENSION,
+      height: WINDOW_SIZE_MIN_DIMENSION,
+    })
   })
 
   it('rejects a windowSize below the minimum dimension', () => {
     expect(() =>
-      SettingsSchema.parse({ windowSize: { width: 399, height: 400 } }),
+      SettingsSchema.parse({
+        windowSize: {
+          width: WINDOW_SIZE_MIN_DIMENSION - 1,
+          height: WINDOW_SIZE_MIN_DIMENSION,
+        },
+      }),
     ).toThrow()
     expect(() =>
-      SettingsSchema.parse({ windowSize: { width: 400, height: 399 } }),
+      SettingsSchema.parse({
+        windowSize: {
+          width: WINDOW_SIZE_MIN_DIMENSION,
+          height: WINDOW_SIZE_MIN_DIMENSION - 1,
+        },
+      }),
     ).toThrow()
   })
 
   it('rejects a non-integer windowSize', () => {
     expect(() =>
-      SettingsSchema.parse({ windowSize: { width: 400.5, height: 400 } }),
+      SettingsSchema.parse({
+        windowSize: {
+          width: WINDOW_SIZE_MIN_DIMENSION + 0.5,
+          height: WINDOW_SIZE_MIN_DIMENSION,
+        },
+      }),
     ).toThrow()
   })
 })

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -3,14 +3,17 @@ import { z } from 'zod'
 import { TERMINAL_APP_IDS } from './constants'
 
 /**
- * Lower bound for a persisted startup window size. Mirrors the
- * `minWidth` / `minHeight` passed to `BrowserWindow` in
- * `src/main/index.ts` so a stored value can never break those
- * invariants (e.g. an oddly small saved size on a high-DPI display
- * being restored on a tiny laptop screen). Upper bound is enforced
- * dynamically in main against the current display work area.
+ * Defense-in-depth floor for a persisted startup window size. Set well
+ * below the BrowserWindow runtime resize floor (`minWidth: 800` /
+ * `minHeight: 600` in `src/main/index.ts`) — those constrain the
+ * interactive resize and constructor sizing, which is the real UX
+ * boundary. This 400px floor is intentionally distinct: it's a sanity
+ * check that catches a corrupted or hand-edited `settings.json`
+ * carrying a nonsense value (e.g. `{ width: 0 }`) before it ever
+ * reaches the launch path. Exported so tests can pin to it instead of
+ * duplicating the literal.
  */
-const WINDOW_SIZE_MIN_DIMENSION = 400
+export const WINDOW_SIZE_MIN_DIMENSION = 400
 
 /**
  * Persisted startup window size. `undefined` means "no preference —

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -3,6 +3,32 @@ import { z } from 'zod'
 import { TERMINAL_APP_IDS } from './constants'
 
 /**
+ * Lower bound for a persisted startup window size. Mirrors the
+ * `minWidth` / `minHeight` passed to `BrowserWindow` in
+ * `src/main/index.ts` so a stored value can never break those
+ * invariants (e.g. an oddly small saved size on a high-DPI display
+ * being restored on a tiny laptop screen). Upper bound is enforced
+ * dynamically in main against the current display work area.
+ */
+const WINDOW_SIZE_MIN_DIMENSION = 400
+
+/**
+ * Persisted startup window size. `undefined` means "no preference —
+ * use the app's launch default". Values are CSS pixels matching what
+ * `BrowserWindow.getBounds()` returns (DPR is handled by Electron).
+ *
+ * Captured from the main window's current bounds when the user clicks
+ * "Use current window size" in Settings → General. Cleared when the
+ * user clicks "Reset to default".
+ */
+const windowSizeSchema = z
+  .object({
+    width: z.number().int().min(WINDOW_SIZE_MIN_DIMENSION),
+    height: z.number().int().min(WINDOW_SIZE_MIN_DIMENSION),
+  })
+  .optional()
+
+/**
  * App-wide user settings schema.
  *
  * - `defaultSkillTab`: right-pane tab on initial render of a skill detail.
@@ -15,6 +41,12 @@ import { TERMINAL_APP_IDS } from './constants'
  *   `open -a <name>`. Trimmed and length-capped (1..64) at the schema
  *   boundary so a malformed value cannot reach `spawn`. Only consulted
  *   when `preferredTerminal === 'custom'`.
+ * - `windowSize`: persisted startup window size. `undefined` means
+ *   "use the app's launch default" (and lets the main process keep its
+ *   prior `maximize()` behavior). When set, the main window opens at
+ *   the saved size — clamped to the current display work area so a
+ *   saved size from a wider monitor never opens off-screen on a smaller
+ *   one.
  *
  * Adding a field here requires widening `IPC_ARG_SCHEMAS['settings:set']`
  * in `src/main/ipc/ipc-schemas.ts` in lockstep — that schema is `.strict()`
@@ -27,6 +59,7 @@ export const SettingsSchema = z.object({
   defaultSkillTab: z.enum(['files', 'info']).default('files'),
   preferredTerminal: z.enum(TERMINAL_APP_IDS).default('terminal'),
   customTerminalAppName: z.string().trim().min(1).max(64).optional(),
+  windowSize: windowSizeSchema,
 })
 
 /**


### PR DESCRIPTION
## Summary

Pair of related Settings/main-window quality-of-life fixes shipped together:

- **#122** — User can pin the main window to a custom startup size (or reset to default + maximize). Saved sizes are clamped to the current display so a window saved on a wider monitor never opens off-screen.
- **#123** — `Cmd+Opt+I` (toggle DevTools) now works in installed builds, not just dev. Dispatches to whichever window has focus (main or Settings).

## #122 — Startup window size

- `SettingsSchema.windowSize` is now `{ width, height } | undefined`, both dims `int >= 400px`. `undefined` is the explicit "no preference" state — preserves the prior 1200×800 + `maximize()` launch UX so existing users see no change.
- New IPC channel `window:getMainBounds` returns `null` when the main window has been closed (Settings can outlive it on macOS); renderer falls back gracefully.
- New `mainWindowState.ts` service decouples the BrowserWindow ref from `src/main/index.ts` so IPC handlers can read it without a circular import.
- Display clamp lives in a tiny pure util (`clampSizeToWorkArea.ts`) with its own unit tests — separated from the launch path so the math is easy to verify.
- Settings → General → **Startup window size** SectionRow ships two buttons:
  - **Use current window size** — captures live `getContentBounds()` of the main window and persists.
  - **Reset to default** — clears the preference (returns to 1200×800 + maximize).

## #123 — Cmd+Opt+I in installed builds

- Removed the `!app.isPackaged` gate around the `View → toggleDevTools` menu role.
- Electron's `role: 'toggleDevTools'` carries the default `Cmd+Opt+I` accelerator and dispatches to the focused webContents — so the shortcut works on both the main window and the Settings window with no extra wiring.

## Test plan

- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test` — 904 passed (incl. 4 new `windowSize` schema cases, 5 new `clampSizeToWorkArea` cases, IPC contract length trip-wire bumped 29→30)
- [x] `npx tsc -p e2e/tsconfig.json --noEmit` — clean
- [x] `pnpm test:e2e` — 31/31 passed (no regression in existing folder-actions / Settings e2e)
- [ ] Manual: open Settings → General → Startup window size → "Use current window size" → quit → relaunch → main window opens at saved size
- [ ] Manual: drag main window onto a smaller external display → "Use current window size" → relaunch on that display → window fully visible (clamp working)
- [ ] Manual: in installed build (`pnpm build:mac`), focus main window → `Cmd+Opt+I` → DevTools opens; focus Settings → `Cmd+Opt+I` → DevTools opens for Settings webContents

Closes #122
Closes #123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ウィンドウサイズの永続化機能を追加しました。アプリケーションの起動時に以前のウィンドウサイズが自動的に復元されます。
  * 「一般設定」に「起動時のウィンドウサイズ」管理パネルを追加しました。ユーザーは現在のウィンドウサイズを保存したり、既定の最大化状態にリセットできます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->