### PR TITLE
[codex] Add G-Stack skill filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ out/
 build/
 .vite/
 storybook-static/
+static-storybook/
 
 # Logs
 logs/

--- a/e2e/spec/hide-agents.e2e.ts
+++ b/e2e/spec/hide-agents.e2e.ts
@@ -5,8 +5,8 @@ import { _electron } from '@playwright/test'
 
 import { test, expect } from '../fixtures/electron-app'
 import { isSnapshotOffline } from '../fixtures/isolated-home'
-import { readSettingsFile, writeSettingsFile } from '../helpers/settings-file'
 import { getStoreState, waitForInitialScan } from '../helpers/redux'
+import { readSettingsFile, writeSettingsFile } from '../helpers/settings-file'
 
 /**
  * PR #144 — Hide unused agents from the sidebar.

--- a/e2e/spec/regression.e2e.ts
+++ b/e2e/spec/regression.e2e.ts
@@ -872,10 +872,9 @@ test('skills list scroll position survives a background refetch (regression 5619
   // ABSENCE of unmount — there's nothing positive to poll for, only the
   // STABILITY of `scrollTop`. requestAnimationFrame is the synchronous
   // analogue: dispatch → reducer → React commit → next paint.
-  await appWindow.evaluate(
-    () =>
-      new Promise<void>((resolve) => requestAnimationFrame(() => resolve())),
-  )
+  await appWindow.evaluate(async () => {
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+  })
 
   const scrollTopAfter = await appWindow.evaluate(() => {
     const scroller = document.querySelector<HTMLElement>(

--- a/e2e/spec/sync.e2e.ts
+++ b/e2e/spec/sync.e2e.ts
@@ -157,7 +157,7 @@ test('per-agent preview narrows scope and echoes forAgent', async ({
   // `{ agentId }` from the renderer, so wiring this through a click
   // would test more than the boundary we care about. The thunk + slice
   // path is already covered by the global test above.
-  const previewRaw = await appWindow.evaluate(() =>
+  const previewRaw = await appWindow.evaluate(async () =>
     window.electron.sync.preview({ agentId: 'cursor' }),
   )
   const preview = previewRaw as {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
     "fallow:dead-code": "pnpm exec fallow dead-code",
     "validate": "run-p lint test typecheck fallow:dead-code storybook:build",

--- a/src/renderer/src/components/layout/MainContent.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.browser.test.tsx
@@ -541,10 +541,10 @@ describe('MainContent SkillTypeFilter dropdown options', () => {
 
     const gstackItem = screen.getByRole('menuitemradio', { name: /G-Stack/i })
     await expect.element(gstackItem).toBeInTheDocument()
-    const dot = gstackItem.element().querySelector('.bg-sky-400')
+    const dot = gstackItem.element().querySelector('.bg-gstack')
     expect(
       dot,
-      'G-Stack menu item should contain a span with bg-sky-400',
+      'G-Stack menu item should contain a span with bg-gstack',
     ).not.toBeNull()
   })
 

--- a/src/renderer/src/components/layout/MainContent.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.browser.test.tsx
@@ -469,10 +469,10 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
   })
 })
 
-describe('MainContent SkillTypeFilter dropdown (Orphan option)', () => {
-  // Pins the agent-only Orphan affordance contract: the dropdown is gated by
-  // `selectedAgentId` (source view never offers it), and selecting Orphan
-  // narrows the visible list to skills whose source dir vanished.
+describe('MainContent SkillTypeFilter dropdown options', () => {
+  // Pins agent-only type filters: the dropdown is gated by `selectedAgentId`
+  // (source view never offers it), and each option writes the Redux state that
+  // selectors use to narrow the visible list.
 
   it('renders the Orphan radio item with a destructive dot when an agent is selected', async () => {
     const { screen, store } = await renderMainContent()
@@ -510,6 +510,41 @@ describe('MainContent SkillTypeFilter dropdown (Orphan option)', () => {
     expect(
       dot,
       'Orphan menu item should contain a span with bg-destructive',
+    ).not.toBeNull()
+  })
+
+  it('renders the G-Stack radio item with a sky dot when an agent is selected', async () => {
+    const { screen, store } = await renderMainContent()
+    const { fetchAgents } =
+      await import('@/renderer/src/redux/slices/agentsSlice')
+    const { selectAgent } = await import('@/renderer/src/redux/slices/uiSlice')
+
+    store.dispatch(
+      fetchAgents.fulfilled(
+        [
+          {
+            id: 'cursor',
+            name: 'Cursor',
+            path: '/Users/me/.cursor/skills' as never,
+            exists: true,
+            skillCount: 0,
+            localSkillCount: 0,
+          },
+        ],
+        'req-id',
+      ),
+    )
+    store.dispatch(selectAgent('cursor'))
+
+    // Open the dropdown — G-Stack sits beside Symlinked/Local as a type filter.
+    await screen.getByRole('button', { name: /^All$/ }).click()
+
+    const gstackItem = screen.getByRole('menuitemradio', { name: /G-Stack/i })
+    await expect.element(gstackItem).toBeInTheDocument()
+    const dot = gstackItem.element().querySelector('.bg-sky-400')
+    expect(
+      dot,
+      'G-Stack menu item should contain a span with bg-sky-400',
     ).not.toBeNull()
   })
 

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -108,7 +108,7 @@ const SKILL_TYPE_FILTER_OPTIONS: {
   { value: 'all', label: 'All' },
   { value: 'symlinked', label: 'Symlinked', dotClass: 'bg-success' },
   { value: 'local', label: 'Local', dotClass: 'bg-emerald-400' },
-  { value: 'gstack', label: 'G-Stack', dotClass: 'bg-sky-400' },
+  { value: 'gstack', label: 'G-Stack', dotClass: 'bg-gstack' },
   { value: 'orphan', label: 'Orphan', dotClass: 'bg-destructive' },
 ]
 

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -108,6 +108,7 @@ const SKILL_TYPE_FILTER_OPTIONS: {
   { value: 'all', label: 'All' },
   { value: 'symlinked', label: 'Symlinked', dotClass: 'bg-success' },
   { value: 'local', label: 'Local', dotClass: 'bg-emerald-400' },
+  { value: 'gstack', label: 'G-Stack', dotClass: 'bg-sky-400' },
   { value: 'orphan', label: 'Orphan', dotClass: 'bg-destructive' },
 ]
 

--- a/src/renderer/src/components/skills/skillItemHelpers.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.ts
@@ -1,4 +1,4 @@
-import { GSTACK_BADGE_AGENT_IDS } from '@/shared/constants'
+import { isGStackManagedForAgent } from '@/renderer/src/utils/gstackSkill'
 import type { AgentId, Skill, SymlinkInfo } from '@/shared/types'
 
 /**
@@ -36,31 +36,6 @@ export interface SkillItemVisibility {
  * of three (function signature, factory return, factory overrides).
  */
 export type SkillVisibilityInput = Pick<Skill, 'symlinks' | 'isOrphan'>
