### PR TITLE
Fix marketplace search result parsing

### DIFF
--- a/src/main/services/skillsCliService.test.ts
+++ b/src/main/services/skillsCliService.test.ts
@@ -128,3 +128,49 @@ describe('skillsCliService.execCli environment', () => {
     )
   })
 })
+
+describe('skillsCliService.search', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+    vi.resetModules()
+    spawnMock.mockReset()
+  })
+
+  afterEach(() => {
+    process.env.PATH = ORIGINAL_PATH
+  })
+
+  it('parses current skills find output with install counts', async () => {
+    simulateCli({
+      stdout: [
+        'Install with npx skills add <owner/repo@skill>',
+        '',
+        'vercel-labs/agent-skills@vercel-react-best-practices 402.7K installs',
+        '└ https://skills.sh/vercel-labs/agent-skills/vercel-react-best-practices',
+        '',
+        'google-labs-code/stitch-skills@react:components 44.5K installs',
+        '└ https://skills.sh/google-labs-code/stitch-skills/react:components',
+      ].join('\n'),
+    })
+
+    const { skillsCliService } = await import('./skillsCliService')
+    const results = await skillsCliService.search('react')
+
+    expect(results).toEqual([
+      {
+        rank: 1,
+        name: 'vercel-react-best-practices',
+        repo: 'vercel-labs/agent-skills',
+        url: 'https://skills.sh/vercel-labs/agent-skills/vercel-react-best-practices',
+        installCount: 402700,
+      },
+      {
+        rank: 2,
+        name: 'react:components',
+        repo: 'google-labs-code/stitch-skills',
+        url: 'https://skills.sh/google-labs-code/stitch-skills/react:components',
+        installCount: 44500,
+      },
+    ])
+  })
+})

--- a/src/main/services/skillsCliService.test.ts
+++ b/src/main/services/skillsCliService.test.ts
@@ -173,4 +173,26 @@ describe('skillsCliService.search', () => {
       },
     ])
   })
+
+  it('parses legacy skills find output without install counts', async () => {
+    simulateCli({
+      stdout: [
+        'vercel-labs/agent-skills@vercel-react-best-practices',
+        '└ https://skills.sh/vercel-labs/agent-skills/vercel-react-best-practices',
+      ].join('\n'),
+    })
+
+    const { skillsCliService } = await import('./skillsCliService')
+    const results = await skillsCliService.search('react')
+
+    expect(results).toEqual([
+      {
+        rank: 1,
+        name: 'vercel-react-best-practices',
+        repo: 'vercel-labs/agent-skills',
+        url: 'https://skills.sh/vercel-labs/agent-skills/vercel-react-best-practices',
+      },
+    ])
+    expect(results[0]).not.toHaveProperty('installCount')
+  })
 })

--- a/src/main/services/skillsCliService.ts
+++ b/src/main/services/skillsCliService.ts
@@ -5,6 +5,7 @@ import { delimiter, join } from 'path'
 
 import { match, P } from 'ts-pattern'
 
+import { parseFormattedCount } from '@/main/services/leaderboardService'
 import { REPO_PATTERN, SKILL_NAME_PATTERN } from '@/main/utils/skillIdentifiers'
 import { AGENT_DEFINITIONS, SKILLS_CLI_VERSION } from '@/shared/constants'
 import { repositoryId } from '@/shared/types'
