### PR TITLE
feat: add Orphan option to skill-type filter

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,29 @@
+# TODOS
+
+Deferred items captured during planning. Pick up when scope and bandwidth allow.
+
+## Orphan filter follow-ups (2026-05-09)
+
+### 1. Source-view orphan visibility
+
+**Context:** The Orphan filter in `SkillTypeFilter` only renders in agent view (`selectedAgentId !== null`). In source view (no agent selected), `selectFilteredSkills` filters to `isSource: true` only — orphans are invisible there because their source dir was deleted.
+
+**Possible directions:**
+
+- Add a separate "Show orphans" toggle/checkbox in source view header
+- Render orphans as a dedicated bottom section below sources (visually demarcated)
+- Add a synthetic "Orphans" entry in the agent sidebar (treats orphans as a pseudo-agent)
+
+**Why deferred:** Decision needs design input on where orphans live in source view conceptually — they're not sources, but they're also not agent-scoped state.
+
+### 2. Filter persistence across agent switches
+
+**Context:** `selectAgent` reducer in `src/renderer/src/redux/slices/uiSlice.ts:246` resets `skillTypeFilter = 'all'` whenever the user picks a different agent. With the new Orphan option, a user investigating orphans across agents has to re-select Orphan each time.
+
+**Possible directions:**
+
+- Persist `skillTypeFilter` across `selectAgent` (drop the reset)
+- Persist Orphan specifically (`'orphan'` survives, `'symlinked'` / `'local'` reset to `'all'`)
+- Surface a "Sticky filter" preference toggle in Settings
+
+**Why deferred:** Reset behavior was a deliberate UX choice for the original 3-option filter; changing it now needs a usage-based justification rather than speculation.