-
-/**
- * Path-segment matcher for `.../skills/gstack/...` on both POSIX and Windows
- * paths. Requires a `skills/` parent so a user-created directory literally
- * named `gstack` outside any agent's skills tree (e.g. `~/projects/gstack/foo`)
- * cannot trigger the badge — a finding raised by the Codex review.
- */
-const GSTACK_SEGMENT_PATTERN = /[\\/]skills[\\/]gstack([\\/]|$)/i
-
-/**
- * Detect whether a filesystem-like path points to a G-Stack-managed location.
- * @param candidatePath - Path candidate from symlink target or link path.
- * @returns
- * - `true`: Path contains a `skills/gstack/` segment.
- * - `false`: Empty path, or `gstack/` lives outside any `skills/` parent.
- * @example
- * isGStackBundlePath('/Users/me/.claude/skills/gstack/skill-a') // => true
- * @example
- * isGStackBundlePath('/Users/me/.agents/skills/task') // => false
- * @example
- * isGStackBundlePath('/Users/me/projects/gstack/skill-a') // => false
- */
-function isGStackBundlePath(candidatePath: string): boolean {
-  return GSTACK_SEGMENT_PATTERN.test(candidatePath)
-}
 
 /**
  * Compute which action buttons to show on a SkillItem card.
@@ -128,23 +103,7 @@ export function getSkillItemVisibility(
   const hasSkillInSelectedAgent = !!selectedAgentSymlink || isLocalSkill
   // Orphan handling — see Skill.isOrphan for why the Add button is gated.
   // Source: scanOrphanSymlinks() in src/main/services/skillScanner.ts.
-  //
-  // gStackPathCandidates — paths inspected for the `skills/gstack/` segment
-  // that identifies a gstack-managed skill. `skillMdSymlinkTarget` is read
-  // ONLY from the selected agent's slot (per-agent attribution): a sibling
-  // agent's gstack-managed twin must not flip the badge on this agent's
-  // unrelated local skill that happens to share a name.
-  const gStackPathCandidates = [
-    selectedAgentSymlink?.targetPath ?? '',
-    selectedAgentSymlink?.linkPath ?? '',
-    selectedLocalSkillInfo?.linkPath ?? '',
-    selectedLocalSkillInfo?.skillMdSymlinkTarget ?? '',
-  ]
-  const isGStackEligibleAgent =
-    selectedAgentId !== null &&
-    GSTACK_BADGE_AGENT_IDS.some((agentId) => agentId === selectedAgentId)
-  const showGStackBadge =
-    isGStackEligibleAgent && gStackPathCandidates.some(isGStackBundlePath)
+  const showGStackBadge = isGStackManagedForAgent(skill, selectedAgentId)
 
   return {
     // Delete is the primary cleanup action for orphans in global view —

--- a/src/renderer/src/components/skills/skillsListHelpers.test.ts
+++ b/src/renderer/src/components/skills/skillsListHelpers.test.ts
@@ -64,6 +64,17 @@ describe('getEmptyListMessage', () => {
     ).toBe('No symlinked skills for this agent')
   })
 
+  it('returns the G-Stack variant when type filter is gstack', () => {
+    expect(
+      getEmptyListMessage({
+        searchQuery: '',
+        selectedSource: null,
+        selectedAgentId: 'cursor',
+        skillTypeFilter: 'gstack',
+      }),
+    ).toBe('No G-Stack skills for this agent')
+  })
+
   it('returns the agent-only message when selectedAgentId is set and type is all', () => {
     expect(
       getEmptyListMessage({

--- a/src/renderer/src/components/skills/skillsListHelpers.ts
+++ b/src/renderer/src/components/skills/skillsListHelpers.ts
@@ -10,6 +10,14 @@ interface EmptyMessageContext {
   skillTypeFilter: SkillTypeFilter
 }
 
+const SKILL_TYPE_FILTER_LABELS = {
+  all: 'all',
+  symlinked: 'symlinked',
+  local: 'local',
+  gstack: 'G-Stack',
+  orphan: 'orphan',
+} as const satisfies Record<SkillTypeFilter, string>
+
 /**
  * Compute the empty-state message for SkillsList based on which filters are
  * currently narrowing the result. The skills list participates in four
@@ -34,7 +42,7 @@ interface EmptyMessageContext {
  * - When `searchQuery` is non-empty: `"No skills match your search"`
  * - When only `selectedSource` is set: `"No skills from <repo>"`
  * - When `selectedAgentId` is set AND `skillTypeFilter !== 'all'`:
- *   `"No <symlinked|local> skills for this agent"`
+ *   `"No <symlinked|local|G-Stack|orphan> skills for this agent"`
  * - When only `selectedAgentId` is set: `"No skills installed for this agent"`
  * - Otherwise: `"No skills match your filter"`
  *
@@ -70,7 +78,8 @@ export function getEmptyListMessage(ctx: EmptyMessageContext): string {
     )
     .with(
       { hasSelectedAgent: true, hasTypeNarrow: true },
-      () => `No ${ctx.skillTypeFilter} skills for this agent`,
+      () =>
+        `No ${SKILL_TYPE_FILTER_LABELS[ctx.skillTypeFilter]} skills for this agent`,
     )
     .with(
       { hasSelectedAgent: true },

--- a/src/renderer/src/redux/selectors.test.ts
+++ b/src/renderer/src/redux/selectors.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import type { SkillTypeFilter } from '@/renderer/src/redux/slices/uiSlice'
 import { repositoryId } from '@/shared/types'
 import type {
+  AbsolutePath,
   AgentId,
   BookmarkedSkill,
   RepositoryId,
@@ -347,6 +348,73 @@ describe('selectFilteredSkills', () => {
     expect(result[0].name).toBe('local-one')
   })
 
+  it('filters by skillTypeFilter=gstack across symlinked and local G-Stack slots', () => {
+    // The G-Stack filter should match the same two production shapes as the
+    // card badge: direct agent symlinks into `skills/gstack/` and local
+    // sibling skills whose SKILL.md points into that tree.
+    const linkedGStack = makeSkill('linked-gstack', 'cursor')
+    linkedGStack.symlinks = [
+      {
+        ...linkedGStack.symlinks[0]!,
+        targetPath:
+          '/Users/me/.cursor/skills/gstack/linked-gstack' as AbsolutePath,
+      },
+    ]
+
+    const localGStack = makeSkill('local-gstack', 'cursor', true)
+    localGStack.symlinks = [
+      {
+        ...localGStack.symlinks[0]!,
+        skillMdSymlinkTarget:
+          '/Users/me/.cursor/skills/gstack/local-gstack/SKILL.md' as AbsolutePath,
+      },
+    ]
+
+    const skills = [
+      makeSkill('linked-plain', 'cursor'),
+      linkedGStack,
+      makeSkill('local-plain', 'cursor', true),
+      localGStack,
+    ]
+    const state = buildState({
+      skills,
+      selectedAgentId: 'cursor',
+      skillTypeFilter: 'gstack',
+    })
+
+    const result = selectFilteredSkills(state as never)
+    expect(result.map((skill) => skill.name)).toEqual([
+      'linked-gstack',
+      'local-gstack',
+    ])
+  })
+
+  it('keeps gstack filtering scoped to the selected agent slot', () => {
+    // Same skill name can exist as a G-Stack-managed sibling in one agent and
+    // as a plain linked skill in another; the selected agent owns the answer.
+    const mixedSkill = makeSkill('mixed-skill', 'cursor')
+    mixedSkill.symlinks = [
+      mixedSkill.symlinks[0]!,
+      {
+        agentId: 'claude-code' as SymlinkInfo['agentId'],
+        agentName: 'Claude Code' as SymlinkInfo['agentName'],
+        linkPath: '/Users/me/.claude/skills/mixed-skill' as AbsolutePath,
+        targetPath:
+          '/Users/me/.claude/skills/gstack/mixed-skill' as AbsolutePath,
+        status: 'valid',
+        isLocal: false,
+      },
+    ]
+
+    const state = buildState({
+      skills: [mixedSkill],
+      selectedAgentId: 'cursor',
+      skillTypeFilter: 'gstack',
+    })
+
+    expect(selectFilteredSkills(state as never)).toHaveLength(0)
+  })
+
   it('filters by skillTypeFilter=orphan in agent view (skill.isOrphan === true)', () => {
     // Mixed list: a normal symlinked skill (NOT orphan), a local skill (NOT
     // orphan), and an orphan whose source dir vanished but still has a broken
@@ -445,7 +513,7 @@ describe('selectFilteredSkills', () => {
     expect(result).toHaveLength(0)
   })
 
-  it.each(['all', 'symlinked', 'local', 'orphan'] as const)(
+  it.each(['all', 'symlinked', 'local', 'gstack', 'orphan'] as const)(
     'skillTypeFilter=%s is ignored in SourceCard view (no agent selected)',
     (skillTypeFilter) => {
       // SourceCard view applies its own source-only filter, so skillTypeFilter

--- a/src/renderer/src/redux/selectors.ts
+++ b/src/renderer/src/redux/selectors.ts
@@ -1,6 +1,7 @@
 import { createSelector } from '@reduxjs/toolkit'
 import { match } from 'ts-pattern'
 
+import { isGStackManagedForAgent } from '@/renderer/src/utils/gstackSkill'
 import type { SkillName, SymlinkInfo } from '@/shared/types'
 
 import { selectBookmarkItems } from './slices/bookmarkSlice'
@@ -66,11 +67,9 @@ export const selectFilteredSkills = createSelector(
     // slots so AgentItem's "Cleanup missing skills..." has rows to act on.
     // `missing` slots are dropped — nothing on disk to surface there.
     //
-    // Each skill-type arm composes the agent-slot gate inline rather than
-    // pre-filtering, so adding the Orphan arm did not require a 2-pass
-    // walk over `skill.symlinks`. The orphan arm still applies the gate so
-    // an `isOrphan` skill whose only broken slot belongs to a different
-    // agent does not leak through.
+    // Each skill-type arm narrows from the selected agent's slot. G-Stack
+    // delegates to the same attribution helper as the card badge so local
+    // sibling skills and direct symlinks stay in sync.
     if (selectedAgentId) {
       const hasAgentSlot = (slot: SymlinkInfo): boolean =>
         slot.agentId === selectedAgentId &&
@@ -91,6 +90,11 @@ export const selectFilteredSkills = createSelector(
             skill.symlinks.some(
               (slot) => hasAgentSlot(slot) && slot.isLocal === true,
             ),
+          ),
+        )
+        .with('gstack', () =>
+          result.filter((skill) =>
+            isGStackManagedForAgent(skill, selectedAgentId),
           ),
         )
         .with('orphan', () =>

--- a/src/renderer/src/redux/slices/uiSlice.ts
+++ b/src/renderer/src/redux/slices/uiSlice.ts
@@ -25,7 +25,12 @@ import { deleteSelectedSkills, unlinkSelectedFromAgent } from './skillsSlice'
 export type BookmarkForDetail = BookmarkedSkill & { isInstalled: boolean }
 
 export type SortOrder = 'asc' | 'desc'
-export type SkillTypeFilter = 'all' | 'symlinked' | 'local' | 'orphan'
+export type SkillTypeFilter =
+  | 'all'
+  | 'symlinked'
+  | 'local'
+  | 'gstack'
+  | 'orphan'
 export type ActiveTab = 'installed' | 'marketplace'
 /**
  * Which field the search box matches against.
@@ -94,7 +99,7 @@ interface UiState {
   selectedAgentId: AgentId | null
   /** Sort direction for skill name (A→Z / Z→A) */
   sortOrder: SortOrder