@@ -39,6 +40,12 @@ const CLI_FLAGS = {
 const SPAWN_TIMEOUT_MS = 60_000
 /** Signal used for user cancel and timeout kill paths. */
 const PROCESS_KILL_SIGNAL: NodeJS.Signals = 'SIGTERM'
+/**
+ * Matches both legacy `owner/repo@skill` output and current CLI lines with
+ * trailing telemetry, for example `owner/repo@skill 402.7K installs`.
+ */
+const CLI_SEARCH_RESULT_PATTERN =
+  /^([^@\s]+)@([^\s]+)(?:\s+(\d[\d,.]*(?:\s*[KMB])?)\s+installs?)?$/i
 
 /**
  * Common Node.js binary locations missing from Finder-launched macOS apps.
@@ -267,7 +274,7 @@ class SkillsCliService extends EventEmitter {
    * Parse `npx skills find` output into structured results
    * Output format:
    * ```
-   * vercel-labs/agent-skills@vercel-react-best-practices
+   * vercel-labs/agent-skills@vercel-react-best-practices 402.7K installs
    * └ https://skills.sh/vercel-labs/agent-skills/vercel-react-best-practices
    * ```
    * @param output - Raw CLI output
@@ -283,10 +290,10 @@ class SkillsCliService extends EventEmitter {
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i].trim()
 
-      // Match pattern: owner/repo@skill-name
-      const match = line.match(/^([^@\s]+)@([^\s]+)$/)
+      // Match result rows while skipping banners, hints, and blank lines.
+      const match = line.match(CLI_SEARCH_RESULT_PATTERN)
       if (match) {
-        const [, repo, name] = match
+        const [, repo, name, installCountText] = match
         // Reject anything that isn't a plain npm/GitHub identifier — see
         // SKILL_NAME_PATTERN comment. Without this, a malformed CLI line
         // could land in aria-labels and copy-paste hints downstream.
@@ -297,12 +304,17 @@ class SkillsCliService extends EventEmitter {
         const urlLine = lines[i + 1]?.trim()
         const urlMatch = urlLine?.match(/^[└├]\s*(https?:\/\/[^\s]+)$/)
 
-        results.push({
+        const searchResult: SkillSearchResult = {
           rank: rank++,
           name,
           repo: repositoryId(repo),
           url: urlMatch?.[1] || `https://skills.sh/${repo}/${name}`,
-        })
+        }
+        // Older CLI output omits telemetry, so only attach the field when seen.
+        if (installCountText) {
+          searchResult.installCount = parseFormattedCount(installCountText)
+        }
+        results.push(searchResult)
       }
     }
 

--- a/src/main/utils/skillIdentifiers.ts
+++ b/src/main/utils/skillIdentifiers.ts
@@ -6,15 +6,19 @@
  * metacharacters, whitespace, or `..` traversal-shaped tokens that
  * surface as broken UI or, worse, get pasted into a terminal verbatim.
  *
- * Each segment must:
+ * Repo segments must:
  *  - start with an alphanumeric (rejects `.`, `..`, `.git`, `-x`)
  *  - contain only `[a-zA-Z0-9._-]` thereafter
+ *
+ * Skill names follow the same rule and additionally allow `:` because the
+ * upstream skills CLI returns namespaced skills like `react:components`.
  *
  * Sharing one source means both parsers stay in lockstep — bumping
  * the rule in one place can't silently leave the other parser laxer.
  */
-const SEGMENT = /[a-zA-Z0-9][a-zA-Z0-9._-]*/
-export const SKILL_NAME_PATTERN = new RegExp(`^${SEGMENT.source}$`)
+const REPO_SEGMENT = /[a-zA-Z0-9][a-zA-Z0-9._-]*/
+const SKILL_SEGMENT = /[a-zA-Z0-9][a-zA-Z0-9._:-]*/
+export const SKILL_NAME_PATTERN = new RegExp(`^${SKILL_SEGMENT.source}$`)
 export const REPO_PATTERN = new RegExp(
-  `^${SEGMENT.source}\\/${SEGMENT.source}$`,
+  `^${REPO_SEGMENT.source}\\/${REPO_SEGMENT.source}$`,
 )


### PR DESCRIPTION
## Summary
- parse current `skills find` output that includes trailing install counts
- preserve legacy search output compatibility when telemetry is absent
- allow namespaced skill IDs such as `react:components` from the upstream CLI

## Validation
- `pnpm vitest run src/main/services/skillsCliService.test.ts src/main/services/leaderboardService.test.ts`
- `pnpm validate`
- `pnpm test:e2e`
- Playwright CLI manual check: Marketplace search for `react` rendered `Found 6 skills for "react"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * スキル検索結果にインストール数（formatted → 数値）を含める出力に対応しました。新形式ではinstall数が数値として返され、旧形式では付与されません。
  * 名前空間を含むスキル名（例: react:components）を許容するようになりました。

* **テスト**
  * 新旧出力それぞれの振る舞い（install数の有無と数値化）を検証するテストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/skills-desktop/pull/166?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->