### PR TITLE
Add copy action to skill info paths

### DIFF
--- a/src/renderer/src/components/skills/SkillDetail.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillDetail.browser.test.tsx
@@ -9,6 +9,7 @@ import type { Agent, AgentId, Skill, SymlinkInfo } from '@/shared/types'
 const SOURCE_PATH = '/home/user/.agents/skills/task'
 const CURSOR_PATH = '/home/user/.cursor/skills/task'
 const mockWriteText = vi.fn()
+let originalClipboardDescriptor: PropertyDescriptor | undefined
 
 vi.mock('sonner', () => ({
   toast: {
@@ -71,6 +72,10 @@ function makeSkill(): Skill {
 beforeEach(() => {
   mockWriteText.mockReset()
   mockWriteText.mockResolvedValue(undefined)
+  originalClipboardDescriptor = Object.getOwnPropertyDescriptor(
+    navigator,
+    'clipboard',
+  )
   Object.defineProperty(navigator, 'clipboard', {
     configurable: true,
     value: { writeText: mockWriteText },
@@ -78,6 +83,11 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  if (originalClipboardDescriptor) {
+    Object.defineProperty(navigator, 'clipboard', originalClipboardDescriptor)
+  } else {
+    Reflect.deleteProperty(navigator, 'clipboard')
+  }
   vi.restoreAllMocks()
 })
 

--- a/src/renderer/src/components/skills/SkillDetail.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillDetail.browser.test.tsx
@@ -1,0 +1,153 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import { DEFAULT_SETTINGS } from '@/shared/settings'
+import type { Agent, AgentId, Skill, SymlinkInfo } from '@/shared/types'
+
+const SOURCE_PATH = '/home/user/.agents/skills/task'
+const CURSOR_PATH = '/home/user/.cursor/skills/task'
+const mockWriteText = vi.fn()
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}))
+
+vi.mock('./CodePreview', () => ({
+  CodePreview: () => <div data-testid="mock-code-preview" />,
+}))
+
+/**
+ * Build a minimal installed-agent fixture for SkillDetail tests.
+ * @param overrides - Agent fields that differ from the default Cursor row.
+ * @returns Complete Agent object.
+ * @example
+ * makeAgent({ id: 'claude-code', name: 'Claude Code' })
+ */
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: 'cursor' as AgentId,
+    name: 'Cursor',
+    path: '/home/user/.cursor/skills',
+    exists: true,
+    skillCount: 1,
+    localSkillCount: 0,
+    ...overrides,
+  }
+}
+
+/**
+ * Build a minimal skill fixture with one valid Cursor symlink.
+ * @returns Complete Skill object.
+ * @example
+ * makeSkill()
+ */
+function makeSkill(): Skill {
+  const symlinks: SymlinkInfo[] = [
+    {
+      agentId: 'cursor' as AgentId,
+      agentName: 'Cursor',
+      status: 'valid',
+      targetPath: SOURCE_PATH,
+      linkPath: CURSOR_PATH,
+      isLocal: false,
+    },
+  ]
+
+  return {
+    name: 'task',
+    description: 'Task workflow',
+    path: SOURCE_PATH,
+    symlinkCount: symlinks.length,
+    symlinks,
+    isSource: true,
+    isOrphan: false,
+  }
+}
+
+beforeEach(() => {
+  mockWriteText.mockReset()
+  mockWriteText.mockResolvedValue(undefined)
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: { writeText: mockWriteText },
+  })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+/**
+ * Render SkillDetail on the Info tab with the smallest real Redux state shape.
+ * @param selectedAgentId - Optional selected agent; when present, Location shows both source and symlink paths.
+ * @returns Render handle and Redux store.
+ */
+async function renderSkillDetail(selectedAgentId: AgentId | null = null) {
+  const { default: settingsReducer } =
+    await import('@/renderer/src/redux/slices/settingsSlice')
+  const { setSettings } =
+    await import('@/renderer/src/redux/slices/settingsSlice')
+  const { default: agentsReducer } =
+    await import('@/renderer/src/redux/slices/agentsSlice')
+  const { default: uiReducer, selectAgent } =
+    await import('@/renderer/src/redux/slices/uiSlice')
+  const { SkillDetail } = await import('./SkillDetail')
+
+  const store = configureStore({
+    reducer: {
+      settings: settingsReducer,
+      agents: agentsReducer,
+      ui: uiReducer,
+    },
+    preloadedState: {
+      agents: {
+        items: [makeAgent()],
+        loading: false,
+        error: null,
+        agentToDelete: null,
+        deleting: false,
+      },
+    },
+  })
+
+  store.dispatch(setSettings({ ...DEFAULT_SETTINGS, defaultSkillTab: 'info' }))
+  store.dispatch(selectAgent(selectedAgentId))
+
+  const screen = await render(
+    <Provider store={store}>
+      <SkillDetail skill={makeSkill()} />
+    </Provider>,
+  )
+
+  return { screen, store }
+}
+
+describe('SkillDetail Info path copy', () => {
+  it('copies the single source path when no agent is selected', async () => {
+    const { screen } = await renderSkillDetail()
+
+    await expect.element(screen.getByText('Path')).toBeInTheDocument()
+    await screen.getByRole('button', { name: /^Copy path$/i }).click()
+
+    expect(mockWriteText).toHaveBeenCalledWith(SOURCE_PATH)
+    await expect
+      .element(screen.getByRole('button', { name: /^Copy path$/i }))
+      .toHaveTextContent(/Copied/)
+  })
+
+  it('copies source and symlink paths independently in agent view', async () => {
+    const { screen } = await renderSkillDetail('cursor' as AgentId)
+
+    await screen
+      .getByRole('button', { name: /Copy Source Files path/i })
+      .click()
+    await screen.getByRole('button', { name: /Copy Symlink path/i }).click()
+
+    expect(mockWriteText).toHaveBeenNthCalledWith(1, SOURCE_PATH)
+    expect(mockWriteText).toHaveBeenNthCalledWith(2, CURSOR_PATH)
+  })
+})

--- a/src/renderer/src/components/skills/SkillDetail.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillDetail.browser.test.tsx
@@ -9,11 +9,12 @@ import type { Agent, AgentId, Skill, SymlinkInfo } from '@/shared/types'
 const SOURCE_PATH = '/home/user/.agents/skills/task'
 const CURSOR_PATH = '/home/user/.cursor/skills/task'
 const mockWriteText = vi.fn()
+const toastErrorMock = vi.fn()
 let originalClipboardDescriptor: PropertyDescriptor | undefined
 
 vi.mock('sonner', () => ({
   toast: {
-    error: vi.fn(),
+    error: (...args: unknown[]) => toastErrorMock(...args),
   },
 }))
 
@@ -72,6 +73,7 @@ function makeSkill(): Skill {
 beforeEach(() => {
   mockWriteText.mockReset()
   mockWriteText.mockResolvedValue(undefined)
+  toastErrorMock.mockReset()
   originalClipboardDescriptor = Object.getOwnPropertyDescriptor(
     navigator,
     'clipboard',
@@ -159,5 +161,17 @@ describe('SkillDetail Info path copy', () => {
 
     expect(mockWriteText).toHaveBeenNthCalledWith(1, SOURCE_PATH)
     expect(mockWriteText).toHaveBeenNthCalledWith(2, CURSOR_PATH)
+  })
+
+  it('toasts when copying the source path fails', async () => {
+    mockWriteText.mockRejectedValueOnce(new Error('copy failed'))
+    const { screen } = await renderSkillDetail()
+
+    await screen.getByRole('button', { name: /^Copy path$/i }).click()
+
+    expect(mockWriteText).toHaveBeenCalledWith(SOURCE_PATH)
+    await expect
+      .poll(() => toastErrorMock.mock.calls[0]?.[0])
+      .toBe('Failed to copy path')
   })
 })

--- a/src/renderer/src/components/skills/SkillDetail.tsx
+++ b/src/renderer/src/components/skills/SkillDetail.tsx
@@ -1,7 +1,9 @@
-import { Unlink2 } from 'lucide-react'
+import { Check, Copy, Unlink2 } from 'lucide-react'
 import React, { Activity } from 'react'
+import { toast } from 'sonner'
 
 import { SymlinkStatus } from '@/renderer/src/components/status/SymlinkStatus'
+import { Button } from '@/renderer/src/components/ui/button'
 import { Separator } from '@/renderer/src/components/ui/separator'
 import { useUpdateSettings } from '@/renderer/src/hooks/useUpdateSettings'
 import { cn } from '@/renderer/src/lib/utils'
@@ -159,6 +161,58 @@ interface InfoViewProps {
   location: LocationViewModel
 }
 
+interface LocationPathClipboardState {
+  copiedPath: string | null
+  copyPath: (path: string, label: string) => Promise<void>
+}
+
+/**
+ * Manage clipboard writes and short-lived copied feedback for Location path rows.
+ * @returns Copied path state and copy handler for LocationPathRow.
+ * @example
+ * const { copiedPath, copyPath } = useLocationPathClipboard()
+ */
+function useLocationPathClipboard(): LocationPathClipboardState {
+  const [copiedPath, setCopiedPath] = React.useState<string | null>(null)
+  const resetCopiedPathTimeoutRef = React.useRef<number | null>(null)
+
+  React.useEffect(() => {
+    return () => {
+      if (resetCopiedPathTimeoutRef.current !== null) {
+        window.clearTimeout(resetCopiedPathTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  const copyPath = React.useCallback(
+    async (path: string, label: string): Promise<void> => {
+      try {
+        if (!navigator.clipboard?.writeText) {
+          throw new Error('Clipboard API unavailable')
+        }
+        await navigator.clipboard.writeText(path)
+        setCopiedPath(path)
+
+        // Reset feedback after a short confirmation window.
+        if (resetCopiedPathTimeoutRef.current !== null) {
+          window.clearTimeout(resetCopiedPathTimeoutRef.current)
+        }
+        resetCopiedPathTimeoutRef.current = window.setTimeout(() => {
+          setCopiedPath((currentPath) =>
+            currentPath === path ? null : currentPath,
+          )
+          resetCopiedPathTimeoutRef.current = null
+        }, 1600)
+      } catch {
+        toast.error(`Failed to copy ${getLocationPathCopyName(label)}`)
+      }
+    },
+    [],
+  )
+
+  return { copiedPath, copyPath }
+}
+
 const InfoView = React.memo(function InfoView({
   skill,
   filteredSymlinks,
@@ -166,6 +220,8 @@ const InfoView = React.memo(function InfoView({
   brokenCount,
   location,
 }: InfoViewProps): React.ReactElement {
+  const { copiedPath, copyPath } = useLocationPathClipboard()
+
   return (
     <div className="p-4 overflow-auto h-full">
       <SourceLink source={skill.source} sourceUrl={skill.sourceUrl} />
@@ -202,27 +258,100 @@ const InfoView = React.memo(function InfoView({
         </h3>
         {location.symlinkPath ? (
           <div className="space-y-2">
-            <div>
-              <div className="text-xs text-muted-foreground mb-1">
-                Source Files
-              </div>
-              <code className="text-xs bg-muted px-2 py-1 rounded break-all inline-block max-w-full">
-                {location.sourcePath}
-              </code>
-            </div>
-            <div>
-              <div className="text-xs text-muted-foreground mb-1">Symlink</div>
-              <code className="text-xs bg-muted px-2 py-1 rounded break-all inline-block max-w-full">
-                {location.symlinkPath}
-              </code>
-            </div>
+            <LocationPathRow
+              label="Source Files"
+              path={location.sourcePath}
+              isCopied={copiedPath === location.sourcePath}
+              onCopy={copyPath}
+            />
+            <LocationPathRow
+              label="Symlink"
+              path={location.symlinkPath}
+              isCopied={copiedPath === location.symlinkPath}
+              onCopy={copyPath}
+            />
           </div>
         ) : (
-          <code className="text-xs bg-muted px-2 py-1 rounded break-all inline-block max-w-full">
-            {location.sourcePath}
-          </code>
+          <LocationPathRow
+            label="Path"
+            path={location.sourcePath}
+            isCopied={copiedPath === location.sourcePath}
+            onCopy={copyPath}
+          />
         )}
       </div>
     </div>
   )
 })
+
+interface LocationPathRowProps {
+  label: string
+  path: string
+  isCopied: boolean
+  onCopy: (path: string, label: string) => Promise<void>
+}
+
+/**
+ * Render one copyable path row in the Skill Info Location section.
+ * @param label - Short label shown above the path and used in copy feedback.
+ * @param path - Absolute filesystem path displayed to the user.
+ * @param isCopied - Whether this row is currently showing copied feedback.
+ * @param onCopy - Clipboard writer owned by InfoView.
+ * @returns A labelled path with a compact Copy/Copied action.
+ * @example
+ * <LocationPathRow label="Path" path="/Users/me/.agents/skills/foo" isCopied={false} onCopy={copyPath} />
+ */
+const LocationPathRow = React.memo(function LocationPathRow({
+  label,
+  path,
+  isCopied,
+  onCopy,
+}: LocationPathRowProps): React.ReactElement {
+  const copyName = getLocationPathCopyName(label)
+  const handleCopyClick = React.useCallback((): void => {
+    void onCopy(path, label)
+  }, [label, onCopy, path])
+
+  return (
+    <div>
+      <div className="text-xs text-muted-foreground mb-1">{label}</div>
+      <div className="flex items-start gap-2 min-w-0">
+        <code className="flex-1 min-w-0 text-xs bg-muted px-2 py-1 rounded break-all">
+          {path}
+        </code>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={handleCopyClick}
+          aria-label={`Copy ${copyName}`}
+          className="h-7 shrink-0 px-2 text-xs text-muted-foreground hover:text-foreground"
+        >
+          {isCopied ? (
+            <>
+              <Check className="h-3.5 w-3.5" aria-hidden />
+              Copied
+            </>
+          ) : (
+            <>
+              <Copy className="h-3.5 w-3.5" aria-hidden />
+              Copy
+            </>
+          )}
+        </Button>
+      </div>
+    </div>
+  )
+})
+
+/**
+ * Build human copy for Location path actions without producing "path path".
+ * @param label - Visible row label from the Location section.
+ * @returns Lowercase phrase used in aria labels and error toasts.
+ * @example
+ * getLocationPathCopyName('Path') // => 'path'
+ * getLocationPathCopyName('Source Files') // => 'source files path'
+ */
+function getLocationPathCopyName(label: string): string {
+  return label === 'Path' ? 'path' : `${label.toLowerCase()} path`
+}

--- a/src/renderer/src/components/skills/SkillDetail.tsx
+++ b/src/renderer/src/components/skills/SkillDetail.tsx
@@ -16,6 +16,9 @@ import type { Skill, SymlinkInfo } from '@/shared/types'
 import { CodePreview } from './CodePreview'
 import { SourceLink } from './SourceLink'
 
+// Keep copied feedback visible long enough to be noticed without lingering.
+const COPIED_FEEDBACK_DURATION_MS = 1600
+
 interface SkillDetailProps {
   skill: Skill
 }
@@ -202,7 +205,7 @@ function useLocationPathClipboard(): LocationPathClipboardState {
             currentPath === path ? null : currentPath,
           )
           resetCopiedPathTimeoutRef.current = null
-        }, 1600)
+        }, COPIED_FEEDBACK_DURATION_MS)
       } catch {
         toast.error(`Failed to copy ${getLocationPathCopyName(label)}`)
       }


### PR DESCRIPTION
## Summary
- Add compact Copy/Copied actions to Skill Info Location paths
- Support both single source path and selected-agent Source Files/Symlink path rows
- Cover clipboard behavior with browser-mode tests

## Validation
- pnpm validate
- Electron dev + playwright-cli manual check for Info tab Copy path and macOS clipboard output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Skill詳細画面の Location 表示をコピー可能な行に変更しました。単一表示／「Source Files」と「Symlink」両対応で、コピー成功時は「Copied」表示とアイコンに切替、失敗時はエラートーストを表示します。

* **テスト**
  * ブラウザ上でのパスコピー挙動を検証するテストを追加しました（エージェント選択の有無／Source・Symlinkのコピー順／コピー失敗時のエラーハンドリングを確認）。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/skills-desktop/pull/167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->