### PR TITLE
fix: make opacity blur visually translucent

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,7 @@
 import laststanceReactNextPlugin from '@laststance/react-next-eslint-plugin'
 import tsPrefixer from 'eslint-config-ts-prefixer'
+import { createTypeScriptImportResolver } from 'eslint-import-resolver-typescript'
+import { createNodeResolver } from 'eslint-plugin-import-x'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactYouMightNotNeedAnEffect from 'eslint-plugin-react-you-might-not-need-an-effect'
 import { defineConfig } from 'eslint/config'
@@ -39,8 +41,54 @@ const laststanceReactNextRules = Object.fromEntries(
   ]),
 )
 
+const nodeResolverExtensions = [
+  '.mjs',
+  '.js',
+  '.cjs',
+  '.mts',
+  '.ts',
+  '.jsx',
+  '.tsx',
+]
+
+const importXResolverSettings = {
+  'import-x/resolver-next': [
+    createTypeScriptImportResolver({
+      alwaysTryTypes: true,
+      project: './tsconfig.json',
+    }),
+    createNodeResolver({
+      extensions: nodeResolverExtensions,
+    }),
+  ],
+}
+
+/**
+ * Rewrite `eslint-config-ts-prefixer`'s legacy import-x resolver setting.
+ * @param config - One flat-config entry from the shared preset.
+ * @returns Equivalent config with the current resolver-next API.
+ * @example
+ * tsPrefixer.map(withImportXResolverNext)
+ */
+function withImportXResolverNext(config) {
+  if (!config.settings?.['import-x/resolver']) return config
+
+  const { ['import-x/resolver']: _legacyResolver, ...settings } =
+    config.settings
+
+  // eslint-plugin-import-x now expects resolver objects from resolver-next;
+  // keeping the legacy key makes every import rule fail before real linting.
+  return {
+    ...config,
+    settings: {
+      ...settings,
+      ...importXResolverSettings,
+    },
+  }
+}
+
 export default defineConfig([
-  ...tsPrefixer,
+  ...tsPrefixer.map(withImportXResolverNext),
   {
     languageOptions: {
       parserOptions: {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,8 @@
     "electron-vite": "^5.0.0",
     "eslint": "^10.3.0",
     "eslint-config-ts-prefixer": "^4.2.0",
+    "eslint-import-resolver-typescript": "4.4.4",
+    "eslint-plugin-import-x": "4.16.2",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-you-might-not-need-an-effect": "^0.10.1",
     "fallow": "2.69.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,7 +160,13 @@ importers:
         version: 10.3.0(jiti@2.7.0)
       eslint-config-ts-prefixer:
         specifier: ^4.2.0
-        version: 4.2.0(@typescript-eslint/utils@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.3.0(jiti@2.7.0)))(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3)
+        version: 4.2.0(@typescript-eslint/utils@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3)
+      eslint-import-resolver-typescript:
+        specifier: 4.4.4
+        version: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint@10.3.0(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@10.3.0(jiti@2.7.0))
+      eslint-plugin-import-x:
+        specifier: 4.16.2
+        version: 4.16.2(@typescript-eslint/utils@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint@10.3.0(jiti@2.7.0))
       eslint-plugin-react-hooks:
         specifier: ^7.1.1
         version: 7.1.1(eslint@10.3.0(jiti@2.7.0))
@@ -7749,10 +7755,10 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-ts-prefixer@4.2.0(@typescript-eslint/utils@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.3.0(jiti@2.7.0)))(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3):
+  eslint-config-ts-prefixer@4.2.0(@typescript-eslint/utils@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3):
     dependencies:
       eslint: 10.3.0(jiti@2.7.0)
-      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint@10.3.0(jiti@2.7.0)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.3.0(jiti@2.7.0)))(eslint@10.3.0(jiti@2.7.0))
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint@10.3.0(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@10.3.0(jiti@2.7.0))
       eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint@10.3.0(jiti@2.7.0))
       globals: 17.6.0
       typescript: 6.0.3
@@ -7779,7 +7785,7 @@ snapshots:
       - supports-color
     optional: true
 
-  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint@10.3.0(jiti@2.7.0)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.3.0(jiti@2.7.0)))(eslint@10.3.0(jiti@2.7.0)):
+  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint@10.3.0(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@10.3.0(jiti@2.7.0)):
     dependencies:
       debug: 4.4.3
       eslint: 10.3.0(jiti@2.7.0)
