### PR TITLE
feat(agents): hide unused agents from sidebar via settings

### DIFF
--- a/src/main/ipc/ipc-schemas.test.ts
+++ b/src/main/ipc/ipc-schemas.test.ts
@@ -152,4 +152,14 @@ describe('settings:set lockstep with SettingsSchema', () => {
         .success,
     ).toBe(false)
   })
+
+  it('rejects a hiddenAgentIds payload longer than AGENT_IDS', () => {
+    // Defense-in-depth payload cap — a misbehaving renderer cannot push
+    // an arbitrarily long list past the IPC boundary. Every legitimate
+    // entry beyond AGENT_IDS.length would have to be a duplicate anyway.
+    const oversized = Array.from({ length: 100 }, () => 'claude-code' as const)
+    expect(schema.safeParse([{ hiddenAgentIds: oversized }]).success).toBe(
+      false,
+    )
+  })
 })

--- a/src/main/ipc/ipc-schemas.test.ts
+++ b/src/main/ipc/ipc-schemas.test.ts
@@ -125,4 +125,31 @@ describe('settings:set lockstep with SettingsSchema', () => {
         .success,
     ).toBe(false)
   })
+
+  it('parsing a partial without hiddenAgentIds does NOT inject a default', () => {
+    // Regression for the wipe-on-every-write bug: when the IPC schema for
+    // `hiddenAgentIds` chained `.optional()` over the disk schema's
+    // `.default([])`, every settings:set call that omitted the key
+    // materialized `hiddenAgentIds: []` in the parsed output, which then
+    // clobbered the persisted value via `{ ...current, ...partial }` in
+    // saveSettings(). Pin this so the IPC schema can never re-inherit a
+    // default.
+    const parsed = schema.parse([{ defaultSkillTab: 'info' }]) as [object]
+    expect('hiddenAgentIds' in parsed[0]).toBe(false)
+  })
+
+  it('accepts an explicit hiddenAgentIds array on settings:set', () => {
+    expect(
+      schema.safeParse([{ hiddenAgentIds: ['claude-code'] }]).success,
+    ).toBe(true)
+  })
+
+  it('rejects an unknown id in hiddenAgentIds at the IPC boundary', () => {
+    // The renderer should never emit a non-AgentId. Disk reads are
+    // forgiving (drop stale ids); the IPC channel is strict.
+    expect(
+      schema.safeParse([{ hiddenAgentIds: ['definitely-not-an-agent'] }])
+        .success,
+    ).toBe(false)
+  })
 })

--- a/src/main/ipc/ipc-schemas.ts
+++ b/src/main/ipc/ipc-schemas.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-import { TERMINAL_APP_IDS } from '@/shared/constants'
+import { AGENT_IDS, TERMINAL_APP_IDS } from '@/shared/constants'
 import type { IpcInvokeChannel } from '@/shared/ipc-contract'
 import { SettingsSchema } from '@/shared/settings'
 
@@ -281,10 +281,16 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
         // the {min,int} constraints can never drift. `undefined` is how
         // the Settings UI clears the persisted size back to "use default".
         windowSize: SettingsSchema.shape.windowSize,
-        // Reuse `SettingsSchema.shape.hiddenAgentIds` so the `z.enum(AGENT_IDS)`
-        // constraint here cannot drift from the persisted-state validator.
-        // `.optional()` lets clients send a partial update (only this key).
-        hiddenAgentIds: SettingsSchema.shape.hiddenAgentIds.optional(),
+        // Strict z.enum here — renderers should only ever emit valid ids.
+        // Intentionally NOT chained off `SettingsSchema.shape.hiddenAgentIds`:
+        // that field carries a `.default([])` for forgiving disk reads, and
+        // wrapping it with `.optional()` materializes the default whenever
+        // the key is omitted from a partial update — which then clobbers
+        // the persisted hidden-agent set on every unrelated `settings:set`
+        // call. Independent declaration keeps the IPC and disk concerns
+        // separate; both still reference the same `AGENT_IDS` constant so
+        // the enum cannot drift.
+        hiddenAgentIds: z.array(z.enum(AGENT_IDS)).optional(),
       })
       .strict(),
   ]),

--- a/src/main/ipc/ipc-schemas.ts
+++ b/src/main/ipc/ipc-schemas.ts
@@ -281,6 +281,10 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
         // the {min,int} constraints can never drift. `undefined` is how
         // the Settings UI clears the persisted size back to "use default".
         windowSize: SettingsSchema.shape.windowSize,
+        // Reuse `SettingsSchema.shape.hiddenAgentIds` so the `z.enum(AGENT_IDS)`
+        // constraint here cannot drift from the persisted-state validator.
+        // `.optional()` lets clients send a partial update (only this key).
+        hiddenAgentIds: SettingsSchema.shape.hiddenAgentIds.optional(),
       })
       .strict(),
   ]),

--- a/src/main/ipc/ipc-schemas.ts
+++ b/src/main/ipc/ipc-schemas.ts
@@ -289,8 +289,14 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
         // the persisted hidden-agent set on every unrelated `settings:set`
         // call. Independent declaration keeps the IPC and disk concerns
         // separate; both still reference the same `AGENT_IDS` constant so
-        // the enum cannot drift.
-        hiddenAgentIds: z.array(z.enum(AGENT_IDS)).optional(),
+        // the enum cannot drift. `.max(AGENT_IDS.length)` caps payload size
+        // so a misbehaving renderer cannot send an arbitrarily long list
+        // (every entry past `AGENT_IDS.length` would have to be a duplicate
+        // anyway, since the enum constrains values).
+        hiddenAgentIds: z
+          .array(z.enum(AGENT_IDS))
+          .max(AGENT_IDS.length)
+          .optional(),
       })
       .strict(),
   ]),

--- a/src/main/services/settings.test.ts
+++ b/src/main/services/settings.test.ts
@@ -109,4 +109,43 @@ describe('areSettingsEqual', () => {
       true,
     )
   })
+
+  it('returns true for hiddenAgentIds with identical contents in identical order', () => {
+    expect(
+      areSettingsEqual(
+        { ...baseSettings, hiddenAgentIds: ['claude-code', 'cursor'] },
+        { ...baseSettings, hiddenAgentIds: ['claude-code', 'cursor'] },
+      ),
+    ).toBe(true)
+  })
+
+  it('returns true for hiddenAgentIds with identical contents in different order (set semantics)', () => {
+    // Renderer treats hiddenAgentIds as a set; equality must match that
+    // semantic so an order-only drift between disk and renderer doesn't
+    // trigger a redundant atomic write + settings:changed broadcast.
+    expect(
+      areSettingsEqual(
+        { ...baseSettings, hiddenAgentIds: ['claude-code', 'cursor'] },
+        { ...baseSettings, hiddenAgentIds: ['cursor', 'claude-code'] },
+      ),
+    ).toBe(true)
+  })
+
+  it('returns false when hiddenAgentIds length differs', () => {
+    expect(
+      areSettingsEqual(
+        { ...baseSettings, hiddenAgentIds: ['claude-code'] },
+        { ...baseSettings, hiddenAgentIds: ['claude-code', 'cursor'] },
+      ),
+    ).toBe(false)
+  })
+
+  it('returns false when hiddenAgentIds have same length but different members', () => {
+    expect(
+      areSettingsEqual(
+        { ...baseSettings, hiddenAgentIds: ['claude-code'] },
+        { ...baseSettings, hiddenAgentIds: ['cursor'] },
+      ),
+    ).toBe(false)
+  })
 })

