### PR TITLE
Compact dashboard bookmark remove button

### DIFF
--- a/src/renderer/src/components/dashboard/widgets/BookmarksWidget.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/widgets/BookmarksWidget.browser.test.tsx
@@ -3,6 +3,7 @@ import { Provider } from 'react-redux'
 import { describe, expect, it } from 'vitest'
 import { render } from 'vitest-browser-react'
 
+import '@/renderer/src/styles/globals.css'
 import type { HttpUrl, RepositoryId, SkillName } from '@/shared/types'
 
 /**
@@ -44,16 +45,17 @@ async function renderBookmarksWidget(
 }
 
 describe('BookmarksWidget', () => {
-  it('keeps the remove button compact and out of row layout', async () => {
+  it('keeps long bookmark text reachable alongside the remove control', async () => {
     const { screen } = await renderBookmarksWidget()
+
+    await expect.element(screen.getByText('very-long-skill-name')).toBeVisible()
+    await expect.element(screen.getByText('laststance/skills')).toBeVisible()
 
     const removeButton = screen
       .getByRole('button', { name: /Remove bookmark very-long-skill-name/i })
       .element() as HTMLButtonElement
-    expect(removeButton.classList.contains('absolute')).toBe(true)
-    expect(removeButton.classList.contains('size-7')).toBe(true)
-    expect(removeButton.classList.contains('min-w-11')).toBe(false)
-    expect(removeButton.classList.contains('min-h-11')).toBe(false)
+
+    expect(removeButton.title).toBe('Remove very-long-skill-name')
   })
 
   it('still removes the bookmark through the compact control', async () => {

--- a/src/renderer/src/components/dashboard/widgets/BookmarksWidget.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/widgets/BookmarksWidget.browser.test.tsx
@@ -1,0 +1,69 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import { describe, expect, it } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import type { HttpUrl, RepositoryId, SkillName } from '@/shared/types'
+
+/**
+ * Render the real BookmarksWidget reducer with one bookmark.
+ * @param name - Skill name shown in the widget row.
+ * @returns Render screen plus the backing Redux store.
+ */
+async function renderBookmarksWidget(
+  name: SkillName = 'very-long-skill-name' as SkillName,
+) {
+  const [{ default: bookmarkReducer, addBookmark }, { BookmarksWidget }] =
+    await Promise.all([
+      import('@/renderer/src/redux/slices/bookmarkSlice'),
+      import('./BookmarksWidget'),
+    ])
+  const store = configureStore({
+    reducer: {
+      bookmarks: bookmarkReducer,
+    },
+  })
+
+  store.dispatch(
+    addBookmark({
+      name,
+      repo: 'laststance/skills' as RepositoryId,
+      url: 'https://skills.sh/very-long-skill-name' as HttpUrl,
+    }),
+  )
+
+  const screen = await render(
+    <Provider store={store}>
+      <div style={{ width: 160 }}>
+        <BookmarksWidget />
+      </div>
+    </Provider>,
+  )
+
+  return { screen, store }
+}
+
+describe('BookmarksWidget', () => {
+  it('keeps the remove button compact and out of row layout', async () => {
+    const { screen } = await renderBookmarksWidget()
+
+    const removeButton = screen
+      .getByRole('button', { name: /Remove bookmark very-long-skill-name/i })
+      .element() as HTMLButtonElement
+    expect(removeButton.classList.contains('absolute')).toBe(true)
+    expect(removeButton.classList.contains('size-7')).toBe(true)
+    expect(removeButton.classList.contains('min-w-11')).toBe(false)
+    expect(removeButton.classList.contains('min-h-11')).toBe(false)
+  })
+
+  it('still removes the bookmark through the compact control', async () => {
+    const { screen, store } = await renderBookmarksWidget('task' as SkillName)
+    const removeButton = screen
+      .getByRole('button', { name: /Remove bookmark task/i })
+      .element() as HTMLButtonElement
+
+    removeButton.click()
+
+    expect(store.getState().bookmarks.items).toEqual([])
+  })
+})

