### PR TITLE
fix(settings): structural windowSize compare + disable button when main window closed

### DIFF
--- a/src/main/services/settings.test.ts
+++ b/src/main/services/settings.test.ts
@@ -83,4 +83,29 @@ describe('areSettingsEqual', () => {
       ),
     ).toBe(false)
   })
+
+  it('returns false when one side omits the windowSize key entirely and the other has a value', () => {
+    // The asymmetric-shape bug: `Object.keys(a)` alone would skip a key
+    // that lives only on `b`, so an absent-vs-defined comparison would
+    // wrongly return `true`. Iterating the union of both objects' keys
+    // is what surfaces the difference.
+    expect(
+      areSettingsEqual(
+        { ...baseSettings },
+        { ...baseSettings, windowSize: { width: 1200, height: 800 } },
+      ),
+    ).toBe(false)
+    expect(
+      areSettingsEqual(
+        { ...baseSettings, windowSize: { width: 1200, height: 800 } },
+        { ...baseSettings },
+      ),
+    ).toBe(false)
+  })
+
+  it('returns true when both sides omit windowSize entirely', () => {
+    expect(areSettingsEqual({ ...baseSettings }, { ...baseSettings })).toBe(
+      true,
+    )
+  })
 })

--- a/src/main/services/settings.test.ts
+++ b/src/main/services/settings.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+
+import type { Settings } from '@/shared/settings'
+
+import { areSettingsEqual } from './settings'
+
+/**
+ * Unit tests for the `areSettingsEqual` no-op guard. The motivation is
+ * that Zod's `SettingsSchema.parse` always returns a fresh object — so a
+ * naive `===` comparison on `windowSize` would always say "changed",
+ * causing `saveSettings` to write `settings.json` and broadcast
+ * `settings:changed` on every "Use current window size" click even when
+ * the saved dimensions are identical.
+ */
+describe('areSettingsEqual', () => {
+  const baseSettings: Settings = {
+    defaultSkillTab: 'files',
+    preferredTerminal: 'terminal',
+  }
+
+  it('returns true for identical primitive-only settings', () => {
+    expect(areSettingsEqual(baseSettings, { ...baseSettings })).toBe(true)
+  })
+
+  it('returns false when any primitive field differs', () => {
+    expect(
+      areSettingsEqual(baseSettings, {
+        ...baseSettings,
+        defaultSkillTab: 'info',
+      }),
+    ).toBe(false)
+  })
+
+  it('returns true when both windowSize values are undefined', () => {
+    expect(
+      areSettingsEqual(
+        { ...baseSettings, windowSize: undefined },
+        { ...baseSettings, windowSize: undefined },
+      ),
+    ).toBe(true)
+  })
+
+  it('returns true when windowSize objects describe identical dimensions despite different references', () => {
+    // The bug this guards against: Zod parse produces a fresh object on
+    // every call, so the references are different even when values match.
+    expect(
+      areSettingsEqual(
+        { ...baseSettings, windowSize: { width: 1200, height: 800 } },
+        { ...baseSettings, windowSize: { width: 1200, height: 800 } },
+      ),
+    ).toBe(true)
+  })
+
+  it('returns false when only windowSize.width differs', () => {
+    expect(
+      areSettingsEqual(
+        { ...baseSettings, windowSize: { width: 1200, height: 800 } },
+        { ...baseSettings, windowSize: { width: 1201, height: 800 } },
+      ),
+    ).toBe(false)
+  })
+
+  it('returns false when only windowSize.height differs', () => {
+    expect(
+      areSettingsEqual(
+        { ...baseSettings, windowSize: { width: 1200, height: 800 } },
+        { ...baseSettings, windowSize: { width: 1200, height: 801 } },
+      ),
+    ).toBe(false)
+  })
+
+  it('returns false when one side has undefined windowSize and the other has a value', () => {
+    expect(
+      areSettingsEqual(
+        { ...baseSettings, windowSize: { width: 1200, height: 800 } },
+        { ...baseSettings, windowSize: undefined },
+      ),
+    ).toBe(false)
+    expect(
+      areSettingsEqual(
+        { ...baseSettings, windowSize: undefined },
+        { ...baseSettings, windowSize: { width: 1200, height: 800 } },
+      ),
+    ).toBe(false)
+  })
+})