-  /** Filter by skill type in agent view (all / symlinked / local / orphan) */
+  /** Filter by skill type in agent view (all / symlinked / local / G-Stack / orphan) */
   skillTypeFilter: SkillTypeFilter
   /** Whether sync operation is in progress */
   isSyncing: boolean

--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -68,6 +68,10 @@
     --input: oklch(0.3 var(--chroma-6) var(--theme-hue));
     --ring: oklch(0.7 var(--theme-chroma) var(--theme-hue));
 
+    /* G-Stack is a skill-type accent, so its dot follows the active theme
+     * axis instead of using a fixed utility palette color. */
+    --gstack: oklch(0.7 var(--theme-chroma) var(--theme-hue));
+
     /* Success — fixed green regardless of theme. This is the "linked /
      * valid symlink" status color used across badges, heatmap cells,
      * and the coverage bar. Keeping it theme-invariant avoids the
@@ -110,6 +114,8 @@
     --border: oklch(0.88 var(--chroma-4) var(--theme-hue));
     --input: oklch(0.88 var(--chroma-4) var(--theme-hue));
     --ring: oklch(0.5 var(--theme-chroma) var(--theme-hue));
+
+    --gstack: oklch(0.5 var(--theme-chroma) var(--theme-hue));
 
     --success: oklch(0.55 0.17 155);
     --success-foreground: oklch(0.99 0.01 155);

--- a/src/renderer/src/utils/gstackSkill.ts
+++ b/src/renderer/src/utils/gstackSkill.ts
@@ -1,0 +1,86 @@
+import { GSTACK_BADGE_AGENT_IDS } from '@/shared/constants'
+import type { AgentId, Skill, SymlinkInfo } from '@/shared/types'
+
+/**
+ * Path-segment matcher for `.../skills/gstack/...` on both POSIX and Windows
+ * paths. Requires a `skills/` parent so a user-created directory literally
+ * named `gstack` outside any agent's skills tree cannot trigger G-Stack UI.
+ */
+const GSTACK_SEGMENT_PATTERN = /[\\/]skills[\\/]gstack([\\/]|$)/i
+
+/**
+ * Detect whether a filesystem-like path points to a G-Stack-managed location.
+ * @param candidatePath - Path candidate from symlink target or link path.
+ * @returns `true` when the path contains a `skills/gstack/` segment.
+ * @example
+ * isGStackBundlePath('/Users/me/.claude/skills/gstack/skill-a') // true
+ * @example
+ * isGStackBundlePath('/Users/me/projects/gstack/skill-a') // false
+ */
+function isGStackBundlePath(candidatePath: string): boolean {
+  return GSTACK_SEGMENT_PATTERN.test(candidatePath)
+}
+
+/**
+ * Collect only the selected agent's G-Stack attribution paths for a skill.
+ * This keeps sibling agents isolated: a Claude Code G-Stack copy must not make
+ * the Cursor row look G-Stack-managed when Cursor owns a plain local copy.
+ *
+ * @param symlinks - Per-agent slot records attached to a skill.
+ * @param selectedAgentId - Agent whose list is currently being filtered.
+ * @returns Candidate paths that can prove this selected agent's slot is G-Stack-managed.
+ * @example
+ * getGStackPathCandidatesForAgent(skill.symlinks, 'claude-code')
+ * // ['/Users/me/.claude/skills/gstack/ship', '/Users/me/.claude/skills/ship', ...]
+ */
+function getGStackPathCandidatesForAgent(
+  symlinks: readonly SymlinkInfo[],
+  selectedAgentId: AgentId,
+): string[] {
+  const selectedAgentSymlink =
+    symlinks.find(
+      (slot) =>
+        slot.agentId === selectedAgentId &&
+        (slot.status === 'valid' || slot.status === 'broken') &&
+        !slot.isLocal,
+    ) ?? null
+
+  const selectedLocalSkillInfo =
+    symlinks.find((slot) => slot.agentId === selectedAgentId && slot.isLocal) ??
+    null
+
+  return [
+    selectedAgentSymlink?.targetPath ?? '',
+    selectedAgentSymlink?.linkPath ?? '',
+    selectedLocalSkillInfo?.linkPath ?? '',
+    selectedLocalSkillInfo?.skillMdSymlinkTarget ?? '',
+  ]
+}
+
+/**
+ * Determine whether the selected agent's slot for this skill is G-Stack-managed.
+ * Used by both the skill-card badge and the agent-view `G-Stack` type filter so
+ * both surfaces answer the same question.
+ *
+ * @param skill - Skill record whose `symlinks` hold per-agent path evidence.
+ * @param selectedAgentId - Currently selected agent, or `null` outside agent view.
+ * @returns `true` only for supported agents with a selected slot under `skills/gstack/`.
+ * @example
+ * isGStackManagedForAgent(skill, 'claude-code') // true for ~/.claude/skills/gstack/ship
+ */
+export function isGStackManagedForAgent(
+  skill: Pick<Skill, 'symlinks'>,
+  selectedAgentId: AgentId | null,
+): boolean {
+  if (selectedAgentId === null) return false
+
+  // Only agents known to host G-Stack-managed sibling skills get this UI.
+  const isGStackEligibleAgent = GSTACK_BADGE_AGENT_IDS.some(
+    (agentId) => agentId === selectedAgentId,
+  )
+  if (!isGStackEligibleAgent) return false
+
+  return getGStackPathCandidatesForAgent(skill.symlinks, selectedAgentId).some(
+    isGStackBundlePath,
+  )
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -42,6 +42,10 @@ const config: Config = {
           DEFAULT: 'var(--success)',
           foreground: 'var(--success-foreground)',
         },
+        // Theme-axis accent used for the G-Stack skill-type filter dot.
+        gstack: {
+          DEFAULT: 'var(--gstack)',
+        },
         border: 'var(--border)',
         input: 'var(--input)',
         ring: 'var(--ring)',


### PR DESCRIPTION
## Summary

- Add a G-Stack skill type filter alongside Symlinked, Local, and Orphan in the installed skills agent view.
- Reuse the same per-agent G-Stack attribution helper for the card badge and the filter so sibling-agent state cannot bleed across rows.
- Ignore `static-storybook/` and make `pnpm lint` fail on any ESLint warning with `--max-warnings 0`.
- Clean up the existing lint warnings that would fail the stricter lint gate.

## Validation

- `pnpm exec vitest run --project node src/renderer/src/redux/selectors.test.ts src/renderer/src/components/skills/skillsListHelpers.test.ts src/renderer/src/components/skills/skillItemHelpers.test.ts`
- `pnpm exec vitest run --project browser src/renderer/src/components/layout/MainContent.browser.test.tsx`
- `pnpm lint`
- `pnpm validate`
- `/review` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * インストール済みエージェントビューのスキル種別フィルタに「G-Stack」オプションを追加しました。

* **テスト**
  * E2Eテストのタイミング信頼性を改善しました。
  * スキルフィルタリング機能のテストカバレッジを拡張しました。

* **その他**
  * リント設定を更新し、警告を厳格に管理するようにしました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/skills-desktop/pull/152)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->