### PR TITLE
Fix Codex agent-only linked skill visibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,155 @@
+# Skills Desktop
+
+Electron desktop app (macOS) for visualizing Skills symlink status across AI agents.
+
+
+- Never use direct `fs` in renderer Context isolation error
+- Build macOS `APPLE_KEYCHAIN_PROFILE=skills-desktop pnpm build:mac`
+
+### 🔴 Releases — Use `/electron-release` ONLY
+
+`/electron-release` is the single source of truth for the entire release pipeline:
+
+**version bump → notarized build → ZIP rename → GitHub release → website URL update → artifacts upload**
+
+**Forbidden:**
+- `/ship` MUST NOT bump `package.json` version. `/ship` is for code commits/PRs only. Version bumps are owned exclusively by `/electron-release`.
+- Manual `gh release create` outside `/electron-release` (skips notarization check, ZIP rename, website update — auto-update breaks)
+- Manual edit of `package.json` `"version"` field
+
+For local production build verification (no release):
+
+```bash
+APPLE_KEYCHAIN_PROFILE=skills-desktop pnpm build:mac
+```
+
+Without `APPLE_KEYCHAIN_PROFILE`: signing succeeds but notarization fails → Gatekeeper blocks the app.
+
+## Gotchas
+
+- **`*.browser.test.tsx`** runs in the Chromium lane via vitest browser mode. Vitest 4 projects need `dedupe + optimizeDeps` duplicated inline or React context breaks across files
+- **`npx skills remove <name>` defaults to local scope** while `npx skills add` defaults to global. Always pass `--global` for uninstall hints surfaced to users — see `SkillRowMarketplace.tsx` installed badge `aria-label`
+- **Port 9222 sticks** if `pnpm dev` died unclean. `kill-port 9222` (or `pkill -f electron`) before relaunching
+
+## Quality Gate
+
+Before opening or merging a PR, run the fast gates first:
+
+```bash
+pnpm lint
+pnpm test
+pnpm typecheck
+pnpm fallow:dead-code
+```
+
+Only after all four pass, run the Electron e2e suite:
+
+```bash
+pnpm test:e2e
+```
+
+PRs are ready to ship only when the fast gates and e2e both pass in that order.
+
+## Domain Concepts
+
+| Entity    | Location             | Description                                                    |
+| --------- | -------------------- | -------------------------------------------------------------- |
+| Skill     | `~/.agents/skills/`  | Directory with SKILL.md                                        |
+| Agent     | `~/.<agent>/skills/` | AI agents (count = `AGENT_DEFINITIONS.length` in `src/shared/constants.ts`) |
+| Symlink   | Agent→Skill          | `valid` / `broken` / `missing`                                 |
+| Universal | `~/.agents/skills/`  | 12 agents share this source dir (see `UNIVERSAL_AGENT_IDS` in `src/shared/constants.ts`) |
+
+### Skills CLI
+
+| Resource       | Location                                                                                       |
+| -------------- | ---------------------------------------------------------------------------------------------- |
+| Repository     | https://github.com/vercel-labs/skills (paths below are inside that repo)                       |
+| CLI agent list | `src/agents.ts`                                                                                |
+| CLI types      | `src/types.ts`                                                                                 |
+| Pinned version | `SKILLS_CLI_VERSION` in `src/shared/constants.ts` (currently `1.5.1`) — bump via `/cli-upgrade` |
+
+`AGENT_DEFINITIONS` in `src/shared/constants.ts` mirrors the CLI's agent
+list. Each entry: `id` (app state), `cliId` (`--agent` flag), `name`
+(display), `dir` (home subpath like `.claude`).
+
+## UI Verification
+
+Drive the running app via **`playwright-cli`** (CDP attach to Electron's
+`:9222` debug port). The full workflow (phases, triage, report template)
+lives in the `/qa-electron` skill — invoke it for systematic QA runs.
+Quick ad-hoc verification commands:
+
+```bash
+# 1. Start dev server (exposes CDP on :9222)
+pnpm dev
+
+# 2. Attach once per session
+playwright-cli attach --cdp=http://localhost:9222
+
+# 3. Inspect + interact (use --s=default for the attached session)
+playwright-cli --s=default snapshot                  # a11y tree with eN element refs
+playwright-cli --s=default screenshot --filename=/tmp/shot.png
+playwright-cli --s=default click e5                  # interact by ref from snapshot
+playwright-cli --s=default fill e3 "text"
+playwright-cli --s=default press Escape
+playwright-cli --s=default eval 'document.title'     # run JS in renderer
+
+# 4. Detach when done (does NOT close the app — pnpm dev still owns it)
+playwright-cli --s=default detach
+```
+
+Re-snapshot after any action that mutates the DOM — `eN` refs are valid
+only for the most recent snapshot.
+
+## QA Safety
+
+During QA runs, **do NOT delete skills under `~/.claude/skills/` or `~/.cursor/skills/`** — those are the user's live Claude Code and Cursor working sets. Skills under any other agent directory are safe to delete: they can be reinstalled instantly via the Marketplace tab or sync flow.
+
+| Path                  | Deletable in QA? | Reason                                |
+| --------------------- | ---------------- | ------------------------------------- |
+| `~/.claude/skills/`   | ❌               | User's live Claude Code working set   |
+| `~/.cursor/skills/`   | ❌               | User's live Cursor working set        |
+| `~/.<other>/skills/`  | ✅               | Reinstallable via marketplace or sync |
+
+## Design Context
+
+### Users
+Developers who use multiple AI coding agents (Claude Code, Cursor, Codex, etc.) and need to manage shared skills/plugins across them. They use this app to visualize symlink status, install skills from a marketplace, and keep their agent environments in sync. Context: quick glances during workflow, not prolonged sessions.
+
+### Brand Personality
+**Technical, Minimal, Sharp** — An engineering tool that respects the developer's intelligence. No hand-holding, no visual noise. Every pixel earns its place.
+
+### Emotional Goals
+- **Trust & confidence**: "My skills are properly linked, nothing is broken"
+- **Control**: "I can see and manage every agent's state from one place"
+
+### Aesthetic Direction
+- **Visual tone**: Dark-first, high information density without clutter. Terminal-inspired clarity with native macOS polish
+- **References**: Warp terminal, Linear, VS Code Dark+
+- **Anti-references**: AWS Console, Jira — information-overloaded dashboards with competing visual hierarchies
+- **Theme**: OKLCH color system with dual `--theme-hue` × `--theme-chroma` axes. 27 presets (17 color hues + 2 pure neutral + 8 tinted neutral, see `THEME_PRESETS` in `src/shared/constants.ts`) persist via `@laststance/redux-storage-middleware` (version-migrated v0→v1→v2). Dark mode is default, light supported
+
+### Color System
+- OKLCH-based; every shadcn token derives from `oklch(L calc(var(--theme-chroma) * K) var(--theme-hue))`, so a single preset table (`THEME_PRESETS` in `src/shared/constants.ts`) drives all surfaces
+- `--theme-chroma`: `0` (neutral/shadcn grayscale) or `COLOR_PRESET_CHROMA = 0.16` (color preset) — same formula, two modes. `--theme-hue`: OKLCH angle (0–360), irrelevant when chroma is 0
+- Status tokens: `--success` (fixed green, theme-invariant) = valid/linked, amber = broken, `--muted-foreground` = missing. `--success` stays green even in neutral presets so "linked" never collapses to mid-gray
+- Skill type borders: `--success` = symlinked, emerald = local
+- Low-chroma backgrounds, high-chroma accents — information through color, not decoration
+
+### Typography
+- **Sans**: Inter — neutral, highly legible at small sizes, tabular-nums for data
+- **Mono**: JetBrains Mono — code blocks, paths, technical content
+- System font stack fallback for native feel
+
+### Spacing & Layout
+- Base unit: 4px grid (Tailwind default)
+- Border radius: 8px (`--radius: 0.5rem`)
+- Panel layout: react-resizable-panels with collapsible Inspector pattern
+- Sidebar: fixed 240px, content panels: percentage-based
+
+### Design Principles
+1. **Information density over decoration** — Show data, not chrome. Every visual element communicates state
+2. **Status at a glance** — Color-coded symlink states (success green / amber / muted) should stay readable in peripheral vision regardless of chosen theme preset
+3. **Native macOS feel** — Window glow effects, drag regions, system-level keyboard shortcuts. Feels like it belongs on macOS
+4. **Progressive disclosure** — Default 3-column layout; Detail Inspector appears only when needed (Apple HIG Inspector pattern)
+5. **Developer respect** — No tooltips explaining obvious things, no confirmation dialogs for safe actions, no marketing language in the UI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 Electron desktop app (macOS) for visualizing Skills symlink status across AI agents.
 
 
-- Never use direct `fs` in renderer Context isolation error
+- Never use direct `fs` access in the renderer when Context Isolation is enabled; use preload IPC instead.
 - Build macOS `APPLE_KEYCHAIN_PROFILE=skills-desktop pnpm build:mac`
 
 ### 🔴 Releases — Use `/electron-release` ONLY

