### PR TITLE
Install React and Redux DevTools in development

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "culori": "^4.0.2",
     "electron": "^42.0.1",
     "electron-builder": "^26.8.1",
+    "electron-devtools-installer": "^4.0.0",
     "electron-vite": "^5.0.0",
     "eslint": "^10.3.0",
     "eslint-config-ts-prefixer": "^4.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
       electron-builder:
         specifier: ^26.8.1
         version: 26.8.1(electron-builder-squirrel-windows@26.8.1)
+      electron-devtools-installer:
+        specifier: ^4.0.0
+        version: 4.0.0
       electron-vite:
         specifier: ^5.0.0
         version: 5.0.0(vite@8.0.12(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
@@ -2666,6 +2669,9 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
+  electron-devtools-installer@4.0.0:
+    resolution: {integrity: sha512-9Tntu/jtfSn0n6N/ZI6IdvRqXpDyLQiDuuIbsBI+dL+1Ef7C8J2JwByw58P3TJiNeuqyV3ZkphpNWuZK5iSY2w==}
+
   electron-publish@26.8.1:
     resolution: {integrity: sha512-q+jrSTIh/Cv4eGZa7oVR+grEJo/FoLMYBAnSL5GCtqwUpr1T+VgKB/dn1pnzxIxqD8S/jP1yilT9VrwCqINR4w==}
 
@@ -3215,6 +3221,9 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   immer@11.1.8:
     resolution: {integrity: sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==}
 
@@ -3381,6 +3390,9 @@ packages:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
@@ -3470,6 +3482,9 @@ packages:
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -3482,6 +3497,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -3955,6 +3973,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
@@ -4058,6 +4079,9 @@ packages:
   proc-log@6.1.0:
     resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
@@ -4197,6 +4221,9 @@ packages:
     resolution: {integrity: sha512-qpt8EwugBWDw2cgE2W+/3oxC+KTez2uSVR8JU9Q36TXPAGCaozfQUs59v4j4GFpWTaw0i6hAZSvOmu1J0uOEUg==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
   recast@0.23.11:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
@@ -4303,6 +4330,9 @@ packages:
     resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
     engines: {node: '>=0.4'}
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
     engines: {node: '>= 0.4'}
@@ -4360,6 +4390,9 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -4511,6 +4544,9 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
@@ -4740,6 +4776,9 @@ packages:
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
 
+  unzip-crx-3@0.2.0:
+    resolution: {integrity: sha512-0+JiUq/z7faJ6oifVB5nSwt589v1KCduqIJupNVDoWSXZtWDmjDGO3RAEOvwJ07w90aoXoP4enKsR7ecMrJtWQ==}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -4776,6 +4815,9 @@ packages:
 
   utf8-byte-length@1.0.5:
     resolution: {integrity: sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   verror@1.10.1:
     resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
@@ -4970,6 +5012,9 @@ packages:
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
+
+  yaku@0.16.7:
+    resolution: {integrity: sha512-Syu3IB3rZvKvYk7yTiyl1bo/jiEFaaStrgv1V2TIJTqYPStSMQVO8EQjg/z+DRzLq/4LIIharNT3iH1hylEIRw==}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -7252,8 +7297,7 @@ snapshots:
       is-what: 5.5.0
     optional: true
 
-  core-util-is@1.0.2:
-    optional: true
+  core-util-is@1.0.2: {}
 
   crc@3.8.0:
     dependencies:
@@ -7440,6 +7484,10 @@ snapshots:
     transitivePeerDependencies:
       - electron-builder-squirrel-windows
       - supports-color
+
+  electron-devtools-installer@4.0.0:
+    dependencies:
+      unzip-crx-3: 0.2.0
 
   electron-publish@26.8.1:
     dependencies:
@@ -8231,6 +8279,8 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immediate@3.0.6: {}
+
   immer@11.1.8: {}
 
   imurmurhash@0.1.4: {}
@@ -8416,6 +8466,8 @@ snapshots:
     dependencies:
       is-inside-container: 1.0.0
 
+  isarray@1.0.0: {}
+
   isarray@2.0.5:
     optional: true
 
@@ -8488,6 +8540,13 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -8503,6 +8562,10 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -9174,6 +9237,8 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  pako@1.0.11: {}
+
   parse-entities@4.0.2:
     dependencies:
       '@types/unist': 2.0.11
@@ -9266,6 +9331,8 @@ snapshots:
       react-is: 17.0.2
 
   proc-log@6.1.0: {}
+
+  process-nextick-args@2.0.1: {}
 
   progress@2.0.3: {}
 
@@ -9426,6 +9493,16 @@ snapshots:
     dependencies:
       json-parse-even-better-errors: 4.0.0
       npm-normalize-package-bin: 4.0.0
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.2
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
 
   recast@0.23.11:
     dependencies:
@@ -9592,6 +9669,8 @@ snapshots:
       isarray: 2.0.5
     optional: true
 
+  safe-buffer@5.1.2: {}
+
   safe-push-apply@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -9655,6 +9734,8 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
     optional: true
+
+  setimmediate@1.0.5: {}
 
   sharp@0.34.5:
     dependencies:
@@ -9875,6 +9956,10 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
     optional: true
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   stringify-entities@4.0.4:
     dependencies:
@@ -10151,6 +10236,12 @@ snapshots:
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
 
+  unzip-crx-3@0.2.0:
+    dependencies:
+      jszip: 3.10.1
+      mkdirp: 0.5.6
+      yaku: 0.16.7
+
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
@@ -10181,6 +10272,8 @@ snapshots:
       react: 19.2.6
 
   utf8-byte-length@1.0.5: {}
+
+  util-deprecate@1.0.2: {}
 
   verror@1.10.1:
     dependencies:
@@ -10350,6 +10443,8 @@ snapshots:
   xmlbuilder@15.1.1: {}
 
   y18n@5.0.8: {}
+
+  yaku@0.16.7: {}
 
   yallist@3.1.1: {}
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -20,6 +20,7 @@ import { initAutoUpdater } from './updater'
 import { attachExternalLinkHandler } from './utils/attachExternalLinkHandler'
 import { clampSizeToWorkArea } from './utils/clampSizeToWorkArea'
 import { isE2EBackgroundLaunch } from './utils/e2eEnv'
+import { installDevelopmentDevToolsExtensions } from './utils/installDevelopmentDevToolsExtensions'
 import { getSecureWebPreferences } from './utils/secureWebPreferences'
 import {
   applyWindowBackgroundBlur,
@@ -297,6 +298,10 @@ app.whenReady().then(async () => {
 
   // Register IPC handlers before creating window
   registerAllHandlers()
+
+  // Dev-only: load React/Redux DevTools before renderer windows exist so
+  // Cmd+Opt+I opens with the extension panels already registered.
+  await installDevelopmentDevToolsExtensions()
 
   // Hydrate settings cache before any window opens so the first
   // `settings:get` from the renderer returns persisted values rather

--- a/src/main/utils/installDevelopmentDevToolsExtensions.test.ts
+++ b/src/main/utils/installDevelopmentDevToolsExtensions.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockState = vi.hoisted(() => ({
+  isPackaged: false,
+  isE2EBackgroundLaunch: false,
+}))
+
+const mockInstallExtension = vi.hoisted(() => vi.fn())
+
+vi.mock('electron', () => ({
+  app: {
+    get isPackaged() {
+      return mockState.isPackaged
+    },
+  },
+}))
+
+vi.mock('./e2eEnv', () => ({
+  get isE2EBackgroundLaunch() {
+    return mockState.isE2EBackgroundLaunch
+  },
+}))
+
+vi.mock('electron-devtools-installer', () => ({
+  installExtension: mockInstallExtension,
+  REACT_DEVELOPER_TOOLS: { id: 'react-devtools' },
+  REDUX_DEVTOOLS: { id: 'redux-devtools' },
+}))
+
+import {
+  installDevelopmentDevToolsExtensions,
+  shouldInstallDevelopmentDevToolsExtensions,
+} from './installDevelopmentDevToolsExtensions'
+
+/**
+ * DevTools extension loader guards. These tests keep the installer dev-only so
+ * production, E2E, and local opt-out launches do not download Chrome Web Store
+ * extensions during startup.
+ */
+describe('installDevelopmentDevToolsExtensions', () => {
+  beforeEach(() => {
+    mockState.isPackaged = false
+    mockState.isE2EBackgroundLaunch = false
+    delete process.env['SKILLS_DESKTOP_DISABLE_DEVTOOLS_EXTENSIONS']
+    mockInstallExtension.mockReset()
+    vi.spyOn(console, 'info').mockImplementation(() => undefined)
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('installs React and Redux DevTools for local development', async () => {
+    mockInstallExtension.mockResolvedValue([
+      { name: 'React Developer Tools' },
+      { name: 'Redux DevTools' },
+    ])
+
+    await installDevelopmentDevToolsExtensions()
+
+    expect(mockInstallExtension).toHaveBeenCalledWith(
+      [{ id: 'react-devtools' }, { id: 'redux-devtools' }],
+      {
+        loadExtensionOptions: {
+          allowFileAccess: true,
+        },
+      },
+    )
+    expect(console.info).toHaveBeenCalledWith(
+      'Installed Electron DevTools extensions: React Developer Tools, Redux DevTools',
+    )
+  })
+
+  it('skips packaged builds', async () => {
+    mockState.isPackaged = true
+
+    expect(shouldInstallDevelopmentDevToolsExtensions()).toBe(false)
+    await installDevelopmentDevToolsExtensions()
+
+    expect(mockInstallExtension).not.toHaveBeenCalled()
+  })
+
+  it('skips hidden E2E launches', async () => {
+    mockState.isE2EBackgroundLaunch = true
+
+    expect(shouldInstallDevelopmentDevToolsExtensions()).toBe(false)
+    await installDevelopmentDevToolsExtensions()
+
+    expect(mockInstallExtension).not.toHaveBeenCalled()
+  })
+
+  it('skips when the local opt-out env var is enabled', async () => {
+    process.env['SKILLS_DESKTOP_DISABLE_DEVTOOLS_EXTENSIONS'] = '1'
+
+    expect(shouldInstallDevelopmentDevToolsExtensions()).toBe(false)
+    await installDevelopmentDevToolsExtensions()
+
+    expect(mockInstallExtension).not.toHaveBeenCalled()
+  })
+
+  it('logs installer errors without blocking startup', async () => {
+    const error = new Error('chrome web store unavailable')
+    mockInstallExtension.mockRejectedValue(error)
+
+    await expect(
+      installDevelopmentDevToolsExtensions(),
+    ).resolves.toBeUndefined()
+
+    expect(console.warn).toHaveBeenCalledWith(
+      'Failed to install Electron DevTools extensions:',
+      error,
+    )
+  })
+})

--- a/src/main/utils/installDevelopmentDevToolsExtensions.ts
+++ b/src/main/utils/installDevelopmentDevToolsExtensions.ts
@@ -1,0 +1,73 @@
+import { app } from 'electron'
+
+import { isE2EBackgroundLaunch } from './e2eEnv'
+
+/**
+ * Environment variable for temporarily disabling Chrome DevTools extension
+ * installation while debugging local startup problems.
+ */
+const DISABLE_DEVTOOLS_EXTENSIONS_ENV =
+  'SKILLS_DESKTOP_DISABLE_DEVTOOLS_EXTENSIONS'
+
+/**
+ * Decides whether this process should install Electron DevTools extensions.
+ *
+ * The extensions are only useful during local interactive development. They
+ * download Chrome Web Store packages into Electron's `userData`, so packaged
+ * builds and hidden Playwright launches skip them to avoid network work and
+ * test flake.
+ *
+ * @returns `true` when the current process is a local interactive dev launch.
+ * @example
+ * if (shouldInstallDevelopmentDevToolsExtensions()) await installDevelopmentDevToolsExtensions()
+ */
+export function shouldInstallDevelopmentDevToolsExtensions(): boolean {
+  // Production builds should not download or load debugging extensions.
+  if (app.isPackaged) return false
+
+  // E2E launches drive the app through Playwright and should stay deterministic.
+  if (isE2EBackgroundLaunch) return false
+
+  // Local escape hatch for debugging installer/network issues.
+  if (process.env[DISABLE_DEVTOOLS_EXTENSIONS_ENV] === '1') return false
+
+  return true
+}
+
+/**
+ * Installs React DevTools and Redux DevTools into Electron's default session.
+ *
+ * Called from `app.whenReady()` before windows are created so the extensions
+ * are available when the user opens DevTools. Installer failures are non-fatal:
+ * the app should still start if Chrome Web Store downloads fail or the user is
+ * offline.
+ *
+ * @returns A promise that resolves after installation is attempted.
+ * @example
+ * await installDevelopmentDevToolsExtensions()
+ */
+export async function installDevelopmentDevToolsExtensions(): Promise<void> {
+  if (!shouldInstallDevelopmentDevToolsExtensions()) return
+
+  try {
+    const { installExtension, REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS } =
+      await import('electron-devtools-installer')
+
+    const extensions = await installExtension(
+      [REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS],
+      {
+        loadExtensionOptions: {
+          // Required when local builds render from loadFile() instead of Vite dev URL.
+          allowFileAccess: true,
+        },
+      },
+    )
+    const extensionNames = extensions.map((extension) => extension.name)
+
+    console.info(
+      `Installed Electron DevTools extensions: ${extensionNames.join(', ')}`,
+    )
+  } catch (error) {
+    console.warn('Failed to install Electron DevTools extensions:', error)
+  }
+}


### PR DESCRIPTION
## Summary
- add electron-devtools-installer as a dev dependency
- load React DevTools and Redux DevTools before dev windows are created
- skip packaged builds, hidden E2E launches, and local opt-out launches
- cover the dev-only guards and non-fatal installer failure path

## Verification
- pnpm exec vitest run src/main/utils/installDevelopmentDevToolsExtensions.test.ts
- pnpm typecheck
- pnpm lint
- pnpm exec fallow dead-code
- pnpm validate
- pnpm test:e2e
- pnpm validate (after commit hook formatting)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 開発環境でのデバッグツール統合を実装しました。
  * 開発ビルドに対する条件付きツール初期化ロジックを追加しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/skills-desktop/pull/157)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->