--- a/e2e/spec/orphan-filter.e2e.ts
+++ b/e2e/spec/orphan-filter.e2e.ts
@@ -1,0 +1,143 @@
+import { existsSync, lstatSync, mkdirSync, symlinkSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { test, expect } from '../fixtures/electron-app'
+import { isSnapshotOffline } from '../fixtures/isolated-home'
+import {
+  dispatchAction,
+  getStoreState,
+  refreshSkillsState,
+  waitForInitialScan,
+} from '../helpers/redux'
+
+/**
+ * End-to-end FS-truth → user-visible-list contract for the new Orphan
+ * filter. The selector logic itself is unit-tested at
+ * `src/renderer/src/redux/selectors.test.ts`; this spec only owns the
+ * "dangling symlink on disk → orphan row in filtered list" path.
+ *
+ * Mirrors the orphan staging from `regression.e2e.ts` (windsurf scanDir
+ * is non-universal, so the orphan's only `'broken'` slot lands on a
+ * single agent, which makes the negative-control under cursor meaningful).
+ */
+
+// Negative-control assertion below references azure-ai by name; an empty
+// snapshot would silently invalidate it.
+test.beforeEach(() => {
+  test.skip(
+    isSnapshotOffline(),
+    'azure-* skills required to seed non-orphan rows for the negative-control assertion; runner is offline (global-setup wrote snapshot.offline=true)',
+  )
+})
+
+/**
+ * Replicates `selectFilteredSkills`'s agent-slot-gated orphan predicate
+ * inside the renderer via `Function.toString`. Hoisted so the windsurf
+ * positive case and the cursor negative case share one body — the e2e
+ * bundle does not surface individual selector modules to `page.evaluate`.
+ */
+const filterOrphanNamesByAgent = (
+  state: unknown,
+  args: { agentId: string },
+): string[] => {
+  const root = state as {
+    skills: {
+      items: Array<{
+        name: string
+        isOrphan: boolean
+        symlinks: Array<{
+          agentId: string
+          status: 'valid' | 'broken' | 'missing'
+          isLocal: boolean
+        }>
+      }>
+    }
+  }
+  return root.skills.items
+    .filter(
+      (skill) =>
+        skill.isOrphan === true &&
+        skill.symlinks.some(
+          (slot) =>
+            slot.agentId === args.agentId &&
+            (slot.status === 'valid' || slot.status === 'broken'),
+        ),
+    )
+    .map((skill) => skill.name)
+}
+
+test('Orphan filter narrows visible list to orphan skills only', async ({
+  appWindow,
+  isolatedHome,
+}) => {
+  await waitForInitialScan(appWindow)
+
+  const orphanSkillName = 'orphan-filter-fixture'
+  const windsurfSkillsDir = join(isolatedHome, '.codeium', 'windsurf', 'skills')
+  mkdirSync(windsurfSkillsDir, { recursive: true })
+
+  // Target intentionally absent — `scanOrphanSymlinks` requires a dangling
+  // link to surface a synthetic Skill row.
+  const phantomSourcePath = join(
+    isolatedHome,
+    '.agents',
+    'skills',
+    orphanSkillName,
+  )
+  const orphanLinkPath = join(windsurfSkillsDir, orphanSkillName)
+  symlinkSync(phantomSourcePath, orphanLinkPath)
+
+  expect(lstatSync(orphanLinkPath).isSymbolicLink()).toBe(true)
+  expect(existsSync(phantomSourcePath)).toBe(false)
+
+  await refreshSkillsState(appWindow)
+
+  await dispatchAction(appWindow, {
+    type: 'ui/selectAgent',
+    payload: 'windsurf',
+  })
+  await dispatchAction(appWindow, {
+    type: 'ui/setSkillTypeFilter',
+    payload: 'orphan',
+  })
+
+  const uiState = await getStoreState(appWindow, (state) => {
+    const root = state as {
+      ui: { selectedAgentId: string | null; skillTypeFilter: string }
+    }
+    return {
+      selectedAgentId: root.ui.selectedAgentId,
+      skillTypeFilter: root.ui.skillTypeFilter,
+    }
+  })
+  expect(uiState.selectedAgentId).toBe('windsurf')
+  expect(uiState.skillTypeFilter).toBe('orphan')
+
+  // Single-row equality (not `.toContain`) so a regression that lets
+  // non-orphan rows leak shows the offending names in the failure diff.
+  const filteredNames = await getStoreState(
+    appWindow,
+    filterOrphanNamesByAgent,
+    { agentId: 'windsurf' },
+  )
+  expect(filteredNames).toEqual([orphanSkillName])
+
+  // Negative control — the orphan's only `'broken'` slot is on windsurf,
+  // so the agent-slot gate must drop it under cursor. Without this leg,
+  // a regression that ran the orphan predicate against the unfiltered
+  // skills array would still pass the positive assertion above.
+  await dispatchAction(appWindow, {
+    type: 'ui/selectAgent',
+    payload: 'cursor',
+  })
+
+  const filteredNamesUnderCursor = await getStoreState(
+    appWindow,
+    filterOrphanNamesByAgent,
+    { agentId: 'cursor' },
+  )
+  expect(
+    filteredNamesUnderCursor,
+    'orphan must NOT surface under cursor — its only broken slot is on windsurf',
+  ).not.toContain(orphanSkillName)
+})

--- a/src/renderer/src/components/layout/MainContent.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.browser.test.tsx
@@ -505,7 +505,7 @@ describe('MainContent SkillTypeFilter dropdown (Orphan option)', () => {
     // The colored dot is a sibling span; assert the className substring is
     // present somewhere within the menu item's subtree so a future markup
     // tweak (wrapping the dot in another span, etc.) still passes.
-    const orphanItemElement = await orphanItem.element()
+    const orphanItemElement = orphanItem.element()
     const dot = orphanItemElement.querySelector('.bg-destructive')
     expect(
       dot,

--- a/src/renderer/src/components/layout/MainContent.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.browser.test.tsx
@@ -469,6 +469,127 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
   })
 })
 
