### PR TITLE
Fix cleanup dialog hook-order crash

### DIFF
--- a/src/renderer/src/components/sidebar/CleanupAgentDialog.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/CleanupAgentDialog.browser.test.tsx
@@ -79,6 +79,23 @@ async function renderClosedThenOpen(agentId: AgentId) {
 }
 
 describe('CleanupAgentDialog', () => {
+  it('stays closed and skips preview when no agent target is active', async () => {
+    const store = await createStore()
+    const { CleanupAgentDialog } = await import('./CleanupAgentDialog')
+
+    const screen = await render(
+      <Provider store={store}>
+        <CleanupAgentDialog />
+      </Provider>,
+    )
+
+    await expect.poll(() => mockSyncPreview.mock.calls.length).toBe(0)
+    expect(screen.getByText(/Cleanup missing skills/i).query()).toBeNull()
+    expect(
+      screen.getByRole('button', { name: /Cleanup \d+ skills/ }).query(),
+    ).toBeNull()
+  })
+
   it('opens from the closed state without changing the hook order', async () => {
     const { screen } = await renderClosedThenOpen('claude-code')
 

--- a/src/renderer/src/components/sidebar/CleanupAgentDialog.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/CleanupAgentDialog.browser.test.tsx
@@ -83,8 +83,12 @@ describe('CleanupAgentDialog', () => {
     const { screen } = await renderClosedThenOpen('claude-code')
 
     await expect
-      .poll(() => mockSyncPreview.mock.calls)
-      .toEqual([[{ agentId: 'claude-code' }]])
+      .poll(() =>
+        mockSyncPreview.mock.calls.some(
+          ([options]) => options?.agentId === 'claude-code',
+        ),
+      )
+      .toBe(true)
     await expect
       .element(screen.getByText(/Cleanup missing skills.*Claude Code/))
       .toBeInTheDocument()

--- a/src/renderer/src/components/sidebar/CleanupAgentDialog.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/CleanupAgentDialog.browser.test.tsx
@@ -1,0 +1,96 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import type { AgentId, SyncPreviewResult } from '@/shared/types'
+
+const mockSyncPreview = vi.fn()
+const mockSyncExecute = vi.fn()
+
+const SCOPED_PREVIEW: SyncPreviewResult = {
+  totalSkills: 4,
+  totalAgents: 1,
+  toCreate: 2,
+  alreadySynced: 2,
+  conflicts: [],
+  forAgent: 'claude-code',
+}
+
+beforeEach(() => {
+  mockSyncPreview.mockReset()
+  mockSyncPreview.mockResolvedValue(SCOPED_PREVIEW)
+  mockSyncExecute.mockReset()
+  mockSyncExecute.mockResolvedValue({ details: [] })
+  // Browser mode replaces Electron's preload bridge, so install the sync IPC
+  // surface that CleanupAgentDialog reaches through the Redux thunks.
+  vi.stubGlobal('electron', {
+    sync: {
+      preview: mockSyncPreview,
+      execute: mockSyncExecute,
+    },
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+/**
+ * Build the smallest Redux store CleanupAgentDialog needs.
+ * @returns Store with the ui slice wired for preview target dispatches.
+ * @example
+ * const store = await createStore()
+ * store.dispatch(setCleanupAgentTarget('claude-code'))
+ */
+async function createStore() {
+  const { default: uiReducer } =
+    await import('@/renderer/src/redux/slices/uiSlice')
+  return configureStore({
+    reducer: { ui: uiReducer },
+  })
+}
+
+/**
+ * Opens the dialog through Redux after the component's first closed render.
+ * This mirrors the production path where AgentItem sets cleanupAgentTarget
+ * from a context-menu click after CleanupAgentDialog has already mounted.
+ * @param agentId - Agent receiving the scoped cleanup preview.
+ * @returns The rendered browser screen and backing store.
+ * @example
+ * const { screen } = await renderClosedThenOpen('claude-code')
+ */
+async function renderClosedThenOpen(agentId: AgentId) {
+  const store = await createStore()
+  const { CleanupAgentDialog } = await import('./CleanupAgentDialog')
+  const { setCleanupAgentTarget } =
+    await import('@/renderer/src/redux/slices/uiSlice')
+
+  const screen = await render(
+    <Provider store={store}>
+      <CleanupAgentDialog />
+    </Provider>,
+  )
+
+  // The crash video opened the dialog from an already-mounted, closed state.
+  store.dispatch(setCleanupAgentTarget(agentId))
+
+  return { screen, store }
+}
+
+describe('CleanupAgentDialog', () => {
+  it('opens from the closed state without changing the hook order', async () => {
+    const { screen } = await renderClosedThenOpen('claude-code')
+
+    await expect
+      .poll(() => mockSyncPreview.mock.calls)
+      .toEqual([[{ agentId: 'claude-code' }]])
+    await expect
+      .element(screen.getByText(/Cleanup missing skills.*Claude Code/))
+      .toBeInTheDocument()
+    await expect.element(screen.getByText('Symlinks to create')).toBeVisible()
+    await expect
+      .element(screen.getByRole('button', { name: 'Cleanup 2 skills' }))
+      .toBeVisible()
+  })
+})

--- a/src/renderer/src/components/sidebar/CleanupAgentDialog.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/CleanupAgentDialog.browser.test.tsx
@@ -89,7 +89,8 @@ describe('CleanupAgentDialog', () => {
       </Provider>,
     )
 
-    await expect.poll(() => mockSyncPreview.mock.calls.length).toBe(0)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(mockSyncPreview).toHaveBeenCalledTimes(0)
     expect(screen.getByText(/Cleanup missing skills/i).query()).toBeNull()
     expect(
       screen.getByRole('button', { name: /Cleanup \d+ skills/ }).query(),

--- a/src/renderer/src/components/sidebar/CleanupAgentDialog.tsx
+++ b/src/renderer/src/components/sidebar/CleanupAgentDialog.tsx
@@ -82,6 +82,29 @@ export const CleanupAgentDialog = React.memo(
       )
     }, [cleanupAgentTarget, dispatch])
 
+    const handleClose = useCallback((): void => {
+      if (!isExecuting) {
+        dispatch(clearCleanupAgentTarget())
+      }
+    }, [dispatch, isExecuting])
+
+    const handleCleanup = useCallback(async (): Promise<void> => {
+      // When the dialog is closed this handler can still exist from the
+      // stable hook order; only execute once a concrete agent owns the flow.
+      if (!cleanupAgentTarget) return
+
+      const succeeded = await executeCleanup({
+        replaceConflicts: [],
+        agentId: cleanupAgentTarget,
+      })
+      if (succeeded) {
+        // Close this dialog so `SyncResultDialog` (which `executeSyncAction`
+        // already populated via `syncResult`) becomes the sole foreground
+        // surface — otherwise the per-agent dialog stays mounted underneath.
+        dispatch(clearCleanupAgentTarget())
+      }
+    }, [cleanupAgentTarget, dispatch, executeCleanup])
+
     if (!cleanupAgentTarget) return null
 
     // Stale-preview guard: only trust the preview when its `forAgent`
@@ -99,25 +122,6 @@ export const CleanupAgentDialog = React.memo(
     const alreadySyncedCount = previewMatchesTarget?.alreadySynced ?? 0
     const hasWork = missingCount > 0
     const isLoadingPreview = !previewMatchesTarget
-
-    const handleClose = useCallback((): void => {
-      if (!isExecuting) {
-        dispatch(clearCleanupAgentTarget())
-      }
-    }, [dispatch, isExecuting])
-
-    const handleCleanup = useCallback(async (): Promise<void> => {
-      const succeeded = await executeCleanup({
-        replaceConflicts: [],
-        agentId: cleanupAgentTarget,
-      })
-      if (succeeded) {
-        // Close this dialog so `SyncResultDialog` (which `executeSyncAction`
-        // already populated via `syncResult`) becomes the sole foreground
-        // surface — otherwise the per-agent dialog stays mounted underneath.
-        dispatch(clearCleanupAgentTarget())
-      }
-    }, [cleanupAgentTarget, dispatch, executeCleanup])
 
     return (
       <Dialog open onOpenChange={handleClose}>


### PR DESCRIPTION
## Summary
- keep CleanupAgentDialog hooks in a stable order when opening from the sidebar context menu
- guard the cleanup handler when no agent target is active
- add a browser regression test that opens the dialog after its initial closed render

## Verification
- pnpm test -- src/renderer/src/components/sidebar/CleanupAgentDialog.browser.test.tsx
- pnpm validate
- pnpm test:e2e
- playwright-cli: Junie right-click -> Cleanup missing skills... opens dialog with 0 console errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * ブラウザ環境向けのテストを追加し、ダイアログの開閉挙動、プレビュー呼び出しの発生、適切なエージェント情報の表示や「Cleanup 2 skills」ボタンの表示を検証しました。  
* **Bug Fixes**
  * ダイアログの閉鎖〜実行フローの安定性を強化し、閉じた後の不要な実行や状態不整合が起きないよう保護を追加しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/skills-desktop/pull/159)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->