### PR TITLE
feat: use sonner's built-in close button on UndoToast

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,19 +36,18 @@ Without `APPLE_KEYCHAIN_PROFILE`: signing succeeds but notarization fails → Ga
 Before opening or merging a PR, run the fast gates first:
 
 ```bash
-pnpm lint
-pnpm test
-pnpm typecheck
-pnpm fallow:dead-code
+pnpm validate
 ```
 
-Only after all four pass, run the Electron e2e suite:
+Runs `lint`, `test`, `typecheck`, and `fallow:dead-code` in parallel via `run-p`.
+
+Only after it passes, run the Electron e2e suite:
 
 ```bash
 pnpm test:e2e
 ```
 
-PRs are ready to ship only when the fast gates and e2e both pass in that order.
+PRs are ready to ship only when `validate` and e2e both pass in that order.
 
 ## Domain Concepts
 
@@ -110,6 +109,23 @@ During QA runs, **do NOT delete skills under `~/.claude/skills/` or `~/.cursor/s
 | `~/.claude/skills/`   | ❌               | User's live Claude Code working set   |
 | `~/.cursor/skills/`   | ❌               | User's live Cursor working set        |
 | `~/.<other>/skills/`  | ✅               | Reinstallable via marketplace or sync |
+
+### Adding a test skill for QA (global install)
+
+When a verification run needs a fresh, throwaway skill (e.g. to exercise the
+delete + UndoToast flow without touching anything the user actually relies on),
+install one globally in non-interactive mode:
+
+```bash
+npx skills add --yes --global https://github.com/microsoft/azure-skills --skill azure-ai
+```
+
+`--yes` skips the skills CLI's confirmation prompts (scope, etc.); `--global`
+forces the install into `~/.agents/skills/` regardless of CWD (without it,
+running from inside a project with a local `.agents/` directory installs
+project-local instead). The new skill is symlinked into every installed agent
+immediately and is safe to delete in the same run. Use this in preference to
+deleting an existing user skill.
 
 ## Design Context
 

--- a/e2e/spec/undo-toast.e2e.ts
+++ b/e2e/spec/undo-toast.e2e.ts
@@ -1,0 +1,210 @@
+import { existsSync, lstatSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { test, expect } from '../fixtures/electron-app'
+import { isSnapshotOffline } from '../fixtures/isolated-home'
+import {
+  getStoreState,
+  refreshSkillsState,
+  waitForInitialScan,
+} from '../helpers/redux'
+
+interface SymlinkSnapshot {
+  agentId: string
+  status: 'valid' | 'broken' | 'missing'
+  isLocal: boolean
+  linkPath: string
+}
+
+interface AzureSnapshot {
+  hasAzure: boolean
+  sourcePath: string | null
+  validSymlinks: SymlinkSnapshot[]
+}
+
+const AZURE_AI_NAME = 'azure-ai'
+
+/**
+ * Snapshot selector for azure-ai. Mirrors `azureSnapshotSelector` in
+ * delete.e2e.ts. Inlined here (rather than imported from a shared helper)
+ * because `getStoreState` serializes the function via `Function.prototype.toString`
+ * — the body must NOT close over outer-scope identifiers, so the literal
+ * `'azure-ai'` is hard-coded inside.
+ */
+const azureSnapshotSelector = (state: unknown): AzureSnapshot => {
+  const root = state as {
+    skills: {
+      items: Array<{
+        name: string
+        path: string
+        symlinks: SymlinkSnapshot[]
+      }>
+    }
+  }
+  const azure = root.skills.items.find((skill) => skill.name === 'azure-ai')
+  return {
+    hasAzure: Boolean(azure),
+    sourcePath: azure?.path ?? null,
+    validSymlinks:
+      azure?.symlinks.filter((symlink) => symlink.status === 'valid') ?? [],
+  }
+}
+
+/**
+ * UI-driven coverage for the Undo button on the post-bulk-delete sonner toast.
+ *
+ * The companion spec `delete.e2e.ts` already verifies the IPC layer
+ * (`SKILLS_DELETE` + `SKILLS_RESTORE_DELETED`) end-to-end. This file
+ * complements it by exercising the renderer click chain that real users hit:
+ *
+ *   bulk select → toolbar Delete → confirm dialog Delete → Undo button
+ *
+ * The user requirement was explicit: "Undoしたあとちゃんとファイルが復元されているか、
+ * は重要度が高い" — file restoration is the load-bearing assertion. So the
+ * post-Undo checks focus on the FS:
+ *   - source dir + SKILL.md back at the original path
+ *   - every originally-valid agent symlink restored AS A REAL SYMLINK
+ *     (via `lstatSync().isSymbolicLink()`, not just `existsSync`)
+ *   - trash entry cleaned up by `finalizeRestore`
+ *   - Redux `state.skills.items` re-populated post-rescan
+ *
+ * Single-skill scope by design: the Undo flow is a single dispatch regardless
+ * of selection size, and the FS restoration logic is identical per-tombstone.
+ * Multi-skill bulk timing edges (≥10 → progress event) are out of scope here;
+ * delete.e2e.ts owns the bulk-delete IPC contract.
+ */
+
+test.beforeEach(() => {
+  test.skip(
+    isSnapshotOffline(),
+    'azure-ai required from snapshot; runner is offline (global-setup wrote snapshot.offline=true)',
+  )
+})
+
+test('UI: clicking Undo on the bulk-delete toast restores azure-ai files and symlinks', async ({
+  appWindow,
+  isolatedHome,
+}) => {
+  await waitForInitialScan(appWindow)
+
+  const expectedSourcePath = join(
+    isolatedHome,
+    '.agents',
+    'skills',
+    AZURE_AI_NAME,
+  )
+  const trashDir = join(isolatedHome, '.agents', '.trash')
+
+  const initial = await getStoreState(appWindow, azureSnapshotSelector)
+  expect(initial.hasAzure, 'azure-ai should be installed by global-setup').toBe(
+    true,
+  )
+  expect(initial.sourcePath).toBe(expectedSourcePath)
+  expect(
+    initial.validSymlinks.length,
+    'expected at least one valid agent symlink so restore actually has work to do',
+  ).toBeGreaterThan(0)
+
+  // Drive Redux directly into the bulk-select + selected state. Action types
+  // are inlined string literals because the dispatch re-evaluates inside the
+  // renderer where the slice action creators are out of scope.
+  //
+  // Order matters: SelectionToolbar gates on BOTH `bulkSelectMode === true`
+  // AND `selectedSkillNames.length > 0` (see SelectionToolbar.tsx). Toggling
+  // selection before entering bulk mode would briefly violate the invariant
+  // and the toolbar would not render — the next `getByRole('button')` lookup
+  // would then time out instead of failing fast.
+  await appWindow.evaluate(() => {
+    const store = window.__store__ ?? window.__store
+    store?.dispatch({ type: 'ui/enterBulkSelectMode' })
+    store?.dispatch({ type: 'skills/toggleSelection', payload: 'azure-ai' })
+  })
+
+  // Toolbar primary button — global view, single skill selected. The label is
+  // sourced from `getToolbarState({ view: 'global', countKind: 'single' })` in
+  // bulkDeleteHelpers.ts; matching the exact aria-label keeps the test
+  // resilient to visual-label tweaks ("Delete skill" → "Remove skill") that
+  // would not change the underlying intent.
+  await appWindow
+    .getByRole('button', { name: 'Delete selected skill permanently' })
+    .click()
+
+  // Confirm dialog mounts via Radix `<Dialog>`. The title is dynamic
+  // ("Delete 1 skill?"); the destructive Delete button has the unambiguous
+  // exact name "Delete" — the toolbar's button uses an aria-label so it
+  // does NOT collide here.
+  await appWindow
+    .getByRole('heading', { name: 'Delete 1 skill?' })
+    .waitFor({ state: 'visible', timeout: 5_000 })
+  await appWindow.getByRole('button', { name: 'Delete', exact: true }).click()
+
+  // Wait for the source dir to be moved to trash. This is the smallest signal
+  // the click chain reached `moveToTrash` — polling Redux is unreliable here
+  // because the bulk thunk's fulfilled state and the rescan-fetch race.
+  await expect
+    .poll(() => existsSync(expectedSourcePath), { timeout: 10_000 })
+    .toBe(false)
+
+  // The UndoToast is rendered via sonner's default-styled wrapper into a
+  // portal under document.body. The Undo button's aria-label is generated
+  // by UndoToast.tsx as `Undo delete of N <skill|skills>`; matching the
+  // prefix keeps the test stable across pluralization tweaks.
+  const undoButton = appWindow.getByRole('button', {
+    name: /^Undo delete of \d+ skills?$/,
+  })
+  await undoButton.waitFor({ state: 'visible', timeout: 5_000 })
+  await undoButton.click()
+
+  // PRIMARY ASSERTION — the source directory comes back at exactly the same
+  // path with the SKILL.md content restored. `lstatSync` (not stat) on the
+  // source path so a regression that restores a *symlink* in place of the
+  // real directory would show up as `isSymbolicLink() === true` here.
+  await expect
+    .poll(() => existsSync(expectedSourcePath), { timeout: 10_000 })
+    .toBe(true)
+  expect(existsSync(join(expectedSourcePath, 'SKILL.md'))).toBe(true)
+  expect(lstatSync(expectedSourcePath).isDirectory()).toBe(true)
+
+  // PRIMARY ASSERTION — every originally-valid agent symlink is back AS A
+  // SYMLINK. Using `existsSync` alone would silently pass if restore wrote
+  // a real file at the link path; `lstatSync().isSymbolicLink()` catches
+  // that regression. This is the load-bearing check the user called out.
+  for (const symlink of initial.validSymlinks) {
+    expect(
+      existsSync(symlink.linkPath),
+      `expected ${symlink.linkPath} to exist after Undo`,
+    ).toBe(true)
+    expect(
+      lstatSync(symlink.linkPath).isSymbolicLink(),
+      `expected ${symlink.linkPath} to be a symlink after Undo (not a regular file)`,
+    ).toBe(true)
+  }
+
+  // Trash entry cleaned up by `finalizeRestore` (rm + cancel TTL timer).
+  // A residual entry would leave a phantom undo target around indefinitely.
+  const residualTrashEntries = existsSync(trashDir)
+    ? readdirSync(trashDir).filter((entry) =>
+        entry.includes(`-${AZURE_AI_NAME}-`),
+      )
+    : []
+  expect(
+    residualTrashEntries,
+    'restore must remove the trash entry — leftover would leak undo targets',
+  ).toEqual([])
+
+  // Redux — azure-ai is back with the same set of valid symlinks. Comparing
+  // the agentId set (not the snapshot identity) is enough: status booleans
+  // for restored agents land on `valid` because the source dir exists and
+  // the symlink target resolves. `refreshSkillsState` is needed because the
+  // `handleUndoDelete` callback in MainContent calls `refreshAllData` but
+  // the renderer's listener races the test's evaluation; an explicit refresh
+  // collapses the race.
+  await refreshSkillsState(appWindow)
+  const restored = await getStoreState(appWindow, azureSnapshotSelector)
+
+  expect(restored.hasAzure).toBe(true)
+  expect(restored.sourcePath).toBe(expectedSourcePath)
+  expect(
+    restored.validSymlinks.map((symlink) => symlink.agentId).sort(),
+  ).toEqual(initial.validSymlinks.map((symlink) => symlink.agentId).sort())
+})

--- a/e2e/spec/undo-toast.e2e.ts
+++ b/e2e/spec/undo-toast.e2e.ts
@@ -155,20 +155,38 @@ test('UI: clicking Undo on the bulk-delete toast restores azure-ai files and sym
   await undoButton.waitFor({ state: 'visible', timeout: 5_000 })
   await undoButton.click()
 
-  // PRIMARY ASSERTION — the source directory comes back at exactly the same
-  // path with the SKILL.md content restored. `lstatSync` (not stat) on the
-  // source path so a regression that restores a *symlink* in place of the
-  // real directory would show up as `isSymbolicLink() === true` here.
+  // PRIMARY ASSERTION — wait for the FULL restored state in a single poll so
+  // we don't race the order of "dir restored → SKILL.md written → symlinks
+  // recreated". Polling only the source-dir existence and then doing
+  // synchronous asserts on the symlinks/SKILL.md flakes on slow runners
+  // when restore writes the dir before the symlinks land.
+  //
+  // `lstatSync` (not stat) on the source + symlinks so a regression that
+  // restores a *symlink* in place of the real directory, or a real file in
+  // place of an agent symlink, surfaces here. This is the load-bearing
+  // check the user called out.
   await expect
-    .poll(() => existsSync(expectedSourcePath), { timeout: 10_000 })
+    .poll(
+      () => {
+        if (!existsSync(expectedSourcePath)) return false
+        if (!lstatSync(expectedSourcePath).isDirectory()) return false
+        if (!existsSync(join(expectedSourcePath, 'SKILL.md'))) return false
+        return initial.validSymlinks.every(
+          (symlink) =>
+            existsSync(symlink.linkPath) &&
+            lstatSync(symlink.linkPath).isSymbolicLink(),
+        )
+      },
+      { timeout: 10_000 },
+    )
     .toBe(true)
-  expect(existsSync(join(expectedSourcePath, 'SKILL.md'))).toBe(true)
-  expect(lstatSync(expectedSourcePath).isDirectory()).toBe(true)
 
-  // PRIMARY ASSERTION — every originally-valid agent symlink is back AS A
-  // SYMLINK. Using `existsSync` alone would silently pass if restore wrote
-  // a real file at the link path; `lstatSync().isSymbolicLink()` catches
-  // that regression. This is the load-bearing check the user called out.
+  // Redundant per-path asserts kept for clearer failure messages — the poll
+  // above guarantees the predicate holds, but a `toBe(true)` failure on the
+  // poll alone would just say "expected true, received false" without naming
+  // the offending path.
+  expect(lstatSync(expectedSourcePath).isDirectory()).toBe(true)
+  expect(existsSync(join(expectedSourcePath, 'SKILL.md'))).toBe(true)
   for (const symlink of initial.validSymlinks) {
     expect(
       existsSync(symlink.linkPath),

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "fallow:dead-code": "pnpm exec fallow dead-code",
+    "validate": "run-p lint test typecheck fallow:dead-code",
     "prepare": "husky",
     "prettier": "prettier --ignore-unknown --write .",
     "clean": "rm -rf dist build .vite node_modules pnpm-lock.yaml"
@@ -76,6 +77,7 @@
     "fallow": "2.65.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
+    "npm-run-all2": "^8.0.4",
     "playwright": "^1.59.1",
     "prettier": "^3.8.3",
     "sharp": "^0.34.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       lint-staged:
         specifier: ^16.4.0
         version: 16.4.0
+      npm-run-all2:
+        specifier: ^8.0.4
+        version: 8.0.4
       playwright:
         specifier: ^1.59.1
         version: 1.59.1
@@ -3053,6 +3056,10 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-parse-even-better-errors@4.0.0:
+    resolution: {integrity: sha512-lR4MXjGNgkJc7tkQ97kb2nuEMnNCyU//XYVH0MKTGcXEiSudQ5MKGKen3C5QubYy0vmq+JGitUg92uuywGEwIA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -3233,6 +3240,10 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  memorystream@0.3.1:
+    resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
+    engines: {node: '>= 0.10.0'}
+
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
@@ -3335,6 +3346,15 @@ packages:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
     engines: {node: '>=10'}
 
+  npm-normalize-package-bin@4.0.0:
+    resolution: {integrity: sha512-TZKxPvItzai9kN9H/TkmCtx/ZN/hvr3vUycjlfmH0ootY9yFBzNOpiXAdIn1Iteqsvk4lQn6B5PTrt+n6h8k/w==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  npm-run-all2@8.0.4:
+    resolution: {integrity: sha512-wdbB5My48XKp2ZfJUlhnLVihzeuA1hgBnqB2J9ahV77wLS+/YAJAlN8I+X3DIFIPZ3m5L7nplmlbhNiFDmXRDA==}
+    engines: {node: ^20.5.0 || >=22.0.0, npm: '>= 10'}
+    hasBin: true
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -3424,6 +3444,11 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  pidtree@0.6.0:
+    resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
+    engines: {node: '>=0.10'}
+    hasBin: true
 
   playwright-core@1.59.1:
     resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
@@ -3590,6 +3615,10 @@ packages:
     resolution: {integrity: sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==}
     hasBin: true
 
+  read-package-json-fast@4.0.0:
+    resolution: {integrity: sha512-qpt8EwugBWDw2cgE2W+/3oxC+KTez2uSVR8JU9Q36TXPAGCaozfQUs59v4j4GFpWTaw0i6hAZSvOmu1J0uOEUg==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   redux-thunk@3.1.0:
     resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
     peerDependencies:
@@ -3727,6 +3756,10 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shell-quote@1.8.3:
+    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.1:
     resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
@@ -7303,6 +7336,8 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
+  json-parse-even-better-errors@4.0.0: {}
+
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
@@ -7470,6 +7505,8 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  memorystream@0.3.1: {}
+
   mime-db@1.52.0: {}
 
   mime-types@2.1.35:
@@ -7553,6 +7590,19 @@ snapshots:
       abbrev: 4.0.0
 
   normalize-url@6.1.0: {}
+
+  npm-normalize-package-bin@4.0.0: {}
+
+  npm-run-all2@8.0.4:
+    dependencies:
+      ansi-styles: 6.2.3
+      cross-spawn: 7.0.6
+      memorystream: 0.3.1
+      picomatch: 4.0.4
+      pidtree: 0.6.0
+      read-package-json-fast: 4.0.0
+      shell-quote: 1.8.3
+      which: 5.0.0
 
   object-assign@4.1.1: {}
 
@@ -7649,6 +7699,8 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  pidtree@0.6.0: {}
 
   playwright-core@1.59.1: {}
 
@@ -7813,6 +7865,11 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  read-package-json-fast@4.0.0:
+    dependencies:
+      json-parse-even-better-errors: 4.0.0
+      npm-normalize-package-bin: 4.0.0
 
   redux-thunk@3.1.0(redux@5.0.1):
     dependencies:
@@ -8019,6 +8076,8 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shell-quote@1.8.3: {}
 
   side-channel-list@1.0.1:
     dependencies:

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -67,18 +67,20 @@ const toastClassNames = {
  * default). Sonner pins the close button to `top: 0`, so we use the transform
  * variable to provide the matching 8px vertical inset.
  *
- * `--width: 310px` overrides sonner's hard-coded `TOAST_WIDTH = 356px`
+ * `--width: 312px` overrides sonner's hard-coded `TOAST_WIDTH = 356px`
  * default (set inline on the toaster root in sonner's `index.mjs`, then read
  * by `[data-sonner-toast][data-styled="true"] { width: var(--width) }`). User
- * `style` is spread AFTER sonner's defaults, so this override wins. 310px is
+ * `style` is spread AFTER sonner's defaults, so this override wins. 312px is
  * narrow enough to remove the dead whitespace sonner's 356px default left to
  * the right of the UndoToast's short summary line, while staying wide enough
- * to fit the longest "Restoring N skills…" label without wrapping. A fixed
- * value (rather than `fit-content`) keeps the toast width stable across
- * summary lengths, so the close button and Undo button do not shift
- * horizontally as the countdown re-renders. Centering bugs reported in sonner
- * #67/#678 only apply to `position="*-center"` — we use `bottom-right`, which
- * stays anchored to the right edge regardless of width.
+ * to fit the longest "Restoring N skills…" label without wrapping, and is a
+ * multiple of 4 so it sits on the project's 4px base grid alongside the 8px
+ * close-button insets. A fixed value (rather than `fit-content`) keeps the
+ * toast width stable across summary lengths, so the close button and Undo
+ * button do not shift horizontally as the countdown re-renders. Centering
+ * bugs reported in sonner #67/#678 only apply to `position="*-center"` — we
+ * use `bottom-right`, which stays anchored to the right edge regardless of
+ * width.
  */
 const toasterStyle = {
   '--normal-bg': 'var(--popover)',
@@ -87,7 +89,7 @@ const toasterStyle = {
   '--toast-close-button-start': '8px',
   '--toast-close-button-end': 'unset',
   '--toast-close-button-transform': 'translate(0, 8px)',
-  '--width': '310px',
+  '--width': '312px',
 } as React.CSSProperties
 
 /**

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -46,6 +46,11 @@ const toastClassNames = {
   description: 'text-muted-foreground',
   actionButton: 'bg-primary text-primary-foreground hover:bg-primary/90',
   cancelButton: 'bg-muted text-muted-foreground hover:bg-muted/80',
+  // Theme sonner's built-in close button with shadcn popover tokens so it
+  // inherits the popover surface in both light/dark modes — sonner's default
+  // light/dark borders look pasted-on against our OKLCH background.
+  closeButton:
+    'bg-popover text-muted-foreground border-border hover:bg-accent hover:text-foreground',
 } as const
 
 /**
@@ -56,11 +61,33 @@ const toastClassNames = {
  * color in both light and dark mode without resorting to `!important` or the
  * `unstyled` escape hatch (which would force us to recreate sonner's entire
  * default layout).
+ *
+ * The `--toast-close-button-*` overrides seat the built-in × inside the toast
+ * at 8px from each edge instead of letting it overhang the corner (sonner's
+ * default). Sonner pins the close button to `top: 0`, so we use the transform
+ * variable to provide the matching 8px vertical inset.
+ *
+ * `--width: 310px` overrides sonner's hard-coded `TOAST_WIDTH = 356px`
+ * default (set inline on the toaster root in sonner's `index.mjs`, then read
+ * by `[data-sonner-toast][data-styled="true"] { width: var(--width) }`). User
+ * `style` is spread AFTER sonner's defaults, so this override wins. 310px is
+ * narrow enough to remove the dead whitespace sonner's 356px default left to
+ * the right of the UndoToast's short summary line, while staying wide enough
+ * to fit the longest "Restoring N skills…" label without wrapping. A fixed
+ * value (rather than `fit-content`) keeps the toast width stable across
+ * summary lengths, so the close button and Undo button do not shift
+ * horizontally as the countdown re-renders. Centering bugs reported in sonner
+ * #67/#678 only apply to `position="*-center"` — we use `bottom-right`, which
+ * stays anchored to the right edge regardless of width.
  */
 const toasterStyle = {
   '--normal-bg': 'var(--popover)',
   '--normal-text': 'var(--popover-foreground)',
   '--normal-border': 'var(--border)',
+  '--toast-close-button-start': '8px',
+  '--toast-close-button-end': 'unset',
+  '--toast-close-button-transform': 'translate(0, 8px)',
+  '--width': '310px',
 } as React.CSSProperties
 
 /**

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -95,6 +95,7 @@ import { FEATURE_FLAGS } from '@/shared/featureFlags'
 import type {
   BulkDeleteItemResult,
   IsoTimestamp,
+  ToastId,
   TombstoneId,
 } from '@/shared/types'
 
@@ -128,7 +129,6 @@ export const MainContent = React.memo(
     const visibleNames = useAppSelector(selectVisibleSkillNames)
     const selectedVisibleNames = useAppSelector(selectSelectedVisibleNames)
     const selectedAllNames = useAppSelector(selectSelectedSkillNames)
-
     const bulkConfirm = useAppSelector(selectBulkConfirm)
     const bulkSelectMode = useAppSelector(selectBulkSelectMode)
     const selectedSource = useAppSelector(selectSelectedSource)
@@ -363,29 +363,35 @@ export const MainContent = React.memo(
           return
         }
 
-        // Render the sonner custom toast. The `onUndo` callback gives the
-        // UndoToast access to the restore thunk without importing redux
-        // hooks (it stays purely presentational).
+        // Render via sonner's default-styled wrapper (NOT `toast.custom`) so
+        // the per-toast `closeButton: true` opt-in injects sonner's built-in ×
+        // — sonner only renders the close affordance on styled toasts, and
+        // `toast.custom` opts out of that styling.
+        //
+        // `onUndoComplete` reads `toastId` through the closure at click time,
+        // so it resolves after the surrounding const has been assigned.
         const expiresAt: IsoTimestamp = new Date(
           Date.now() + UNDO_WINDOW_MS,
         ).toISOString()
         const summary = formatCascadeSummary(action.payload)
-        const toastId = toast.custom(
-          (id) => (
-            <UndoToast
-              toastId={id}
-              skillNames={deletedNames}
-              tombstoneIds={tombstoneIds}
-              expiresAt={expiresAt}
-              summary={summary}
-              onUndo={handleUndoDelete}
-              onDismiss={() => {
-                toast.dismiss(id)
-                dispatch(clearUndoToast())
-              }}
-            />
-          ),
-          { duration: UNDO_WINDOW_MS },
+        const handleToastDismissed = (): void => {
+          dispatch(clearUndoToast())
+        }
+        const toastId: ToastId = toast(
+          <UndoToast
+            skillNames={deletedNames}
+            tombstoneIds={tombstoneIds}
+            expiresAt={expiresAt}
+            summary={summary}
+            onUndo={handleUndoDelete}
+            onUndoComplete={() => toast.dismiss(toastId)}
+          />,
+          {
+            duration: UNDO_WINDOW_MS,
+            closeButton: true,
+            onDismiss: handleToastDismissed,
+            onAutoClose: handleToastDismissed,
+          },
         )
         dispatch(
           setUndoToast({
@@ -618,9 +624,7 @@ export const MainContent = React.memo(
         <CleanupAgentDialog />
 
         {/*
-          Bulk delete / unlink confirmation. Replaces the old `window.confirm`
-          call in handlePrimaryAction (blocks the event loop in Electron, and
-          CodeRabbit flagged it as discouraged renderer API). Copy is driven by
+          Bulk delete / unlink confirmation. Copy is driven by
           the kind flag so the dispatch site stays a single handler.
         */}
         <Dialog

--- a/src/renderer/src/components/skills/UndoToast.tsx
+++ b/src/renderer/src/components/skills/UndoToast.tsx
@@ -1,14 +1,11 @@
 import { Loader2, Undo2 } from 'lucide-react'
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useState } from 'react'
+import { match } from 'ts-pattern'
 
+import { Button } from '@/renderer/src/components/ui/button'
 import { cn } from '@/renderer/src/lib/utils'
 import { pluralize } from '@/renderer/src/utils/pluralize'
-import type {
-  IsoTimestamp,
-  SkillName,
-  ToastId,
-  TombstoneId,
-} from '@/shared/types'
+import type { IsoTimestamp, SkillName, TombstoneId } from '@/shared/types'
 
 /** Tick interval for the countdown (ms). 250 gives smooth updates without thrashing. */
 const COUNTDOWN_TICK_MS = 250
@@ -16,8 +13,6 @@ const COUNTDOWN_TICK_MS = 250
 const URGENT_SECONDS_THRESHOLD = 5
 
 interface UndoToastProps {
-  /** sonner toast id — passed back so callbacks can `toast.dismiss(id)`. */
-  toastId: ToastId
   skillNames: SkillName[]
   /** Empty for unlink (no tombstones produced). */
   tombstoneIds: TombstoneId[]
@@ -27,77 +22,66 @@ interface UndoToastProps {
   summary: string
   /** Callback when the user presses Undo. MainContent owns the dispatch. */
   onUndo: (tombstoneIds: TombstoneId[]) => Promise<void> | void
-  /** Callback when the toast should dismiss itself (timer expired or closed). */
-  onDismiss: () => void
+  /**
+   * Fired after `onUndo` resolves so the parent can `toast.dismiss(id)`.
+   * Sonner's auto-close and built-in close button take care of the other
+   * dismiss paths via `onAutoClose` / `onDismiss` toast options.
+   */
+  onUndoComplete: () => void
 }
 
 /**
- * Body rendered inside `sonner.toast.custom(id => <UndoToast ... />)`.
- *
- * Two lines:
+ * Body rendered as the JSX content of `sonner.toast(<UndoToast ... />)`. Two
+ * lines:
  *   1. Summary (e.g. "Deleted 3 skills. 7 symlinks removed.")
- *   2. Countdown + Undo button (e.g. "Undo · 12s")
+ *   2. Countdown + Undo button (e.g. "12s [Undo]")
+ *
+ * The toast must be rendered via sonner's default-styled wrapper (NOT
+ * `toast.custom`) because sonner only injects its built-in close button on
+ * styled toasts; `toast.custom` opts out of the styled wrapper.
  *
  * Behavior:
  *   - Tick every 250ms; display `Math.ceil(remainingMs / 1000)` so "15..1..0"
  *     reads linearly without snapping to the next integer early.
  *   - Swap text color from `text-muted-foreground` to `text-foreground` when
  *     `remainingMs <= URGENT_SECONDS_THRESHOLD * 1000`.
- *   - When the user clicks Undo: swap the button for a spinner + "Restoring N
- *     skills..." and await the onUndo promise. When it resolves, the parent
- *     emits a `toast.success` and this component is unmounted.
+ *   - On Undo click: swap the button for a spinner + "Restoring N skills..."
+ *     and await `onUndo`. Then fire `onUndoComplete` so the parent can dismiss
+ *     the toast.
  *   - Keyboard: the wrapper is `tabIndex={-1}` so arrow-key focus cycles do
- *     not land on the toast (it is supplemental, not a required interaction).
- *     The Undo button itself is focusable.
+ *     not land on the toast body (it is supplemental, not a required
+ *     interaction). The Undo button and sonner's close button remain focusable.
  *
  * @param props - UndoToastProps — see interface above
  * @returns Rendered toast body
  * @example
- * toast.custom((id) => (
- *   <UndoToast toastId={id} skillNames={['task','theme']} ... />
- * ), { duration: 15_000 })
+ * const toastId = toast(
+ *   <UndoToast skillNames={['task','theme']} ... onUndoComplete={...} />,
+ *   { duration: 15_000, closeButton: true, onDismiss, onAutoClose },
+ * )
  */
 export const UndoToast = React.memo(function UndoToast({
-  toastId: _toastId,
   skillNames,
   tombstoneIds,
   expiresAt,
   summary,
   onUndo,
-  onDismiss,
+  onUndoComplete,
 }: UndoToastProps): React.ReactElement {
   const expiresAtMs = new Date(expiresAt).getTime()
   const [remainingMs, setRemainingMs] = useState(
     Math.max(0, expiresAtMs - Date.now()),
   )
   const [isRestoring, setIsRestoring] = useState(false)
-  const hasDismissedRef = useRef(false)
-
-  // Keep onDismiss in a ref so the countdown effect below doesn't list it in
-  // its deps. Parents often pass a fresh-identity callback on every render
-  // (e.g. inline `() => dispatch(clearUndoToast())`), which would otherwise
-  // tear down and restart `setInterval` every render — losing accumulated
-  // ticks and making the countdown stutter.
-  const onDismissRef = useRef(onDismiss)
-  useEffect(() => {
-    onDismissRef.current = onDismiss
-  }, [onDismiss])
 
   useEffect(() => {
-    // Freeze the countdown once the user commits to Undo. Two reasons:
-    //  1. Firing onDismiss() at the moment restore lands would unmount the
-    //     toast mid-request, stranding the "Restoring N skills..." affordance.
-    //  2. The success/error toast that follows is already owned by the parent.
+    // Freeze the countdown once the user commits to Undo so the displayed
+    // "12s" doesn't keep ticking down behind a "Restoring..." spinner. The
+    // parent dismisses the toast as soon as restore resolves, so the frozen
+    // value is only ever briefly visible.
     if (isRestoring) return
-    // Tick while visible. No `prefers-reduced-motion` branch needed — we
-    // aren't animating, just updating a number.
     const timer = setInterval(() => {
-      const next = Math.max(0, expiresAtMs - Date.now())
-      setRemainingMs(next)
-      if (next === 0 && !hasDismissedRef.current) {
-        hasDismissedRef.current = true
-        onDismissRef.current()
-      }
+      setRemainingMs(Math.max(0, expiresAtMs - Date.now()))
     }, COUNTDOWN_TICK_MS)
     return () => clearInterval(timer)
   }, [expiresAtMs, isRestoring])
@@ -116,25 +100,25 @@ export const UndoToast = React.memo(function UndoToast({
     try {
       await onUndo(tombstoneIds)
     } finally {
-      // Restoring finished — whether success or failure, the parent will emit
-      // the appropriate sonner toast. We don't reset `isRestoring` because the
-      // component will unmount immediately. Route through the ref so we match
-      // the countdown-expiry branch and don't fire a stale closure after a
-      // parent re-render.
-      if (!hasDismissedRef.current) {
-        hasDismissedRef.current = true
-        onDismissRef.current()
-      }
+      // Whether success or failure, the parent emits the appropriate sonner
+      // toast and dismisses this one. We don't reset `isRestoring` because
+      // the component will unmount immediately.
+      onUndoComplete()
     }
   }
 
   return (
     <div
       tabIndex={-1}
-      className="flex flex-col gap-2 w-full min-w-0"
+      className="flex flex-col gap-2 min-w-0"
       aria-live="polite"
     >
-      <div className="text-sm font-medium truncate" title={summary}>
+      {/*
+        `pl-7` reserves space for sonner's built-in × at top-left (8px from
+        the edge + 20px wide). Without this, the close button would overlap
+        the first character of the summary line.
+      */}
+      <div className="text-sm font-medium truncate pl-7" title={summary}>
         {summary}
       </div>
       <div className="flex items-center justify-between gap-3">
@@ -147,37 +131,35 @@ export const UndoToast = React.memo(function UndoToast({
         >
           {remainingSeconds}s
         </span>
-        {isUndoableOperation ? (
-          <button
-            type="button"
-            onClick={handleUndoClick}
-            disabled={!canUndo}
-            className={cn(
-              'inline-flex items-center gap-1.5 rounded-md px-3 min-h-11 text-sm font-medium',
-              'bg-primary text-primary-foreground hover:bg-primary/90',
-              'disabled:opacity-50 disabled:cursor-not-allowed',
-              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-            )}
-            aria-label={
-              isRestoring
-                ? `Restoring ${skillNames.length} ${pluralize(skillNames.length, 'skill')}`
-                : `Undo delete of ${skillNames.length} ${pluralize(skillNames.length, 'skill')}`
-            }
-          >
-            {isRestoring ? (
-              <>
-                <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" />
-                Restoring {skillNames.length}{' '}
-                {pluralize(skillNames.length, 'skill')}...
-              </>
-            ) : (
-              <>
-                <Undo2 className="h-4 w-4" />
-                Undo
-              </>
-            )}
-          </button>
-        ) : null}
+        {match({ isUndoableOperation, isRestoring })
+          .with({ isUndoableOperation: false }, () => null)
+          .with({ isUndoableOperation: true, isRestoring: true }, () => (
+            <Button
+              size="sm"
+              type="button"
+              disabled
+              className="shrink-0"
+              aria-label={`Restoring ${skillNames.length} ${pluralize(skillNames.length, 'skill')}`}
+            >
+              <Loader2 className="animate-spin motion-reduce:animate-none" />
+              Restoring {skillNames.length}{' '}
+              {pluralize(skillNames.length, 'skill')}...
+            </Button>
+          ))
+          .with({ isUndoableOperation: true, isRestoring: false }, () => (
+            <Button
+              size="sm"
+              type="button"
+              onClick={handleUndoClick}
+              disabled={!canUndo}
+              className="shrink-0"
+              aria-label={`Undo delete of ${skillNames.length} ${pluralize(skillNames.length, 'skill')}`}
+            >
+              <Undo2 />
+              Undo
+            </Button>
+          ))
+          .exhaustive()}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- Switch `UndoToast` from `toast.custom` to sonner's default-styled wrapper with `closeButton: true` so sonner's themed × renders in place of the hand-rolled close button — wired via the new `closeButton` className slot (popover tokens) and `--toast-close-button-*` insets; toast width pinned at 310px to trim sonner's 356px default whitespace
- Drop `toastId`/`onDismiss` props in favor of `onUndoComplete` so the parent owns the dismiss path; refactor button branches to `ts-pattern`
- Add `pnpm validate` (parallel lint/test/typecheck/fallow:dead-code via `npm-run-all2`) and a UI-driven E2E test that asserts source dir + `SKILL.md` + every originally-valid agent symlink come back after Undo (`lstatSync().isSymbolicLink()`, not just `existsSync`)

## Test plan
- [x] `pnpm validate` passes (986 tests, lint clean, typecheck clean, no dead code)
- [x] `pnpm test:e2e e2e/spec/undo-toast.e2e.ts` passes (1.8s)
- [ ] Manual: bulk-delete a skill → confirm sonner's × renders top-left of the UndoToast and dismisses cleanly
- [ ] Manual: confirm Undo restores files + symlinks correctly (e2e covers this; eyeball the toast UX)
- [ ] Light/dark mode: × inherits popover surface in both themes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル改善**
  * Undoトーストの表示を改善し、閉じるボタンのスタイリングとトースト幅を統一しました。

* **テスト**
  * 一括削除後のUndo機能に関するエンドツーエンドテストを追加しました。

* **ドキュメント**
  * 開発ワークフローのドキュメントと検証コマンドを更新しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/skills-desktop/pull/149)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->