+describe('MainContent SkillTypeFilter dropdown (Orphan option)', () => {
+  // Pins the agent-only Orphan affordance contract: the dropdown is gated by
+  // `selectedAgentId` (source view never offers it), and selecting Orphan
+  // narrows the visible list to skills whose source dir vanished.
+
+  it('renders the Orphan radio item with a destructive dot when an agent is selected', async () => {
+    const { screen, store } = await renderMainContent()
+    const { fetchAgents } =
+      await import('@/renderer/src/redux/slices/agentsSlice')
+    const { selectAgent } = await import('@/renderer/src/redux/slices/uiSlice')
+
+    store.dispatch(
+      fetchAgents.fulfilled(
+        [
+          {
+            id: 'cursor',
+            name: 'Cursor',
+            path: '/Users/me/.cursor/skills' as never,
+            exists: true,
+            skillCount: 0,
+            localSkillCount: 0,
+          },
+        ],
+        'req-id',
+      ),
+    )
+    store.dispatch(selectAgent('cursor'))
+
+    // Open the dropdown — the trigger label currently reads "All".
+    await screen.getByRole('button', { name: /^All$/ }).click()
+
+    const orphanItem = screen.getByRole('menuitemradio', { name: /Orphan/i })
+    await expect.element(orphanItem).toBeInTheDocument()
+    // The colored dot is a sibling span; assert the className substring is
+    // present somewhere within the menu item's subtree so a future markup
+    // tweak (wrapping the dot in another span, etc.) still passes.
+    const orphanItemElement = await orphanItem.element()
+    const dot = orphanItemElement.querySelector('.bg-destructive')
+    expect(
+      dot,
+      'Orphan menu item should contain a span with bg-destructive',
+    ).not.toBeNull()
+  })
+
+  it('selecting Orphan narrows visible list to skills with isOrphan=true', async () => {
+    const { screen, store } = await renderMainContent()
+    const { fetchAgents } =
+      await import('@/renderer/src/redux/slices/agentsSlice')
+    const { selectAgent } = await import('@/renderer/src/redux/slices/uiSlice')
+    const { fetchSkills } =
+      await import('@/renderer/src/redux/slices/skillsSlice')
+
+    const orphanSkill: Skill = {
+      name: 'orphan-one' as SkillName,
+      description: '',
+      path: '/skills/orphan-one' as never,
+      symlinkCount: 1,
+      symlinks: [
+        {
+          agentId: 'cursor' as never,
+          agentName: 'Cursor' as never,
+          linkPath: '/cursor/skills/orphan-one' as never,
+          targetPath: '/skills/orphan-one' as never,
+          status: 'broken',
+          isLocal: false,
+        },
+      ],
+      isSource: false,
+      isOrphan: true,
+    }
+    const linkedSkill: Skill = {
+      name: 'linked-one' as SkillName,
+      description: '',
+      path: '/skills/linked-one' as never,
+      symlinkCount: 1,
+      symlinks: [
+        {
+          agentId: 'cursor' as never,
+          agentName: 'Cursor' as never,
+          linkPath: '/cursor/skills/linked-one' as never,
+          targetPath: '/skills/linked-one' as never,
+          status: 'valid',
+          isLocal: false,
+        },
+      ],
+      isSource: true,
+      isOrphan: false,
+    }
+
+    store.dispatch(
+      fetchAgents.fulfilled(
+        [
+          {
+            id: 'cursor',
+            name: 'Cursor',
+            path: '/Users/me/.cursor/skills' as never,
+            exists: true,
+            skillCount: 0,
+            localSkillCount: 0,
+          },
+        ],
+        'req-id',
+      ),
+    )
+    store.dispatch(selectAgent('cursor'))
+    store.dispatch(fetchSkills.fulfilled([orphanSkill, linkedSkill], 'req-id'))
+
+    await screen.getByRole('button', { name: /^All$/ }).click()
+    await screen.getByRole('menuitemradio', { name: /Orphan/i }).click()
+
+    // Slice state — single source of truth that the selector reads from.
+    expect(store.getState().ui.skillTypeFilter).toBe('orphan')
+
+    // Selector view — the filtered list now contains only the orphan.
+    const { selectFilteredSkills } =
+      await import('@/renderer/src/redux/selectors')
+    const filtered = selectFilteredSkills(store.getState() as never)
+    expect(filtered.map((skill) => skill.name)).toEqual(['orphan-one'])
+  })
+})
+
 describe('MainContent filter pills (Agent + Source orthogonal)', () => {
   // The Agent pill and the Source pill are independent narrowings — the user
   // can be in "agent: Claude Code" view AND filter by "from: vercel-labs/foo"

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -107,6 +107,7 @@ const SKILL_TYPE_FILTER_OPTIONS: {
   { value: 'all', label: 'All' },
   { value: 'symlinked', label: 'Symlinked', dotClass: 'bg-success' },
   { value: 'local', label: 'Local', dotClass: 'bg-emerald-400' },
+  { value: 'orphan', label: 'Orphan', dotClass: 'bg-destructive' },
 ]
 
 const SKILLS_SH_URL = 'https://skills.sh'

--- a/src/renderer/src/redux/selectors.test.ts
+++ b/src/renderer/src/redux/selectors.test.ts
@@ -30,7 +30,7 @@ function buildState(overrides: {
   selectedAgentId?: AgentId | null
   selectedSource?: RepositoryId | null
   sortOrder?: 'asc' | 'desc'
-  skillTypeFilter?: 'all' | 'symlinked' | 'local'
+  skillTypeFilter?: 'all' | 'symlinked' | 'local' | 'orphan'
   bookmarks?: BookmarkedSkill[]
   selectedSkillNames?: SkillName[]
   inFlightDeleteNames?: SkillName[]
@@ -346,6 +346,89 @@ describe('selectFilteredSkills', () => {
     expect(result[0].name).toBe('local-one')
   })
 
+  it('filters by skillTypeFilter=orphan in agent view (skill.isOrphan === true)', () => {
+    // Mixed list: a normal symlinked skill (NOT orphan), a local skill (NOT
+    // orphan), and an orphan whose source dir vanished but still has a broken
+    // symlink under cursor. The Orphan filter must surface only the orphan.
+    const orphanSkill: Skill = {
+      name: 'orphan-one',
+      description: 'orphan',
+      path: '/home/user/.agents/skills/orphan-one',
+      symlinkCount: 1,
+      symlinks: [
+        {
+          agentId: 'cursor' as SymlinkInfo['agentId'],
+          agentName: 'Cursor' as SymlinkInfo['agentName'],
+          linkPath: '/home/user/.cursor/skills/orphan-one',
+          targetPath: '/home/user/.agents/skills/orphan-one',
+          status: 'broken',
+          isLocal: false,
+        },
+      ],
+      isSource: false,
+      isOrphan: true,
+    }
+    const skills = [
+      makeSkill('linked-one', 'cursor'),
+      makeSkill('local-one', 'cursor', true),
+      orphanSkill,
+    ]
+    const state = buildState({
+      skills,
+      selectedAgentId: 'cursor',
+      skillTypeFilter: 'orphan',
+    })
+    const result = selectFilteredSkills(state as never)
+    expect(result.map((s) => s.name)).toEqual(['orphan-one'])
+  })
+
+  it('orphan filter respects agent-slot gate (Pass 1 — orphan with no slot for selected agent is dropped)', () => {
+    // Codex-flagged correctness contract: an orphan whose remaining broken
+    // slot points at agent A must NOT surface when the user is viewing
+    // agent B. Pass 1 (agent-slot gate) drops the row before Pass 2
+    // (skill.isOrphan check) ever runs.
+    const orphanForAgentA: Skill = {
+      name: 'orphan-agent-a',
+      description: 'orphan stranded in agent A',
+      path: '/home/user/.agents/skills/orphan-agent-a',
+      symlinkCount: 1,
+      symlinks: [
+        {
+          agentId: 'claude-code' as SymlinkInfo['agentId'],
+          agentName: 'Claude Code' as SymlinkInfo['agentName'],
+          linkPath: '/home/user/.claude/skills/orphan-agent-a',
+          targetPath: '/home/user/.agents/skills/orphan-agent-a',
+          status: 'broken',
+          isLocal: false,
+        },
+      ],
+      isSource: false,
+      isOrphan: true,
+    }
+    const state = buildState({
+      skills: [orphanForAgentA],
+      selectedAgentId: 'cursor',
+      skillTypeFilter: 'orphan',
+    })
+    expect(selectFilteredSkills(state as never)).toHaveLength(0)
+  })
+
+  it('orphan filter returns empty when no orphan skills exist for selected agent', () => {
+    // Empty-state contract: when the user picks Orphan but every visible
+    // skill is healthy (isOrphan === false), the list is empty and the
+    // empty-state copy ("No orphan skills for this agent") takes over.
+    const skills = [
+      makeSkill('linked-one', 'cursor'),
+      makeSkill('local-one', 'cursor', true),
+    ]
+    const state = buildState({
+      skills,
+      selectedAgentId: 'cursor',
+      skillTypeFilter: 'orphan',
+    })
+    expect(selectFilteredSkills(state as never)).toHaveLength(0)
+  })
+
   it('returns empty when search + type filter combined exclude all', () => {
     const skills = [
       makeSkill('linked-one', 'cursor'),
@@ -361,7 +444,7 @@ describe('selectFilteredSkills', () => {
     expect(result).toHaveLength(0)
   })
 
-  it.each(['all', 'symlinked', 'local'] as const)(
+  it.each(['all', 'symlinked', 'local', 'orphan'] as const)(
     'skillTypeFilter=%s is ignored in SourceCard view (no agent selected)',
     (skillTypeFilter) => {
       // SourceCard view applies its own source-only filter, so skillTypeFilter

--- a/src/renderer/src/redux/selectors.test.ts
+++ b/src/renderer/src/redux/selectors.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import type { SkillTypeFilter } from '@/renderer/src/redux/slices/uiSlice'
 import { repositoryId } from '@/shared/types'
 import type {
   AgentId,
@@ -30,7 +31,7 @@ function buildState(overrides: {
   selectedAgentId?: AgentId | null
   selectedSource?: RepositoryId | null
   sortOrder?: 'asc' | 'desc'
-  skillTypeFilter?: 'all' | 'symlinked' | 'local' | 'orphan'
+  skillTypeFilter?: SkillTypeFilter
   bookmarks?: BookmarkedSkill[]
   selectedSkillNames?: SkillName[]
   inFlightDeleteNames?: SkillName[]

--- a/src/renderer/src/redux/selectors.ts
+++ b/src/renderer/src/redux/selectors.ts
@@ -1,7 +1,7 @@
 import { createSelector } from '@reduxjs/toolkit'
 import { match } from 'ts-pattern'
 
-import type { SkillName } from '@/shared/types'
+import type { SkillName, SymlinkInfo } from '@/shared/types'
 
 import { selectBookmarkItems } from './slices/bookmarkSlice'
 import {
@@ -59,30 +59,47 @@ export const selectFilteredSkills = createSelector(
   ) => {
     let result = skills
 
-    // Filter by selected agent (and optionally by skill type), or — when no
-    // agent is selected — narrow to SOURCE_DIR skills so the SourceCard view
+    // Source view (no agent) narrows to SOURCE_DIR skills so the SourceCard
     // matches its `~/.agents/skills/` label instead of leaking agent-local
-    // folders (e.g. `~/.claude/skills/<name>` that has no symlink under
-    // `~/.agents/skills/`). See "hides agent-local-only skills from the
-    // SourceCard view (no agent selected)" test in selectors.test.ts.
+    // folders (e.g. `~/.claude/skills/<name>` with no symlink under
+    // `~/.agents/skills/`). Agent view keeps both `valid` and `broken`
+    // slots so AgentItem's "Cleanup missing skills..." has rows to act on.
+    // `missing` slots are dropped — nothing on disk to surface there.
     //
-    // Per-agent surface includes both `valid` and `broken` symlinks so the
-    // user can see and clean up orphans (symlinks whose source dir vanished)
-    // from the agent view — that's the entry point for "Cleanup missing
-    // skills..." driven by AgentItem's right-click menu. `missing` entries
-    // are filtered out because they represent agent slots with no on-disk
-    // symlink at all (nothing to surface or clean up there).
+    // Each skill-type arm composes the agent-slot gate inline rather than
+    // pre-filtering, so adding the Orphan arm did not require a 2-pass
+    // walk over `skill.symlinks`. The orphan arm still applies the gate so
+    // an `isOrphan` skill whose only broken slot belongs to a different
+    // agent does not leak through.
     if (selectedAgentId) {
-      const checkType = skillTypeFilter !== 'all'
-      const wantLocal = skillTypeFilter === 'local'
-      result = result.filter((skill) =>
-        skill.symlinks.some(
-          (s) =>
-            s.agentId === selectedAgentId &&
-            (s.status === 'valid' || s.status === 'broken') &&
-            (!checkType || s.isLocal === wantLocal),
-        ),
-      )
+      const hasAgentSlot = (slot: SymlinkInfo): boolean =>
+        slot.agentId === selectedAgentId &&
+        (slot.status === 'valid' || slot.status === 'broken')
+      result = match(skillTypeFilter)
+        .with('all', () =>
+          result.filter((skill) => skill.symlinks.some(hasAgentSlot)),
+        )
+        .with('symlinked', () =>
+          result.filter((skill) =>
+            skill.symlinks.some(
+              (slot) => hasAgentSlot(slot) && slot.isLocal === false,
+            ),
+          ),
+        )
+        .with('local', () =>
+          result.filter((skill) =>
+            skill.symlinks.some(
+              (slot) => hasAgentSlot(slot) && slot.isLocal === true,
+            ),
+          ),
+        )
+        .with('orphan', () =>
+          result.filter(
+            (skill) =>
+              skill.isOrphan === true && skill.symlinks.some(hasAgentSlot),
+          ),
+        )
+        .exhaustive()
     } else {
       result = result.filter((skill) => skill.isSource)
     }

--- a/src/renderer/src/redux/slices/uiSlice.ts
+++ b/src/renderer/src/redux/slices/uiSlice.ts
@@ -25,7 +25,7 @@ import { deleteSelectedSkills, unlinkSelectedFromAgent } from './skillsSlice'
 export type BookmarkForDetail = BookmarkedSkill & { isInstalled: boolean }
 
 export type SortOrder = 'asc' | 'desc'
-export type SkillTypeFilter = 'all' | 'symlinked' | 'local'
+export type SkillTypeFilter = 'all' | 'symlinked' | 'local' | 'orphan'
 export type ActiveTab = 'installed' | 'marketplace'
 /**
  * Which field the search box matches against.
@@ -94,7 +94,7 @@ interface UiState {
   selectedAgentId: AgentId | null
   /** Sort direction for skill name (A→Z / Z→A) */
   sortOrder: SortOrder
-  /** Filter by skill type in agent view (all / symlinked / local) */
+  /** Filter by skill type in agent view (all / symlinked / local / orphan) */
   skillTypeFilter: SkillTypeFilter
   /** Whether sync operation is in progress */
   isSyncing: boolean


### PR DESCRIPTION
## Summary

Adds a 4th option (**Orphan**) to the agent-view skill-type filter dropdown so users can isolate dangling symlinks for cleanup. Refactors the selector to use `ts-pattern` `.with().exhaustive()` — adding a new `SkillTypeFilter` union member is now a compile-time failure if any arm is missing.

The orphan arm composes with the agent-slot gate so an orphan whose only broken slot belongs to a different agent does **not** leak into the current agent's view.

## What changed

| File | Change |
| --- | --- |
| `src/renderer/src/redux/slices/uiSlice.ts` | Extend `SkillTypeFilter` union with `'orphan'` |
| `src/renderer/src/redux/selectors.ts` | Refactor `selectFilteredSkills` to `match().with().exhaustive()` and add `'orphan'` arm with shared `hasAgentSlot` helper |
| `src/renderer/src/components/layout/MainContent.tsx` | Add `{ value: 'orphan', label: 'Orphan', dotClass: 'bg-destructive' }` to dropdown options |
| `src/renderer/src/redux/selectors.test.ts` | 3 new unit tests: orphan filter positive, agent-slot gate negative, empty-state. Parametrize SourceCard test over all 4 SkillTypeFilter values |
| `src/renderer/src/components/layout/MainContent.browser.test.tsx` | 2 new browser tests: dropdown rendering + dot styling |
| `e2e/spec/orphan-filter.e2e.ts` | NEW — Playwright Electron spec exercising FS-truth via dangling symlink + negative control |
| `TODOS.md` | NEW — track 2 deferred follow-ups |

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `npx tsc -p e2e/tsconfig.json --noEmit` — clean
- [x] `pnpm test` — 985/985 pass (69 files)
- [x] `pnpm test:e2e e2e/spec/orphan-filter.e2e.ts` — 1/1 pass (731ms)
- [x] Verified via `playwright-cli` against running dev app: dropdown shows Orphan with red dot; selecting it filters to orphans only; switching agents resets filter (per existing reducer behavior)

## Adversarial review

- **Codex structured review** — 0 findings (tests + typecheck clean, no behavior-breaking bugs)
- **Claude adversarial subagent** — `Recommendation: SHIP` (0 BLOCKER/HIGH/MEDIUM, 2 LOW e2e quality concerns documented below, 13 INFORMATIONAL)
- **Codex adversarial challenge** — inconclusive (timed out at 280s without synthesis)

## Known coverage gaps (skipped, INFORMATIONAL)

The Testing specialist flagged 2 informational gaps that were intentionally not addressed in this PR:

1. **Search + Orphan combo** — no test pins behavior when a name-search query stacks with the Orphan filter. The selector composes filters in fixed order (type → source pill → search → sort), so this is implicitly covered by the existing search tests, but a dedicated test would lock the contract.
2. **Trigger label parametrization** — the dropdown trigger label is asserted in a single test rather than parametrized across all 4 filter values.

Neither gap affects shipped behavior; both can be follow-ups.

## E2E quality follow-ups (LOW, documented)

- The e2e spec reimplements the orphan predicate inside `page.evaluate` because the e2e bundle does not surface selector modules. The actual selector is exercised by 49 unit tests; the e2e covers the FS-truth → store contract.
- The negative-control under cursor uses the helper-side predicate which ignores the `skillTypeFilter` reset triggered by `selectAgent`. The slot-gate-drops-cross-agent-orphan invariant is covered directly by `selectors.test.ts:367-378`.

## Follow-ups (TODOS.md)

1. Source-view orphan visibility — needs design input on where orphans live conceptually.
2. Filter persistence across agent switches — needs usage-based justification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * スキルタイプフィルターに「オーファン」オプションを追加しました。孤立または破損したスキルを選択したエージェント別にフィルタリングして表示できるようになりました。

* **テスト**
  * 新しいオーファンフィルター機能の包括的なテストカバレッジを追加しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/skills-desktop/pull/146)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->