### PR TITLE
refactor(types): colorful-types phase 3 sweep

### DIFF
--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -1,3 +1,4 @@
+import type { Stats } from 'node:fs'
 import * as fs from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
 
@@ -54,7 +55,7 @@ async function removeFromAgent(
       error: extractErrorMessage(error, 'Invalid link path'),
     }
   }
-  let stats: Awaited<ReturnType<typeof fs.lstat>>
+  let stats: Stats
   try {
     stats = await fs.lstat(linkPath)
   } catch (error) {

--- a/src/main/services/skillScanner.ts
+++ b/src/main/services/skillScanner.ts
@@ -43,6 +43,17 @@ interface SkillLockEntry {
 }
 
 /**
+ * Top-level shape of `~/.agents/.skill-lock.json` — the skills CLI writes
+ * `{ skills: { <name>: SkillLockEntry } }`. Older lock files (or a
+ * partially-initialized agents dir) may omit the `skills` key entirely,
+ * so the field is optional.
+ * @example { skills: { 'frontend-design': { source: 'pbakaus/impeccable', sourceType: 'github', sourceUrl: '...' } } }
+ */
+interface SkillLockContent {
+  skills?: Record<string, SkillLockEntry>
+}
+
+/**
  * Read the global skill lock file to get source info for installed skills
  * @returns Map of skill name to lock entry
  * @example
@@ -53,9 +64,7 @@ async function readSkillLock(): Promise<Map<SkillName, SkillLockEntry>> {
   try {
     const lockPath = join(homedir(), '.agents', '.skill-lock.json')
     const content = await readFile(lockPath, 'utf-8')
-    const parsed = JSON.parse(content) as {
-      skills?: Record<string, SkillLockEntry>
-    }
+    const parsed = JSON.parse(content) as SkillLockContent
     return new Map(Object.entries(parsed.skills ?? {}))
   } catch {
     return new Map()

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from 'node:crypto'
+import type { Stats } from 'node:fs'
 import * as fs from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { dirname, isAbsolute, join, resolve } from 'node:path'
@@ -217,7 +218,7 @@ async function scanLocalCopies(
     } catch {
       continue
     }
-    let stats: Awaited<ReturnType<typeof fs.lstat>>
+    let stats: Stats
     try {
       stats = await fs.lstat(linkPath)
     } catch (error) {
@@ -271,7 +272,7 @@ async function scanOrphanSymlinkPaths(
       continue
     }
 
-    let stats: Awaited<ReturnType<typeof fs.lstat>>
+    let stats: Stats
     try {
       stats = await fs.lstat(linkPath)
     } catch (error) {
@@ -542,7 +543,7 @@ async function moveSourceBackedToTrash(
       continue
     }
 
-    let stats: Awaited<ReturnType<typeof fs.lstat>>
+    let stats: Stats
     try {
       stats = await fs.lstat(linkPath)
     } catch (error) {

--- a/src/renderer/src/redux/slices/bookmarkSlice.ts
+++ b/src/renderer/src/redux/slices/bookmarkSlice.ts
@@ -5,6 +5,15 @@ import type { RootState } from '@/renderer/src/redux/store'
 import type { BookmarkedSkill, SkillName } from '@/shared/types'
 
 /**
+ * Payload for the `addBookmark` action — every BookmarkedSkill field
+ * except `bookmarkedAt`, which the reducer stamps with `new Date().toISOString()`.
+ * Named so callers (BookmarkButton, install handlers) reference one shape
+ * instead of repeating `Omit<BookmarkedSkill, 'bookmarkedAt'>` inline.
+ * @example { name: 'task', repo: 'vercel-labs/skills', url: 'https://skills.sh/task' }
+ */
+export type AddBookmarkPayload = Omit<BookmarkedSkill, 'bookmarkedAt'>
+
+/**
  * Redux state for the Bookmarks feature.
  * Persisted to localStorage via redux-persist so entries survive app restarts.
  */
@@ -27,10 +36,7 @@ const bookmarkSlice = createSlice({
      * @example
      * dispatch(addBookmark({ name: 'task', repo: 'vercel-labs/skills', url: 'https://skills.sh/task' }))
      */
-    addBookmark: (
-      state,
-      action: PayloadAction<Omit<BookmarkedSkill, 'bookmarkedAt'>>,
-    ) => {
+    addBookmark: (state, action: PayloadAction<AddBookmarkPayload>) => {
       const exists = state.items.some((b) => b.name === action.payload.name)
       if (!exists) {
         state.items.push({

--- a/src/renderer/src/redux/slices/marketplaceSlice.ts
+++ b/src/renderer/src/redux/slices/marketplaceSlice.ts
@@ -14,6 +14,15 @@ import type {
 /** Cache TTL: 30 minutes in milliseconds */
 const CACHE_TTL_MS = 30 * 60 * 1000
 
+/**
+ * Per-filter leaderboard cache. Indexed by `RankingFilter`; each entry
+ * carries its own `lastFetched` timestamp and `status` so the three tabs
+ * (`all-time` / `trending` / `hot`) load and expire independently.
+ * `Partial<>` because a tab is `undefined` until the user has visited it.
+ * @example { 'all-time': { skills: [...], lastFetched: 1713045600000, filter: 'all-time', status: 'idle' } }
+ */
+type LeaderboardCache = Partial<Record<RankingFilter, LeaderboardData>>
+
 interface MarketplaceState {
   /** Current marketplace operation state (search / install / idle). */
   status: MarketplaceStatus
@@ -30,7 +39,7 @@ interface MarketplaceState {
   /** Human-readable error from the last failed operation. */
   error: string | null
   /** Per-filter leaderboard cache. Each filter tracks its own data and loading state. */
-  leaderboard: Partial<Record<RankingFilter, LeaderboardData>>
+  leaderboard: LeaderboardCache
 }
 
 const initialState: MarketplaceState = {

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -8,9 +8,12 @@ import type {
   SkillFile,
   SkillFileContent,
   UpdateInfo,
+  UpdateErrorPayload,
   DeleteProgressPayload,
   DownloadProgress,
   FolderActionResult,
+  PixelHeight,
+  PixelWidth,
   RankingFilter,
   SkillSearchResult,
   InstallOptions,
@@ -95,7 +98,7 @@ declare global {
           callback: (progress: DownloadProgress) => void,
         ) => () => void
         onDownloaded: (callback: (info: UpdateInfo) => void) => () => void
-        onError: (callback: (error: { message: string }) => void) => () => void
+        onError: (callback: (error: UpdateErrorPayload) => void) => () => void
         // Actions
         download: () => Promise<void>
         install: () => Promise<void>
@@ -133,7 +136,10 @@ declare global {
         ) => Promise<FolderActionResult>
       }
       window: {
-        getMainBounds: () => Promise<{ width: number; height: number } | null>
+        getMainBounds: () => Promise<{
+          width: PixelWidth
+          height: PixelHeight
+        } | null>
       }
     }
   }

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -9,6 +9,7 @@ import type {
   CopyToAgentsResult,
   CreateSymlinksOptions,
   CreateSymlinksResult,
+  DeleteProgressPayload,
   DeleteSkillOptions,
   DeleteSkillResult,
   DeleteSkillsOptions,
@@ -17,6 +18,8 @@ import type {
   HttpUrl,
   InstallOptions,
   InstallProgress,
+  PixelHeight,
+  PixelWidth,
   RankingFilter,
   RemoveAllFromAgentOptions,
   RemoveAllFromAgentResult,
@@ -36,6 +39,7 @@ import type {
   UnlinkFromAgentOptions,
   UnlinkManyFromAgentOptions,
   UnlinkResult,
+  UpdateErrorPayload,
   UpdateInfo,
 } from './types'
 
@@ -126,7 +130,7 @@ export interface IpcInvokeContract {
   // calls this and writes the result into `settings.windowSize`.
   'window:getMainBounds': {
     args: []
-    result: { width: number; height: number } | null
+    result: { width: PixelWidth; height: PixelHeight } | null
   }
 }
 
@@ -141,13 +145,13 @@ export interface IpcInvokeContract {
  */
 export interface IpcEventContract {
   'skills:cli:progress': InstallProgress
-  'skills:deleteProgress': { current: number; total: number }
+  'skills:deleteProgress': DeleteProgressPayload
   'update:checking': void
   'update:available': UpdateInfo
   'update:not-available': void
   'update:progress': DownloadProgress
   'update:downloaded': UpdateInfo
-  'update:error': { message: string }
+  'update:error': UpdateErrorPayload
   'settings:changed': Settings
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -9,6 +9,14 @@ export type { FilePreviewKind } from './fileTypes'
 // ----------------------------------------------------------------------------
 // These types replace raw `string` / `number` at domain boundaries so signatures
 // communicate WHAT a value represents, not just its runtime shape.
+//
+// Plain aliases (`type X = string` / `type X = number`) are documentation-only:
+// TypeScript's structural typing makes them mutually assignable, so `PixelWidth`
+// and `PixelHeight` (or `SymlinkCount` and `InstallCount`) are exchange-safe at
+// the API surface. If nominal/compile-time exchange prevention is later needed,
+// migrate to the `Brand<T, B>` utility below (e.g., `Brand<number, 'PixelWidth'>`)
+// — branded types require an explicit construction site but reject accidental
+// swaps between structurally identical values.
 // ============================================================================
 
 /**
@@ -93,9 +101,13 @@ export type PixelWidth = number
 export type PixelHeight = number
 
 /**
- * A non-negative count of agent symlinks in a sync operation outcome
- * (created / replaced / skipped). Distinguishes "number of symlinks" from
- * other counts (skill counts, install counts) at sync IPC boundaries.
+ * A non-negative count of agent symlinks. Used in two senses, both of which
+ * count valid symlinks (broken/missing entries are excluded by callers):
+ * - Sync operation outcomes — `SyncExecuteResult.{created,replaced,skipped}`
+ *   and `SyncPreviewResult.{toCreate,alreadySynced}`
+ * - "Agents linked to this skill" — `Skill.symlinkCount`
+ * Distinguishes "number of symlinks" from other counts (skill counts,
+ * install counts) at sync IPC boundaries and skill-list rendering.
  * @example 12
  */
 export type SymlinkCount = number
@@ -184,7 +196,7 @@ export interface Skill {
   /** Absolute filesystem path to the skill directory. @example "/Users/me/.agents/skills/tdd-workflow" */
   path: AbsolutePath
   /** Number of agents this skill is symlinked to (valid symlinks only). @example 3 */
-  symlinkCount: number
+  symlinkCount: SymlinkCount
   /** Per-agent symlink status entries */
   symlinks: SymlinkInfo[]
   /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -77,10 +77,42 @@ export type UnixTimestampMs = number
 export type HumanFileSize = string
 
 /**
- * Human-readable date string (locale-formatted, not machine-parseable).
- * @example "Apr 10, 2026"
+ * CSS-pixel width. Matches what `BrowserWindow.getContentBounds()` returns
+ * and what `window.innerWidth` reports — Electron handles DPR scaling so
+ * callers do not multiply by `devicePixelRatio`.
+ * @example 1280
  */
-export type HumanDate = string
+export type PixelWidth = number
+
+/**
+ * CSS-pixel height. Matches what `BrowserWindow.getContentBounds()` returns
+ * and what `window.innerHeight` reports — Electron handles DPR scaling so
+ * callers do not multiply by `devicePixelRatio`.
+ * @example 800
+ */
+export type PixelHeight = number
+
+/**
+ * A non-negative count of agent symlinks in a sync operation outcome
+ * (created / replaced / skipped). Distinguishes "number of symlinks" from
+ * other counts (skill counts, install counts) at sync IPC boundaries.
+ * @example 12
+ */
+export type SymlinkCount = number
+
+/**
+ * 1-indexed rank of a skill in a leaderboard listing. `1` is the top result.
+ * @example 1
+ */
+export type SkillRank = number
+
+/**
+ * Total install count for a skill, scraped from skills.sh and surfaced in
+ * the marketplace right-pane stats. Absent on CLI-search results that
+ * lack telemetry data.
+ * @example 2480
+ */
+export type InstallCount = number
 
 /**
  * Free-form marketplace search text typed by the user.
@@ -247,17 +279,32 @@ export interface SymlinkInfo {
 }
 
 /**
- * Symlink status type
- * - valid: Symlink exists and points to valid target
- * - broken: Symlink exists but target is missing
- * - missing: No symlink for this agent
+ * Symlink state between a skill source and an agent's skills directory.
+ * Surfaced in `SymlinkInfo.status` and color-coded in the UI:
+ * `--success` (green) for valid, amber for broken, `--muted-foreground`
+ * for missing — the status drives every status-at-a-glance affordance.
+ *
+ * - `valid`: symlink exists and points to a present source skill.
+ * - `broken`: symlink exists but the target is missing (orphan).
+ * - `missing`: no symlink for this agent (the skill is not linked here).
+ *
+ * @example 'valid'
+ * @example 'broken'
+ * @example 'missing'
  */
 export type SymlinkStatus = 'valid' | 'broken' | 'missing'
 
 /**
- * Skill type indicating source of the skill
- * - source: Skill from ~/.agents/skills/ (symlinked to agents)
- * - local: Skill created directly in agent's skills directory
+ * Origin of a skill — determines how it shows up in agent directories
+ * and what destructive operations are available.
+ *
+ * - `source`: lives in `~/.agents/skills/` and is symlinked into
+ *   each agent's skills directory.
+ * - `local`: a real folder inside a single agent's skills directory
+ *   (no symlink). User-authored or copied for agent collaboration.
+ *
+ * @example 'source'
+ * @example 'local'
  */
 export type SkillType = 'source' | 'local'
 
@@ -422,6 +469,18 @@ export interface SkillBinaryContent {
 }
 
 /**
+ * Payload for the `update:error` IPC event. Just the user-safe error message —
+ * electron-updater's `Error` object is intentionally NOT forwarded over IPC
+ * (it's not structured-cloneable and may carry stack frames the renderer has
+ * no use for).
+ * @example { message: 'Could not connect to update server' }
+ */
+export interface UpdateErrorPayload {
+  /** Human-readable error message surfaced in the update toast. */
+  message: string
+}
+
+/**
  * Update information from electron-updater.
  * Emitted on `update:available` and `update:downloaded` events.
  * @example { version: '0.8.0', releaseNotes: 'Added marketplace search' }
@@ -462,7 +521,21 @@ export interface DownloadProgress {
 }
 
 /**
- * Update status for UI state management
+ * Auto-update flow state surfaced in the renderer's update toast / banner.
+ * Drives which CTA renders (Check / Download / Install) and which
+ * electron-updater event is awaited next.
+ *
+ * - `idle`: no update activity (initial state, or after dismiss).
+ * - `checking`: `update:checking` received; awaiting `update:available`
+ *   or `update:not-available`.
+ * - `available`: a newer version exists; user can choose to download.
+ * - `downloading`: `update:progress` events stream; user sees % bar.
+ * - `ready`: download finished; "Install and restart" CTA shown.
+ * - `error`: most recent step failed; the toast carries
+ *   `UpdateErrorPayload.message`.
+ *
+ * @example 'idle'
+ * @example 'downloading'
  */
 export type UpdateStatus =
   | 'idle'
@@ -486,7 +559,7 @@ export type UpdateStatus =
  */
 export interface SkillSearchResult {
   /** 1-indexed rank in the source listing (CLI output order or leaderboard). @example 1 */
-  rank: number
+  rank: SkillRank
   /** Skill name (directory-style identifier). @example "task" */
   name: SkillName
   /** Source repository in GitHub owner/repo format. @example "vercel-labs/skills" */
@@ -494,7 +567,7 @@ export interface SkillSearchResult {
   /** Canonical URL to the skill on skills.sh or its GitHub source. @example "https://skills.sh/task" */
   url: HttpUrl
   /** Install count from skills.sh when available (absent for CLI search results). @example 2480 */
-  installCount?: number
+  installCount?: InstallCount
 }
 
 /**
@@ -567,18 +640,43 @@ export interface InstallProgress {
 }
 
 /**
- * Marketplace operation status
+ * Marketplace operation flow state — drives spinners, disables the
+ * search box during install, and gates the cancel button.
+ *
+ * - `idle`: marketplace is at rest.
+ * - `searching`: a `skills find` CLI process is running.
+ * - `installing`: a `skills install` CLI process is running; progress
+ *   events stream into `installProgress`.
+ * - `error`: most recent op failed; UI shows a Retry CTA.
+ *
+ * @example 'idle'
+ * @example 'searching'
  */
 export type MarketplaceStatus = 'idle' | 'searching' | 'installing' | 'error'
 
 /**
- * Filter for marketplace leaderboard ranking tabs.
- * Maps to skills.sh pages: / (all-time), /trending, /hot
+ * Ranking tab in the marketplace leaderboard. Each value maps 1:1 to a
+ * skills.sh page used as the scrape target by `fetchLeaderboard()`.
+ *
+ * - `all-time`: `https://skills.sh/`
+ * - `trending`: `https://skills.sh/trending`
+ * - `hot`: `https://skills.sh/hot`
+ *
+ * @example 'all-time'
+ * @example 'trending'
  */
 export type RankingFilter = 'all-time' | 'trending' | 'hot'
 
 /**
- * Per-filter leaderboard loading status
+ * Per-filter leaderboard fetch status. Stored alongside cached results
+ * so each ranking tab tracks its own loading state independently.
+ *
+ * - `idle`: cache is fresh or has never been loaded.
+ * - `loading`: a fetch is in flight for this filter.
+ * - `error`: the last fetch failed; `LeaderboardData.error` carries the message.
+ *
+ * @example 'idle'
+ * @example 'loading'
  */
 export type LeaderboardStatus = 'idle' | 'loading' | 'error'
 
@@ -917,9 +1015,9 @@ export interface SyncPreviewResult {
   /** Number of agents considered (1 when scoped to one agent). @example 3 */
   totalAgents: number
   /** Symlinks that would be created on execute (excludes conflicts). @example 10 */
-  toCreate: number
+  toCreate: SymlinkCount
   /** Symlinks already in place — nothing to do for these. @example 5 */
-  alreadySynced: number
+  alreadySynced: SymlinkCount
   /** Per-agent folders that block creation until the user chooses to replace. */
   conflicts: SyncConflict[]
   /**
@@ -946,11 +1044,20 @@ export interface SyncExecuteOptions {
 }
 
 /**
- * Action type for each item processed during sync execution.
- * - `created`: new symlink was created
- * - `replaced`: existing conflict was overwritten with a symlink
- * - `skipped`: already-synced symlink or user-declined conflict (no filesystem change)
- * - `error`: operation failed; message is carried on the item
+ * Outcome of a single (skill × agent) row processed during sync execution.
+ * Each row in `SyncExecuteResult.details` carries one of these — the
+ * renderer uses the value to render a per-row icon and color in the
+ * post-sync result dialog.
+ *
+ * - `created`: new symlink was created at this slot.
+ * - `replaced`: existing conflict folder was overwritten with a symlink
+ *   (only for slots the user opted to replace).
+ * - `skipped`: slot was already in the desired state (already-synced
+ *   symlink or user-declined conflict) — no filesystem change.
+ * - `error`: operation failed; the row carries a `error: string` message.
+ *
+ * @example 'created'
+ * @example 'skipped'
  */
 export type SyncResultAction = 'created' | 'replaced' | 'skipped' | 'error'
 
@@ -980,11 +1087,11 @@ export interface SyncExecuteResult {
   /** true if every planned operation succeeded (errors.length === 0). */
   success: boolean
   /** Number of newly-created symlinks. @example 10 */
-  created: number
+  created: SymlinkCount
   /** Number of existing folders replaced with symlinks (user opted-in). @example 2 */
-  replaced: number
+  replaced: SymlinkCount
   /** Number of already-synced items that were skipped. @example 5 */
-  skipped: number
+  skipped: SymlinkCount
   /** Per-path errors encountered during execution (empty on full success). */
   errors: Array<{ path: AbsolutePath; error: string }>
   /** Per-item action details for displaying a sync diff in the UI. */


### PR DESCRIPTION
## Summary

Phase 3 of the `/colorful-type` workflow — targets code added since PR #72 (2026-04-16, the Phase 2 merge) that escaped earlier sweeps: Settings window, sync dialog refactor, orphan symlink IPC, gstack badge attribution, window-size persistence.

Pure type-level changes. No runtime behavior touched.

### A. JSDoc enrichment on 7 unions

Adds `@description` and `@example` to: `SymlinkStatus`, `SkillType`, `UpdateStatus`, `MarketplaceStatus`, `RankingFilter`, `LeaderboardStatus`, `SyncResultAction`. Each value is now self-documenting at IDE hover-time without the reader having to chase usage sites.

### C. Five new numeric aliases

`PixelWidth`, `PixelHeight`, `SymlinkCount`, `SkillRank`, `InstallCount` — all propagated to:
- `IpcInvokeContract['window:getMainBounds']` (the IPC boundary that crosses main↔renderer)
- `window.electron.window.getMainBounds` preload contract + `update.onError` callback
- `SyncExecuteResult.{created, replaced, skipped}` and `SyncPreviewResult.{toCreate, alreadySynced}`
- `SkillSearchResult.{rank, installCount}`

Aliases (not brands) per the [decision matrix](https://github.com/laststance/skills-desktop/blob/main/src/shared/types.ts) — these are high-traffic numeric quantities where structural-identity isn't a footgun and cast friction would outweigh safety. Same logic that landed `SkillName`/`AbsolutePath` as plain aliases in PR #72.

### D. Extract utility-type repetitions to named types

| Was inline | Now named | Where |
|------------|-----------|-------|
| `Awaited<ReturnType<typeof fs.lstat>>` (4×) | `Stats` from `node:fs` | `skills.ts` + `trashService.ts` |
| `Omit<BookmarkedSkill, 'bookmarkedAt'>` | `AddBookmarkPayload` | `bookmarkSlice.ts` |
| `Partial<Record<RankingFilter, LeaderboardData>>` | `LeaderboardCache` | `marketplaceSlice.ts` |
| `{ message: string }` (event payload) | `UpdateErrorPayload` | `ipc-contract.ts`, `electron.d.ts` |
| Inline cast in `readSkillLock()` | `SkillLockContent` | `skillScanner.ts` |
| `{ current: number; total: number }` | `DeleteProgressPayload` (existed but unused at IPC contract) | `ipc-contract.ts` |

For `Awaited<ReturnType<typeof fs.lstat>>` I chose to import `Stats` from `node:fs` rather than coin a new `FileStats` alias — per ts-rules ("prefer reusing existing types over defining new ones") and to avoid a layer that adds nothing semantic over the upstream type.

### E. Delete unused `HumanDate`

`HumanDate` was added in PR #72 but never imported. Removed. `HumanFileSize` stays — it's referenced by `SourceStats.totalSize`.

## Test plan

- [x] `pnpm typecheck` — zero errors
- [x] `npx tsc -p e2e/tsconfig.json --noEmit` — zero errors
- [x] `pnpm lint` — zero warnings
- [x] `pnpm test` — 928/928 passing across 64 files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタ**
  * 内部型システムを改善し、コード品質を向上させました。
  * エラー処理の一貫性と IPC 通信の型安全性を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->