--- a/e2e/spec/agent-linked-symlinks.e2e.ts
+++ b/e2e/spec/agent-linked-symlinks.e2e.ts
@@ -27,7 +27,7 @@ const STORE_READY_TIMEOUT_MS = 10_000
 const waitForStoreReady = async (page: Page): Promise<void> => {
   await page.waitForFunction(
     () => {
-      const store = window.__store__ ?? window.__store
+      const store = window.__store__
       if (!store) return false
       const state = store.getState() as {
         agents?: { items?: unknown[]; loading?: boolean }

--- a/e2e/spec/agent-linked-symlinks.e2e.ts
+++ b/e2e/spec/agent-linked-symlinks.e2e.ts
@@ -1,0 +1,188 @@
+import { lstatSync, mkdirSync, symlinkSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import type { Page } from '@playwright/test'
+
+import { test, expect } from '../fixtures/electron-app'
+import {
+  dispatchAction,
+  getStoreState,
+  refreshSkillsState,
+} from '../helpers/redux'
+
+const AGENT_ID = 'codex'
+const LINK_NAME = 'agent-only-linked-fixture'
+const FRONTMATTER_NAME = 'frontmatter-name-must-not-win'
+const EXTERNAL_SKILL_DESCRIPTION =
+  'External linked skill used to guard agent-only symlink surfacing.'
+const STORE_READY_TIMEOUT_MS = 10_000
+
+/**
+ * Waits for the renderer Redux store and initial agent scan to be ready.
+ * @param page - Electron renderer page.
+ * @returns Resolves when `agents.items` is populated and the skills scan is idle.
+ * @example
+ * await waitForStoreReady(appWindow)
+ */
+const waitForStoreReady = async (page: Page): Promise<void> => {
+  await page.waitForFunction(
+    () => {
+      const store = window.__store__ ?? window.__store
+      if (!store) return false
+      const state = store.getState() as {
+        agents?: { items?: unknown[]; loading?: boolean }
+        skills?: { loading?: boolean }
+      }
+      return Boolean(
+        state.agents?.items?.length &&
+        state.agents.loading === false &&
+        state.skills?.loading === false,
+      )
+    },
+    undefined,
+    { timeout: STORE_READY_TIMEOUT_MS },
+  )
+}
+
+/**
+ * Selects skill scan facts for one agent from the renderer store.
+ * @param state - Renderer Redux root state.
+ * @param args - Target agent id and skill name.
+ * @returns
+ * - `null` when the skill is absent from the store.
+ * - A compact skill/slot summary when present.
+ * @example
+ * selectAgentLinkedSkillFacts(state, {
+ *   agentId: 'codex',
+ *   skillName: 'agent-only-linked-fixture',
+ * })
+ * // => { name: 'agent-only-linked-fixture', slot: { status: 'valid' } }
+ */
+const selectAgentLinkedSkillFacts = (
+  state: unknown,
+  args: { agentId: string; skillName: string },
+): {
+  name: string
+  path: string
+  description: string
+  isSource: boolean
+  isOrphan: boolean
+  symlinkCount: number
+  slot:
+    | {
+        agentId: string
+        status: 'valid' | 'broken' | 'missing'
+        isLocal: boolean
+        linkPath: string
+        targetPath?: string
+      }
+    | undefined
+} | null => {
+  const root = state as {
+    skills: {
+      items: Array<{
+        name: string
+        path: string
+        description: string
+        isSource: boolean
+        isOrphan: boolean
+        symlinkCount: number
+        symlinks: Array<{
+          agentId: string
+          status: 'valid' | 'broken' | 'missing'
+          isLocal: boolean
+          linkPath: string
+          targetPath?: string
+        }>
+      }>
+    }
+  }
+  const skill = root.skills.items.find((item) => item.name === args.skillName)
+  if (!skill) return null
+  return {
+    name: skill.name,
+    path: skill.path,
+    description: skill.description,
+    isSource: skill.isSource,
+    isOrphan: skill.isOrphan,
+    symlinkCount: skill.symlinkCount,
+    slot: (() => {
+      const symlink = skill.symlinks.find(
+        (item) => item.agentId === args.agentId,
+      )
+      if (!symlink) return undefined
+      return {
+        agentId: symlink.agentId,
+        status: symlink.status,
+        isLocal: symlink.isLocal,
+        linkPath: symlink.linkPath,
+        targetPath: symlink.targetPath,
+      }
+    })(),
+  }
+}
+
+test('agent-only valid symlinks appear as linked skills in the selected agent view', async ({
+  appWindow,
+  isolatedHome,
+}) => {
+  await waitForStoreReady(appWindow)
+
+  const externalSkillPath = join(isolatedHome, 'external-skills', LINK_NAME)
+  const codexSkillsDir = join(isolatedHome, '.codex', 'skills')
+  const codexLinkPath = join(codexSkillsDir, LINK_NAME)
+
+  mkdirSync(externalSkillPath, { recursive: true })
+  mkdirSync(codexSkillsDir, { recursive: true })
+  writeFileSync(
+    join(externalSkillPath, 'SKILL.md'),
+    [
+      '---',
+      `name: ${FRONTMATTER_NAME}`,
+      `description: ${EXTERNAL_SKILL_DESCRIPTION}`,
+      '---',
+      '',
+    ].join('\n'),
+  )
+  symlinkSync(externalSkillPath, codexLinkPath)
+
+  expect(lstatSync(codexLinkPath).isSymbolicLink()).toBe(true)
+
+  await refreshSkillsState(appWindow)
+  await dispatchAction(appWindow, {
+    type: 'ui/selectAgent',
+    payload: AGENT_ID,
+  })
+
+  const scanFacts = await getStoreState(
+    appWindow,
+    selectAgentLinkedSkillFacts,
+    { agentId: AGENT_ID, skillName: LINK_NAME },
+  )
+  expect(scanFacts).toEqual({
+    name: LINK_NAME,
+    path: externalSkillPath,
+    description: EXTERNAL_SKILL_DESCRIPTION,
+    isSource: false,
+    isOrphan: false,
+    symlinkCount: 1,
+    slot: {
+      agentId: AGENT_ID,
+      status: 'valid',
+      isLocal: false,
+      linkPath: codexLinkPath,
+      targetPath: externalSkillPath,
+    },
+  })
+
+  await expect(
+    appWindow.getByRole('heading', {
+      name: new RegExp(`Linked skill ${LINK_NAME}`),
+    }),
+  ).toBeVisible()
+  await expect(
+    appWindow.getByRole('heading', {
+      name: new RegExp(FRONTMATTER_NAME),
+    }),
+  ).toHaveCount(0)
+})

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "fallow:dead-code": "npx fallow dead-code",
     "prepare": "husky",
     "prettier": "prettier --ignore-unknown --write .",
     "clean": "rm -rf dist build .vite node_modules pnpm-lock.yaml"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "fallow:dead-code": "npx fallow dead-code",
+    "fallow:dead-code": "pnpm exec fallow dead-code",
     "prepare": "husky",
     "prettier": "prettier --ignore-unknown --write .",
     "clean": "rm -rf dist build .vite node_modules pnpm-lock.yaml"
@@ -73,6 +73,7 @@
     "eslint": "^10.3.0",
     "eslint-config-ts-prefixer": "^4.2.0",
     "eslint-plugin-react-you-might-not-need-an-effect": "^0.10.0",
+    "fallow": "2.65.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "playwright": "^1.59.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       eslint-plugin-react-you-might-not-need-an-effect:
         specifier: ^0.10.0
         version: 0.10.0(eslint@10.3.0(jiti@2.6.1))
+      fallow:
+        specifier: 2.65.0
+        version: 2.65.0
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -679,6 +682,46 @@ packages:
   '@eslint/plugin-kit@0.7.1':
     resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@fallow-cli/darwin-arm64@2.65.0':
+    resolution: {integrity: sha512-dS7ZtFLfh9YSY816wlgzMSlM+ZbGI2K6cnnDUw88CQfM4R1SRpi+lRmB1/929C2899W7e4PuT/upEvCAkHSACw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@fallow-cli/darwin-x64@2.65.0':
+    resolution: {integrity: sha512-TRZgXAtHWa2q7JMsjmAEEVwsT+sJCSPkFNi6vJAOwKA7Q7p3QM/ytiYRdeXnp+ZjGM31A4+Iq9kNykjES+hwUA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@fallow-cli/linux-arm64-gnu@2.65.0':
+    resolution: {integrity: sha512-VTzQ+VnRpKEBTB2B5DKF/T8xbeLFrh3WLmUNKmfVmEun6Cq3wGtxmVZzSU23I9wvTkb/yqWoI7s+XNOdpw+ISQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@fallow-cli/linux-arm64-musl@2.65.0':
+    resolution: {integrity: sha512-SlJoT/5wPVs8qshk8xaquRRO7CIUPYQB+NUMFnvl3z3pN3lUtbcapDmwzqGpnPGwbTIY4gkRONwvVMIsVMqAGQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@fallow-cli/linux-x64-gnu@2.65.0':
+    resolution: {integrity: sha512-Ma3bWyCmqm2OV/BHH1y19vWZDaIS7bxz+KMuqA3F4D0QRckBAri4MNrvs7fQIps67CsIBbKkVsUygc7PzJ2zxw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@fallow-cli/linux-x64-musl@2.65.0':
+    resolution: {integrity: sha512-XH4oCygmOMPDx/q7QH3X+9X2UZdZFf+CWsO+p2KGXuk8wG28/HXrWNj59A8FiVr9RMeUicwPUkfbNdkyX4+Nvg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@fallow-cli/win32-arm64-msvc@2.65.0':
+    resolution: {integrity: sha512-RIrNyRdGGPqgNvDPJ1xq0ktn8Ep5EUVHrzpFsRWe74h4e4KewLzCWXi4cKVzrXui24In47pEXB6h7xXhbgY4FQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@fallow-cli/win32-x64-msvc@2.65.0':
+    resolution: {integrity: sha512-pCb+/xluBi3yLhTgFS5AWgMciUFYRbOZtIIApmH0EYxl0sJuTsq076KFMKXM8XhNj24BEfb5xoA9p1AeAAB7YA==}
+    cpu: [x64]
+    os: [win32]
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -2569,6 +2612,11 @@ packages:
   extsprintf@1.4.1:
     resolution: {integrity: sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==}
     engines: {'0': node >=0.6.0}
+
+  fallow@2.65.0:
+    resolution: {integrity: sha512-bobD23qViXEC14+aKH8ssX05NY59eRSa6cn8HX5TpCT/S7wNNvGhzooR+DDsmhTqVAxPtQL2m0kd3g+xhKRsmg==}
+    engines: {node: '>=16'}
+    hasBin: true
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -4667,6 +4715,30 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
+  '@fallow-cli/darwin-arm64@2.65.0':
+    optional: true
+
+  '@fallow-cli/darwin-x64@2.65.0':
+    optional: true
+
+  '@fallow-cli/linux-arm64-gnu@2.65.0':
+    optional: true
+
+  '@fallow-cli/linux-arm64-musl@2.65.0':
+    optional: true
+
+  '@fallow-cli/linux-x64-gnu@2.65.0':
+    optional: true
+
+  '@fallow-cli/linux-x64-musl@2.65.0':
+    optional: true
+
+  '@fallow-cli/win32-arm64-msvc@2.65.0':
+    optional: true
+
+  '@fallow-cli/win32-x64-msvc@2.65.0':
+    optional: true
+
   '@floating-ui/core@1.7.5':
     dependencies:
       '@floating-ui/utils': 0.2.11
@@ -6730,6 +6802,19 @@ snapshots:
 
   extsprintf@1.4.1:
     optional: true
+
+  fallow@2.65.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      '@fallow-cli/darwin-arm64': 2.65.0
+      '@fallow-cli/darwin-x64': 2.65.0
+      '@fallow-cli/linux-arm64-gnu': 2.65.0
+      '@fallow-cli/linux-arm64-musl': 2.65.0
+      '@fallow-cli/linux-x64-gnu': 2.65.0
+      '@fallow-cli/linux-x64-musl': 2.65.0
+      '@fallow-cli/win32-arm64-msvc': 2.65.0
+      '@fallow-cli/win32-x64-msvc': 2.65.0
 
   fast-deep-equal@3.1.3: {}
 

--- a/src/main/services/skillScanner.test.ts
+++ b/src/main/services/skillScanner.test.ts
@@ -55,10 +55,14 @@ vi.mock('./metadataParser', () => ({
 
 const checkSymlinkTargetFromKnownLinkMock = vi.fn()
 const readSymlinkTargetIfPresentMock = vi.fn()
+const countValidSymlinksMock = vi.fn(
+  (symlinks: Array<{ status: string }>): number =>
+    symlinks.filter((s) => s.status === 'valid').length,
+)
 
 vi.mock('./symlinkChecker', () => ({
   checkSkillSymlinks: vi.fn(async () => []),
-  countValidSymlinks: vi.fn(() => 0),
+  countValidSymlinks: countValidSymlinksMock,
   checkSymlinkTargetFromKnownLink: checkSymlinkTargetFromKnownLinkMock,
   readSymlinkTargetIfPresent: readSymlinkTargetIfPresentMock,
 }))
@@ -71,6 +75,7 @@ describe('scanSkills local skill aggregation', () => {
     checkSymlinkTargetFromKnownLinkMock.mockResolvedValue('missing')
     readSymlinkTargetIfPresentMock.mockReset()
     readSymlinkTargetIfPresentMock.mockResolvedValue(undefined)
+    countValidSymlinksMock.mockClear()
 
     readdirMock.mockImplementation(async (path: string) => {
       if (path === '/mock/source/skills') {
@@ -205,6 +210,75 @@ describe('scanSkills local skill aggregation', () => {
   })
 })
 
+describe('scanSkills agent-only linked symlink surfacing', () => {
+  beforeEach(() => {
+    readdirMock.mockReset()
+    accessMock.mockReset()
+    statMock.mockReset()
+    checkSymlinkTargetFromKnownLinkMock.mockReset()
+    readSymlinkTargetIfPresentMock.mockReset()
+    readSymlinkTargetIfPresentMock.mockResolvedValue(undefined)
+    countValidSymlinksMock.mockClear()
+  })
+
+  it('surfaces valid agent symlinks whose names are not in the source directory', async () => {
+    // Codex has a valid gstack-managed symlink, but ~/.agents/skills has no
+    // matching source directory. The sidebar count includes this link, so the
+    // central agent view must include a linked card for the same on-disk entry.
+    readdirMock.mockImplementation(async (path: string) => {
+      if (path === '/mock/source/skills') return []
+      if (path === '/mock/agents/codex/skills') {
+        return [
+          createDirent('gstack-browse', {
+            isDirectory: false,
+            isSymbolicLink: true,
+          }),
+        ]
+      }
+      return []
+    })
+    accessMock.mockRejectedValue(new Error('ENOENT'))
+    statMock.mockRejectedValue(new Error('ENOENT'))
+    checkSymlinkTargetFromKnownLinkMock.mockImplementation(
+      async (linkPath: string) => {
+        if (linkPath === '/mock/agents/codex/skills/gstack-browse') {
+          return 'valid'
+        }
+        return 'missing'
+      },
+    )
+    readSymlinkTargetIfPresentMock.mockImplementation(
+      async (linkPath: string) => {
+        if (linkPath === '/mock/agents/codex/skills/gstack-browse') {
+          return '/mock/external/gstack-browse'
+        }
+        return undefined
+      },
+    )
+
+    const { scanSkills } = await import('./skillScanner')
+    const skills = await scanSkills()
+
+    expect(skills).toHaveLength(1)
+    const linked = skills[0]
+    expect(linked.name).toBe('gstack-browse')
+    expect(linked.path).toBe('/mock/external/gstack-browse')
+    expect(linked.symlinkCount).toBe(1)
+    expect(linked.isSource).toBe(false)
+    expect(linked.isOrphan).toBe(false)
+
+    const codex = linked.symlinks.find((s) => s.agentId === 'codex')
+    const cursor = linked.symlinks.find((s) => s.agentId === 'cursor')
+    expect(codex).toMatchObject({
+      status: 'valid',
+      isLocal: false,
+      linkPath: '/mock/agents/codex/skills/gstack-browse',
+      targetPath: '/mock/external/gstack-browse',
+    })
+    expect(cursor).toMatchObject({ status: 'missing', isLocal: false })
+  })
+})
+
 describe('scanSkills orphan symlink surfacing (issue #127)', () => {
   beforeEach(() => {
     readdirMock.mockReset()
@@ -213,6 +287,7 @@ describe('scanSkills orphan symlink surfacing (issue #127)', () => {
     checkSymlinkTargetFromKnownLinkMock.mockReset()
     readSymlinkTargetIfPresentMock.mockReset()
     readSymlinkTargetIfPresentMock.mockResolvedValue(undefined)
+    countValidSymlinksMock.mockClear()
   })
 
   it('surfaces broken symlinks whose source is missing as orphan Skill records', async () => {

--- a/src/main/services/skillScanner.ts
+++ b/src/main/services/skillScanner.ts
@@ -90,22 +90,36 @@ async function readSkillLock(): Promise<Map<SkillName, SkillLockEntry>> {
  * // => [{ name: 'theme-generator', symlinkCount: 3, ... }]
  */
 export async function scanSkills(): Promise<Skill[]> {
-  // Orphan scan needs sourceNames to skip live sources, so it chains off
-  // sourceSkills via .then() instead of awaiting separately — that lets it
-  // overlap with scanAllLocalSkills and readSkillLock in the same Promise.all.
+  // Agent-only symlink scans need sourceNames to skip live sources, so they
+  // chain off sourceSkills via .then() instead of awaiting separately — that
+  // lets them overlap with scanAllLocalSkills and readSkillLock in the same
+  // Promise.all.
   const sourceSkillsPromise = scanSourceSkills()
-  const orphanSkillsPromise = sourceSkillsPromise.then(async (src) =>
-    scanOrphanSymlinks(new Set(src.map((s) => s.name))),
+  const sourceNamesPromise = sourceSkillsPromise.then(
+    (src) => new Set(src.map((s) => s.name)),
   )
-  const [sourceSkills, localSkills, lockEntries, orphanSkills] =
-    await Promise.all([
-      sourceSkillsPromise,
-      scanAllLocalSkills(),
-      readSkillLock(),
-      orphanSkillsPromise,
-    ])
+  const linkedAgentSkillsPromise = sourceNamesPromise.then(
+    async (sourceNames) => scanAgentLinkedSymlinks(sourceNames),
+  )
+  const orphanSkillsPromise = sourceNamesPromise.then(async (sourceNames) =>
+    scanOrphanSymlinks(sourceNames),
+  )
+  const [
+    sourceSkills,
+    localSkills,
+    linkedAgentSkills,
+    lockEntries,
+    orphanSkills,
+  ] = await Promise.all([
+    sourceSkillsPromise,
+    scanAllLocalSkills(),
+    linkedAgentSkillsPromise,
+    readSkillLock(),
+    orphanSkillsPromise,
+  ])
 
-  // Merge precedence: source > local > orphan (first record's metadata wins).
+  // Merge precedence: source > local > linked-agent > orphan (first record's
+  // metadata wins).
   // Naive first-wins discards later records entirely — but a `local + orphan`
   // collision (real folder in agent A, broken symlink in agent B for the
   // same name) needs the orphan's broken slots merged into the local record,
@@ -114,7 +128,12 @@ export async function scanSkills(): Promise<Skill[]> {
   // 'valid+local' and 'broken' (a path is either a directory or a symlink),
   // so per-slot non-missing-wins is conflict-free.
   const byName = new Map<SkillName, Skill>()
-  for (const skill of [...sourceSkills, ...localSkills, ...orphanSkills]) {
+  for (const skill of [
+    ...sourceSkills,
+    ...localSkills,
+    ...linkedAgentSkills,
+    ...orphanSkills,
+  ]) {
     const existing = byName.get(skill.name)
     if (!existing) {
       byName.set(skill.name, skill)
@@ -177,6 +196,102 @@ async function scanSourceSkills(): Promise<Skill[]> {
   )
 
   return skills
+}
+
+/**
+ * Scan agent directories for valid symlinks whose link names are not present
+ * in `~/.agents/skills/`.
+ *
+ * These entries still count as "linked" in `scanAgents()` because the agent
+ * has a valid symlink on disk, but they used to be invisible in the skills
+ * list because `scanSourceSkills()` only starts from the universal source
+ * directory. The displayed `Skill.name` intentionally follows the agent-side
+ * link name (not `SKILL.md` frontmatter) so row actions like bulk unlink still
+ * address the actual path under the selected agent.
+ *
+ * @param sourceNames - Source skill names already represented by `scanSourceSkills`.
+ * @returns Agent-only linked skills with valid non-local symlink slots.
+ * @example
+ * // ~/.codex/skills/gstack-browse -> ~/gstack/.agents/skills/gstack-browse
+ * scanAgentLinkedSymlinks(new Set())
+ * // => [{ name: 'gstack-browse', isSource: false, symlinkCount: 1, ... }]
+ */
+async function scanAgentLinkedSymlinks(
+  sourceNames: Set<SkillName>,
+): Promise<Skill[]> {
+  const linkedHits = (
+    await Promise.all(
+      AGENTS.map(async (agent) => {
+        try {
+          const entries = await readdir(agent.path, { withFileTypes: true })
+          const candidates = entries.filter(
+            (entry) => entry.isSymbolicLink() && !sourceNames.has(entry.name),
+          )
+          const statuses = await Promise.all(
+            candidates.map(async (link) => {
+              const linkPath = join(agent.path, link.name) as AbsolutePath
+              const status = await checkSymlinkTargetFromKnownLink(linkPath)
+              if (status !== 'valid') return null
+
+              const targetPath = await readSymlinkTargetIfPresent(linkPath)
+              if (!targetPath) return null
+
+              const metadata = await parseSkillMetadata(targetPath)
+              return {
+                agent,
+                name: link.name,
+                linkPath,
+                targetPath,
+                metadata,
+              }
+            }),
+          )
+          return statuses.filter(
+            (item): item is NonNullable<typeof item> => item !== null,
+          )
+        } catch {
+          return []
+        }
+      }),
+    )
+  ).flat()
+
+  const linkedSkillsByName = new Map<SkillName, Skill>()
+  for (const { agent, name, linkPath, targetPath, metadata } of linkedHits) {
+    let skill = linkedSkillsByName.get(name)
+    if (!skill) {
+      skill = {
+        name,
+        description: metadata.description,
+        path: targetPath,
+        symlinkCount: 0,
+        symlinks: AGENTS.map((a) => ({
+          agentId: a.id,
+          agentName: a.name,
+          status: 'missing',
+          linkPath: join(a.path, name) as AbsolutePath,
+          isLocal: false,
+        })),
+        isSource: false,
+        isOrphan: false,
+      }
+      linkedSkillsByName.set(name, skill)
+    }
+
+    const slot = skill.symlinks.findIndex((s) => s.agentId === agent.id)
+    if (slot >= 0) {
+      skill.symlinks[slot] = {
+        ...skill.symlinks[slot],
+        status: 'valid',
+        targetPath,
+        linkPath,
+        isLocal: false,
+      }
+      skill.symlinkCount = countValidSymlinks(skill.symlinks)
+    }
+  }
+
+  return Array.from(linkedSkillsByName.values())
 }
 
 /**


### PR DESCRIPTION
## Summary
- surface valid agent-only symlinks as linked skills in agent views
- add unit and Electron e2e regression coverage for Codex-style external skill symlinks
- add `fallow:dead-code` script and document the quality gate in AGENTS/CLAUDE

## Quality Gate
- `pnpm lint` ✅ (0 errors, existing 3 warnings)
- `pnpm test` ✅ (69 files, 986 tests)
- `pnpm typecheck` ✅
- `pnpm fallow:dead-code` ✅
- `pnpm test:e2e` ✅ (41 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * エージェント選択時に、リンクされたスキルがUIに表示されるようになりました。

* **ドキュメント**
  * アプリケーションの詳細なドキュメントを追加しました。

* **テスト**
  * リンクされたスキル機能の自動テストを追加しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/skills-desktop/pull/147)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->