### PR TITLE
test(e2e): pin v0.16.0 fixes and uncovered sync flow

### DIFF
--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -45,6 +45,12 @@ export const test = baseTest.extend<ElectronFixtures>({
       env: {
         ...process.env,
         HOME: isolatedHome,
+        // Force Electron's `userData` into the isolated HOME — without
+        // this, `app.getPath('userData')` resolves via the OS user (NOT
+        // `$HOME`) and tests writing settings.json or session storage
+        // would silently target the developer's real profile. See
+        // src/main/index.ts where `E2E_USERDATA_DIR` is consumed.
+        E2E_USERDATA_DIR: resolve(isolatedHome, 'userData'),
         E2E_DISABLE_UPDATE: '1',
         // Default to fully-hidden windows; allow opt-out when the developer
         // wants to watch the test (e.g. `E2E_BACKGROUND_LAUNCH=0 pnpm test:e2e:headed`).

--- a/e2e/helpers/redux.ts
+++ b/e2e/helpers/redux.ts
@@ -185,6 +185,60 @@ export async function waitForInitialScan(
 }
 
 /**
+ * Wait until the renderer's sync flow is settled — `state.ui.isSyncing`
+ * has returned to `false` AND the relevant outcome slice is populated.
+ *
+ * Why a single helper with a discriminator instead of two functions: a
+ * naive `isSyncing === false` poll resolves immediately because the slice
+ * starts at `false` BEFORE the trigger ever fires (`fetchSyncPreview`
+ * pending/`executeSyncAction` pending flip it to `true`). The race
+ * window is tens of milliseconds in tests, so polling on the OUTCOME
+ * (`syncPreview` for the preview phase, `syncResult` for the execute
+ * phase) is the unambiguous signal.
+ *
+ * Both phases share the same slice flag, so a single helper with the
+ * `expects` discriminator avoids duplication while keeping the failure
+ * message specific to the phase under test ("expected syncResult, found
+ * null after 10s" pinpoints the failed assertion better than a generic
+ * "isSyncing" timeout).
+ *
+ * @param page - The Playwright page
+ * @param expects - Which slice to wait for. `'preview'` for
+ *                  `fetchSyncPreview`, `'result'` for `executeSyncAction`
+ * @param timeoutMs - Poll timeout (default 10s, matches `waitForInitialScan`)
+ * @example
+ * await dispatchPreview(appWindow)
+ * await waitForSyncSettled(appWindow, 'preview')
+ * @example
+ * await clickDialogSync(appWindow)
+ * await waitForSyncSettled(appWindow, 'result')
+ */
+export async function waitForSyncSettled(
+  page: Page,
+  expects: 'preview' | 'result' = 'preview',
+  timeoutMs = 10_000,
+): Promise<void> {
+  await page.waitForFunction(
+    (expectsLiteral) => {
+      const store = window.__store__ ?? window.__store
+      if (!store) return false
+      const state = store.getState() as {
+        ui?: {
+          syncPreview?: unknown
+          syncResult?: unknown
+          isSyncing?: boolean
+        }
+      }
+      if (state.ui?.isSyncing !== false) return false
+      if (expectsLiteral === 'preview') return Boolean(state.ui?.syncPreview)
+      return Boolean(state.ui?.syncResult)
+    },
+    expects,
+    { timeout: timeoutMs },
+  )
+}
+
+/**
  * Wait until `state.skills.selectedSkillNames.length === count`. Useful after
  * tab/agent switches that should clear selection (regression 2f05684).
  *

--- a/e2e/helpers/settings-file.ts
+++ b/e2e/helpers/settings-file.ts
@@ -1,0 +1,79 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+
+/**
+ * Relative path inside an isolated HOME where the e2e fixture redirects
+ * Electron's `userData` directory via `E2E_USERDATA_DIR`. The override
+ * lives in `src/main/index.ts` (top-level) and the fixture wires the env
+ * var in `e2e/fixtures/electron-app.ts`. Both sides MUST agree on this
+ * literal — if either drifts, tests silently read/write the wrong file.
+ *
+ * Why not the macOS-typical `Library/Application Support/skills-desktop`?
+ * macOS's `app.getPath('userData')` uses `getpwuid(getuid())`, NOT
+ * `$HOME`, so the conventional path doesn't help isolation. Picking a
+ * dedicated `userData/` directory keeps the helper, fixture, and main-
+ * process override all referring to the same simple subpath.
+ */
+const SETTINGS_RELATIVE = 'userData/settings.json'
+
+/**
+ * Resolves the on-disk path for `settings.json` inside an isolated test
+ * HOME, matching the `E2E_USERDATA_DIR` override applied by the fixture
+ * (and consumed by `src/main/index.ts`).
+ * @param home - The isolated HOME directory created by the e2e fixture
+ * @returns Absolute path to settings.json under the isolated profile
+ * @example
+ * settingsFilePath('/tmp/skills-desktop-e2e-home-X9z')
+ * // => '/tmp/skills-desktop-e2e-home-X9z/userData/settings.json'
+ */
+export function settingsFilePath(home: string): string {
+  return join(home, SETTINGS_RELATIVE)
+}
+
+/**
+ * Reads `settings.json` from an isolated HOME. Returns `null` when the
+ * file doesn't exist (first launch, before any user interaction). Parses
+ * JSON eagerly — a malformed file throws at the call site so the test
+ * author sees the exact JSON error instead of a downstream
+ * `expect(...).toContain(...)` failure on `null`.
+ * @param home - The isolated HOME directory
+ * @returns
+ * - The parsed JSON object when present
+ * - `null` when settings.json doesn't exist yet
+ * @example
+ * const persisted = readSettingsFile(isolatedHome) as { hiddenAgentIds: string[] }
+ * expect(persisted.hiddenAgentIds).toContain('cursor')
+ */
+export function readSettingsFile(home: string): unknown {
+  const filePath = settingsFilePath(home)
+  if (!existsSync(filePath)) return null
+  return JSON.parse(readFileSync(filePath, 'utf8'))
+}
+
+/**
+ * Writes `settings.json` to an isolated HOME, creating the
+ * `Library/Application Support/skills-desktop` directory chain when it
+ * doesn't already exist. Used by tests that need to pre-stage settings
+ * before the app launches (e.g. round-tripping a hand-edited file with a
+ * stale agent id to verify the disk schema's forgiveness).
+ *
+ * Accepts `Record<string, unknown>` rather than `Partial<Settings>`
+ * because tests intentionally write invalid shapes (stale agent ids,
+ * unknown fields) to verify the disk-side schema's `.transform` path —
+ * narrowing the input type would block exactly the cases we need.
+ * @param home - The isolated HOME directory
+ * @param contents - The full JSON object to write (overwrites any existing file)
+ * @example
+ * writeSettingsFile(isolatedHome, {
+ *   hiddenAgentIds: ['cursor', 'removed-agent-zzz'],
+ *   defaultSkillTab: 'info',
+ * })
+ */
+export function writeSettingsFile(
+  home: string,
+  contents: Record<string, unknown>,
+): void {
+  const filePath = settingsFilePath(home)
+  mkdirSync(dirname(filePath), { recursive: true })
+  writeFileSync(filePath, JSON.stringify(contents, null, 2), 'utf8')
+}

--- a/e2e/spec/hide-agents.e2e.ts
+++ b/e2e/spec/hide-agents.e2e.ts
@@ -1,0 +1,291 @@
+import { mkdirSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+import { _electron } from '@playwright/test'
+
+import { test, expect } from '../fixtures/electron-app'
+import { isSnapshotOffline } from '../fixtures/isolated-home'
+import { readSettingsFile, writeSettingsFile } from '../helpers/settings-file'
+import { getStoreState, waitForInitialScan } from '../helpers/redux'
+
+/**
+ * PR #144 — Hide unused agents from the sidebar.
+ *
+ * Coverage strategy: the feature crosses three boundaries that each fail
+ * differently, so each gets its own test rather than a single flow that
+ * couples them:
+ *
+ *   1. **UI flow** — Settings → Agents checkbox → optimistic dispatch →
+ *      `settings:set` IPC → atomic disk write → `settings:changed`
+ *      broadcast → main window `useSettingsSync` replaces state. A
+ *      regression in any link of this chain breaks the user-visible
+ *      "click to hide" gesture.
+ *
+ *   2. **IPC strict-enum boundary** — `IPC_ARG_SCHEMAS['settings:set']`
+ *      uses `z.array(z.enum(AGENT_IDS))` (strict). A malicious or buggy
+ *      renderer that emits an unknown id must be rejected at the
+ *      boundary, not silently persisted. Pre-fix, the only test for this
+ *      lived in `settings.test.ts` against the schema in isolation —
+ *      this spec pins the LIVE boundary by going through the real preload
+ *      bridge.
+ *
+ *   3. **Disk forgiving-schema boundary** — `HIDDEN_AGENT_IDS_SCHEMA` in
+ *      `src/shared/settings.ts` is intentionally forgiving on disk read:
+ *      it filters unknown ids via `.transform` so a stale id from a prior
+ *      version (after `/cli-upgrade` removes an agent) silently drops
+ *      without taking down the whole settings file. If a future refactor
+ *      tightens the disk schema, users with stale ids would lose their
+ *      OTHER settings (default tab, terminal, window size) — a far worse
+ *      blast radius than a phantom hidden entry. This test pins that
+ *      contract end-to-end (settings.json on disk → loadSettings parse →
+ *      Redux state) so the regression surfaces here, not in production.
+ *
+ * Why three tests instead of one: cases 2 and 3 hit code paths the UI
+ * flow can't reach (renderers don't emit invalid ids; the disk schema
+ * can't be exercised without a hand-staged file). Bundling them into the
+ * UI flow would require dispatching synthetic actions and writing files
+ * mid-flow — making the failure mode of each ambiguous.
+ */
+
+test.beforeEach(() => {
+  // The UI test (case 1) needs Cursor's `exists=true`, which means the
+  // `~/.cursor/skills` dir must be present when the renderer scans. The
+  // sidebar render path also depends on the SOURCE_DIR (`~/.agents/skills`)
+  // being populated by `installAzureSkills`. Skip when offline so a network
+  // blip degrades to "skipped" rather than a confusing "Cursor row not
+  // found" failure mid-spec.
+  test.skip(
+    isSnapshotOffline(),
+    'snapshot SOURCE_DIR required to render the sidebar; runner is offline (global-setup wrote snapshot.offline=true)',
+  )
+})
+
+test('toggling Cursor in Settings → Agents hides it from the sidebar and persists to disk', async ({
+  appWindow,
+  electronApp,
+  isolatedHome,
+}) => {
+  // Pre-stage `~/.cursor/skills` so Cursor reports `exists: true` in the
+  // agent scan. Without this, all 21 agents land in the "21 not installed"
+  // disclosure and the "Show Cursor in sidebar" checkbox renders disabled.
+  // Same recipe as folder-actions.e2e.ts:65 for the AgentItem context-menu
+  // test.
+  mkdirSync(join(isolatedHome, '.cursor', 'skills'), { recursive: true })
+
+  await waitForInitialScan(appWindow)
+
+  // The mount-time `fetchAgents` thunk in the main window has already
+  // fired by the time the fixture hands us `appWindow` — it captured the
+  // pre-mkdir state where Cursor.exists was false. Re-fetch into the
+  // SAME store via direct IPC + a synthetic fulfilled action so the
+  // sidebar's `agents.items` reflects the now-existing `.cursor/skills`
+  // dir. Equivalent in effect to dispatching the thunk; cheaper because
+  // we skip the pending → thunk → fulfilled cycle.
+  await appWindow.evaluate(async () => {
+    const fresh = await window.electron.agents.getAll()
+    const store = window.__store__ ?? window.__store
+    if (!store) throw new Error('window.__store__ is not exposed')
+    store.dispatch({
+      type: 'agents/fetchAll/fulfilled',
+      payload: fresh,
+      meta: { requestId: 'e2e-stage-cursor', requestStatus: 'fulfilled' },
+    })
+  })
+
+  // Sanity: Cursor is now installed in the main window's store. If this
+  // assertion fails, the rest of the test is meaningless because the
+  // Settings checkbox would refer to a "not installed" agent.
+  const cursorExistsBefore = await getStoreState(appWindow, (state) => {
+    const root = state as {
+      agents: { items: Array<{ id: string; exists: boolean }> }
+    }
+    return root.agents.items.find((a) => a.id === 'cursor')?.exists
+  })
+  expect(cursorExistsBefore).toBe(true)
+
+  // Initial state: nothing hidden yet — settings.json doesn't even exist
+  // on disk because `saveSettings` only writes after the first mutation.
+  const hiddenBefore = await getStoreState(appWindow, (state) => {
+    const root = state as { settings: { hiddenAgentIds: string[] } }
+    return root.settings.hiddenAgentIds
+  })
+  expect(hiddenBefore).toEqual([])
+
+  // Open Settings — spawns a second BrowserWindow. Capture the window
+  // event BEFORE clicking; Electron fires it synchronously when the new
+  // webContents is created and racing it surfaces as a flaky timeout.
+  // Pattern mirrors folder-actions.e2e.ts:122.
+  const settingsWindowPromise = electronApp.waitForEvent('window')
+  await appWindow.getByLabel('Open settings').click()
+  const settingsWindow = await settingsWindowPromise
+  await settingsWindow.waitForLoadState('domcontentloaded')
+
+  // Navigate to Agents pane. The nav rail is plain `<button>` elements
+  // (SettingsApp.tsx:79), so role=button + name='Agents' is the most
+  // robust selector; aria-label is not set on these buttons.
+  await settingsWindow.getByRole('button', { name: 'Agents' }).click()
+
+  const cursorCheckbox = settingsWindow.getByRole('checkbox', {
+    name: 'Show Cursor in sidebar',
+  })
+  await expect(cursorCheckbox).toBeVisible()
+  await expect(cursorCheckbox).toBeChecked()
+
+  await cursorCheckbox.click()
+
+  // Wait for the cross-window IPC roundtrip to land. The sequence is:
+  //   1. Settings window: optimistic `setSettings` dispatch.
+  //   2. Settings window: `settings:set` IPC fires.
+  //   3. Main process: `saveSettings` writes settings.json atomically.
+  //   4. Main process: broadcasts `settings:changed` to every window.
+  //   5. Main window: `useSettingsSync` receives → dispatches `setSettings`.
+  // Polling on the MAIN window's state asserts the broadcast actually
+  // reached it, which is the load-bearing cross-window invariant.
+  await appWindow.waitForFunction(() => {
+    const store = window.__store__ ?? window.__store
+    if (!store) return false
+    const state = store.getState() as {
+      settings: { hiddenAgentIds: string[] }
+    }
+    return state.settings.hiddenAgentIds.includes('cursor')
+  })
+
+  // Sidebar reflects the hide: the disclosure summary appears. The
+  // strict regex anchors prevent matching e.g. "11 hidden" if a future
+  // bug accidentally hides every agent.
+  await expect(appWindow.getByText(/^1 hidden$/)).toBeVisible()
+
+  // Disk-side: settings.json contains `cursor`. Asserts the atomic
+  // write (saveSettings does writeFile to a tempfile then rename) actually
+  // landed, not just the optimistic dispatch in the renderer.
+  const persisted = readSettingsFile(isolatedHome) as {
+    hiddenAgentIds: string[]
+  } | null
+  expect(
+    persisted,
+    'settings.json should exist after first mutation',
+  ).not.toBeNull()
+  expect(persisted?.hiddenAgentIds).toContain('cursor')
+})
+
+test('IPC strict-enum boundary rejects unknown agent ids without persisting', async ({
+  appWindow,
+  isolatedHome,
+}) => {
+  await waitForInitialScan(appWindow)
+
+  // Direct preload-bridge call, bypassing `useUpdateSettings` — that hook
+  // does an optimistic dispatch FIRST and then voids the IPC promise, so
+  // a rejection there would silently leave the renderer with the bad
+  // value. The boundary we're testing is the IPC schema, so we hit it
+  // directly and observe the rejection.
+  const result = await appWindow.evaluate(async () => {
+    try {
+      // `window.electron.settings.set` is typed loosely in `e2e/types.d.ts`
+      // (Record<string, unknown>) precisely so this boundary test can pass
+      // values the production type system would reject — that's the whole
+      // point of an "invalid id" assertion.
+      await window.electron.settings.set({ hiddenAgentIds: ['bogus-id'] })
+      return { rejected: false, message: null as string | null }
+    } catch (err) {
+      return {
+        rejected: true,
+        message: err instanceof Error ? err.message : String(err),
+      }
+    }
+  })
+
+  expect(
+    result.rejected,
+    'settings.set should reject on unknown agent id',
+  ).toBe(true)
+  // typedHandle wraps ZodError into `Error('IPC validation failed on ${channel}: ...')`.
+  // Asserting both substrings pins the channel-name AND the validation
+  // marker so a future refactor of the error message either preserves
+  // both or surfaces here.
+  expect(result.message).toMatch(/IPC validation failed/)
+  expect(result.message).toMatch(/settings:set/)
+
+  // Renderer state is untouched — no optimistic update happened because
+  // we bypassed `useUpdateSettings`.
+  const hiddenAfter = await getStoreState(appWindow, (state) => {
+    const root = state as { settings: { hiddenAgentIds: string[] } }
+    return root.settings.hiddenAgentIds
+  })
+  expect(hiddenAfter).toEqual([])
+
+  // Disk-side: settings.json was never written. Pre-fix `saveSettings`
+  // ran BEFORE Zod validation moved into typedHandle, leaving on-disk
+  // garbage on a rejected call. This assertion pins that the validation
+  // gate stays UPSTREAM of disk writes.
+  expect(readSettingsFile(isolatedHome)).toBeNull()
+})
+
+test('stale agent id is filtered from settings.json without dropping siblings', async ({
+  isolatedHome,
+}) => {
+  // Pre-stage settings.json with a mix of valid + stale ids and several
+  // sibling fields. Writes must happen BEFORE Electron boots so
+  // `loadSettings` parses this file on startup. We don't request
+  // `electronApp` or `appWindow` from the fixture so Playwright's lazy
+  // fixture instantiation skips them — the default fixture would launch
+  // Electron in series with `isolatedHome` creation, leaving no window
+  // for us to write into the userData dir before parse.
+  writeSettingsFile(isolatedHome, {
+    hiddenAgentIds: ['cursor', 'removed-agent-zzz'],
+    defaultSkillTab: 'info',
+    preferredTerminal: 'iterm',
+  })
+
+  // Manual launch with the same env contract as the default fixture so
+  // the IPC surface, the E2E build flag, the userData override, and the
+  // auto-update suppression all match what the rest of the suite uses.
+  // `E2E_USERDATA_DIR` is critical here: without it, `app.getPath('userData')`
+  // would resolve to the developer's REAL Application Support dir on
+  // macOS (NSSearchPath ignores `$HOME`), and the pre-staged
+  // settings.json above would never be parsed by `loadSettings()`.
+  const repoRoot = resolve(__dirname, '..', '..')
+  const mainEntry = resolve(repoRoot, 'out', 'main', 'index.mjs')
+  const electronApp = await _electron.launch({
+    args: [mainEntry],
+    env: {
+      ...process.env,
+      HOME: isolatedHome,
+      E2E_USERDATA_DIR: resolve(isolatedHome, 'userData'),
+      E2E_DISABLE_UPDATE: '1',
+      E2E_BACKGROUND_LAUNCH: process.env['E2E_BACKGROUND_LAUNCH'] ?? '1',
+    },
+  })
+  try {
+    const appWindow = await electronApp.firstWindow()
+    await appWindow.waitForLoadState('domcontentloaded')
+    await waitForInitialScan(appWindow)
+
+    const settings = await getStoreState(appWindow, (state) => {
+      const root = state as {
+        settings: {
+          hiddenAgentIds: string[]
+          defaultSkillTab: string
+          preferredTerminal: string
+        }
+      }
+      return root.settings
+    })
+
+    // The stale id ('removed-agent-zzz') is filtered out by the disk
+    // schema's `.transform` step; the valid id ('cursor') passes through.
+    // Order is preserved because `Array.from(new Set(...))` keeps
+    // insertion order for the surviving elements.
+    expect(settings.hiddenAgentIds).toEqual(['cursor'])
+
+    // Sibling fields are unaffected — load-bearing assertion. If the disk
+    // schema ever changes from `.transform` to strict `.enum`, the entire
+    // `SettingsSchema.parse()` would throw on the stale id, `loadSettings`
+    // would catch and fall back to DEFAULT_SETTINGS, and these two
+    // expectations would both fail with `'files'` and `'terminal'`.
+    expect(settings.defaultSkillTab).toBe('info')
+    expect(settings.preferredTerminal).toBe('iterm')
+  } finally {
+    await electronApp.close()
+  }
+})

--- a/e2e/spec/regression.e2e.ts
+++ b/e2e/spec/regression.e2e.ts
@@ -819,8 +819,21 @@ test('skills list scroll position survives a background refetch (regression 5619
   // without re-running the search (which could find a different overflowing
   // element if another component happens to also overflow).
   const scrolled = await appWindow.evaluate(() => {
+    // Scope the scroller hunt to the visible tabpanel only — Radix renders
+    // inactive `<TabsContent>` with `hidden` and `display: none`, but their
+    // descendants can still report `scrollHeight > clientHeight`. Picking
+    // one of those would attach `data-e2e-scroll-target` to a non-visible
+    // element and let the regression slip through.
+    const activePanel = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="tabpanel"]'),
+    ).find(
+      (el) =>
+        !el.hasAttribute('hidden') &&
+        window.getComputedStyle(el).display !== 'none',
+    )
+    if (!activePanel) return null
     const candidates = Array.from(
-      document.querySelectorAll<HTMLElement>('[role="tabpanel"] *'),
+      activePanel.querySelectorAll<HTMLElement>('*'),
     )
     const scroller = candidates.find(
       (el) => el.scrollHeight > el.clientHeight + 1,

--- a/e2e/spec/regression.e2e.ts
+++ b/e2e/spec/regression.e2e.ts
@@ -646,3 +646,267 @@ test('scanSkills surfaces broken symlinks as orphan skills (regression #127)', a
   expect(azureRecord?.isOrphan).toBe(false)
   expect(azureRecord?.isSource).toBe(true)
 })
+
+/**
+ * v0.16.0 — Sidebar truncate invariant (regression a541de9).
+ *
+ * The Sidebar `<aside aria-label="Agent sidebar" class="w-68">` measures 272px
+ * (Tailwind v4 auto-generates `w-68` as `width: 17rem`). Inside it, Radix's
+ * `<ScrollArea>` injects a wrapper `<div style="min-width: 100%; display:
+ * table">` between `ScrollAreaPrimitive.Viewport` and our content. `display:
+ * table` makes the wrapper grow to its `min-content` width when any descendant
+ * is `whitespace-nowrap` / `truncate` — in our case the SourceCard's `<p
+ * class="truncate">~/.agents/skills</p>` plus the agents list defeated
+ * truncation entirely, inflating the wrapper to ~325px and bleeding the long
+ * path into the center panel.
+ *
+ * The fix is the `[&>div]:!block` modifier on `ScrollAreaPrimitive.Viewport`
+ * in `src/renderer/src/components/ui/scroll-area.tsx:39`, which forces Radix's
+ * inline `display: table` to `block`. The `!important` is required because
+ * Radix sets `display` via inline style — class rules don't outrank inline
+ * styles without it. With `display: block`, the wrapper takes exactly the
+ * viewport width and `truncate` can clip again.
+ *
+ * Surface assertions, ranked by load-bearing-ness:
+ *
+ *   1. Inner Radix wrapper width ≤ aside width — the bug visualises here. Pre-fix
+ *      this was 325 vs 272; post-fix it's ≤ 272. Asserting `≤` rather than `===`
+ *      stays robust against future cosmetic changes (e.g. a vertical scrollbar
+ *      narrowing the viewport by 8-10px).
+ *
+ *   2. `getComputedStyle(wrapper).display === 'block'` — the SOURCE of the bug. A
+ *      regression that removes `[&>div]:!block` from scroll-area.tsx flips this
+ *      back to 'table' first, and only THEN inflates the width. Catching the
+ *      style change directly gives a clearer failure message ("display reverted
+ *      to table") than only catching the downstream width inflation.
+ *
+ *   3. Sanity — the SourceCard truncate target's offsetWidth is ≤ aside content
+ *      width (aside - p-4×2 = 272 - 32 = 240). Pre-fix this was wider because
+ *      "~/.agents/skills" rendered at its natural width inside the inflated
+ *      wrapper. Downstream of (1) but pins the user-visible symptom in case the
+ *      wrapper width assertion ever loses precision against a future Radix
+ *      version.
+ *
+ * This test does not depend on the snapshot's azure-* skills — it only needs
+ * the Sidebar mounted with the SourceCard visible. The file-level
+ * `test.beforeEach` skip-gate against `isSnapshotOffline()` is irrelevant here
+ * but harmless; we accept the false-positive skip on offline runs to keep the
+ * suite uniform.
+ */
+test('sidebar inner ScrollArea wrapper does not inflate beyond aside width (regression a541de9)', async ({
+  appWindow,
+}) => {
+  await waitForInitialScan(appWindow)
+
+  const aside = appWindow.locator('aside[aria-label="Agent sidebar"]')
+  const wrapper = aside
+    .locator('[data-radix-scroll-area-viewport] > div')
+    .first()
+  const truncatedPath = aside.getByText('~/.agents/skills', { exact: true })
+
+  await expect(aside).toBeVisible()
+  await expect(wrapper).toBeAttached()
+  await expect(truncatedPath).toBeVisible()
+
+  const asideBox = await aside.boundingBox()
+  const wrapperBox = await wrapper.boundingBox()
+  expect(
+    asideBox,
+    'aside produced no bounding box; selector regression',
+  ).not.toBeNull()
+  expect(
+    wrapperBox,
+    'inner Radix wrapper produced no bounding box; selector regression',
+  ).not.toBeNull()
+  if (!asideBox || !wrapperBox) return
+
+  // Load-bearing #1: the Radix wrapper must NOT exceed the aside width.
+  // Pre-fix: 325 vs 272. Post-fix: any value ≤ 272 is acceptable; a
+  // vertical scrollbar can chip a few px off without indicating a regression.
+  expect(
+    wrapperBox.width,
+    `Radix wrapper width (${wrapperBox.width}) exceeds aside width (${asideBox.width}) — ` +
+      'inner ScrollArea div has reverted to display:table inflation. ' +
+      'Check [&>div]:!block on ScrollAreaPrimitive.Viewport in scroll-area.tsx.',
+  ).toBeLessThanOrEqual(asideBox.width)
+
+  // Load-bearing #2: the SOURCE of the bug. A regression that removes
+  // `[&>div]:!block` flips display back to 'table' BEFORE width inflates,
+  // so checking the computed style directly produces a precise failure
+  // message ("display reverted to table") rather than the downstream
+  // width-inflation symptom.
+  const wrapperDisplay = await wrapper.evaluate(
+    (el) => window.getComputedStyle(el).display,
+  )
+  expect(
+    wrapperDisplay,
+    'Radix Viewport inner wrapper computed display reverted to a non-block value — ' +
+      '[&>div]:!block on ScrollAreaPrimitive.Viewport has been removed or overridden.',
+  ).toBe('block')
+
+  // Sanity #3: the truncated path's rendered width fits inside the aside's
+  // content area. p-4 on the inner wrapper = 16px each side = 32px total
+  // horizontal padding. Asserting `≤ asideWidth - 32` pins the user-visible
+  // symptom one layer downstream of the wrapper width itself.
+  const pathOffsetWidth = await truncatedPath.evaluate(
+    (el) => (el as HTMLElement).offsetWidth,
+  )
+  expect(
+    pathOffsetWidth,
+    `Truncated source-card path width (${pathOffsetWidth}) exceeds the aside's ` +
+      `content area (${asideBox.width - 32}). truncate has stopped clipping.`,
+  ).toBeLessThanOrEqual(asideBox.width - 32)
+})
+
+/**
+ * v0.16.0 — Skills list scroll position survives a background refetch
+ * (regression 5619bb7).
+ *
+ * Pre-fix `SkillsList.tsx:93` was `if (loading) return <Loading />`. ANY
+ * refetch (post-sync, manual refresh, post-mutation) flipped
+ * `state.skills.loading` to `true` and unmounted the entire react-window
+ * `<List>` until the next `fulfilled`. Mid-scroll users saw the list reset
+ * to the top, losing their position and any in-progress reading.
+ *
+ * Post-fix the guard became `if (loading && skills.length === 0)` — the
+ * Loading state only renders on the FIRST fetch (when `items` is still
+ * empty). Subsequent refetches keep the List mounted with stale data
+ * showing, then swap to fresh data on `fulfilled` without remounting. This
+ * preserves the scroll container's `scrollTop`.
+ *
+ * Test mechanism — synthetic action dispatch over UI-driven refetch:
+ *
+ * Rather than triggering an actual refetch via a click flow that depends on
+ * an unrelated subsystem (sync, marketplace install, etc.), we dispatch the
+ * thunk's lifecycle action directly. RTK's `createAsyncThunk('skills/fetchAll', ...)`
+ * auto-generates `skills/fetchAll/pending`, and the slice's `extraReducers`
+ * handler at `skillsSlice.ts:383-385` sets `state.loading = true` on it. The
+ * renderer's SkillsList sees `loading=true` with `skills.length > 0` and —
+ * post-fix — does NOT remount. Pre-fix would unmount immediately, drop the
+ * scroll container, and reset `scrollTop` to 0.
+ *
+ * After the assertion we dispatch `skills/fetchAll/fulfilled` with the
+ * current items to flip `loading` back to `false`, leaving the slice in a
+ * consistent post-test state for the suite cleanup.
+ *
+ * Why a single test rather than two (UI-driven vs synthetic)? UI-driven
+ * coverage of the same code path is part of the sync test suite (T4); this
+ * regression test isolates the guard at SkillsList.tsx:93 specifically, so a
+ * UI flow would only add brittleness (button visibility / disabled state)
+ * without strengthening the assertion against this guard.
+ */
+test('skills list scroll position survives a background refetch (regression 5619bb7)', async ({
+  appWindow,
+}) => {
+  await waitForInitialScan(appWindow)
+
+  const itemCount = await getStoreState(appWindow, (state) => {
+    const root = state as { skills: { items: unknown[] } }
+    return root.skills.items.length
+  })
+  expect(
+    itemCount,
+    'snapshot must contain skills for the SkillsList to render rows',
+  ).toBeGreaterThan(0)
+
+  // Resolve the scrollable container. The wrapper around `<SkillsList />` is
+  // `<div class="flex-1 min-h-0 overflow-auto p-4">` (MainContent.tsx:598)
+  // and react-window v2 may add its own inner scroll container. Find the
+  // first descendant inside the active TabsContent panel whose
+  // `scrollHeight > clientHeight` — that's the ACTUAL scroller regardless of
+  // which layer wins. Returning a unique data-attr-tag on the resolved
+  // element lets us read it back deterministically after the dispatch
+  // without re-running the search (which could find a different overflowing
+  // element if another component happens to also overflow).
+  const scrolled = await appWindow.evaluate(() => {
+    const candidates = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="tabpanel"] *'),
+    )
+    const scroller = candidates.find(
+      (el) => el.scrollHeight > el.clientHeight + 1,
+    )
+    if (!scroller) return null
+    scroller.setAttribute('data-e2e-scroll-target', 'true')
+    scroller.scrollTop = 200
+    return { applied: scroller.scrollTop, target: 200 }
+  })
+  expect(
+    scrolled,
+    'no overflowing scroller found inside the active TabsContent panel — ' +
+      'snapshot may have fewer skills than the viewport can contain. ' +
+      'Adjust global-setup or the row-height constants if this is intentional.',
+  ).not.toBeNull()
+  if (!scrolled) return
+  expect(
+    scrolled.applied,
+    'browser refused the scrollTop assignment — element is not scrollable',
+  ).toBeGreaterThan(0)
+
+  // Dispatch the thunk's pending action directly. Pre-fix, SkillsList's
+  // top-level `if (loading)` would unmount the List on the next render
+  // tick, dropping the scroll container.
+  await dispatchAction(appWindow, {
+    type: 'skills/fetchAll/pending',
+    meta: {
+      arg: undefined,
+      requestId: 'e2e-t3-refetch',
+      requestStatus: 'pending',
+    },
+  })
+
+  // Allow one paint frame so React commits the loading=true state. We do
+  // NOT use waitForFunction here because the bug under test is the
+  // ABSENCE of unmount — there's nothing positive to poll for, only the
+  // STABILITY of `scrollTop`. requestAnimationFrame is the synchronous
+  // analogue: dispatch → reducer → React commit → next paint.
+  await appWindow.evaluate(
+    () =>
+      new Promise<void>((resolve) => requestAnimationFrame(() => resolve())),
+  )
+
+  const scrollTopAfter = await appWindow.evaluate(() => {
+    const scroller = document.querySelector<HTMLElement>(
+      '[data-e2e-scroll-target="true"]',
+    )
+    return scroller?.scrollTop ?? null
+  })
+
+  // Allow ±2px for layout settle (font metrics, scrollbar fractional pixel
+  // rounding). Pre-fix: 0. Post-fix: ~200.
+  expect(
+    scrollTopAfter,
+    'data-e2e-scroll-target attribute lost — the element was removed from the DOM. ' +
+      'SkillsList remounted instead of staying mounted with stale data. ' +
+      'Check the `loading && skills.length === 0` guard at SkillsList.tsx:93.',
+  ).not.toBeNull()
+  if (scrollTopAfter === null) return
+  expect(
+    scrollTopAfter,
+    `scrollTop reset from ${scrolled.applied} to ${scrollTopAfter} — list remounted on refetch.`,
+  ).toBeGreaterThanOrEqual(scrolled.applied - 2)
+
+  // Cleanup — flip loading back to false so subsequent tests start from a
+  // consistent slice state. Dispatching fulfilled with the in-store items
+  // (read inline) is one IPC roundtrip cheaper than `refreshSkillsState`
+  // and avoids re-scanning disk for content we already have. Also remove
+  // the data attribute so it doesn't leak into the next test.
+  await appWindow.evaluate(() => {
+    const store = window.__store__ ?? window.__store
+    if (!store) return
+    const state = store.getState() as {
+      skills: { items: unknown[] }
+    }
+    store.dispatch({
+      type: 'skills/fetchAll/fulfilled',
+      payload: state.skills.items,
+      meta: {
+        arg: undefined,
+        requestId: 'e2e-t3-restore',
+        requestStatus: 'fulfilled',
+      },
+    })
+    document
+      .querySelector('[data-e2e-scroll-target="true"]')
+      ?.removeAttribute('data-e2e-scroll-target')
+  })
+})

--- a/e2e/spec/sync.e2e.ts
+++ b/e2e/spec/sync.e2e.ts
@@ -1,0 +1,280 @@
+import { existsSync, lstatSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { test, expect } from '../fixtures/electron-app'
+import { isSnapshotOffline } from '../fixtures/isolated-home'
+import {
+  getStoreState,
+  waitForInitialScan,
+  waitForSyncSettled,
+} from '../helpers/redux'
+
+/**
+ * Sync flow — `fetchSyncPreview` → `executeSyncAction` → `SyncResultDialog`.
+ *
+ * Why this needs E2E coverage at all: the sync flow crosses two IPC
+ * channels (`SYNC_PREVIEW`, `SYNC_EXECUTE`), four dialog components
+ * (`SyncConfirmDialog`, `SyncConflictDialog`, `SyncResultDialog`, plus
+ * the `SourceCard` trigger), and creates real symlinks under the user's
+ * home directory. Until now the unit-test layer had `syncService.test.ts`
+ * for the main-process service and the slice tests for the reducer, but
+ * NOTHING exercised the wired-up `<button onClick={dispatch(thunk)}>`
+ * → preload bridge → main service → fs.symlink → broadcast → dialog
+ * loop. A regression in any of those joints (e.g. broken `electron.sync.execute`
+ * binding, dialog gate predicate flip, `replaceConflicts: []` arg drop)
+ * would silently land on main without any test going red.
+ *
+ * Coverage strategy: three tests, each isolated by the per-test fixture
+ * HOME so symlinks created in one don't pollute another:
+ *
+ *   1. **Global preview** — UI-driven via the SourceCard's "Sync" button.
+ *      Pins the SourceCard wiring, the thunk dispatch, the slice reducer,
+ *      AND the dialog auto-open predicate (`shouldShowSyncConfirm`).
+ *
+ *   2. **Per-agent preview** — direct IPC call. The per-agent option has
+ *      no UI surface (it's invoked by the per-agent Cleanup flow as an
+ *      internal API), so calling the preload bridge directly is the
+ *      only way to assert the `forAgent` echo and the `totalAgents === 1`
+ *      narrowing rule at the boundary `getExistingAgents` filters at.
+ *
+ *   3. **Execute → SyncResultDialog** — UI-driven end-to-end. Asserts
+ *      both the slice (`syncResult.success`, `created`, `errors`) AND
+ *      the filesystem (`lstatSync(...).isSymbolicLink()`) AND the
+ *      auto-opened result dialog. Filesystem proof matters because a
+ *      future refactor that updates the slice without actually creating
+ *      symlinks would still pass the slice assertions alone.
+ *
+ * Snapshot-state caveat: the global-setup runs `npx skills add ... --global`
+ * which side-effects ~30 agent dirs into the home (`.adal/`, `.bob/`,
+ * `.claude/`, etc.) AND fully links every azure-* skill into each of
+ * them. So the BASELINE preview against an unmodified isolated HOME
+ * already shows `totalAgents ≈ 31, alreadySynced ≈ 217, toCreate = 0` —
+ * meaning the only way to drive `toCreate > 0` is to stage an agent dir
+ * that is NOT in the snapshot. Cursor and Cline both qualify
+ * (`.cursor/` and `.cline/` are absent from the snapshot HOME despite
+ * being in `UNIVERSAL_AGENT_IDS`). This is why we mkdir those parents
+ * — they're the only fresh slots the sync logic has to fill.
+ */
+
+test.beforeEach(() => {
+  // Sync needs the 7 azure-* skills from the snapshot SOURCE_DIR. When
+  // the runner is offline, global-setup leaves the snapshot empty and
+  // `syncPreview` returns `toCreate: 0` → assertions fail with confusing
+  // "expected 7, got 0" messages. Skipping cleanly is much better triage.
+  test.skip(
+    isSnapshotOffline(),
+    'sync preview/execute requires azure-* skills from snapshot install (offline run)',
+  )
+})
+
+test('fetchSyncPreview populates state.ui.syncPreview with non-zero toCreate (global)', async ({
+  appWindow,
+  isolatedHome,
+}) => {
+  await waitForInitialScan(appWindow)
+
+  // Stage two agent dirs that the snapshot did NOT pre-stage. Cursor and
+  // Cline are both chosen because their parent dirs (`.cursor/`,
+  // `.cline/`) are absent from the snapshot HOME — the snapshot's
+  // `npx skills add --global` side-effects most other agent dirs but
+  // leaves these two alone (verified via debug spec). Using two staged
+  // agents exposes the `+14 toCreate` contribution unambiguously: a
+  // single agent could be confused with snapshot noise on a future CLI
+  // version, two won't.
+  mkdirSync(join(isolatedHome, '.cursor'), { recursive: true })
+  mkdirSync(join(isolatedHome, '.cline'), { recursive: true })
+
+  // Click the SourceCard's Sync button. Scoped to `<aside>` so the
+  // selector also-matches-by-text doesn't collide with the
+  // SyncConfirmDialog's submit button (which is named "Sync" too) — the
+  // dialog isn't mounted yet at this moment, but using a scoped locator
+  // keeps the intent explicit and survives a future refactor that might
+  // mount the dialog earlier.
+  await appWindow
+    .locator('aside')
+    .getByRole('button', { name: 'Sync', exact: true })
+    .click()
+
+  await waitForSyncSettled(appWindow, 'preview')
+
+  const preview = await getStoreState(appWindow, (state) => {
+    const root = state as {
+      ui: {
+        syncPreview: {
+          totalSkills: number
+          totalAgents: number
+          toCreate: number
+          alreadySynced: number
+          conflicts: unknown[]
+          forAgent?: string
+        } | null
+      }
+    }
+    return root.ui.syncPreview
+  })
+
+  expect(
+    preview,
+    'syncPreview should be populated after thunk fulfills',
+  ).not.toBeNull()
+  // 7 azure-* skills is invariant — the snapshot installs exactly that.
+  expect(preview!.totalSkills).toBe(7)
+  // totalAgents bound: cursor + cline contribute 2; the snapshot's
+  // `npx skills add --global` side-effects ~30 more pre-existing agent
+  // dirs. Lower bound is the only stable assertion; an exact number
+  // would tie the test to whatever the current skills-CLI version
+  // happens to side-effect this week.
+  expect(preview!.totalAgents).toBeGreaterThanOrEqual(2)
+  // toCreate is exact: cursor + cline each have 7 empty azure-* slots,
+  // and every snapshot-staged agent is already fully linked
+  // (alreadySynced=N×7 in the baseline). If a future skills-CLI version
+  // changes the snapshot's link state, this exact number will need to
+  // be reviewed — a deliberate forcing function.
+  expect(preview!.toCreate).toBe(14)
+  expect(preview!.conflicts).toEqual([])
+  // Global preview omits `forAgent`. Pinning `undefined` (not `null`)
+  // pins the `...(options?.agentId ? { forAgent: options.agentId } : {})`
+  // spread in syncService — a refactor that always emits the field
+  // would land here as "expected undefined, got null".
+  expect(preview!.forAgent).toBeUndefined()
+})
+
+test('per-agent preview narrows scope and echoes forAgent', async ({
+  appWindow,
+  isolatedHome,
+}) => {
+  await waitForInitialScan(appWindow)
+
+  // The snapshot already pre-stages ~30 agent dirs (see file-level doc),
+  // so the multi-agent baseline exists for free. We stage `.cursor`
+  // because our scoped preview will target cursor — the assertion below
+  // proves the `filterAgentsByOption` filter actually narrows the result
+  // even though the baseline has many agents on disk.
+  mkdirSync(join(isolatedHome, '.cursor'), { recursive: true })
+
+  // Direct preload-bridge call. The per-agent Cleanup flow uses this
+  // option internally; there's no top-level UI button that emits
+  // `{ agentId }` from the renderer, so wiring this through a click
+  // would test more than the boundary we care about. The thunk + slice
+  // path is already covered by the global test above.
+  const previewRaw = await appWindow.evaluate(() =>
+    window.electron.sync.preview({ agentId: 'cursor' }),
+  )
+  const preview = previewRaw as {
+    totalSkills: number
+    totalAgents: number
+    toCreate: number
+    alreadySynced: number
+    conflicts: unknown[]
+    forAgent?: string
+  }
+
+  expect(preview.forAgent).toBe('cursor')
+  // Despite ~31 agents existing on disk (snapshot side-effects + our
+  // staged cursor), totalAgents collapses to 1 because the filter ran.
+  // If the filter regressed to a no-op, this would be ≥31 and the test
+  // would fail loud.
+  expect(preview.totalAgents).toBe(1)
+  expect(preview.toCreate).toBe(7)
+  expect(preview.conflicts).toEqual([])
+})
+
+test('executing sync creates symlinks and opens SyncResultDialog', async ({
+  appWindow,
+  isolatedHome,
+}) => {
+  await waitForInitialScan(appWindow)
+
+  // One staged agent is enough for the execute proof — keeping it to
+  // cursor minimizes assertion surface and matches the path we'll lstat
+  // for filesystem evidence below.
+  mkdirSync(join(isolatedHome, '.cursor'), { recursive: true })
+
+  // Step 1: trigger preview via the SourceCard. The dialog auto-mounts
+  // when `state.ui.syncPreview.toCreate > 0 && conflicts.length === 0`
+  // (via `shouldShowSyncConfirm`), so this single click both fetches
+  // the preview AND surfaces the confirm dialog whose Sync button we
+  // need next.
+  await appWindow
+    .locator('aside')
+    .getByRole('button', { name: 'Sync', exact: true })
+    .click()
+  await waitForSyncSettled(appWindow, 'preview')
+
+  // Step 2: confirm dialog is visible — assert before clicking so a
+  // gate-predicate regression (e.g. accidental flip to
+  // `toCreate === 0`) shows here rather than as a flaky "click missed"
+  // failure. Title comes from `<DialogIconHeader title="Sync Skills" />`.
+  const confirmDialog = appWindow.getByRole('dialog', { name: 'Sync Skills' })
+  await expect(confirmDialog).toBeVisible()
+
+  // Step 3: click the dialog's Sync button. Scoping to the dialog
+  // disambiguates it from the SourceCard's Sync button (both are
+  // present in the DOM at this moment).
+  await confirmDialog.getByRole('button', { name: 'Sync', exact: true }).click()
+
+  await waitForSyncSettled(appWindow, 'result')
+
+  const result = await getStoreState(appWindow, (state) => {
+    const root = state as {
+      ui: {
+        syncResult: {
+          success: boolean
+          created: number
+          replaced: number
+          skipped: number
+          errors: unknown[]
+          details: unknown[]
+        } | null
+      }
+    }
+    return root.ui.syncResult
+  })
+
+  expect(
+    result,
+    'syncResult should be populated after execute fulfills',
+  ).not.toBeNull()
+  expect(result!.success).toBe(true)
+  expect(result!.errors).toEqual([])
+  // 7 newly-created symlinks (cursor staged with empty parent dir →
+  // every azure-* slot is missing → all 7 fall in the
+  // `.with({ exists: false }, ...)` arm of the match in syncExecute).
+  // The snapshot's pre-existing agent dirs all start fully linked, so
+  // their slots fall in the `.with({ isSymlink: true }, ...)` arm and
+  // contribute to `skipped` — NOT `created`. So `created === 7` exactly.
+  expect(result!.created).toBe(7)
+  // No `replaceConflicts` were passed; pre-fix this could spuriously
+  // count if the resolver leaked. Pin the contract.
+  expect(result!.replaced).toBe(0)
+  // `skipped` floor depends on snapshot link count (~217 in current
+  // CLI version). Lower-bound only: a precise pin would couple this
+  // test to skills-CLI side-effects unrelated to our regression target.
+  expect(result!.skipped).toBeGreaterThanOrEqual(0)
+
+  // Filesystem proof. The thunk could conceivably mark itself fulfilled
+  // without making the actual filesystem change (a unit test against a
+  // stubbed service would still pass), so we lstat one of the expected
+  // symlink targets. `azure-ai` is the alphabetically-first azure-* skill,
+  // making it stable across CLI install ordering changes.
+  const cursorSkillsDir = join(isolatedHome, '.cursor', 'skills')
+  expect(
+    existsSync(cursorSkillsDir),
+    'syncExecute should mkdir the agent skills dir',
+  ).toBe(true)
+  const azureAiLink = join(cursorSkillsDir, 'azure-ai')
+  expect(existsSync(azureAiLink)).toBe(true)
+  expect(
+    lstatSync(azureAiLink).isSymbolicLink(),
+    'azure-ai should be a SYMLINK, not a copy or real dir',
+  ).toBe(true)
+
+  // Step 4: SyncResultDialog opens automatically when `syncResult` is
+  // populated. Title comes from `<DialogTitle>Sync Results</DialogTitle>`
+  // in SyncResultDialog.tsx. The plural form ("Results", not "Result")
+  // is load-bearing — a refactor that singularized the title would land
+  // here.
+  await expect(
+    appWindow.getByRole('dialog', { name: 'Sync Results' }),
+  ).toBeVisible()
+})

--- a/e2e/types.d.ts
+++ b/e2e/types.d.ts
@@ -119,6 +119,35 @@ declare global {
           error?: string
         }>
       }
+      agents: {
+        getAll: () => Promise<unknown[]>
+      }
+      /**
+       * Settings IPC. The `set` argument is intentionally typed as
+       * `Record<string, unknown>` (NOT `Partial<Settings>`) because the
+       * hide-agents suite directly tests the strict-enum boundary at
+       * `IPC_ARG_SCHEMAS['settings:set']` by passing values the renderer's
+       * type system would normally reject. A tighter type here would
+       * force every such test to add an `as unknown as ...` escape hatch.
+       */
+      settings: {
+        get: () => Promise<unknown>
+        set: (partial: Record<string, unknown>) => Promise<unknown>
+      }
+      /**
+       * Sync IPC. Both methods return rich result objects; the spec types
+       * them via local cast at the call site so this surface stays as
+       * `unknown` here — keeping the surface narrow protects the test
+       * suite from drift in the production `SyncPreviewResult` /
+       * `SyncExecuteResult` shapes (which evolve with feature work).
+       */
+      sync: {
+        preview: (options?: { agentId?: string }) => Promise<unknown>
+        execute: (options: {
+          replaceConflicts: string[]
+          agentId?: string
+        }) => Promise<unknown>
+      }
     }
   }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -26,6 +26,23 @@ process.on('unhandledRejection', (reason, promise) => {
   console.error('Unhandled Rejection at:', promise, 'reason:', reason)
 })
 
+// E2E: redirect Electron's `userData` directory into the test's isolated
+// HOME. On macOS `app.getPath('userData')` is implemented via
+// `NSSearchPathForDirectoriesInDomains`, which uses `getpwuid(getuid())`
+// for the user's home dir — it ignores `$HOME`. Without this override
+// Playwright tests would write `settings.json` to the developer's REAL
+// `~/Library/Application Support/skills-desktop`, polluting their actual
+// app state and breaking any test that reads/writes settings under an
+// "isolated" home. Must run synchronously at module load (before
+// `app.whenReady()` and before any code path that touches `userData`)
+// so `loadSettings()` and the BrowserWindow's session storage land in
+// the isolated tree on first read. `setPath` is undocumented-but-safe to
+// call this early — Electron resolves the path lazily on first use.
+const e2eUserDataDir = process.env['E2E_USERDATA_DIR']
+if (e2eUserDataDir) {
+  app.setPath('userData', e2eUserDataDir)
+}
+
 /**
  * Default launch size used when the user has no persisted `windowSize`
  * preference. Mirrors the previous hard-coded constructor values; with no


### PR DESCRIPTION
## Summary

Closes the four most visible E2E coverage gaps after v0.16.0:

- **`hide-agents.e2e.ts` (3 cases)** — pins PR #144 end-to-end: UI hide round-trip across Settings ↔ main window, IPC strict-enum boundary at `IPC_ARG_SCHEMAS['settings:set']`, and the disk-side forgiving-schema filter that drops stale agent ids without taking down sibling fields.
- **`regression.e2e.ts` (+2 cases)** — sidebar `ScrollArea` viewport wrapper width invariant (commit `a541de9`) and skills list `scrollTop` preservation across a background `skills/fetchAll/pending` (commit `5619bb7`).
- **`sync.e2e.ts` (3 cases)** — first E2E for the sync flow: `fetchSyncPreview` global lifecycle via SourceCard click, per-agent `forAgent` echo / `filterAgentsByOption` narrowing, and full `executeSyncAction` → `SyncResultDialog` round-trip with filesystem proof (`lstatSync(...).isSymbolicLink()`).

## Side-effect fix

`src/main/index.ts` now reads `E2E_USERDATA_DIR` and calls `app.setPath('userData', ...)` synchronously at module load. macOS `app.getPath('userData')` resolves via `getpwuid(getuid())` and ignores `$HOME`, so prior tests that touched `settings.json` were silently writing to the developer's real `~/Library/Application Support/skills-desktop`. The fixture (`e2e/fixtures/electron-app.ts`) now passes the override through; `e2e/helpers/settings-file.ts` reads/writes the isolated path. This made the hide-agents tests possible and removes a long-standing leak in the existing folder-actions terminal-preference test.

## New helpers

- `waitForSyncSettled(page, expects)` in `e2e/helpers/redux.ts` — slice-aware poll (`'preview'` | `'result'`) that avoids the false-positive of the `isSyncing` flag starting `false` before the trigger fires.
- `e2e/helpers/settings-file.ts` — `readSettingsFile(home)` / `writeSettingsFile(home, contents)` for round-tripping settings.json on disk.

## Test plan

- [x] `pnpm test:e2e e2e/spec/sync.e2e.ts` — 3/3 pass
- [x] `pnpm test:e2e e2e/spec/hide-agents.e2e.ts` — 3/3 pass
- [x] `pnpm test:e2e --grep "regression a541de9"` — 1/1 pass
- [x] `pnpm test:e2e --grep "regression 5619bb7"` — 1/1 pass
- [x] `pnpm test:e2e` — full suite **39/39** pass
- [x] `npx tsc -p e2e/tsconfig.json --noEmit` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * e2e テスト環境の隔離と管理機能を強化
  * エージェント非表示機能、同期フロー、回帰テストに関する新しいテストスイートを追加
  * テスト用ヘルパー機能の拡張

* **その他**
  * テスト環境設定の管理機能を改善

<!-- end of auto-generated comment: release notes by coderabbit.ai -->