--- a/src/main/services/settings.test.ts
+++ b/src/main/services/settings.test.ts
@@ -16,6 +16,7 @@ describe('areSettingsEqual', () => {
   const baseSettings: Settings = {
     defaultSkillTab: 'files',
     preferredTerminal: 'terminal',
+    hiddenAgentIds: [],
   }
 
   it('returns true for identical primitive-only settings', () => {

--- a/src/main/services/settings.ts
+++ b/src/main/services/settings.ts
@@ -107,17 +107,18 @@ export function areSettingsEqual(a: Settings, b: Settings): boolean {
       continue
     }
     if (key === 'hiddenAgentIds') {
-      // Array — Zod's `.parse()` returns a fresh reference every call, so
-      // a `!==` would always say "changed" even when the contents match.
-      // Order is significant only as it appears in settings.json; the
-      // renderer treats the array as a set, so we treat the same set with
-      // a different order as not-equal here (caller writes once, that's
-      // fine). Length-then-pairwise is enough for the small N (~44 max).
+      // Renderer treats the array as a set — so does the equality check.
+      // Without a set comparison, an order-only drift between disk and
+      // renderer (e.g. JSON load order ≠ optimistic-update order) would
+      // trigger a redundant disk write + `settings:changed` broadcast on
+      // every settings:set roundtrip. Length-then-membership is enough
+      // for the small N (~44 max).
       const ah = a.hiddenAgentIds
       const bh = b.hiddenAgentIds
       if (ah.length !== bh.length) return false
-      for (let i = 0; i < ah.length; i++) {
-        if (ah[i] !== bh[i]) return false
+      const bSet = new Set<string>(bh)
+      for (const id of ah) {
+        if (!bSet.has(id)) return false
       }
       continue
     }

--- a/src/main/services/settings.ts
+++ b/src/main/services/settings.ts
@@ -106,6 +106,21 @@ export function areSettingsEqual(a: Settings, b: Settings): boolean {
       if (aw.width !== bw.width || aw.height !== bw.height) return false
       continue
     }
+    if (key === 'hiddenAgentIds') {
+      // Array — Zod's `.parse()` returns a fresh reference every call, so
+      // a `!==` would always say "changed" even when the contents match.
+      // Order is significant only as it appears in settings.json; the
+      // renderer treats the array as a set, so we treat the same set with
+      // a different order as not-equal here (caller writes once, that's
+      // fine). Length-then-pairwise is enough for the small N (~44 max).
+      const ah = a.hiddenAgentIds
+      const bh = b.hiddenAgentIds
+      if (ah.length !== bh.length) return false
+      for (let i = 0; i < ah.length; i++) {
+        if (ah[i] !== bh[i]) return false
+      }
+      continue
+    }
     if (a[key] !== b[key]) return false
   }
   return true

--- a/src/renderer/settings/SettingsApp.tsx
+++ b/src/renderer/settings/SettingsApp.tsx
@@ -4,6 +4,7 @@ import {
   Palette,
   RefreshCw,
   SlidersHorizontal,
+  Users,
 } from 'lucide-react'
 import React, { useState } from 'react'
 import { match } from 'ts-pattern'
@@ -13,6 +14,7 @@ import { useSettingsSync } from '@/renderer/src/hooks/useSettingsSync'
 import { cn } from '@/renderer/src/lib/utils'
 
 import { About } from './sections/About'
+import { Agents } from './sections/Agents'
 import { Appearance } from './sections/Appearance'
 import { AutoUpdates } from './sections/AutoUpdates'
 import { General } from './sections/General'
@@ -31,6 +33,7 @@ import { Keybindings } from './sections/Keybindings'
 const NAV_ITEMS = [
   { id: 'general', label: 'General', icon: SlidersHorizontal },
   { id: 'appearance', label: 'Appearance', icon: Palette },
+  { id: 'agents', label: 'Agents', icon: Users },
   { id: 'autoUpdates', label: 'Auto Updates', icon: RefreshCw },
   { id: 'keybindings', label: 'Keybindings', icon: Keyboard },
   { id: 'about', label: 'About', icon: Info },
@@ -97,6 +100,7 @@ export const SettingsApp = React.memo(
             {match(activeSection)
               .with('general', () => <General />)
               .with('appearance', () => <Appearance />)
+              .with('agents', () => <Agents />)
               .with('autoUpdates', () => <AutoUpdates />)
               .with('keybindings', () => <Keybindings />)
               .with('about', () => <About />)

--- a/src/renderer/settings/sections/Agents.browser.test.tsx
+++ b/src/renderer/settings/sections/Agents.browser.test.tsx
@@ -1,0 +1,165 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
+import { DEFAULT_SETTINGS } from '@/shared/settings'
+import type { Agent, AgentId } from '@/shared/types'
+
+const mockSettingsSet = vi.fn()
+const mockAgentsGetAll = vi.fn()
+
+/**
+ * Two-agent fixture is enough to exercise the toggle/show-all paths without
+ * dragging the full 44-agent matrix into the DOM each test.
+ */
+const FIXTURE_AGENTS: Agent[] = [
+  {
+    id: 'claude-code',
+    name: 'Claude Code',
+    path: '/Users/test/.claude/skills',
+    exists: true,
+    skillCount: 3,
+    localSkillCount: 0,
+  },
+  {
+    id: 'cursor',
+    name: 'Cursor',
+    path: '/Users/test/.cursor/skills',
+    exists: true,
+    skillCount: 1,
+    localSkillCount: 0,
+  },
+]
+
+beforeEach(() => {
+  mockSettingsSet.mockReset()
+  mockSettingsSet.mockResolvedValue(undefined)
+  mockAgentsGetAll.mockReset()
+  mockAgentsGetAll.mockResolvedValue(FIXTURE_AGENTS)
+  // Browser mode replaces the preload context bridge — install a fake so the
+  // optimistic-then-IPC pair in `useUpdateSettings` doesn't crash on
+  // `window.electron.settings.set`.
+  vi.stubGlobal('electron', {
+    settings: {
+      set: mockSettingsSet,
+      // No `get` / `subscribe` needed — Agents.tsx never calls them; the
+      // store seed already represents what `useSettingsSync` would deliver.
+    },
+    agents: {
+      getAll: mockAgentsGetAll,
+    },
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+/**
+ * Build a minimal Redux store with the slices Agents.tsx reads.
+ * Seeds `agents.items` directly so the section renders immediately
+ * without waiting on the mount-time fetch effect.
+ * @param hiddenAgentIds - initial hidden ids (defaults to `[]`)
+ */
+async function createStore(hiddenAgentIds: AgentId[] = []) {
+  const { default: settingsReducer } =
+    await import('@/renderer/src/redux/slices/settingsSlice')
+  const { default: agentsReducer } =
+    await import('@/renderer/src/redux/slices/agentsSlice')
+  return configureStore({
+    reducer: {
+      settings: settingsReducer,
+      agents: agentsReducer,
+    },
+    preloadedState: {
+      settings: { ...DEFAULT_SETTINGS, hiddenAgentIds },
+      agents: {
+        items: FIXTURE_AGENTS,
+        loading: false,
+        error: null,
+        agentToDelete: null,
+        deleting: false,
+      },
+    },
+  })
+}
+
+async function renderAgents(hiddenAgentIds: AgentId[] = []) {
+  const store = await createStore(hiddenAgentIds)
+  const { Agents } = await import('./Agents')
+  const screen = await render(
+    <Provider store={store}>
+      <TooltipProvider>
+        <Agents />
+      </TooltipProvider>
+    </Provider>,
+  )
+  return { screen, store }
+}
+
+/**
+ * Browser-mode regression: the Agents settings pane is the user-facing knob
+ * for `hiddenAgentIds`. These tests pin the contract main → renderer relies
+ * on:
+ *  - unchecking a row appends that agent id to `hiddenAgentIds`
+ *  - re-checking it removes the id again
+ *  - "Show all" clears the array entirely
+ *  - "Show all" is disabled when nothing is hidden
+ */
+describe('Settings → Agents', () => {
+  it('unchecking an installed agent appends its id to hiddenAgentIds', async () => {
+    const { screen } = await renderAgents([])
+
+    const claudeCheckbox = screen.getByRole('checkbox', {
+      name: /Show Claude Code in sidebar/i,
+    })
+    await claudeCheckbox.click()
+
+    expect(mockSettingsSet).toHaveBeenCalledTimes(1)
+    expect(mockSettingsSet).toHaveBeenCalledWith({
+      hiddenAgentIds: ['claude-code'],
+    })
+  })
+
+  it('re-checking a hidden agent removes its id from hiddenAgentIds', async () => {
+    const { screen } = await renderAgents(['claude-code'])
+
+    const claudeCheckbox = screen.getByRole('checkbox', {
+      name: /Show Claude Code in sidebar/i,
+    })
+    await claudeCheckbox.click()
+
+    expect(mockSettingsSet).toHaveBeenCalledWith({
+      hiddenAgentIds: [],
+    })
+  })
+
+  it('"Show all" clears every hidden agent', async () => {
+    const { screen } = await renderAgents(['claude-code', 'cursor'])
+
+    const showAllButton = screen.getByRole('button', { name: /Show all/i })
+    await showAllButton.click()
+
+    expect(mockSettingsSet).toHaveBeenCalledWith({
+      hiddenAgentIds: [],
+    })
+  })
+
+  it('"Show all" is disabled when nothing is hidden', async () => {
+    const { screen } = await renderAgents([])
+
+    const showAllButton = screen.getByRole('button', { name: /Show all/i })
+    await expect.element(showAllButton).toBeDisabled()
+  })
+
+  it('renders the "X visible · Y hidden" counter', async () => {
+    const { screen } = await renderAgents(['cursor'])
+
+    // 2 installed, 1 hidden → 1 visible · 1 hidden
+    await expect
+      .element(screen.getByText(/1 visible · 1 hidden/i))
+      .toBeInTheDocument()
+  })
+})

--- a/src/renderer/settings/sections/Agents.browser.test.tsx
+++ b/src/renderer/settings/sections/Agents.browser.test.tsx
@@ -62,8 +62,14 @@ afterEach(() => {
  * Seeds `agents.items` directly so the section renders immediately
  * without waiting on the mount-time fetch effect.
  * @param hiddenAgentIds - initial hidden ids (defaults to `[]`)
+ * @param items - agent items to seed (defaults to FIXTURE_AGENTS)
+ * @param loading - agents.loading flag (defaults to false)
  */
-async function createStore(hiddenAgentIds: AgentId[] = []) {
+async function createStore(
+  hiddenAgentIds: AgentId[] = [],
+  items: Agent[] = FIXTURE_AGENTS,
+  loading = false,
+) {
   const { default: settingsReducer } =
     await import('@/renderer/src/redux/slices/settingsSlice')
   const { default: agentsReducer } =
@@ -76,8 +82,8 @@ async function createStore(hiddenAgentIds: AgentId[] = []) {
     preloadedState: {
       settings: { ...DEFAULT_SETTINGS, hiddenAgentIds },
       agents: {
-        items: FIXTURE_AGENTS,
-        loading: false,
+        items,
+        loading,
         error: null,
         agentToDelete: null,
         deleting: false,
@@ -86,8 +92,12 @@ async function createStore(hiddenAgentIds: AgentId[] = []) {
   })
 }
 
-async function renderAgents(hiddenAgentIds: AgentId[] = []) {
-  const store = await createStore(hiddenAgentIds)
+async function renderAgents(
+  hiddenAgentIds: AgentId[] = [],
+  items: Agent[] = FIXTURE_AGENTS,
+  loading = false,
+) {
+  const store = await createStore(hiddenAgentIds, items, loading)
   const { Agents } = await import('./Agents')
   const screen = await render(
     <Provider store={store}>
@@ -161,5 +171,76 @@ describe('Settings → Agents', () => {
     await expect
       .element(screen.getByText(/1 visible · 1 hidden/i))
       .toBeInTheDocument()
+  })
+
+  it('shows the loading placeholder while agents.loading is true and the list is empty', async () => {
+    // Settings can open before the main window has finished its first
+    // scan. Without the loading placeholder users see "No agents
+    // detected" mid-scan and panic that nothing's installed.
+    //
+    // The component re-fires fetchAgents on mount when items is empty.
+    // Force the in-flight Promise to never resolve so the seeded
+    // `loading: true` flag survives long enough for the assertion.
+    mockAgentsGetAll.mockReturnValueOnce(new Promise(() => {}))
+    const { screen } = await renderAgents([], [], true)
+    await expect
+      .element(screen.getByText(/Loading agents/i))
+      .toBeInTheDocument()
+  })
+
+  it('shows the empty-installed message when no agents are detected', async () => {
+    // Distinct copy from the loading state — once the scan finishes and
+    // genuinely finds nothing, the user gets a fresh-machine hint.
+    //
+    // Override the default fixture: the empty preloaded state triggers
+    // an on-mount fetchAgents() that would otherwise resolve to
+    // FIXTURE_AGENTS and replace the empty list.
+    mockAgentsGetAll.mockResolvedValueOnce([])
+    const { screen } = await renderAgents([], [], false)
+    await expect
+      .element(screen.getByText(/No agents detected on this machine/i))
+      .toBeInTheDocument()
+  })
+
+  it('renders a disabled disclosure for not-installed agents', async () => {
+    // The "N not installed" details/summary is the only place the user
+    // sees uninstalled agents in this pane. Ensure it shows up with the
+    // count and a disabled checkbox so a future refactor cannot
+    // accidentally make these toggleable.
+    const NOT_INSTALLED_AGENT: Agent = {
+      id: 'codex' as AgentId,
+      name: 'Codex',
+      path: '/Users/test/.codex/skills',
+      exists: false,
+      skillCount: 0,
+      localSkillCount: 0,
+    }
+    const { screen } = await renderAgents(
+      [],
+      [...FIXTURE_AGENTS, NOT_INSTALLED_AGENT],
+    )
+    // Summary always renders even when <details> is collapsed.
+    await expect
+      .element(screen.getByText(/1 not installed/i))
+      .toBeInTheDocument()
+    // Expand the disclosure so the disabled checkbox inside is visible
+    // to the role query — collapsed <details> hides children from the
+    // accessibility tree.
+    const summary = screen.getByText(/1 not installed/i)
+    await summary.click()
+    const disabledCheckbox = screen.getByRole('checkbox', {
+      name: /Codex \(not installed\)/i,
+    })
+    await expect.element(disabledCheckbox).toBeDisabled()
+  })
+
+  it('renders a "Hidden" tag inside the row of a hidden agent', async () => {
+    // Visual cue inside the row tells the user at a glance which agents
+    // are currently hidden — without it the only signal is the unchecked
+    // checkbox, easy to miss while scanning a long list.
+    const { screen } = await renderAgents(['claude-code'])
+    // The "Hidden" label is rendered inside the label wrapping the
+    // claude-code row. There is exactly one match in this fixture.
+    await expect.element(screen.getByText(/^Hidden$/)).toBeInTheDocument()
   })
 })

--- a/src/renderer/settings/sections/Agents.tsx
+++ b/src/renderer/settings/sections/Agents.tsx
@@ -44,6 +44,17 @@ export const Agents = React.memo(function Agents(): React.ReactElement {
   const updateSettings = useUpdateSettings()
 
   useEffect(() => {
+    // Deliberately keyed on `agents.length` only (NOT `loading`). The
+    // length value transitions 0 → N exactly once per mount lifecycle,
+    // so the effect dispatches once and never re-fires within a mount.
+    // Adding `!loading` + `loading` to deps was tried and reverted: it
+    // creates a re-fetch loop when the scan resolves to `[]` (length
+    // stays 0, loading flips true → false, deps change, effect runs
+    // again, dispatches, and so on). The cross-window "duplicate IPC"
+    // concern that motivated the guard does not apply here either —
+    // each Electron renderer owns its own Redux store, so this
+    // window's `loading` flag carries no information about another
+    // window's in-flight scan.
     if (agents.length === 0) {
       dispatch(fetchAgents())
     }

--- a/src/renderer/settings/sections/Agents.tsx
+++ b/src/renderer/settings/sections/Agents.tsx
@@ -120,7 +120,7 @@ export const Agents = React.memo(function Agents(): React.ReactElement {
                 {notInstalled.length} not installed
               </summary>
               <ul
-                className="mt-2 flex flex-col gap-1 rounded-md border border-border bg-card/30 p-2 opacity-50"
+                className="mt-2 flex flex-col gap-1 rounded-md border border-border bg-card/30 p-2"
                 aria-label="Not-installed agents"
               >
                 {notInstalled.map((agent) => (

--- a/src/renderer/settings/sections/Agents.tsx
+++ b/src/renderer/settings/sections/Agents.tsx
@@ -1,0 +1,193 @@
+import { Eye, EyeOff } from 'lucide-react'
+import React, { useEffect } from 'react'
+
+import { Button } from '@/renderer/src/components/ui/button'
+import { Checkbox } from '@/renderer/src/components/ui/checkbox'
+import { useUpdateSettings } from '@/renderer/src/hooks/useUpdateSettings'
+import { cn, toggleArrayMember } from '@/renderer/src/lib/utils'
+import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
+import { fetchAgents } from '@/renderer/src/redux/slices/agentsSlice'
+import { selectHiddenAgentIds } from '@/renderer/src/redux/slices/settingsSlice'
+import type { Agent, AgentId } from '@/shared/types'
+
+import { SectionFrame } from './SectionFrame'
+
+/**
+ * Settings → Agents pane.
+ *
+ * Lets the user pick which installed agents are shown in the main
+ * sidebar. The persisted shape is `Settings.hiddenAgentIds` (the small
+ * common-case set), but the UI inverts to "Show in sidebar" — checked
+ * means visible — because that matches the mental model better than a
+ * double-negative "uncheck to hide".
+ *
+ * Important: this is a pure visibility toggle. The agent's skills
+ * folder, symlinks, and Marketplace presence are unaffected — the
+ * user can flip an agent back on at any time and the sidebar entry
+ * (with all its counts and right-click actions) reappears intact.
+ *
+ * Sync flow on every toggle:
+ *  1. `useUpdateSettings` does the optimistic local dispatch +
+ *     `settings:set` IPC.
+ *  2. Main writes `settings.json` atomically and broadcasts
+ *     `settings:changed` to every window — `useSettingsSync` in the
+ *     main window receives it and re-renders the sidebar.
+ *
+ * Settings can open before the main window has finished scanning, so
+ * we re-fire `fetchAgents` on mount when the slice is empty. Idempotent
+ * with the main window's mount-time fetch.
+ */
+export const Agents = React.memo(function Agents(): React.ReactElement {
+  const dispatch = useAppDispatch()
+  const { items: agents, loading } = useAppSelector((state) => state.agents)
+  const hiddenAgentIds = useAppSelector(selectHiddenAgentIds)
+  const updateSettings = useUpdateSettings()
+
+  useEffect(() => {
+    if (agents.length === 0) {
+      dispatch(fetchAgents())
+    }
+  }, [dispatch, agents.length])
+
+  const installed = agents.filter((a) => a.exists)
+  const notInstalled = agents.filter((a) => !a.exists)
+  const visibleCount = installed.filter(
+    (a) => !hiddenAgentIds.includes(a.id),
+  ).length
+  const hiddenCount = installed.length - visibleCount
+
+  const handleToggle = (agentId: AgentId): void => {
+    // Inversion: "Show in sidebar" checkbox flip ⇄ membership in
+    // hiddenAgentIds. We treat every click as a toggle relative to the
+    // latest known state instead of trusting the next-state from the
+    // checkbox event — the schema upstream already pins membership, so
+    // either side of the flip lands on the correct array.
+    updateSettings({
+      hiddenAgentIds: toggleArrayMember(hiddenAgentIds, agentId),
+    })
+  }
+
+  const handleShowAll = (): void => {
+    updateSettings({ hiddenAgentIds: [] })
+  }
+
+  return (
+    <SectionFrame
+      title="Agents"
+      description="Choose which agents appear in the main window sidebar. Hiding an agent here doesn't uninstall it — skills and symlinks are unaffected."
+    >
+      {loading && installed.length === 0 ? (
+        <p className="text-sm text-muted-foreground">Loading agents…</p>
+      ) : installed.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No agents detected on this machine yet.
+        </p>
+      ) : (
+        <>
+          <div className="flex items-center justify-between" aria-live="polite">
+            <p className="text-xs text-muted-foreground tabular-nums">
+              {visibleCount} visible · {hiddenCount} hidden
+            </p>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={handleShowAll}
+              disabled={hiddenCount === 0}
+            >
+              <Eye className="h-3.5 w-3.5 mr-1.5" />
+              Show all
+            </Button>
+          </div>
+
+          <ul
+            className="flex flex-col gap-1 rounded-md border border-border bg-card/30 p-2"
+            aria-label="Installed agents"
+          >
+            {installed.map((agent) => (
+              <AgentToggleRow
+                key={agent.id}
+                agent={agent}
+                isVisible={!hiddenAgentIds.includes(agent.id)}
+                onToggle={handleToggle}
+              />
+            ))}
+          </ul>
+
+          {notInstalled.length > 0 && (
+            <details className="mt-1">
+              <summary className="text-xs text-muted-foreground cursor-pointer hover:text-foreground select-none">
+                {notInstalled.length} not installed
+              </summary>
+              <ul
+                className="mt-2 flex flex-col gap-1 rounded-md border border-border bg-card/30 p-2 opacity-50"
+                aria-label="Not-installed agents"
+              >
+                {notInstalled.map((agent) => (
+                  <li
+                    key={agent.id}
+                    className="flex items-center gap-3 px-2 py-1.5"
+                  >
+                    {/* Disabled — there's nothing for the user to hide */}
+                    {/* when the agent isn't installed in the first place. */}
+                    <Checkbox
+                      checked={false}
+                      disabled
+                      aria-label={`${agent.name} (not installed)`}
+                    />
+                    <span className="text-sm text-muted-foreground">
+                      {agent.name}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </details>
+          )}
+        </>
+      )}
+    </SectionFrame>
+  )
+})
+
+interface AgentToggleRowProps {
+  agent: Agent
+  isVisible: boolean
+  onToggle: (agentId: AgentId) => void
+}
+
+const AgentToggleRow = React.memo(function AgentToggleRow({
+  agent,
+  isVisible,
+  onToggle,
+}: AgentToggleRowProps): React.ReactElement {
+  const checkboxId = `agent-visibility-${agent.id}`
+  return (
+    <li className="flex items-center gap-3 px-2 py-1.5 rounded hover:bg-muted/30">
+      <Checkbox
+        id={checkboxId}
+        checked={isVisible}
+        onCheckedChange={(next) => {
+          // Radix passes `boolean | "indeterminate"`. Ignore the indeterminate
+          // case — we never set it, but treating it like a flip would dispatch
+          // a phantom hide/show.
+          if (typeof next === 'boolean') onToggle(agent.id)
+        }}
+        aria-label={`Show ${agent.name} in sidebar`}
+      />
+      <label
+        htmlFor={checkboxId}
+        className="flex-1 flex items-center justify-between cursor-pointer text-sm"
+      >
+        <span className={cn(!isVisible && 'text-muted-foreground')}>
+          {agent.name}
+        </span>
+        {!isVisible && (
+          <span className="flex items-center gap-1 text-xs text-muted-foreground">
+            <EyeOff className="h-3 w-3" />
+            Hidden
+          </span>
+        )}
+      </label>
+    </li>
+  )
+})

--- a/src/renderer/src/components/sidebar/AgentItem.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/AgentItem.browser.test.tsx
@@ -98,7 +98,7 @@ describe('Sidebar → AgentItem context menu', () => {
     const trigger = screen.getByRole('button', {
       name: /Filter skills by Claude Code/i,
     })
-    const triggerElement = await trigger.element()
+    const triggerElement = trigger.element()
     triggerElement.dispatchEvent(
       new MouseEvent('contextmenu', { bubbles: true, cancelable: true }),
     )
@@ -115,7 +115,7 @@ describe('Sidebar → AgentItem context menu', () => {
     const trigger = screen.getByRole('button', {
       name: /Filter skills by Claude Code/i,
     })
-    const triggerElement = await trigger.element()
+    const triggerElement = trigger.element()
     triggerElement.dispatchEvent(
       new MouseEvent('contextmenu', { bubbles: true, cancelable: true }),
     )
@@ -132,7 +132,7 @@ describe('Sidebar → AgentItem context menu', () => {
     const trigger = screen.getByRole('button', {
       name: /Filter skills by Claude Code/i,
     })
-    const triggerElement = await trigger.element()
+    const triggerElement = trigger.element()
     triggerElement.dispatchEvent(
       new MouseEvent('contextmenu', { bubbles: true, cancelable: true }),
     )
@@ -149,7 +149,7 @@ describe('Sidebar → AgentItem context menu', () => {
     const trigger = screen.getByRole('button', {
       name: /Filter skills by Claude Code/i,
     })
-    const triggerElement = await trigger.element()
+    const triggerElement = trigger.element()
     triggerElement.dispatchEvent(
       new MouseEvent('contextmenu', { bubbles: true, cancelable: true }),
     )

--- a/src/renderer/src/components/sidebar/AgentItem.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/AgentItem.browser.test.tsx
@@ -1,0 +1,162 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
+import { DEFAULT_SETTINGS } from '@/shared/settings'
+import type { Agent, AgentId } from '@/shared/types'
+
+const mockSettingsSet = vi.fn()
+const mockRevealInFinder = vi.fn()
+const mockOpenInTerminal = vi.fn()
+
+const FIXTURE_AGENT: Agent = {
+  id: 'claude-code',
+  name: 'Claude Code',
+  path: '/Users/test/.claude/skills',
+  exists: true,
+  skillCount: 3,
+  localSkillCount: 0,
+}
+
+beforeEach(() => {
+  mockSettingsSet.mockReset()
+  mockSettingsSet.mockResolvedValue(undefined)
+  mockRevealInFinder.mockReset()
+  mockRevealInFinder.mockResolvedValue({ ok: true })
+  mockOpenInTerminal.mockReset()
+  mockOpenInTerminal.mockResolvedValue({ ok: true })
+  // Browser mode replaces the preload context bridge — install fakes for
+  // every window.electron.* surface AgentItem can reach.
+  vi.stubGlobal('electron', {
+    settings: { set: mockSettingsSet },
+    folder: {
+      revealInFinder: mockRevealInFinder,
+      openInTerminal: mockOpenInTerminal,
+    },
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+/**
+ * Build a store with the slices AgentItem subscribes to. `ui` is needed
+ * because `selectedAgentId` drives the selected-styling branch, and
+ * `agents` is needed for `setAgentToDelete`/cleanup target dispatchers.
+ */
+async function createStore(hiddenAgentIds: AgentId[] = []) {
+  const { default: settingsReducer } =
+    await import('@/renderer/src/redux/slices/settingsSlice')
+  const { default: uiReducer } =
+    await import('@/renderer/src/redux/slices/uiSlice')
+  const { default: agentsReducer } =
+    await import('@/renderer/src/redux/slices/agentsSlice')
+  return configureStore({
+    reducer: {
+      settings: settingsReducer,
+      ui: uiReducer,
+      agents: agentsReducer,
+    },
+    preloadedState: {
+      settings: { ...DEFAULT_SETTINGS, hiddenAgentIds },
+    },
+  })
+}
+
+async function renderItem(hiddenAgentIds: AgentId[] = []) {
+  const store = await createStore(hiddenAgentIds)
+  const { AgentItem } = await import('./AgentItem')
+  const screen = await render(
+    <Provider store={store}>
+      <TooltipProvider>
+        <AgentItem agent={FIXTURE_AGENT} />
+      </TooltipProvider>
+    </Provider>,
+  )
+  return { screen, store }
+}
+
+/**
+ * Browser-mode regression: AgentItem gained a "Hide from sidebar" /
+ * "Show in sidebar" menu item on this branch. These tests pin:
+ *  - the right-click menu item opens with the correct label depending
+ *    on whether the agent is currently hidden
+ *  - selecting that item dispatches `settings:set` with the toggled
+ *    hiddenAgentIds array
+ *
+ * Radix's DropdownMenu portals the content outside the trigger's DOM
+ * subtree, so we drive interaction via `contextmenu` on the trigger
+ * button (mirrors the production right-click flow).
+ */
+describe('Sidebar → AgentItem context menu', () => {
+  it('shows "Hide from sidebar" when the agent is currently visible', async () => {
+    const { screen } = await renderItem([])
+    // Open the dropdown via right-click on the agent row trigger.
+    const trigger = screen.getByRole('button', {
+      name: /Filter skills by Claude Code/i,
+    })
+    const triggerElement = await trigger.element()
+    triggerElement.dispatchEvent(
+      new MouseEvent('contextmenu', { bubbles: true, cancelable: true }),
+    )
+    await expect
+      .element(screen.getByText(/^Hide from sidebar$/))
+      .toBeInTheDocument()
+  })
+
+  it('shows "Show in sidebar" when the agent is currently hidden', async () => {
+    // Hidden state flips the menu copy — without this branch users would
+    // see "Hide from sidebar" on an already-hidden item with no obvious
+    // way to restore it from the sidebar context menu.
+    const { screen } = await renderItem(['claude-code'])
+    const trigger = screen.getByRole('button', {
+      name: /Filter skills by Claude Code/i,
+    })
+    const triggerElement = await trigger.element()
+    triggerElement.dispatchEvent(
+      new MouseEvent('contextmenu', { bubbles: true, cancelable: true }),
+    )
+    await expect
+      .element(screen.getByText(/^Show in sidebar$/))
+      .toBeInTheDocument()
+  })
+
+  it('selecting "Hide from sidebar" dispatches settings:set with the agent appended', async () => {
+    // The whole point of the menu item — clicking it must reach the IPC
+    // boundary with the toggled array. Without this assertion the menu
+    // could silently no-op and only Settings → Agents would work.
+    const { screen } = await renderItem([])
+    const trigger = screen.getByRole('button', {
+      name: /Filter skills by Claude Code/i,
+    })
+    const triggerElement = await trigger.element()
+    triggerElement.dispatchEvent(
+      new MouseEvent('contextmenu', { bubbles: true, cancelable: true }),
+    )
+    const hideItem = screen.getByText(/^Hide from sidebar$/)
+    await hideItem.click()
+    expect(mockSettingsSet).toHaveBeenCalledWith({
+      hiddenAgentIds: ['claude-code'],
+    })
+  })
+
+  it('selecting "Show in sidebar" dispatches settings:set with the agent removed', async () => {
+    // Inverse path — toggling an already-hidden agent must remove it.
+    const { screen } = await renderItem(['claude-code'])
+    const trigger = screen.getByRole('button', {
+      name: /Filter skills by Claude Code/i,
+    })
+    const triggerElement = await trigger.element()
+    triggerElement.dispatchEvent(
+      new MouseEvent('contextmenu', { bubbles: true, cancelable: true }),
+    )
+    const showItem = screen.getByText(/^Show in sidebar$/)
+    await showItem.click()
+    expect(mockSettingsSet).toHaveBeenCalledWith({
+      hiddenAgentIds: [],
+    })
+  })
+})

--- a/src/renderer/src/components/sidebar/AgentItem.tsx
+++ b/src/renderer/src/components/sidebar/AgentItem.tsx
@@ -1,4 +1,4 @@
-import { Eraser, FolderOpen, Terminal, Trash2 } from 'lucide-react'
+import { Eraser, EyeOff, FolderOpen, Terminal, Trash2 } from 'lucide-react'
 import React, { useMemo, useState } from 'react'
 
 import {
@@ -14,9 +14,11 @@ import {
   TooltipTrigger,
 } from '@/renderer/src/components/ui/tooltip'
 import { useOpenFolder } from '@/renderer/src/hooks/useOpenFolder'
-import { cn } from '@/renderer/src/lib/utils'
+import { useUpdateSettings } from '@/renderer/src/hooks/useUpdateSettings'
+import { cn, toggleArrayMember } from '@/renderer/src/lib/utils'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import { setAgentToDelete } from '@/renderer/src/redux/slices/agentsSlice'
+import { selectHiddenAgentIds } from '@/renderer/src/redux/slices/settingsSlice'
 import {
   selectAgent,
   setCleanupAgentTarget,
@@ -78,9 +80,12 @@ export const AgentItem = React.memo(function AgentItem({
 }: AgentItemProps): React.ReactElement {
   const dispatch = useAppDispatch()
   const { selectedAgentId } = useAppSelector((state) => state.ui)
+  const hiddenAgentIds = useAppSelector(selectHiddenAgentIds)
   const isSelected = selectedAgentId === agent.id
+  const isHidden = hiddenAgentIds.includes(agent.id)
   const [contextOpen, setContextOpen] = useState(false)
   const { revealInFinder, openInTerminal } = useOpenFolder()
+  const updateSettings = useUpdateSettings()
 
   const handleClick = (): void => {
     if (!agent.exists) return
@@ -111,6 +116,16 @@ export const AgentItem = React.memo(function AgentItem({
     // `fetchSyncPreview({ agentId })` once it mounts, so we don't need
     // to chain it here — keeps the menu handler synchronous.
     dispatch(setCleanupAgentTarget(agent.id))
+    setContextOpen(false)
+  }
+
+  const handleToggleHidden = (): void => {
+    // Pure visibility toggle — skills, symlinks, and marketplace presence
+    // are untouched. Matching unhide affordances live in Settings → Agents
+    // and inside the "N hidden" sidebar disclosure.
+    updateSettings({
+      hiddenAgentIds: toggleArrayMember(hiddenAgentIds, agent.id),
+    })
     setContextOpen(false)
   }
 
@@ -173,6 +188,11 @@ export const AgentItem = React.memo(function AgentItem({
           <DropdownMenuItem onSelect={handleOpenInTerminal}>
             <Terminal className="h-4 w-4 mr-2" />
             Open in Terminal
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={handleToggleHidden}>
+            <EyeOff className="h-4 w-4 mr-2" />
+            {isHidden ? 'Show in sidebar' : 'Hide from sidebar'}
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem onClick={handleCleanupMissing}>

--- a/src/renderer/src/components/sidebar/AgentsSection.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/AgentsSection.browser.test.tsx
@@ -1,0 +1,201 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
+import { DEFAULT_SETTINGS } from '@/shared/settings'
+import type { Agent, AgentId } from '@/shared/types'
+
+const mockSettingsSet = vi.fn()
+const mockAgentsGetAll = vi.fn()
+const mockRevealInFinder = vi.fn()
+const mockOpenInTerminal = vi.fn()
+
+/**
+ * Two-agent fixture covers the visible/hidden split paths without inflating
+ * the store with the full 44-agent matrix.
+ */
+const FIXTURE_AGENTS: Agent[] = [
+  {
+    id: 'claude-code',
+    name: 'Claude Code',
+    path: '/Users/test/.claude/skills',
+    exists: true,
+    skillCount: 3,
+    localSkillCount: 0,
+  },
+  {
+    id: 'cursor',
+    name: 'Cursor',
+    path: '/Users/test/.cursor/skills',
+    exists: true,
+    skillCount: 1,
+    localSkillCount: 0,
+  },
+]
+
+const NOT_INSTALLED_AGENT: Agent = {
+  id: 'codex' as AgentId,
+  name: 'Codex',
+  path: '/Users/test/.codex/skills',
+  exists: false,
+  skillCount: 0,
+  localSkillCount: 0,
+}
+
+beforeEach(() => {
+  mockSettingsSet.mockReset()
+  mockSettingsSet.mockResolvedValue(undefined)
+  mockAgentsGetAll.mockReset()
+  mockAgentsGetAll.mockResolvedValue(FIXTURE_AGENTS)
+  mockRevealInFinder.mockReset()
+  mockRevealInFinder.mockResolvedValue({ ok: true })
+  mockOpenInTerminal.mockReset()
+  mockOpenInTerminal.mockResolvedValue({ ok: true })
+  // Browser mode replaces the preload context bridge — install fakes for every
+  // window.electron.* surface AgentItem can reach (settings, folder, agents).
+  vi.stubGlobal('electron', {
+    settings: {
+      set: mockSettingsSet,
+    },
+    agents: {
+      getAll: mockAgentsGetAll,
+    },
+    folder: {
+      revealInFinder: mockRevealInFinder,
+      openInTerminal: mockOpenInTerminal,
+    },
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+/**
+ * Build a minimal Redux store with the slices AgentsSection / AgentItem read.
+ * Pre-seeds `agents.items` so the on-mount fetchAgents() doesn't race the
+ * assertions in the loading branch.
+ */
+async function createStore(
+  hiddenAgentIds: AgentId[] = [],
+  items: Agent[] = FIXTURE_AGENTS,
+  loading = false,
+) {
+  const { default: settingsReducer } =
+    await import('@/renderer/src/redux/slices/settingsSlice')
+  const { default: agentsReducer } =
+    await import('@/renderer/src/redux/slices/agentsSlice')
+  const { default: uiReducer } =
+    await import('@/renderer/src/redux/slices/uiSlice')
+  return configureStore({
+    reducer: {
+      settings: settingsReducer,
+      agents: agentsReducer,
+      ui: uiReducer,
+    },
+    preloadedState: {
+      settings: { ...DEFAULT_SETTINGS, hiddenAgentIds },
+      agents: {
+        items,
+        loading,
+        error: null,
+        agentToDelete: null,
+        deleting: false,
+      },
+    },
+  })
+}
+
+async function renderSection(
+  hiddenAgentIds: AgentId[] = [],
+  items: Agent[] = FIXTURE_AGENTS,
+  loading = false,
+) {
+  const store = await createStore(hiddenAgentIds, items, loading)
+  const { AgentsSection } = await import('./AgentsSection')
+  const screen = await render(
+    <Provider store={store}>
+      <TooltipProvider>
+        <AgentsSection />
+      </TooltipProvider>
+    </Provider>,
+  )
+  return { screen, store }
+}
+
+/**
+ * Browser-mode regression: AgentsSection is the sidebar surface for the
+ * hide-from-sidebar feature. These tests pin the four render branches that
+ * only exist on this branch:
+ *  - loading placeholder
+ *  - "All installed agents are hidden" empty-after-hide message
+ *  - the "N hidden" disclosure
+ *  - "(n)" header counter reflects ONLY visible agents
+ */
+describe('Sidebar → AgentsSection', () => {
+  it('shows the loading placeholder while agents.loading is true', async () => {
+    // Pre-seed the loading flag and force the on-mount fetchAgents() to never
+    // resolve so the placeholder survives the assertion window.
+    mockAgentsGetAll.mockReturnValueOnce(new Promise(() => {}))
+    const { screen } = await renderSection([], [], true)
+    await expect.element(screen.getByText(/Loading\.\.\./i)).toBeInTheDocument()
+  })
+
+  it('shows "No agents detected" when nothing is installed', async () => {
+    // totalInstalled === 0 branch — happens on a fresh machine where no agent
+    // directories exist yet.
+    mockAgentsGetAll.mockResolvedValueOnce([])
+    const { screen } = await renderSection([], [], false)
+    await expect
+      .element(screen.getByText(/No agents detected/i))
+      .toBeInTheDocument()
+  })
+
+  it('shows the all-hidden hint when every installed agent is hidden', async () => {
+    // Distinct fall-through: totalInstalled > 0 but visibleInstalled.length === 0.
+    // The user has installed agents but hidden every one; copy points back at
+    // Settings → Agents so they can recover without leaving the sidebar.
+    const allHidden: AgentId[] = ['claude-code', 'cursor']
+    const { screen } = await renderSection(allHidden)
+    await expect
+      .element(screen.getByText(/All installed agents are hidden/i))
+      .toBeInTheDocument()
+    await expect
+      .element(screen.getByText(/Open Settings . Agents to show some/i))
+      .toBeInTheDocument()
+  })
+
+  it('renders the "N hidden" disclosure when at least one agent is hidden', async () => {
+    // The disclosure exists ONLY when hiddenInstalled.length > 0 — the inverse
+    // case (no hidden agents → no disclosure) is implicitly covered by the
+    // visible-counter test below.
+    const { screen } = await renderSection(['cursor'])
+    await expect.element(screen.getByText(/^1 hidden$/)).toBeInTheDocument()
+  })
+
+  it('header counter reflects ONLY visible agents, not the total installed set', async () => {
+    // With one hidden of two installed, the "(n)" counter must show "(1)"
+    // rather than "(2)" — otherwise the user can't tell at a glance that a
+    // hide is in effect.
+    const { screen } = await renderSection(['cursor'])
+    await expect.element(screen.getByText(/^\(1\)$/)).toBeInTheDocument()
+  })
+
+  it('renders the "N not installed" disclosure alongside hidden when both exist', async () => {
+    // missingAgents.length > 0 path coexists with hiddenInstalled.length > 0;
+    // both disclosures must render. Pinning the dual case here guards against
+    // a future refactor that conflates the two lists.
+    //
+    // Override the fetchAgents resolution too — the on-mount effect would
+    // otherwise resolve with FIXTURE_AGENTS and drop the NOT_INSTALLED seed.
+    const itemsWithMissing = [...FIXTURE_AGENTS, NOT_INSTALLED_AGENT]
+    mockAgentsGetAll.mockResolvedValueOnce(itemsWithMissing)
+    const { screen } = await renderSection(['cursor'], itemsWithMissing)
+    await expect.element(screen.getByText(/^1 hidden$/)).toBeInTheDocument()
+    await expect
+      .element(screen.getByText(/^1 not installed$/))
+      .toBeInTheDocument()
+  })
+})

--- a/src/renderer/src/components/sidebar/AgentsSection.tsx
+++ b/src/renderer/src/components/sidebar/AgentsSection.tsx
@@ -90,7 +90,7 @@ export const AgentsSection = React.memo(
             <summary className="text-xs text-muted-foreground cursor-pointer hover:text-foreground">
               {hiddenInstalled.length} hidden
             </summary>
-            <div className="mt-2 space-y-1 opacity-50">
+            <div className="mt-2 space-y-1">
               {hiddenInstalled.map((agent) => (
                 <AgentItem key={agent.id} agent={agent} />
               ))}

--- a/src/renderer/src/components/sidebar/AgentsSection.tsx
+++ b/src/renderer/src/components/sidebar/AgentsSection.tsx
@@ -2,23 +2,43 @@ import React, { useEffect } from 'react'
 
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import { fetchAgents } from '@/renderer/src/redux/slices/agentsSlice'
+import { selectHiddenAgentIds } from '@/renderer/src/redux/slices/settingsSlice'
 
 import { AgentItem } from './AgentItem'
 
 /**
- * Agents section showing list of detected AI agents
+ * Sidebar section listing detected AI agents.
+ *
+ * Three-way partition over `agents`:
+ * - **visibleInstalled** — installed *and* not hidden via settings. Primary list.
+ * - **hiddenInstalled** — installed but the user has chosen to hide them
+ *   from the sidebar. Rendered inside a `<details>` disclosure so the user
+ *   can expand to see / restore them without leaving the sidebar.
+ * - **missingAgents** — not installed on this machine. Rendered inside
+ *   the existing "N not installed" disclosure (greyed out).
+ *
+ * The stale-selection invariant (clear `selectedAgentId` when its agent
+ * gets hidden) lives in `redux/listener.ts` so it fires regardless of
+ * whether this component is mounted.
  */
 export const AgentsSection = React.memo(
   function AgentsSection(): React.ReactElement {
     const dispatch = useAppDispatch()
     const { items: agents, loading } = useAppSelector((state) => state.agents)
+    const hiddenAgentIds = useAppSelector(selectHiddenAgentIds)
 
     useEffect(() => {
       dispatch(fetchAgents())
     }, [dispatch])
 
-    const existingAgents = agents.filter((a) => a.exists)
+    const visibleInstalled = agents.filter(
+      (a) => a.exists && !hiddenAgentIds.includes(a.id),
+    )
+    const hiddenInstalled = agents.filter(
+      (a) => a.exists && hiddenAgentIds.includes(a.id),
+    )
     const missingAgents = agents.filter((a) => !a.exists)
+    const totalInstalled = visibleInstalled.length + hiddenInstalled.length
 
     if (loading) {
       return (
@@ -40,20 +60,42 @@ export const AgentsSection = React.memo(
             Agents
           </span>
           <span className="text-xs text-muted-foreground">
-            ({existingAgents.length})
+            ({visibleInstalled.length})
           </span>
         </div>
 
-        {existingAgents.length === 0 ? (
+        {totalInstalled === 0 ? (
           <div className="text-xs text-muted-foreground py-2">
             No agents detected
           </div>
+        ) : visibleInstalled.length === 0 ? (
+          // Distinct from "No agents detected": the user has installed
+          // agents but hidden every one of them. Point them back at the
+          // place they can fix it.
+          <div className="text-xs text-muted-foreground py-2 leading-relaxed">
+            All installed agents are hidden.
+            <br />
+            Open Settings → Agents to show some.
+          </div>
         ) : (
           <div className="space-y-1">
-            {existingAgents.map((agent) => (
+            {visibleInstalled.map((agent) => (
               <AgentItem key={agent.id} agent={agent} />
             ))}
           </div>
+        )}
+
+        {hiddenInstalled.length > 0 && (
+          <details className="mt-4">
+            <summary className="text-xs text-muted-foreground cursor-pointer hover:text-foreground">
+              {hiddenInstalled.length} hidden
+            </summary>
+            <div className="mt-2 space-y-1 opacity-50">
+              {hiddenInstalled.map((agent) => (
+                <AgentItem key={agent.id} agent={agent} />
+              ))}
+            </div>
+          </details>
         )}
 
         {missingAgents.length > 0 && (

--- a/src/renderer/src/lib/utils.test.ts
+++ b/src/renderer/src/lib/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { formatInstallCount } from './utils'
+import { formatInstallCount, toggleArrayMember } from './utils'
 
 describe('formatInstallCount', () => {
   it('returns em dash when count is undefined', () => {
@@ -22,5 +22,53 @@ describe('formatInstallCount', () => {
 
   it('formats 1M boundary as M notation', () => {
     expect(formatInstallCount(1_000_000)).toBe('1.0M')
+  })
+})
+
+/**
+ * `toggleArrayMember` is the single primitive backing every
+ * hide-from-sidebar flow (right-click toggle, settings checkbox).
+ * The contract these tests pin:
+ *  - membership flip works in both directions
+ *  - the returned reference is always fresh so callers can dispatch
+ *    it straight into Redux without aliasing the previous state
+ *  - the input array is not mutated (defense against accidental
+ *    .push / .splice rewrites that would break `setSettings` referential
+ *    equality and the listener invariants downstream)
+ */
+describe('toggleArrayMember', () => {
+  it('appends a value when it is not already present', () => {
+    expect(toggleArrayMember(['a', 'b'], 'c')).toEqual(['a', 'b', 'c'])
+  })
+
+  it('removes a value when it is already present', () => {
+    expect(toggleArrayMember(['a', 'b'], 'a')).toEqual(['b'])
+  })
+
+  it('appends to an empty array', () => {
+    expect(toggleArrayMember<string>([], 'x')).toEqual(['x'])
+  })
+
+  it('returns an empty array when removing the only member', () => {
+    expect(toggleArrayMember(['x'], 'x')).toEqual([])
+  })
+
+  it('returns a new reference even when the result is structurally equal to the input', () => {
+    // Callers (e.g. updateSettings({ hiddenAgentIds: ... })) rely on
+    // a fresh reference for `setSettings` to be detected as a change
+    // by Redux's default ===-equality checks. Aliasing the input would
+    // silently drop optimistic updates.
+    const input = ['a', 'b']
+    const removed = toggleArrayMember(input, 'a')
+    const appended = toggleArrayMember(input, 'c')
+    expect(removed).not.toBe(input)
+    expect(appended).not.toBe(input)
+  })
+
+  it('does not mutate the input array', () => {
+    const input = ['a', 'b']
+    toggleArrayMember(input, 'a')
+    toggleArrayMember(input, 'c')
+    expect(input).toEqual(['a', 'b'])
   })
 })

--- a/src/renderer/src/lib/utils.ts
+++ b/src/renderer/src/lib/utils.ts
@@ -11,6 +11,14 @@ export function cn(...inputs: ClassValue[]): string {
 }
 
 /**
+ * Primitive types comparable by `===`. Constrains `toggleArrayMember`
+ * so an object literal can never silently slip through the reference-
+ * equality check (e.g. `toggleArrayMember([{id:'a'}], {id:'a'})` would
+ * always append, never remove — caught at compile time now).
+ */
+type Primitive = string | number | boolean | bigint | symbol | null | undefined
+
+/**
  * Toggle membership of `value` in `arr`. Returns a new array with the
  * value appended if absent, or removed if present. Always returns a
  * fresh reference so callers can pass the result straight into a Redux
@@ -18,8 +26,9 @@ export function cn(...inputs: ClassValue[]): string {
  *
  * Used by hide-from-sidebar flows where the next state is the inverse
  * of current membership (right-click toggle in `AgentItem`, checkbox
- * flip in Settings → Agents pane). Equality is `===`, so this is for
- * primitive ids — not deep object membership.
+ * flip in Settings → Agents pane). Equality is `===`, so the generic
+ * is constrained to `Primitive` — passing an object literal is a
+ * compile-time error rather than a silent reference-equality bug.
  * @param arr - The current array (treated as immutable)
  * @param value - The value to toggle
  * @returns A new array with `value` appended or removed
@@ -27,7 +36,10 @@ export function cn(...inputs: ClassValue[]): string {
  * toggleArrayMember(['a', 'b'], 'c') // => ['a', 'b', 'c']
  * toggleArrayMember(['a', 'b'], 'a') // => ['b']
  */
-export function toggleArrayMember<T>(arr: readonly T[], value: T): T[] {
+export function toggleArrayMember<T extends Primitive>(
+  arr: readonly T[],
+  value: T,
+): T[] {
   return arr.includes(value)
     ? arr.filter((item) => item !== value)
     : [...arr, value]

--- a/src/renderer/src/lib/utils.ts
+++ b/src/renderer/src/lib/utils.ts
@@ -11,6 +11,29 @@ export function cn(...inputs: ClassValue[]): string {
 }
 
 /**
+ * Toggle membership of `value` in `arr`. Returns a new array with the
+ * value appended if absent, or removed if present. Always returns a
+ * fresh reference so callers can pass the result straight into a Redux
+ * setter / IPC payload without aliasing the previous state.
+ *
+ * Used by hide-from-sidebar flows where the next state is the inverse
+ * of current membership (right-click toggle in `AgentItem`, checkbox
+ * flip in Settings → Agents pane). Equality is `===`, so this is for
+ * primitive ids — not deep object membership.
+ * @param arr - The current array (treated as immutable)
+ * @param value - The value to toggle
+ * @returns A new array with `value` appended or removed
+ * @example
+ * toggleArrayMember(['a', 'b'], 'c') // => ['a', 'b', 'c']
+ * toggleArrayMember(['a', 'b'], 'a') // => ['b']
+ */
+export function toggleArrayMember<T>(arr: readonly T[], value: T): T[] {
+  return arr.includes(value)
+    ? arr.filter((item) => item !== value)
+    : [...arr, value]
+}
+
+/**
  * Format install count for display with K/M suffixes.
  * Handles rounding overflow: values near 1M that round to "1000.0K"
  * are promoted to the M tier instead.

--- a/src/renderer/src/redux/listener.test.ts
+++ b/src/renderer/src/redux/listener.test.ts
@@ -124,6 +124,61 @@ describe('theme listener — applyThemeToDOM', () => {
     expect(root.classList.contains('dark')).toBe(true)
   })
 
+  it('clears selectedAgentId when setSettings hides the currently-selected agent', async () => {
+    // Cross-slice invariant: hiding an agent from the sidebar must not
+    // leave the central skill list filtering by an agent the user can no
+    // longer see. The listener middleware enforces this regardless of
+    // whether AgentsSection is mounted (Settings can hide an agent during
+    // a navigation transition in the main window). Without this listener,
+    // selecting an agent in the sidebar then hiding it from Settings would
+    // leave selectedAgentId pinned to the now-invisible agent.
+    const { listenerMiddleware } = await import('./listener')
+    const { default: settingsReducer, setSettings } =
+      await import('./slices/settingsSlice')
+    const { default: uiReducer, selectAgent } = await import('./slices/uiSlice')
+    const { DEFAULT_SETTINGS } = await import('@/shared/settings')
+
+    const store = configureStore({
+      reducer: { settings: settingsReducer, ui: uiReducer },
+      middleware: (getDefault) =>
+        getDefault().prepend(listenerMiddleware.middleware),
+    })
+
+    store.dispatch(selectAgent('claude-code'))
+    expect(store.getState().ui.selectedAgentId).toBe('claude-code')
+
+    store.dispatch(
+      setSettings({ ...DEFAULT_SETTINGS, hiddenAgentIds: ['claude-code'] }),
+    )
+
+    expect(store.getState().ui.selectedAgentId).toBeNull()
+  })
+
+  it('preserves selectedAgentId when setSettings hides a different agent', async () => {
+    // Inverse case for the invariant above: if the hidden agent isn't
+    // the one currently selected, the listener must not clobber the
+    // selection. Pinning this guards against an over-eager `selectAgent(null)`
+    // dispatch that would lose the user's filter on every settings write.
+    const { listenerMiddleware } = await import('./listener')
+    const { default: settingsReducer, setSettings } =
+      await import('./slices/settingsSlice')
+    const { default: uiReducer, selectAgent } = await import('./slices/uiSlice')
+    const { DEFAULT_SETTINGS } = await import('@/shared/settings')
+
+    const store = configureStore({
+      reducer: { settings: settingsReducer, ui: uiReducer },
+      middleware: (getDefault) =>
+        getDefault().prepend(listenerMiddleware.middleware),
+    })
+
+    store.dispatch(selectAgent('cursor'))
+    store.dispatch(
+      setSettings({ ...DEFAULT_SETTINGS, hiddenAgentIds: ['claude-code'] }),
+    )
+
+    expect(store.getState().ui.selectedAgentId).toBe('cursor')
+  })
+
   it('rapid preset switches write to the DOM in dispatch order (no stale/async reordering)', async () => {
     // Regression guard for the "stale listener write" class of bug — if the
     // listener ever queues async writes (via Promise.resolve, microtask,

--- a/src/renderer/src/redux/listener.test.ts
+++ b/src/renderer/src/redux/listener.test.ts
@@ -179,6 +179,35 @@ describe('theme listener — applyThemeToDOM', () => {
     expect(store.getState().ui.selectedAgentId).toBe('cursor')
   })
 
+  it('does not dispatch selectAgent(null) when no agent is selected and a hide lands', async () => {
+    // The third arm of the listener guard: selectedAgentId is already
+    // null. Without the `selectedAgentId !== null` short-circuit the
+    // listener would dispatch a redundant `selectAgent(null)` on every
+    // settings write — wasted middleware churn and a phantom transition
+    // for any selector that watches `ui.selectedAgentId` for changes.
+    const { listenerMiddleware } = await import('./listener')
+    const { default: settingsReducer, setSettings } =
+      await import('./slices/settingsSlice')
+    const { default: uiReducer } = await import('./slices/uiSlice')
+    const { DEFAULT_SETTINGS } = await import('@/shared/settings')
+
+    const store = configureStore({
+      reducer: { settings: settingsReducer, ui: uiReducer },
+      middleware: (getDefault) =>
+        getDefault().prepend(listenerMiddleware.middleware),
+    })
+
+    // Capture the ui slice reference before the settings update — if the
+    // listener's no-op short-circuit holds, the reducer is never re-run
+    // and the ui slice keeps the same reference.
+    const uiBefore = store.getState().ui
+    store.dispatch(
+      setSettings({ ...DEFAULT_SETTINGS, hiddenAgentIds: ['claude-code'] }),
+    )
+    expect(store.getState().ui).toBe(uiBefore)
+    expect(store.getState().ui.selectedAgentId).toBeNull()
+  })
+
   it('rapid preset switches write to the DOM in dispatch order (no stale/async reordering)', async () => {
     // Regression guard for the "stale listener write" class of bug — if the
     // listener ever queues async writes (via Promise.resolve, microtask,

--- a/src/renderer/src/redux/listener.ts
+++ b/src/renderer/src/redux/listener.ts
@@ -1,6 +1,10 @@
 import { ACTION_HYDRATE_COMPLETE } from '@laststance/redux-storage-middleware'
 import { createListenerMiddleware, isAnyOf } from '@reduxjs/toolkit'
 
+import type { Settings } from '@/shared/settings'
+import type { AgentId } from '@/shared/types'
+
+import { setSettings } from './slices/settingsSlice'
 import { clearSelection } from './slices/skillsSlice'
 import { setTheme, toggleMode } from './slices/themeSlice'
 import type { ThemeState } from './slices/themeSlice'
@@ -11,6 +15,8 @@ export const listenerMiddleware = createListenerMiddleware()
 // Type for state accessed in listeners (avoids circular RootState import)
 interface ListenerState {
   theme: ThemeState
+  settings: Settings
+  ui: { selectedAgentId: AgentId | null }
 }
 
 /**
@@ -79,5 +85,32 @@ listenerMiddleware.startListening({
   matcher: isAnyOf(setActiveTab, selectAgent, fetchSyncPreview.pending),
   effect: (_action, listenerApi) => {
     listenerApi.dispatch(clearSelection())
+  },
+})
+
+/**
+ * Cross-slice invariant: when a settings update lands that hides the
+ * currently-selected agent, clear the selection so the central skill
+ * list doesn't keep filtering by an agent the user can no longer see
+ * in the sidebar.
+ *
+ * Living here (instead of an `AgentsSection` `useEffect`) means the
+ * invariant fires regardless of whether that component is mounted —
+ * the Settings window can hide an agent during a navigation transition
+ * in the main window without a window-of-vulnerability where the stale
+ * selection survives. The cascading `selectAgent`-listener above also
+ * clears `selectedSkillNames`, so the user never sees stale ticks
+ * either.
+ */
+listenerMiddleware.startListening({
+  actionCreator: setSettings,
+  effect: (_action, listenerApi) => {
+    const { ui, settings } = listenerApi.getState() as ListenerState
+    if (
+      ui.selectedAgentId !== null &&
+      settings.hiddenAgentIds.includes(ui.selectedAgentId)
+    ) {
+      listenerApi.dispatch(selectAgent(null))
+    }
   },
 })

--- a/src/renderer/src/redux/slices/settingsSlice.test.ts
+++ b/src/renderer/src/redux/slices/settingsSlice.test.ts
@@ -1,0 +1,83 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { describe, expect, it } from 'vitest'
+
+import type { RootState } from '@/renderer/src/redux/store'
+import { DEFAULT_SETTINGS } from '@/shared/settings'
+
+/**
+ * Unit tests for the renderer-side settings cache. The slice itself is
+ * intentionally minimal (single idempotent `setSettings` reducer), so
+ * the contract worth pinning here is twofold:
+ *  - the slice initializes from `DEFAULT_SETTINGS` (including the new
+ *    empty `hiddenAgentIds`)
+ *  - `selectHiddenAgentIds` returns the same array reference held in
+ *    state so React-Redux's default reference equality skips re-renders
+ *    when the underlying array hasn't changed
+ *
+ * Dynamic imports follow the pattern established by the other slice
+ * test files so each test starts from a pristine reducer.
+ */
+async function createTestStore() {
+  const { default: settingsReducer } = await import('./settingsSlice')
+  return configureStore({ reducer: { settings: settingsReducer } })
+}
+
+describe('settingsSlice', () => {
+  it('initial state matches DEFAULT_SETTINGS (with empty hiddenAgentIds)', async () => {
+    const store = await createTestStore()
+    expect(store.getState().settings).toEqual(DEFAULT_SETTINGS)
+    expect(store.getState().settings.hiddenAgentIds).toEqual([])
+  })
+
+  it('setSettings replaces the entire settings object idempotently', async () => {
+    const { setSettings } = await import('./settingsSlice')
+    const store = await createTestStore()
+
+    store.dispatch(
+      setSettings({
+        ...DEFAULT_SETTINGS,
+        defaultSkillTab: 'info',
+        hiddenAgentIds: ['claude-code'],
+      }),
+    )
+
+    expect(store.getState().settings.defaultSkillTab).toBe('info')
+    expect(store.getState().settings.hiddenAgentIds).toEqual(['claude-code'])
+  })
+})
+
+/**
+ * `selectHiddenAgentIds` is the single read site for sidebar / settings
+ * components. Two tests pin the contract:
+ *  - it returns the array as-is (no copy / sort / dedupe)
+ *  - it preserves reference identity across reads so React-Redux's
+ *    default `===` comparison can short-circuit downstream re-renders
+ */
+describe('selectHiddenAgentIds', () => {
+  it('returns the persisted hiddenAgentIds array', async () => {
+    const { selectHiddenAgentIds } = await import('./settingsSlice')
+    const { setSettings } = await import('./settingsSlice')
+    const store = await createTestStore()
+
+    store.dispatch(
+      setSettings({
+        ...DEFAULT_SETTINGS,
+        hiddenAgentIds: ['claude-code', 'cursor'],
+      }),
+    )
+
+    expect(selectHiddenAgentIds(store.getState() as RootState)).toEqual([
+      'claude-code',
+      'cursor',
+    ])
+  })
+
+  it('returns the same reference across consecutive reads when state is unchanged', async () => {
+    const { selectHiddenAgentIds } = await import('./settingsSlice')
+    const store = await createTestStore()
+
+    const firstRead = selectHiddenAgentIds(store.getState() as RootState)
+    const secondRead = selectHiddenAgentIds(store.getState() as RootState)
+    expect(firstRead).toBe(secondRead)
+  })
+})

--- a/src/renderer/src/redux/slices/settingsSlice.ts
+++ b/src/renderer/src/redux/slices/settingsSlice.ts
@@ -1,7 +1,9 @@
 import type { PayloadAction } from '@reduxjs/toolkit'
 import { createSlice } from '@reduxjs/toolkit'
 
+import type { RootState } from '@/renderer/src/redux/store'
 import { DEFAULT_SETTINGS, type Settings } from '@/shared/settings'
+import type { AgentId } from '@/shared/types'
 
 /**
  * Renderer-side cache of the user settings owned by the main process.
@@ -32,3 +34,16 @@ const settingsSlice = createSlice({
 
 export const { setSettings } = settingsSlice.actions
 export default settingsSlice.reducer
+
+/**
+ * Renderer selector for `Settings.hiddenAgentIds`. Centralizing the
+ * read here lets sidebar / settings-pane components reach for one
+ * stable hook signature instead of inlining the slice path each time
+ * — also the right place to swap the storage shape (e.g. Set) later.
+ * @param state - Root Redux state
+ * @returns The list of agent ids the user has hidden from the sidebar
+ * @example
+ * useAppSelector(selectHiddenAgentIds) // => ['cursor', 'zed']
+ */
+export const selectHiddenAgentIds = (state: RootState): AgentId[] =>
+  state.settings.hiddenAgentIds

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -537,6 +537,27 @@ export type ThemePresetName = keyof typeof THEME_PRESETS
 export type AgentId = (typeof AGENT_DEFINITIONS)[number]['id']
 
 /**
+ * Runtime tuple of every AgentId, derived from AGENT_DEFINITIONS so the
+ * two stay in lockstep automatically. The double-cast (`unknown` first)
+ * is needed because `.map()` returns `AgentId[]` and TypeScript can't
+ * statically infer the non-empty tuple shape `z.enum` requires — but
+ * the value is genuinely non-empty (AGENT_DEFINITIONS is hand-authored
+ * with 40+ entries, and the `[number]` indexed access on its type
+ * would not compile if it were empty).
+ *
+ * Consumed by `SettingsSchema.shape.hiddenAgentIds` (`z.enum(AGENT_IDS)`)
+ * so the persisted-state validator drops any stale id from a prior
+ * version (e.g. an agent removed upstream by `/cli-upgrade`) instead of
+ * surfacing it as a phantom hidden entry.
+ * @example
+ * z.enum(AGENT_IDS).safeParse('claude-code').success // => true
+ * z.enum(AGENT_IDS).safeParse('removed-agent').success // => false
+ */
+export const AGENT_IDS = AGENT_DEFINITIONS.map(
+  (definition) => definition.id,
+) as unknown as readonly [AgentId, ...AgentId[]]
+
+/**
  * Agent display names shown in UI.
  * Derived from AGENT_DEFINITIONS to avoid manual union maintenance.
  */

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -538,24 +538,28 @@ export type AgentId = (typeof AGENT_DEFINITIONS)[number]['id']
 
 /**
  * Runtime tuple of every AgentId, derived from AGENT_DEFINITIONS so the
- * two stay in lockstep automatically. The double-cast (`unknown` first)
- * is needed because `.map()` returns `AgentId[]` and TypeScript can't
- * statically infer the non-empty tuple shape `z.enum` requires — but
- * the value is genuinely non-empty (AGENT_DEFINITIONS is hand-authored
- * with 40+ entries, and the `[number]` indexed access on its type
- * would not compile if it were empty).
+ * two stay in lockstep automatically. A single cast asserts the
+ * non-empty tuple shape that `z.enum` requires — `.map()` returns
+ * `AgentId[]` which the type system can't narrow further on its own.
+ * AGENT_DEFINITIONS is hand-authored with 40+ entries, but the runtime
+ * guard below catches the future case where a refactor empties it
+ * before the cast can lie about a non-existent first element.
  *
- * Consumed by `SettingsSchema.shape.hiddenAgentIds` (`z.enum(AGENT_IDS)`)
- * so the persisted-state validator drops any stale id from a prior
- * version (e.g. an agent removed upstream by `/cli-upgrade`) instead of
- * surfacing it as a phantom hidden entry.
+ * Consumed by the IPC `settings:set` schema (strict `z.enum(AGENT_IDS)`)
+ * and by the disk-side `HIDDEN_AGENT_IDS_SCHEMA` (forgiving filter that
+ * drops stale ids without rejecting the rest of the settings file).
  * @example
  * z.enum(AGENT_IDS).safeParse('claude-code').success // => true
  * z.enum(AGENT_IDS).safeParse('removed-agent').success // => false
  */
-export const AGENT_IDS = AGENT_DEFINITIONS.map(
-  (definition) => definition.id,
-) as unknown as readonly [AgentId, ...AgentId[]]
+const _AGENT_IDS = AGENT_DEFINITIONS.map((definition) => definition.id)
+if (_AGENT_IDS.length === 0) {
+  throw new Error('AGENT_DEFINITIONS must not be empty')
+}
+export const AGENT_IDS = _AGENT_IDS as unknown as readonly [
+  AgentId,
+  ...AgentId[],
+]
 
 /**
  * Agent display names shown in UI.

--- a/src/shared/settings.test.ts
+++ b/src/shared/settings.test.ts
@@ -139,12 +139,39 @@ describe('SettingsSchema', () => {
     expect(parsed.hiddenAgentIds).toEqual([firstAgentId])
   })
 
-  it('rejects an unknown agent id in hiddenAgentIds', () => {
-    // Simulates a corrupted / hand-edited settings.json. `z.enum(AGENT_IDS)`
-    // is a closed set so unknown ids never reach the renderer.
-    expect(() =>
-      SettingsSchema.parse({ hiddenAgentIds: ['bogus-agent'] }),
-    ).toThrow()
+  it('drops unknown agent ids from hiddenAgentIds without rejecting the file', () => {
+    // The schema is forgiving on disk reads — strict z.enum here would
+    // throw the WHOLE settings file out (and reset every other field to
+    // defaults) when one stale id slips in.
+    const parsed = SettingsSchema.parse({
+      hiddenAgentIds: ['bogus-agent'],
+    })
+    expect(parsed.hiddenAgentIds).toEqual([])
+  })
+
+  it('preserves valid hiddenAgentIds while dropping stale ids alongside', () => {
+    // Regression for the `/cli-upgrade`-removed-an-agent scenario: with
+    // strict z.enum the whole array (and everything else in settings.json)
+    // would reject. The transform must filter, not throw.
+    const firstAgentId = AGENT_DEFINITIONS[0]!.id
+    const parsed = SettingsSchema.parse({
+      hiddenAgentIds: [firstAgentId, 'removed-agent'],
+    })
+    expect(parsed.hiddenAgentIds).toEqual([firstAgentId])
+  })
+
+  it('preserves all other settings fields when hiddenAgentIds contains stale ids', () => {
+    // The blast radius of a strict-enum failure was every field in the
+    // file dropping back to defaults. Pin the boundary here so a future
+    // refactor can't quietly resurrect that behavior.
+    const parsed = SettingsSchema.parse({
+      defaultSkillTab: 'info',
+      preferredTerminal: 'iterm',
+      hiddenAgentIds: ['removed-agent'],
+    })
+    expect(parsed.defaultSkillTab).toBe('info')
+    expect(parsed.preferredTerminal).toBe('iterm')
+    expect(parsed.hiddenAgentIds).toEqual([])
   })
 
   it('rejects a non-array hiddenAgentIds', () => {

--- a/src/shared/settings.test.ts
+++ b/src/shared/settings.test.ts
@@ -180,6 +180,22 @@ describe('SettingsSchema', () => {
     ).toThrow()
   })
 
+  it('drops non-string elements without rejecting the file', () => {
+    // Regression for the array-element-validation cliff: with the prior
+    // `z.array(z.string())` element schema, a single non-string entry
+    // (e.g. a hand-edited `123`) would fail BEFORE `.transform()` ran,
+    // taking the whole settings parse down with it. Element type is
+    // `z.unknown()` so the typeof-string filter inside transform can
+    // do its job — same forgiving contract as the stale-id case.
+    const firstAgentId = AGENT_DEFINITIONS[0]!.id
+    const parsed = SettingsSchema.parse({
+      defaultSkillTab: 'info',
+      hiddenAgentIds: [firstAgentId, 123, null, { not: 'a string' }],
+    })
+    expect(parsed.defaultSkillTab).toBe('info')
+    expect(parsed.hiddenAgentIds).toEqual([firstAgentId])
+  })
+
   it('deduplicates hiddenAgentIds on parse', () => {
     // A hand-edited settings.json containing duplicates would otherwise
     // false-positive the length-then-membership equality check in

--- a/src/shared/settings.test.ts
+++ b/src/shared/settings.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 
+import { AGENT_DEFINITIONS } from './constants'
 import {
   DEFAULT_SETTINGS,
   SettingsSchema,
@@ -124,6 +125,31 @@ describe('SettingsSchema', () => {
           height: WINDOW_SIZE_MIN_DIMENSION,
         },
       }),
+    ).toThrow()
+  })
+
+  it('hiddenAgentIds defaults to an empty array on a fresh parse', () => {
+    const parsed = SettingsSchema.parse({})
+    expect(parsed.hiddenAgentIds).toEqual([])
+  })
+
+  it('accepts an installed agent id in hiddenAgentIds', () => {
+    const firstAgentId = AGENT_DEFINITIONS[0]!.id
+    const parsed = SettingsSchema.parse({ hiddenAgentIds: [firstAgentId] })
+    expect(parsed.hiddenAgentIds).toEqual([firstAgentId])
+  })
+
+  it('rejects an unknown agent id in hiddenAgentIds', () => {
+    // Simulates a corrupted / hand-edited settings.json. `z.enum(AGENT_IDS)`
+    // is a closed set so unknown ids never reach the renderer.
+    expect(() =>
+      SettingsSchema.parse({ hiddenAgentIds: ['bogus-agent'] }),
+    ).toThrow()
+  })
+
+  it('rejects a non-array hiddenAgentIds', () => {
+    expect(() =>
+      SettingsSchema.parse({ hiddenAgentIds: 'claude-code' }),
     ).toThrow()
   })
 })

--- a/src/shared/settings.test.ts
+++ b/src/shared/settings.test.ts
@@ -179,4 +179,17 @@ describe('SettingsSchema', () => {
       SettingsSchema.parse({ hiddenAgentIds: 'claude-code' }),
     ).toThrow()
   })
+
+  it('deduplicates hiddenAgentIds on parse', () => {
+    // A hand-edited settings.json containing duplicates would otherwise
+    // false-positive the length-then-membership equality check in
+    // `areSettingsEqual` (e.g. ['cursor','cursor'] vs ['cursor','claude-code']
+    // would compare equal and silently drop the legitimate write). The
+    // disk schema deduplicates so the equality contract stays honest.
+    const firstAgentId = AGENT_DEFINITIONS[0]!.id
+    const parsed = SettingsSchema.parse({
+      hiddenAgentIds: [firstAgentId, firstAgentId],
+    })
+    expect(parsed.hiddenAgentIds).toEqual([firstAgentId])
+  })
 })

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -44,6 +44,12 @@ const windowSizeSchema = z
  * window size). The `.includes` cast is needed because `.includes` on
  * a `readonly` tuple narrows to its literal members.
  *
+ * Also dedupes — `areSettingsEqual` uses length-then-membership for
+ * set-equality, which would false-positive if one side had duplicates
+ * (e.g. a hand-edited settings.json with `["cursor","cursor"]` would
+ * compare equal to a different 2-element list sharing one member). The
+ * Set drop is cheap and keeps the equality contract honest.
+ *
  * NOTE: this is the DISK schema. The IPC boundary uses a strict
  * `z.array(z.enum(AGENT_IDS))` — renderers should only ever emit valid
  * ids, and an invalid id at that layer is a bug rather than a schema-
@@ -51,11 +57,12 @@ const windowSizeSchema = z
  */
 const HIDDEN_AGENT_IDS_SCHEMA = z
   .array(z.string())
-  .transform((arr): AgentId[] =>
-    arr.filter((id): id is AgentId =>
+  .transform((arr): AgentId[] => {
+    const valid = arr.filter((id): id is AgentId =>
       (AGENT_IDS as readonly string[]).includes(id),
-    ),
-  )
+    )
+    return Array.from(new Set(valid))
+  })
   .default([])
 
 /**

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
 import { AGENT_IDS, TERMINAL_APP_IDS } from './constants'
+import type { AgentId } from './types'
 
 /**
  * Defense-in-depth floor for a persisted startup window size. Set well
@@ -30,6 +31,32 @@ const windowSizeSchema = z
     height: z.number().int().min(WINDOW_SIZE_MIN_DIMENSION),
   })
   .optional()
+
+/**
+ * Forgiving disk-side schema for `hiddenAgentIds`.
+ *
+ * Pre-filters against `AGENT_IDS` via `transform` instead of validating
+ * with `z.enum(AGENT_IDS)`: if an upstream `/cli-upgrade` removes an
+ * agent that was previously hidden, the stale id silently falls out of
+ * the array rather than rejecting the whole settings file. With strict
+ * enum validation, ONE bad id makes `loadSettings()` fall back to
+ * defaults — wiping every other field too (default tab, terminal,
+ * window size). The `.includes` cast is needed because `.includes` on
+ * a `readonly` tuple narrows to its literal members.
+ *
+ * NOTE: this is the DISK schema. The IPC boundary uses a strict
+ * `z.array(z.enum(AGENT_IDS))` — renderers should only ever emit valid
+ * ids, and an invalid id at that layer is a bug rather than a schema-
+ * evolution event.
+ */
+const HIDDEN_AGENT_IDS_SCHEMA = z
+  .array(z.string())
+  .transform((arr): AgentId[] =>
+    arr.filter((id): id is AgentId =>
+      (AGENT_IDS as readonly string[]).includes(id),
+    ),
+  )
+  .default([])
 
 /**
  * App-wide user settings schema.
@@ -69,7 +96,7 @@ export const SettingsSchema = z.object({
   preferredTerminal: z.enum(TERMINAL_APP_IDS).default('terminal'),
   customTerminalAppName: z.string().trim().min(1).max(64).optional(),
   windowSize: windowSizeSchema,
-  hiddenAgentIds: z.array(z.enum(AGENT_IDS)).default([]),
+  hiddenAgentIds: HIDDEN_AGENT_IDS_SCHEMA,
 })
 
 /**

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-import { TERMINAL_APP_IDS } from './constants'
+import { AGENT_IDS, TERMINAL_APP_IDS } from './constants'
 
 /**
  * Defense-in-depth floor for a persisted startup window size. Set well
@@ -50,19 +50,26 @@ const windowSizeSchema = z
  *   the saved size — clamped to the current display work area so a
  *   saved size from a wider monitor never opens off-screen on a smaller
  *   one.
+ * - `hiddenAgentIds`: agents the user has chosen to hide from the
+ *   sidebar's installed list. Pure visibility toggle — the agent's
+ *   skills folder, symlinks, and Marketplace presence are unaffected.
+ *   Validated against `AGENT_IDS` so a stale id from a prior version
+ *   (e.g. an agent removed upstream by `/cli-upgrade`) is silently
+ *   dropped on parse rather than surfacing as a phantom hidden entry.
  *
  * Adding a field here requires widening `IPC_ARG_SCHEMAS['settings:set']`
  * in `src/main/ipc/ipc-schemas.ts` in lockstep — that schema is `.strict()`
  * so unknown keys are rejected at the IPC boundary (defense in depth).
  *
  * @example
- * SettingsSchema.parse({}) // { defaultSkillTab: 'files', preferredTerminal: 'terminal' }
+ * SettingsSchema.parse({}) // { defaultSkillTab: 'files', preferredTerminal: 'terminal', hiddenAgentIds: [] }
  */
 export const SettingsSchema = z.object({
   defaultSkillTab: z.enum(['files', 'info']).default('files'),
   preferredTerminal: z.enum(TERMINAL_APP_IDS).default('terminal'),
   customTerminalAppName: z.string().trim().min(1).max(64).optional(),
   windowSize: windowSizeSchema,
+  hiddenAgentIds: z.array(z.enum(AGENT_IDS)).default([]),
 })
 
 /**
@@ -82,4 +89,5 @@ export type Settings = z.infer<typeof SettingsSchema>
 export const DEFAULT_SETTINGS: Settings = {
   defaultSkillTab: 'files',
   preferredTerminal: 'terminal',
+  hiddenAgentIds: [],
 }

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -44,6 +44,14 @@ const windowSizeSchema = z
  * window size). The `.includes` cast is needed because `.includes` on
  * a `readonly` tuple narrows to its literal members.
  *
+ * Element type is `z.unknown()` (not `z.string()`) on purpose: a single
+ * non-string element in a hand-edited settings.json (e.g. `[123]`)
+ * would otherwise fail array-element validation BEFORE `.transform()`
+ * ever runs, taking the entire `SettingsSchema.parse()` down with it
+ * — the same blast-radius bug that strict-enum validation has. The
+ * `typeof === 'string'` filter inside transform handles the bad
+ * element while keeping the rest of the file intact.
+ *
  * Also dedupes — `areSettingsEqual` uses length-then-membership for
  * set-equality, which would false-positive if one side had duplicates
  * (e.g. a hand-edited settings.json with `["cursor","cursor"]` would
@@ -56,10 +64,11 @@ const windowSizeSchema = z
  * evolution event.
  */
 const HIDDEN_AGENT_IDS_SCHEMA = z
-  .array(z.string())
+  .array(z.unknown())
   .transform((arr): AgentId[] => {
-    const valid = arr.filter((id): id is AgentId =>
-      (AGENT_IDS as readonly string[]).includes(id),
+    const valid = arr.filter(
+      (id): id is AgentId =>
+        typeof id === 'string' && (AGENT_IDS as readonly string[]).includes(id),
     )
     return Array.from(new Set(valid))
   })


### PR DESCRIPTION
## Summary

- Adds a per-user "hide unused agents from sidebar" feature: Settings → Agents pane lets the user toggle which installed agents appear in the sidebar; right-click on a sidebar agent has "Hide from sidebar" / "Show in sidebar"
- New `hiddenAgentIds: AgentId[]` field on `Settings`, persisted atomically; disk schema is forgiving (drops stale ids from upstream `/cli-upgrade` removals) while the IPC schema is strict and `.max()`-capped
- Redux listener clears `selectedAgentId` when its agent is hidden so the right-pane can't dangle on a hidden agent

## What changed

**Schema / persistence**
- `src/shared/settings.ts` — `HIDDEN_AGENT_IDS_SCHEMA` filter+dedup transform; `hiddenAgentIds` added to `SettingsSchema`
- `src/main/services/settings.ts` — `areSettingsEqual` set-semantics for `hiddenAgentIds` (avoids redundant write+broadcast on every roundtrip)
- `src/main/ipc/ipc-schemas.ts` — `settings:set` accepts `hiddenAgentIds: z.array(z.enum(AGENT_IDS)).max(AGENT_IDS.length).optional()`; deliberately decoupled from disk default to close the wipe-on-write hole

**Renderer**
- `src/renderer/settings/sections/Agents.tsx` (new) — full Agents settings pane with installed/not-installed disclosure, "Show all" reset, indeterminate-checkbox guard
- `src/renderer/settings/SettingsApp.tsx` — wires the new "Agents" nav item
- `src/renderer/src/components/sidebar/AgentItem.tsx` — context-menu "Hide from sidebar" / "Show in sidebar"
- `src/renderer/src/components/sidebar/AgentsSection.tsx` — three-way partition (visible / hidden disclosure / missing disclosure), counter `(n)` in header
- `src/renderer/src/redux/listener.ts` — `setSettings` listener dispatches `selectAgent(null)` if the selected agent becomes hidden
- `src/renderer/src/redux/slices/settingsSlice.ts` — `selectHiddenAgentIds` memoized selector
- `src/renderer/src/lib/utils.ts` — `toggleArrayMember` helper

## Coverage audit (Step 7)

**Coverage: 90%** (36/40 codepaths) — gate ≥80% PASS.

4 justified gaps:
1. `constants.ts:557` defensive throw — `AGENT_DEFINITIONS` empty is structurally impossible
2. `Agents.tsx:173` indeterminate-checkbox guard — Radix only emits boolean
3-4. `SettingsApp.tsx` 'agents' nav wiring — trivial wiring, E2E territory

## Adversarial review (Step 11)

Codex CLI + Claude security-coder ran in parallel. 13 total findings, triaged:

**Fixed in this branch** (commit `e2a37f8`):
- BLOCKER: `areSettingsEqual` could false-positive on duplicate agent ids → disk schema now dedupes
- HIGH: same-root-cause duplicate corruption surface → fixed by dedup
- MED: `opacity-50` on hidden-agents disclosure failed WCAG 2.2 AA contrast → removed (semantic distinction now: visible/hidden = full clarity, missing = muted)
- MED: IPC `hiddenAgentIds` lacked size cap → added `.max(AGENT_IDS.length)` defense-in-depth

**Deferred — pre-existing, out of branch scope:**
- `saveSettings` lacks serialization lock (concurrent two-window writes can race on tmp file) — pre-existing in `src/main/services/settings.ts`
- `useUpdateSettings` lacks IPC-failure rollback — pre-existing in `src/renderer/src/hooks/useUpdateSettings.ts`
- `onClick` vs `onSelect` inconsistency on `DropdownMenuItem` for `handleCleanupMissing`/`handleDelete` — pre-existing

**Dismissed:**
- "Hidden agent shouldn't be selectable on click" — misframed invariant; design is "hidden disclosure remains interactive"
- 44pt tap targets — desktop app, not iOS touch

**Follow-up filed mentally** (not blockers):
- Focus restoration when keyboard-hiding a sidebar agent (real a11y concern; non-trivial fix)

## Test plan
- [x] Unit + integration tests: 977 / 977 pass
- [x] Lint clean (0 warnings after browser-test `await` cleanup)
- [x] Typecheck clean (`tsc --noEmit`)
- [ ] Manual: open Settings → Agents, toggle a few agents, verify sidebar updates and disclosure shows correct count
- [ ] Manual: right-click sidebar agent → Hide from sidebar; right-click agent in disclosure → Show in sidebar
- [ ] Manual: hide the currently-selected agent and confirm right pane clears (listener fires)
- [ ] Manual: hand-edit `~/Library/Application Support/skills-desktop/settings.json` to add `"hiddenAgentIds": ["bogus-agent", "claude-code", "claude-code"]` → verify app starts, drops bogus, dedupes claude-code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
* サイドバーのエージェント表示・非表示機能を追加
* 設定画面に新しい「エージェント」セクションを追加
* エージェントの右クリックメニューから表示状態を切り替え可能
* 非表示エージェント数を表示するカウンターを追加
* エージェント設定がアプリケーション全体で永続化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->