### PR TITLE
Add installed repo and exclude filters

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,8 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-pnpmfileChecksum: sha256-SoNlK6SszOtET4cXDvK0mG7PO1eYzd5GlpKR+wL6+So=
-
 importers:
 
   .:

--- a/src/renderer/src/components/layout/MainContent.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.browser.test.tsx
@@ -164,6 +164,26 @@ async function waitForBulkSelectReady(
     .toBeInTheDocument()
 }
 
+/**
+ * Build a source-repo skill for toolbar facet tests.
+ * @param name - Visible skill name.
+ * @param source - Repository slug shown in the repo dropdown.
+ * @returns Skill row with source metadata and no agent slot.
+ */
+function makeSourceSkill(name: string, source: string): Skill {
+  return {
+    name: name as SkillName,
+    description: '',
+    path: `/skills/${name}` as never,
+    symlinkCount: 0,
+    symlinks: [],
+    isSource: true,
+    isOrphan: false,
+    source: repositoryId(source),
+    sourceUrl: `https://github.com/${source}.git`,
+  }
+}
+
 describe('MainContent bulk-select toggle button', () => {
   it('shows "Select" and aria-pressed=false by default', async () => {
     const { screen } = await renderMainContent()
@@ -497,8 +517,10 @@ describe('MainContent SkillTypeFilter dropdown options', () => {
     )
     store.dispatch(selectAgent('cursor'))
 
-    // Open the dropdown — the trigger label currently reads "All".
-    await screen.getByRole('button', { name: /^All$/ }).click()
+    // Open the dropdown from the agent-only skill type trigger.
+    await screen
+      .getByRole('button', { name: /Skill type filter: All/i })
+      .click()
 
     const orphanItem = screen.getByRole('menuitemradio', { name: /Orphan/i })
     await expect.element(orphanItem).toBeInTheDocument()
@@ -537,7 +559,9 @@ describe('MainContent SkillTypeFilter dropdown options', () => {
     store.dispatch(selectAgent('cursor'))
 
     // Open the dropdown — G-Stack sits beside Symlinked/Local as a type filter.
-    await screen.getByRole('button', { name: /^All$/ }).click()
+    await screen
+      .getByRole('button', { name: /Skill type filter: All/i })
+      .click()
 
     const gstackItem = screen.getByRole('menuitemradio', { name: /G-Stack/i })
     await expect.element(gstackItem).toBeInTheDocument()
@@ -611,7 +635,9 @@ describe('MainContent SkillTypeFilter dropdown options', () => {
     store.dispatch(selectAgent('cursor'))
     store.dispatch(fetchSkills.fulfilled([orphanSkill, linkedSkill], 'req-id'))
 
-    await screen.getByRole('button', { name: /^All$/ }).click()
+    await screen
+      .getByRole('button', { name: /Skill type filter: All/i })
+      .click()
     await screen.getByRole('menuitemradio', { name: /Orphan/i }).click()
 
     // Slice state — single source of truth that the selector reads from.
@@ -622,6 +648,72 @@ describe('MainContent SkillTypeFilter dropdown options', () => {
       await import('@/renderer/src/redux/selectors')
     const filtered = selectFilteredSkills(store.getState() as never)
     expect(filtered.map((skill) => skill.name)).toEqual(['orphan-one'])
+  })
+
+  it('toggling an exclude checkbox updates state while keeping the dropdown open', async () => {
+    const { screen, store } = await renderMainContent()
+    const { fetchAgents } =
+      await import('@/renderer/src/redux/slices/agentsSlice')
+    const { selectAgent } = await import('@/renderer/src/redux/slices/uiSlice')
+
+    store.dispatch(
+      fetchAgents.fulfilled(
+        [
+          {
+            id: 'cursor',
+            name: 'Cursor',
+            path: '/Users/me/.cursor/skills' as never,
+            exists: true,
+            skillCount: 0,
+            localSkillCount: 0,
+          },
+        ],
+        'req-id',
+      ),
+    )
+    store.dispatch(selectAgent('cursor'))
+
+    await screen
+      .getByRole('button', { name: /Skill type filter: All/i })
+      .click()
+    await screen.getByRole('menuitemcheckbox', { name: /Local/i }).click()
+
+    expect(store.getState().ui.excludedSkillTypeFilters).toEqual(['local'])
+    await expect
+      .element(screen.getByRole('menuitem', { name: /Clear excludes/i }))
+      .toBeInTheDocument()
+  })
+})
+
+describe('MainContent repo facet dropdown', () => {
+  it('selects a repository from source-count options', async () => {
+    const { screen, store } = await renderMainContent()
+    const { fetchSkills } =
+      await import('@/renderer/src/redux/slices/skillsSlice')
+
+    store.dispatch(
+      fetchSkills.fulfilled(
+        [
+          makeSourceSkill('alpha', 'vercel-labs/skills'),
+          makeSourceSkill('beta', 'vercel-labs/skills'),
+          makeSourceSkill('gamma', 'pbakaus/impeccable'),
+        ],
+        'req-id',
+      ),
+    )
+
+    await screen
+      .getByRole('button', { name: /Filter by source repository/i })
+      .click()
+    await screen
+      .getByRole('menuitemradio', {
+        name: /pbakaus\/impeccable, 1 skill/i,
+      })
+      .click()
+
+    expect(store.getState().ui.selectedSource).toBe(
+      repositoryId('pbakaus/impeccable'),
+    )
   })
 })
 

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -4,9 +4,10 @@ import {
   CheckSquare,
   ChevronDown,
   ExternalLink,
+  GitBranch,
   X,
 } from 'lucide-react'
-import React, { useCallback, useRef } from 'react'
+import React, { useCallback, useMemo, useRef } from 'react'
 import { toast } from 'sonner'
 
 import { SkillsMarketplace } from '@/renderer/src/components/marketplace'
@@ -37,9 +38,13 @@ import {
 } from '@/renderer/src/components/ui/dialog'
 import {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/renderer/src/components/ui/dropdown-menu'
 import { FilterPill } from '@/renderer/src/components/ui/FilterPill'
@@ -55,6 +60,7 @@ import { useRenderEffect } from '@/renderer/src/hooks/useRenderEffect'
 import { cn } from '@/renderer/src/lib/utils'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import {
+  selectRepoFacetOptions,
   selectSelectedVisibleNames,
   selectVisibleSkillNames,
 } from '@/renderer/src/redux/selectors'
@@ -70,22 +76,28 @@ import {
 } from '@/renderer/src/redux/slices/skillsSlice'
 import {
   clearBulkConfirm,
+  clearExcludedSkillTypeFilters,
   clearSelectedSource,
   clearUndoToast,
   enterBulkSelectMode,
   exitBulkSelectMode,
+  getAvailableExcludeTypes,
   selectAgent,
   selectBulkConfirm,
   selectBulkSelectMode,
+  selectExcludedSkillTypeFilters,
   selectSelectedSource,
   setActiveTab,
   setBulkConfirm,
+  setSelectedSource,
   setSkillTypeFilter,
   setUndoToast,
+  toggleExcludedSkillTypeFilter,
   toggleSortOrder,
 } from '@/renderer/src/redux/slices/uiSlice'
 import type {
   ActiveTab,
+  ExcludableSkillTypeFilter,
   SkillTypeFilter,
 } from '@/renderer/src/redux/slices/uiSlice'
 import { refreshAllData } from '@/renderer/src/redux/thunks'
@@ -98,6 +110,7 @@ import { FEATURE_FLAGS } from '@/shared/featureFlags'
 import type {
   BulkDeleteItemResult,
   IsoTimestamp,
+  RepositoryId,
   ToastId,
   TombstoneId,
 } from '@/shared/types'
@@ -114,6 +127,48 @@ const SKILL_TYPE_FILTER_OPTIONS: {
   { value: 'gstack', label: 'G-Stack', dotClass: 'bg-gstack' },
   { value: 'orphan', label: 'Orphan', dotClass: 'bg-destructive' },
 ]
+
+const EXCLUDABLE_SKILL_TYPE_FILTER_OPTIONS = SKILL_TYPE_FILTER_OPTIONS.filter(
+  (
+    option,
+  ): option is {
+    value: ExcludableSkillTypeFilter
+    label: string
+    dotClass?: string
+  } => option.value !== 'all',
+)
+
+/**
+ * Compress long repository slugs for toolbar triggers while preserving both
+ * owner and repo clues. The full value remains in aria-labels and filter pills.
+ * @param source - Repository slug, usually `owner/repo`.
+ * @returns Short label safe for compact toolbar buttons.
+ * @example
+ * formatRepositoryFacetLabel('very-long-owner-name/extremely-long-repository')
+ * // => "very-long-ow...ng-repository"
+ */
+function formatRepositoryFacetLabel(source: RepositoryId): string {
+  if (source.length <= 28) return source
+  return `${source.slice(0, 12)}...${source.slice(-13)}`
+}
+
+/**
+ * Explain why an exclude checkbox is unavailable for the current include mode.
+ * @param includeFilter - Positive skill type selected in the Include group.
+ * @param excludeFilter - Negative skill type shown in the Exclude group.
+ * @returns Short helper copy, or null when the option is available.
+ * @example
+ * getUnavailableExcludeReason('symlinked', 'local') // => "Not in view"
+ */
+function getUnavailableExcludeReason(
+  includeFilter: SkillTypeFilter,
+  excludeFilter: ExcludableSkillTypeFilter,
+): string | null {
+  if (getAvailableExcludeTypes(includeFilter).includes(excludeFilter)) {
+    return null
+  }
+  return includeFilter === excludeFilter ? 'Already included' : 'Not in view'
+}
 
 const SKILLS_SH_URL = 'https://skills.sh'
 
@@ -136,8 +191,23 @@ export const MainContent = React.memo(
     const bulkConfirm = useAppSelector(selectBulkConfirm)
     const bulkSelectMode = useAppSelector(selectBulkSelectMode)
     const selectedSource = useAppSelector(selectSelectedSource)
+    const repoFacetOptions = useAppSelector(selectRepoFacetOptions)
+    const excludedSkillTypeFilters = useAppSelector(
+      selectExcludedSkillTypeFilters,
+    )
 
     const selectedAgent = agents.find((a) => a.id === selectedAgentId)
+    const selectedSkillTypeLabel = SKILL_TYPE_FILTER_OPTIONS.find(
+      (option) => option.value === skillTypeFilter,
+    )!.label
+    const availableExcludeTypes = getAvailableExcludeTypes(skillTypeFilter)
+    const skillTypeTriggerLabel =
+      excludedSkillTypeFilters.length === 0
+        ? selectedSkillTypeLabel
+        : `${selectedSkillTypeLabel} · ${excludedSkillTypeFilters.length} excluded`
+    const selectedSourceLabel = selectedSource
+      ? formatRepositoryFacetLabel(selectedSource)
+      : 'Source'
 
     const handleClearFilter = useCallback((): void => {
       dispatch(selectAgent(null))
@@ -244,6 +314,55 @@ export const MainContent = React.memo(
         dispatch(setSkillTypeFilter(value as SkillTypeFilter))
       },
       [dispatch],
+    )
+
+    const handleRepoFacetChange = useCallback(
+      (value: string): void => {
+        if (value === 'all') {
+          dispatch(clearSelectedSource())
+          return
+        }
+        dispatch(setSelectedSource(value as RepositoryId))
+      },
+      [dispatch],
+    )
+
+    const handleToggleExcludedSkillTypeFilter = useCallback(
+      (value: ExcludableSkillTypeFilter): void => {
+        dispatch(toggleExcludedSkillTypeFilter(value))
+      },
+      [dispatch],
+    )
+    const excludedSkillTypeToggleHandlers = useMemo(
+      () => ({
+        symlinked: () => {
+          handleToggleExcludedSkillTypeFilter('symlinked')
+        },
+        local: () => {
+          handleToggleExcludedSkillTypeFilter('local')
+        },
+        gstack: () => {
+          handleToggleExcludedSkillTypeFilter('gstack')
+        },
+        orphan: () => {
+          handleToggleExcludedSkillTypeFilter('orphan')
+        },
+      }),
+      [handleToggleExcludedSkillTypeFilter],
+    )
+
+    const handleClearExcludedSkillTypeFilters = useCallback((): void => {
+      dispatch(clearExcludedSkillTypeFilters())
+    }, [dispatch])
+    const handleKeepDropdownOpen = useCallback((event: Event): void => {
+      event.preventDefault()
+    }, [])
+    const handleSelectClearExcludedSkillTypeFilters = useCallback(
+      (event: Event): void => {
+        event.preventDefault()
+        handleClearExcludedSkillTypeFilters()
+      },
+      [handleClearExcludedSkillTypeFilters],
     )
 
     /**
@@ -482,8 +601,8 @@ export const MainContent = React.memo(
             value="installed"
             className="flex-1 m-0 data-[state=active]:flex data-[state=active]:flex-col min-h-0 overflow-hidden"
           >
-            <div className="p-4 border-b border-border shrink-0 flex items-center gap-2">
-              <div className="flex-1 min-w-0">
+            <div className="p-4 border-b border-border shrink-0 flex flex-wrap items-center gap-2">
+              <div className="min-w-64 flex-[1_1_20rem]">
                 <SearchBox />
               </div>
 
@@ -505,6 +624,63 @@ export const MainContent = React.memo(
                   <ArrowUpAZ className="h-4 w-4" />
                 )}
               </Button>
+
+              {/* Repo facet: exact source filter with counts from the current
+                  agent/type population, independent of the text query. */}
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    aria-label={
+                      selectedSource
+                        ? `Filtering by source repository ${selectedSource}`
+                        : 'Filter by source repository'
+                    }
+                    className={cn(
+                      'shrink-0 gap-1.5 min-h-11 max-w-44',
+                      selectedSource
+                        ? 'text-primary'
+                        : 'text-muted-foreground hover:text-foreground',
+                    )}
+                  >
+                    <GitBranch className="h-4 w-4" />
+                    <span className="max-w-32 truncate">
+                      {selectedSourceLabel}
+                    </span>
+                    <ChevronDown className="h-3 w-3" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-72">
+                  <DropdownMenuLabel>Source repository</DropdownMenuLabel>
+                  <DropdownMenuRadioGroup
+                    value={selectedSource ?? 'all'}
+                    onValueChange={handleRepoFacetChange}
+                  >
+                    <DropdownMenuRadioItem value="all">
+                      <span className="min-w-0 flex-1">All repos</span>
+                    </DropdownMenuRadioItem>
+                    {repoFacetOptions.map((option) => (
+                      <DropdownMenuRadioItem
+                        key={option.source}
+                        value={option.source}
+                        aria-label={`${option.source}, ${option.count} ${pluralize(
+                          option.count,
+                          'skill',
+                        )}`}
+                        className="gap-2"
+                      >
+                        <span className="min-w-0 flex-1 truncate">
+                          {option.source}
+                        </span>
+                        <span className="ml-auto text-xs text-muted-foreground">
+                          {option.count}
+                        </span>
+                      </DropdownMenuRadioItem>
+                    ))}
+                  </DropdownMenuRadioGroup>
+                </DropdownMenuContent>
+              </DropdownMenu>
 
               {/* Bulk-select toggle — reveals checkboxes on skill cards and
                   activates Cmd/Ctrl+A + Esc shortcuts. Exiting clears any
@@ -541,21 +717,27 @@ export const MainContent = React.memo(
                     <Button
                       variant="ghost"
                       size="sm"
-                      className={`shrink-0 gap-1.5 min-h-11 ${
-                        skillTypeFilter !== 'all'
-                          ? 'text-primary'
-                          : 'text-muted-foreground hover:text-foreground'
-                      }`}
-                    >
-                      {
-                        SKILL_TYPE_FILTER_OPTIONS.find(
-                          (o) => o.value === skillTypeFilter,
-                        )!.label
+                      aria-label={
+                        excludedSkillTypeFilters.length === 0
+                          ? `Skill type filter: ${selectedSkillTypeLabel}`
+                          : `Skill type filter: ${selectedSkillTypeLabel}, excluding ${excludedSkillTypeFilters.length} types`
                       }
+                      className={cn(
+                        'shrink-0 gap-1.5 min-h-11 max-w-48',
+                        skillTypeFilter !== 'all' ||
+                          excludedSkillTypeFilters.length > 0
+                          ? 'text-primary'
+                          : 'text-muted-foreground hover:text-foreground',
+                      )}
+                    >
+                      <span className="max-w-36 truncate">
+                        {skillTypeTriggerLabel}
+                      </span>
                       <ChevronDown className="h-3 w-3" />
                     </Button>
                   </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
+                  <DropdownMenuContent align="end" className="w-60">
+                    <DropdownMenuLabel>Include</DropdownMenuLabel>
                     <DropdownMenuRadioGroup
                       value={skillTypeFilter}
                       onValueChange={handleSkillTypeFilterChange}
@@ -577,6 +759,57 @@ export const MainContent = React.memo(
                         </DropdownMenuRadioItem>
                       ))}
                     </DropdownMenuRadioGroup>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuLabel>Exclude</DropdownMenuLabel>
+                    {EXCLUDABLE_SKILL_TYPE_FILTER_OPTIONS.map((option) => {
+                      const isAvailable = availableExcludeTypes.includes(
+                        option.value,
+                      )
+                      const unavailableReason = getUnavailableExcludeReason(
+                        skillTypeFilter,
+                        option.value,
+                      )
+                      return (
+                        <DropdownMenuCheckboxItem
+                          key={option.value}
+                          checked={excludedSkillTypeFilters.includes(
+                            option.value,
+                          )}
+                          disabled={!isAvailable}
+                          onCheckedChange={
+                            excludedSkillTypeToggleHandlers[option.value]
+                          }
+                          onSelect={handleKeepDropdownOpen}
+                          aria-label={
+                            unavailableReason
+                              ? `${option.label}, unavailable: ${unavailableReason}`
+                              : option.label
+                          }
+                          className="gap-2"
+                        >
+                          {option.dotClass ? (
+                            <span
+                              className={`h-2 w-2 rounded-full ${option.dotClass}`}
+                            />
+                          ) : null}
+                          <span className="min-w-0 flex-1 truncate">
+                            {option.label}
+                          </span>
+                          {unavailableReason ? (
+                            <span className="ml-auto shrink-0 text-[11px] text-muted-foreground">
+                              {unavailableReason}
+                            </span>
+                          ) : null}
+                        </DropdownMenuCheckboxItem>
+                      )
+                    })}
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      disabled={excludedSkillTypeFilters.length === 0}
+                      onSelect={handleSelectClearExcludedSkillTypeFilters}
+                    >
+                      Clear excludes
+                    </DropdownMenuItem>
                   </DropdownMenuContent>
                 </DropdownMenu>
               )}

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -197,9 +197,10 @@ export const MainContent = React.memo(
     )
 
     const selectedAgent = agents.find((a) => a.id === selectedAgentId)
-    const selectedSkillTypeLabel = SKILL_TYPE_FILTER_OPTIONS.find(
-      (option) => option.value === skillTypeFilter,
-    )!.label
+    const selectedSkillTypeLabel =
+      SKILL_TYPE_FILTER_OPTIONS.find(
+        (option) => option.value === skillTypeFilter,
+      )?.label ?? 'All'
     const availableExcludeTypes = getAvailableExcludeTypes(skillTypeFilter)
     const skillTypeTriggerLabel =
       excludedSkillTypeFilters.length === 0

--- a/src/renderer/src/components/skills/SkillsList.tsx
+++ b/src/renderer/src/components/skills/SkillsList.tsx
@@ -11,6 +11,7 @@ import {
   selectSkillsLoading,
 } from '@/renderer/src/redux/slices/skillsSlice'
 import {
+  selectExcludedSkillTypeFilters,
   selectSearchQuery,
   selectSelectedAgentId,
   selectSelectedSource,
@@ -69,6 +70,9 @@ export const SkillsList = React.memo(function SkillsList(): React.ReactElement {
   const skillTypeFilter = useAppSelector(selectSkillTypeFilter)
   const searchQuery = useAppSelector(selectSearchQuery)
   const selectedSource = useAppSelector(selectSelectedSource)
+  const excludedSkillTypeFilters = useAppSelector(
+    selectExcludedSkillTypeFilters,
+  )
   const filteredSkills = useAppSelector(selectFilteredSkills)
 
   useInitialEffect(() => {
@@ -129,6 +133,7 @@ export const SkillsList = React.memo(function SkillsList(): React.ReactElement {
       selectedSource,
       selectedAgentId,
       skillTypeFilter,
+      excludedSkillTypeFilters,
     })
     return (
       <div className="flex items-center justify-center py-12">

--- a/src/renderer/src/components/skills/skillsListHelpers.test.ts
+++ b/src/renderer/src/components/skills/skillsListHelpers.test.ts
@@ -5,9 +5,9 @@ import { repositoryId } from '@/shared/types'
 import { getEmptyListMessage } from './skillsListHelpers'
 
 describe('getEmptyListMessage', () => {
-  it('returns the search message when searchQuery is non-empty (highest priority)', () => {
-    // Even with every other filter active, search wins because the user's
-    // most recent narrowing action is what they want named in the message.
+  it('returns the search message with repo context when searchQuery and source are active', () => {
+    // Search still wins as the user's most recent narrowing action, but the
+    // active repo facet is named so the empty state explains the intersection.
     expect(
       getEmptyListMessage({
         searchQuery: 'react',
@@ -15,7 +15,7 @@ describe('getEmptyListMessage', () => {
         selectedAgentId: 'cursor',
         skillTypeFilter: 'local',
       }),
-    ).toBe('No skills match your search')
+    ).toBe('No skills match your search in vercel-labs/skills')
   })
 
   it('returns the source message when only selectedSource is set', () => {
@@ -42,6 +42,17 @@ describe('getEmptyListMessage', () => {
     ).toBe('No skills from pbakaus/impeccable')
   })
 
+  it('adds repository context to a search result when both query and source are active', () => {
+    expect(
+      getEmptyListMessage({
+        searchQuery: 'trace',
+        selectedSource: repositoryId('laststance/skills'),
+        selectedAgentId: 'cursor',
+        skillTypeFilter: 'all',
+      }),
+    ).toBe('No skills match your search in laststance/skills')
+  })
+
   it('returns the agent + type message when both are set (no source / search)', () => {
     expect(
       getEmptyListMessage({
@@ -51,6 +62,34 @@ describe('getEmptyListMessage', () => {
         skillTypeFilter: 'local',
       }),
     ).toBe('No local skills for this agent')
+  })
+
+  it('adds excluded skill types to the selected source message', () => {
+    expect(
+      getEmptyListMessage({
+        searchQuery: '',
+        selectedSource: repositoryId('vercel-labs/skills'),
+        selectedAgentId: 'cursor',
+        skillTypeFilter: 'all',
+        excludedSkillTypeFilters: ['gstack', 'orphan'],
+      }),
+    ).toBe(
+      'No skills from vercel-labs/skills while excluding G-Stack and orphan',
+    )
+  })
+
+  it('adds excluded skill types to the agent-only message', () => {
+    expect(
+      getEmptyListMessage({
+        searchQuery: '',
+        selectedSource: null,
+        selectedAgentId: 'cursor',
+        skillTypeFilter: 'all',
+        excludedSkillTypeFilters: ['local', 'gstack', 'orphan'],
+      }),
+    ).toBe(
+      'No skills installed for this agent while excluding local, G-Stack, and orphan',
+    )
   })
 
   it('returns the symlinked variant when type filter is symlinked', () => {

--- a/src/renderer/src/components/skills/skillsListHelpers.ts
+++ b/src/renderer/src/components/skills/skillsListHelpers.ts
@@ -1,6 +1,9 @@
 import { match } from 'ts-pattern'
 
-import type { SkillTypeFilter } from '@/renderer/src/redux/slices/uiSlice'
+import type {
+  ExcludableSkillTypeFilter,
+  SkillTypeFilter,
+} from '@/renderer/src/redux/slices/uiSlice'
 import type { AgentId, RepositoryId } from '@/shared/types'
 
 interface EmptyMessageContext {
@@ -8,6 +11,7 @@ interface EmptyMessageContext {
   selectedSource: RepositoryId | null
   selectedAgentId: AgentId | null
   skillTypeFilter: SkillTypeFilter
+  excludedSkillTypeFilters?: ExcludableSkillTypeFilter[]
 }
 
 const SKILL_TYPE_FILTER_LABELS = {
@@ -17,6 +21,51 @@ const SKILL_TYPE_FILTER_LABELS = {
   gstack: 'G-Stack',
   orphan: 'orphan',
 } as const satisfies Record<SkillTypeFilter, string>
+
+const EXCLUDED_SKILL_TYPE_FILTER_LABELS = {
+  symlinked: 'symlinked',
+  local: 'local',
+  gstack: 'G-Stack',
+  orphan: 'orphan',
+} as const satisfies Record<ExcludableSkillTypeFilter, string>
+
+/**
+ * Join active exclude labels in compact English for empty-state copy.
+ * @param excludedSkillTypeFilters - Excluded type filters in UI state order.
+ * @returns Human-readable label list, e.g. `"local and G-Stack"`.
+ * @example
+ * formatExcludedSkillTypeFilters(['local', 'gstack'])
+ * // => "local and G-Stack"
+ */
+function formatExcludedSkillTypeFilters(
+  excludedSkillTypeFilters: ExcludableSkillTypeFilter[],
+): string {
+  const labels = excludedSkillTypeFilters.map(
+    (filter) => EXCLUDED_SKILL_TYPE_FILTER_LABELS[filter],
+  )
+  if (labels.length <= 1) return labels[0] ?? ''
+  if (labels.length === 2) return `${labels[0]} and ${labels[1]}`
+  return `${labels.slice(0, -1).join(', ')}, and ${labels.at(-1)}`
+}
+
+/**
+ * Add exclude context to an empty-state sentence only when an exclude is active.
+ * @param message - Base empty-state sentence chosen by the priority ladder.
+ * @param excludedSkillTypeFilters - Active exclude filters.
+ * @returns Sentence with optional `" while excluding ..."` suffix.
+ * @example
+ * withExcludeContext('No skills installed for this agent', ['local'])
+ * // => "No skills installed for this agent while excluding local"
+ */
+function withExcludeContext(
+  message: string,
+  excludedSkillTypeFilters: ExcludableSkillTypeFilter[],
+): string {
+  if (excludedSkillTypeFilters.length === 0) return message
+  return `${message} while excluding ${formatExcludedSkillTypeFilters(
+    excludedSkillTypeFilters,
+  )}`
+}
 
 /**
  * Compute the empty-state message for SkillsList based on which filters are
@@ -45,6 +94,7 @@ const SKILL_TYPE_FILTER_LABELS = {
  *   `"No <symlinked|local|G-Stack|orphan> skills for this agent"`
  * - When only `selectedAgentId` is set: `"No skills installed for this agent"`
  * - Otherwise: `"No skills match your filter"`
+ * Active excludes append `" while excluding <types>"` to whichever branch wins.
  *
  * @example
  * getEmptyListMessage({
@@ -52,6 +102,7 @@ const SKILL_TYPE_FILTER_LABELS = {
  *   selectedSource: repositoryId('vercel-labs/skills'),
  *   selectedAgentId: null,
  *   skillTypeFilter: 'all',
+ *   excludedSkillTypeFilters: [],
  * })
  * // => "No skills from vercel-labs/skills"
  *
@@ -61,16 +112,21 @@ const SKILL_TYPE_FILTER_LABELS = {
  *   selectedSource: null,
  *   selectedAgentId: 'cursor',
  *   skillTypeFilter: 'local',
+ *   excludedSkillTypeFilters: ['gstack'],
  * })
- * // => "No local skills for this agent"
+ * // => "No local skills for this agent while excluding G-Stack"
  */
 export function getEmptyListMessage(ctx: EmptyMessageContext): string {
-  return match({
+  const baseMessage = match({
     hasSearchQuery: ctx.searchQuery.length > 0,
     hasSelectedSource: ctx.selectedSource !== null,
     hasSelectedAgent: ctx.selectedAgentId !== null,
     hasTypeNarrow: ctx.skillTypeFilter !== 'all',
   })
+    .with(
+      { hasSearchQuery: true, hasSelectedSource: true },
+      () => `No skills match your search in ${ctx.selectedSource}`,
+    )
     .with({ hasSearchQuery: true }, () => 'No skills match your search')
     .with(
       { hasSelectedSource: true },
@@ -86,4 +142,6 @@ export function getEmptyListMessage(ctx: EmptyMessageContext): string {
       () => 'No skills installed for this agent',
     )
     .otherwise(() => 'No skills match your filter')
+
+  return withExcludeContext(baseMessage, ctx.excludedSkillTypeFilters ?? [])
 }

--- a/src/renderer/src/components/ui/FilterPill.tsx
+++ b/src/renderer/src/components/ui/FilterPill.tsx
@@ -45,15 +45,17 @@ export const FilterPill = React.memo(function FilterPill({
   return (
     <div
       data-testid={testId}
-      className="px-4 py-2 border-b border-border bg-primary/5 flex items-center justify-between shrink-0"
+      className="px-4 py-2 border-b border-border bg-primary/5 flex items-center justify-between gap-3 shrink-0"
     >
-      <span className="text-sm">Showing skills {label}</span>
+      <span className="min-w-0 flex-1 truncate text-sm">
+        Showing skills {label}
+      </span>
       <Button
         variant="ghost"
         size="sm"
         onClick={onClear}
         style={filterPillButtonStyle}
-        className="px-3"
+        className="shrink-0 px-3"
       >
         <X className="h-3 w-3 mr-1" />
         Clear

--- a/src/renderer/src/redux/selectors.test.ts
+++ b/src/renderer/src/redux/selectors.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
-import type { SkillTypeFilter } from '@/renderer/src/redux/slices/uiSlice'
+import type {
+  ExcludableSkillTypeFilter,
+  SkillTypeFilter,
+} from '@/renderer/src/redux/slices/uiSlice'
 import { repositoryId } from '@/shared/types'
 import type {
   AbsolutePath,
@@ -17,6 +20,7 @@ import {
   selectFilteredSkills,
   selectHiddenSelectedCount,
   selectInFlightDeleteNamesSet,
+  selectRepoFacetOptions,
   selectSelectedCount,
   selectSelectedSkillNamesSet,
   selectSelectedVisibleCount,
@@ -33,6 +37,7 @@ function buildState(overrides: {
   selectedSource?: RepositoryId | null
   sortOrder?: 'asc' | 'desc'
   skillTypeFilter?: SkillTypeFilter
+  excludedSkillTypeFilters?: ExcludableSkillTypeFilter[]
   bookmarks?: BookmarkedSkill[]
   selectedSkillNames?: SkillName[]
   inFlightDeleteNames?: SkillName[]
@@ -71,6 +76,7 @@ function buildState(overrides: {
       selectedAgentId: overrides.selectedAgentId ?? null,
       sortOrder: overrides.sortOrder ?? 'asc',
       skillTypeFilter: overrides.skillTypeFilter ?? 'all',
+      excludedSkillTypeFilters: overrides.excludedSkillTypeFilters ?? [],
       isSyncing: false,
       syncPreview: null,
       syncResult: null,
@@ -350,6 +356,20 @@ describe('selectFilteredSkills', () => {
     expect(result[0].name).toBe('local-one')
   })
 
+  it('subtracts excluded local skills from the all-types agent list', () => {
+    const skills = [
+      makeSkill('linked-one', 'cursor'),
+      makeSkill('local-one', 'cursor', true),
+    ]
+    const state = buildState({
+      skills,
+      selectedAgentId: 'cursor',
+      excludedSkillTypeFilters: ['local'],
+    })
+    const result = selectFilteredSkills(state as never)
+    expect(result.map((s) => s.name)).toEqual(['linked-one'])
+  })
+
   it('filters by skillTypeFilter=gstack across symlinked and local G-Stack slots', () => {
     // The G-Stack filter should match the same two production shapes as the
     // card badge: direct agent symlinks into `skills/gstack/` and local
@@ -389,6 +409,36 @@ describe('selectFilteredSkills', () => {
       'linked-gstack',
       'local-gstack',
     ])
+  })
+
+  it('subtracts local rows from the G-Stack include population', () => {
+    const linkedGStack = makeSkill('linked-gstack', 'cursor')
+    linkedGStack.symlinks = [
+      {
+        ...linkedGStack.symlinks[0]!,
+        targetPath:
+          '/Users/me/.cursor/skills/gstack/linked-gstack' as AbsolutePath,
+      },
+    ]
+
+    const localGStack = makeSkill('local-gstack', 'cursor', true)
+    localGStack.symlinks = [
+      {
+        ...localGStack.symlinks[0]!,
+        skillMdSymlinkTarget:
+          '/Users/me/.cursor/skills/gstack/local-gstack/SKILL.md' as AbsolutePath,
+      },
+    ]
+
+    const state = buildState({
+      skills: [linkedGStack, localGStack],
+      selectedAgentId: 'cursor',
+      skillTypeFilter: 'gstack',
+      excludedSkillTypeFilters: ['local'],
+    })
+
+    const result = selectFilteredSkills(state as never)
+    expect(result.map((skill) => skill.name)).toEqual(['linked-gstack'])
   })
 
   it('keeps gstack filtering scoped to the selected agent slot', () => {
@@ -692,6 +742,28 @@ describe('selectFilteredSkills', () => {
     })
     const result = selectFilteredSkills(state as never)
     expect(result.map((s) => s.name)).toEqual([])
+  })
+
+  it('repo facet options count repos after agent/type gates and ignore source pill plus query', () => {
+    const skills = [
+      makeSkill('alpha', 'cursor', false, 'vercel-labs/skills'),
+      makeSkill('beta', 'cursor', false, 'vercel-labs/skills'),
+      makeSkill('gamma', 'cursor', false, 'pbakaus/impeccable'),
+      makeSkill('local-only', 'cursor', true),
+      makeSkill('other-agent', 'claude-code', false, 'vercel-labs/skills'),
+    ]
+    const state = buildState({
+      skills,
+      selectedAgentId: 'cursor',
+      selectedSource: repositoryId('pbakaus/impeccable'),
+      searchQuery: 'nothing matches',
+      searchScope: 'repo',
+    })
+
+    expect(selectRepoFacetOptions(state as never)).toEqual([
+      { source: repositoryId('pbakaus/impeccable'), count: 1 },
+      { source: repositoryId('vercel-labs/skills'), count: 2 },
+    ])
   })
 
   it('is memoized (returns same reference for same inputs)', () => {

--- a/src/renderer/src/redux/selectors.ts
+++ b/src/renderer/src/redux/selectors.ts
@@ -2,7 +2,13 @@ import { createSelector } from '@reduxjs/toolkit'
 import { match } from 'ts-pattern'
 
 import { isGStackManagedForAgent } from '@/renderer/src/utils/gstackSkill'
-import type { SkillName, SymlinkInfo } from '@/shared/types'
+import type {
+  AgentId,
+  RepositoryId,
+  Skill,
+  SkillName,
+  SymlinkInfo,
+} from '@/shared/types'
 
 import { selectBookmarkItems } from './slices/bookmarkSlice'
 import {
@@ -11,6 +17,7 @@ import {
   selectSkillsItems,
 } from './slices/skillsSlice'
 import {
+  selectExcludedSkillTypeFilters,
   selectSearchQuery,
   selectSearchScope,
   selectSelectedAgentId,
@@ -18,10 +25,120 @@ import {
   selectSkillTypeFilter,
   selectSortOrder,
 } from './slices/uiSlice'
+import type {
+  ExcludableSkillTypeFilter,
+  SkillTypeFilter,
+} from './slices/uiSlice'
+
+interface RepoFacetOption {
+  source: RepositoryId
+  count: number
+}
+
+/**
+ * Detect whether one scanner slot belongs to the active agent list.
+ * @param slot - Symlink slot emitted by the skill scanner.
+ * @param selectedAgentId - Agent currently selected in the Installed view.
+ * @returns True for valid or broken slots that should appear in that agent.
+ * @example
+ * isSelectedAgentSlot(skill.symlinks[0], 'cursor')
+ */
+function isSelectedAgentSlot(
+  slot: SymlinkInfo,
+  selectedAgentId: AgentId,
+): boolean {
+  return (
+    slot.agentId === selectedAgentId &&
+    (slot.status === 'valid' || slot.status === 'broken')
+  )
+}
+
+/**
+ * Check whether a skill belongs to one installed type for the selected agent.
+ * Include and exclude filtering both call this helper so G-Stack, orphan, local,
+ * and symlinked semantics cannot drift apart.
+ * @param skill - Installed skill row from the scanner.
+ * @param selectedAgentId - Active agent list owner; null means no agent type match.
+ * @param skillTypeFilter - Positive type to test.
+ * @returns True when the row matches the requested type for the selected agent.
+ * @example
+ * matchesSkillTypeFilter(skill, 'cursor', 'local')
+ */
+function matchesSkillTypeFilter(
+  skill: Skill,
+  selectedAgentId: AgentId | null,
+  skillTypeFilter: SkillTypeFilter,
+): boolean {
+  if (selectedAgentId === null) return false
+
+  const hasSelectedAgentSlot = (slot: SymlinkInfo): boolean =>
+    isSelectedAgentSlot(slot, selectedAgentId)
+
+  return match(skillTypeFilter)
+    .with('all', () => skill.symlinks.some(hasSelectedAgentSlot))
+    .with('symlinked', () =>
+      skill.symlinks.some(
+        (slot) => hasSelectedAgentSlot(slot) && slot.isLocal === false,
+      ),
+    )
+    .with('local', () =>
+      skill.symlinks.some(
+        (slot) => hasSelectedAgentSlot(slot) && slot.isLocal === true,
+      ),
+    )
+    .with('gstack', () => isGStackManagedForAgent(skill, selectedAgentId))
+    .with(
+      'orphan',
+      () =>
+        skill.isOrphan === true && skill.symlinks.some(hasSelectedAgentSlot),
+    )
+    .exhaustive()
+}
+
+/**
+ * Apply the shared first-pass Installed population gate.
+ * Source view returns source-directory skills; agent view returns the selected
+ * include type minus any active excludes before repo/search/sort run.
+ * @param skills - Raw skill scanner rows from Redux.
+ * @param selectedAgentId - Active agent, or null for source view.
+ * @param skillTypeFilter - Positive include mode.
+ * @param excludedSkillTypeFilters - Negative type filters to subtract.
+ * @returns Skills eligible for downstream repo/search/sort filters.
+ * @example
+ * applyAgentAndTypeFilters(skills, 'cursor', 'all', ['local'])
+ */
+function applyAgentAndTypeFilters(
+  skills: Skill[],
+  selectedAgentId: AgentId | null,
+  skillTypeFilter: SkillTypeFilter,
+  excludedSkillTypeFilters: ExcludableSkillTypeFilter[],
+): Skill[] {
+  if (selectedAgentId === null) {
+    return skills.filter((skill) => skill.isSource)
+  }
+
+  let result = skills.filter((skill) =>
+    matchesSkillTypeFilter(skill, selectedAgentId, skillTypeFilter),
+  )
+  if (excludedSkillTypeFilters.length === 0) return result
+
+  const excludedTypes = new Set<ExcludableSkillTypeFilter>(
+    excludedSkillTypeFilters,
+  )
+  result = result.filter((skill) => {
+    for (const excludedType of excludedTypes) {
+      if (matchesSkillTypeFilter(skill, selectedAgentId, excludedType)) {
+        return false
+      }
+    }
+    return true
+  })
+  return result
+}
 
 /**
  * Memoized selector for filtered and sorted skills list.
- * Applies (in order): agent filter, skill type filter, source-repo pill,
+ * Applies (in order): agent/type include, type excludes, source-repo pill,
  * scope-aware search query, and name sort.
  *
  * Search scope rules:
@@ -48,6 +165,7 @@ export const selectFilteredSkills = createSelector(
     selectSelectedSource,
     selectSortOrder,
     selectSkillTypeFilter,
+    selectExcludedSkillTypeFilters,
   ],
   (
     skills,
@@ -57,56 +175,14 @@ export const selectFilteredSkills = createSelector(
     selectedSource,
     sortOrder,
     skillTypeFilter,
+    excludedSkillTypeFilters,
   ) => {
-    let result = skills
-
-    // Source view (no agent) narrows to SOURCE_DIR skills so the SourceCard
-    // matches its `~/.agents/skills/` label instead of leaking agent-local
-    // folders (e.g. `~/.claude/skills/<name>` with no symlink under
-    // `~/.agents/skills/`). Agent view keeps both `valid` and `broken`
-    // slots so AgentItem's "Cleanup missing skills..." has rows to act on.
-    // `missing` slots are dropped — nothing on disk to surface there.
-    //
-    // Each skill-type arm narrows from the selected agent's slot. G-Stack
-    // delegates to the same attribution helper as the card badge so local
-    // sibling skills and direct symlinks stay in sync.
-    if (selectedAgentId) {
-      const hasAgentSlot = (slot: SymlinkInfo): boolean =>
-        slot.agentId === selectedAgentId &&
-        (slot.status === 'valid' || slot.status === 'broken')
-      result = match(skillTypeFilter)
-        .with('all', () =>
-          result.filter((skill) => skill.symlinks.some(hasAgentSlot)),
-        )
-        .with('symlinked', () =>
-          result.filter((skill) =>
-            skill.symlinks.some(
-              (slot) => hasAgentSlot(slot) && slot.isLocal === false,
-            ),
-          ),
-        )
-        .with('local', () =>
-          result.filter((skill) =>
-            skill.symlinks.some(
-              (slot) => hasAgentSlot(slot) && slot.isLocal === true,
-            ),
-          ),
-        )
-        .with('gstack', () =>
-          result.filter((skill) =>
-            isGStackManagedForAgent(skill, selectedAgentId),
-          ),
-        )
-        .with('orphan', () =>
-          result.filter(
-            (skill) =>
-              skill.isOrphan === true && skill.symlinks.some(hasAgentSlot),
-          ),
-        )
-        .exhaustive()
-    } else {
-      result = result.filter((skill) => skill.isSource)
-    }
+    let result = applyAgentAndTypeFilters(
+      skills,
+      selectedAgentId,
+      skillTypeFilter,
+      excludedSkillTypeFilters,
+    )
 
     // Source-repo filter pill — exact match. Local skills (source undefined)
     // can never match a non-null pill value, so they drop out implicitly.
@@ -139,6 +215,44 @@ export const selectFilteredSkills = createSelector(
     })
 
     return sorted
+  },
+)
+
+/**
+ * Exact repo choices for the Installed toolbar. It shares the agent/type gates
+ * with `selectFilteredSkills`, but intentionally ignores the active source pill
+ * and text query so users can recover from an over-narrowed filter.
+ * @returns Sorted source options with matching row counts.
+ * @example
+ * const repoOptions = useAppSelector(selectRepoFacetOptions)
+ */
+export const selectRepoFacetOptions = createSelector(
+  [
+    selectSkillsItems,
+    selectSelectedAgentId,
+    selectSkillTypeFilter,
+    selectExcludedSkillTypeFilters,
+  ],
+  (
+    skills,
+    selectedAgentId,
+    skillTypeFilter,
+    excludedSkillTypeFilters,
+  ): RepoFacetOption[] => {
+    const sourceCounts = new Map<RepositoryId, number>()
+    const visibleByAgentAndType = applyAgentAndTypeFilters(
+      skills,
+      selectedAgentId,
+      skillTypeFilter,
+      excludedSkillTypeFilters,
+    )
+    for (const skill of visibleByAgentAndType) {
+      if (!skill.source) continue
+      sourceCounts.set(skill.source, (sourceCounts.get(skill.source) ?? 0) + 1)
+    }
+    return [...sourceCounts.entries()]
+      .sort(([sourceA], [sourceB]) => sourceA.localeCompare(sourceB))
+      .map(([source, count]) => ({ source, count }))
   },
 )
 

--- a/src/renderer/src/redux/slices/uiSlice.test.ts
+++ b/src/renderer/src/redux/slices/uiSlice.test.ts
@@ -100,6 +100,60 @@ describe('uiSlice activeTab', () => {
   })
 })
 
+describe('uiSlice skill type excludes', () => {
+  it('starts with no excluded skill types', async () => {
+    const store = await createTestStore()
+    expect(store.getState().ui.excludedSkillTypeFilters).toEqual([])
+  })
+
+  it('toggles an available excluded skill type on and off', async () => {
+    const store = await createTestStore()
+    const { toggleExcludedSkillTypeFilter } = await import('./uiSlice')
+
+    store.dispatch(toggleExcludedSkillTypeFilter('local'))
+    expect(store.getState().ui.excludedSkillTypeFilters).toEqual(['local'])
+
+    store.dispatch(toggleExcludedSkillTypeFilter('local'))
+    expect(store.getState().ui.excludedSkillTypeFilters).toEqual([])
+  })
+
+  it('ignores an excluded skill type unavailable for the active include filter', async () => {
+    const store = await createTestStore()
+    const { setSkillTypeFilter, toggleExcludedSkillTypeFilter } =
+      await import('./uiSlice')
+
+    store.dispatch(setSkillTypeFilter('local'))
+    store.dispatch(toggleExcludedSkillTypeFilter('symlinked'))
+
+    expect(store.getState().ui.excludedSkillTypeFilters).toEqual([])
+  })
+
+  it('prunes stale excludes when the include filter changes', async () => {
+    const store = await createTestStore()
+    const { setSkillTypeFilter, toggleExcludedSkillTypeFilter } =
+      await import('./uiSlice')
+
+    store.dispatch(toggleExcludedSkillTypeFilter('local'))
+    store.dispatch(toggleExcludedSkillTypeFilter('gstack'))
+    store.dispatch(setSkillTypeFilter('local'))
+
+    expect(store.getState().ui.excludedSkillTypeFilters).toEqual(['gstack'])
+  })
+
+  it('selectAgent resets include and exclude filters together', async () => {
+    const store = await createTestStore()
+    const { selectAgent, setSkillTypeFilter, toggleExcludedSkillTypeFilter } =
+      await import('./uiSlice')
+
+    store.dispatch(setSkillTypeFilter('gstack'))
+    store.dispatch(toggleExcludedSkillTypeFilter('local'))
+    store.dispatch(selectAgent('cursor' as AgentId))
+
+    expect(store.getState().ui.skillTypeFilter).toBe('all')
+    expect(store.getState().ui.excludedSkillTypeFilters).toEqual([])
+  })
+})
+
 describe('uiSlice sync thunks', () => {
   beforeEach(() => {
     vi.resetAllMocks()

--- a/src/renderer/src/redux/slices/uiSlice.ts
+++ b/src/renderer/src/redux/slices/uiSlice.ts
@@ -31,6 +31,7 @@ export type SkillTypeFilter =
   | 'local'
   | 'gstack'
   | 'orphan'
+export type ExcludableSkillTypeFilter = Exclude<SkillTypeFilter, 'all'>
 export type ActiveTab = 'installed' | 'marketplace'
 /**
  * Which field the search box matches against.
@@ -101,6 +102,12 @@ interface UiState {
   sortOrder: SortOrder
   /** Filter by skill type in agent view (all / symlinked / local / G-Stack / orphan) */
   skillTypeFilter: SkillTypeFilter
+  /**
+   * Skill types subtracted from the selected agent list. Kept transient like
+   * the rest of `ui`; reducer guards below prevent impossible include/exclude
+   * combinations from becoming user-visible labels.
+   */
+  excludedSkillTypeFilters: ExcludableSkillTypeFilter[]
   /** Whether sync operation is in progress */
   isSyncing: boolean
   /** Sync preview result (null when not previewing) */
@@ -151,6 +158,7 @@ const initialState: UiState = {
   selectedAgentId: null,
   sortOrder: 'asc',
   skillTypeFilter: 'all',
+  excludedSkillTypeFilters: [],
   isSyncing: false,
   syncPreview: null,
   syncResult: null,
@@ -204,6 +212,32 @@ export const executeSyncAction = createAsyncThunk(
   },
 )
 
+/**
+ * Return exclude types that can actually change the current include population.
+ * The UI uses this to disable impossible rows; reducers use it as the source of
+ * truth so accidental dispatches cannot create contradictory labels.
+ * @param skillTypeFilter - The active positive include mode.
+ * @returns Exclude filters that can subtract at least one possible row.
+ * @example
+ * getAvailableExcludeTypes('local') // => ['gstack']
+ */
+export function getAvailableExcludeTypes(
+  skillTypeFilter: SkillTypeFilter,
+): ExcludableSkillTypeFilter[] {
+  switch (skillTypeFilter) {
+    case 'all':
+      return ['symlinked', 'local', 'gstack', 'orphan']
+    case 'symlinked':
+      return ['gstack', 'orphan']
+    case 'local':
+      return ['gstack']
+    case 'gstack':
+      return ['symlinked', 'local', 'orphan']
+    case 'orphan':
+      return ['gstack']
+  }
+}
+
 const uiSlice = createSlice({
   name: 'ui',
   initialState,
@@ -249,6 +283,7 @@ const uiSlice = createSlice({
     selectAgent: (state, action: PayloadAction<AgentId | null>) => {
       state.selectedAgentId = action.payload
       state.skillTypeFilter = 'all'
+      state.excludedSkillTypeFilters = []
       // Agent change swaps the entire list out; an undo referencing names the
       // user can no longer see would be misleading. Dismiss the toast.
       state.undoToast = null
@@ -262,6 +297,29 @@ const uiSlice = createSlice({
     },
     setSkillTypeFilter: (state, action: PayloadAction<SkillTypeFilter>) => {
       state.skillTypeFilter = action.payload
+      const available = new Set(getAvailableExcludeTypes(action.payload))
+      state.excludedSkillTypeFilters = state.excludedSkillTypeFilters.filter(
+        (value) => available.has(value),
+      )
+    },
+    toggleExcludedSkillTypeFilter: (
+      state,
+      action: PayloadAction<ExcludableSkillTypeFilter>,
+    ) => {
+      const available = getAvailableExcludeTypes(state.skillTypeFilter)
+      if (!available.includes(action.payload)) return
+
+      const currentIndex = state.excludedSkillTypeFilters.indexOf(
+        action.payload,
+      )
+      if (currentIndex >= 0) {
+        state.excludedSkillTypeFilters.splice(currentIndex, 1)
+        return
+      }
+      state.excludedSkillTypeFilters.push(action.payload)
+    },
+    clearExcludedSkillTypeFilters: (state) => {
+      state.excludedSkillTypeFilters = []
     },
     setSyncPreview: (
       state,
@@ -429,6 +487,8 @@ export const {
   selectAgent,
   toggleSortOrder,
   setSkillTypeFilter,
+  toggleExcludedSkillTypeFilter,
+  clearExcludedSkillTypeFilters,
   setSyncPreview,
   clearSyncResult,
   setSelectedBookmarkForDetail,
@@ -464,6 +524,9 @@ export const selectSortOrder = (state: RootState): SortOrder =>
   state.ui.sortOrder
 export const selectSkillTypeFilter = (state: RootState): SkillTypeFilter =>
   state.ui.skillTypeFilter
+export const selectExcludedSkillTypeFilters = (
+  state: RootState,
+): ExcludableSkillTypeFilter[] => state.ui.excludedSkillTypeFilters
 export const selectSelectedBookmarkForDetail = (
   state: RootState,
 ): BookmarkForDetail | null => state.ui.selectedBookmarkForDetail


### PR DESCRIPTION
## Summary
- add an Installed toolbar source repository facet with counts
- add skill-type exclude filters with reducer guards and shared selector logic
- update empty-state/filter-pill UI and cover the new flows with selector, slice, helper, and browser tests
- refresh the root pnpm lockfile config checksum so CI frozen installs pass

## Validation
- pnpm install --frozen-lockfile
- pnpm validate
- git diff --check origin/main
- GitHub Actions: build, lint, typecheck, test, e2e, fallow dead-code/dupes/health all passing
- Vercel preview passing
- CodeRabbit completed successfully

## Review Notes
- Local /review found no remaining implementation issues after removing unnecessary internal exports
- Electron QA and web design review were run with ignored artifacts under qa-reports/
- Claude review was requested, but Claude CLI auth was missing locally, so it did not run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * スキルタイプフィルタに除外機能を追加しました。特定のスキル種別を検索結果から除外できるようになります。
  * ツールバーにリポジトリ選択用ドロップダウンを追加しました。ソースを絞り込んで検索できます。

* **改善**
  * 空の検索結果表示メッセージを改善し、適用中のフィルタ情報を明確に表示するようにしました。
  * UI のレイアウトを調整し、フィルタ表示の見た目を最適化しました。

* **テスト**
  * 新しいフィルタ機能の動作を検証するテストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/skills-desktop/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->