--- a/src/renderer/src/components/dashboard/widgets/BookmarksWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/BookmarksWidget.tsx
@@ -23,14 +23,14 @@ const BookmarkRow = React.memo(function BookmarkRow({
   onRemove,
 }: BookmarkRowProps): React.ReactElement {
   return (
-    <li className="group flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-muted">
+    <li className="group relative flex items-center gap-2 rounded-md px-2 py-1.5 pr-1 hover:bg-muted">
       <Bookmark className="h-3 w-3 shrink-0 text-primary" aria-hidden="true" />
       <a
         href={bookmark.url}
         target="_blank"
         rel="noopener noreferrer"
         className="
-          flex-1 min-w-0 inline-flex items-center gap-1 text-xs
+          flex-1 min-w-0 inline-flex items-center gap-1 pr-7 text-xs
           text-foreground hover:text-primary focus-visible:outline-none
           focus-visible:ring-2 focus-visible:ring-ring rounded
         "
@@ -50,13 +50,18 @@ const BookmarkRow = React.memo(function BookmarkRow({
         type="button"
         onClick={() => onRemove(bookmark.name)}
         aria-label={`Remove bookmark ${bookmark.name}`}
-        // 44×44 hit area per HIG — the visible X stays small so it doesn't
-        // dominate the row; opacity-0 until hover mirrors the SkillItem pattern.
+        title={`Remove ${bookmark.name}`}
+        data-bookmark-remove-button
+        // Absolute placement keeps the destructive action out of row layout,
+        // so long skill names keep the space previously consumed by 44px.
         className="
-          min-h-11 min-w-11 flex items-center justify-center
-          rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10
+          absolute right-1 top-1/2 z-10 flex size-7 -translate-y-1/2 items-center justify-center
+          rounded-md text-muted-foreground hover:bg-destructive/10 hover:text-destructive
+          pointer-events-none group-hover:pointer-events-auto focus-visible:pointer-events-auto
           opacity-0 group-hover:opacity-100 focus-visible:opacity-100
-          transition-opacity
+          transition-[opacity,background-color,color]
+          after:absolute after:-inset-1.5 after:content-['']
+          focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring
         "
       >
         <X className="h-3 w-3" aria-hidden="true" />

--- a/src/renderer/src/components/dashboard/widgets/BookmarksWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/BookmarksWidget.tsx
@@ -57,7 +57,6 @@ const BookmarkRow = React.memo(function BookmarkRow({
         className="
           absolute right-1 top-1/2 z-10 flex size-7 -translate-y-1/2 items-center justify-center
           rounded-md text-muted-foreground hover:bg-destructive/10 hover:text-destructive
-          pointer-events-none group-hover:pointer-events-auto focus-visible:pointer-events-auto
           opacity-0 group-hover:opacity-100 focus-visible:opacity-100
           transition-[opacity,background-color,color]
           after:absolute after:-inset-1.5 after:content-['']

--- a/src/renderer/src/components/dashboard/widgets/BookmarksWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/BookmarksWidget.tsx
@@ -59,7 +59,7 @@ const BookmarkRow = React.memo(function BookmarkRow({
           rounded-md text-muted-foreground hover:bg-destructive/10 hover:text-destructive
           opacity-0 group-hover:opacity-100 focus-visible:opacity-100
           transition-[opacity,background-color,color]
-          after:absolute after:-inset-1.5 after:content-['']
+          after:pointer-events-none after:absolute after:-inset-1.5 after:content-['']
           focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring
         "
       >

--- a/src/renderer/src/components/dashboard/widgets/BookmarksWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/BookmarksWidget.tsx
@@ -53,7 +53,7 @@ const BookmarkRow = React.memo(function BookmarkRow({
         title={`Remove ${bookmark.name}`}
         data-bookmark-remove-button
         // Absolute placement keeps the destructive action out of row layout,
-        // so long skill names keep the space previously consumed by 44px.
+        // reserving 32px (28px button + 4px offset) on the right edge.
         className="
           absolute right-1 top-1/2 z-10 flex size-7 -translate-y-1/2 items-center justify-center
           rounded-md text-muted-foreground hover:bg-destructive/10 hover:text-destructive


### PR DESCRIPTION
## Summary
- move the dashboard bookmark remove action out of the flex row layout
- keep the visible remove affordance to a compact icon overlay while preserving hover/focus behavior
- add a browser regression test for the compact button and removal behavior

## Inspiration / checks
- Mobbin search: dense saved/list action patterns; first query had no exact match, second confirmed compact button-heavy web surfaces
- 21st Magic MCP: attempted, but unavailable due missing x-api-key
- Product inspiration / web references: compact icon buttons are appropriate in dense layouts with labels/tooltip affordances

## Validation
- pnpm exec vitest run src/renderer/src/components/dashboard/widgets/BookmarksWidget.browser.test.tsx
- pnpm validate
- pnpm test:e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **テスト**
  * ブラウザ向けのブックマークウィジェット検証スイートを追加し、長い名前やリポジトリ表示、削除操作が正しくレンダリングされ状態が更新されることを確認。

* **スタイル・UI**
  * ブックマーク行のレイアウトを調整して右側に余白を確保。
  * 削除ボタンを右端に配置し、ホバー／フォーカス時の表示遷移と title 属性によるアクセシビリティを改善。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/skills-desktop/pull/161)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->