### PR TITLE
fix(ui): align SearchBox toggle height with input + zero gap

### DIFF
--- a/src/renderer/src/components/skills/SearchBox.tsx
+++ b/src/renderer/src/components/skills/SearchBox.tsx
@@ -60,12 +60,20 @@ export const SearchBox = React.memo(function SearchBox(): React.ReactElement {
           }
         }}
         aria-label="Search field"
-        className="shrink-0"
+        className="shrink-0 gap-0"
       >
-        <ToggleGroupItem value="name" aria-label="Search by skill name">
+        <ToggleGroupItem
+          value="name"
+          aria-label="Search by skill name"
+          className="h-9 min-w-0 rounded-r-none focus:z-10 focus-visible:z-10"
+        >
           Name
         </ToggleGroupItem>
-        <ToggleGroupItem value="repo" aria-label="Search by repository">
+        <ToggleGroupItem
+          value="repo"
+          aria-label="Search by repository"
+          className="h-9 min-w-0 rounded-l-none border-l-0 focus:z-10 focus-visible:z-10"
+        >
           Repo
         </ToggleGroupItem>
       </ToggleGroup>


### PR DESCRIPTION
## Summary

- Match `ToggleGroupItem` height to the search `Input` (h-9, was h-11) so Name/Repo and the search box sit on the same baseline
- Join Name | Repo into a segmented-control look — `gap-0` + `rounded-r-none` / `rounded-l-none` + `border-l-0` (shadcn v4 `spacing={0}` pattern, reproduced locally so the shared `toggle-group.tsx` stays untouched)
- Add `focus:z-10` on both items so the focus ring is not clipped by the adjacent border on the joined layout

## Why local overrides instead of editing `toggle-group.tsx`?

The shared component intentionally defaults to `h-11` (44px) so every other call site (Settings → Appearance / General) clears the Apple HIG / WCAG 2.2 AA tap-target floor without callers needing to remember a `size`. Pulling that floor down globally would silently regress those toolbars; pushing the change through the SearchBox call site keeps the regression surface to one component.

## Visual

| State | Result |
|-------|--------|
| Name selected | `ToggleGroup` / Name / Repo / Input all measured at **height 36px** |
| Gap between Name and Repo | **0px** (`nameBtn.right === repoBtn.left === 352.42`) |
| Repo selected | Active state flips, placeholder switches to `Search by repository...`, layout stays joined |

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` 928/928 passed
- [x] `playwright-cli` attached via CDP — DOM rect check confirms equal heights and zero-gap
- [x] Visual check: Installed tab, both Name-active and Repo-active states

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * 検索ボックスのアクセシビリティとスタイリングを改善しました。ユーザーインターフェースの使いやすさが向上しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->