### PR TITLE
feat(skills): G-Stack badge on gstack-managed sibling skills

### DIFF
--- a/src/main/services/skillScanner.test.ts
+++ b/src/main/services/skillScanner.test.ts
@@ -54,11 +54,13 @@ vi.mock('./metadataParser', () => ({
 }))
 
 const checkSymlinkTargetFromKnownLinkMock = vi.fn()
+const readSymlinkTargetIfPresentMock = vi.fn()
 
 vi.mock('./symlinkChecker', () => ({
   checkSkillSymlinks: vi.fn(async () => []),
   countValidSymlinks: vi.fn(() => 0),
   checkSymlinkTargetFromKnownLink: checkSymlinkTargetFromKnownLinkMock,
+  readSymlinkTargetIfPresent: readSymlinkTargetIfPresentMock,
 }))
 
 describe('scanSkills local skill aggregation', () => {
@@ -67,6 +69,8 @@ describe('scanSkills local skill aggregation', () => {
     accessMock.mockReset()
     checkSymlinkTargetFromKnownLinkMock.mockReset()
     checkSymlinkTargetFromKnownLinkMock.mockResolvedValue('missing')
+    readSymlinkTargetIfPresentMock.mockReset()
+    readSymlinkTargetIfPresentMock.mockResolvedValue(undefined)
 
     readdirMock.mockImplementation(async (path: string) => {
       if (path === '/mock/source/skills') {
@@ -134,6 +138,40 @@ describe('scanSkills local skill aggregation', () => {
     expect(codex).toMatchObject({ status: 'valid', isLocal: true })
     expect(cursor).toMatchObject({ status: 'valid', isLocal: true })
   })
+
+  it('populates skillMdSymlinkTarget when SKILL.md is a symlink (gstack-managed sibling)', async () => {
+    // gstack creates real folders like ~/.claude/skills/ship/ whose only entry
+    // is a SKILL.md symlink into the gstack source tree. The scanner must
+    // surface that target so the renderer can show the G-Stack badge on every
+    // gstack-managed skill, not just the parent `gstack` directory.
+    readSymlinkTargetIfPresentMock.mockImplementation(async (path: string) => {
+      if (
+        path ===
+        join('/mock/agents/codex/skills', 'frontend-design', 'SKILL.md')
+      ) {
+        return '/mock/.claude/skills/gstack/frontend-design/SKILL.md'
+      }
+      return undefined
+    })
+
+    const { scanSkills } = await import('./skillScanner')
+    const skills = await scanSkills()
+
+    expect(skills).toHaveLength(1)
+    expect(skills[0].skillMdSymlinkTarget).toBe(
+      '/mock/.claude/skills/gstack/frontend-design/SKILL.md',
+    )
+  })
+
+  it('leaves skillMdSymlinkTarget undefined when SKILL.md is a regular file', async () => {
+    // Default mock returns undefined — explicit assertion guards against
+    // someone later changing the default and silently flipping the badge on.
+    const { scanSkills } = await import('./skillScanner')
+    const skills = await scanSkills()
+
+    expect(skills).toHaveLength(1)
+    expect(skills[0].skillMdSymlinkTarget).toBeUndefined()
+  })
 })
 
 describe('scanSkills orphan symlink surfacing (issue #127)', () => {
@@ -142,6 +180,8 @@ describe('scanSkills orphan symlink surfacing (issue #127)', () => {
     accessMock.mockReset()
     statMock.mockReset()
     checkSymlinkTargetFromKnownLinkMock.mockReset()
+    readSymlinkTargetIfPresentMock.mockReset()
+    readSymlinkTargetIfPresentMock.mockResolvedValue(undefined)
   })
 
   it('surfaces broken symlinks whose source is missing as orphan Skill records', async () => {

--- a/src/main/services/skillScanner.test.ts
+++ b/src/main/services/skillScanner.test.ts
@@ -172,6 +172,30 @@ describe('scanSkills local skill aggregation', () => {
     expect(skills).toHaveLength(1)
     expect(skills[0].skillMdSymlinkTarget).toBeUndefined()
   })
+
+  it('promotes skillMdSymlinkTarget from a later sighting when the first sighting lacked one', async () => {
+    // codex sees frontend-design as a regular folder (no symlink target).
+    // cursor sees frontend-design as a gstack-managed twin with a SKILL.md
+    // symlink. Phase 2 must surface the gstack target on the merged record,
+    // otherwise the badge would be hidden on this skill.
+    readSymlinkTargetIfPresentMock.mockImplementation(async (path: string) => {
+      if (
+        path ===
+        join('/mock/agents/cursor/skills', 'frontend-design', 'SKILL.md')
+      ) {
+        return '/mock/.claude/skills/gstack/frontend-design/SKILL.md'
+      }
+      return undefined
+    })
+
+    const { scanSkills } = await import('./skillScanner')
+    const skills = await scanSkills()
+
+    expect(skills).toHaveLength(1)
+    expect(skills[0].skillMdSymlinkTarget).toBe(
+      '/mock/.claude/skills/gstack/frontend-design/SKILL.md',
+    )
+  })
 })
 
 describe('scanSkills orphan symlink surfacing (issue #127)', () => {

--- a/src/main/services/skillScanner.test.ts
+++ b/src/main/services/skillScanner.test.ts
@@ -139,11 +139,12 @@ describe('scanSkills local skill aggregation', () => {
     expect(cursor).toMatchObject({ status: 'valid', isLocal: true })
   })
 
-  it('populates skillMdSymlinkTarget when SKILL.md is a symlink (gstack-managed sibling)', async () => {
+  it('populates skillMdSymlinkTarget on the agent slot when SKILL.md is a symlink (gstack-managed sibling)', async () => {
     // gstack creates real folders like ~/.claude/skills/ship/ whose only entry
     // is a SKILL.md symlink into the gstack source tree. The scanner must
-    // surface that target so the renderer can show the G-Stack badge on every
-    // gstack-managed skill, not just the parent `gstack` directory.
+    // surface that target ON THE PER-AGENT SLOT so the renderer can show the
+    // G-Stack badge for the agent that holds the gstack twin, without
+    // bleeding to sibling agents that share the skill name.
     readSymlinkTargetIfPresentMock.mockImplementation(async (path: string) => {
       if (
         path ===
@@ -158,30 +159,33 @@ describe('scanSkills local skill aggregation', () => {
     const skills = await scanSkills()
 
     expect(skills).toHaveLength(1)
-    expect(skills[0].skillMdSymlinkTarget).toBe(
+    const codex = skills[0].symlinks.find((s) => s.agentId === 'codex')
+    expect(codex?.skillMdSymlinkTarget).toBe(
       '/mock/.claude/skills/gstack/frontend-design/SKILL.md',
     )
   })
 
-  it('leaves skillMdSymlinkTarget undefined when SKILL.md is a regular file', async () => {
+  it('leaves skillMdSymlinkTarget undefined on every slot when SKILL.md is a regular file', async () => {
     // Default mock returns undefined — explicit assertion guards against
     // someone later changing the default and silently flipping the badge on.
     const { scanSkills } = await import('./skillScanner')
     const skills = await scanSkills()
 
     expect(skills).toHaveLength(1)
-    expect(skills[0].skillMdSymlinkTarget).toBeUndefined()
+    for (const slot of skills[0].symlinks) {
+      expect(slot.skillMdSymlinkTarget).toBeUndefined()
+    }
   })
 
-  it('promotes skillMdSymlinkTarget from a later sighting when the first sighting lacked one', async () => {
-    // codex sees frontend-design as a regular folder (no symlink target).
-    // cursor sees frontend-design as a gstack-managed twin with a SKILL.md
-    // symlink. Phase 2 must surface the gstack target on the merged record,
-    // otherwise the badge would be hidden on this skill.
+  it('binds skillMdSymlinkTarget to the slot that detected it without bleeding to sibling agents', async () => {
+    // codex slot is a gstack-managed twin (SKILL.md symlinks into gstack);
+    // cursor slot is a plain local folder. Per-agent attribution: codex's
+    // slot must carry the target, cursor's slot must NOT — otherwise the
+    // badge would falsely appear on cursor's unrelated copy.
     readSymlinkTargetIfPresentMock.mockImplementation(async (path: string) => {
       if (
         path ===
-        join('/mock/agents/cursor/skills', 'frontend-design', 'SKILL.md')
+        join('/mock/agents/codex/skills', 'frontend-design', 'SKILL.md')
       ) {
         return '/mock/.claude/skills/gstack/frontend-design/SKILL.md'
       }
@@ -192,9 +196,12 @@ describe('scanSkills local skill aggregation', () => {
     const skills = await scanSkills()
 
     expect(skills).toHaveLength(1)
-    expect(skills[0].skillMdSymlinkTarget).toBe(
+    const codex = skills[0].symlinks.find((s) => s.agentId === 'codex')
+    const cursor = skills[0].symlinks.find((s) => s.agentId === 'cursor')
+    expect(codex?.skillMdSymlinkTarget).toBe(
       '/mock/.claude/skills/gstack/frontend-design/SKILL.md',
     )
+    expect(cursor?.skillMdSymlinkTarget).toBeUndefined()
   })
 })
 

--- a/src/main/services/skillScanner.ts
+++ b/src/main/services/skillScanner.ts
@@ -21,6 +21,7 @@ import {
   checkSkillSymlinks,
   checkSymlinkTargetFromKnownLink,
   countValidSymlinks,
+  readSymlinkTargetIfPresent,
 } from './symlinkChecker'
 
 /**
@@ -149,8 +150,16 @@ async function scanSourceSkills(): Promise<Skill[]> {
 
   const skills = await Promise.all(
     validDirs.map(async (dir) => {
-      const metadata = await parseSkillMetadata(dir.path)
-      const symlinks = await checkSkillSymlinks(dir.name)
+      // Three IO calls run in parallel — readSymlinkTargetIfPresent is added to
+      // detect skills whose `SKILL.md` is itself a symlink (e.g. a gstack-managed
+      // sibling that lives under SOURCE_DIR via some unusual user setup). For
+      // the typical source-dir skill, SKILL.md is a real file and the helper
+      // returns undefined, leaving the field absent on the resulting Skill.
+      const [metadata, symlinks, skillMdSymlinkTarget] = await Promise.all([
+        parseSkillMetadata(dir.path),
+        checkSkillSymlinks(dir.name),
+        readSymlinkTargetIfPresent(join(dir.path, 'SKILL.md')),
+      ])
 
       return {
         name: metadata.name,
@@ -160,6 +169,7 @@ async function scanSourceSkills(): Promise<Skill[]> {
         symlinks,
         isSource: true,
         isOrphan: false,
+        skillMdSymlinkTarget,
       }
     }),
   )
@@ -276,8 +286,23 @@ async function scanAllLocalSkills(): Promise<Skill[]> {
             candidates.map(async (dir) => {
               const skillPath = join(agent.path, dir.name) as AbsolutePath
               if (!(await isValidSkillDir(skillPath))) return null
-              const metadata = await parseSkillMetadata(skillPath)
-              return { agent, dirName: dir.name, skillPath, metadata }
+              // Parse metadata and probe SKILL.md for a symlink target in
+              // parallel — gstack-managed sibling skills (e.g. ~/.claude/skills/ship)
+              // are real directories whose SKILL.md is a symlink into the
+              // gstack source tree (~/.claude/skills/gstack/<name>/SKILL.md).
+              // Capturing that target lets the renderer display the G-Stack
+              // badge on every gstack-managed skill, not just the parent.
+              const [metadata, skillMdSymlinkTarget] = await Promise.all([
+                parseSkillMetadata(skillPath),
+                readSymlinkTargetIfPresent(join(skillPath, 'SKILL.md')),
+              ])
+              return {
+                agent,
+                dirName: dir.name,
+                skillPath,
+                metadata,
+                skillMdSymlinkTarget,
+              }
             }),
           )
           return validated.filter(
@@ -293,8 +318,21 @@ async function scanAllLocalSkills(): Promise<Skill[]> {
   // Phase 2 — group by skill name. First sighting builds the full per-agent
   // template (every agent 'missing'); every sighting (including the first)
   // then flips its own agent slot to a valid local entry. Single branch.
+  //
+  // skillMdSymlinkTarget is captured on the first sighting only — the same
+  // gstack-managed skill installed in two agent dirs will have identical
+  // SKILL.md targets (both point into the same gstack source), so first-wins
+  // is correct. If the first sighting was a non-gstack local skill that later
+  // overlaps with a gstack-managed one, the renderer's regex check stays
+  // tolerant: undefined is just one of four candidates, others may still match.
   const localSkillsByName = new Map<SkillName, Skill>()
-  for (const { agent, dirName, skillPath, metadata } of localHits) {
+  for (const {
+    agent,
+    dirName,
+    skillPath,
+    metadata,
+    skillMdSymlinkTarget,
+  } of localHits) {
     let skill = localSkillsByName.get(metadata.name)
     if (!skill) {
       skill = {
@@ -311,6 +349,7 @@ async function scanAllLocalSkills(): Promise<Skill[]> {
         })),
         isSource: false,
         isOrphan: false,
+        skillMdSymlinkTarget,
       }
       localSkillsByName.set(metadata.name, skill)
     }

--- a/src/main/services/skillScanner.ts
+++ b/src/main/services/skillScanner.ts
@@ -150,15 +150,9 @@ async function scanSourceSkills(): Promise<Skill[]> {
 
   const skills = await Promise.all(
     validDirs.map(async (dir) => {
-      // Three IO calls run in parallel — readSymlinkTargetIfPresent is added to
-      // detect skills whose `SKILL.md` is itself a symlink (e.g. a gstack-managed
-      // sibling that lives under SOURCE_DIR via some unusual user setup). For
-      // the typical source-dir skill, SKILL.md is a real file and the helper
-      // returns undefined, leaving the field absent on the resulting Skill.
-      const [metadata, symlinks, skillMdSymlinkTarget] = await Promise.all([
+      const [metadata, symlinks] = await Promise.all([
         parseSkillMetadata(dir.path),
         checkSkillSymlinks(dir.name),
-        readSymlinkTargetIfPresent(join(dir.path, 'SKILL.md')),
       ])
 
       return {
@@ -169,7 +163,6 @@ async function scanSourceSkills(): Promise<Skill[]> {
         symlinks,
         isSource: true,
         isOrphan: false,
-        skillMdSymlinkTarget,
       }
     }),
   )
@@ -319,12 +312,12 @@ async function scanAllLocalSkills(): Promise<Skill[]> {
   // template (every agent 'missing'); every sighting (including the first)
   // then flips its own agent slot to a valid local entry. Single branch.
   //
-  // skillMdSymlinkTarget is captured on the first sighting only — the same
-  // gstack-managed skill installed in two agent dirs will have identical
-  // SKILL.md targets (both point into the same gstack source), so first-wins
-  // is correct. If the first sighting was a non-gstack local skill that later
-  // overlaps with a gstack-managed one, the renderer's regex check stays
-  // tolerant: undefined is just one of four candidates, others may still match.
+  // skillMdSymlinkTarget is promoted whenever ANY sighting carries one — the
+  // first-sighting may be a non-gstack copy whose SKILL.md is a regular file
+  // (target undefined) while a later sighting in another agent dir is the
+  // gstack-managed twin (target points into the gstack source tree). Without
+  // this merge the badge would be hidden whenever the agents are scanned in
+  // an order that puts the non-gstack copy first.
   const localSkillsByName = new Map<SkillName, Skill>()
   for (const {
     agent,
@@ -352,6 +345,8 @@ async function scanAllLocalSkills(): Promise<Skill[]> {
         skillMdSymlinkTarget,
       }
       localSkillsByName.set(metadata.name, skill)
+    } else if (!skill.skillMdSymlinkTarget && skillMdSymlinkTarget) {
+      skill.skillMdSymlinkTarget = skillMdSymlinkTarget
     }
     const slot = skill.symlinks.findIndex((s) => s.agentId === agent.id)
     if (slot >= 0) {

--- a/src/main/services/skillScanner.ts
+++ b/src/main/services/skillScanner.ts
@@ -287,7 +287,9 @@ async function scanAllLocalSkills(): Promise<Skill[]> {
               // badge on every gstack-managed skill, not just the parent.
               const [metadata, skillMdSymlinkTarget] = await Promise.all([
                 parseSkillMetadata(skillPath),
-                readSymlinkTargetIfPresent(join(skillPath, 'SKILL.md')),
+                readSymlinkTargetIfPresent(
+                  join(skillPath, 'SKILL.md') as AbsolutePath,
+                ),
               ])
               return {
                 agent,
@@ -310,14 +312,10 @@ async function scanAllLocalSkills(): Promise<Skill[]> {
 
   // Phase 2 — group by skill name. First sighting builds the full per-agent
   // template (every agent 'missing'); every sighting (including the first)
-  // then flips its own agent slot to a valid local entry. Single branch.
-  //
-  // skillMdSymlinkTarget is promoted whenever ANY sighting carries one — the
-  // first-sighting may be a non-gstack copy whose SKILL.md is a regular file
-  // (target undefined) while a later sighting in another agent dir is the
-  // gstack-managed twin (target points into the gstack source tree). Without
-  // this merge the badge would be hidden whenever the agents are scanned in
-  // an order that puts the non-gstack copy first.
+  // then flips its own agent slot to a valid local entry, carrying the
+  // SKILL.md symlink target ON THE SLOT — per-agent attribution prevents
+  // cross-agent badge bleed when two agents share a skill name but only one
+  // is gstack-managed.
   const localSkillsByName = new Map<SkillName, Skill>()
   for (const {
     agent,
@@ -342,11 +340,8 @@ async function scanAllLocalSkills(): Promise<Skill[]> {
         })),
         isSource: false,
         isOrphan: false,
-        skillMdSymlinkTarget,
       }
       localSkillsByName.set(metadata.name, skill)
-    } else if (!skill.skillMdSymlinkTarget && skillMdSymlinkTarget) {
-      skill.skillMdSymlinkTarget = skillMdSymlinkTarget
     }
     const slot = skill.symlinks.findIndex((s) => s.agentId === agent.id)
     if (slot >= 0) {
@@ -355,6 +350,7 @@ async function scanAllLocalSkills(): Promise<Skill[]> {
         status: 'valid',
         linkPath: join(agent.path, dirName) as AbsolutePath,
         isLocal: true,
+        skillMdSymlinkTarget,
       }
     }
   }

--- a/src/main/services/symlinkChecker.test.ts
+++ b/src/main/services/symlinkChecker.test.ts
@@ -287,6 +287,115 @@ describe('checkSkillSymlinks', () => {
   })
 })
 
+describe('readSymlinkTargetIfPresent', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('returns resolved absolute target when path is a symlink with absolute target', async () => {
+    // gstack creates symlinks with absolute targets (verified on a real machine
+    // via `readlink ~/.claude/skills/ship/SKILL.md`). This is the production case.
+    lstatMock.mockResolvedValue(
+      createStats({ isSymbolicLink: true, isDirectory: false }),
+    )
+    readlinkMock.mockResolvedValue('/mock/.claude/skills/gstack/ship/SKILL.md')
+
+    const { readSymlinkTargetIfPresent } = await import('./symlinkChecker')
+    const result = await readSymlinkTargetIfPresent(
+      '/mock/.claude/skills/ship/SKILL.md',
+    )
+
+    expect(result).toBe('/mock/.claude/skills/gstack/ship/SKILL.md')
+  })
+
+  it('returns resolved absolute target when path is a symlink with relative target', async () => {
+    // Defensive case: if a user (or a future gstack version) creates the
+    // symlink with a relative target, the helper must still return an
+    // absolute path so the renderer's regex check on the gstack segment works.
+    const linkPath = '/mock/.claude/skills/ship/SKILL.md'
+    const relativeTarget = '../gstack/ship/SKILL.md'
+    const expectedResolved = resolve(dirname(linkPath), relativeTarget)
+
+    lstatMock.mockResolvedValue(
+      createStats({ isSymbolicLink: true, isDirectory: false }),
+    )
+    readlinkMock.mockResolvedValue(relativeTarget)
+
+    const { readSymlinkTargetIfPresent } = await import('./symlinkChecker')
+    const result = await readSymlinkTargetIfPresent(linkPath)
+
+    expect(result).toBe(expectedResolved)
+    expect(result).toMatch(/^\//) // Must be absolute
+  })
+
+  it('returns resolved target even when symlink is broken (target does not exist)', async () => {
+    // The helper does NOT call access() — it only needs the target string for
+    // the renderer's path-segment match. Broken symlinks still surface a target.
+    lstatMock.mockResolvedValue(
+      createStats({ isSymbolicLink: true, isDirectory: false }),
+    )
+    readlinkMock.mockResolvedValue(
+      '/mock/.claude/skills/gstack/dangling/SKILL.md',
+    )
+
+    const { readSymlinkTargetIfPresent } = await import('./symlinkChecker')
+    const result = await readSymlinkTargetIfPresent(
+      '/mock/.claude/skills/dangling/SKILL.md',
+    )
+
+    expect(result).toBe('/mock/.claude/skills/gstack/dangling/SKILL.md')
+    expect(accessMock).not.toHaveBeenCalled() // No existence probe
+  })
+
+  it('returns undefined when path is a regular file (not a symlink)', async () => {
+    lstatMock.mockResolvedValue(
+      createStats({ isSymbolicLink: false, isDirectory: false }),
+    )
+
+    const { readSymlinkTargetIfPresent } = await import('./symlinkChecker')
+    const result = await readSymlinkTargetIfPresent(
+      '/mock/.agents/skills/foo/SKILL.md',
+    )
+
+    expect(result).toBeUndefined()
+    expect(readlinkMock).not.toHaveBeenCalled() // Skipped: not a symlink
+  })
+
+  it('returns undefined when path is a directory', async () => {
+    lstatMock.mockResolvedValue(
+      createStats({ isSymbolicLink: false, isDirectory: true }),
+    )
+
+    const { readSymlinkTargetIfPresent } = await import('./symlinkChecker')
+    const result = await readSymlinkTargetIfPresent('/mock/some/dir')
+
+    expect(result).toBeUndefined()
+  })
+
+  it('returns undefined when path does not exist (lstat throws)', async () => {
+    lstatMock.mockRejectedValue(new Error('ENOENT'))
+
+    const { readSymlinkTargetIfPresent } = await import('./symlinkChecker')
+    const result = await readSymlinkTargetIfPresent('/mock/missing/SKILL.md')
+
+    expect(result).toBeUndefined()
+  })
+
+  it('returns undefined when readlink races with deletion (lstat ok, readlink fails)', async () => {
+    lstatMock.mockResolvedValue(
+      createStats({ isSymbolicLink: true, isDirectory: false }),
+    )
+    readlinkMock.mockRejectedValue(new Error('ENOENT'))
+
+    const { readSymlinkTargetIfPresent } = await import('./symlinkChecker')
+    const result = await readSymlinkTargetIfPresent(
+      '/mock/race-condition/SKILL.md',
+    )
+
+    expect(result).toBeUndefined()
+  })
+})
+
 describe('countValidSymlinks', () => {
   it('counts only valid symlinks from mixed array', async () => {
     const { countValidSymlinks } = await import('./symlinkChecker')

--- a/src/main/services/symlinkChecker.test.ts
+++ b/src/main/services/symlinkChecker.test.ts
@@ -359,6 +359,7 @@ describe('readSymlinkTargetIfPresent', () => {
 
     expect(result).toBeUndefined()
     expect(readlinkMock).not.toHaveBeenCalled() // Skipped: not a symlink
+    expect(accessMock).not.toHaveBeenCalled() // No existence probe
   })
 
   it('returns undefined when path is a directory', async () => {
@@ -370,6 +371,8 @@ describe('readSymlinkTargetIfPresent', () => {
     const result = await readSymlinkTargetIfPresent('/mock/some/dir')
 
     expect(result).toBeUndefined()
+    expect(readlinkMock).not.toHaveBeenCalled() // Skipped: not a symlink
+    expect(accessMock).not.toHaveBeenCalled() // No existence probe
   })
 
   it('returns undefined when path does not exist (lstat throws)', async () => {

--- a/src/main/services/symlinkChecker.ts
+++ b/src/main/services/symlinkChecker.ts
@@ -169,6 +169,46 @@ export async function checkSymlinkTargetFromKnownLink(
 }
 
 /**
+ * Read the resolved target of a symbolic link if (and only if) the given path
+ * is itself a symlink. Returns `undefined` when the path is a regular file or
+ * directory, when it does not exist, or when readlink races with deletion.
+ *
+ * Used by the skill scanner to capture where a `SKILL.md` symlink points —
+ * gstack-managed sibling skills (e.g. `~/.claude/skills/ship/`) have a real
+ * directory whose `SKILL.md` is a symlink into the gstack source tree. The
+ * raw target string is exposed to the renderer so it can match the `gstack`
+ * path segment and decorate those skills with the G-Stack badge.
+ *
+ * @param path - Path that *may or may not* be a symbolic link
+ * @returns
+ * - Path is a symlink: resolved absolute target (handles both absolute and
+ *   relative `readlink(2)` results by anchoring relatives to the link's dir)
+ * - Path is a regular file/directory, missing, or fails mid-syscall: `undefined`
+ * @example
+ * await readSymlinkTargetIfPresent('/Users/me/.claude/skills/ship/SKILL.md')
+ * // => '/Users/me/.claude/skills/gstack/ship/SKILL.md' (when symlinked)
+ * await readSymlinkTargetIfPresent('/Users/me/.agents/skills/foo/SKILL.md')
+ * // => undefined (regular file)
+ */
+export async function readSymlinkTargetIfPresent(
+  path: string,
+): Promise<AbsolutePath | undefined> {
+  try {
+    const stats = await lstat(path)
+    if (!stats.isSymbolicLink()) return undefined
+
+    // readlink(2) returns the raw stored target — absolute when the link was
+    // created with an absolute target, relative otherwise. resolve(dirname,
+    // target) is a no-op for absolute targets and the correct anchor for
+    // relative ones, mirroring the resolveSymlinkTarget() helper above.
+    const target = await readlink(path)
+    return resolve(dirname(path), target) as AbsolutePath
+  } catch {
+    return undefined
+  }
+}
+
+/**
  * Shared core: read the symlink, resolve it relative to its own directory
  * (handles both absolute and relative targets), then probe for existence.
  * Centralizing this makes the slow-path and fast-path identical in meaning.

--- a/src/main/services/symlinkChecker.ts
+++ b/src/main/services/symlinkChecker.ts
@@ -97,6 +97,7 @@ export async function checkSkillSymlinks(
       // `AbsolutePath` contract requires an absolute path, so resolve it
       // against the symlink's parent directory, mirroring checkSymlinkStatus.
       let targetPath: AbsolutePath | undefined
+      let skillMdSymlinkTarget: AbsolutePath | undefined
       if (status !== 'missing' && !isLocal) {
         try {
           const target = await readlink(linkPath)
@@ -104,6 +105,13 @@ export async function checkSkillSymlinks(
         } catch {
           // Leave undefined — the link disappeared between lstat and readlink
         }
+      } else if (isLocal) {
+        // Local folder: probe the SKILL.md inside it for a gstack-managed
+        // symlink. Per-agent so the renderer's badge attribution is bound to
+        // THIS slot, not to a sibling agent that happens to share the name.
+        skillMdSymlinkTarget = await readSymlinkTargetIfPresent(
+          join(linkPath, 'SKILL.md') as AbsolutePath,
+        )
       }
 
       return {
@@ -113,6 +121,7 @@ export async function checkSkillSymlinks(
         targetPath,
         linkPath,
         isLocal,
+        skillMdSymlinkTarget,
       }
     }),
   )
@@ -179,7 +188,7 @@ export async function checkSymlinkTargetFromKnownLink(
  * raw target string is exposed to the renderer so it can match the `gstack`
  * path segment and decorate those skills with the G-Stack badge.
  *
- * @param path - Path that *may or may not* be a symbolic link
+ * @param path - Absolute path that *may or may not* be a symbolic link
  * @returns
  * - Path is a symlink: resolved absolute target (handles both absolute and
  *   relative `readlink(2)` results by anchoring relatives to the link's dir)
@@ -191,7 +200,7 @@ export async function checkSymlinkTargetFromKnownLink(
  * // => undefined (regular file)
  */
 export async function readSymlinkTargetIfPresent(
-  path: string,
+  path: AbsolutePath,
 ): Promise<AbsolutePath | undefined> {
   try {
     const stats = await lstat(path)

--- a/src/renderer/src/components/skills/SkillItem.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillItem.browser.test.tsx
@@ -5,7 +5,7 @@ import { render } from 'vitest-browser-react'
 
 import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
 import { GSTACK_REPOSITORY_URL } from '@/shared/constants'
-import type { Skill, SkillName } from '@/shared/types'
+import type { Skill, SkillName, SymlinkInfo } from '@/shared/types'
 import { repositoryId } from '@/shared/types'
 
 const mockGetAll = vi.fn()
@@ -368,10 +368,10 @@ describe('SkillItem G-Stack badge', () => {
             status: 'valid',
             linkPath: '/Users/me/.claude/skills/ship',
             isLocal: true,
+            skillMdSymlinkTarget:
+              '/Users/me/.claude/skills/gstack/ship/SKILL.md' as SymlinkInfo['skillMdSymlinkTarget'],
           },
         ],
-        skillMdSymlinkTarget:
-          '/Users/me/.claude/skills/gstack/ship/SKILL.md' as Skill['skillMdSymlinkTarget'],
       }),
     )
     const { selectAgent } = await import('@/renderer/src/redux/slices/uiSlice')
@@ -383,6 +383,38 @@ describe('SkillItem G-Stack badge', () => {
     await expect
       .element(gstackLink)
       .toHaveAttribute('href', GSTACK_REPOSITORY_URL)
+  })
+
+  it('hides the badge when skillMdSymlinkTarget points outside the gstack tree', async () => {
+    // Negative coverage at the wired-up SkillItem level: a local skill with
+    // skillMdSymlinkTarget set but pointing at a user-managed path (no
+    // `gstack` segment) must NOT receive the badge. The pure helper covers
+    // this case in isolation, but a regression where someone fed
+    // skillMdSymlinkTarget straight into the JSX (bypassing the helper)
+    // would only surface here.
+    const { screen, store } = await renderSkillItem(
+      makeSkill({
+        name: 'custom' as SkillName,
+        path: '/Users/me/.claude/skills/custom' as Skill['path'],
+        isSource: false,
+        symlinks: [
+          {
+            agentId: 'claude-code',
+            agentName: 'Claude Code',
+            status: 'valid',
+            linkPath: '/Users/me/.claude/skills/custom',
+            isLocal: true,
+            skillMdSymlinkTarget:
+              '/Users/me/projects/my-skills/custom/SKILL.md' as SymlinkInfo['skillMdSymlinkTarget'],
+          },
+        ],
+      }),
+    )
+    const { selectAgent } = await import('@/renderer/src/redux/slices/uiSlice')
+
+    store.dispatch(selectAgent('claude-code'))
+
+    expect(screen.getByRole('link', { name: /G-Stack/i }).query()).toBeNull()
   })
 })
 

--- a/src/renderer/src/components/skills/SkillItem.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillItem.browser.test.tsx
@@ -349,6 +349,41 @@ describe('SkillItem G-Stack badge', () => {
 
     expect(screen.getByRole('link', { name: /G-Stack/i }).query()).toBeNull()
   })
+
+  it('shows badge for gstack-managed sibling skills (local skill whose SKILL.md symlinks into gstack)', async () => {
+    // Real production scenario: ~/.claude/skills/ship/ is a real directory
+    // whose only entry is a SKILL.md symlink → ~/.claude/skills/gstack/ship/SKILL.md.
+    // The skill's linkPath/targetPath alone do NOT contain "gstack" — only
+    // the new skillMdSymlinkTarget field does. Without it, the badge is
+    // hidden on every gstack sibling, which is the whole bug being fixed.
+    const { screen, store } = await renderSkillItem(
+      makeSkill({
+        name: 'ship' as SkillName,
+        path: '/Users/me/.claude/skills/ship' as Skill['path'],
+        isSource: false,
+        symlinks: [
+          {
+            agentId: 'claude-code',
+            agentName: 'Claude Code',
+            status: 'valid',
+            linkPath: '/Users/me/.claude/skills/ship',
+            isLocal: true,
+          },
+        ],
+        skillMdSymlinkTarget:
+          '/Users/me/.claude/skills/gstack/ship/SKILL.md' as Skill['skillMdSymlinkTarget'],
+      }),
+    )
+    const { selectAgent } = await import('@/renderer/src/redux/slices/uiSlice')
+
+    store.dispatch(selectAgent('claude-code'))
+
+    const gstackLink = screen.getByRole('link', { name: /G-Stack/i })
+    await expect.element(gstackLink).toBeInTheDocument()
+    await expect
+      .element(gstackLink)
+      .toHaveAttribute('href', GSTACK_REPOSITORY_URL)
+  })
 })
 
 describe('SkillItem bulk-select checkbox stopPropagation', () => {

--- a/src/renderer/src/components/skills/skillItemHelpers.test.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest'
 
 import type { AbsolutePath, AgentId, Skill, SymlinkInfo } from '@/shared/types'
 
-import { getSkillItemVisibility } from './skillItemHelpers'
+import {
+  getSkillItemVisibility,
+  type SkillVisibilityInput,
+} from './skillItemHelpers'
 
 /**
  * Create a mock SymlinkInfo for testing
@@ -25,14 +28,14 @@ function makeSymlink(
  * {@link getSkillItemVisibility} reads. `isOrphan` is auto-derived from the
  * symlinks (every entry broken/missing AND no local copy = orphan), matching
  * what `scanOrphanSymlinks` would set in production. Override when a test
- * needs to assert the inverse. `skillMdSymlinkTarget` defaults to undefined —
- * pass it in `overrides` to simulate a gstack-managed local skill whose
- * SKILL.md symlinks into the gstack source tree.
+ * needs to assert the inverse. `skillMdSymlinkTarget` lives on each
+ * `SymlinkInfo` slot — pass it via `makeSymlink` to simulate a gstack-managed
+ * local skill whose SKILL.md symlinks into the gstack source tree.
  */
 function makeSkill(
   symlinks: SymlinkInfo[],
-  overrides?: Partial<Pick<Skill, 'isOrphan' | 'skillMdSymlinkTarget'>>,
-): Pick<Skill, 'symlinks' | 'isOrphan' | 'skillMdSymlinkTarget'> {
+  overrides?: Partial<Pick<Skill, 'isOrphan'>>,
+): SkillVisibilityInput {
   const derivedOrphan =
     symlinks.length > 0 &&
     symlinks.some((s) => s.status === 'broken') &&
@@ -40,7 +43,6 @@ function makeSkill(
   return {
     symlinks,
     isOrphan: overrides?.isOrphan ?? derivedOrphan,
-    skillMdSymlinkTarget: overrides?.skillMdSymlinkTarget,
   }
 }
 
@@ -256,11 +258,16 @@ describe('getSkillItemVisibility', () => {
       expect(result.showGStackBadge).toBe(true)
     })
 
-    it('shows badge for relative gstack symlink targets', () => {
+    it('shows badge for codex-managed gstack symlinks (multi-agent coverage)', () => {
+      // symlinkChecker resolves relative readlink results to absolute paths
+      // before populating `targetPath`, so the renderer always sees the
+      // resolved form (e.g. `/Users/me/.codex/skills/gstack/task`). This
+      // guards multi-agent coverage of GSTACK_BADGE_AGENT_IDS — earlier
+      // versions only matched on `claude-code`.
       const symlinks = [
         makeSymlink({
           agentId: 'codex',
-          targetPath: '../gstack/task',
+          targetPath: '/Users/me/.codex/skills/gstack/task',
           linkPath: '/Users/me/.codex/skills/task',
           isLocal: false,
           status: 'valid',
@@ -313,16 +320,12 @@ describe('getSkillItemVisibility', () => {
           isLocal: true,
           status: 'valid',
           targetPath: undefined,
-        }),
-      ]
-
-      const result = getSkillItemVisibility(
-        'claude-code',
-        makeSkill(symlinks, {
           skillMdSymlinkTarget:
             '/Users/me/.claude/skills/gstack/ship/SKILL.md' as AbsolutePath,
         }),
-      )
+      ]
+
+      const result = getSkillItemVisibility('claude-code', makeSkill(symlinks))
       expect(result.showGStackBadge).toBe(true)
     })
 
@@ -336,16 +339,12 @@ describe('getSkillItemVisibility', () => {
           isLocal: true,
           status: 'valid',
           targetPath: undefined,
-        }),
-      ]
-
-      const result = getSkillItemVisibility(
-        'claude-code',
-        makeSkill(symlinks, {
           skillMdSymlinkTarget:
             '/Users/me/projects/my-skills/custom/SKILL.md' as AbsolutePath,
         }),
-      )
+      ]
+
+      const result = getSkillItemVisibility('claude-code', makeSkill(symlinks))
       expect(result.showGStackBadge).toBe(false)
     })
 

--- a/src/renderer/src/components/skills/skillItemHelpers.test.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.test.ts
@@ -25,12 +25,14 @@ function makeSymlink(
  * {@link getSkillItemVisibility} reads. `isOrphan` is auto-derived from the
  * symlinks (every entry broken/missing AND no local copy = orphan), matching
  * what `scanOrphanSymlinks` would set in production. Override when a test
- * needs to assert the inverse.
+ * needs to assert the inverse. `skillMdSymlinkTarget` defaults to undefined —
+ * pass it in `overrides` to simulate a gstack-managed local skill whose
+ * SKILL.md symlinks into the gstack source tree.
  */
 function makeSkill(
   symlinks: SymlinkInfo[],
-  overrides?: Partial<Pick<Skill, 'isOrphan'>>,
-): Pick<Skill, 'symlinks' | 'isOrphan'> {
+  overrides?: Partial<Pick<Skill, 'isOrphan' | 'skillMdSymlinkTarget'>>,
+): Pick<Skill, 'symlinks' | 'isOrphan' | 'skillMdSymlinkTarget'> {
   const derivedOrphan =
     symlinks.length > 0 &&
     symlinks.some((s) => s.status === 'broken') &&
@@ -38,6 +40,7 @@ function makeSkill(
   return {
     symlinks,
     isOrphan: overrides?.isOrphan ?? derivedOrphan,
+    skillMdSymlinkTarget: overrides?.skillMdSymlinkTarget,
   }
 }
 
@@ -295,6 +298,74 @@ describe('getSkillItemVisibility', () => {
 
       const result = getSkillItemVisibility('gemini-cli', makeSkill(symlinks))
       expect(result.showGStackBadge).toBe(false)
+    })
+
+    it('shows badge for local skill whose SKILL.md symlinks into gstack tree', () => {
+      // Real production case: ~/.claude/skills/ship/ is a real folder whose
+      // only entry is a SKILL.md symlink into ~/.claude/skills/gstack/ship/.
+      // Neither the linkPath (the real folder) nor any agent symlink contains
+      // the "gstack" segment — only the resolved SKILL.md target does.
+      // Without the fourth candidate, the badge would be hidden.
+      const symlinks = [
+        makeSymlink({
+          agentId: 'claude-code',
+          linkPath: '/Users/me/.claude/skills/ship' as AbsolutePath,
+          isLocal: true,
+          status: 'valid',
+          targetPath: undefined,
+        }),
+      ]
+
+      const result = getSkillItemVisibility(
+        'claude-code',
+        makeSkill(symlinks, {
+          skillMdSymlinkTarget:
+            '/Users/me/.claude/skills/gstack/ship/SKILL.md' as AbsolutePath,
+        }),
+      )
+      expect(result.showGStackBadge).toBe(true)
+    })
+
+    it('hides badge when SKILL.md target does not contain the gstack segment', () => {
+      // A user-installed local skill whose SKILL.md happens to be a symlink
+      // into a different location (not gstack) — no badge should show.
+      const symlinks = [
+        makeSymlink({
+          agentId: 'claude-code',
+          linkPath: '/Users/me/.claude/skills/custom' as AbsolutePath,
+          isLocal: true,
+          status: 'valid',
+          targetPath: undefined,
+        }),
+      ]
+
+      const result = getSkillItemVisibility(
+        'claude-code',
+        makeSkill(symlinks, {
+          skillMdSymlinkTarget:
+            '/Users/me/projects/my-skills/custom/SKILL.md' as AbsolutePath,
+        }),
+      )
+      expect(result.showGStackBadge).toBe(false)
+    })
+
+    it('falls back to existing candidates when skillMdSymlinkTarget is undefined (regression)', () => {
+      // Guards the existing 3-candidate path — agent symlink whose targetPath
+      // contains "gstack" must still flip the badge on, exactly as before.
+      // skillMdSymlinkTarget defaults to undefined via makeSkill(), simulating
+      // a Skill record produced before the new field landed.
+      const symlinks = [
+        makeSymlink({
+          agentId: 'claude-code',
+          targetPath: '/Users/me/.claude/skills/gstack/task' as AbsolutePath,
+          linkPath: '/Users/me/.claude/skills/task' as AbsolutePath,
+          isLocal: false,
+          status: 'valid',
+        }),
+      ]
+
+      const result = getSkillItemVisibility('claude-code', makeSkill(symlinks))
+      expect(result.showGStackBadge).toBe(true)
     })
   })
 

--- a/src/renderer/src/components/skills/skillItemHelpers.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.ts
@@ -96,9 +96,9 @@ function isGStackBundlePath(candidatePath: string): boolean {
  */
 export function getSkillItemVisibility(
   selectedAgentId: AgentId | null,
-  skill: Pick<Skill, 'symlinks' | 'isOrphan'>,
+  skill: Pick<Skill, 'symlinks' | 'isOrphan' | 'skillMdSymlinkTarget'>,
 ): SkillItemVisibility {
-  const { symlinks, isOrphan } = skill
+  const { symlinks, isOrphan, skillMdSymlinkTarget } = skill
   const selectedAgentSymlink = selectedAgentId
     ? (symlinks.find(
         (s) =>
@@ -116,10 +116,18 @@ export function getSkillItemVisibility(
   const hasSkillInSelectedAgent = !!selectedAgentSymlink || isLocalSkill
   // Orphan handling — see Skill.isOrphan for why the Add button is gated.
   // Source: scanOrphanSymlinks() in src/main/services/skillScanner.ts.
+  //
+  // gStackPathCandidates — paths inspected for the `gstack` segment that
+  // identifies a gstack-managed skill. The fourth entry,
+  // `skillMdSymlinkTarget`, is the resolved target of a local skill's
+  // `SKILL.md` symlink and is what surfaces sibling skills like `ship`,
+  // `review`, or `plan-eng-review` whose enclosing directory does not itself
+  // contain "gstack" but whose SKILL.md points into the gstack source tree.
   const gStackPathCandidates = [
     selectedAgentSymlink?.targetPath ?? '',
     selectedAgentSymlink?.linkPath ?? '',
     selectedLocalSkillInfo?.linkPath ?? '',
+    skillMdSymlinkTarget ?? '',
   ]
   const isGStackEligibleAgent =
     selectedAgentId !== null &&

--- a/src/renderer/src/components/skills/skillItemHelpers.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.ts
@@ -30,21 +30,33 @@ export interface SkillItemVisibility {
   showGStackBadge: boolean
 }
 
-/** Path-segment matcher for `.../gstack/...` on both POSIX and Windows paths. */
-const GSTACK_SEGMENT_PATTERN = /(^|[\\/])gstack([\\/]|$)/i
+/**
+ * Subset of `Skill` that `getSkillItemVisibility` actually reads. Reused by
+ * the test factory so a future field addition is a one-line change instead
+ * of three (function signature, factory return, factory overrides).
+ */
+export type SkillVisibilityInput = Pick<Skill, 'symlinks' | 'isOrphan'>
+
+/**
+ * Path-segment matcher for `.../skills/gstack/...` on both POSIX and Windows
+ * paths. Requires a `skills/` parent so a user-created directory literally
+ * named `gstack` outside any agent's skills tree (e.g. `~/projects/gstack/foo`)
+ * cannot trigger the badge — a finding raised by the Codex review.
+ */
+const GSTACK_SEGMENT_PATTERN = /[\\/]skills[\\/]gstack([\\/]|$)/i
 
 /**
  * Detect whether a filesystem-like path points to a G-Stack-managed location.
  * @param candidatePath - Path candidate from symlink target or link path.
  * @returns
- * - `true`: Path contains a standalone `gstack` segment.
- * - `false`: Empty or non-matching path.
+ * - `true`: Path contains a `skills/gstack/` segment.
+ * - `false`: Empty path, or `gstack/` lives outside any `skills/` parent.
  * @example
  * isGStackBundlePath('/Users/me/.claude/skills/gstack/skill-a') // => true
  * @example
- * isGStackBundlePath('../gstack/skill-a') // => true
- * @example
  * isGStackBundlePath('/Users/me/.agents/skills/task') // => false
+ * @example
+ * isGStackBundlePath('/Users/me/projects/gstack/skill-a') // => false
  */
 function isGStackBundlePath(candidatePath: string): boolean {
   return GSTACK_SEGMENT_PATTERN.test(candidatePath)
@@ -96,9 +108,9 @@ function isGStackBundlePath(candidatePath: string): boolean {
  */
 export function getSkillItemVisibility(
   selectedAgentId: AgentId | null,
-  skill: Pick<Skill, 'symlinks' | 'isOrphan' | 'skillMdSymlinkTarget'>,
+  skill: SkillVisibilityInput,
 ): SkillItemVisibility {
-  const { symlinks, isOrphan, skillMdSymlinkTarget } = skill
+  const { symlinks, isOrphan } = skill
   const selectedAgentSymlink = selectedAgentId
     ? (symlinks.find(
         (s) =>
@@ -117,17 +129,16 @@ export function getSkillItemVisibility(
   // Orphan handling — see Skill.isOrphan for why the Add button is gated.
   // Source: scanOrphanSymlinks() in src/main/services/skillScanner.ts.
   //
-  // gStackPathCandidates — paths inspected for the `gstack` segment that
-  // identifies a gstack-managed skill. The fourth entry,
-  // `skillMdSymlinkTarget`, is the resolved target of a local skill's
-  // `SKILL.md` symlink and is what surfaces sibling skills like `ship`,
-  // `review`, or `plan-eng-review` whose enclosing directory does not itself
-  // contain "gstack" but whose SKILL.md points into the gstack source tree.
+  // gStackPathCandidates — paths inspected for the `skills/gstack/` segment
+  // that identifies a gstack-managed skill. `skillMdSymlinkTarget` is read
+  // ONLY from the selected agent's slot (per-agent attribution): a sibling
+  // agent's gstack-managed twin must not flip the badge on this agent's
+  // unrelated local skill that happens to share a name.
   const gStackPathCandidates = [
     selectedAgentSymlink?.targetPath ?? '',
     selectedAgentSymlink?.linkPath ?? '',
     selectedLocalSkillInfo?.linkPath ?? '',
-    skillMdSymlinkTarget ?? '',
+    selectedLocalSkillInfo?.skillMdSymlinkTarget ?? '',
   ]
   const isGStackEligibleAgent =
     selectedAgentId !== null &&

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -172,15 +172,6 @@ export interface Skill {
   source?: RepositoryId
   /** Full URL to the source repository. @example "https://github.com/vercel-labs/skills.git" */
   sourceUrl?: HttpUrl
-  /**
-   * Resolved absolute path that the skill's `SKILL.md` file symlinks to, when
-   * `SKILL.md` itself is a symbolic link (e.g. gstack-managed sibling skills
-   * whose `SKILL.md` points into `~/.claude/skills/gstack/<name>/SKILL.md`).
-   * `undefined` when `SKILL.md` is a regular file or does not exist.
-   * Used by the renderer to detect gstack-managed skills via path-segment match.
-   * @example "/Users/me/.claude/skills/gstack/ship/SKILL.md"
-   */
-  skillMdSymlinkTarget?: AbsolutePath
 }
 
 /**
@@ -242,6 +233,17 @@ export interface SymlinkInfo {
   linkPath: AbsolutePath
   /** true = real folder in agent dir (local skill), false = symlink */
   isLocal: boolean
+  /**
+   * Resolved absolute path of THIS agent slot's `SKILL.md` symlink target,
+   * when the slot is a real local folder whose `SKILL.md` is a symlink (e.g.
+   * gstack-managed sibling skills whose `SKILL.md` points into
+   * `~/.<agent>/skills/gstack/<name>/SKILL.md`). Per-agent so the badge does
+   * not bleed across agents that share a skill name (cross-agent spoofing).
+   * `undefined` when the slot is a symlink, missing, or its `SKILL.md` is a
+   * regular file.
+   * @example "/Users/me/.claude/skills/gstack/ship/SKILL.md"
+   */
+  skillMdSymlinkTarget?: AbsolutePath
 }
 
 /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -172,6 +172,15 @@ export interface Skill {
   source?: RepositoryId
   /** Full URL to the source repository. @example "https://github.com/vercel-labs/skills.git" */
   sourceUrl?: HttpUrl
+  /**
+   * Resolved absolute path that the skill's `SKILL.md` file symlinks to, when
+   * `SKILL.md` itself is a symbolic link (e.g. gstack-managed sibling skills
+   * whose `SKILL.md` points into `~/.claude/skills/gstack/<name>/SKILL.md`).
+   * `undefined` when `SKILL.md` is a regular file or does not exist.
+   * Used by the renderer to detect gstack-managed skills via path-segment match.
+   * @example "/Users/me/.claude/skills/gstack/ship/SKILL.md"
+   */
+  skillMdSymlinkTarget?: AbsolutePath
 }
 
 /**


### PR DESCRIPTION
## Summary

- Show the G-Stack badge on **every** gstack-managed sibling skill (e.g. `~/.claude/skills/ship/SKILL.md → ~/.claude/skills/gstack/ship/SKILL.md`), not just the parent `gstack/` directory.
- Per-agent badge attribution: the `skillMdSymlinkTarget` field lives on each `SymlinkInfo` slot rather than on the global `Skill`, so a gstack-managed twin in one agent (e.g. `.claude`) cannot bleed the badge onto an unrelated local skill in another agent (e.g. `.codex`) that happens to share a name.
- Tighten `GSTACK_SEGMENT_PATTERN` to require a `skills/` parent — `~/projects/gstack/foo` no longer trips the badge.

## Why

Sibling skills (`ship`, `review`, `plan-eng-review`, …) are real local folders whose `SKILL.md` is a symlink into `~/.claude/skills/gstack/<name>/SKILL.md`. Without this PR they showed as ordinary local skills because the renderer only inspected the slot's own `linkPath` for the `gstack` segment.

The per-agent attribution and tightened regex were called out in cross-model review (Codex P1 + P2). Both are now fixed at the data-model level — the renderer only ever reads from the selected agent's slot.

## Threat-model note

Cross-model adversarial review flagged a residual badge-spoofability vector: a user staging `~/projects/skills/gstack/foo/SKILL.md` as a symlink target on their own filesystem can still surface the badge. Shipped as-is — the user controls their own filesystem, agents already execute skills at full trust, and the badge does not gate any privileged action. If remote sync of skills lands later, the threat model would need to be revisited (anchor-check the resolved target against `agent.path/gstack/<skillName>/`).

## Test plan

- [x] `pnpm typecheck` (0 errors)
- [x] `pnpm lint` (0 warnings)
- [x] `pnpm test` (928 passed across 64 files)
- [x] `npx tsc -p e2e/tsconfig.json --noEmit` (0 errors)
- [x] Per-agent attribution: `skillScanner.test.ts` covers cross-agent name collision (gstack twin in one agent, plain local in another)
- [x] Regex tightening: `skillItemHelpers.test.ts` rejects `~/projects/gstack/foo`, accepts `~/.codex/skills/gstack/task`
- [x] Browser test: `SkillItem.browser.test.tsx` renders the badge from `selectedLocalSkillInfo.skillMdSymlinkTarget`

## Reviews

- Pre-landing review (gstack `/review`, diff-scoped): 1 critical (badge-spoofability) — judged ship-as-is per threat model above.
- Adversarial review: Claude subagent + Codex adversarial + Codex structured. Codex structured GATE: PASS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ローカルスキルのSKILL.mdシンボリックリンクターゲットの追跡機能を追加
  * G-Stackバッジの検出精度を向上（パス検出ロジックを改善）
  * スキルメタデータとシンボリックリンク確認の並列処理を実装

* **テスト**
  * シンボリックリンクターゲット解決に関するテストケースを拡充
  * エージェント間での複数シンボリックリンク対応テストを追加
  * G-Stackバッジ表示動作の検証テストを強化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->