@@ -7790,18 +7796,19 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.3.0(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@10.3.0(jiti@2.7.0))
       eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint@10.3.0(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint@10.3.0(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@10.3.0(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3)
       eslint: 10.3.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint@10.3.0(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@10.3.0(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -7825,7 +7832,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.3.0(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@10.3.0(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7836,7 +7843,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 10.3.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint@10.3.0(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@10.3.0(jiti@2.7.0))
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -8153,7 +8160,7 @@ snapshots:
       es6-error: 4.1.1
       matcher: 3.0.0
       roarr: 2.15.4
-      semver: 7.7.4
+      semver: 7.8.0
       serialize-error: 7.0.1
     optional: true
 
@@ -9140,14 +9147,14 @@ snapshots:
 
   node-abi@4.31.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.0
 
   node-addon-api@1.7.2:
     optional: true
 
   node-api-version@0.2.1:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.0
 
   node-gyp@12.3.0:
     dependencies:
@@ -9156,7 +9163,7 @@ snapshots:
       graceful-fs: 4.2.11
       nopt: 9.0.0
       proc-log: 6.1.0
-      semver: 7.7.4
+      semver: 7.8.0
       tar: 7.5.15
       tinyglobby: 0.2.16
       undici: 6.25.0

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -24,7 +24,8 @@ import { installDevelopmentDevToolsExtensions } from './utils/installDevelopment
 import { getSecureWebPreferences } from './utils/secureWebPreferences'
 import {
   applyWindowBackgroundBlur,
-  MAIN_WINDOW_OPAQUE_BACKGROUND,
+  getMainWindowBackgroundColor,
+  shouldUseNativeWindowBlur,
 } from './utils/windowBackgroundBlur'
 
 process.on('unhandledRejection', (reason, promise) => {
@@ -71,6 +72,9 @@ function createWindow(): void {
   const launchSize = hasCustomSize
     ? clampSizeToWorkArea(persistedWindowSize, primaryWorkArea)
     : { width: DEFAULT_LAUNCH_WIDTH, height: DEFAULT_LAUNCH_HEIGHT }
+  const shouldStartWithNativeBlur = shouldUseNativeWindowBlur(
+    settings.windowBackgroundBlurRadius,
+  )
 
   const window = new BrowserWindow({
     // `useContentSize` makes `width`/`height` (and `minWidth`/`minHeight`)
@@ -86,7 +90,18 @@ function createWindow(): void {
     minWidth: 800,
     minHeight: 600,
     show: false,
-    backgroundColor: MAIN_WINDOW_OPAQUE_BACKGROUND,
+    backgroundColor: getMainWindowBackgroundColor(
+      settings.windowBackgroundBlurRadius,
+    ),
+    ...(shouldStartWithNativeBlur
+      ? {
+          // Native macOS material blur must exist below the transparent
+          // Chromium layer; otherwise translucent renderer surfaces just show
+          // a flat dark BrowserWindow backplate.
+          vibrancy: 'under-window' as const,
+          visualEffectState: 'active' as const,
+        }
+      : {}),
     // Required for the renderer root and Electron contentView alpha channel
     // to reveal the native background blur when the Appearance slider is on.
     transparent: true,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -25,7 +25,7 @@ import { getSecureWebPreferences } from './utils/secureWebPreferences'
 import {
   applyWindowBackgroundBlur,
   getMainWindowBackgroundColor,
-  shouldUseNativeWindowBlur,
+  getMainWindowOpacity,
 } from './utils/windowBackgroundBlur'
 
 process.on('unhandledRejection', (reason, promise) => {
@@ -72,10 +72,6 @@ function createWindow(): void {
   const launchSize = hasCustomSize
     ? clampSizeToWorkArea(persistedWindowSize, primaryWorkArea)
     : { width: DEFAULT_LAUNCH_WIDTH, height: DEFAULT_LAUNCH_HEIGHT }
-  const shouldStartWithNativeBlur = shouldUseNativeWindowBlur(
-    settings.windowBackgroundBlurRadius,
-  )
-
   const window = new BrowserWindow({
     // `useContentSize` makes `width`/`height` (and `minWidth`/`minHeight`)
     // describe the content area instead of the outer frame. Required for
@@ -93,17 +89,9 @@ function createWindow(): void {
     backgroundColor: getMainWindowBackgroundColor(
       settings.windowBackgroundBlurRadius,
     ),
-    ...(shouldStartWithNativeBlur
-      ? {
-          // Native macOS material blur must exist below the transparent
-          // Chromium layer; otherwise translucent renderer surfaces just show
-          // a flat dark BrowserWindow backplate.
-          vibrancy: 'under-window' as const,
-          visualEffectState: 'active' as const,
-        }
-      : {}),
-    // Required for the renderer root and Electron contentView alpha channel
-    // to reveal the native background blur when the Appearance slider is on.
+    opacity: getMainWindowOpacity(settings.windowBackgroundBlurRadius),
+    // Required for the clear BrowserWindow backplate and real window opacity
+    // to reveal the desktop behind the app when the Appearance slider is on.
     transparent: true,
     titleBarStyle: 'hiddenInset',
     trafficLightPosition: { x: 16, y: 16 },

--- a/src/main/utils/windowBackgroundBlur.test.ts
+++ b/src/main/utils/windowBackgroundBlur.test.ts
@@ -8,7 +8,27 @@ import {
   getMainWindowBackgroundColor,
   MAIN_WINDOW_OPAQUE_BACKGROUND,
   normalizeWindowBackgroundBlurRadius,
+  shouldUseNativeWindowBlur,
 } from './windowBackgroundBlur'
+
+/**
+ * Assert macOS-only vibrancy behavior without making Linux CI fail.
+ * @param window - Mock BrowserWindow returned from `makeWindowMock`.
+ * @param material - Expected vibrancy material on macOS, or null when disabled.
+ * @example
+ * expectMacVibrancy(window, 'under-window')
+ */
+function expectMacVibrancy(
+  window: BrowserWindow,
+  material: 'under-window' | null,
+): void {
+  const setVibrancy = vi.mocked(window.setVibrancy)
+  if (process.platform === 'darwin') {
+    expect(setVibrancy).toHaveBeenCalledWith(material)
+    return
+  }
+  expect(setVibrancy).not.toHaveBeenCalled()
+}
 
 /**
  * Build the minimal BrowserWindow/contentView surface the blur mutator uses.
@@ -29,6 +49,7 @@ function makeWindowMock(
   }
   const window = {
     setBackgroundColor: vi.fn(),
+    setVibrancy: vi.fn(),
     contentView,
   } as unknown as BrowserWindow
   return { window, contentView }
@@ -56,6 +77,11 @@ describe('windowBackgroundBlur helpers', () => {
     expect(getMainWindowBackgroundColor(12)).toBe('rgba(10, 15, 28, 0.92)')
   })
 
+  it('enables native blur only for non-zero radius values', () => {
+    expect(shouldUseNativeWindowBlur(0)).toBe(false)
+    expect(shouldUseNativeWindowBlur(1)).toBe(true)
+  })
+
   it('applies opaque color and zero blur when the radius is disabled', () => {
     const { window, contentView } = makeWindowMock(true)
 
@@ -64,6 +90,7 @@ describe('windowBackgroundBlur helpers', () => {
     expect(window.setBackgroundColor).toHaveBeenCalledWith(
       MAIN_WINDOW_OPAQUE_BACKGROUND,
     )
+    expectMacVibrancy(window, null)
     expect(contentView.setBackgroundColor).toHaveBeenCalledWith(
       MAIN_WINDOW_OPAQUE_BACKGROUND,
     )
@@ -78,6 +105,7 @@ describe('windowBackgroundBlur helpers', () => {
     expect(window.setBackgroundColor).toHaveBeenCalledWith(
       'rgba(10, 15, 28, 0.68)',
     )
+    expectMacVibrancy(window, 'under-window')
     expect(contentView.setBackgroundColor).toHaveBeenCalledWith(
       'rgba(10, 15, 28, 0.68)',
     )

--- a/src/main/utils/windowBackgroundBlur.test.ts
+++ b/src/main/utils/windowBackgroundBlur.test.ts
@@ -6,7 +6,9 @@ import { WINDOW_BACKGROUND_BLUR_MAX_RADIUS } from '@/shared/settings'
 import {
   applyWindowBackgroundBlur,
   getMainWindowBackgroundColor,
+  getMainWindowOpacity,
   MAIN_WINDOW_OPAQUE_BACKGROUND,
+  MAIN_WINDOW_TRANSPARENT_BACKGROUND,
   normalizeWindowBackgroundBlurRadius,
   shouldUseNativeWindowBlur,
 } from './windowBackgroundBlur'
@@ -49,6 +51,7 @@ function makeWindowMock(
   }
   const window = {
     setBackgroundColor: vi.fn(),
+    setOpacity: vi.fn(),
     setVibrancy: vi.fn(),
     contentView,
   } as unknown as BrowserWindow
@@ -73,8 +76,15 @@ describe('windowBackgroundBlur helpers', () => {
     expect(getMainWindowBackgroundColor(0)).toBe(MAIN_WINDOW_OPAQUE_BACKGROUND)
   })
 
-  it('uses slider-derived alpha background when blur is enabled', () => {
-    expect(getMainWindowBackgroundColor(12)).toBe('rgba(10, 15, 28, 0.92)')
+  it('uses a clear background when blur is enabled', () => {
+    expect(getMainWindowBackgroundColor(12)).toBe(
+      MAIN_WINDOW_TRANSPARENT_BACKGROUND,
+    )
+  })
+
+  it('maps the blur slider to real BrowserWindow opacity', () => {
+    expect(getMainWindowOpacity(0)).toBe(1)
+    expect(getMainWindowOpacity(WINDOW_BACKGROUND_BLUR_MAX_RADIUS)).toBe(0.45)
   })
 
   it('enables native blur only for non-zero radius values', () => {
@@ -87,6 +97,7 @@ describe('windowBackgroundBlur helpers', () => {
 
     applyWindowBackgroundBlur(window, 0)
 
+    expect(window.setOpacity).toHaveBeenCalledWith(1)
     expect(window.setBackgroundColor).toHaveBeenCalledWith(
       MAIN_WINDOW_OPAQUE_BACKGROUND,
     )
@@ -102,12 +113,13 @@ describe('windowBackgroundBlur helpers', () => {
 
     applyWindowBackgroundBlur(window, WINDOW_BACKGROUND_BLUR_MAX_RADIUS + 1)
 
+    expect(window.setOpacity).toHaveBeenCalledWith(0.45)
     expect(window.setBackgroundColor).toHaveBeenCalledWith(
-      'rgba(10, 15, 28, 0.68)',
+      MAIN_WINDOW_TRANSPARENT_BACKGROUND,
     )
     expectMacVibrancy(window, 'under-window')
     expect(contentView.setBackgroundColor).toHaveBeenCalledWith(
-      'rgba(10, 15, 28, 0.68)',
+      MAIN_WINDOW_TRANSPARENT_BACKGROUND,
     )
     expect(contentView.setBackgroundBlur).toHaveBeenCalledWith(
       WINDOW_BACKGROUND_BLUR_MAX_RADIUS,
@@ -118,11 +130,12 @@ describe('windowBackgroundBlur helpers', () => {
     const { window, contentView } = makeWindowMock(false)
 
     expect(() => applyWindowBackgroundBlur(window, 12)).not.toThrow()
+    expect(window.setOpacity).toHaveBeenCalledWith(0.86)
     expect(window.setBackgroundColor).toHaveBeenCalledWith(
-      'rgba(10, 15, 28, 0.92)',
+      MAIN_WINDOW_TRANSPARENT_BACKGROUND,
     )
     expect(contentView.setBackgroundColor).toHaveBeenCalledWith(
-      'rgba(10, 15, 28, 0.92)',
+      MAIN_WINDOW_TRANSPARENT_BACKGROUND,
     )
     expect('setBackgroundBlur' in contentView).toBe(false)
   })
@@ -131,8 +144,9 @@ describe('windowBackgroundBlur helpers', () => {
     const { window, contentView } = makeWindowMock(true, false)
 
     expect(() => applyWindowBackgroundBlur(window, 12)).not.toThrow()
+    expect(window.setOpacity).toHaveBeenCalledWith(0.86)
     expect(window.setBackgroundColor).toHaveBeenCalledWith(
-      'rgba(10, 15, 28, 0.92)',
+      MAIN_WINDOW_TRANSPARENT_BACKGROUND,
     )
     expect('setBackgroundColor' in contentView).toBe(false)
     expect(contentView.setBackgroundBlur).toHaveBeenCalledWith(12)

--- a/src/main/utils/windowBackgroundBlur.ts
+++ b/src/main/utils/windowBackgroundBlur.ts
@@ -22,7 +22,23 @@ type BackgroundBlurCapableView = View & {
   setBackgroundBlur?: (blurRadius: number) => void
 }
 
+const MACOS_VIBRANCY_MATERIAL = 'under-window'
+
 export { normalizeWindowBackgroundBlurRadius } from '@/shared/settings'
+
+/**
+ * Decide whether the native macOS material blur should be enabled.
+ * @param blurRadius - Normalized or raw blur radius.
+ * @returns true when the Appearance setting asks for a non-opaque window.
+ * @example
+ * shouldUseNativeWindowBlur(48) // => true
+ */
+export function shouldUseNativeWindowBlur(blurRadius: number): boolean {
+  return (
+    normalizeWindowBackgroundBlurRadius(blurRadius) >
+    normalizeWindowBackgroundBlurRadius(0)
+  )
+}
 
 /**
  * Pick the window backplate color required by Electron's blur renderer.
@@ -54,8 +70,14 @@ export function applyWindowBackgroundBlur(
 ): void {
   const normalizedRadius = normalizeWindowBackgroundBlurRadius(blurRadius)
   const backgroundColor = getMainWindowBackgroundColor(normalizedRadius)
+  const shouldEnableNativeBlur = shouldUseNativeWindowBlur(normalizedRadius)
 
   window.setBackgroundColor(backgroundColor)
+  if (process.platform === 'darwin') {
+    // macOS vibrancy supplies the system material seen through the transparent
+    // Chromium surface. Turning it off at radius 0 restores the solid app.
+    window.setVibrancy(shouldEnableNativeBlur ? MACOS_VIBRANCY_MATERIAL : null)
+  }
 
   const contentView = window.contentView as BackgroundBlurCapableView
   if (typeof contentView.setBackgroundColor === 'function') {

--- a/src/main/utils/windowBackgroundBlur.ts
+++ b/src/main/utils/windowBackgroundBlur.ts
@@ -13,10 +13,10 @@ import {
 export const MAIN_WINDOW_OPAQUE_BACKGROUND = 'rgb(10, 15, 28)'
 
 /**
- * RGB channels for the dark app canvas used by Electron before renderer CSS
- * is available. The renderer uses the OKLCH token equivalent.
+ * Fully transparent BrowserWindow backplate used when real window opacity is on.
+ * Corelive BrainDump uses the same clear backplate before applying setOpacity.
  */
-export const MAIN_WINDOW_BACKGROUND_RGB_CHANNELS = '10, 15, 28'
+export const MAIN_WINDOW_TRANSPARENT_BACKGROUND = '#00000000'
 
 type BackgroundBlurCapableView = View & {
   setBackgroundBlur?: (blurRadius: number) => void
@@ -34,25 +34,33 @@ export { normalizeWindowBackgroundBlurRadius } from '@/shared/settings'
  * shouldUseNativeWindowBlur(48) // => true
  */
 export function shouldUseNativeWindowBlur(blurRadius: number): boolean {
-  return (
-    normalizeWindowBackgroundBlurRadius(blurRadius) >
-    normalizeWindowBackgroundBlurRadius(0)
-  )
+  return normalizeWindowBackgroundBlurRadius(blurRadius) > 0
 }
 
 /**
- * Pick the window backplate color required by Electron's blur renderer.
+ * Convert the blur slider into the real Electron window opacity.
  * @param blurRadius - Normalized or raw blur radius.
- * @returns Opaque color when blur is off; slider-derived alpha when blur is on.
+ * @returns Whole-window opacity from opaque to Corelive-style transparent.
  * @example
- * getMainWindowBackgroundColor(48) // => 'rgba(10, 15, 28, 0.68)'
+ * getMainWindowOpacity(48) // => 0.45
+ */
+export function getMainWindowOpacity(blurRadius: number): number {
+  return getWindowBackgroundOpacity(blurRadius)
+}
+
+/**
+ * Pick the BrowserWindow backplate color for the current transparency mode.
+ * @param blurRadius - Normalized or raw blur radius.
+ * @returns Opaque color when blur is off; clear backplate when blur is on.
+ * @example
+ * getMainWindowBackgroundColor(48) // => '#00000000'
  */
 export function getMainWindowBackgroundColor(blurRadius: number): string {
   const normalizedRadius = normalizeWindowBackgroundBlurRadius(blurRadius)
   if (normalizedRadius > 0) {
-    const opacity = getWindowBackgroundOpacity(normalizedRadius)
-    // Electron only shows native blur through an alpha BrowserWindow backplate.
-    return `rgba(${MAIN_WINDOW_BACKGROUND_RGB_CHANNELS}, ${opacity})`
+    // The renderer paints the app chrome; Electron's native backplate must stay
+    // clear so BrowserWindow.setOpacity can reveal the desktop underneath.
+    return MAIN_WINDOW_TRANSPARENT_BACKGROUND
   }
   return MAIN_WINDOW_OPAQUE_BACKGROUND
 }
@@ -70,8 +78,10 @@ export function applyWindowBackgroundBlur(
 ): void {
   const normalizedRadius = normalizeWindowBackgroundBlurRadius(blurRadius)
   const backgroundColor = getMainWindowBackgroundColor(normalizedRadius)
+  const windowOpacity = getMainWindowOpacity(normalizedRadius)
   const shouldEnableNativeBlur = shouldUseNativeWindowBlur(normalizedRadius)
 
+  window.setOpacity(windowOpacity)
   window.setBackgroundColor(backgroundColor)
   if (process.platform === 'darwin') {
     // macOS vibrancy supplies the system material seen through the transparent

--- a/src/renderer/settings/sections/Appearance.browser.test.tsx
+++ b/src/renderer/settings/sections/Appearance.browser.test.tsx
@@ -53,7 +53,7 @@ describe('Settings → Appearance', () => {
     const slider = screen.getByRole('slider', { name: /Opacity/i })
     await slider.fill('24')
 
-    await expect.element(screen.getByText('84% / 24px')).toBeVisible()
+    await expect.element(screen.getByText('72% / 24px')).toBeVisible()
     await expect.poll(() => mockSettingsSet.mock.calls.length).toBe(1)
     expect(mockSettingsSet).toHaveBeenCalledWith({
       windowBackgroundBlurRadius: 24,

--- a/src/renderer/src/App.browser.test.tsx
+++ b/src/renderer/src/App.browser.test.tsx
@@ -58,7 +58,7 @@ vi.mock('./hooks/useUpdateNotification', () => ({
 
 /**
  * Render App with only the slices it reads directly. Heavy child panels are
- * mocked so this test can focus on the window-surface opacity contract.
+ * mocked so this test can focus on the window-surface paint contract.
  * @param windowBackgroundBlurRadius - Slider value persisted in settings.
  * @returns Browser test screen for the rendered shell.
  * @example
@@ -84,19 +84,13 @@ async function renderAppWithBlur(windowBackgroundBlurRadius: number) {
 }
 
 describe('App window surface', () => {
-  it('uses slider-derived opacity on the app backplate', async () => {
+  it('keeps the renderer surface solid while Electron owns opacity', async () => {
     const screen = await renderAppWithBlur(24)
     const surface = screen
       .getByTestId('window-background-surface')
       .element() as HTMLElement
 
-    expect(surface.style.backgroundColor).toBe(
-      'oklch(from var(--background-solid) l c h / 0.84)',
-    )
-    expect(surface.dataset['windowTranslucent']).toBe('true')
-    expect(surface.style.getPropertyValue('--window-panel-opacity')).toBe(
-      '0.45',
-    )
-    expect(surface.style.getPropertyValue('--window-fill-opacity')).toBe('0.52')
+    expect(surface.style.backgroundColor).toBe('var(--background)')
+    expect(surface.dataset['windowTranslucent']).toBeUndefined()
   })
 })

--- a/src/renderer/src/App.browser.test.tsx
+++ b/src/renderer/src/App.browser.test.tsx
@@ -91,7 +91,12 @@ describe('App window surface', () => {
       .element() as HTMLElement
 
     expect(surface.style.backgroundColor).toBe(
-      'oklch(from var(--background) l c h / 0.84)',
+      'oklch(from var(--background-solid) l c h / 0.84)',
     )
+    expect(surface.dataset['windowTranslucent']).toBe('true')
+    expect(surface.style.getPropertyValue('--window-panel-opacity')).toBe(
+      '0.45',
+    )
+    expect(surface.style.getPropertyValue('--window-fill-opacity')).toBe('0.52')
   })
 })

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -2,8 +2,6 @@ import React from 'react'
 import { Panel, Group, Separator } from 'react-resizable-panels'
 import { Toaster } from 'sonner'
 
-import { getWindowBackgroundOpacity } from '@/shared/settings'
-
 import { DetailPanel } from './components/layout/DetailPanel'
 import { MainContent } from './components/layout/MainContent'
 import { Sidebar } from './components/layout/Sidebar'
@@ -98,13 +96,6 @@ const toasterStyle = {
   '--width': '312px',
 } as React.CSSProperties
 
-type WindowSurfaceStyle = React.CSSProperties & {
-  '--window-background-opacity': string
-  '--window-panel-opacity': string
-  '--window-fill-opacity': string
-  '--window-popover-opacity': string
-}
-
 /**
  * Skills Desktop main application component
  * Layout: Sidebar (240px) | Main | Detail
@@ -125,34 +116,16 @@ const App = React.memo(function App(): React.ReactElement {
   // Drive sonner's theme prop from the persisted redux mode so toasts honor
   // the user's light/dark choice. Pre-fix this was hardcoded `theme="dark"`.
   const mode = useAppSelector((state) => state.theme.mode)
-  const windowBackgroundBlurRadius = useAppSelector(
-    (state) => state.settings.windowBackgroundBlurRadius,
-  )
-  const windowBackgroundOpacity = getWindowBackgroundOpacity(
-    windowBackgroundBlurRadius,
-  )
-  const isWindowTranslucent = windowBackgroundOpacity < 1
-  // Child panes use a lower alpha than the root so stacked backgrounds still
-  // reveal the native macOS blur instead of recomposing back to opaque black.
-  const windowPanelOpacity = Number((windowBackgroundOpacity * 0.54).toFixed(2))
-  const windowFillOpacity = Number((windowBackgroundOpacity * 0.62).toFixed(2))
-  const windowSurfaceStyle = {
-    '--window-background-opacity': `${windowBackgroundOpacity}`,
-    '--window-panel-opacity': `${windowPanelOpacity}`,
-    '--window-fill-opacity': `${windowFillOpacity}`,
-    '--window-popover-opacity': isWindowTranslucent ? '0.94' : '1',
-    backgroundColor: `oklch(from var(--background-solid) l c h / ${windowBackgroundOpacity})`,
-  } satisfies WindowSurfaceStyle
 
   return (
     <TooltipProvider delayDuration={200}>
       {/* Window glow effect - subtle inner shadow for depth */}
       <div
         data-testid="window-background-surface"
-        data-window-translucent={isWindowTranslucent ? 'true' : 'false'}
         className="window-background-surface flex h-screen text-foreground window-glow transition-[background-color]"
-        // Keep text opaque while the slider changes only the app backplate.
-        style={windowSurfaceStyle}
+        // Match Corelive BrainDump: renderer paints a solid surface, while
+        // BrowserWindow.setOpacity controls real desktop transparency.
+        style={{ backgroundColor: 'var(--background)' }}
       >
         <Sidebar />
         <Group orientation="horizontal" className="flex-1 h-full">

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -98,6 +98,13 @@ const toasterStyle = {
   '--width': '312px',
 } as React.CSSProperties
 
+type WindowSurfaceStyle = React.CSSProperties & {
+  '--window-background-opacity': string
+  '--window-panel-opacity': string
+  '--window-fill-opacity': string
+  '--window-popover-opacity': string
+}
+
 /**
  * Skills Desktop main application component
  * Layout: Sidebar (240px) | Main | Detail
@@ -124,17 +131,28 @@ const App = React.memo(function App(): React.ReactElement {
   const windowBackgroundOpacity = getWindowBackgroundOpacity(
     windowBackgroundBlurRadius,
   )
+  const isWindowTranslucent = windowBackgroundOpacity < 1
+  // Child panes use a lower alpha than the root so stacked backgrounds still
+  // reveal the native macOS blur instead of recomposing back to opaque black.
+  const windowPanelOpacity = Number((windowBackgroundOpacity * 0.54).toFixed(2))
+  const windowFillOpacity = Number((windowBackgroundOpacity * 0.62).toFixed(2))
+  const windowSurfaceStyle = {
+    '--window-background-opacity': `${windowBackgroundOpacity}`,
+    '--window-panel-opacity': `${windowPanelOpacity}`,
+    '--window-fill-opacity': `${windowFillOpacity}`,
+    '--window-popover-opacity': isWindowTranslucent ? '0.94' : '1',
+    backgroundColor: `oklch(from var(--background-solid) l c h / ${windowBackgroundOpacity})`,
+  } satisfies WindowSurfaceStyle
 
   return (
     <TooltipProvider delayDuration={200}>
       {/* Window glow effect - subtle inner shadow for depth */}
       <div
         data-testid="window-background-surface"
-        className="flex h-screen text-foreground window-glow transition-[background-color]"
+        data-window-translucent={isWindowTranslucent ? 'true' : 'false'}
+        className="window-background-surface flex h-screen text-foreground window-glow transition-[background-color]"
         // Keep text opaque while the slider changes only the app backplate.
-        style={{
-          backgroundColor: `oklch(from var(--background) l c h / ${windowBackgroundOpacity})`,
-        }}
+        style={windowSurfaceStyle}
       >
         <Sidebar />
         <Group orientation="horizontal" className="flex-1 h-full">

--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -35,16 +35,13 @@
    * ============================================ */
 
   .dark {
-    --background-solid: oklch(0.12 var(--chroma-5) var(--theme-hue));
-    --background: var(--background-solid);
+    --background: oklch(0.12 var(--chroma-5) var(--theme-hue));
     --foreground: oklch(0.98 var(--chroma-3) var(--theme-hue));
 
-    --card-solid: oklch(0.18 var(--chroma-6) var(--theme-hue));
-    --card: var(--card-solid);
+    --card: oklch(0.18 var(--chroma-6) var(--theme-hue));
     --card-foreground: oklch(0.98 var(--chroma-3) var(--theme-hue));
 
-    --popover-solid: oklch(0.18 var(--chroma-6) var(--theme-hue));
-    --popover: var(--popover-solid);
+    --popover: oklch(0.18 var(--chroma-6) var(--theme-hue));
     --popover-foreground: oklch(0.98 var(--chroma-3) var(--theme-hue));
 
     /* Primary / accent ride the theme-chroma axis directly so color
@@ -53,12 +50,10 @@
     --primary: oklch(0.7 var(--theme-chroma) var(--theme-hue));
     --primary-foreground: oklch(0.12 var(--chroma-5) var(--theme-hue));
 
-    --secondary-solid: oklch(0.25 var(--chroma-7) var(--theme-hue));
-    --secondary: var(--secondary-solid);
+    --secondary: oklch(0.25 var(--chroma-7) var(--theme-hue));
     --secondary-foreground: oklch(0.98 var(--chroma-3) var(--theme-hue));
 
-    --muted-solid: oklch(0.25 var(--chroma-7) var(--theme-hue));
-    --muted: var(--muted-solid);
+    --muted: oklch(0.25 var(--chroma-7) var(--theme-hue));
     --muted-foreground: oklch(0.65 var(--chroma-5) var(--theme-hue));
 
     --accent: oklch(0.7 var(--theme-chroma) var(--theme-hue));
@@ -92,27 +87,22 @@
   }
 
   .light {
-    --background-solid: oklch(0.99 var(--chroma-1) var(--theme-hue));
-    --background: var(--background-solid);
+    --background: oklch(0.99 var(--chroma-1) var(--theme-hue));
     --foreground: oklch(0.15 var(--chroma-7) var(--theme-hue));
 
-    --card-solid: oklch(0.97 var(--chroma-2) var(--theme-hue));
-    --card: var(--card-solid);
+    --card: oklch(0.97 var(--chroma-2) var(--theme-hue));
     --card-foreground: oklch(0.15 var(--chroma-7) var(--theme-hue));
 
-    --popover-solid: oklch(0.99 var(--chroma-1) var(--theme-hue));
-    --popover: var(--popover-solid);
+    --popover: oklch(0.99 var(--chroma-1) var(--theme-hue));
     --popover-foreground: oklch(0.15 var(--chroma-7) var(--theme-hue));
 
     --primary: oklch(0.5 var(--theme-chroma) var(--theme-hue));
     --primary-foreground: oklch(0.99 var(--chroma-1) var(--theme-hue));
 
-    --secondary-solid: oklch(0.95 var(--chroma-4) var(--theme-hue));
-    --secondary: var(--secondary-solid);
+    --secondary: oklch(0.95 var(--chroma-4) var(--theme-hue));
     --secondary-foreground: oklch(0.15 var(--chroma-7) var(--theme-hue));
 
-    --muted-solid: oklch(0.95 var(--chroma-4) var(--theme-hue));
-    --muted: var(--muted-solid);
+    --muted: oklch(0.95 var(--chroma-4) var(--theme-hue));
     --muted-foreground: oklch(0.45 var(--chroma-5) var(--theme-hue));
 
     --accent: oklch(0.5 var(--theme-chroma) var(--theme-hue));
@@ -144,20 +134,6 @@
     font-variant-numeric: tabular-nums;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-  }
-
-  .window-background-surface[data-window-translucent='true'] {
-    --background: oklch(
-      from var(--background-solid) l c h / var(--window-background-opacity)
-    );
-    --card: oklch(from var(--card-solid) l c h / var(--window-panel-opacity));
-    --muted: oklch(from var(--muted-solid) l c h / var(--window-fill-opacity));
-    --secondary: oklch(
-      from var(--secondary-solid) l c h / var(--window-fill-opacity)
-    );
-    --popover: oklch(
-      from var(--popover-solid) l c h / var(--window-popover-opacity)
-    );
   }
 
   /* Electron window drag region */

--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -35,13 +35,16 @@
    * ============================================ */
 
   .dark {
-    --background: oklch(0.12 var(--chroma-5) var(--theme-hue));
+    --background-solid: oklch(0.12 var(--chroma-5) var(--theme-hue));
+    --background: var(--background-solid);
     --foreground: oklch(0.98 var(--chroma-3) var(--theme-hue));
 
-    --card: oklch(0.18 var(--chroma-6) var(--theme-hue));
+    --card-solid: oklch(0.18 var(--chroma-6) var(--theme-hue));
+    --card: var(--card-solid);
     --card-foreground: oklch(0.98 var(--chroma-3) var(--theme-hue));
 
-    --popover: oklch(0.18 var(--chroma-6) var(--theme-hue));
+    --popover-solid: oklch(0.18 var(--chroma-6) var(--theme-hue));
+    --popover: var(--popover-solid);
     --popover-foreground: oklch(0.98 var(--chroma-3) var(--theme-hue));
 
     /* Primary / accent ride the theme-chroma axis directly so color
@@ -50,10 +53,12 @@
     --primary: oklch(0.7 var(--theme-chroma) var(--theme-hue));
     --primary-foreground: oklch(0.12 var(--chroma-5) var(--theme-hue));
 
-    --secondary: oklch(0.25 var(--chroma-7) var(--theme-hue));
+    --secondary-solid: oklch(0.25 var(--chroma-7) var(--theme-hue));
+    --secondary: var(--secondary-solid);
     --secondary-foreground: oklch(0.98 var(--chroma-3) var(--theme-hue));
 
-    --muted: oklch(0.25 var(--chroma-7) var(--theme-hue));
+    --muted-solid: oklch(0.25 var(--chroma-7) var(--theme-hue));
+    --muted: var(--muted-solid);
     --muted-foreground: oklch(0.65 var(--chroma-5) var(--theme-hue));
 
     --accent: oklch(0.7 var(--theme-chroma) var(--theme-hue));
@@ -87,22 +92,27 @@
   }
 
   .light {
-    --background: oklch(0.99 var(--chroma-1) var(--theme-hue));
+    --background-solid: oklch(0.99 var(--chroma-1) var(--theme-hue));
+    --background: var(--background-solid);
     --foreground: oklch(0.15 var(--chroma-7) var(--theme-hue));
 
-    --card: oklch(0.97 var(--chroma-2) var(--theme-hue));
+    --card-solid: oklch(0.97 var(--chroma-2) var(--theme-hue));
+    --card: var(--card-solid);
     --card-foreground: oklch(0.15 var(--chroma-7) var(--theme-hue));
 
-    --popover: oklch(0.99 var(--chroma-1) var(--theme-hue));
+    --popover-solid: oklch(0.99 var(--chroma-1) var(--theme-hue));
+    --popover: var(--popover-solid);
     --popover-foreground: oklch(0.15 var(--chroma-7) var(--theme-hue));
 
     --primary: oklch(0.5 var(--theme-chroma) var(--theme-hue));
     --primary-foreground: oklch(0.99 var(--chroma-1) var(--theme-hue));
 
-    --secondary: oklch(0.95 var(--chroma-4) var(--theme-hue));
+    --secondary-solid: oklch(0.95 var(--chroma-4) var(--theme-hue));
+    --secondary: var(--secondary-solid);
     --secondary-foreground: oklch(0.15 var(--chroma-7) var(--theme-hue));
 
-    --muted: oklch(0.95 var(--chroma-4) var(--theme-hue));
+    --muted-solid: oklch(0.95 var(--chroma-4) var(--theme-hue));
+    --muted: var(--muted-solid);
     --muted-foreground: oklch(0.45 var(--chroma-5) var(--theme-hue));
 
     --accent: oklch(0.5 var(--theme-chroma) var(--theme-hue));
@@ -134,6 +144,20 @@
     font-variant-numeric: tabular-nums;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+  }
+
+  .window-background-surface[data-window-translucent='true'] {
+    --background: oklch(
+      from var(--background-solid) l c h / var(--window-background-opacity)
+    );
+    --card: oklch(from var(--card-solid) l c h / var(--window-panel-opacity));
+    --muted: oklch(from var(--muted-solid) l c h / var(--window-fill-opacity));
+    --secondary: oklch(
+      from var(--secondary-solid) l c h / var(--window-fill-opacity)
+    );
+    --popover: oklch(
+      from var(--popover-solid) l c h / var(--window-popover-opacity)
+    );
   }
 
   /* Electron window drag region */

--- a/src/shared/settings.test.ts
+++ b/src/shared/settings.test.ts
@@ -249,7 +249,7 @@ describe('SettingsSchema', () => {
 
 /**
  * Pure helpers shared by the main process and renderer. These keep Electron's
- * native backplate and the React app root on the same visible opacity curve.
+ * native backplate and the real Electron window opacity on the same curve.
  */
 describe('window background appearance helpers', () => {
   it('clamps blur radius values before opacity math', () => {
@@ -273,6 +273,6 @@ describe('window background appearance helpers', () => {
   })
 
   it('maps mid slider values to visibly different opacity', () => {
-    expect(getWindowBackgroundOpacity(24)).toBe(0.84)
+    expect(getWindowBackgroundOpacity(24)).toBe(0.72)
   })
 })

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -27,11 +27,11 @@ export const WINDOW_BACKGROUND_BLUR_MAX_RADIUS = 48
 
 /**
  * Visual opacity range paired with the background blur slider.
- * `1` keeps the app surface fully opaque when blur is off; the minimum keeps
- * text contrast comfortable while still revealing macOS material underneath.
+ * `1` keeps the app surface fully opaque when blur is off; the minimum mirrors
+ * Corelive BrainDump's real Electron window opacity so the desktop is visible.
  */
 export const WINDOW_BACKGROUND_OPACITY_MAX = 1
-export const WINDOW_BACKGROUND_OPACITY_MIN = 0.68
+export const WINDOW_BACKGROUND_OPACITY_MIN = 0.45
 
 /**
  * Clamp a persisted blur radius before it touches Electron or CSS surfaces.
@@ -52,9 +52,9 @@ export function normalizeWindowBackgroundBlurRadius(
 /**
  * Convert the blur slider into the visible app-surface opacity.
  * @param blurRadius - User setting from `settings.json` or IPC.
- * @returns Background alpha, where higher blur means more transparency.
+ * @returns BrowserWindow opacity, where higher blur means more transparency.
  * @example
- * getWindowBackgroundOpacity(24) // => 0.84
+ * getWindowBackgroundOpacity(24) // => 0.72
  */
 export function getWindowBackgroundOpacity(blurRadius: number): number {
   const normalizedRadius = normalizeWindowBackgroundBlurRadius(blurRadius)


### PR DESCRIPTION
## Summary
- Match Corelive BrainDump transparency: use a clear Electron backplate plus `BrowserWindow.setOpacity()` so the actual desktop/windows behind Skills Desktop are visible.
- Keep the renderer surface solid and let Electron own opacity, preventing nested panes/cards from cancelling transparency.
- Change the Opacity/Blur curve to reach 45% at 48px, matching the Corelive BrainDump reference.
- Keep macOS vibrancy/background blur enabled as an enhancement, and update tests around the new window-opacity contract.
- Update the ESLint import-x resolver config required by the current resolver API.

## Verification
- Context7 Electron docs checked for `transparent`, `BrowserWindow.opacity`, `win.setOpacity()`, and `win.setVibrancy()` behavior.
- Compared against Corelive implementation:
  - `/Users/ryotamurakami/laststance/corelive/electron/WindowManager.ts` uses `transparent: true`, `backgroundColor: #00000000`, and `setOpacity()` for BrainDump.
  - `/Users/ryotamurakami/laststance/corelive/src/components/braindump/BrainDumpEditor.tsx` drives the opacity slider through `brainDumpAPI.window.setOpacity()`.
- Visual verification: set Skills Desktop `windowBackgroundBlurRadius` to 48 through CDP, confirmed setting persisted and captured a screenshot showing the desktop wallpaper/icons through the full app window.
- `pnpm test -- src/main/utils/windowBackgroundBlur.test.ts src/shared/settings.test.ts src/renderer/src/App.browser.test.tsx src/renderer/settings/sections/Appearance.browser.test.tsx`
- `pnpm validate`
- `pnpm test:e2e` (41 passed, 2 skipped)

## Visual Proof
Attached with `gh attach`.

Top: Corelive BrainDump reference. Bottom: verified Skills Desktop real window opacity result.

![Corelive vs Skills Desktop real opacity](https://github.com/laststance/skills-desktop/releases/download/gh-attach-assets/corelive-vs-skills-desktop-real-opacity.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * macOS での ネイティブビブランシー機能を追加しました。

* **バグ修正**
  * ウィンドウ背景のぼかし処理を改善し、動的な不透明度と背景色の計算を実装しました。
  * ウィンドウ外観のスタイリングを簡潔に改善しました。

* **変更**
  * 不透明度の計算ロジックを調整しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/skills-desktop/pull/165)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->