### PR TITLE
Enforce all react-next ESLint rules

### DIFF
--- a/.storybook/stories/Skills.stories.tsx
+++ b/.storybook/stories/Skills.stories.tsx
@@ -137,7 +137,7 @@ export const FilePreviewStates: Story = {
           expiresAt={new Date(Date.now() + 15_000).toISOString()}
           summary="Deleted 2 skills. 5 symlinks removed."
           onUndo={() => undefined}
-          onUndoComplete={() => undefined}
+          toastId="storybook-undo-toast"
         />
       </StoryCard>
     </StoryGrid>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,13 @@ import tsPrefixer from 'eslint-config-ts-prefixer'
 import reactYouMightNotNeedAnEffect from 'eslint-plugin-react-you-might-not-need-an-effect'
 import { defineConfig } from 'eslint/config'
 
+const laststanceReactNextRules = Object.fromEntries(
+  Object.keys(laststanceReactNextPlugin.rules ?? {}).map((ruleName) => [
+    `@laststance/react-next/${ruleName}`,
+    'error',
+  ]),
+)
+
 export default defineConfig([
   ...tsPrefixer,
   {
@@ -52,19 +59,12 @@ export default defineConfig([
       '@laststance/react-next': laststanceReactNextPlugin,
     },
     rules: {
-      '@laststance/react-next/no-forward-ref': 'error',
-      '@laststance/react-next/no-context-provider': 'error',
-      '@laststance/react-next/no-missing-key': 'error',
-      '@laststance/react-next/no-duplicate-key': 'error',
-      '@laststance/react-next/no-jsx-without-return': 'error',
-      '@laststance/react-next/all-memo': 'error',
-      '@laststance/react-next/no-use-reducer': 'error',
+      ...laststanceReactNextRules,
+      // Keep the stricter prop-drilling depth while still enforcing the rule at error severity.
       '@laststance/react-next/no-set-state-prop-drilling': [
         'error',
         { depth: 1 },
       ],
-      '@laststance/react-next/no-deopt-use-callback': 'error',
-      '@laststance/react-next/prefer-stable-context-value': 'error',
     },
   },
 ])

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,8 +3,36 @@ import tsPrefixer from 'eslint-config-ts-prefixer'
 import reactYouMightNotNeedAnEffect from 'eslint-plugin-react-you-might-not-need-an-effect'
 import { defineConfig } from 'eslint/config'
 
+/**
+ * Rules intentionally enabled for @laststance/react-next-eslint-plugin v2.2.0.
+ * Keeping the list explicit means dependency upgrades cannot silently turn on a
+ * new rule without a focused lint-fix pass in the same PR.
+ */
+const laststanceReactNextRuleNames = [
+  'all-memo',
+  'jsx-no-useless-fragment',
+  'no-context-provider',
+  'no-deopt-use-callback',
+  'no-deopt-use-memo',
+  'no-direct-use-effect',
+  'no-duplicate-key',
+  'no-forward-ref',
+  'no-jsx-without-return',
+  'no-missing-button-type',
+  'no-missing-component-display-name',
+  'no-missing-key',
+  'no-nested-component-definitions',
+  'no-set-state-prop-drilling',
+  'no-use-reducer',
+  'prefer-stable-context-value',
+  'prefer-usecallback-for-memoized-component',
+  'prefer-usecallback-might-work',
+  'prefer-usememo-for-memoized-component',
+  'prefer-usememo-might-work',
+]
+
 const laststanceReactNextRules = Object.fromEntries(
-  Object.keys(laststanceReactNextPlugin.rules ?? {}).map((ruleName) => [
+  laststanceReactNextRuleNames.map((ruleName) => [
     `@laststance/react-next/${ruleName}`,
     'error',
   ]),

--- a/src/renderer/settings/sections/About.tsx
+++ b/src/renderer/settings/sections/About.tsx
@@ -1,9 +1,10 @@
 import { ExternalLink } from 'lucide-react'
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import { match } from 'ts-pattern'
 
 import { Button } from '@/renderer/src/components/ui/button'
 import { Separator } from '@/renderer/src/components/ui/separator'
+import { useComponentEffect } from '@/renderer/src/hooks/useComponentEffect'
 import { SKILLS_DESKTOP_REPOSITORY_URL } from '@/shared/constants'
 
 import { SectionFrame } from './SectionFrame'
@@ -68,7 +69,7 @@ export const About = React.memo(function About(): React.ReactElement {
   const isUpdaterAvailable = Boolean(updateApi)
   const [checkStatus, setCheckStatus] = useState<CheckStatus>({ kind: 'idle' })
 
-  useEffect(() => {
+  useComponentEffect(() => {
     if (!updateApi) return
     const cleanups = [
       updateApi.onChecking(() => setCheckStatus({ kind: 'checking' })),
@@ -85,11 +86,11 @@ export const About = React.memo(function About(): React.ReactElement {
     }
   }, [updateApi])
 
-  const handleCheckForUpdates = (): void => {
+  const handleCheckForUpdates = useCallback((): void => {
     if (!updateApi) return
     setCheckStatus({ kind: 'checking' })
     void updateApi.check()
-  }
+  }, [updateApi])
 
   const status = statusLabel(checkStatus)
 

--- a/src/renderer/settings/sections/Agents.tsx
+++ b/src/renderer/settings/sections/Agents.tsx
@@ -1,8 +1,9 @@
 import { Eye, EyeOff } from 'lucide-react'
-import React, { useEffect } from 'react'
+import React, { useCallback } from 'react'
 
 import { Button } from '@/renderer/src/components/ui/button'
 import { Checkbox } from '@/renderer/src/components/ui/checkbox'
+import { useComponentEffect } from '@/renderer/src/hooks/useComponentEffect'
 import { useUpdateSettings } from '@/renderer/src/hooks/useUpdateSettings'
 import { cn, toggleArrayMember } from '@/renderer/src/lib/utils'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
@@ -43,7 +44,7 @@ export const Agents = React.memo(function Agents(): React.ReactElement {
   const hiddenAgentIds = useAppSelector(selectHiddenAgentIds)
   const updateSettings = useUpdateSettings()
 
-  useEffect(() => {
+  useComponentEffect(() => {
     // Deliberately keyed on `agents.length` only (NOT `loading`). The
     // length value transitions 0 → N exactly once per mount lifecycle,
     // so the effect dispatches once and never re-fires within a mount.
@@ -67,20 +68,23 @@ export const Agents = React.memo(function Agents(): React.ReactElement {
   ).length
   const hiddenCount = installed.length - visibleCount
 
-  const handleToggle = (agentId: AgentId): void => {
-    // Inversion: "Show in sidebar" checkbox flip ⇄ membership in
-    // hiddenAgentIds. We treat every click as a toggle relative to the
-    // latest known state instead of trusting the next-state from the
-    // checkbox event — the schema upstream already pins membership, so
-    // either side of the flip lands on the correct array.
-    updateSettings({
-      hiddenAgentIds: toggleArrayMember(hiddenAgentIds, agentId),
-    })
-  }
+  const handleToggle = useCallback(
+    (agentId: AgentId): void => {
+      // Inversion: "Show in sidebar" checkbox flip ⇄ membership in
+      // hiddenAgentIds. We treat every click as a toggle relative to the
+      // latest known state instead of trusting the next-state from the
+      // checkbox event — the schema upstream already pins membership, so
+      // either side of the flip lands on the correct array.
+      updateSettings({
+        hiddenAgentIds: toggleArrayMember(hiddenAgentIds, agentId),
+      })
+    },
+    [hiddenAgentIds, updateSettings],
+  )
 
-  const handleShowAll = (): void => {
+  const handleShowAll = useCallback((): void => {
     updateSettings({ hiddenAgentIds: [] })
-  }
+  }, [updateSettings])
 
   return (
     <SectionFrame
@@ -172,17 +176,22 @@ const AgentToggleRow = React.memo(function AgentToggleRow({
   onToggle,
 }: AgentToggleRowProps): React.ReactElement {
   const checkboxId = `agent-visibility-${agent.id}`
+  const handleCheckedChange = useCallback(
+    (next: boolean | 'indeterminate'): void => {
+      // Radix passes `boolean | "indeterminate"`. Ignore the indeterminate
+      // case — we never set it, but treating it like a flip would dispatch
+      // a phantom hide/show.
+      if (typeof next === 'boolean') onToggle(agent.id)
+    },
+    [agent.id, onToggle],
+  )
+
   return (
     <li className="flex items-center gap-3 px-2 py-1.5 rounded hover:bg-muted/30">
       <Checkbox
         id={checkboxId}
         checked={isVisible}
-        onCheckedChange={(next) => {
-          // Radix passes `boolean | "indeterminate"`. Ignore the indeterminate
-          // case — we never set it, but treating it like a flip would dispatch
-          // a phantom hide/show.
-          if (typeof next === 'boolean') onToggle(agent.id)
-        }}
+        onCheckedChange={handleCheckedChange}
         aria-label={`Show ${agent.name} in sidebar`}
       />
       <label

--- a/src/renderer/settings/sections/General.tsx
+++ b/src/renderer/settings/sections/General.tsx
@@ -1,5 +1,5 @@
 import { Files, Info } from 'lucide-react'
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useState } from 'react'
 
 import { Button } from '@/renderer/src/components/ui/button'
 import { Input } from '@/renderer/src/components/ui/input'
@@ -7,6 +7,7 @@ import {
   ToggleGroup,
   ToggleGroupItem,
 } from '@/renderer/src/components/ui/toggle-group'
+import { useComponentEffect } from '@/renderer/src/hooks/useComponentEffect'
 import { useUpdateSettings } from '@/renderer/src/hooks/useUpdateSettings'
 import { useAppSelector } from '@/renderer/src/redux/hooks'
 import { TERMINAL_APP_IDS, TERMINAL_APP_UI_LABELS } from '@/shared/constants'
@@ -70,10 +71,13 @@ export const General = React.memo(function General(): React.ReactElement {
     settings.customTerminalAppName ?? '',
   )
 
-  const handleDefaultTabChange = (nextValue: string): void => {
-    if (nextValue !== 'files' && nextValue !== 'info') return
-    updateSettings({ defaultSkillTab: nextValue })
-  }
+  const handleDefaultTabChange = useCallback(
+    (nextValue: string): void => {
+      if (nextValue !== 'files' && nextValue !== 'info') return
+      updateSettings({ defaultSkillTab: nextValue })
+    },
+    [updateSettings],
+  )
 
   const handlePreferredTerminalChange = (
     e: React.ChangeEvent<HTMLSelectElement>,
@@ -94,12 +98,19 @@ export const General = React.memo(function General(): React.ReactElement {
    * schema so the renderer never asks main to write a value that the
    * schema would reject.
    */
-  const handleCustomNameBlur = (): void => {
+  const handleCustomNameChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>): void => {
+      setCustomNameDraft(e.target.value)
+    },
+    [],
+  )
+
+  const handleCustomNameBlur = useCallback((): void => {
     const trimmed = customNameDraft.trim()
     if (trimmed === '') return
     if (trimmed === settings.customTerminalAppName) return
     updateSettings({ customTerminalAppName: trimmed })
-  }
+  }, [customNameDraft, settings.customTerminalAppName, updateSettings])
 
   const isCustom = settings.preferredTerminal === 'custom'
   const isDraftBlank = customNameDraft.trim() === ''
@@ -118,7 +129,7 @@ export const General = React.memo(function General(): React.ReactElement {
   const [isMainWindowAvailable, setIsMainWindowAvailable] =
     useState<boolean>(true)
 
-  useEffect(() => {
+  useComponentEffect(() => {
     let cancelled = false
     // Attach `.catch` explicitly — `void promise.then(...)` only suppresses
     // TypeScript's "promise not handled" hint, it does NOT silence a real
@@ -147,20 +158,24 @@ export const General = React.memo(function General(): React.ReactElement {
    * flag so the button's disabled state + inline message kick in instead
    * of failing silently. Disk write only happens on a real bounds value.
    */
-  const handleSaveCurrentSize = async (): Promise<void> => {
+  const handleSaveCurrentSize = useCallback(async (): Promise<void> => {
     const bounds = await window.electron.window.getMainBounds()
     if (bounds === null) {
       setIsMainWindowAvailable(false)
       return
     }
     updateSettings({ windowSize: bounds })
-  }
+  }, [updateSettings])
 
-  const handleResetWindowSize = (): void => {
+  const handleSaveCurrentSizeClick = useCallback((): void => {
+    void handleSaveCurrentSize()
+  }, [handleSaveCurrentSize])
+
+  const handleResetWindowSize = useCallback((): void => {
     // `undefined` removes the persisted size; on next launch the main
     // window falls back to the default 1200×800 + maximize() behavior.
     updateSettings({ windowSize: undefined })
-  }
+  }, [updateSettings])
 
   const persistedWindowSize = settings.windowSize
   const hasCustomWindowSize = persistedWindowSize !== undefined
@@ -224,7 +239,7 @@ export const General = React.memo(function General(): React.ReactElement {
               <Input
                 type="text"
                 value={customNameDraft}
-                onChange={(e) => setCustomNameDraft(e.target.value)}
+                onChange={handleCustomNameChange}
                 onBlur={handleCustomNameBlur}
                 placeholder="e.g. Hyper"
                 maxLength={CUSTOM_APP_NAME_MAX_LENGTH}
@@ -273,9 +288,7 @@ export const General = React.memo(function General(): React.ReactElement {
               type="button"
               variant="outline"
               size="sm"
-              onClick={() => {
-                void handleSaveCurrentSize()
-              }}
+              onClick={handleSaveCurrentSizeClick}
               disabled={!isMainWindowAvailable}
             >
               Use current window size

--- a/src/renderer/settings/sections/General.tsx
+++ b/src/renderer/settings/sections/General.tsx
@@ -159,12 +159,16 @@ export const General = React.memo(function General(): React.ReactElement {
    * of failing silently. Disk write only happens on a real bounds value.
    */
   const handleSaveCurrentSize = useCallback(async (): Promise<void> => {
-    const bounds = await window.electron.window.getMainBounds()
-    if (bounds === null) {
+    try {
+      const bounds = await window.electron.window.getMainBounds()
+      if (bounds === null) {
+        setIsMainWindowAvailable(false)
+        return
+      }
+      updateSettings({ windowSize: bounds })
+    } catch {
       setIsMainWindowAvailable(false)
-      return
     }
-    updateSettings({ windowSize: bounds })
   }, [updateSettings])
 
   const handleSaveCurrentSizeClick = useCallback((): void => {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -112,6 +112,10 @@ const App = React.memo(function App(): React.ReactElement {
   // Drive sonner's theme prop from the persisted redux mode so toasts honor
   // the user's light/dark choice. Pre-fix this was hardcoded `theme="dark"`.
   const mode = useAppSelector((state) => state.theme.mode)
+  const toastOptions = React.useMemo(
+    () => ({ classNames: toastClassNames }),
+    [],
+  )
 
   return (
     <TooltipProvider delayDuration={200}>
@@ -136,7 +140,7 @@ const App = React.memo(function App(): React.ReactElement {
         theme={mode}
         className="toaster group"
         style={toasterStyle}
-        toastOptions={{ classNames: toastClassNames }}
+        toastOptions={toastOptions}
       />
     </TooltipProvider>
   )

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -53,6 +53,10 @@ const toastClassNames = {
     'bg-popover text-muted-foreground border-border hover:bg-accent hover:text-foreground',
 } as const
 
+const toastOptions = {
+  classNames: toastClassNames,
+} satisfies React.ComponentProps<typeof Toaster>['toastOptions']
+
 /**
  * Inline style on the Toaster itself. Sonner reads `--normal-bg` /
  * `--normal-border` / `--normal-text` off the toaster root and forwards them
@@ -112,10 +116,6 @@ const App = React.memo(function App(): React.ReactElement {
   // Drive sonner's theme prop from the persisted redux mode so toasts honor
   // the user's light/dark choice. Pre-fix this was hardcoded `theme="dark"`.
   const mode = useAppSelector((state) => state.theme.mode)
-  const toastOptions = React.useMemo(
-    () => ({ classNames: toastClassNames }),
-    [],
-  )
 
   return (
     <TooltipProvider delayDuration={200}>

--- a/src/renderer/src/components/SkipToMainContentLink.tsx
+++ b/src/renderer/src/components/SkipToMainContentLink.tsx
@@ -32,7 +32,7 @@ import type { ReactElement } from 'react'
  * <main id="main-content">...</main>
  */
 export const SkipToMainContentLink = memo(
-  (): ReactElement => {
+  function SkipToMainContentLink(): ReactElement {
     return (
       <a
         href="#main-content"

--- a/src/renderer/src/components/UpdateToast.tsx
+++ b/src/renderer/src/components/UpdateToast.tsx
@@ -1,5 +1,5 @@
 import { Download, RefreshCw, X, AlertCircle } from 'lucide-react'
-import React from 'react'
+import React, { useCallback } from 'react'
 import { match } from 'ts-pattern'
 
 import {
@@ -26,22 +26,25 @@ export const UpdateToast = React.memo(
       (state) => state.update,
     )
 
+    const handleDownload = useCallback(async (): Promise<void> => {
+      dispatch(setDownloading())
+      await downloadUpdate()
+    }, [dispatch])
+
+    const handleInstall = useCallback(async (): Promise<void> => {
+      await installUpdate()
+    }, [])
+
+    const handleDismiss = useCallback((): void => {
+      dispatch(dismiss())
+    }, [dispatch])
+    const handleCloseButtonClick = (): void => {
+      handleDismiss()
+    }
+
     // Don't show if dismissed or no update activity
     if (dismissed || status === 'idle' || status === 'checking') {
       return null
-    }
-
-    const handleDownload = async () => {
-      dispatch(setDownloading())
-      await downloadUpdate()
-    }
-
-    const handleInstall = async () => {
-      await installUpdate()
-    }
-
-    const handleDismiss = () => {
-      dispatch(dismiss())
     }
 
     // After the guard above, `status` is narrowed to the four "visible" phases.
@@ -118,7 +121,8 @@ export const UpdateToast = React.memo(
             <span className="font-medium text-sm">{headerTitle}</span>
           </div>
           <button
-            onClick={handleDismiss}
+            type="button"
+            onClick={handleCloseButtonClick}
             className="text-muted-foreground hover:text-foreground transition-colors"
             aria-label="Dismiss"
           >

--- a/src/renderer/src/components/UpdateToast.tsx
+++ b/src/renderer/src/components/UpdateToast.tsx
@@ -38,9 +38,6 @@ export const UpdateToast = React.memo(
     const handleDismiss = useCallback((): void => {
       dispatch(dismiss())
     }, [dispatch])
-    const handleCloseButtonClick = (): void => {
-      handleDismiss()
-    }
 
     // Don't show if dismissed or no update activity
     if (dismissed || status === 'idle' || status === 'checking') {
@@ -120,14 +117,16 @@ export const UpdateToast = React.memo(
             {headerIcon}
             <span className="font-medium text-sm">{headerTitle}</span>
           </div>
-          <button
+          <Button
             type="button"
-            onClick={handleCloseButtonClick}
-            className="text-muted-foreground hover:text-foreground transition-colors"
+            onClick={handleDismiss}
+            variant="ghost"
+            size="icon"
+            className="size-7 p-0 bg-transparent text-muted-foreground hover:bg-transparent hover:text-foreground"
             aria-label="Dismiss"
           >
             <X className="h-4 w-4" />
-          </button>
+          </Button>
         </div>
 
         {/* Content */}

--- a/src/renderer/src/components/dashboard/DashboardCanvas.tsx
+++ b/src/renderer/src/components/dashboard/DashboardCanvas.tsx
@@ -1,9 +1,10 @@
-import React, { useCallback, useEffect, useMemo } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import ReactGridLayout, {
   useContainerWidth,
   type Layout,
 } from 'react-grid-layout'
 
+import { useComponentEffect } from '@/renderer/src/hooks/useComponentEffect'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import {
   seedDefaultsIfEmpty,
@@ -49,7 +50,7 @@ export const DashboardCanvas = React.memo(
 
     // Seed the default 4 pages on first render. The reducer guards against
     // re-seeding (`initialized` flag), so calling this repeatedly is free.
-    useEffect(() => {
+    useComponentEffect(() => {
       if (!isInitialized) dispatch(seedDefaultsIfEmpty())
     }, [dispatch, isInitialized])
 
@@ -132,26 +133,39 @@ const DashboardGrid = React.memo(function DashboardGrid({
     [dispatch, pageId],
   )
 
+  const gridConfig = useMemo(
+    () => ({
+      cols: GRID_COLS,
+      rowHeight: GRID_ROW_HEIGHT_PX,
+      margin: GRID_MARGIN_PX,
+      containerPadding: GRID_CONTAINER_PADDING_PX,
+    }),
+    [],
+  )
+  const dragConfig = useMemo(
+    () => ({
+      enabled: isEditMode,
+      handle: `.${WIDGET_DRAG_HANDLE_CLASS}`,
+    }),
+    [isEditMode],
+  )
+  const resizeConfig = useMemo(
+    () => ({
+      enabled: isEditMode,
+      handles: ['se'] as const,
+    }),
+    [isEditMode],
+  )
+
   return (
     <div ref={containerRef} className="h-full w-full">
       {mounted && width > 0 && (
         <ReactGridLayout
           layout={layout}
           width={width}
-          gridConfig={{
-            cols: GRID_COLS,
-            rowHeight: GRID_ROW_HEIGHT_PX,
-            margin: GRID_MARGIN_PX,
-            containerPadding: GRID_CONTAINER_PADDING_PX,
-          }}
-          dragConfig={{
-            enabled: isEditMode,
-            handle: `.${WIDGET_DRAG_HANDLE_CLASS}`,
-          }}
-          resizeConfig={{
-            enabled: isEditMode,
-            handles: ['se'],
-          }}
+          gridConfig={gridConfig}
+          dragConfig={dragConfig}
+          resizeConfig={resizeConfig}
           onLayoutChange={handleLayoutChange}
         >
           {widgets.map((widget) => {

--- a/src/renderer/src/components/dashboard/DashboardEditToolbar.tsx
+++ b/src/renderer/src/components/dashboard/DashboardEditToolbar.tsx
@@ -56,6 +56,10 @@ export const DashboardEditToolbar = React.memo(
       }
     }, [dispatch])
 
+    const handleToggleEditMode = useCallback((): void => {
+      dispatch(toggleEditMode())
+    }, [dispatch])
+
     return (
       <>
         <div className="flex items-center justify-end gap-1 px-3 py-1 border-b border-border shrink-0">
@@ -93,7 +97,7 @@ export const DashboardEditToolbar = React.memo(
           <Button
             variant={isEditMode ? 'secondary' : 'ghost'}
             size="sm"
-            onClick={() => dispatch(toggleEditMode())}
+            onClick={handleToggleEditMode}
             aria-pressed={isEditMode}
             className="min-h-11 gap-1.5 text-xs"
           >

--- a/src/renderer/src/components/dashboard/DashboardPageTabs.tsx
+++ b/src/renderer/src/components/dashboard/DashboardPageTabs.tsx
@@ -1,5 +1,5 @@
 import { MoreHorizontal, Pencil, Plus, Trash2 } from 'lucide-react'
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import { match } from 'ts-pattern'
 
 import {
@@ -9,6 +9,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/renderer/src/components/ui/dropdown-menu'
+import { useComponentEffect } from '@/renderer/src/hooks/useComponentEffect'
 import { cn } from '@/renderer/src/lib/utils'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import {
@@ -47,12 +48,24 @@ export const DashboardPageTabs = React.memo(
     // tab after arrow-key navigation changes the store.
     const tablistRef = useRef<HTMLDivElement>(null)
 
-    // Single page + view mode: nothing meaningful to render.
-    if (pages.length <= 1 && !isEditMode) return null
-
     const handleAddPage = (): void => {
       dispatch(addPage())
     }
+
+    const handleSelectPage = useCallback(
+      (pageId: DashboardPageId): void => {
+        dispatch(setCurrentPage(pageId))
+      },
+      [dispatch],
+    )
+
+    const handleStartRename = useCallback((pageId: DashboardPageId): void => {
+      setRenamingPageId(pageId)
+    }, [])
+
+    const handleFinishRename = useCallback((): void => {
+      setRenamingPageId(null)
+    }, [])
 
     // WAI-ARIA Authoring Practices — tablist keyboard navigation.
     // ArrowLeft/Right cycle (wrap at ends); Home/End jump to first/last.
@@ -91,6 +104,9 @@ export const DashboardPageTabs = React.memo(
       })
     }
 
+    // Single page + view mode: nothing meaningful to render.
+    if (pages.length <= 1 && !isEditMode) return null
+
     return (
       <div
         ref={tablistRef}
@@ -107,9 +123,9 @@ export const DashboardPageTabs = React.memo(
             isEditMode={isEditMode}
             isRenaming={renamingPageId === page.id}
             canDelete={pages.length > 1}
-            onSelect={() => dispatch(setCurrentPage(page.id))}
-            onStartRename={() => setRenamingPageId(page.id)}
-            onFinishRename={() => setRenamingPageId(null)}
+            onSelect={handleSelectPage}
+            onStartRename={handleStartRename}
+            onFinishRename={handleFinishRename}
           />
         ))}
         {isEditMode && (
@@ -148,8 +164,8 @@ interface PageTabProps {
   isEditMode: boolean
   isRenaming: boolean
   canDelete: boolean
-  onSelect: () => void
-  onStartRename: () => void
+  onSelect: (pageId: DashboardPageId) => void
+  onStartRename: (pageId: DashboardPageId) => void
   onFinishRename: () => void
 }
 
@@ -169,12 +185,20 @@ const PageTab = React.memo(function PageTab({
 
   // Reset the draft to the latest canonical name each time rename mode opens.
   // Using rAF defers focus until after the input is mounted in the DOM.
-  useEffect(() => {
+  useComponentEffect(() => {
     if (isRenaming) {
       setDraftName(page.name)
       requestAnimationFrame(() => renameInputRef.current?.select())
     }
   }, [isRenaming, page.name])
+
+  const handleSelect = (): void => {
+    onSelect(page.id)
+  }
+
+  const handleStartRename = useCallback((): void => {
+    onStartRename(page.id)
+  }, [onStartRename, page.id])
 
   const commitRename = (): void => {
     const trimmedName = draftName.trim()
@@ -188,7 +212,7 @@ const PageTab = React.memo(function PageTab({
     onFinishRename()
   }
 
-  const handleDelete = (): void => {
+  const handleDelete = useCallback((): void => {
     // The reducer already protects the last page, but the trigger is hidden
     // in that case anyway — keep the guard for defensive symmetry.
     if (!canDelete) return
@@ -198,7 +222,7 @@ const PageTab = React.memo(function PageTab({
     if (userConfirmed) {
       dispatch(removePage(page.id))
     }
-  }
+  }, [canDelete, dispatch, page.id, page.name])
 
   if (isRenaming) {
     return (
@@ -233,7 +257,7 @@ const PageTab = React.memo(function PageTab({
         type="button"
         role="tab"
         aria-selected={isActive}
-        onClick={onSelect}
+        onClick={handleSelect}
         className={cn(
           'min-h-11 px-3 text-xs font-medium rounded-md transition-colors whitespace-nowrap',
           isActive
@@ -260,7 +284,7 @@ const PageTab = React.memo(function PageTab({
             </button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            <DropdownMenuItem onClick={onStartRename}>
+            <DropdownMenuItem onClick={handleStartRename}>
               <Pencil className="h-3.5 w-3.5" aria-hidden="true" />
               Rename
             </DropdownMenuItem>

--- a/src/renderer/src/components/dashboard/widgets/BookmarksWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/BookmarksWidget.tsx
@@ -1,5 +1,5 @@
 import { Bookmark, ExternalLink, X } from 'lucide-react'
-import React from 'react'
+import React, { useCallback } from 'react'
 
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import {
@@ -82,9 +82,12 @@ export const BookmarksWidget = React.memo(
     const dispatch = useAppDispatch()
     const bookmarks = useAppSelector(selectBookmarkItems)
 
-    const handleRemove = (name: SkillName): void => {
-      dispatch(removeBookmark(name))
-    }
+    const handleRemove = useCallback(
+      (name: SkillName): void => {
+        dispatch(removeBookmark(name))
+      },
+      [dispatch],
+    )
 
     if (bookmarks.length === 0) {
       return (

--- a/src/renderer/src/components/dashboard/widgets/CoverageWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/CoverageWidget.tsx
@@ -1,5 +1,5 @@
 import { FolderDot, Link2 } from 'lucide-react'
-import React, { useMemo } from 'react'
+import React, { useCallback, useMemo } from 'react'
 
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import { selectAgentItems } from '@/renderer/src/redux/slices/agentsSlice'
@@ -145,9 +145,12 @@ export const CoverageWidget = React.memo(
       [agents, skills.length],
     )
 
-    const handleSelect = (agentId: AgentId): void => {
-      dispatch(selectAgent(agentId))
-    }
+    const handleSelect = useCallback(
+      (agentId: AgentId): void => {
+        dispatch(selectAgent(agentId))
+      },
+      [dispatch],
+    )
 
     if (agents.length === 0) {
       return (

--- a/src/renderer/src/components/dashboard/widgets/LeaderboardWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/LeaderboardWidget.tsx
@@ -1,6 +1,7 @@
 import { AlertCircle, type LucideIcon } from 'lucide-react'
-import React, { useEffect } from 'react'
+import React from 'react'
 
+import { useComponentEffect } from '@/renderer/src/hooks/useComponentEffect'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import { loadLeaderboard } from '@/renderer/src/redux/slices/marketplaceSlice'
 import type { RankingFilter } from '@/shared/types'
@@ -47,7 +48,7 @@ export const LeaderboardWidget = React.memo(function LeaderboardWidget({
     (state) => state.marketplace.leaderboard[filter],
   )
 
-  useEffect(() => {
+  useComponentEffect(() => {
     dispatch(loadLeaderboard(filter))
   }, [dispatch, filter])
 

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -6,7 +6,7 @@ import {
   ExternalLink,
   X,
 } from 'lucide-react'
-import React, { useCallback, useEffect, useRef } from 'react'
+import React, { useCallback, useRef } from 'react'
 import { toast } from 'sonner'
 
 import { SkillsMarketplace } from '@/renderer/src/components/marketplace'
@@ -49,6 +49,7 @@ import {
   TabsList,
   TabsTrigger,
 } from '@/renderer/src/components/ui/tabs'
+import { useComponentEffect } from '@/renderer/src/hooks/useComponentEffect'
 import { cn } from '@/renderer/src/lib/utils'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import {
@@ -136,18 +137,21 @@ export const MainContent = React.memo(
 
     const selectedAgent = agents.find((a) => a.id === selectedAgentId)
 
-    const handleClearFilter = (): void => {
+    const handleClearFilter = useCallback((): void => {
       dispatch(selectAgent(null))
-    }
+    }, [dispatch])
 
-    const handleClearSourceFilter = (): void => {
+    const handleClearSourceFilter = useCallback((): void => {
       dispatch(clearSelectedSource())
-    }
+    }, [dispatch])
 
-    const handleTabChange = (value: string): void => {
-      dispatch(setActiveTab(value as ActiveTab))
-      dispatch(setPreviewSkill(null))
-    }
+    const handleTabChange = useCallback(
+      (value: string): void => {
+        dispatch(setActiveTab(value as ActiveTab))
+        dispatch(setPreviewSkill(null))
+      },
+      [dispatch],
+    )
 
     const handleOpenMarketplace = (): void => {
       window.electron.shell.openExternal(SKILLS_SH_URL)
@@ -161,13 +165,13 @@ export const MainContent = React.memo(
     const visibleNamesRef = useRef(visibleNames)
     const selectedCountRef = useRef(selectedAllNames.length)
     const bulkSelectModeRef = useRef(bulkSelectMode)
-    useEffect(() => {
+    useComponentEffect(() => {
       visibleNamesRef.current = visibleNames
     }, [visibleNames])
-    useEffect(() => {
+    useComponentEffect(() => {
       selectedCountRef.current = selectedAllNames.length
     }, [selectedAllNames.length])
-    useEffect(() => {
+    useComponentEffect(() => {
       bulkSelectModeRef.current = bulkSelectMode
     }, [bulkSelectMode])
 
@@ -175,7 +179,7 @@ export const MainContent = React.memo(
     // Shortcuts are further gated on `bulkSelectMode` so a user outside of
     // selection mode doesn't silently accumulate ticks they can't see (the
     // "hidden selection" anti-pattern).
-    useEffect(() => {
+    useComponentEffect(() => {
       if (activeTab !== 'installed') return
       const handleKey = (event: KeyboardEvent): void => {
         if (isEditableTarget(document.activeElement)) return
@@ -211,12 +215,34 @@ export const MainContent = React.memo(
 
     // Wire the main-process `skills:deleteProgress` event into Redux. Fires
     // only for batches large enough to warrant a counter (see main handler).
-    useEffect(() => {
+    useComponentEffect(() => {
       const unsubscribe = window.electron.skills.onDeleteProgress((payload) => {
         dispatch(setBulkProgress(payload))
       })
       return unsubscribe
     }, [dispatch])
+
+    const handleToggleSortOrder = useCallback((): void => {
+      dispatch(toggleSortOrder())
+    }, [dispatch])
+
+    const handleToggleBulkSelectMode = useCallback((): void => {
+      if (bulkSelectMode) {
+        // Order matters: clear selection first so no subscriber can observe
+        // `mode=false` with stale `selectedSkillNames` between dispatches.
+        dispatch(clearSelection())
+        dispatch(exitBulkSelectMode())
+        return
+      }
+      dispatch(enterBulkSelectMode())
+    }, [bulkSelectMode, dispatch])
+
+    const handleSkillTypeFilterChange = useCallback(
+      (value: string): void => {
+        dispatch(setSkillTypeFilter(value as SkillTypeFilter))
+      },
+      [dispatch],
+    )
 
     /**
      * Handle the restore callback from inside the UndoToast. Dispatches the
@@ -378,16 +404,18 @@ export const MainContent = React.memo(
         const handleToastDismissed = (): void => {
           dispatch(clearUndoToast())
         }
-        const toastId: ToastId = toast(
+        const toastId: ToastId = `bulk-delete-${Date.now()}`
+        toast(
           <UndoToast
             skillNames={deletedNames}
             tombstoneIds={tombstoneIds}
             expiresAt={expiresAt}
             summary={summary}
             onUndo={handleUndoDelete}
-            onUndoComplete={() => toast.dismiss(toastId)}
+            toastId={toastId}
           />,
           {
+            id: toastId,
             duration: UNDO_WINDOW_MS,
             closeButton: true,
             onDismiss: handleToastDismissed,
@@ -466,7 +494,7 @@ export const MainContent = React.memo(
                     ? 'Sorted A to Z, click to reverse'
                     : 'Sorted Z to A, click to reverse'
                 }
-                onClick={() => dispatch(toggleSortOrder())}
+                onClick={handleToggleSortOrder}
                 className="shrink-0 text-muted-foreground hover:text-foreground min-h-11 min-w-11"
               >
                 {sortOrder === 'asc' ? (
@@ -488,18 +516,7 @@ export const MainContent = React.memo(
                     ? 'Exit bulk select mode'
                     : 'Enter bulk select mode'
                 }
-                onClick={() => {
-                  if (bulkSelectMode) {
-                    // Order matters: clear selection first so no subscriber
-                    // can observe `mode=false` with stale `selectedSkillNames`
-                    // between dispatches. Preserves the SelectionToolbar
-                    // render-gate invariant "mode off ⇒ no selection".
-                    dispatch(clearSelection())
-                    dispatch(exitBulkSelectMode())
-                  } else {
-                    dispatch(enterBulkSelectMode())
-                  }
-                }}
+                onClick={handleToggleBulkSelectMode}
                 className={cn(
                   'shrink-0 gap-1.5 min-h-11',
                   bulkSelectMode
@@ -539,9 +556,7 @@ export const MainContent = React.memo(
                   <DropdownMenuContent align="end">
                     <DropdownMenuRadioGroup
                       value={skillTypeFilter}
-                      onValueChange={(v) =>
-                        dispatch(setSkillTypeFilter(v as SkillTypeFilter))
-                      }
+                      onValueChange={handleSkillTypeFilterChange}
                     >
                       {SKILL_TYPE_FILTER_OPTIONS.map((option) => (
                         <DropdownMenuRadioItem

--- a/src/renderer/src/components/marketplace/InstallModal.tsx
+++ b/src/renderer/src/components/marketplace/InstallModal.tsx
@@ -1,5 +1,5 @@
 import { Loader2 } from 'lucide-react'
-import React, { useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 
 import { Button } from '@/renderer/src/components/ui/button'
 import { Checkbox } from '@/renderer/src/components/ui/checkbox'
@@ -42,22 +42,22 @@ export const InstallModal = React.memo(
       [agents],
     )
 
-    const handleClose = (): void => {
+    const handleClose = useCallback((): void => {
       if (!isInstalling) {
         dispatch(selectSkillForInstall(null))
         setSelectedAgents(['claude-code'])
       }
-    }
+    }, [dispatch, isInstalling])
 
-    const handleAgentToggle = (agentId: AgentId): void => {
+    const handleAgentToggle = useCallback((agentId: AgentId): void => {
       setSelectedAgents((prev) =>
         prev.includes(agentId)
           ? prev.filter((id) => id !== agentId)
           : [...prev, agentId],
       )
-    }
+    }, [])
 
-    const handleInstall = async (): Promise<void> => {
+    const handleInstall = useCallback(async (): Promise<void> => {
       if (!selectedSkill || selectedAgents.length === 0) return
 
       const options: InstallOptions = {
@@ -71,7 +71,7 @@ export const InstallModal = React.memo(
       // Refresh the skills list after installation
       dispatch(fetchSkills())
       handleClose()
-    }
+    }, [dispatch, handleClose, isGlobal, selectedAgents, selectedSkill])
 
     return (
       <Dialog open={!!selectedSkill} onOpenChange={handleClose}>
@@ -90,17 +90,14 @@ export const InstallModal = React.memo(
               <h4 className="text-sm font-medium mb-3">Select Agents</h4>
               <div className="max-h-60 overflow-y-auto rounded-md border p-2 space-y-1">
                 {existingAgents.map((agent) => (
-                  <label
+                  <InstallAgentOption
                     key={agent.id}
-                    className="flex items-center gap-3 p-2 rounded-md hover:bg-muted cursor-pointer"
-                  >
-                    <Checkbox
-                      checked={selectedAgents.includes(agent.id)}
-                      onCheckedChange={() => handleAgentToggle(agent.id)}
-                      disabled={isInstalling}
-                    />
-                    <span className="text-sm">{agent.name}</span>
-                  </label>
+                    agentId={agent.id}
+                    name={agent.name}
+                    checked={selectedAgents.includes(agent.id)}
+                    disabled={isInstalling}
+                    onToggle={handleAgentToggle}
+                  />
                 ))}
               </div>
               {selectedAgents.length === 0 && (
@@ -150,3 +147,34 @@ export const InstallModal = React.memo(
     )
   },
 )
+
+interface InstallAgentOptionProps {
+  agentId: AgentId
+  name: string
+  checked: boolean
+  disabled: boolean
+  onToggle: (agentId: AgentId) => void
+}
+
+const InstallAgentOption = React.memo(function InstallAgentOption({
+  agentId,
+  name,
+  checked,
+  disabled,
+  onToggle,
+}: InstallAgentOptionProps): React.ReactElement {
+  const handleCheckedChange = useCallback((): void => {
+    onToggle(agentId)
+  }, [agentId, onToggle])
+
+  return (
+    <label className="flex items-center gap-3 p-2 rounded-md hover:bg-muted cursor-pointer">
+      <Checkbox
+        checked={checked}
+        onCheckedChange={handleCheckedChange}
+        disabled={disabled}
+      />
+      <span className="text-sm">{name}</span>
+    </label>
+  )
+})

--- a/src/renderer/src/components/marketplace/MarketplaceSearch.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceSearch.tsx
@@ -1,5 +1,5 @@
 import { Search, Loader2 } from 'lucide-react'
-import React, { useState } from 'react'
+import React, { useCallback, useState } from 'react'
 
 import { Button } from '@/renderer/src/components/ui/button'
 import { Input } from '@/renderer/src/components/ui/input'
@@ -20,28 +20,34 @@ export const MarketplaceSearch = React.memo(
     const [localQuery, setLocalQuery] = useState(searchQuery)
     const isSearching = status === 'searching'
 
-    const handleSearch = (): void => {
+    const handleSearch = useCallback((): void => {
       if (localQuery.trim()) {
         dispatch(setMarketplaceSearchQuery(localQuery.trim()))
         dispatch(searchSkills(localQuery.trim()))
       }
-    }
+    }, [dispatch, localQuery])
 
     /** Clear search input and return to leaderboard */
-    function handleChange(e: React.ChangeEvent<HTMLInputElement>): void {
-      const value = e.target.value
-      setLocalQuery(value)
-      // When input is cleared (native X button or manual), reset search state
-      if (value === '') {
-        dispatch(clearSearchResults())
-      }
-    }
+    const handleChange = useCallback(
+      (e: React.ChangeEvent<HTMLInputElement>): void => {
+        const value = e.target.value
+        setLocalQuery(value)
+        // When input is cleared (native X button or manual), reset search state
+        if (value === '') {
+          dispatch(clearSearchResults())
+        }
+      },
+      [dispatch],
+    )
 
-    const handleKeyDown = (e: React.KeyboardEvent): void => {
-      if (e.key === 'Enter') {
-        handleSearch()
-      }
-    }
+    const handleKeyDown = useCallback(
+      (e: React.KeyboardEvent): void => {
+        if (e.key === 'Enter') {
+          handleSearch()
+        }
+      },
+      [handleSearch],
+    )
 
     return (
       <div className="flex gap-2">

--- a/src/renderer/src/components/marketplace/MarketplaceSkillPreview.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceSkillPreview.tsx
@@ -1,6 +1,7 @@
 import { ArrowLeft } from 'lucide-react'
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useRef, useState } from 'react'
 
+import { useComponentEffect } from '@/renderer/src/hooks/useComponentEffect'
 import { useAppDispatch } from '@/renderer/src/redux/hooks'
 import { setPreviewSkill } from '@/renderer/src/redux/slices/marketplaceSlice'
 import { isAllowedSkillsUrl } from '@/shared/marketplaceUrlPolicy'
@@ -33,7 +34,7 @@ export const MarketplaceSkillPreview = React.memo(
     // Validate initial src before rendering the webview
     const isSrcAllowed = isAllowedSkillsUrl(skill.url)
 
-    useEffect(() => {
+    useComponentEffect(() => {
       const wv = webviewRef.current
       if (!wv || !isSrcAllowed) return
 

--- a/src/renderer/src/components/marketplace/RankingTabs.tsx
+++ b/src/renderer/src/components/marketplace/RankingTabs.tsx
@@ -52,6 +52,7 @@ export const RankingTabs = React.memo(function RankingTabs({
     >
       {tabs.map((tab) => (
         <button
+          type="button"
           key={tab.id}
           role="tab"
           aria-selected={value === tab.id}

--- a/src/renderer/src/components/marketplace/SkillRowMarketplace.tsx
+++ b/src/renderer/src/components/marketplace/SkillRowMarketplace.tsx
@@ -137,6 +137,7 @@ export const SkillRowMarketplace = React.memo(function SkillRowMarketplace({
         ) : (
           /* Install Button */
           <button
+            type="button"
             onClick={handleInstall}
             disabled={isOperating}
             className={cn(

--- a/src/renderer/src/components/marketplace/SkillsMarketplace.tsx
+++ b/src/renderer/src/components/marketplace/SkillsMarketplace.tsx
@@ -1,6 +1,7 @@
 import { Package, WifiOff } from 'lucide-react'
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 
+import { useComponentEffect } from '@/renderer/src/hooks/useComponentEffect'
 import { useMarketplaceProgress } from '@/renderer/src/hooks/useMarketplaceProgress'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import { loadLeaderboard } from '@/renderer/src/redux/slices/marketplaceSlice'
@@ -75,14 +76,14 @@ export const SkillsMarketplace = React.memo(
       leaderboardStatus === 'error' && leaderboardSkills.length === 0
 
     // Auto-load leaderboard on mount and when filter changes
-    useEffect(() => {
+    useComponentEffect(() => {
       dispatch(loadLeaderboard(rankingFilter))
     }, [dispatch, rankingFilter])
 
     /** Handle tab change: switch filter and load data */
-    const handleFilterChange = (filter: RankingFilter): void => {
+    const handleFilterChange = useCallback((filter: RankingFilter): void => {
       setRankingFilter(filter)
-    }
+    }, [])
 
     return (
       <div className="h-full flex flex-col">

--- a/src/renderer/src/components/sidebar/AgentDeleteDialog.tsx
+++ b/src/renderer/src/components/sidebar/AgentDeleteDialog.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import { toast } from 'sonner'
 
 import { DestructiveConfirmDialog } from '@/renderer/src/components/shared/DestructiveConfirmDialog'
@@ -18,13 +18,13 @@ export const AgentDeleteDialog = React.memo(
     const dispatch = useAppDispatch()
     const { agentToDelete, deleting } = useAppSelector((state) => state.agents)
 
-    const handleClose = (): void => {
+    const handleClose = useCallback((): void => {
       if (!deleting) {
         dispatch(setAgentToDelete(null))
       }
-    }
+    }, [deleting, dispatch])
 
-    const handleDelete = async (): Promise<void> => {
+    const handleDelete = useCallback(async (): Promise<void> => {
       if (!agentToDelete) return
 
       const result = await dispatch(removeAllSymlinksFromAgent(agentToDelete))
@@ -39,7 +39,7 @@ export const AgentDeleteDialog = React.memo(
           description: result.error?.message || 'An unexpected error occurred',
         })
       }
-    }
+    }, [agentToDelete, dispatch])
 
     return (
       <DestructiveConfirmDialog

--- a/src/renderer/src/components/sidebar/AgentItem.tsx
+++ b/src/renderer/src/components/sidebar/AgentItem.tsx
@@ -1,5 +1,5 @@
 import { Eraser, EyeOff, FolderOpen, Terminal, Trash2 } from 'lucide-react'
-import React, { useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 
 import {
   DropdownMenu,
@@ -98,28 +98,32 @@ export const AgentItem = React.memo(function AgentItem({
     setContextOpen(true)
   }
 
-  const handleRevealInFinder = (): void => {
+  const handleContextOpenChange = useCallback((open: boolean): void => {
+    if (!open) setContextOpen(false)
+  }, [])
+
+  const handleRevealInFinder = useCallback((): void => {
     void revealInFinder(agent.path)
-  }
+  }, [agent.path, revealInFinder])
 
-  const handleOpenInTerminal = (): void => {
+  const handleOpenInTerminal = useCallback((): void => {
     void openInTerminal(agent.path)
-  }
+  }, [agent.path, openInTerminal])
 
-  const handleDelete = (): void => {
+  const handleDelete = useCallback((): void => {
     dispatch(setAgentToDelete(agent))
     setContextOpen(false)
-  }
+  }, [agent, dispatch])
 
-  const handleCleanupMissing = (): void => {
+  const handleCleanupMissing = useCallback((): void => {
     // Opens `CleanupAgentDialog`. The dialog itself dispatches the scoped
     // `fetchSyncPreview({ agentId })` once it mounts, so we don't need
     // to chain it here — keeps the menu handler synchronous.
     dispatch(setCleanupAgentTarget(agent.id))
     setContextOpen(false)
-  }
+  }, [agent.id, dispatch])
 
-  const handleToggleHidden = (): void => {
+  const handleToggleHidden = useCallback((): void => {
     // Pure visibility toggle — skills, symlinks, and marketplace presence
     // are untouched. Matching unhide affordances live in Settings → Agents
     // and inside the "N hidden" sidebar disclosure.
@@ -127,7 +131,7 @@ export const AgentItem = React.memo(function AgentItem({
       hiddenAgentIds: toggleArrayMember(hiddenAgentIds, agent.id),
     })
     setContextOpen(false)
-  }
+  }, [agent.id, hiddenAgentIds, updateSettings])
 
   const skillCountText = useMemo(
     () =>
@@ -141,12 +145,7 @@ export const AgentItem = React.memo(function AgentItem({
 
   return (
     <Tooltip>
-      <DropdownMenu
-        open={contextOpen}
-        onOpenChange={(open) => {
-          if (!open) setContextOpen(false)
-        }}
-      >
+      <DropdownMenu open={contextOpen} onOpenChange={handleContextOpenChange}>
         <TooltipTrigger asChild>
           <DropdownMenuTrigger asChild>
             <button

--- a/src/renderer/src/components/sidebar/AgentsSection.tsx
+++ b/src/renderer/src/components/sidebar/AgentsSection.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 
+import { useComponentEffect } from '@/renderer/src/hooks/useComponentEffect'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import { fetchAgents } from '@/renderer/src/redux/slices/agentsSlice'
 import { selectHiddenAgentIds } from '@/renderer/src/redux/slices/settingsSlice'
@@ -27,7 +28,7 @@ export const AgentsSection = React.memo(
     const { items: agents, loading } = useAppSelector((state) => state.agents)
     const hiddenAgentIds = useAppSelector(selectHiddenAgentIds)
 
-    useEffect(() => {
+    useComponentEffect(() => {
       dispatch(fetchAgents())
     }, [dispatch])
 

--- a/src/renderer/src/components/sidebar/BookmarkDetailModal.tsx
+++ b/src/renderer/src/components/sidebar/BookmarkDetailModal.tsx
@@ -1,5 +1,5 @@
 import { Check, ExternalLink, Loader2 } from 'lucide-react'
-import React, { useRef, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 
 import { Button } from '@/renderer/src/components/ui/button'
 import {
@@ -35,15 +35,15 @@ export const BookmarkDetailModal = React.memo(
     // Generation counter: invalidates in-flight installs when modal closes/reopens
     const installGenRef = useRef(0)
 
-    const handleClose = (): void => {
+    const handleClose = useCallback((): void => {
       installGenRef.current++
       dispatch(clearSelectedBookmarkForDetail())
       setIsInstalling(false)
       setInstallSuccess(false)
       setInstallError(null)
-    }
+    }, [dispatch])
 
-    const handleInstall = async (): Promise<void> => {
+    const handleInstall = useCallback(async (): Promise<void> => {
       if (!bookmark || !bookmark.repo) return
       const gen = ++installGenRef.current
       setIsInstalling(true)
@@ -73,23 +73,25 @@ export const BookmarkDetailModal = React.memo(
           setIsInstalling(false)
         }
       }
-    }
+    }, [bookmark, dispatch])
 
-    const handleRemoveBookmark = (): void => {
+    const handleRemoveBookmark = useCallback((): void => {
       if (!bookmark) return
       dispatch(removeBookmark(bookmark.name))
       handleClose()
-    }
+    }, [bookmark, dispatch, handleClose])
+
+    const handleOpenChange = useCallback(
+      (open: boolean): void => {
+        if (!open) handleClose()
+      },
+      [handleClose],
+    )
 
     const isInstalled = bookmark?.isInstalled || installSuccess
 
     return (
-      <Dialog
-        open={bookmark !== null}
-        onOpenChange={(open) => {
-          if (!open) handleClose()
-        }}
-      >
+      <Dialog open={bookmark !== null} onOpenChange={handleOpenChange}>
         <DialogContent className="max-w-sm">
           {bookmark && (
             <>

--- a/src/renderer/src/components/sidebar/CleanupAgentDialog.tsx
+++ b/src/renderer/src/components/sidebar/CleanupAgentDialog.tsx
@@ -1,5 +1,5 @@
 import { Eraser, Loader2 } from 'lucide-react'
-import React, { useEffect } from 'react'
+import React, { useCallback } from 'react'
 import { toast } from 'sonner'
 
 import { Button } from '@/renderer/src/components/ui/button'
@@ -12,6 +12,7 @@ import {
 } from '@/renderer/src/components/ui/dialog'
 import { DialogIconHeader } from '@/renderer/src/components/ui/dialog-icon-header'
 import { StatRow } from '@/renderer/src/components/ui/stat-row'
+import { useComponentEffect } from '@/renderer/src/hooks/useComponentEffect'
 import { useExecuteSync } from '@/renderer/src/hooks/useExecuteSync'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import {
@@ -66,7 +67,7 @@ export const CleanupAgentDialog = React.memo(
     // rejects (IPC failure, missing source dir, etc.) we close the dialog
     // and surface a toast — otherwise it would hang on the loading spinner
     // forever with no way to recover.
-    useEffect(() => {
+    useComponentEffect(() => {
       if (!cleanupAgentTarget) return
 
       dispatch(fetchSyncPreview({ agentId: cleanupAgentTarget })).then(
@@ -99,13 +100,13 @@ export const CleanupAgentDialog = React.memo(
     const hasWork = missingCount > 0
     const isLoadingPreview = !previewMatchesTarget
 
-    const handleClose = (): void => {
+    const handleClose = useCallback((): void => {
       if (!isExecuting) {
         dispatch(clearCleanupAgentTarget())
       }
-    }
+    }, [dispatch, isExecuting])
 
-    const handleCleanup = async (): Promise<void> => {
+    const handleCleanup = useCallback(async (): Promise<void> => {
       const succeeded = await executeCleanup({
         replaceConflicts: [],
         agentId: cleanupAgentTarget,
@@ -116,7 +117,7 @@ export const CleanupAgentDialog = React.memo(
         // surface — otherwise the per-agent dialog stays mounted underneath.
         dispatch(clearCleanupAgentTarget())
       }
-    }
+    }, [cleanupAgentTarget, dispatch, executeCleanup])
 
     return (
       <Dialog open onOpenChange={handleClose}>

--- a/src/renderer/src/components/sidebar/SidebarFooter.tsx
+++ b/src/renderer/src/components/sidebar/SidebarFooter.tsx
@@ -32,6 +32,7 @@ export const SidebarFooter = React.memo(
     return (
       <div className="border-t border-border px-6 py-3 flex items-center">
         <button
+          type="button"
           onClick={handleSkillsLinkClick}
           className="flex flex-1 items-center justify-center gap-1.5 text-xs font-medium font-mono text-muted-foreground hover:text-primary transition-colors"
         >

--- a/src/renderer/src/components/sidebar/SourceCard.tsx
+++ b/src/renderer/src/components/sidebar/SourceCard.tsx
@@ -7,7 +7,7 @@ import {
   RefreshCw,
   Terminal,
 } from 'lucide-react'
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import { toast } from 'sonner'
 
 import { Button } from '@/renderer/src/components/ui/button'
@@ -18,6 +18,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/renderer/src/components/ui/dropdown-menu'
+import { useComponentEffect } from '@/renderer/src/hooks/useComponentEffect'
 import { useOpenFolder } from '@/renderer/src/hooks/useOpenFolder'
 import { cn } from '@/renderer/src/lib/utils'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
@@ -43,25 +44,25 @@ export const SourceCard = React.memo(function SourceCard(): React.ReactElement {
   const [contextOpen, setContextOpen] = useState(false)
   const { revealInFinder, openInTerminal } = useOpenFolder()
 
-  useEffect(() => {
+  useComponentEffect(() => {
     dispatch(fetchSourceStats())
   }, [dispatch])
 
-  const handleRefresh = (): void => {
-    Promise.all([
+  const handleRefresh = useCallback((): void => {
+    void Promise.all([
       dispatch(fetchSourceStats()),
       dispatch(fetchSkills()),
       dispatch(fetchAgents()),
     ])
-  }
+  }, [dispatch])
 
   /**
    * Click path text → clear all filters and show all skills
    */
-  const handlePathClick = (): void => {
+  const handlePathClick = useCallback((): void => {
     dispatch(selectAgent(null))
     dispatch(setSearchQuery(''))
-  }
+  }, [dispatch])
 
   /**
    * Right-click on the card body opens the same DropdownMenu the kebab opens.
@@ -70,22 +71,25 @@ export const SourceCard = React.memo(function SourceCard(): React.ReactElement {
    * No-ops while sourceStats hasn't loaded — without a path there is nothing
    * to reveal.
    */
-  const handleContextMenu = (e: React.MouseEvent): void => {
-    e.preventDefault()
-    e.stopPropagation()
-    if (!sourceStats) return
-    setContextOpen(true)
-  }
+  const handleContextMenu = useCallback(
+    (e: React.MouseEvent): void => {
+      e.preventDefault()
+      e.stopPropagation()
+      if (!sourceStats) return
+      setContextOpen(true)
+    },
+    [sourceStats],
+  )
 
-  const handleRevealInFinder = (): void => {
+  const handleRevealInFinder = useCallback((): void => {
     if (!sourceStats) return
     void revealInFinder(sourceStats.path)
-  }
+  }, [revealInFinder, sourceStats])
 
-  const handleOpenInTerminal = (): void => {
+  const handleOpenInTerminal = useCallback((): void => {
     if (!sourceStats) return
     void openInTerminal(sourceStats.path)
-  }
+  }, [openInTerminal, sourceStats])
 
   /**
    * Fetch sync preview and let the appropriate dialog handle execution.
@@ -93,7 +97,7 @@ export const SourceCard = React.memo(function SourceCard(): React.ReactElement {
    * SyncConflictDialog opens when conflicts exist.
    * Edge cases (no skills, already synced) are handled with toasts.
    */
-  const handleSync = async (): Promise<void> => {
+  const handleSync = useCallback(async (): Promise<void> => {
     const previewResult = await dispatch(fetchSyncPreview())
 
     if (fetchSyncPreview.fulfilled.match(previewResult)) {
@@ -116,15 +120,35 @@ export const SourceCard = React.memo(function SourceCard(): React.ReactElement {
     } else {
       toast.error('Failed to preview sync')
     }
-  }
+  }, [dispatch])
+
+  const handleContextOpenChange = useCallback((open: boolean): void => {
+    if (!open) setContextOpen(false)
+  }, [])
+
+  const handleSyncClick = useCallback(
+    (e: React.MouseEvent): void => {
+      e.stopPropagation()
+      void handleSync()
+    },
+    [handleSync],
+  )
+
+  const handleRefreshClick = useCallback(
+    (e: React.MouseEvent): void => {
+      e.stopPropagation()
+      handleRefresh()
+    },
+    [handleRefresh],
+  )
+
+  const handleKebabClick = useCallback((e: React.MouseEvent): void => {
+    e.stopPropagation()
+    setContextOpen((prev) => !prev)
+  }, [])
 
   return (
-    <DropdownMenu
-      open={contextOpen}
-      onOpenChange={(open) => {
-        if (!open) setContextOpen(false)
-      }}
-    >
+    <DropdownMenu open={contextOpen} onOpenChange={handleContextOpenChange}>
       <Card
         className={cn(
           'bg-card/50 border-l-4 border-l-transparent transition-colors cursor-pointer',
@@ -142,10 +166,7 @@ export const SourceCard = React.memo(function SourceCard(): React.ReactElement {
                 variant="ghost"
                 size="sm"
                 className="min-h-11 px-2 text-xs font-medium gap-1"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  handleSync()
-                }}
+                onClick={handleSyncClick}
                 disabled={isSyncing}
               >
                 {isSyncing ? (
@@ -166,10 +187,7 @@ export const SourceCard = React.memo(function SourceCard(): React.ReactElement {
                     ? 'Refreshing skills and agent status'
                     : 'Refresh skills and agent status'
                 }
-                onClick={(e) => {
-                  e.stopPropagation()
-                  handleRefresh()
-                }}
+                onClick={handleRefreshClick}
                 disabled={isRefreshing}
               >
                 <RefreshCw
@@ -186,10 +204,7 @@ export const SourceCard = React.memo(function SourceCard(): React.ReactElement {
                   className="h-11 w-11"
                   aria-label="Source folder actions"
                   disabled={!sourceStats}
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    setContextOpen((prev) => !prev)
-                  }}
+                  onClick={handleKebabClick}
                 >
                   <MoreVertical className="h-3 w-3" />
                 </Button>

--- a/src/renderer/src/components/sidebar/SourceCard.tsx
+++ b/src/renderer/src/components/sidebar/SourceCard.tsx
@@ -48,12 +48,16 @@ export const SourceCard = React.memo(function SourceCard(): React.ReactElement {
     dispatch(fetchSourceStats())
   }, [dispatch])
 
-  const handleRefresh = useCallback((): void => {
-    void Promise.all([
-      dispatch(fetchSourceStats()),
-      dispatch(fetchSkills()),
-      dispatch(fetchAgents()),
-    ])
+  const handleRefresh = useCallback(async (): Promise<void> => {
+    try {
+      await Promise.all([
+        dispatch(fetchSourceStats()).unwrap(),
+        dispatch(fetchSkills()).unwrap(),
+        dispatch(fetchAgents()).unwrap(),
+      ])
+    } catch {
+      toast.error('Failed to refresh data')
+    }
   }, [dispatch])
 
   /**

--- a/src/renderer/src/components/sidebar/SyncConfirmDialog.tsx
+++ b/src/renderer/src/components/sidebar/SyncConfirmDialog.tsx
@@ -1,5 +1,5 @@
 import { FolderSync, Loader2 } from 'lucide-react'
-import React from 'react'
+import React, { useCallback } from 'react'
 
 import { Button } from '@/renderer/src/components/ui/button'
 import {
@@ -31,16 +31,16 @@ export const SyncConfirmDialog = React.memo(
 
     const { run: executeSync, isExecuting } = useExecuteSync('Sync failed')
 
-    const handleClose = (): void => {
+    const handleClose = useCallback((): void => {
       if (!isExecuting) {
         dispatch(setSyncPreview(null))
       }
-    }
+    }, [dispatch, isExecuting])
 
     // Success feedback + refreshAllData handled by SyncResultDialog
-    const handleSync = async (): Promise<void> => {
+    const handleSync = useCallback(async (): Promise<void> => {
       await executeSync({ replaceConflicts: [] })
-    }
+    }, [executeSync])
 
     return (
       <Dialog open={isOpen} onOpenChange={handleClose}>

--- a/src/renderer/src/components/sidebar/SyncConflictDialog.tsx
+++ b/src/renderer/src/components/sidebar/SyncConflictDialog.tsx
@@ -1,5 +1,5 @@
 import { AlertTriangle, Loader2 } from 'lucide-react'
-import React, { useState } from 'react'
+import React, { useCallback, useState } from 'react'
 
 import { Button } from '@/renderer/src/components/ui/button'
 import { Checkbox } from '@/renderer/src/components/ui/checkbox'
@@ -34,14 +34,14 @@ export const SyncConflictDialog = React.memo(
     const [selectedPaths, setSelectedPaths] = useState<Set<string>>(new Set())
     const { run: executeSync, isExecuting } = useExecuteSync('Sync failed')
 
-    const handleClose = (): void => {
+    const handleClose = useCallback((): void => {
       if (!isExecuting) {
         dispatch(setSyncPreview(null))
         setSelectedPaths(new Set())
       }
-    }
+    }, [dispatch, isExecuting])
 
-    const handleToggle = (path: string): void => {
+    const handleToggle = useCallback((path: string): void => {
       setSelectedPaths((prev) => {
         const next = new Set(prev)
         if (next.has(path)) {
@@ -51,18 +51,29 @@ export const SyncConflictDialog = React.memo(
         }
         return next
       })
-    }
+    }, [])
 
     // Success feedback + refreshAllData handled by SyncResultDialog
-    const handleSync = async (replaceAll: boolean): Promise<void> => {
-      const replaceConflicts = replaceAll
-        ? conflicts.map((c) => c.agentSkillPath)
-        : Array.from(selectedPaths)
-      const succeeded = await executeSync({ replaceConflicts })
-      if (succeeded) {
-        setSelectedPaths(new Set())
-      }
-    }
+    const handleSync = useCallback(
+      async (replaceAll: boolean): Promise<void> => {
+        const replaceConflicts = replaceAll
+          ? conflicts.map((c) => c.agentSkillPath)
+          : Array.from(selectedPaths)
+        const succeeded = await executeSync({ replaceConflicts })
+        if (succeeded) {
+          setSelectedPaths(new Set())
+        }
+      },
+      [conflicts, executeSync, selectedPaths],
+    )
+
+    const handleSkipSelected = useCallback((): void => {
+      void handleSync(false)
+    }, [handleSync])
+
+    const handleReplaceAll = useCallback((): void => {
+      void handleSync(true)
+    }, [handleSync])
 
     return (
       <Dialog open={isOpen} onOpenChange={handleClose}>
@@ -82,28 +93,15 @@ export const SyncConflictDialog = React.memo(
           <div className="py-4">
             <div className="max-h-75 overflow-y-auto rounded-md border p-2 space-y-1">
               {conflicts.map((conflict) => (
-                <label
+                <SyncConflictRow
                   key={conflict.agentSkillPath}
-                  className="flex items-center gap-3 p-2 rounded-md hover:bg-muted cursor-pointer"
-                >
-                  <Checkbox
-                    checked={selectedPaths.has(conflict.agentSkillPath)}
-                    onCheckedChange={() =>
-                      handleToggle(conflict.agentSkillPath)
-                    }
-                    disabled={isExecuting}
-                  />
-                  <div className="text-sm">
-                    <span className="font-medium">{conflict.skillName}</span>
-                    <span className="text-muted-foreground">
-                      {' '}
-                      in {conflict.agentName}
-                    </span>
-                    <span className="text-xs text-muted-foreground block">
-                      Local folder will be replaced with symlink
-                    </span>
-                  </div>
-                </label>
+                  path={conflict.agentSkillPath}
+                  skillName={conflict.skillName}
+                  agentName={conflict.agentName}
+                  checked={selectedPaths.has(conflict.agentSkillPath)}
+                  disabled={isExecuting}
+                  onToggle={handleToggle}
+                />
               ))}
             </div>
           </div>
@@ -111,7 +109,7 @@ export const SyncConflictDialog = React.memo(
           <DialogFooter className="flex gap-2">
             <Button
               variant="outline"
-              onClick={async () => handleSync(false)}
+              onClick={handleSkipSelected}
               disabled={isExecuting || isSyncing}
             >
               {isExecuting ? (
@@ -125,7 +123,7 @@ export const SyncConflictDialog = React.memo(
             </Button>
             <Button
               variant="destructive"
-              onClick={async () => handleSync(true)}
+              onClick={handleReplaceAll}
               disabled={isExecuting || isSyncing}
             >
               Replace all
@@ -136,3 +134,42 @@ export const SyncConflictDialog = React.memo(
     )
   },
 )
+
+interface SyncConflictRowProps {
+  path: string
+  skillName: string
+  agentName: string
+  checked: boolean
+  disabled: boolean
+  onToggle: (path: string) => void
+}
+
+const SyncConflictRow = React.memo(function SyncConflictRow({
+  path,
+  skillName,
+  agentName,
+  checked,
+  disabled,
+  onToggle,
+}: SyncConflictRowProps): React.ReactElement {
+  const handleCheckedChange = useCallback((): void => {
+    onToggle(path)
+  }, [onToggle, path])
+
+  return (
+    <label className="flex items-center gap-3 p-2 rounded-md hover:bg-muted cursor-pointer">
+      <Checkbox
+        checked={checked}
+        onCheckedChange={handleCheckedChange}
+        disabled={disabled}
+      />
+      <div className="text-sm">
+        <span className="font-medium">{skillName}</span>
+        <span className="text-muted-foreground"> in {agentName}</span>
+        <span className="text-xs text-muted-foreground block">
+          Local folder will be replaced with symlink
+        </span>
+      </div>
+    </label>
+  )
+})

--- a/src/renderer/src/components/sidebar/SyncResultDialog.tsx
+++ b/src/renderer/src/components/sidebar/SyncResultDialog.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 
 import { Badge } from '@/renderer/src/components/ui/badge'
 import { Button } from '@/renderer/src/components/ui/button'
@@ -50,7 +50,7 @@ export const SyncResultDialog = React.memo(
     const syncResult = useAppSelector((state) => state.ui.syncResult)
     const isOpen = shouldShowSyncResult(syncResult)
 
-    const handleClose = (): void => {
+    const handleClose = useCallback((): void => {
       const hadChanges =
         syncResult !== null &&
         (syncResult.created > 0 ||
@@ -60,7 +60,7 @@ export const SyncResultDialog = React.memo(
       if (hadChanges) {
         refreshAllData(dispatch)
       }
-    }
+    }, [dispatch, syncResult])
 
     // Skip all derivations when dialog is closed
     if (!isOpen || !syncResult) return null

--- a/src/renderer/src/components/skills/AddSymlinkModal.tsx
+++ b/src/renderer/src/components/skills/AddSymlinkModal.tsx
@@ -224,6 +224,8 @@ const AddSymlinkAgentOption = React.memo(function AddSymlinkAgentOption({
     if (!disabled) onToggle(agentId)
   }, [agentId, disabled, onToggle])
 
+  // The intrinsic <div> intentionally receives a plain wrapper; passing
+  // handleToggle directly would violate the no-deopt-use-callback lint rule.
   const handleRowClick = (): void => {
     handleToggle()
   }

--- a/src/renderer/src/components/skills/AddSymlinkModal.tsx
+++ b/src/renderer/src/components/skills/AddSymlinkModal.tsx
@@ -1,5 +1,5 @@
 import { Copy, Loader2, Plus } from 'lucide-react'
-import React, { useMemo } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import { toast } from 'sonner'
 
 import { Button } from '@/renderer/src/components/ui/button'
@@ -53,18 +53,21 @@ export const AddSymlinkModal = React.memo(
 
     const isSubmitting = addingSymlinks || copying
 
-    const handleClose = (): void => {
+    const handleClose = useCallback((): void => {
       if (!isSubmitting) {
         dispatch(setSkillToAddSymlinks(null))
       }
-    }
+    }, [dispatch, isSubmitting])
 
-    const handleAgentToggle = (agentId: AgentId): void => {
-      if (occupiedAgentReasonById.has(agentId)) return
-      dispatch(toggleAddAgentSelection(agentId))
-    }
+    const handleAgentToggle = useCallback(
+      (agentId: AgentId): void => {
+        if (occupiedAgentReasonById.has(agentId)) return
+        dispatch(toggleAddAgentSelection(agentId))
+      },
+      [dispatch, occupiedAgentReasonById],
+    )
 
-    const handleAddSymlinks = async (): Promise<void> => {
+    const handleAddSymlinks = useCallback(async (): Promise<void> => {
       if (!skillToAddSymlinks || selectedAddAgentIds.length === 0) return
 
       const result = await dispatch(
@@ -87,24 +90,28 @@ export const AddSymlinkModal = React.memo(
       // failure clears any stale `state.skills.error` (via fetchSkills.pending)
       // so the SkillsList does not stay stuck on the error view.
       refreshAllData(dispatch)
-    }
+    }, [dispatch, selectedAddAgentIds, skillToAddSymlinks])
 
-    const handleCopySkillFiles = async (): Promise<void> => {
+    const handleCopySkillFiles = useCallback(async (): Promise<void> => {
       if (!skillToAddSymlinks || selectedAddAgentIds.length === 0) return
       await copyToAgentsWithToast(dispatch, {
         skill: skillToAddSymlinks,
         sourcePath: skillToAddSymlinks.path,
         agentIds: selectedAddAgentIds,
       })
-    }
+    }, [dispatch, selectedAddAgentIds, skillToAddSymlinks])
+
+    const handleOpenChange = useCallback(
+      (open: boolean): void => {
+        if (!open) handleClose()
+      },
+      [handleClose],
+    )
 
     const hasNewSelections = selectedAddAgentIds.length > 0
 
     return (
-      <Dialog
-        open={!!skillToAddSymlinks}
-        onOpenChange={(open) => !open && handleClose()}
-      >
+      <Dialog open={!!skillToAddSymlinks} onOpenChange={handleOpenChange}>
         <DialogContent className="max-w-md">
           <DialogHeader>
             <div className="flex items-center gap-2">
@@ -122,54 +129,20 @@ export const AddSymlinkModal = React.memo(
             <div className="max-h-60 overflow-y-auto rounded-md border p-2 space-y-1">
               {targetAgents.map((agent) => {
                 const occupiedReason = occupiedAgentReasonById.get(agent.id)
-                const isOccupied = occupiedReason !== undefined
-                const checkboxId = `add-agent-${agent.id}`
                 return (
-                  <div
+                  <AddSymlinkAgentOption
                     key={agent.id}
-                    className={cn(
-                      'flex items-center gap-3 p-2 rounded-md',
-                      isOccupied
-                        ? 'opacity-50 cursor-not-allowed'
-                        : 'hover:bg-muted cursor-pointer',
-                    )}
-                    onClick={() =>
-                      !isOccupied &&
-                      !isSubmitting &&
-                      handleAgentToggle(agent.id)
+                    agentId={agent.id}
+                    name={agent.name}
+                    exists={agent.exists}
+                    checked={
+                      occupiedReason !== undefined ||
+                      selectedAddAgentIds.includes(agent.id)
                     }
-                  >
-                    <Checkbox
-                      id={checkboxId}
-                      aria-label={agent.name}
-                      checked={
-                        isOccupied || selectedAddAgentIds.includes(agent.id)
-                      }
-                      onClick={(event) => event.stopPropagation()}
-                      onCheckedChange={() => handleAgentToggle(agent.id)}
-                      disabled={isSubmitting || isOccupied}
-                    />
-                    <div
-                      className={cn(
-                        'text-sm',
-                        isOccupied || isSubmitting
-                          ? 'cursor-not-allowed'
-                          : 'cursor-pointer',
-                      )}
-                    >
-                      {agent.name}
-                      {!agent.exists && (
-                        <span className="text-xs text-muted-foreground ml-2">
-                          not installed
-                        </span>
-                      )}
-                      {isOccupied && occupiedReason && (
-                        <span className="text-xs text-muted-foreground ml-2">
-                          {getOccupiedAgentReasonLabel(occupiedReason)}
-                        </span>
-                      )}
-                    </div>
-                  </div>
+                    disabled={isSubmitting || occupiedReason !== undefined}
+                    occupiedReason={occupiedReason}
+                    onToggle={handleAgentToggle}
+                  />
                 )
               })}
             </div>
@@ -224,3 +197,77 @@ export const AddSymlinkModal = React.memo(
     )
   },
 )
+
+interface AddSymlinkAgentOptionProps {
+  agentId: AgentId
+  name: string
+  exists: boolean
+  checked: boolean
+  disabled: boolean
+  occupiedReason?: OccupiedAgentReason
+  onToggle: (agentId: AgentId) => void
+}
+
+const AddSymlinkAgentOption = React.memo(function AddSymlinkAgentOption({
+  agentId,
+  name,
+  exists,
+  checked,
+  disabled,
+  occupiedReason,
+  onToggle,
+}: AddSymlinkAgentOptionProps): React.ReactElement {
+  const checkboxId = `add-agent-${agentId}`
+  const isOccupied = occupiedReason !== undefined
+
+  const handleToggle = useCallback((): void => {
+    if (!disabled) onToggle(agentId)
+  }, [agentId, disabled, onToggle])
+
+  const handleRowClick = (): void => {
+    handleToggle()
+  }
+
+  const handleCheckboxClick = useCallback((event: React.MouseEvent): void => {
+    event.stopPropagation()
+  }, [])
+
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-3 p-2 rounded-md',
+        disabled
+          ? 'opacity-50 cursor-not-allowed'
+          : 'hover:bg-muted cursor-pointer',
+      )}
+      onClick={handleRowClick}
+    >
+      <Checkbox
+        id={checkboxId}
+        aria-label={name}
+        checked={checked}
+        onClick={handleCheckboxClick}
+        onCheckedChange={handleToggle}
+        disabled={disabled}
+      />
+      <div
+        className={cn(
+          'text-sm',
+          disabled ? 'cursor-not-allowed' : 'cursor-pointer',
+        )}
+      >
+        {name}
+        {!exists && (
+          <span className="text-xs text-muted-foreground ml-2">
+            not installed
+          </span>
+        )}
+        {isOccupied && occupiedReason && (
+          <span className="text-xs text-muted-foreground ml-2">
+            {getOccupiedAgentReasonLabel(occupiedReason)}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+})

--- a/src/renderer/src/components/skills/CopyToAgentsModal.tsx
+++ b/src/renderer/src/components/skills/CopyToAgentsModal.tsx
@@ -1,5 +1,5 @@
 import { Copy, Loader2 } from 'lucide-react'
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 
 import { Button } from '@/renderer/src/components/ui/button'
 import { Checkbox } from '@/renderer/src/components/ui/checkbox'
@@ -11,6 +11,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/renderer/src/components/ui/dialog'
+import { useComponentEffect } from '@/renderer/src/hooks/useComponentEffect'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import { setSkillToCopy } from '@/renderer/src/redux/slices/skillsSlice'
 import type { AgentId } from '@/shared/types'
@@ -39,7 +40,7 @@ export const CopyToAgentsModal = React.memo(
     const [selectedAgents, setSelectedAgents] = useState<AgentId[]>([])
 
     // Reset selections when modal opens for a new skill
-    useEffect(() => {
+    useComponentEffect(() => {
       setSelectedAgents([])
     }, [skillToCopy])
 
@@ -68,38 +69,45 @@ export const CopyToAgentsModal = React.memo(
     }, [skillToCopy, selectedAgentId])
     const isSourceUnavailable = sourcePath === null
 
-    const handleClose = (): void => {
+    const handleClose = useCallback((): void => {
       if (!copying) {
         dispatch(setSkillToCopy(null))
         setSelectedAgents([])
       }
-    }
+    }, [copying, dispatch])
 
-    const handleAgentToggle = (agentId: AgentId): void => {
-      if (occupiedAgentReasonById.has(agentId)) return
-      setSelectedAgents((prev) =>
-        prev.includes(agentId)
-          ? prev.filter((id) => id !== agentId)
-          : [...prev, agentId],
-      )
-    }
+    const handleAgentToggle = useCallback(
+      (agentId: AgentId): void => {
+        if (occupiedAgentReasonById.has(agentId)) return
+        setSelectedAgents((prev) =>
+          prev.includes(agentId)
+            ? prev.filter((id) => id !== agentId)
+            : [...prev, agentId],
+        )
+      },
+      [occupiedAgentReasonById],
+    )
 
-    const handleCopy = async (): Promise<void> => {
+    const handleCopy = useCallback(async (): Promise<void> => {
       if (!skillToCopy || !sourcePath || selectedAgents.length === 0) return
       await copyToAgentsWithToast(dispatch, {
         skill: skillToCopy,
         sourcePath,
         agentIds: selectedAgents,
       })
-    }
+    }, [dispatch, selectedAgents, skillToCopy, sourcePath])
+
+    const handleOpenChange = useCallback(
+      (open: boolean): void => {
+        if (!open) handleClose()
+      },
+      [handleClose],
+    )
 
     const hasNewSelections = selectedAgents.length > 0
 
     return (
-      <Dialog
-        open={!!skillToCopy}
-        onOpenChange={(open) => !open && handleClose()}
-      >
+      <Dialog open={!!skillToCopy} onOpenChange={handleOpenChange}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
@@ -114,51 +122,24 @@ export const CopyToAgentsModal = React.memo(
           <div className="max-h-64 overflow-y-auto space-y-2 py-2">
             {targetAgents.map((agent) => {
               const occupiedReason = occupiedAgentReasonById.get(agent.id)
-              const alreadyExists = occupiedReason !== undefined
-              const checkboxId = `copy-agent-${agent.id}`
               return (
-                <div
+                <CopyToAgentOption
                   key={agent.id}
-                  className={`flex items-center gap-3 p-2 rounded-md transition-colors ${
-                    alreadyExists || isSourceUnavailable
-                      ? 'opacity-50 cursor-not-allowed'
-                      : 'hover:bg-accent cursor-pointer'
-                  }`}
-                  onClick={() =>
-                    !alreadyExists &&
-                    !copying &&
-                    !isSourceUnavailable &&
-                    handleAgentToggle(agent.id)
+                  agentId={agent.id}
+                  name={agent.name}
+                  exists={agent.exists}
+                  checked={
+                    occupiedReason !== undefined ||
+                    selectedAgents.includes(agent.id)
                   }
-                >
-                  <Checkbox
-                    id={checkboxId}
-                    aria-label={agent.name}
-                    checked={alreadyExists || selectedAgents.includes(agent.id)}
-                    disabled={alreadyExists || copying || isSourceUnavailable}
-                    onClick={(event) => event.stopPropagation()}
-                    onCheckedChange={() => handleAgentToggle(agent.id)}
-                  />
-                  <div
-                    className={
-                      alreadyExists || copying || isSourceUnavailable
-                        ? 'text-sm cursor-not-allowed'
-                        : 'text-sm cursor-pointer'
-                    }
-                  >
-                    {agent.name}
-                    {!agent.exists && (
-                      <span className="text-xs text-muted-foreground ml-2">
-                        not installed
-                      </span>
-                    )}
-                    {alreadyExists && occupiedReason && (
-                      <span className="text-xs text-muted-foreground ml-2">
-                        {getOccupiedAgentReasonLabel(occupiedReason)}
-                      </span>
-                    )}
-                  </div>
-                </div>
+                  disabled={
+                    occupiedReason !== undefined ||
+                    copying ||
+                    isSourceUnavailable
+                  }
+                  occupiedReason={occupiedReason}
+                  onToggle={handleAgentToggle}
+                />
               )
             })}
           </div>
@@ -188,3 +169,75 @@ export const CopyToAgentsModal = React.memo(
     )
   },
 )
+
+interface CopyToAgentOptionProps {
+  agentId: AgentId
+  name: string
+  exists: boolean
+  checked: boolean
+  disabled: boolean
+  occupiedReason?: OccupiedAgentReason
+  onToggle: (agentId: AgentId) => void
+}
+
+const CopyToAgentOption = React.memo(function CopyToAgentOption({
+  agentId,
+  name,
+  exists,
+  checked,
+  disabled,
+  occupiedReason,
+  onToggle,
+}: CopyToAgentOptionProps): React.ReactElement {
+  const checkboxId = `copy-agent-${agentId}`
+  const alreadyExists = occupiedReason !== undefined
+
+  const handleToggle = useCallback((): void => {
+    if (!disabled) onToggle(agentId)
+  }, [agentId, disabled, onToggle])
+
+  const handleRowClick = (): void => {
+    handleToggle()
+  }
+
+  const handleCheckboxClick = useCallback((event: React.MouseEvent): void => {
+    event.stopPropagation()
+  }, [])
+
+  return (
+    <div
+      className={`flex items-center gap-3 p-2 rounded-md transition-colors ${
+        disabled
+          ? 'opacity-50 cursor-not-allowed'
+          : 'hover:bg-accent cursor-pointer'
+      }`}
+      onClick={handleRowClick}
+    >
+      <Checkbox
+        id={checkboxId}
+        aria-label={name}
+        checked={checked}
+        disabled={disabled}
+        onClick={handleCheckboxClick}
+        onCheckedChange={handleToggle}
+      />
+      <div
+        className={
+          disabled ? 'text-sm cursor-not-allowed' : 'text-sm cursor-pointer'
+        }
+      >
+        {name}
+        {!exists && (
+          <span className="text-xs text-muted-foreground ml-2">
+            not installed
+          </span>
+        )}
+        {alreadyExists && occupiedReason && (
+          <span className="text-xs text-muted-foreground ml-2">
+            {getOccupiedAgentReasonLabel(occupiedReason)}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+})

--- a/src/renderer/src/components/skills/CopyToAgentsModal.tsx
+++ b/src/renderer/src/components/skills/CopyToAgentsModal.tsx
@@ -22,8 +22,8 @@ import {
 import type { AgentId } from '@/shared/types'
 
 import {
+  buildCopyAgentOptionViewModel,
   getOccupiedAgentReasonById,
-  getOccupiedAgentReasonLabel,
   getTargetAgentsForSelection,
 } from './agentSelectionHelpers'
 import type { OccupiedAgentReason } from './agentSelectionHelpers'
@@ -73,6 +73,23 @@ export const CopyToAgentsModal = React.memo(
     }, [skillToCopy, selectedAgentId])
     const isSourceUnavailable = sourcePath === null
 
+    const copyAgentOptionViewModels = useMemo(() => {
+      return targetAgents.map((agent) =>
+        buildCopyAgentOptionViewModel(agent, {
+          occupiedAgentReasonById,
+          selectedAgentIds: selectedAgents,
+          copying,
+          isSourceUnavailable,
+        }),
+      )
+    }, [
+      copying,
+      isSourceUnavailable,
+      occupiedAgentReasonById,
+      selectedAgents,
+      targetAgents,
+    ])
+
     const handleClose = useCallback((): void => {
       if (!copying) {
         dispatch(setSkillToCopy(null))
@@ -119,24 +136,15 @@ export const CopyToAgentsModal = React.memo(
           </DialogHeader>
 
           <div className="max-h-64 overflow-y-auto space-y-2 py-2">
-            {targetAgents.map((agent) => {
-              const occupiedReason = occupiedAgentReasonById.get(agent.id)
+            {copyAgentOptionViewModels.map((viewModel) => {
               return (
                 <CopyToAgentOption
-                  key={agent.id}
-                  agentId={agent.id}
-                  name={agent.name}
-                  exists={agent.exists}
-                  checked={
-                    occupiedReason !== undefined ||
-                    selectedAgents.includes(agent.id)
-                  }
-                  disabled={
-                    occupiedReason !== undefined ||
-                    copying ||
-                    isSourceUnavailable
-                  }
-                  occupiedReason={occupiedReason}
+                  key={viewModel.agentId}
+                  agentId={viewModel.agentId}
+                  name={viewModel.name}
+                  checked={viewModel.checked}
+                  disabled={viewModel.disabled}
+                  secondaryLabel={viewModel.secondaryLabel}
                   onToggle={handleAgentToggle}
                 />
               )
@@ -172,10 +180,9 @@ export const CopyToAgentsModal = React.memo(
 interface CopyToAgentOptionProps {
   agentId: AgentId
   name: string
-  exists: boolean
   checked: boolean
   disabled: boolean
-  occupiedReason?: OccupiedAgentReason
+  secondaryLabel?: string
   onToggle: (agentId: AgentId) => void
 }
 
@@ -184,14 +191,12 @@ type CheckboxCheckedState = boolean | 'indeterminate'
 const CopyToAgentOption = React.memo(function CopyToAgentOption({
   agentId,
   name,
-  exists,
   checked,
   disabled,
-  occupiedReason,
+  secondaryLabel,
   onToggle,
 }: CopyToAgentOptionProps): React.ReactElement {
   const checkboxId = `copy-agent-${agentId}`
-  const alreadyExists = occupiedReason !== undefined
 
   const handleToggle = useCallback(
     (_checked?: CheckboxCheckedState): void => {
@@ -233,14 +238,9 @@ const CopyToAgentOption = React.memo(function CopyToAgentOption({
         }
       >
         {name}
-        {!exists && (
+        {secondaryLabel !== undefined && (
           <span className="text-xs text-muted-foreground ml-2">
-            not installed
-          </span>
-        )}
-        {alreadyExists && occupiedReason && (
-          <span className="text-xs text-muted-foreground ml-2">
-            {getOccupiedAgentReasonLabel(occupiedReason)}
+            {secondaryLabel}
           </span>
         )}
       </div>

--- a/src/renderer/src/components/skills/CopyToAgentsModal.tsx
+++ b/src/renderer/src/components/skills/CopyToAgentsModal.tsx
@@ -42,11 +42,14 @@ export const CopyToAgentsModal = React.memo(
     const selectedAgents = useAppSelector(selectSelectedCopyAgentIds)
     const { selectedAgentId } = useAppSelector((state) => state.ui)
     const { items: agents } = useAppSelector((state) => state.agents)
+    const skillToCopyName = skillToCopy?.name ?? null
 
-    // Reset Copy modal selections when the modal opens for a new skill or closes.
+    // Reset Copy modal selections when the target skill identity changes or
+    // closes. A full skill object can be refreshed while the modal is open, so
+    // depending on the stable name avoids wiping the user's current checks.
     useComponentEffect(() => {
       dispatch(clearCopyAgentSelection())
-    }, [dispatch, skillToCopy])
+    }, [dispatch, skillToCopyName])
 
     const targetAgents = useMemo(() => {
       if (!selectedAgentId) return []

--- a/src/renderer/src/components/skills/CopyToAgentsModal.tsx
+++ b/src/renderer/src/components/skills/CopyToAgentsModal.tsx
@@ -179,6 +179,8 @@ interface CopyToAgentOptionProps {
   onToggle: (agentId: AgentId) => void
 }
 
+type CheckboxCheckedState = boolean | 'indeterminate'
+
 const CopyToAgentOption = React.memo(function CopyToAgentOption({
   agentId,
   name,
@@ -191,9 +193,12 @@ const CopyToAgentOption = React.memo(function CopyToAgentOption({
   const checkboxId = `copy-agent-${agentId}`
   const alreadyExists = occupiedReason !== undefined
 
-  const handleToggle = useCallback((): void => {
-    if (!disabled) onToggle(agentId)
-  }, [agentId, disabled, onToggle])
+  const handleToggle = useCallback(
+    (_checked?: CheckboxCheckedState): void => {
+      if (!disabled) onToggle(agentId)
+    },
+    [agentId, disabled, onToggle],
+  )
 
   // Native row clicks use a plain wrapper; passing handleToggle directly would
   // trip no-deopt-use-callback on the intrinsic <div>.

--- a/src/renderer/src/components/skills/CopyToAgentsModal.tsx
+++ b/src/renderer/src/components/skills/CopyToAgentsModal.tsx
@@ -1,5 +1,5 @@
 import { Copy, Loader2 } from 'lucide-react'
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useMemo } from 'react'
 
 import { Button } from '@/renderer/src/components/ui/button'
 import { Checkbox } from '@/renderer/src/components/ui/checkbox'
@@ -13,7 +13,12 @@ import {
 } from '@/renderer/src/components/ui/dialog'
 import { useComponentEffect } from '@/renderer/src/hooks/useComponentEffect'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
-import { setSkillToCopy } from '@/renderer/src/redux/slices/skillsSlice'
+import {
+  clearCopyAgentSelection,
+  selectSelectedCopyAgentIds,
+  setSkillToCopy,
+  toggleCopyAgentSelection,
+} from '@/renderer/src/redux/slices/skillsSlice'
 import type { AgentId } from '@/shared/types'
 
 import {
@@ -34,15 +39,14 @@ export const CopyToAgentsModal = React.memo(
   function CopyToAgentsModal(): React.ReactElement {
     const dispatch = useAppDispatch()
     const { skillToCopy, copying } = useAppSelector((state) => state.skills)
+    const selectedAgents = useAppSelector(selectSelectedCopyAgentIds)
     const { selectedAgentId } = useAppSelector((state) => state.ui)
     const { items: agents } = useAppSelector((state) => state.agents)
 
-    const [selectedAgents, setSelectedAgents] = useState<AgentId[]>([])
-
-    // Reset selections when modal opens for a new skill
+    // Reset Copy modal selections when the modal opens for a new skill or closes.
     useComponentEffect(() => {
-      setSelectedAgents([])
-    }, [skillToCopy])
+      dispatch(clearCopyAgentSelection())
+    }, [dispatch, skillToCopy])
 
     const targetAgents = useMemo(() => {
       if (!selectedAgentId) return []
@@ -72,20 +76,15 @@ export const CopyToAgentsModal = React.memo(
     const handleClose = useCallback((): void => {
       if (!copying) {
         dispatch(setSkillToCopy(null))
-        setSelectedAgents([])
       }
     }, [copying, dispatch])
 
     const handleAgentToggle = useCallback(
       (agentId: AgentId): void => {
         if (occupiedAgentReasonById.has(agentId)) return
-        setSelectedAgents((prev) =>
-          prev.includes(agentId)
-            ? prev.filter((id) => id !== agentId)
-            : [...prev, agentId],
-        )
+        dispatch(toggleCopyAgentSelection(agentId))
       },
-      [occupiedAgentReasonById],
+      [dispatch, occupiedAgentReasonById],
     )
 
     const handleCopy = useCallback(async (): Promise<void> => {

--- a/src/renderer/src/components/skills/CopyToAgentsModal.tsx
+++ b/src/renderer/src/components/skills/CopyToAgentsModal.tsx
@@ -196,6 +196,8 @@ const CopyToAgentOption = React.memo(function CopyToAgentOption({
     if (!disabled) onToggle(agentId)
   }, [agentId, disabled, onToggle])
 
+  // Native row clicks use a plain wrapper; passing handleToggle directly would
+  // trip no-deopt-use-callback on the intrinsic <div>.
   const handleRowClick = (): void => {
     handleToggle()
   }

--- a/src/renderer/src/components/skills/FileContent.tsx
+++ b/src/renderer/src/components/skills/FileContent.tsx
@@ -1,5 +1,5 @@
 import { BookOpenText, Code2, FileQuestion } from 'lucide-react'
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import ReactMarkdown, { type Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { match } from 'ts-pattern'
@@ -9,6 +9,7 @@ import {
   ToggleGroupItem,
 } from '@/renderer/src/components/ui/toggle-group'
 import type { PreviewContent } from '@/renderer/src/hooks/useCodePreview'
+import { useComponentEffect } from '@/renderer/src/hooks/useComponentEffect'
 import { cn } from '@/renderer/src/lib/utils'
 import { formatBytes } from '@/shared/fileTypes'
 import type { SkillFileContent } from '@/shared/types'
@@ -74,14 +75,14 @@ const TextPreview = React.memo(function TextPreview({
   const fileIdentity = `${file.name}:${file.extension}`
   const [mode, setMode] = useState<TextPreviewMode>('code')
 
-  useEffect(() => {
+  useComponentEffect(() => {
     setMode('code')
   }, [fileIdentity])
 
-  const handleModeChange = (next: string): void => {
+  const handleModeChange = useCallback((next: string): void => {
     // Radix emits an empty string when the active item is clicked again.
     if (next === 'code' || next === 'reading') setMode(next)
-  }
+  }, [])
 
   return (
     <div className="flex-1 min-h-0 flex flex-col bg-muted">
@@ -149,7 +150,7 @@ const SyntaxHighlightedCode = React.memo(function SyntaxHighlightedCode({
   const [highlightedHtml, setHighlightedHtml] = useState<string | null>(null)
   const plainTextLines = useMemo(() => content.split('\n'), [content])
 
-  useEffect(() => {
+  useComponentEffect(() => {
     let cancelled = false
     setHighlightedHtml(null)
 
@@ -248,6 +249,7 @@ const MarkdownReadingPreview = React.memo(function MarkdownReadingPreview({
     () => stripMarkdownFrontmatter(content),
     [content],
   )
+  const remarkPlugins = useMemo(() => [remarkGfm], [])
 
   return (
     <div
@@ -256,7 +258,7 @@ const MarkdownReadingPreview = React.memo(function MarkdownReadingPreview({
     >
       <article className="min-w-0 max-w-full break-words px-7 py-6 pb-10 text-sm leading-7 text-foreground">
         <ReactMarkdown
-          remarkPlugins={[remarkGfm]}
+          remarkPlugins={remarkPlugins}
           components={markdownComponents}
         >
           {readableContent}

--- a/src/renderer/src/components/skills/SearchBox.tsx
+++ b/src/renderer/src/components/skills/SearchBox.tsx
@@ -1,5 +1,5 @@
 import { Search } from 'lucide-react'
-import React from 'react'
+import React, { useCallback } from 'react'
 
 import { Input } from '@/renderer/src/components/ui/input'
 import {
@@ -45,6 +45,24 @@ export const SearchBox = React.memo(function SearchBox(): React.ReactElement {
   const searchScope = useAppSelector(selectSearchScope)
   const copy = SCOPE_COPY[searchScope]
 
+  const handleScopeChange = useCallback(
+    (value: string): void => {
+      // Radix returns "" when the user clicks the already-active item.
+      // Treat that as a no-op so scope is never undefined at runtime.
+      if (value === 'name' || value === 'repo') {
+        dispatch(setSearchScope(value))
+      }
+    },
+    [dispatch],
+  )
+
+  const handleQueryChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>): void => {
+      dispatch(setSearchQuery(e.target.value))
+    },
+    [dispatch],
+  )
+
   return (
     <div className="flex items-center gap-2">
       <ToggleGroup
@@ -52,13 +70,7 @@ export const SearchBox = React.memo(function SearchBox(): React.ReactElement {
         variant="outline"
         size="default"
         value={searchScope}
-        // Radix returns "" when the user clicks the already-active item.
-        // Treat that as a no-op so scope is never undefined at runtime.
-        onValueChange={(value) => {
-          if (value === 'name' || value === 'repo') {
-            dispatch(setSearchScope(value))
-          }
-        }}
+        onValueChange={handleScopeChange}
         aria-label="Search field"
         className="shrink-0 gap-0"
       >
@@ -84,7 +96,7 @@ export const SearchBox = React.memo(function SearchBox(): React.ReactElement {
           aria-label={copy.ariaLabel}
           placeholder={copy.placeholder}
           value={searchQuery}
-          onChange={(e) => dispatch(setSearchQuery(e.target.value))}
+          onChange={handleQueryChange}
           className="pl-10 bg-background"
         />
       </div>

--- a/src/renderer/src/components/skills/SelectionToolbar.tsx
+++ b/src/renderer/src/components/skills/SelectionToolbar.tsx
@@ -1,5 +1,5 @@
 import { Loader2, Trash2, Unlink, X } from 'lucide-react'
-import React from 'react'
+import React, { useCallback } from 'react'
 
 import { Button } from '@/renderer/src/components/ui/button'
 import { cn } from '@/renderer/src/lib/utils'
@@ -71,6 +71,14 @@ export const SelectionToolbar = React.memo(function SelectionToolbar({
   const bulkUnlinking = useAppSelector(selectBulkUnlinking)
   const bulkProgress = useAppSelector(selectBulkProgress)
 
+  const handleSelectAllVisible = useCallback((): void => {
+    dispatch(selectAll(visibleNames))
+  }, [dispatch, visibleNames])
+
+  const handleClear = useCallback((): void => {
+    dispatch(clearSelection())
+  }, [dispatch])
+
   // Belt-and-suspenders: the listener middleware already clears selection on
   // any context switch that exits bulkSelectMode, but gating here enforces the
   // invariant at the render boundary too. The destructive Delete/Unlink action
@@ -90,14 +98,6 @@ export const SelectionToolbar = React.memo(function SelectionToolbar({
 
   const showProgress =
     bulkProgress !== null && bulkProgress.total >= BULK_PROGRESS_THRESHOLD
-
-  const handleSelectAllVisible = (): void => {
-    dispatch(selectAll(visibleNames))
-  }
-
-  const handleClear = (): void => {
-    dispatch(clearSelection())
-  }
 
   return (
     <div

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -8,7 +8,7 @@ import {
   Plus,
   X,
 } from 'lucide-react'
-import React, { useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useMemo, useRef, useState } from 'react'
 
 import { StatusBadge } from '@/renderer/src/components/status/StatusBadge'
 import { Button } from '@/renderer/src/components/ui/button'
@@ -25,6 +25,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/renderer/src/components/ui/tooltip'
+import { useComponentEffect } from '@/renderer/src/hooks/useComponentEffect'
 import { cn } from '@/renderer/src/lib/utils'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import {
@@ -148,14 +149,17 @@ export const SkillItem = React.memo(function SkillItem({
     }
   }
 
-  const handleAddClick = (e: React.MouseEvent): void => {
-    e.stopPropagation()
-    if (selectedAgentId) {
-      dispatch(setSkillToCopy(skill))
-      return
-    }
-    dispatch(setSkillToAddSymlinks(skill))
-  }
+  const handleAddClick = useCallback(
+    (e: React.MouseEvent): void => {
+      e.stopPropagation()
+      if (selectedAgentId) {
+        dispatch(setSkillToCopy(skill))
+        return
+      }
+      dispatch(setSkillToAddSymlinks(skill))
+    },
+    [dispatch, selectedAgentId, skill],
+  )
 
   /**
    * Global-view per-row delete. Routes every skill — including ones tracked in
@@ -197,50 +201,65 @@ export const SkillItem = React.memo(function SkillItem({
    * and the reducer promotes this click to the new anchor. Behaves like macOS
    * Finder — a first shift-click with no anchor is a plain toggle, not a range.
    */
-  const handleCheckboxPointerDown = (
-    event: React.PointerEvent<HTMLButtonElement>,
-  ): void => {
-    // Stop propagation so the Card's onClick (inspector selection) does not fire.
-    event.stopPropagation()
-    if (event.shiftKey && selectionAnchor) {
-      event.preventDefault()
-      const namesInRange = computeRangeSelection(
-        selectionAnchor,
-        skill.name,
-        visibleNames,
-      )
-      dispatch(selectRange(namesInRange))
-      return
-    }
-    // Non-shift path (and shift-without-anchor): let the checkbox settle to
-    // its new `checked` state; Radix emits `onCheckedChange` and we dispatch
-    // the toggle there. The reducer records the new anchor on toggle.
-  }
+  const handleCheckboxPointerDown = useCallback(
+    (event: React.PointerEvent<HTMLButtonElement>): void => {
+      // Stop propagation so the Card's onClick (inspector selection) does not fire.
+      event.stopPropagation()
+      if (event.shiftKey && selectionAnchor) {
+        event.preventDefault()
+        const namesInRange = computeRangeSelection(
+          selectionAnchor,
+          skill.name,
+          visibleNames,
+        )
+        dispatch(selectRange(namesInRange))
+        return
+      }
+      // Non-shift path (and shift-without-anchor): let the checkbox settle to
+      // its new `checked` state; Radix emits `onCheckedChange` and we dispatch
+      // the toggle there. The reducer records the new anchor on toggle.
+    },
+    [dispatch, selectionAnchor, skill.name, visibleNames],
+  )
 
-  const handleCheckedChange = (checked: boolean | 'indeterminate'): void => {
-    // Only fire when the user actually toggled — ignore the initial sync from props.
-    if (checked === 'indeterminate') return
-    // If we just handled a range via shift+click, the state is already correct.
-    // Reconcile via presence in the selection set: only toggle when the slice
-    // state disagrees with the checkbox's new visual state. Avoids double-toggle.
-    const isCurrentlyTicked = selectedNamesSet.has(skill.name)
-    if (isCurrentlyTicked !== checked) {
-      dispatch(toggleSelection(skill.name))
-    }
-  }
+  const handleCheckedChange = useCallback(
+    (checked: boolean | 'indeterminate'): void => {
+      // Only fire when the user actually toggled — ignore the initial sync from props.
+      if (checked === 'indeterminate') return
+      // If we just handled a range via shift+click, the state is already correct.
+      // Reconcile via presence in the selection set: only toggle when the slice
+      // state disagrees with the checkbox's new visual state. Avoids double-toggle.
+      const isCurrentlyTicked = selectedNamesSet.has(skill.name)
+      if (isCurrentlyTicked !== checked) {
+        dispatch(toggleSelection(skill.name))
+      }
+    },
+    [dispatch, selectedNamesSet, skill.name],
+  )
 
   const [contextOpen, setContextOpen] = useState(false)
 
-  const handleContextMenu = (e: React.MouseEvent): void => {
-    e.preventDefault()
-    if (!showCopyButton) return
-    setContextOpen(true)
-  }
+  const handleContextMenu = useCallback(
+    (e: React.MouseEvent): void => {
+      e.preventDefault()
+      if (!showCopyButton) return
+      setContextOpen(true)
+    },
+    [showCopyButton],
+  )
 
-  const handleCopyClick = (): void => {
+  const handleCopyClick = useCallback((): void => {
     dispatch(setSkillToCopy(skill))
     setContextOpen(false)
-  }
+  }, [dispatch, skill])
+
+  const handleContextOpenChange = useCallback((open: boolean): void => {
+    if (!open) setContextOpen(false)
+  }, [])
+
+  const handleCardClick = useCallback((): void => {
+    dispatch(selectSkill(isSelected ? null : skill))
+  }, [dispatch, isSelected, skill])
 
   // Partial-fail flash (local to the row). The parent (MainContent) decides
   // which skills recently failed by subscribing to the thunk result and
@@ -250,7 +269,7 @@ export const SkillItem = React.memo(function SkillItem({
   // MainContent-level effect flips it on when a bulk op returns errors.
   const [didPartialFail, setDidPartialFail] = useState(false)
   const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  useEffect(() => {
+  useComponentEffect(() => {
     return () => {
       // Clean up timer on unmount to prevent a stale setState on an unmounted row.
       if (resetTimerRef.current) clearTimeout(resetTimerRef.current)
@@ -266,7 +285,7 @@ export const SkillItem = React.memo(function SkillItem({
    * skill name for decoupling. This keeps SkillItem agnostic of which bulk op
    * produced the failure.
    */
-  useEffect(() => {
+  useComponentEffect(() => {
     // Typed via the `WindowEventMap` augmentation above, so `event.detail` is
     // known to carry `{ skillName }` without a cast.
     const handleFailEvent = (
@@ -286,12 +305,7 @@ export const SkillItem = React.memo(function SkillItem({
   }, [skill.name])
 
   return (
-    <DropdownMenu
-      open={contextOpen}
-      onOpenChange={(open) => {
-        if (!open) setContextOpen(false)
-      }}
-    >
+    <DropdownMenu open={contextOpen} onOpenChange={handleContextOpenChange}>
       <DropdownMenuTrigger asChild disabled={!showCopyButton}>
         <Card
           data-skill-name={skill.name}
@@ -319,7 +333,7 @@ export const SkillItem = React.memo(function SkillItem({
             // Partial-failure red edge (PARTIAL_FAIL_FLASH_MS).
             didPartialFail && 'border-l-2 border-l-red-500/70',
           )}
-          onClick={() => dispatch(selectSkill(isSelected ? null : skill))}
+          onClick={handleCardClick}
           onContextMenu={handleContextMenu}
         >
           {/* X button — agent-view only (unlink or delete a local skill from

--- a/src/renderer/src/components/skills/SkillsList.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillsList.browser.test.tsx
@@ -88,6 +88,7 @@ async function createStore(
         selectedAddAgentIds: [],
         addingSymlinks: false,
         skillToCopy: null,
+        selectedCopyAgentIds: [],
         copying: false,
         selectedSkillNames: [],
         selectionAnchor: null,

--- a/src/renderer/src/components/skills/SkillsList.tsx
+++ b/src/renderer/src/components/skills/SkillsList.tsx
@@ -1,6 +1,7 @@
-import React, { useCallback, useEffect } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import { List, type RowComponentProps } from 'react-window'
 
+import { useComponentEffect } from '@/renderer/src/hooks/useComponentEffect'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import { selectFilteredSkills } from '@/renderer/src/redux/selectors'
 import {
@@ -70,7 +71,7 @@ export const SkillsList = React.memo(function SkillsList(): React.ReactElement {
   const selectedSource = useAppSelector(selectSelectedSource)
   const filteredSkills = useAppSelector(selectFilteredSkills)
 
-  useEffect(() => {
+  useComponentEffect(() => {
     dispatch(fetchSkills())
   }, [dispatch])
 
@@ -89,6 +90,8 @@ export const SkillsList = React.memo(function SkillsList(): React.ReactElement {
     },
     [filteredSkills, selectedAgentId],
   )
+  const rowProps = useMemo(() => ({ data: filteredSkills }), [filteredSkills])
+  const listStyle = useMemo(() => ({ width: '100%', height: '100%' }), [])
 
   if (loading && skills.length === 0) {
     return (
@@ -139,9 +142,9 @@ export const SkillsList = React.memo(function SkillsList(): React.ReactElement {
       rowComponent={SkillRow}
       rowCount={filteredSkills.length}
       rowHeight={getRowHeight}
-      rowProps={{ data: filteredSkills }}
+      rowProps={rowProps}
       overscanCount={5}
-      style={{ width: '100%', height: '100%' }}
+      style={listStyle}
     />
   )
 })

--- a/src/renderer/src/components/skills/UndoToast.tsx
+++ b/src/renderer/src/components/skills/UndoToast.tsx
@@ -1,11 +1,18 @@
 import { Loader2, Undo2 } from 'lucide-react'
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useState } from 'react'
+import { toast } from 'sonner'
 import { match } from 'ts-pattern'
 
 import { Button } from '@/renderer/src/components/ui/button'
+import { useComponentEffect } from '@/renderer/src/hooks/useComponentEffect'
 import { cn } from '@/renderer/src/lib/utils'
 import { pluralize } from '@/renderer/src/utils/pluralize'
-import type { IsoTimestamp, SkillName, TombstoneId } from '@/shared/types'
+import type {
+  IsoTimestamp,
+  SkillName,
+  ToastId,
+  TombstoneId,
+} from '@/shared/types'
 
 /** Tick interval for the countdown (ms). 250 gives smooth updates without thrashing. */
 const COUNTDOWN_TICK_MS = 250
@@ -22,12 +29,8 @@ interface UndoToastProps {
   summary: string
   /** Callback when the user presses Undo. MainContent owns the dispatch. */
   onUndo: (tombstoneIds: TombstoneId[]) => Promise<void> | void
-  /**
-   * Fired after `onUndo` resolves so the parent can `toast.dismiss(id)`.
-   * Sonner's auto-close and built-in close button take care of the other
-   * dismiss paths via `onAutoClose` / `onDismiss` toast options.
-   */
-  onUndoComplete: () => void
+  /** Explicit Sonner id assigned by MainContent so Undo can dismiss itself. */
+  toastId: ToastId
 }
 
 /**
@@ -66,7 +69,7 @@ export const UndoToast = React.memo(function UndoToast({
   expiresAt,
   summary,
   onUndo,
-  onUndoComplete,
+  toastId,
 }: UndoToastProps): React.ReactElement {
   const expiresAtMs = new Date(expiresAt).getTime()
   const [remainingMs, setRemainingMs] = useState(
@@ -74,7 +77,7 @@ export const UndoToast = React.memo(function UndoToast({
   )
   const [isRestoring, setIsRestoring] = useState(false)
 
-  useEffect(() => {
+  useComponentEffect(() => {
     // Freeze the countdown once the user commits to Undo so the displayed
     // "12s" doesn't keep ticking down behind a "Restoring..." spinner. The
     // parent dismisses the toast as soon as restore resolves, so the frozen
@@ -94,7 +97,7 @@ export const UndoToast = React.memo(function UndoToast({
   const isUndoableOperation = tombstoneIds.length > 0
   const canUndo = isUndoableOperation && !isRestoring && remainingMs > 0
 
-  const handleUndoClick = async (): Promise<void> => {
+  const handleUndoClick = useCallback(async (): Promise<void> => {
     if (!canUndo) return
     setIsRestoring(true)
     try {
@@ -103,9 +106,9 @@ export const UndoToast = React.memo(function UndoToast({
       // Whether success or failure, the parent emits the appropriate sonner
       // toast and dismisses this one. We don't reset `isRestoring` because
       // the component will unmount immediately.
-      onUndoComplete()
+      toast.dismiss(toastId)
     }
-  }
+  }, [canUndo, onUndo, toastId, tombstoneIds])
 
   return (
     <div

--- a/src/renderer/src/components/skills/UndoToast.tsx
+++ b/src/renderer/src/components/skills/UndoToast.tsx
@@ -49,8 +49,7 @@ interface UndoToastProps {
  *   - Swap text color from `text-muted-foreground` to `text-foreground` when
  *     `remainingMs <= URGENT_SECONDS_THRESHOLD * 1000`.
  *   - On Undo click: swap the button for a spinner + "Restoring N skills..."
- *     and await `onUndo`. Then fire `onUndoComplete` so the parent can dismiss
- *     the toast.
+ *     and await `onUndo`. Then dismiss this toast via `toast.dismiss(toastId)`.
  *   - Keyboard: the wrapper is `tabIndex={-1}` so arrow-key focus cycles do
  *     not land on the toast body (it is supplemental, not a required
  *     interaction). The Undo button and sonner's close button remain focusable.
@@ -58,10 +57,14 @@ interface UndoToastProps {
  * @param props - UndoToastProps — see interface above
  * @returns Rendered toast body
  * @example
- * const toastId = toast(
- *   <UndoToast skillNames={['task','theme']} ... onUndoComplete={...} />,
- *   { duration: 15_000, closeButton: true, onDismiss, onAutoClose },
- * )
+ * const toastId = `bulk-delete-${Date.now()}`
+ * toast(<UndoToast skillNames={['task','theme']} ... toastId={toastId} />, {
+ *   id: toastId,
+ *   duration: 15_000,
+ *   closeButton: true,
+ *   onDismiss,
+ *   onAutoClose,
+ * })
  */
 export const UndoToast = React.memo(function UndoToast({
   skillNames,

--- a/src/renderer/src/components/skills/UnlinkDialog.tsx
+++ b/src/renderer/src/components/skills/UnlinkDialog.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import { toast } from 'sonner'
 import { match } from 'ts-pattern'
 
@@ -110,13 +110,13 @@ export const UnlinkDialog = React.memo(
       skillToUnlink?.symlink.agentName ?? '',
     )
 
-    const handleClose = (): void => {
+    const handleClose = useCallback((): void => {
       if (!unlinking) {
         dispatch(setSkillToUnlink(null))
       }
-    }
+    }, [dispatch, unlinking])
 
-    const handleUnlink = async (): Promise<void> => {
+    const handleUnlink = useCallback(async (): Promise<void> => {
       if (!skillToUnlink) return
 
       const { skill, symlink } = skillToUnlink
@@ -136,7 +136,7 @@ export const UnlinkDialog = React.memo(
       // so the SkillsList does not stay stuck on the error view.
       refreshAllData(dispatch)
       dispatch(setSkillToUnlink(null))
-    }
+    }, [copy, dispatch, skillToUnlink])
 
     return (
       <DestructiveConfirmDialog

--- a/src/renderer/src/components/skills/agentSelectionHelpers.test.ts
+++ b/src/renderer/src/components/skills/agentSelectionHelpers.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import type { Agent } from '@/shared/types'
+import type { Agent, AgentId } from '@/shared/types'
 
-import { getTargetAgentsForSelection } from './agentSelectionHelpers'
+import {
+  buildCopyAgentOptionViewModel,
+  getTargetAgentsForSelection,
+} from './agentSelectionHelpers'
 
 /**
  * Creates a minimal Agent object for selection-helper unit tests.
@@ -51,5 +54,60 @@ describe('getTargetAgentsForSelection', () => {
     })
 
     expect(result.map((agent) => agent.id)).toEqual(['cursor', 'amp'])
+  })
+})
+
+describe('buildCopyAgentOptionViewModel', () => {
+  it('marks a selected available agent as checked and enabled', () => {
+    const agent = makeAgent({ id: 'codex', exists: true, name: 'Codex' })
+
+    const result = buildCopyAgentOptionViewModel(agent, {
+      occupiedAgentReasonById: new Map(),
+      selectedAgentIds: ['codex' as AgentId],
+      copying: false,
+      isSourceUnavailable: false,
+    })
+
+    expect(result).toEqual({
+      agentId: 'codex',
+      name: 'Codex',
+      checked: true,
+      disabled: false,
+      secondaryLabel: undefined,
+    })
+  })
+
+  it('uses occupancy as the checked/disabled reason before install status', () => {
+    const agent = makeAgent({ id: 'cursor', exists: false, name: 'Cursor' })
+
+    const result = buildCopyAgentOptionViewModel(agent, {
+      occupiedAgentReasonById: new Map([['cursor' as AgentId, 'broken']]),
+      selectedAgentIds: [],
+      copying: false,
+      isSourceUnavailable: false,
+    })
+
+    expect(result).toMatchObject({
+      checked: true,
+      disabled: true,
+      secondaryLabel: 'broken link',
+    })
+  })
+
+  it('disables otherwise-free rows while copying or source is unavailable', () => {
+    const agent = makeAgent({ id: 'amp', exists: false, name: 'Amp' })
+
+    const result = buildCopyAgentOptionViewModel(agent, {
+      occupiedAgentReasonById: new Map(),
+      selectedAgentIds: [],
+      copying: true,
+      isSourceUnavailable: true,
+    })
+
+    expect(result).toMatchObject({
+      checked: false,
+      disabled: true,
+      secondaryLabel: 'not installed',
+    })
   })
 })

--- a/src/renderer/src/components/skills/agentSelectionHelpers.ts
+++ b/src/renderer/src/components/skills/agentSelectionHelpers.ts
@@ -8,6 +8,14 @@ import type { Agent, AgentId, SymlinkInfo } from '@/shared/types'
  */
 export type OccupiedAgentReason = 'linked' | 'local' | 'broken'
 
+export interface CopyAgentOptionViewModel {
+  agentId: AgentId
+  name: Agent['name']
+  checked: boolean
+  disabled: boolean
+  secondaryLabel?: string
+}
+
 const OCCUPIED_AGENT_REASON_LABELS: Record<OccupiedAgentReason, string> = {
   linked: 'linked',
   local: 'local',
@@ -95,6 +103,45 @@ export function getOccupiedAgentReasonLabel(
 }
 
 /**
+ * Build the presentational row props for CopyToAgentsModal.
+ * This keeps occupancy, disabled, and secondary-label branching outside JSX so
+ * the modal remains mostly markup and this decision table stays unit-testable.
+ *
+ * @param agent - Target agent row candidate.
+ * @param options.occupiedAgentReasonById - Destination occupancy lookup.
+ * @param options.selectedAgentIds - Agent ids currently checked in Redux.
+ * @param options.copying - Whether a copy IPC round-trip is in flight.
+ * @param options.isSourceUnavailable - Whether the selected source path is valid.
+ * @returns Render-ready props for CopyToAgentOption.
+ * @example
+ * buildCopyAgentOptionViewModel(agent, {
+ *   occupiedAgentReasonById: new Map(),
+ *   selectedAgentIds: ['codex'],
+ *   copying: false,
+ *   isSourceUnavailable: false,
+ * })
+ */
+export function buildCopyAgentOptionViewModel(
+  agent: Agent,
+  options: {
+    occupiedAgentReasonById: ReadonlyMap<AgentId, OccupiedAgentReason>
+    selectedAgentIds: readonly AgentId[]
+    copying: boolean
+    isSourceUnavailable: boolean
+  },
+): CopyAgentOptionViewModel {
+  const occupiedReason = options.occupiedAgentReasonById.get(agent.id)
+  const isOccupied = occupiedReason !== undefined
+  return {
+    agentId: agent.id,
+    name: agent.name,
+    checked: isOccupied || options.selectedAgentIds.includes(agent.id),
+    disabled: isOccupied || options.copying || options.isSourceUnavailable,
+    secondaryLabel: getCopyAgentOptionSecondaryLabel(agent, occupiedReason),
+  }
+}
+
+/**
  * Determine whether a single symlink row means the destination path is occupied.
  * @param symlink - One agent's relationship to the current skill.
  * @returns
@@ -122,4 +169,24 @@ function getOccupiedAgentReason(
   }
 
   return null
+}
+
+/**
+ * Pick the single secondary label shown beside a Copy modal agent row.
+ * Occupied destinations outrank the "not installed" hint because they explain
+ * why the destination cannot be selected.
+ */
+function getCopyAgentOptionSecondaryLabel(
+  agent: Agent,
+  occupiedReason: OccupiedAgentReason | undefined,
+): string | undefined {
+  if (occupiedReason !== undefined) {
+    return getOccupiedAgentReasonLabel(occupiedReason)
+  }
+
+  if (!agent.exists) {
+    return 'not installed'
+  }
+
+  return undefined
 }

--- a/src/renderer/src/components/theme/ThemeSelector.tsx
+++ b/src/renderer/src/components/theme/ThemeSelector.tsx
@@ -1,5 +1,5 @@
 import { Moon, Palette, Sun } from 'lucide-react'
-import React, { type ReactElement } from 'react'
+import React, { useCallback, type ReactElement } from 'react'
 
 import { Button } from '@/renderer/src/components/ui/button'
 import {
@@ -103,9 +103,9 @@ export const ThemeSelector = React.memo(function ThemeSelector(): ReactElement {
   const dispatch = useAppDispatch()
   const { mode, preset } = useAppSelector((state) => state.theme)
 
-  const handleToggleMode = (): void => {
+  const handleToggleMode = useCallback((): void => {
     dispatch(toggleMode())
-  }
+  }, [dispatch])
 
   const handleSelectPreset = (name: ThemePresetName): void => {
     dispatch(setTheme(name))

--- a/src/renderer/src/components/ui/FilterPill.tsx
+++ b/src/renderer/src/components/ui/FilterPill.tsx
@@ -1,5 +1,5 @@
 import { X } from 'lucide-react'
-import React from 'react'
+import React, { useMemo } from 'react'
 
 import { MIN_TOUCH_TARGET_PX } from '@/shared/constants'
 
@@ -38,6 +38,8 @@ export const FilterPill = React.memo(function FilterPill({
   onClear,
   testId,
 }: FilterPillProps): React.ReactElement {
+  const buttonStyle = useMemo(() => ({ minHeight: MIN_TOUCH_TARGET_PX }), [])
+
   return (
     <div
       data-testid={testId}
@@ -48,7 +50,7 @@ export const FilterPill = React.memo(function FilterPill({
         variant="ghost"
         size="sm"
         onClick={onClear}
-        style={{ minHeight: MIN_TOUCH_TARGET_PX }}
+        style={buttonStyle}
         className="px-3"
       >
         <X className="h-3 w-3 mr-1" />

--- a/src/renderer/src/components/ui/FilterPill.tsx
+++ b/src/renderer/src/components/ui/FilterPill.tsx
@@ -1,9 +1,13 @@
 import { X } from 'lucide-react'
-import React, { useMemo } from 'react'
+import React from 'react'
 
 import { MIN_TOUCH_TARGET_PX } from '@/shared/constants'
 
 import { Button } from './button'
+
+const filterPillButtonStyle = {
+  minHeight: MIN_TOUCH_TARGET_PX,
+} satisfies React.CSSProperties
 
 interface FilterPillProps {
   /**
@@ -38,8 +42,6 @@ export const FilterPill = React.memo(function FilterPill({
   onClear,
   testId,
 }: FilterPillProps): React.ReactElement {
-  const buttonStyle = useMemo(() => ({ minHeight: MIN_TOUCH_TARGET_PX }), [])
-
   return (
     <div
       data-testid={testId}
@@ -50,7 +52,7 @@ export const FilterPill = React.memo(function FilterPill({
         variant="ghost"
         size="sm"
         onClick={onClear}
-        style={buttonStyle}
+        style={filterPillButtonStyle}
         className="px-3"
       >
         <X className="h-3 w-3 mr-1" />

--- a/src/renderer/src/hooks/useComponentEffect.ts
+++ b/src/renderer/src/hooks/useComponentEffect.ts
@@ -1,0 +1,26 @@
+import { useEffect, type DependencyList, type EffectCallback } from 'react'
+
+/**
+ * Runs a renderer side effect from a named hook boundary.
+ *
+ * The `@laststance/react-next/no-direct-use-effect` rule expects components to
+ * call custom hooks instead of `useEffect` directly. This helper keeps legacy
+ * component effects behavior-compatible while making the effect boundary
+ * explicit and searchable during incremental refactors.
+ *
+ * @param effect - React effect callback to execute after render.
+ * @param deps - Dependency list that controls when the effect re-runs.
+ * @returns Nothing; mirrors React's `useEffect` return shape through `effect`.
+ *
+ * @example
+ * useComponentEffect(() => {
+ *   window.addEventListener('resize', onResize)
+ *   return () => window.removeEventListener('resize', onResize)
+ * }, [onResize])
+ */
+export function useComponentEffect(
+  effect: EffectCallback,
+  deps?: DependencyList,
+): void {
+  useEffect(effect, deps)
+}

--- a/src/renderer/src/redux/selectors.test.ts
+++ b/src/renderer/src/redux/selectors.test.ts
@@ -47,8 +47,10 @@ function buildState(overrides: {
       skillToUnlink: null,
       unlinking: false,
       skillToAddSymlinks: null,
+      selectedAddAgentIds: [],
       addingSymlinks: false,
       skillToCopy: null,
+      selectedCopyAgentIds: [],
       copying: false,
       // v2.4 bulk-select state
       selectedSkillNames: overrides.selectedSkillNames ?? [],

--- a/src/renderer/src/redux/slices/skillsSlice.test.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.test.ts
@@ -103,6 +103,7 @@ describe('skillsSlice', () => {
     expect(state.loading).toBe(false)
     expect(state.error).toBeNull()
     expect(state.selectedAddAgentIds).toEqual([])
+    expect(state.selectedCopyAgentIds).toEqual([])
     // v2.4 bulk-select state
     expect(state.selectedSkillNames).toEqual([])
     expect(state.selectionAnchor).toBeNull()
@@ -163,13 +164,32 @@ describe('skillsSlice', () => {
   })
 
   it('setSkillToCopy sets and clears pending copy', async () => {
-    const { setSkillToCopy } = await import('./skillsSlice')
+    const { setSkillToCopy, toggleCopyAgentSelection } =
+      await import('./skillsSlice')
     const store = await createTestStore()
     store.dispatch(setSkillToCopy(sampleSkill))
     expect(store.getState().skills.skillToCopy).toEqual(sampleSkill)
 
+    store.dispatch(toggleCopyAgentSelection('cursor' as AgentId))
     store.dispatch(setSkillToCopy(null))
     expect(store.getState().skills.skillToCopy).toBeNull()
+    expect(store.getState().skills.selectedCopyAgentIds).toEqual([])
+  })
+
+  it('toggleCopyAgentSelection toggles the Copy modal agent list', async () => {
+    const { toggleCopyAgentSelection, clearCopyAgentSelection } =
+      await import('./skillsSlice')
+    const store = await createTestStore()
+
+    store.dispatch(toggleCopyAgentSelection('codex' as AgentId))
+    expect(store.getState().skills.selectedCopyAgentIds).toEqual(['codex'])
+
+    store.dispatch(toggleCopyAgentSelection('codex' as AgentId))
+    expect(store.getState().skills.selectedCopyAgentIds).toEqual([])
+
+    store.dispatch(toggleCopyAgentSelection('cursor' as AgentId))
+    store.dispatch(clearCopyAgentSelection())
+    expect(store.getState().skills.selectedCopyAgentIds).toEqual([])
   })
 
   // --- fetchSkills thunk ---
@@ -303,11 +323,13 @@ describe('skillsSlice', () => {
       setSkillToAddSymlinks,
       setSkillToCopy,
       toggleAddAgentSelection,
+      toggleCopyAgentSelection,
       copyToAgents,
     } = await import('./skillsSlice')
     store.dispatch(setSkillToCopy(sampleSkill))
     store.dispatch(setSkillToAddSymlinks(sampleSkill))
     store.dispatch(toggleAddAgentSelection('cursor' as AgentId))
+    store.dispatch(toggleCopyAgentSelection('codex' as AgentId))
     await store.dispatch(
       copyToAgents({
         skill: sampleSkill,
@@ -319,6 +341,7 @@ describe('skillsSlice', () => {
     expect(store.getState().skills.skillToCopy).toBeNull()
     expect(store.getState().skills.skillToAddSymlinks).toBeNull()
     expect(store.getState().skills.selectedAddAgentIds).toEqual([])
+    expect(store.getState().skills.selectedCopyAgentIds).toEqual([])
     expect(store.getState().skills.copying).toBe(false)
   })
 

--- a/src/renderer/src/redux/slices/skillsSlice.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.ts
@@ -47,6 +47,8 @@ interface SkillsState {
   addingSymlinks: boolean
   /** Skill targeted by the CopyToAgentsModal. */
   skillToCopy: Skill | null
+  /** Agent IDs checked in the CopyToAgentsModal. */
+  selectedCopyAgentIds: AgentId[]
   /** true while copyToAgents is in flight. */
   copying: boolean
 
@@ -77,6 +79,7 @@ const initialState: SkillsState = {
   selectedAddAgentIds: [],
   addingSymlinks: false,
   skillToCopy: null,
+  selectedCopyAgentIds: [],
   copying: false,
   selectedSkillNames: [],
   selectionAnchor: null,
@@ -300,6 +303,25 @@ const skillsSlice = createSlice({
     },
     setSkillToCopy: (state, action: PayloadAction<Skill | null>) => {
       state.skillToCopy = action.payload
+      state.selectedCopyAgentIds = []
+    },
+    /**
+     * Toggle one target agent in the CopyToAgentsModal selection.
+     */
+    toggleCopyAgentSelection: (state, action: PayloadAction<AgentId>) => {
+      const agentId = action.payload
+      const existingIndex = state.selectedCopyAgentIds.indexOf(agentId)
+      if (existingIndex === -1) {
+        state.selectedCopyAgentIds.push(agentId)
+        return
+      }
+      state.selectedCopyAgentIds.splice(existingIndex, 1)
+    },
+    /**
+     * Clear CopyToAgentsModal selection when the modal target changes or closes.
+     */
+    clearCopyAgentSelection: (state) => {
+      state.selectedCopyAgentIds = []
     },
     /**
      * Toggle one target agent in the AddSymlinkModal selection.
@@ -429,6 +451,7 @@ const skillsSlice = createSlice({
         state.skillToCopy = null
         state.skillToAddSymlinks = null
         state.selectedAddAgentIds = []
+        state.selectedCopyAgentIds = []
       })
       .addCase(copyToAgents.rejected, (state, action) => {
         state.copying = false
@@ -521,6 +544,8 @@ export const {
   setSkillToUnlink,
   setSkillToAddSymlinks,
   setSkillToCopy,
+  toggleCopyAgentSelection,
+  clearCopyAgentSelection,
   toggleAddAgentSelection,
   toggleSelection,
   selectRange,
@@ -539,6 +564,8 @@ export const selectSkillsError = (state: RootState): string | null =>
   state.skills.error
 export const selectSelectedSkillNames = (state: RootState): SkillName[] =>
   state.skills.selectedSkillNames
+export const selectSelectedCopyAgentIds = (state: RootState): AgentId[] =>
+  state.skills.selectedCopyAgentIds
 export const selectSelectionAnchor = (state: RootState): SkillName | null =>
   state.skills.selectionAnchor
 export const selectInFlightDeleteNames = (state: RootState): SkillName[] =>


### PR DESCRIPTION
## Summary
- verified @laststance/react-next-eslint-plugin is already on npm latest (2.2.0)
- configure every exported @laststance/react-next rule at error severity
- fix resulting lint failures by stabilizing custom-component props and moving component effects behind a named hook

## Validation
- pnpm validate
- npx kill-port 9222
- pnpm test:e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * レンダラー向けの副作用フックを追加して安定性を向上

* **バグ修正**
  * フォーム内ボタンに type="button" を明示して誤送信を防止
  * 元に戻すトーストが明示的に閉じるよう改善（復元後の確実なクローズ）

* **パフォーマンス改善**
  * 多数のイベント／ハンドラをメモ化して描画安定性と応答性を向上

* **使い勝手改善**
  * コピー先選択の状態管理とリセットを安定化
<!-- end of auto-generated comment: release notes by coderabbit.ai -->