--- a/src/main/services/settings.ts
+++ b/src/main/services/settings.ts
@@ -77,6 +77,11 @@ export function getSettings(): Settings {
  * `windowSize` (the only nested field) compares by `width` + `height`
  * because Zod's `.parse()` always materializes a fresh object reference.
  *
+ * Iterates the **union** of keys from both inputs so an asymmetric
+ * shape (e.g. `a` lacks the `windowSize` key entirely while `b` has it
+ * defined) is detected rather than swallowed — `Object.keys(a)` alone
+ * would skip keys that exist only on `b`.
+ *
  * Adding another nested field requires a parallel branch here — there's
  * no recursive deep-equal because the schema is intentionally narrow.
  * @param a - First settings snapshot
@@ -88,16 +93,22 @@ export function getSettings(): Settings {
  * areSettingsEqual({ defaultSkillTab: 'files', preferredTerminal: 'terminal' }, { defaultSkillTab: 'files', preferredTerminal: 'terminal' }) // => true
  */
 export function areSettingsEqual(a: Settings, b: Settings): boolean {
-  return (Object.keys(a) as Array<keyof Settings>).every((key) => {
+  const allKeys = new Set<keyof Settings>([
+    ...(Object.keys(a) as Array<keyof Settings>),
+    ...(Object.keys(b) as Array<keyof Settings>),
+  ])
+  for (const key of allKeys) {
     if (key === 'windowSize') {
       const aw = a.windowSize
       const bw = b.windowSize
-      if (aw === bw) return true
+      if (aw === bw) continue
       if (aw === undefined || bw === undefined) return false
-      return aw.width === bw.width && aw.height === bw.height
+      if (aw.width !== bw.width || aw.height !== bw.height) return false
+      continue
     }
-    return a[key] === b[key]
-  })
+    if (a[key] !== b[key]) return false
+  }
+  return true
 }
 
 /**

--- a/src/main/services/settings.ts
+++ b/src/main/services/settings.ts
@@ -73,6 +73,34 @@ export function getSettings(): Settings {
 }
 
 /**
+ * Structural equality for `Settings`. Primitives compare by value;
+ * `windowSize` (the only nested field) compares by `width` + `height`
+ * because Zod's `.parse()` always materializes a fresh object reference.
+ *
+ * Adding another nested field requires a parallel branch here — there's
+ * no recursive deep-equal because the schema is intentionally narrow.
+ * @param a - First settings snapshot
+ * @param b - Second settings snapshot
+ * @returns
+ * - `true` when every field is structurally equal
+ * - `false` otherwise
+ * @example
+ * areSettingsEqual({ defaultSkillTab: 'files', preferredTerminal: 'terminal' }, { defaultSkillTab: 'files', preferredTerminal: 'terminal' }) // => true
+ */
+export function areSettingsEqual(a: Settings, b: Settings): boolean {
+  return (Object.keys(a) as Array<keyof Settings>).every((key) => {
+    if (key === 'windowSize') {
+      const aw = a.windowSize
+      const bw = b.windowSize
+      if (aw === bw) return true
+      if (aw === undefined || bw === undefined) return false
+      return aw.width === bw.width && aw.height === bw.height
+    }
+    return a[key] === b[key]
+  })
+}
+
+/**
  * Merges `partial` over the current settings and writes the result
  * atomically (temp file + rename) so a crash mid-write cannot corrupt
  * the file. The merged value is validated with Zod before disk write —
@@ -90,15 +118,18 @@ export async function saveSettings(
 ): Promise<Settings> {
   const current = getSettings()
   const merged = SettingsSchema.parse({ ...current, ...partial })
-  // Shallow-compare guard: when nothing actually changed (e.g. tapping
-  // the already-active radio), short-circuit before disk write so
+  // No-op guard: when nothing actually changed (e.g. tapping the
+  // already-active radio, or clicking "Use current window size" twice
+  // at the same dimensions), short-circuit before disk write so
   // `ipc/settings.ts` can also skip the broadcast — no fan-out, no
-  // redundant Redux replace in every open window. Safe today because
-  // `Settings` is a flat object; revisit if a nested field lands.
-  const isUnchanged = (Object.keys(merged) as Array<keyof Settings>).every(
-    (key) => merged[key] === current[key],
-  )
-  if (isUnchanged) return current
+  // redundant Redux replace in every open window.
+  //
+  // `windowSize` needs structural equality because Zod's `.parse()`
+  // always returns a fresh object, so `merged.windowSize === current.windowSize`
+  // would always be `false` for any defined value — even when both
+  // sides describe identical dimensions. Other fields are primitives
+  // and compare by value via `===`.
+  if (areSettingsEqual(merged, current)) return current
   const target = settingsFilePath()
   const tempPath = `${target}.tmp`
   // Ensure userData dir exists — first run on a fresh profile may lack it.

--- a/src/renderer/settings/sections/General.tsx
+++ b/src/renderer/settings/sections/General.tsx
@@ -1,5 +1,5 @@
 import { Files, Info } from 'lucide-react'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import { Button } from '@/renderer/src/components/ui/button'
 import { Input } from '@/renderer/src/components/ui/input'
@@ -105,16 +105,43 @@ export const General = React.memo(function General(): React.ReactElement {
   const isDraftBlank = customNameDraft.trim() === ''
 
   /**
+   * Tracks whether the main window is currently alive — Settings can
+   * outlive it on macOS (window-all-closed keeps the app running). When
+   * absent, `window:getMainBounds` resolves to `null`, so capturing the
+   * "current size" is impossible. Reflected in the button's disabled
+   * state + a small explanatory message so the click never silently no-ops.
+   *
+   * Default `true` is optimistic: the common case (Cmd+, from main window)
+   * has the main window present at mount. The probe in the effect below
+   * corrects to `false` only when the IPC actually returns null.
+   */
+  const [isMainWindowAvailable, setIsMainWindowAvailable] =
+    useState<boolean>(true)
+
+  useEffect(() => {
+    let cancelled = false
+    void window.electron.window.getMainBounds().then((bounds) => {
+      if (cancelled) return
+      setIsMainWindowAvailable(bounds !== null)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  /**
    * Capture the live main-window bounds via IPC and persist them.
    * `getMainBounds()` resolves to `null` when the main window has been
-   * closed (Settings can outlive it on macOS) — in that case we keep the
-   * existing setting silently rather than overwriting with garbage. The
-   * UI surfaces the unavailability via the `mainWindowAvailable` state
-   * below.
+   * closed (Settings can outlive it on macOS) — flip the availability
+   * flag so the button's disabled state + inline message kick in instead
+   * of failing silently. Disk write only happens on a real bounds value.
    */
   const handleSaveCurrentSize = async (): Promise<void> => {
     const bounds = await window.electron.window.getMainBounds()
-    if (bounds === null) return
+    if (bounds === null) {
+      setIsMainWindowAvailable(false)
+      return
+    }
     updateSettings({ windowSize: bounds })
   }
 
@@ -238,6 +265,7 @@ export const General = React.memo(function General(): React.ReactElement {
               onClick={() => {
                 void handleSaveCurrentSize()
               }}
+              disabled={!isMainWindowAvailable}
             >
               Use current window size
             </Button>
@@ -251,6 +279,12 @@ export const General = React.memo(function General(): React.ReactElement {
               Reset to default
             </Button>
           </div>
+          {!isMainWindowAvailable && (
+            <p className="text-xs text-muted-foreground">
+              Main window is closed — open it again, then reopen Settings to
+              capture its size.
+            </p>
+          )}
           <p className="text-xs text-muted-foreground">
             Takes effect the next time you launch the app.
           </p>

--- a/src/renderer/settings/sections/General.tsx
+++ b/src/renderer/settings/sections/General.tsx
@@ -120,10 +120,21 @@ export const General = React.memo(function General(): React.ReactElement {
 
   useEffect(() => {
     let cancelled = false
-    void window.electron.window.getMainBounds().then((bounds) => {
-      if (cancelled) return
-      setIsMainWindowAvailable(bounds !== null)
-    })
+    // Attach `.catch` explicitly — `void promise.then(...)` only suppresses
+    // TypeScript's "promise not handled" hint, it does NOT silence a real
+    // runtime rejection. If the IPC channel disconnects mid-call we want
+    // the button to fall back to disabled rather than logging an
+    // unhandled-promise warning to the renderer console.
+    window.electron.window
+      .getMainBounds()
+      .then((bounds) => {
+        if (cancelled) return
+        setIsMainWindowAvailable(bounds !== null)
+      })
+      .catch(() => {
+        if (cancelled) return
+        setIsMainWindowAvailable(false)
+      })
     return () => {
       cancelled = true
     }


### PR DESCRIPTION
## Summary

Two P3 follow-ups surfaced by `codex review` on merged PR #135. Both are low-priority polish items but represent real implementation gaps that affect the windowSize feature added for #122.

### Fix 1 — `saveSettings` no-op guard now uses structural equality

**Problem**: `SettingsSchema.parse()` always returns a fresh object, so `merged.windowSize === current.windowSize` was always `false` for any defined value — even when both sides described identical dimensions. As a result, clicking "Use current window size" twice at the same size triggered redundant `settings.json` writes and `settings:changed` broadcasts to every open window.

**Fix**: Extracted `areSettingsEqual(a, b)` helper that compares `windowSize` by `width` + `height` and primitives by `===`. Replaced the shallow `every((key) => merged[key] === current[key])` short-circuit in `saveSettings` with `areSettingsEqual(merged, current)`.

**Tests**: New `src/main/services/settings.test.ts` with 7 unit cases covering the bug surface (identical primitives, primitive diff, both-undefined windowSize, identical-by-value windowSize via different references, width-only diff, height-only diff, undefined ↔ value asymmetry both directions).

### Fix 2 — "Use current window size" button disables when main window is closed

**Problem**: Settings can outlive the main window on macOS (window-all-closed keeps the app running). In that state `getMainBounds()` resolves to `null`, so `handleSaveCurrentSize` would silently `return` — the click would appear to succeed but nothing would happen.

**Fix**: Added `isMainWindowAvailable` state with a `useEffect` probe at mount (optimistic default `true`). Click handler also flips the flag to `false` when `getMainBounds()` returns `null` mid-session. Button gets `disabled={!isMainWindowAvailable}` and an inline recovery message: "Main window is closed — open it again, then reopen Settings to capture its size."

## Validation

| Gate | Result |
|------|--------|
| `pnpm typecheck` | ✅ exit 0 |
| `pnpm lint` | ✅ exit 0 |
| `pnpm test` | ✅ 911/911 passed (was 904 — +7 new `areSettingsEqual` cases) |

## Test plan

- [ ] `pnpm dev`, set custom window size in Settings → click "Use current window size" twice at same dimensions → confirm `settings.json` mtime only changes once
- [ ] Close main window via red traffic light → switch to Settings via Cmd+, → button should be disabled with "Main window is closed" message
- [ ] Re-open main window → reopen Settings → button should be enabled again

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 設定保存時の変更検出ロジックを強化しました。ウィンドウサイズなどの複雑な設定値の比較精度が向上しています。

* **新機能**
  * メインウィンドウが現在利用できない場合、設定画面に案内メッセージを表示するようになりました。ユーザーがウィンドウサイズ取得機能を使用する際、より適切なフィードバックが得られます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->