### PR TITLE
Fix Marketplace install PATH for macOS GUI launches

### DIFF
--- a/e2e/spec/marketplace-install-regression.e2e.ts
+++ b/e2e/spec/marketplace-install-regression.e2e.ts
@@ -96,7 +96,7 @@ echo "Installation complete"
  */
 async function waitForClaudeCodeAgent(appWindow: Page): Promise<void> {
   await appWindow.waitForFunction(() => {
-    const store = window.__store__ ?? window.__store
+    const store = window.__store__
     const state = store?.getState() as
       | { agents?: { items?: Array<{ id: string; exists: boolean }> } }
       | undefined

--- a/e2e/spec/marketplace-install-regression.e2e.ts
+++ b/e2e/spec/marketplace-install-regression.e2e.ts
@@ -1,0 +1,176 @@
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+
+import { _electron, type Page } from '@playwright/test'
+
+import { SKILLS_CLI_VERSION } from '@/shared/constants'
+
+import { test, expect } from '../fixtures/electron-app'
+import { dispatchAction } from '../helpers/redux'
+
+const SPARSE_GUI_PATH = '/usr/bin:/bin:/usr/sbin:/sbin'
+const MARKETPLACE_SKILL = {
+  rank: 1,
+  name: 'find-skills',
+  repo: 'vercel-labs/skills',
+  url: 'https://skills.sh/vercel-labs/skills/find-skills',
+  installCount: 1,
+}
+
+/**
+ * Install a fake `npx` binary into a user-level directory that Finder-launched
+ * macOS apps do not receive in PATH by default.
+ *
+ * @param home - Isolated E2E HOME used by the Electron process
+ * @returns Path to the marker file written by the fake `npx`
+ * @example
+ * const markerPath = stageFallbackNpx('/tmp/home')
+ * // Electron can only execute it when skillsCliService extends PATH.
+ */
+function stageFallbackNpx(home: string): string {
+  const markerPath = join(home, '.e2e-fake-npx-args')
+  const fakeNpxPath = join(home, 'Library', 'pnpm', 'npx')
+  mkdirSync(dirname(fakeNpxPath), { recursive: true })
+
+  writeFileSync(
+    fakeNpxPath,
+    `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" > "$HOME/.e2e-fake-npx-args"
+
+repo=""
+skill=""
+next=""
+for arg in "$@"; do
+  if [ "$next" = "source" ]; then
+    repo="$arg"
+    next=""
+    continue
+  fi
+  if [ "$next" = "skill" ]; then
+    skill="$arg"
+    next=""
+    continue
+  fi
+  case "$arg" in
+    add) next="source" ;;
+    --skill) next="skill" ;;
+  esac
+done
+
+if [ "$repo" != "vercel-labs/skills" ] || [ "$skill" != "find-skills" ]; then
+  echo "unexpected fake npx invocation: $*" >&2
+  exit 64
+fi
+
+mkdir -p "$HOME/.agents/skills/$skill" "$HOME/.claude/skills"
+cat > "$HOME/.agents/skills/$skill/SKILL.md" <<'EOF_SKILL'
+---
+name: find-skills
+description: E2E fake skill for Marketplace install regression.
+---
+# find-skills
+EOF_SKILL
+rm -f "$HOME/.claude/skills/$skill"
+ln -s "../../.agents/skills/$skill" "$HOME/.claude/skills/$skill"
+echo "Installation complete"
+`,
+  )
+  chmodSync(fakeNpxPath, 0o755)
+  return markerPath
+}
+
+/**
+ * Wait until the renderer store has scanned the staged Claude Code agent dir.
+ *
+ * @param appWindow - Main Electron renderer window
+ * @returns Promise that resolves when Claude Code is installable in the modal
+ * @example
+ * await waitForClaudeCodeAgent(appWindow)
+ */
+async function waitForClaudeCodeAgent(appWindow: Page): Promise<void> {
+  await appWindow.waitForFunction(() => {
+    const store = window.__store__ ?? window.__store
+    const state = store?.getState() as
+      | { agents?: { items?: Array<{ id: string; exists: boolean }> } }
+      | undefined
+    return state?.agents?.items?.some(
+      (agent) => agent.id === 'claude-code' && agent.exists,
+    )
+  })
+}
+
+test('Marketplace Install works when Electron starts with sparse macOS GUI PATH', async ({
+  isolatedHome,
+}) => {
+  // Stage the agent dir before Electron boots so the install modal can offer
+  // Claude Code without touching the developer's real ~/.claude directory.
+  mkdirSync(join(isolatedHome, '.agents', 'skills'), { recursive: true })
+  mkdirSync(join(isolatedHome, '.claude', 'skills'), { recursive: true })
+  const markerPath = stageFallbackNpx(isolatedHome)
+
+  const repoRoot = resolve(__dirname, '..', '..')
+  const mainEntry = resolve(repoRoot, 'out', 'main', 'index.mjs')
+  const electronApp = await _electron.launch({
+    args: [mainEntry],
+    env: {
+      ...process.env,
+      HOME: isolatedHome,
+      PATH: SPARSE_GUI_PATH,
+      E2E_USERDATA_DIR: resolve(isolatedHome, 'userData'),
+      E2E_DISABLE_UPDATE: '1',
+      E2E_BACKGROUND_LAUNCH: process.env['E2E_BACKGROUND_LAUNCH'] ?? '1',
+    },
+  })
+
+  try {
+    const appWindow = await electronApp.firstWindow()
+    await appWindow.waitForLoadState('domcontentloaded')
+    await waitForClaudeCodeAgent(appWindow)
+
+    // Drive the real Marketplace UI without relying on skills.sh or the real
+    // skills CLI search endpoint. The Install button still goes through IPC,
+    // skillsCliService, and child_process.spawn.
+    await dispatchAction(appWindow, {
+      type: 'marketplace/setMarketplaceSearchQuery',
+      payload: 'find-skills',
+    })
+    await dispatchAction(appWindow, {
+      type: 'marketplace/search/fulfilled',
+      payload: [MARKETPLACE_SKILL],
+      meta: {
+        arg: 'find-skills',
+        requestId: 'e2e-marketplace-install-path',
+        requestStatus: 'fulfilled',
+      },
+    })
+
+    await appWindow.getByRole('tab', { name: 'Marketplace' }).click()
+    await appWindow
+      .getByRole('button', { name: 'Install', exact: true })
+      .first()
+      .click()
+
+    const dialog = appWindow.getByRole('dialog', { name: 'Install Skill' })
+    await expect(dialog.getByText('find-skills')).toBeVisible()
+    await dialog.getByRole('button', { name: 'Install', exact: true }).click()
+
+    await expect
+      .poll(() => existsSync(markerPath), { timeout: 10_000 })
+      .toBe(true)
+    expect(readFileSync(markerPath, 'utf-8')).toContain(
+      `skills@${SKILLS_CLI_VERSION} add vercel-labs/skills`,
+    )
+    await expect(
+      appWindow.getByRole('img', { name: /find-skills is installed/i }),
+    ).toBeVisible()
+  } finally {
+    await electronApp.close()
+  }
+})

--- a/src/main/services/skillsCliService.test.ts
+++ b/src/main/services/skillsCliService.test.ts
@@ -1,6 +1,8 @@
 import { EventEmitter } from 'events'
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { SKILLS_CLI_VERSION } from '@/shared/constants'
 
 /**
  * Fake child process so we can drive stdout/stderr/close from the test.
@@ -19,12 +21,14 @@ class FakeChildProcess extends EventEmitter {
 // evaluation time. Otherwise spawnMock is `undefined` when the service first
 // imports child_process and the handlers never fire (→ test timeouts).
 const { spawnMock } = vi.hoisted(() => ({
-  spawnMock: vi.fn<() => FakeChildProcess>(),
+  spawnMock: vi.fn<(...args: unknown[]) => FakeChildProcess>(),
 }))
 
 vi.mock('child_process', () => ({
-  spawn: (...args: unknown[]) => spawnMock(...(args as [])),
+  spawn: (...args: unknown[]) => spawnMock(...args),
 }))
+
+const ORIGINAL_PATH = process.env.PATH
 
 /**
  * Drive the fake process to simulate a CLI invocation. `spawn` is called by
@@ -68,6 +72,10 @@ describe('skillsCliService.cancel', () => {
     spawnMock.mockReset()
   })
 
+  afterEach(() => {
+    process.env.PATH = ORIGINAL_PATH
+  })
+
   it('kills all running CLI children on cancel()', async () => {
     const first = simulateCli({ autoClose: false })
     const second = simulateCli({ autoClose: false })
@@ -84,5 +92,39 @@ describe('skillsCliService.cancel', () => {
     first.emit('close', 0)
     second.emit('close', 0)
     await Promise.all([searchA, searchB])
+  })
+})
+
+describe('skillsCliService.execCli environment', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+    vi.resetModules()
+    spawnMock.mockReset()
+    process.env.PATH = '/usr/bin:/bin:/usr/sbin:/sbin'
+  })
+
+  afterEach(() => {
+    process.env.PATH = ORIGINAL_PATH
+  })
+
+  it('adds common Node toolchain paths so Finder-launched installs can find npx', async () => {
+    simulateCli({
+      stdout:
+        'vercel-labs/skills@find-skills\n└ https://skills.sh/vercel-labs/skills/find-skills\n',
+    })
+
+    const { skillsCliService } = await import('./skillsCliService')
+    await skillsCliService.search('find-skills')
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'npx',
+      [`skills@${SKILLS_CLI_VERSION}`, 'find', 'find-skills'],
+      expect.objectContaining({
+        env: expect.objectContaining({
+          FORCE_COLOR: '0',
+          PATH: expect.stringContaining('/opt/homebrew/bin'),
+        }),
+      }),
+    )
   })
 })

--- a/src/main/services/skillsCliService.test.ts
+++ b/src/main/services/skillsCliService.test.ts
@@ -122,7 +122,7 @@ describe('skillsCliService.execCli environment', () => {
       expect.objectContaining({
         env: expect.objectContaining({
           FORCE_COLOR: '0',
-          PATH: expect.stringContaining('/opt/homebrew/bin'),
+          PATH: expect.stringMatching(/\/usr\/bin.*\/opt\/homebrew\/bin/),
         }),
       }),
     )

--- a/src/main/services/skillsCliService.ts
+++ b/src/main/services/skillsCliService.ts
@@ -1,5 +1,7 @@
 import { spawn, type ChildProcess } from 'child_process'
 import { EventEmitter } from 'events'
+import { homedir } from 'os'
+import { delimiter, join } from 'path'
 
 import { match, P } from 'ts-pattern'
 
@@ -39,6 +41,23 @@ const SPAWN_TIMEOUT_MS = 60_000
 const PROCESS_KILL_SIGNAL: NodeJS.Signals = 'SIGTERM'
 
 /**
+ * Common Node.js binary locations missing from Finder-launched macOS apps.
+ * GUI apps usually inherit only `/usr/bin:/bin:/usr/sbin:/sbin`, so `npx`
+ * installed by Homebrew, mise, asdf, Volta, pnpm, or Bun is invisible unless
+ * we add these user-level toolchain paths before spawning the skills CLI.
+ */
+const CLI_PATH_FALLBACKS = [
+  join(homedir(), '.local', 'bin'),
+  join(homedir(), '.local', 'share', 'mise', 'shims'),
+  join(homedir(), '.asdf', 'shims'),
+  join(homedir(), '.volta', 'bin'),
+  join(homedir(), '.bun', 'bin'),
+  join(homedir(), 'Library', 'pnpm'),
+  '/opt/homebrew/bin',
+  '/usr/local/bin',
+] as const
+
+/**
  * Internal execution payload from `execCli`.
  * Extends `CliCommandResult` with a timeout sentinel so callers can map
  * user-facing error copy without overloading `code`.
@@ -54,6 +73,35 @@ interface CliExecutionResult extends CliCommandResult {
  */
 function stripAnsi(text: string): string {
   return text.replace(/\x1B\[[0-9;]*[a-zA-Z]/g, '').replace(/\[[\d;]*m/g, '')
+}
+
+/**
+ * Build a CLI-friendly PATH without requiring the app to be launched from a
+ * terminal session.
+ * @param basePath - PATH inherited by the Electron main process
+ * @returns PATH with common Node toolchain directories appended once
+ * @example
+ * buildCliPath('/usr/bin:/bin').includes('/opt/homebrew/bin') // => true
+ */
+function buildCliPath(basePath = process.env.PATH ?? ''): string {
+  const entries = [...basePath.split(delimiter), ...CLI_PATH_FALLBACKS].filter(
+    Boolean,
+  )
+  return Array.from(new Set(entries)).join(delimiter)
+}
+
+/**
+ * Environment used for `npx skills ...` child processes.
+ * @returns Process env with ANSI disabled and GUI-safe PATH expansion
+ * @example
+ * buildCliEnv().FORCE_COLOR // => '0'
+ */
+function buildCliEnv(): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    FORCE_COLOR: '0',
+    PATH: buildCliPath(),
+  }
 }
 
 /**
@@ -146,9 +194,10 @@ class SkillsCliService extends EventEmitter {
       let stderr = ''
       let settled = false
 
-      // Use npx to run skills CLI with FORCE_COLOR=0 to disable ANSI colors
+      // Finder-launched macOS apps do not inherit shell PATH, so buildCliEnv()
+      // restores the common Node toolchain locations before resolving `npx`.
       const proc = spawn('npx', [`skills@${SKILLS_CLI_VERSION}`, ...args], {
-        env: { ...process.env, FORCE_COLOR: '0' },
+        env: buildCliEnv(),
       })
 
       this.runningProcesses.add(proc)


### PR DESCRIPTION
## Summary
- extend the skills CLI child process PATH with common Node toolchain locations for Finder-launched macOS apps
- keep FORCE_COLOR disabled while preserving the inherited environment
- add unit and Electron E2E regression coverage for Marketplace Install with sparse GUI PATH

## Verification
- pnpm validate
- pnpm test:e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正

* macOS で Finder から起動した場合など、PATH が制限されている環境で Marketplace のスキル インストール機能が正常に動作するように改善しました。npx ツールチェーンのパスを自動的に補完し、インストール処理を確実に実行できるようになります。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/skills-desktop/pull/151)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->