### PR TITLE
feat: redesign theme selector to Pattern 1 (Mode-First Compact)

### DIFF
--- a/.storybook/storybook-utils.tsx
+++ b/.storybook/storybook-utils.tsx
@@ -233,10 +233,15 @@ function createStorybookThemeState(
   )
   const config = THEME_PRESETS[preset]
 
+  const resolved = 'mode' in config ? config.mode : mode
   return {
     hue: config.hue,
     chroma: config.chroma,
-    mode: 'mode' in config ? config.mode : mode,
+    mode: resolved,
+    // Storybook has no notion of OS theme; mirror the resolved mode so the
+    // ThemeSelector dropdown's `Light` / `Dark` segmented control reflects
+    // the same value as `<html>` even though Storybook drives it via toolbar.
+    modePreference: resolved,
     preset,
   }
 }

--- a/src/renderer/src/components/theme/ThemeSelector.browser.test.tsx
+++ b/src/renderer/src/components/theme/ThemeSelector.browser.test.tsx
@@ -6,18 +6,21 @@ import { render } from 'vitest-browser-react'
 import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
 
 /**
- * Browser-mode tests for the ThemeSelector dropdown. Runs in Chromium so the
- * Radix DropdownMenu portal, focus trap, and click-through-to-menuitem path
- * exercise the real browser event loop (jsdom's pointer event model silently
- * skips Radix's `pointerdown` heuristics, which is how the same test in
- * happy-dom would pass even if the menu never opened).
+ * Browser-mode tests for the ThemeSelector dropdown (Pattern 1: Mode-First
+ * Compact). Runs in Chromium so the Radix DropdownMenu portal, focus trap,
+ * and click-through-to-control paths exercise the real browser event loop
+ * (jsdom's pointer event model silently skips Radix's `pointerdown`
+ * heuristics, which is how the same test in happy-dom would pass even if
+ * the menu never opened).
  *
  * Covers the user-visible contract:
  *  - Trigger is reachable by accessible name (screen-reader path)
- *  - All 14 presets render as buttons with stable aria-labels
- *  - Clicking a swatch dispatches setTheme and flips aria-pressed
- *  - Neutral presets force chroma=0 and mode side-effects
- *  - Mode toggle (menuitem) dispatches toggleMode
+ *  - All 17 accent swatch buttons render with stable aria-labels
+ *  - All 5 tinted-neutral family swatches render (Neutral / Zinc / Slate / Stone / Mauve)
+ *  - Header shows the active preset name in mono
+ *  - Light / Dark / Auto segmented control dispatches setModePreference
+ *  - Clicking a family swatch resolves to the dark/light partner matching
+ *    state.mode (no surprise mode flip)
  */
 
 async function createStore() {
@@ -41,7 +44,7 @@ async function renderThemeSelector() {
   return { screen, store }
 }
 
-describe('ThemeSelector — dropdown open + preset grid', () => {
+describe('ThemeSelector — Pattern 1 layout', () => {
   it('renders the trigger button with an accessible name', async () => {
     const { screen } = await renderThemeSelector()
 
@@ -50,82 +53,114 @@ describe('ThemeSelector — dropdown open + preset grid', () => {
       .toBeInTheDocument()
   })
 
-  it('renders all 12 color preset buttons when the menu opens', async () => {
+  it('renders all 17 accent swatch buttons when the menu opens', async () => {
+    // Arrange
     const { screen } = await renderThemeSelector()
 
+    // Act
     await screen
       .getByRole('button', { name: /Theme and color options/i })
       .click()
 
-    const colorLabels = [
+    // Assert — hardcode the full 17-color list so a future regression that
+    // silently drops a hue surfaces as a concrete missing-label failure
+    // rather than an opaque "expected 17, got 16" length mismatch.
+    const accentLabels = [
       'Rose',
+      'Pink',
+      'Red',
       'Orange',
       'Amber',
       'Yellow',
       'Lime',
       'Green',
+      'Emerald',
       'Teal',
       'Cyan',
       'Sky',
       'Blue',
       'Indigo',
       'Violet',
+      'Fuchsia',
+      'Magenta',
     ]
-    for (const label of colorLabels) {
+    for (const label of accentLabels) {
       await expect
         .element(screen.getByRole('button', { name: `Select ${label} theme` }))
         .toBeInTheDocument()
     }
   })
 
-  it('renders both neutral preset buttons when the menu opens', async () => {
+  it('renders 5 tinted-neutral family swatches when the menu opens', async () => {
+    // Arrange
     const { screen } = await renderThemeSelector()
 
+    // Act
     await screen
       .getByRole('button', { name: /Theme and color options/i })
       .click()
 
+    // Assert — one button per family. Mode is resolved at click time, so
+    // there's no "Dark"/"Light" suffix in the accessible name.
+    for (const familyLabel of ['Neutral', 'Zinc', 'Slate', 'Stone', 'Mauve']) {
+      await expect
+        .element(
+          screen.getByRole('button', { name: `Select ${familyLabel} theme` }),
+        )
+        .toBeInTheDocument()
+    }
+  })
+
+  it('header displays the current preset label in mono', async () => {
+    // Arrange — initial preset is neutral-dark whose THEME_PRESETS label is
+    // "Neutral Dark", so the header should read that verbatim. `exact: true`
+    // discriminates against the sr-only "Current theme: Neutral Dark" span
+    // which also contains the substring.
+    const { screen } = await renderThemeSelector()
+
+    // Act
+    await screen
+      .getByRole('button', { name: /Theme and color options/i })
+      .click()
+
+    // Assert
     await expect
-      .element(
-        screen.getByRole('button', { name: 'Select Neutral Dark theme' }),
-      )
-      .toBeInTheDocument()
-    await expect
-      .element(
-        screen.getByRole('button', { name: 'Select Neutral Light theme' }),
-      )
+      .element(screen.getByText('Neutral Dark', { exact: true }))
       .toBeInTheDocument()
   })
 
   it('clicking a color swatch dispatches setTheme(presetName) with correct hue/chroma', async () => {
+    // Arrange
     const { screen, store } = await renderThemeSelector()
     const { THEME_PRESETS } = await import('@/shared/constants')
 
+    // Act
     await screen
       .getByRole('button', { name: /Theme and color options/i })
       .click()
     await screen.getByRole('button', { name: 'Select Cyan theme' }).click()
 
+    // Assert
     const { theme } = store.getState()
     expect(theme.preset).toBe('cyan')
     expect(theme.hue).toBe(THEME_PRESETS.cyan.hue)
     expect(theme.chroma).toBe(THEME_PRESETS.cyan.chroma)
   })
 
-  it('aria-pressed reflects the currently selected preset', async () => {
-    // Seed state with `rose` before opening the menu so the component reads
-    // a non-default preset on first render inside the portal. This guards
-    // against the regression where aria-pressed was hard-wired to the
-    // initial render and never updated on preset change.
+  it('aria-pressed reflects the currently selected color preset', async () => {
+    // Arrange — seed a non-default preset before opening the menu so the
+    // component reads it on first render. Guards against a regression where
+    // aria-pressed was hard-wired to the initial state and never updated.
     const { screen, store } = await renderThemeSelector()
     const { setTheme } = await import('@/renderer/src/redux/slices/themeSlice')
-
     store.dispatch(setTheme('rose'))
 
+    // Act
     await screen
       .getByRole('button', { name: /Theme and color options/i })
       .click()
 
+    // Assert
     await expect
       .element(screen.getByRole('button', { name: 'Select Rose theme' }))
       .toHaveAttribute('aria-pressed', 'true')
@@ -134,38 +169,88 @@ describe('ThemeSelector — dropdown open + preset grid', () => {
       .toHaveAttribute('aria-pressed', 'false')
   })
 
-  it('clicking a neutral preset forces chroma=0 and sets mode to match', async () => {
+  it('clicking Zinc family in Dark mode dispatches setTheme("zinc-dark")', async () => {
+    // Arrange — initial mode is dark; user opens the dropdown.
     const { screen, store } = await renderThemeSelector()
 
+    // Act
     await screen
       .getByRole('button', { name: /Theme and color options/i })
       .click()
-    await screen
-      .getByRole('button', { name: 'Select Neutral Light theme' })
-      .click()
+    await screen.getByRole('button', { name: 'Select Zinc theme' }).click()
 
+    // Assert — family swatch resolved to the dark partner.
     const { theme } = store.getState()
-    expect(theme.preset).toBe('neutral-light')
-    expect(theme.chroma).toBe(0)
+    expect(theme.preset).toBe('zinc-dark')
+    expect(theme.mode).toBe('dark')
+  })
+
+  it('clicking Zinc family in Light mode dispatches setTheme("zinc-light")', async () => {
+    // Arrange — pin Light before opening the menu.
+    const { screen, store } = await renderThemeSelector()
+    const { setModePreference } =
+      await import('@/renderer/src/redux/slices/themeSlice')
+    store.dispatch(setModePreference('light'))
+
+    // Act
+    await screen
+      .getByRole('button', { name: /Theme and color options/i })
+      .click()
+    await screen.getByRole('button', { name: 'Select Zinc theme' }).click()
+
+    // Assert
+    const { theme } = store.getState()
+    expect(theme.preset).toBe('zinc-light')
     expect(theme.mode).toBe('light')
   })
 
-  it('the mode-toggle menuitem dispatches toggleMode', async () => {
-    // Discover the initial mode from the store instead of assuming 'dark',
-    // so if the slice's default ever flips (or a future test seeds mode
-    // before opening the menu) this test continues to exercise the real
-    // contract: clicking "Switch to <other>" flips mode to <other>.
+  it('clicking the Light segmented item dispatches setModePreference("light")', async () => {
+    // Arrange
     const { screen, store } = await renderThemeSelector()
-    const initialMode = store.getState().theme.mode
-    const target = initialMode === 'dark' ? 'Light' : 'Dark'
+    expect(store.getState().theme.modePreference).toBe('dark')
 
+    // Act
     await screen
       .getByRole('button', { name: /Theme and color options/i })
       .click()
-    await screen
-      .getByRole('menuitem', { name: new RegExp(`Switch to ${target}`, 'i') })
-      .click()
+    await screen.getByRole('radio', { name: 'Light mode' }).click()
 
-    expect(store.getState().theme.mode).toBe(target.toLowerCase())
+    // Assert
+    expect(store.getState().theme.mode).toBe('light')
+    expect(store.getState().theme.modePreference).toBe('light')
+  })
+
+  it('clicking the Dark segmented item dispatches setModePreference("dark")', async () => {
+    // Arrange — start from Light so the Dark click is observable.
+    const { screen, store } = await renderThemeSelector()
+    const { setModePreference } =
+      await import('@/renderer/src/redux/slices/themeSlice')
+    store.dispatch(setModePreference('light'))
+
+    // Act
+    await screen
+      .getByRole('button', { name: /Theme and color options/i })
+      .click()
+    await screen.getByRole('radio', { name: 'Dark mode' }).click()
+
+    // Assert
+    expect(store.getState().theme.mode).toBe('dark')
+    expect(store.getState().theme.modePreference).toBe('dark')
+  })
+
+  it('clicking the Auto segmented item dispatches setModePreference("system")', async () => {
+    // Arrange
+    const { screen, store } = await renderThemeSelector()
+
+    // Act
+    await screen
+      .getByRole('button', { name: /Theme and color options/i })
+      .click()
+    await screen.getByRole('radio', { name: 'System mode' }).click()
+
+    // Assert — modePreference is persisted; mode is the OS-resolved value
+    // (Chromium reports whatever the test runner's OS appearance is, so we
+    // only assert on modePreference here to keep the test environment-agnostic).
+    expect(store.getState().theme.modePreference).toBe('system')
   })
 })

--- a/src/renderer/src/components/theme/ThemeSelector.test.ts
+++ b/src/renderer/src/components/theme/ThemeSelector.test.ts
@@ -66,4 +66,31 @@ describe('resolveNeutralFamilySelection', () => {
       targetPreset: null,
     })
   })
+
+  it('returns a null click target when the dark family partner is missing in dark mode', () => {
+    // Arrange
+    const incompleteFamily: Parameters<
+      typeof resolveNeutralFamilySelection
+    >[0] = {
+      id: 'custom',
+      label: 'Custom',
+      dark: null,
+      light: 'neutral-light',
+      hue: 0,
+      chroma: 0,
+    }
+
+    // Act
+    const selection = resolveNeutralFamilySelection(
+      incompleteFamily,
+      'neutral-light',
+      'dark',
+    )
+
+    // Assert
+    expect(selection).toEqual({
+      isSelected: true,
+      targetPreset: null,
+    })
+  })
 })

--- a/src/renderer/src/components/theme/ThemeSelector.test.ts
+++ b/src/renderer/src/components/theme/ThemeSelector.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveNeutralFamilySelection } from './ThemeSelector'
+
+const zincFamily: Parameters<typeof resolveNeutralFamilySelection>[0] = {
+  id: 'zinc',
+  label: 'Zinc',
+  dark: 'zinc-dark',
+  light: 'zinc-light',
+  hue: 265,
+  chroma: 0.05,
+}
+
+describe('resolveNeutralFamilySelection', () => {
+  it('marks a neutral family selected when the current preset is either mode partner', () => {
+    // Arrange
+    const preset = 'zinc-light'
+
+    // Act
+    const selection = resolveNeutralFamilySelection(zincFamily, preset, 'dark')
+
+    // Assert
+    expect(selection).toEqual({
+      isSelected: true,
+      targetPreset: 'zinc-dark',
+    })
+  })
+
+  it('resolves the light partner when the current display mode is light', () => {
+    // Arrange
+    const preset = 'rose'
+
+    // Act
+    const selection = resolveNeutralFamilySelection(zincFamily, preset, 'light')
+
+    // Assert
+    expect(selection).toEqual({
+      isSelected: false,
+      targetPreset: 'zinc-light',
+    })
+  })
+
+  it('returns a null click target when a family is missing the requested mode partner', () => {
+    // Arrange
+    const incompleteFamily: Parameters<
+      typeof resolveNeutralFamilySelection
+    >[0] = {
+      id: 'custom',
+      label: 'Custom',
+      dark: 'neutral-dark',
+      light: null,
+      hue: 0,
+      chroma: 0,
+    }
+
+    // Act
+    const selection = resolveNeutralFamilySelection(
+      incompleteFamily,
+      'neutral-dark',
+      'light',
+    )
+
+    // Assert
+    expect(selection).toEqual({
+      isSelected: true,
+      targetPreset: null,
+    })
+  })
+})

--- a/src/renderer/src/components/theme/ThemeSelector.tsx
+++ b/src/renderer/src/components/theme/ThemeSelector.tsx
@@ -1,18 +1,25 @@
-import { Moon, Palette, Sun } from 'lucide-react'
+import { Monitor, Moon, Palette, Sun } from 'lucide-react'
 import React, { useCallback, type ReactElement } from 'react'
 
 import { Button } from '@/renderer/src/components/ui/button'
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/renderer/src/components/ui/dropdown-menu'
+import {
+  ToggleGroup,
+  ToggleGroupItem,
+} from '@/renderer/src/components/ui/toggle-group'
 import { cn } from '@/renderer/src/lib/utils'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
-import { setTheme, toggleMode } from '@/renderer/src/redux/slices/themeSlice'
+import type { ModePreference } from '@/renderer/src/redux/slices/themeSlice'
+import {
+  setModePreference,
+  setTheme,
+} from '@/renderer/src/redux/slices/themeSlice'
 import type { ThemePresetName } from '@/shared/constants'
 import { THEME_PRESETS } from '@/shared/constants'
 
@@ -30,20 +37,28 @@ const NEUTRAL_PRESET_NAMES = PRESET_NAMES.filter(
 )
 
 /**
- * Group neutral presets by family (Neutral, Zinc, Slate, Stone, Mauve) so
- * each row in the dropdown renders a Dark/Light pair under a family label.
- * Keeps individual buttons short ("Dark" / "Light") so the dropdown layout
- * stays compact even when test environments don't apply Tailwind utilities,
- * and gives users a clearer visual scan than 10 monochrome buttons in a grid.
+ * OKLCH lightness for swatch dots in the dropdown. 0.65 sits in the
+ * perceptual middle — light enough for dark backgrounds, dark enough for
+ * light backgrounds — and matches the lightness used by `--primary` in
+ * `globals.css`. Pulling it out of inline styles keeps the eight swatch
+ * call sites in lockstep when designers retune the value.
+ */
+const SWATCH_LIGHTNESS = 0.65
+
+/**
+ * Tinted-neutral families surface in a single row of 5 swatches (no
+ * Dark/Light split — picking the family swatch resolves to the partner
+ * key that matches the user's currently displayed mode). This is the
+ * shape `THEME_PRESETS` produces after grouping by family prefix.
  *
  * Family id is derived from the preset name's prefix (`zinc-dark` → `zinc`).
- * The label is taken from whichever variant exists first; for the canonical
- * "Neutral" family the human label drops the "Dark"/"Light" suffix.
+ * The label drops the "Dark"/"Light" suffix so the row reads as a horizontal
+ * palette picker rather than a list of mode-locked entries.
  *
  * @example
  * NEUTRAL_FAMILIES === [
- *   { id: 'neutral', label: 'Neutral', dark: 'neutral-dark', light: 'neutral-light' },
- *   { id: 'zinc',    label: 'Zinc',    dark: 'zinc-dark',    light: 'zinc-light' },
+ *   { id: 'neutral', label: 'Neutral', dark: 'neutral-dark', light: 'neutral-light', hue: 0,   chroma: 0    },
+ *   { id: 'zinc',    label: 'Zinc',    dark: 'zinc-dark',    light: 'zinc-light',    hue: 265, chroma: 0.05 },
  *   ...
  * ]
  */
@@ -52,6 +67,8 @@ interface NeutralFamily {
   label: string
   dark: ThemePresetName | null
   light: ThemePresetName | null
+  hue: number
+  chroma: number
 }
 
 const NEUTRAL_FAMILIES: readonly NeutralFamily[] = (() => {
@@ -69,6 +86,8 @@ const NEUTRAL_FAMILIES: readonly NeutralFamily[] = (() => {
       label: familyLabel,
       dark: null,
       light: null,
+      hue: config.hue,
+      chroma: config.chroma,
     }
     if (config.mode === 'dark') existing.dark = name
     else existing.light = name
@@ -78,21 +97,40 @@ const NEUTRAL_FAMILIES: readonly NeutralFamily[] = (() => {
 })()
 
 /**
- * Theme selector dropdown. Renders the 27 preset entries (17 hue-based
- * color themes + 5 neutral families × 2 modes = 10 neutral entries) plus
- * a dark/light mode toggle.
- * All preset data flows from `THEME_PRESETS`; this component only maps
- * state → UI and fires a single `setTheme(presetName)` action per click.
+ * Build the live "current theme" string for the dropdown header.
+ * Color presets are mode-agnostic in `THEME_PRESETS` (label = 'Sky'), so we
+ * append the resolved mode for context. Neutral preset labels already
+ * encode the mode (e.g. 'Zinc Dark'), so we use them verbatim.
  *
- * Layout:
- *  - Color themes: 6-column swatch grid (3 rows for 17 hues) — color
- *    presets are mode-agnostic, so a swatch click keeps the user's current
- *    light/dark choice.
- *  - Neutral & Tinted: one row per family (Neutral, Zinc, Slate, Stone,
- *    Mauve), with a fixed-width family label followed by Dark/Light
- *    buttons. Short button labels keep layout stable even when Tailwind
- *    utilities aren't compiled (e.g. inside the vitest browser project,
- *    which doesn't load `@tailwindcss/vite`).
+ * @example
+ * formatCurrentThemeLabel('cyan',        'dark')  // 'Cyan · Dark'
+ * formatCurrentThemeLabel('zinc-light',  'light') // 'Zinc Light'
+ */
+function formatCurrentThemeLabel(
+  preset: ThemePresetName,
+  mode: 'light' | 'dark',
+): string {
+  const config = THEME_PRESETS[preset]
+  if ('mode' in config) return config.label
+  return `${config.label} · ${mode === 'dark' ? 'Dark' : 'Light'}`
+}
+
+/**
+ * Theme selector dropdown (Pattern 1: Mode-First Compact).
+ *
+ * Layout, top to bottom:
+ *  1. Header — "Theme" label with the live current preset name on the right
+ *     (mono, muted) so users always know what they're on without hunting
+ *     for the highlighted swatch.
+ *  2. Mode segmented control — single-select radiogroup of
+ *     Light / Dark / Auto. "Auto" persists as `modePreference === 'system'`
+ *     and follows `prefers-color-scheme` via the listener middleware.
+ *  3. Accent — the 17 hue-based color presets as a 6-column swatch grid.
+ *     Mode-agnostic; clicking keeps the user's current mode.
+ *  4. Tinted Neutral — the 5 families (Neutral, Zinc, Slate, Stone, Mauve)
+ *     as a single horizontal row of swatches with labels underneath. Each
+ *     swatch resolves to `${family}-${currentMode}` so users don't have to
+ *     pick a Dark/Light variant twice.
  *
  * Wrapped in `React.memo` to match the project-wide memoization convention
  * (enforced by `@laststance/react-next/all-memo`). The component takes no
@@ -101,15 +139,32 @@ const NEUTRAL_FAMILIES: readonly NeutralFamily[] = (() => {
  */
 export const ThemeSelector = React.memo(function ThemeSelector(): ReactElement {
   const dispatch = useAppDispatch()
-  const { mode, preset } = useAppSelector((state) => state.theme)
+  const { mode, modePreference, preset } = useAppSelector(
+    (state) => state.theme,
+  )
 
-  const handleToggleMode = useCallback((): void => {
-    dispatch(toggleMode())
-  }, [dispatch])
-
-  const handleSelectPreset = (name: ThemePresetName): void => {
-    dispatch(setTheme(name))
-  }
+  // `useCallback` is intentionally avoided for `handleSelectPreset` and
+  // `handleSelectFamily`: the swatch grid renders an inline arrow per item
+  // (`() => dispatch(setTheme(name))`) to capture the per-item `name` /
+  // `family`. Wrapping a stable `handleSelectPreset` and then re-wrapping
+  // it in the inline arrow would defeat the memoization (enforced by the
+  // `@laststance/react-next/no-deopt-use-callback` lint rule). The inline
+  // arrow is the simplest correct form — each render creates 17 new
+  // closures, which is fine at this scale.
+  //
+  // `handleSelectMode` is different: it is passed directly to Radix's
+  // `onValueChange` (no per-item wrapper), so memoization sticks and pays
+  // off when ToggleGroup memoizes against the prop identity.
+  const handleSelectMode = useCallback(
+    (value: string): void => {
+      // Radix's `onValueChange` can fire with an empty string when the
+      // user tries to deselect the active item — guard so we always have a
+      // value; the segmented control should never enter an "unset" state.
+      if (!value) return
+      dispatch(setModePreference(value as ModePreference))
+    },
+    [dispatch],
+  )
 
   return (
     <DropdownMenu>
@@ -124,30 +179,64 @@ export const ThemeSelector = React.memo(function ThemeSelector(): ReactElement {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-64">
-        <DropdownMenuLabel>Theme</DropdownMenuLabel>
+        {/* Header: section title + live current preset name. Mono + muted so
+         * the active preset reads as metadata rather than competing with the
+         * controls below. */}
+        <DropdownMenuLabel className="flex items-center justify-between gap-2">
+          <span>Theme</span>
+          <span
+            className="font-mono text-xs text-muted-foreground"
+            aria-live="polite"
+          >
+            {formatCurrentThemeLabel(preset, mode)}
+          </span>
+        </DropdownMenuLabel>
         <DropdownMenuSeparator />
 
-        {/* Mode toggle — works for every preset. Color presets flip
-         * dark/light independently; neutral presets swap preset keys
-         * (neutral-dark ↔ neutral-light) via toggleMode. */}
-        <DropdownMenuItem onClick={handleToggleMode}>
-          {mode === 'dark' ? (
-            <>
-              <Sun className="mr-2 h-4 w-4" />
-              Switch to Light
-            </>
-          ) : (
-            <>
-              <Moon className="mr-2 h-4 w-4" />
-              Switch to Dark
-            </>
-          )}
-        </DropdownMenuItem>
+        {/* Mode segmented control. Radix ToggleGroup with type="single"
+         * exposes a `radiogroup` role; each item is `role="radio"`. */}
+        <div className="px-1 py-1">
+          <ToggleGroup
+            type="single"
+            size="sm"
+            variant="outline"
+            value={modePreference}
+            onValueChange={handleSelectMode}
+            className="w-full"
+            aria-label="Color mode"
+          >
+            <ToggleGroupItem
+              value="light"
+              aria-label="Light mode"
+              className="flex-1"
+            >
+              <Sun className="h-3.5 w-3.5" />
+              Light
+            </ToggleGroupItem>
+            <ToggleGroupItem
+              value="dark"
+              aria-label="Dark mode"
+              className="flex-1"
+            >
+              <Moon className="h-3.5 w-3.5" />
+              Dark
+            </ToggleGroupItem>
+            <ToggleGroupItem
+              value="system"
+              aria-label="System mode"
+              className="flex-1"
+            >
+              <Monitor className="h-3.5 w-3.5" />
+              Auto
+            </ToggleGroupItem>
+          </ToggleGroup>
+        </div>
+
         <DropdownMenuSeparator />
 
-        {/* Color themes — chroma > 0, hue varies */}
+        {/* Accent — chroma > 0, hue varies. Mode-agnostic. */}
         <DropdownMenuLabel className="text-xs text-muted-foreground">
-          Color Themes
+          Accent
         </DropdownMenuLabel>
         <div className="grid grid-cols-6 gap-0.5 p-1">
           {COLOR_PRESET_NAMES.map((name) => {
@@ -157,7 +246,7 @@ export const ThemeSelector = React.memo(function ThemeSelector(): ReactElement {
               <button
                 key={name}
                 type="button"
-                onClick={() => handleSelectPreset(name)}
+                onClick={() => dispatch(setTheme(name))}
                 className="min-h-11 min-w-11 flex items-center justify-center"
                 title={config.label}
                 aria-label={`Select ${config.label} theme`}
@@ -170,7 +259,7 @@ export const ThemeSelector = React.memo(function ThemeSelector(): ReactElement {
                       'ring-2 ring-white ring-offset-2 ring-offset-background',
                   )}
                   style={{
-                    backgroundColor: `oklch(0.65 ${config.chroma} ${config.hue})`,
+                    backgroundColor: `oklch(${SWATCH_LIGHTNESS} ${config.chroma} ${config.hue})`,
                   }}
                 />
               </button>
@@ -180,56 +269,52 @@ export const ThemeSelector = React.memo(function ThemeSelector(): ReactElement {
 
         <DropdownMenuSeparator />
 
-        {/* Neutral & tinted-neutral themes — chroma === 0 collapses the OKLCH
-         * ramp to pure grayscale; chroma === TINTED_NEUTRAL_CHROMA produces
-         * shadcn-baseColor-style subtle tints (zinc / slate / stone / mauve).
-         * Same formula as color presets, so there is no parallel HSL block
-         * to maintain. Each row is a (family label, Dark, Light) triplet so
-         * the family name lives in a single header column instead of being
-         * repeated on both buttons. The short "Dark"/"Light" button labels
-         * keep the dropdown layout compact and predictable even when the
-         * test environment doesn't apply Tailwind utilities (the
-         * @tailwindcss/vite plugin is loaded only for the real renderer,
-         * not for the vitest browser project). */}
+        {/* Tinted Neutral — 5 families × 1 swatch (no Dark/Light split).
+         * The previous design rendered 5 × 2 = 10 mode-locked buttons,
+         * which forced users to re-pick the mode every time they switched
+         * family. Pattern 1 collapses the row to one button per family
+         * and resolves the dark/light partner from `state.mode` so the
+         * mode segmented control above stays the single source of truth
+         * for light vs dark. */}
         <DropdownMenuLabel className="text-xs text-muted-foreground">
-          Neutral &amp; Tinted (shadcn)
+          Tinted Neutral
         </DropdownMenuLabel>
-        <div className="flex flex-col gap-0.5 p-1">
-          {NEUTRAL_FAMILIES.map((family) => (
-            <div
-              key={family.id}
-              className="flex items-center gap-1 px-1 py-0.5"
-            >
-              <span className="text-xs text-muted-foreground w-14 shrink-0 truncate">
-                {family.label}
-              </span>
-              {(['dark', 'light'] as const).map((variant) => {
-                const presetName =
-                  variant === 'dark' ? family.dark : family.light
-                if (!presetName) return null
-                const config = THEME_PRESETS[presetName]
-                const isSelected = preset === presetName
-                const Icon = variant === 'dark' ? Moon : Sun
-                return (
-                  <button
-                    key={presetName}
-                    type="button"
-                    onClick={() => handleSelectPreset(presetName)}
-                    aria-label={`Select ${config.label} theme`}
-                    aria-pressed={isSelected}
-                    className={cn(
-                      'flex-1 flex items-center justify-center gap-1 px-2 py-1.5 rounded-md text-xs transition-colors',
-                      'hover:bg-muted',
-                      isSelected && 'bg-muted ring-1 ring-primary',
-                    )}
-                  >
-                    <Icon className="h-3.5 w-3.5" />
-                    {variant === 'dark' ? 'Dark' : 'Light'}
-                  </button>
-                )
-              })}
-            </div>
-          ))}
+        <div className="flex items-stretch gap-0.5 p-1">
+          {NEUTRAL_FAMILIES.map((family) => {
+            const isSelected = preset === family.dark || preset === family.light
+            // Family swatches resolve to the partner preset matching the
+            // user's currently displayed mode so picking "Zinc" while in
+            // Dark goes to zinc-dark without forcing a mode flip the user
+            // didn't ask for.
+            const targetPreset = mode === 'dark' ? family.dark : family.light
+            return (
+              <button
+                key={family.id}
+                type="button"
+                onClick={() => {
+                  if (targetPreset) dispatch(setTheme(targetPreset))
+                }}
+                title={family.label}
+                aria-label={`Select ${family.label} theme`}
+                aria-pressed={isSelected}
+                className="flex-1 flex flex-col items-center gap-1 py-1.5 rounded-md hover:bg-muted transition-colors min-h-11"
+              >
+                <span
+                  className={cn(
+                    'h-6 w-6 rounded-full transition-transform hover:scale-110 block',
+                    isSelected &&
+                      'ring-2 ring-white ring-offset-2 ring-offset-background',
+                  )}
+                  style={{
+                    backgroundColor: `oklch(${SWATCH_LIGHTNESS} ${family.chroma} ${family.hue})`,
+                  }}
+                />
+                <span className="text-[10px] text-muted-foreground leading-none">
+                  {family.label}
+                </span>
+              </button>
+            )
+          })}
         </div>
 
         {/* Screen-reader-only announcement of the active preset. The swatch

--- a/src/renderer/src/components/theme/ThemeSelector.tsx
+++ b/src/renderer/src/components/theme/ThemeSelector.tsx
@@ -71,6 +71,11 @@ interface NeutralFamily {
   chroma: number
 }
 
+interface NeutralFamilySelection {
+  isSelected: boolean
+  targetPreset: ThemePresetName | null
+}
+
 const NEUTRAL_FAMILIES: readonly NeutralFamily[] = (() => {
   const families = new Map<string, NeutralFamily>()
   for (const name of NEUTRAL_PRESET_NAMES) {
@@ -113,6 +118,32 @@ function formatCurrentThemeLabel(
   const config = THEME_PRESETS[preset]
   if ('mode' in config) return config.label
   return `${config.label} · ${mode === 'dark' ? 'Dark' : 'Light'}`
+}
+
+/**
+ * Resolve how a single tinted-neutral family should behave in the menu.
+ * Keeping this out of JSX makes the mode/preset branch testable without
+ * rendering Radix, Redux, or React.
+ *
+ * @param family - One tinted-neutral family row from `NEUTRAL_FAMILIES`.
+ * @param preset - Current theme preset stored in Redux.
+ * @param mode - Current resolved display mode (`light` or `dark`).
+ * @returns Selection state plus the concrete preset to dispatch on click.
+ *
+ * @example
+ * resolveNeutralFamilySelection(zincFamily, 'zinc-light', 'dark')
+ * // { isSelected: true, targetPreset: 'zinc-dark' }
+ */
+export function resolveNeutralFamilySelection(
+  family: NeutralFamily,
+  preset: ThemePresetName,
+  mode: 'light' | 'dark',
+): NeutralFamilySelection {
+  const isSelected = preset === family.dark || preset === family.light
+  // Family swatches follow the displayed mode so selecting "Zinc" in dark
+  // mode chooses `zinc-dark` without flipping the user's mode preference.
+  const targetPreset = mode === 'dark' ? family.dark : family.light
+  return { isSelected, targetPreset }
 }
 
 /**
@@ -281,12 +312,11 @@ export const ThemeSelector = React.memo(function ThemeSelector(): ReactElement {
         </DropdownMenuLabel>
         <div className="flex items-stretch gap-0.5 p-1">
           {NEUTRAL_FAMILIES.map((family) => {
-            const isSelected = preset === family.dark || preset === family.light
-            // Family swatches resolve to the partner preset matching the
-            // user's currently displayed mode so picking "Zinc" while in
-            // Dark goes to zinc-dark without forcing a mode flip the user
-            // didn't ask for.
-            const targetPreset = mode === 'dark' ? family.dark : family.light
+            const { isSelected, targetPreset } = resolveNeutralFamilySelection(
+              family,
+              preset,
+              mode,
+            )
             return (
               <button
                 key={family.id}

--- a/src/renderer/src/redux/listener.test.ts
+++ b/src/renderer/src/redux/listener.test.ts
@@ -9,9 +9,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
  * reacting to Redux state. Tests run in happy-dom so we can assert against a
  * real `document.documentElement`.
  *
- * Matcher coverage: setTheme, toggleMode, ACTION_HYDRATE_COMPLETE. If a future
- * reducer is added that mutates theme state, extending the matcher in
- * listener.ts requires a new test here.
+ * Matcher coverage: setTheme, setModePreference, ACTION_HYDRATE_COMPLETE. If
+ * a future reducer is added that mutates theme state, extending the matcher
+ * in listener.ts requires a new test here.
  *
  * @vitest-environment happy-dom
  */
@@ -81,19 +81,19 @@ describe('theme listener — applyThemeToDOM', () => {
     ).toBe('0')
   })
 
-  it('toggleMode flips .dark ↔ .light classes', async () => {
+  it('setModePreference flips .dark ↔ .light classes', async () => {
     const store = await createThemedStore()
-    const { setTheme, toggleMode } = await import('./slices/themeSlice')
+    const { setTheme, setModePreference } = await import('./slices/themeSlice')
 
     // Start with a color preset so we can flip independently.
     store.dispatch(setTheme('violet'))
     expect(document.documentElement.classList.contains('dark')).toBe(true)
 
-    store.dispatch(toggleMode())
+    store.dispatch(setModePreference('light'))
     expect(document.documentElement.classList.contains('dark')).toBe(false)
     expect(document.documentElement.classList.contains('light')).toBe(true)
 
-    store.dispatch(toggleMode())
+    store.dispatch(setModePreference('dark'))
     expect(document.documentElement.classList.contains('dark')).toBe(true)
     expect(document.documentElement.classList.contains('light')).toBe(false)
   })
@@ -206,6 +206,104 @@ describe('theme listener — applyThemeToDOM', () => {
     )
     expect(store.getState().ui).toBe(uiBefore)
     expect(store.getState().ui.selectedAgentId).toBeNull()
+  })
+
+  it('OS appearance change re-applies theme when modePreference is "system"', async () => {
+    // Arrange — stub matchMedia BEFORE importing listener so the hydrate
+    // handler installs the change listener against our spy.
+    let capturedChangeHandler: ((event: MediaQueryListEvent) => void) | null =
+      null
+    let osPrefersDark = true
+    const matchMediaStub = vi.fn().mockImplementation((query: string) => ({
+      get matches() {
+        return query === '(prefers-color-scheme: dark)' ? osPrefersDark : false
+      },
+      media: query,
+      addEventListener: vi.fn(
+        (event: string, handler: (e: MediaQueryListEvent) => void) => {
+          if (event === 'change') capturedChangeHandler = handler
+        },
+      ),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: matchMediaStub,
+    })
+
+    const store = await createThemedStore()
+    const { setModePreference } = await import('./slices/themeSlice')
+
+    // Act — install the OS-change handler, then opt into Auto with the OS
+    // currently reporting Dark.
+    store.dispatch({ type: ACTION_HYDRATE_COMPLETE })
+    store.dispatch(setModePreference('system'))
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+
+    // Simulate the user flipping macOS Appearance to Light while the app is
+    // running. The OS fires a `change` event on the media query; the
+    // listener must re-resolve and project the new mode onto <html>.
+    osPrefersDark = false
+    expect(capturedChangeHandler).not.toBeNull()
+    capturedChangeHandler!({
+      matches: false,
+      media: '(prefers-color-scheme: dark)',
+    } as MediaQueryListEvent)
+
+    // Assert — DOM followed the OS without the user touching the dropdown.
+    expect(document.documentElement.classList.contains('light')).toBe(true)
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+    expect(store.getState().theme.mode).toBe('light')
+    expect(store.getState().theme.modePreference).toBe('system')
+  })
+
+  it('OS appearance change is ignored when modePreference is sticky light/dark', async () => {
+    // Arrange — same wiring as the Auto test, but user pinned Light.
+    let capturedChangeHandler: ((event: MediaQueryListEvent) => void) | null =
+      null
+    let osPrefersDark = false
+    const matchMediaStub = vi.fn().mockImplementation((query: string) => ({
+      get matches() {
+        return query === '(prefers-color-scheme: dark)' ? osPrefersDark : false
+      },
+      media: query,
+      addEventListener: vi.fn(
+        (event: string, handler: (e: MediaQueryListEvent) => void) => {
+          if (event === 'change') capturedChangeHandler = handler
+        },
+      ),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: matchMediaStub,
+    })
+
+    const store = await createThemedStore()
+    const { setModePreference } = await import('./slices/themeSlice')
+
+    // Act — install the OS-change handler, then explicitly pin Light.
+    store.dispatch({ type: ACTION_HYDRATE_COMPLETE })
+    store.dispatch(setModePreference('light'))
+    expect(document.documentElement.classList.contains('light')).toBe(true)
+
+    // Simulate the OS flipping to Dark — the handler should observe that
+    // modePreference !== 'system' and bail without dispatching anything.
+    osPrefersDark = true
+    capturedChangeHandler!({
+      matches: true,
+      media: '(prefers-color-scheme: dark)',
+    } as MediaQueryListEvent)
+
+    // Assert — app stays Light because the user pinned it.
+    expect(document.documentElement.classList.contains('light')).toBe(true)
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+    expect(store.getState().theme.mode).toBe('light')
+    expect(store.getState().theme.modePreference).toBe('light')
   })
 
   it('rapid preset switches write to the DOM in dispatch order (no stale/async reordering)', async () => {

--- a/src/renderer/src/redux/listener.ts
+++ b/src/renderer/src/redux/listener.ts
@@ -6,7 +6,7 @@ import type { AgentId } from '@/shared/types'
 
 import { setSettings } from './slices/settingsSlice'
 import { clearSelection } from './slices/skillsSlice'
-import { setTheme, toggleMode } from './slices/themeSlice'
+import { setModePreference, setTheme } from './slices/themeSlice'
 import type { ThemeState } from './slices/themeSlice'
 import { fetchSyncPreview, selectAgent, setActiveTab } from './slices/uiSlice'
 
@@ -39,15 +39,61 @@ function applyThemeToDOM(state: ThemeState): void {
 }
 
 /**
+ * Tracks whether the `prefers-color-scheme` listener has been installed.
+ * `ACTION_HYDRATE_COMPLETE` should only fire once per session, but a
+ * conservative guard keeps the subscription idempotent if a future
+ * code path replays the action (e.g. during hot module reload).
+ */
+let systemThemeListenerInstalled = false
+
+/**
+ * Wire `prefers-color-scheme` change events into the store so that when
+ * the user picked "Auto" (modePreference === 'system'), the resolved
+ * `mode` follows OS appearance changes in real time. Re-dispatching
+ * `setModePreference('system')` is the simplest re-resolution path —
+ * the reducer reads matchMedia again and swaps neutral preset keys if
+ * needed, then the existing matcher below pushes the new state to the DOM.
+ *
+ * No-ops in headless environments (vitest unit lane uses happy-dom which
+ * doesn't always implement matchMedia) so the listener stays safe to
+ * import everywhere.
+ */
+function installSystemThemeListener(
+  listenerApi: Parameters<
+    Parameters<typeof listenerMiddleware.startListening>[0]['effect']
+  >[1],
+): void {
+  if (systemThemeListenerInstalled) return
+  if (
+    typeof window === 'undefined' ||
+    typeof window.matchMedia !== 'function'
+  ) {
+    return
+  }
+  const systemQuery = window.matchMedia('(prefers-color-scheme: dark)')
+  systemQuery.addEventListener('change', () => {
+    // Explicit light/dark must stay sticky; only the "Auto" path reacts.
+    const { theme } = listenerApi.getState() as ListenerState
+    if (theme.modePreference === 'system') {
+      listenerApi.dispatch(setModePreference('system'))
+    }
+  })
+  systemThemeListenerInstalled = true
+}
+
+/**
  * Theme initialization listener
- * Applies persisted theme from localStorage after hydration completes
- * This ensures the correct theme is shown after storage-middleware loads state
+ * Applies persisted theme from localStorage after hydration completes.
+ * This ensures the correct theme is shown after storage-middleware loads
+ * state, and installs the system-theme subscription so future OS flips
+ * propagate when the user is on "Auto".
  */
 listenerMiddleware.startListening({
   type: ACTION_HYDRATE_COMPLETE,
   effect: (_action, listenerApi) => {
     const state = listenerApi.getState() as ListenerState
     applyThemeToDOM(state.theme)
+    installSystemThemeListener(listenerApi)
   },
 })
 
@@ -56,7 +102,7 @@ listenerMiddleware.startListening({
  * Listens to all theme-related actions and applies CSS changes
  */
 listenerMiddleware.startListening({
-  matcher: isAnyOf(setTheme, toggleMode),
+  matcher: isAnyOf(setTheme, setModePreference),
   effect: (_action, listenerApi) => {
     const state = listenerApi.getState() as ListenerState
     applyThemeToDOM(state.theme)

--- a/src/renderer/src/redux/migrations.test.ts
+++ b/src/renderer/src/redux/migrations.test.ts
@@ -82,6 +82,7 @@ describe('migrateState — v0 → v1 correctness', () => {
         hue: 300,
         chroma: COLOR_PRESET_CHROMA,
         mode: 'dark' as const,
+        modePreference: 'dark' as const,
         preset: 'violet' as const,
       },
     }
@@ -192,6 +193,7 @@ describe('migrateState — v1 → v2 dashboard widget min-size clamp', () => {
         hue: 0,
         chroma: 0,
         mode: 'dark' as const,
+        modePreference: 'dark' as const,
         preset: 'neutral-dark' as const,
       },
     }
@@ -280,6 +282,125 @@ describe('migrateState — v1 → v2 dashboard widget min-size clamp', () => {
   })
 })
 
+describe('migrateState — v2 → v3 theme modePreference seeding', () => {
+  it('seeds modePreference from dark mode and keeps mode intact', () => {
+    // Arrange
+    const state = {
+      theme: {
+        hue: 195,
+        chroma: COLOR_PRESET_CHROMA,
+        mode: 'dark' as const,
+        preset: 'cyan' as const,
+      } as unknown as ThemeState,
+    }
+
+    // Act
+    const result = migrateState(state, 2)
+
+    // Assert
+    expect(result.theme!.mode).toBe('dark')
+    expect(result.theme!.modePreference).toBe('dark')
+    expect(result.theme!.preset).toBe('cyan')
+    expect(result.theme!.hue).toBe(195)
+  })
+
+  it('seeds modePreference from light mode and keeps mode intact', () => {
+    // Arrange
+    const state = {
+      theme: {
+        hue: 0,
+        chroma: 0,
+        mode: 'light' as const,
+        preset: 'neutral-light' as const,
+      } as unknown as ThemeState,
+    }
+
+    // Act
+    const result = migrateState(state, 2)
+
+    // Assert
+    expect(result.theme!.mode).toBe('light')
+    expect(result.theme!.modePreference).toBe('light')
+    expect(result.theme!.preset).toBe('neutral-light')
+  })
+
+  it('drops a null theme so reducer defaults take over', () => {
+    // Arrange — tampered storage with theme set to null.
+    const state = { theme: null as unknown as ThemeState }
+
+    // Act
+    const result = migrateState(state, 2)
+
+    // Assert
+    expect(result.theme).toBeUndefined()
+  })
+
+  it('falls back both mode and modePreference to dark when mode is invalid', () => {
+    // Arrange — a tampered payload with an out-of-band mode value should not
+    // produce a desynced (mode='dark', modePreference='light') state. Both
+    // fields normalize to the same safe default.
+    const state = {
+      theme: {
+        hue: 195,
+        chroma: COLOR_PRESET_CHROMA,
+        mode: 'twilight' as unknown as 'dark',
+        preset: 'cyan' as const,
+      } as unknown as ThemeState,
+    }
+
+    // Act
+    const result = migrateState(state, 2)
+
+    // Assert
+    expect(result.theme!.mode).toBe('dark')
+    expect(result.theme!.modePreference).toBe('dark')
+  })
+
+  it('does not introduce system preference for legacy users', () => {
+    // Arrange — the whole point of the migration's defensive seeding is to
+    // never surprise an existing user with auto-OS-tracking behavior they
+    // never opted into.
+    const state = {
+      theme: {
+        hue: 0,
+        chroma: 0,
+        mode: 'dark' as const,
+        preset: 'neutral-dark' as const,
+      } as unknown as ThemeState,
+    }
+
+    // Act
+    const result = migrateState(state, 2)
+
+    // Assert
+    expect(result.theme!.modePreference).not.toBe('system')
+  })
+
+  it('chains v0 → v1 → v2 → v3 in one call, producing a v3 shape', () => {
+    // Arrange — a fully legacy v0 payload (presetType discriminator, no
+    // chroma, no modePreference) should land on the current schema after
+    // a single migrateState() invocation. Catches regressions where the
+    // chain breaks at an intermediate version.
+    const state = {
+      theme: {
+        hue: 195,
+        mode: 'dark' as const,
+        preset: 'cyan',
+        presetType: 'color',
+      } as unknown as LegacyTheme,
+    }
+
+    // Act
+    const result = migrateState(state, 0)
+
+    // Assert
+    expect(result.theme!.preset).toBe('cyan')
+    expect(result.theme!.chroma).toBe(THEME_PRESETS.cyan.chroma)
+    expect(result.theme!.mode).toBe('dark')
+    expect(result.theme!.modePreference).toBe('dark')
+  })
+})
+
 describe('V2_WIDGET_MIN_SIZES drift guard', () => {
   // The map in migrations.ts mirrors `WIDGET_REGISTRY[*].minSize`. If anyone
   // bumps a widget's runtime min in the registry without updating the
@@ -339,6 +460,7 @@ describe('migrateState — drift guard', () => {
         hue: 0,
         chroma: 0,
         mode: 'dark' as const,
+        modePreference: 'dark' as const,
         preset: 'neutral-dark' as const,
       },
     }

--- a/src/renderer/src/redux/migrations.ts
+++ b/src/renderer/src/redux/migrations.ts
@@ -143,6 +143,35 @@ function migrateV1ToV2(state: MigratableState): void {
 }
 
 /**
+ * v2 → v3 migration for the theme slice. v3 introduces `modePreference`
+ * (the user's *choice* of light / dark / system) alongside the existing
+ * `mode` (the *resolved* value applied to <html>). v2 users only had
+ * `mode`, so seed `modePreference` from it — they explicitly picked
+ * light or dark before, and silently upgrading them to "system" would
+ * make their app start auto-flipping with the OS without notice.
+ *
+ * `mode` itself is also normalized: anything other than 'light' / 'dark'
+ * (tampered storage, future variants) collapses to 'dark' so both fields
+ * agree on a sane default.
+ */
+function migrateV2ToV3(state: MigratableState): void {
+  // Null, undefined, or non-object theme slot: drop it so the reducer's
+  // initial state takes over. Matches the v0 → v1 defensive style.
+  if (!state.theme || typeof state.theme !== 'object') {
+    delete state.theme
+    return
+  }
+  const legacy = state.theme as { mode?: 'light' | 'dark' }
+  const resolved: 'light' | 'dark' =
+    legacy.mode === 'light' || legacy.mode === 'dark' ? legacy.mode : 'dark'
+  state.theme = {
+    ...(state.theme as ThemeState),
+    mode: resolved,
+    modePreference: resolved,
+  }
+}
+
+/**
  * Chain migrations up to `PERSIST_STATE_VERSION`. Each `case` must advance
  * `current` to the next schema version; unknown sources throw so bumping
  * `PERSIST_STATE_VERSION` without adding a migration fails loudly in tests
@@ -166,6 +195,10 @@ export function migrateState<T extends MigratableState>(
       case 1:
         migrateV1ToV2(state)
         current = 2
+        break
+      case 2:
+        migrateV2ToV3(state)
+        current = 3
         break
       default:
         throw new Error(

--- a/src/renderer/src/redux/slices/themeSlice.test.ts
+++ b/src/renderer/src/redux/slices/themeSlice.test.ts
@@ -1,20 +1,59 @@
 import { configureStore } from '@reduxjs/toolkit'
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { COLOR_PRESET_CHROMA, TINTED_NEUTRAL_CHROMA } from '@/shared/constants'
+
+/**
+ * `setModePreference('system')` reads `window.matchMedia('(prefers-color-scheme: dark)')`
+ * to decide the resolved mode, so this file runs under happy-dom to get a
+ * real `window` object — node-only would fall back to the hard-coded 'dark'
+ * branch in `resolveMode` and the `'system' → light` cases below would all
+ * silently pass with the wrong answer.
+ *
+ * @vitest-environment happy-dom
+ */
 
 async function createTestStore() {
   const { default: themeReducer } = await import('./themeSlice')
   return configureStore({ reducer: { theme: themeReducer } })
 }
 
+/**
+ * Build a `window.matchMedia` stub that always reports a given system
+ * preference. The stub mirrors only the subset of `MediaQueryList` that
+ * `resolveMode` touches (`matches`, `addEventListener`, etc.) — full
+ * compliance would be overkill for these reducer tests.
+ */
+function stubSystemPrefersDark(prefersDark: boolean): void {
+  const matchMediaStub = vi.fn().mockImplementation((query: string) => ({
+    matches: query === '(prefers-color-scheme: dark)' ? prefersDark : false,
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }))
+  // `resolveMode` reads `window.matchMedia` directly, so write to the
+  // window — `vi.stubGlobal('matchMedia', ...)` alone would set the bare
+  // global but not the property on the `window` instance happy-dom exposes.
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: matchMediaStub,
+  })
+}
+
 describe('themeSlice', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
   it('has correct initial state', async () => {
     const store = await createTestStore()
     const state = store.getState().theme
     expect(state.hue).toBe(0)
     expect(state.chroma).toBe(0)
     expect(state.mode).toBe('dark')
+    expect(state.modePreference).toBe('dark')
     expect(state.preset).toBe('neutral-dark')
   })
 
@@ -40,27 +79,54 @@ describe('themeSlice', () => {
     expect(state.mode).toBe('light')
   })
 
-  it('toggleMode flips dark/light for color presets without losing preset', async () => {
-    const { setTheme, toggleMode } = await import('./themeSlice')
+  it('setTheme leaves modePreference untouched so an "Auto" user keeps tracking the OS', async () => {
+    // Arrange — user picked Auto, the listener resolved to dark.
+    const { setTheme, setModePreference } = await import('./themeSlice')
+    stubSystemPrefersDark(true)
+    const store = await createTestStore()
+    store.dispatch(setModePreference('system'))
+    expect(store.getState().theme.modePreference).toBe('system')
+
+    // Act — user picks Cyan from the swatch grid.
+    store.dispatch(setTheme('cyan'))
+
+    // Assert — preset changed but modePreference is still 'system'.
+    expect(store.getState().theme.preset).toBe('cyan')
+    expect(store.getState().theme.modePreference).toBe('system')
+  })
+
+  it('setModePreference flips dark/light for color presets without losing preset', async () => {
+    // Arrange
+    const { setTheme, setModePreference } = await import('./themeSlice')
     const store = await createTestStore()
     store.dispatch(setTheme('cyan'))
     expect(store.getState().theme.mode).toBe('dark')
-    store.dispatch(toggleMode())
+
+    // Act + Assert — pin Light, then Dark; preset stays cyan.
+    store.dispatch(setModePreference('light'))
     expect(store.getState().theme.mode).toBe('light')
+    expect(store.getState().theme.modePreference).toBe('light')
     expect(store.getState().theme.preset).toBe('cyan')
-    store.dispatch(toggleMode())
+
+    store.dispatch(setModePreference('dark'))
     expect(store.getState().theme.mode).toBe('dark')
+    expect(store.getState().theme.modePreference).toBe('dark')
     expect(store.getState().theme.preset).toBe('cyan')
   })
 
-  it('toggleMode swaps neutral-dark ↔ neutral-light so the preset stays consistent with mode', async () => {
-    const { toggleMode } = await import('./themeSlice')
+  it('setModePreference swaps neutral-dark ↔ neutral-light so the preset stays consistent with mode', async () => {
+    // Arrange
+    const { setModePreference } = await import('./themeSlice')
     const store = await createTestStore()
-    // Initial: neutral-dark
-    store.dispatch(toggleMode())
+
+    // Act — initial preset is neutral-dark; pin Light.
+    store.dispatch(setModePreference('light'))
+
+    // Assert — preset key swapped to the light partner.
     expect(store.getState().theme.mode).toBe('light')
     expect(store.getState().theme.preset).toBe('neutral-light')
-    store.dispatch(toggleMode())
+
+    store.dispatch(setModePreference('dark'))
     expect(store.getState().theme.mode).toBe('dark')
     expect(store.getState().theme.preset).toBe('neutral-dark')
   })
@@ -78,9 +144,9 @@ describe('themeSlice', () => {
     ['stone-dark', 'stone-light', 60],
     ['mauve-dark', 'mauve-light', 320],
   ] as const)(
-    'toggleMode swaps %s ↔ %s so preset stays consistent with mode',
+    'setModePreference swaps %s ↔ %s so preset stays consistent with mode',
     async (darkPreset, lightPreset, expectedHue) => {
-      const { setTheme, toggleMode } = await import('./themeSlice')
+      const { setTheme, setModePreference } = await import('./themeSlice')
       const store = await createTestStore()
 
       store.dispatch(setTheme(darkPreset))
@@ -89,17 +155,85 @@ describe('themeSlice', () => {
       expect(store.getState().theme.hue).toBe(expectedHue)
       expect(store.getState().theme.chroma).toBe(TINTED_NEUTRAL_CHROMA)
 
-      store.dispatch(toggleMode())
+      store.dispatch(setModePreference('light'))
       expect(store.getState().theme.mode).toBe('light')
       expect(store.getState().theme.preset).toBe(lightPreset)
       expect(store.getState().theme.hue).toBe(expectedHue)
       expect(store.getState().theme.chroma).toBe(TINTED_NEUTRAL_CHROMA)
 
-      store.dispatch(toggleMode())
+      store.dispatch(setModePreference('dark'))
       expect(store.getState().theme.mode).toBe('dark')
       expect(store.getState().theme.preset).toBe(darkPreset)
     },
   )
+
+  describe('setModePreference("system") — OS appearance resolution', () => {
+    beforeEach(() => {
+      // Each test re-stubs explicitly; clear any leftover stub here so
+      // assertions about "what happens when OS is in Light" can't be
+      // shadowed by a previous "OS in Dark" stub.
+      vi.unstubAllGlobals()
+    })
+
+    it('resolves to dark when the OS reports prefers-color-scheme: dark', async () => {
+      // Arrange
+      stubSystemPrefersDark(true)
+      const { setModePreference } = await import('./themeSlice')
+      const store = await createTestStore()
+
+      // Act
+      store.dispatch(setModePreference('system'))
+
+      // Assert — modePreference is persisted; mode is the OS-resolved value.
+      expect(store.getState().theme.modePreference).toBe('system')
+      expect(store.getState().theme.mode).toBe('dark')
+    })
+
+    it('resolves to light when the OS reports prefers-color-scheme: light', async () => {
+      // Arrange
+      stubSystemPrefersDark(false)
+      const { setModePreference } = await import('./themeSlice')
+      const store = await createTestStore()
+
+      // Act
+      store.dispatch(setModePreference('system'))
+
+      // Assert
+      expect(store.getState().theme.modePreference).toBe('system')
+      expect(store.getState().theme.mode).toBe('light')
+    })
+
+    it('swaps neutral preset to partner when system resolves to a different mode than the current preset', async () => {
+      // Arrange — start in zinc-dark, then move to Auto while the OS is Light.
+      const { setTheme, setModePreference } = await import('./themeSlice')
+      const store = await createTestStore()
+      store.dispatch(setTheme('zinc-dark'))
+      stubSystemPrefersDark(false)
+
+      // Act
+      store.dispatch(setModePreference('system'))
+
+      // Assert — preset followed the OS-resolved mode.
+      expect(store.getState().theme.mode).toBe('light')
+      expect(store.getState().theme.preset).toBe('zinc-light')
+      expect(store.getState().theme.modePreference).toBe('system')
+    })
+
+    it('leaves color presets untouched when system resolves to a new mode', async () => {
+      // Arrange
+      const { setTheme, setModePreference } = await import('./themeSlice')
+      const store = await createTestStore()
+      store.dispatch(setTheme('cyan'))
+      stubSystemPrefersDark(false)
+
+      // Act
+      store.dispatch(setModePreference('system'))
+
+      // Assert — cyan has no baked mode; only state.mode changes.
+      expect(store.getState().theme.preset).toBe('cyan')
+      expect(store.getState().theme.mode).toBe('light')
+    })
+  })
 
   it('switching color → neutral drops chroma to 0', async () => {
     const { setTheme } = await import('./themeSlice')

--- a/src/renderer/src/redux/slices/themeSlice.ts
+++ b/src/renderer/src/redux/slices/themeSlice.ts
@@ -5,17 +5,35 @@ import type { ThemePresetName } from '@/shared/constants'
 import { THEME_PRESETS } from '@/shared/constants'
 
 /**
+ * User-facing palette mode choice.
+ * - 'light' / 'dark' are sticky: the user pinned the palette and we never
+ *   auto-flip it regardless of OS appearance changes.
+ * - 'system' follows prefers-color-scheme: the listener middleware keeps
+ *   state.mode in sync with the OS as long as this preference is active.
+ *
+ * Persisted alongside `mode` so the resolved value can survive cold starts
+ * (read by the pre-hydration bootstrap script) while the preference
+ * survives OS theme changes.
+ */
+export type ModePreference = 'light' | 'dark' | 'system'
+
+/**
  * Shape persisted in localStorage via `@laststance/redux-storage-middleware`.
- * `hue` × `chroma` together project to OKLCH coordinates on `<html>`:
+ * `hue` x `chroma` together project to OKLCH coordinates on `<html>`:
  *   --theme-hue:    state.hue    (angle, ignored when chroma === 0)
  *   --theme-chroma: state.chroma (0 = grayscale ramp, 0.16 = saturated ramp)
  * Mode is tracked independently so users can flip dark/light without losing
  * their color preset. `preset` is the authoritative key; `hue`/`chroma`/`mode`
  * are derived snapshots kept in state so the DOM listener can apply them in
  * one pass without re-looking-up the preset table.
+ *
+ * `mode` is the resolved palette (what `<html>` actually wears) and
+ * `modePreference` is the user's choice. They differ only when the user
+ * picked "system" - in which case `mode` mirrors the OS while
+ * `modePreference` stays `'system'` so the next OS flip can be honored.
  */
 export interface ThemeState {
-  /** OKLCH hue angle (0–360). No visual effect when `chroma === 0`. @example 195 */
+  /** OKLCH hue angle (0-360). No visual effect when `chroma === 0`. @example 195 */
   hue: number
   /**
    * OKLCH chroma scalar driving the entire token ramp. Only two values are
@@ -24,6 +42,11 @@ export interface ThemeState {
   chroma: number
   /** Light vs dark palette selector. Applied as `.light` / `.dark` on `<html>`. */
   mode: 'light' | 'dark'
+  /**
+   * User's explicit mode choice. Persisted so the "Auto" affordance survives
+   * reloads and the resolver can re-apply OS appearance after hydration.
+   */
+  modePreference: ModePreference
   /** Authoritative preset key. Drives ThemeSelector's aria-pressed state. */
   preset: ThemePresetName
 }
@@ -32,7 +55,57 @@ const initialState: ThemeState = {
   hue: 0,
   chroma: 0,
   mode: 'dark',
+  modePreference: 'dark',
   preset: 'neutral-dark',
+}
+
+/**
+ * Resolve a `ModePreference` to the concrete light / dark value that the
+ * `<html>` class should wear. Only `'system'` requires a runtime lookup;
+ * the other two are pass-through.
+ *
+ * Module-internal (no consumers outside this file). Headless / SSR
+ * environments without `matchMedia` get a `'dark'` fallback so the
+ * reducer stays total.
+ *
+ * @example resolveMode('system') // 'dark' when the OS is in Dark Mode
+ */
+function resolveMode(preference: ModePreference): 'light' | 'dark' {
+  if (preference === 'light' || preference === 'dark') return preference
+  if (
+    typeof window === 'undefined' ||
+    typeof window.matchMedia !== 'function'
+  ) {
+    return 'dark'
+  }
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light'
+}
+
+/**
+ * Swap a neutral preset's family suffix to match the given target mode.
+ * Returns the partner preset key if one exists (e.g. zinc-dark -> zinc-light),
+ * or `null` when the preset is a color preset (no baked mode) or the
+ * partner key is missing from THEME_PRESETS.
+ *
+ * Color presets are mode-agnostic, so the caller should keep them as-is
+ * when switching modes; this function returns null to signal that.
+ *
+ * @example partnerForMode('zinc-dark', 'light') // 'zinc-light'
+ * @example partnerForMode('cyan', 'light')      // null (color preset)
+ */
+function partnerForMode(
+  preset: ThemePresetName,
+  target: 'light' | 'dark',
+): ThemePresetName | null {
+  const config = THEME_PRESETS[preset]
+  if (!config || !('mode' in config)) return null
+  const lastDashIndex = preset.lastIndexOf('-')
+  if (lastDashIndex < 0) return null
+  const family = preset.slice(0, lastDashIndex)
+  const partnerKey = `${family}-${target}` as ThemePresetName
+  return partnerKey in THEME_PRESETS ? partnerKey : null
 }
 
 const themeSlice = createSlice({
@@ -43,7 +116,13 @@ const themeSlice = createSlice({
      * Select a preset by name. Pulls `hue`, `chroma`, and (for neutral
      * presets) `mode` from the central `THEME_PRESETS` table so every call
      * site stays in sync. Color presets keep the user's current `mode`
-     * so switching between e.g. cyan → rose doesn't silently dark-flip.
+     * so switching between e.g. cyan -> rose doesn't silently dark-flip.
+     *
+     * `modePreference` is intentionally NOT touched here: a user who is on
+     * "Auto" and picks Zinc should still follow the OS next time it flips.
+     * The neutral preset key encodes the *currently resolved* mode, which
+     * the listener will swap to its partner if the OS later flips.
+     *
      * @example
      * dispatch(setTheme('rose'))          // rose hue, current mode
      * dispatch(setTheme('neutral-light')) // chroma=0, mode forced to light
@@ -71,45 +150,29 @@ const themeSlice = createSlice({
     },
 
     /**
-     * Flip between dark and light. Presets that bake `mode` into the
-     * config (`neutral-*` and the tinted-neutral families: zinc / slate /
-     * stone / mauve) are persisted as explicit `<family>-dark` /
-     * `<family>-light` pairs in `THEME_PRESETS`, so a mode flip must also
-     * swap the preset key — otherwise `state.preset` and `state.mode`
-     * desync, breaking the dropdown's `aria-pressed` state and the
-     * sr-only "Current theme: …" announcement.
+     * Set the user's explicit mode preference (light / dark / system).
+     * Resolves to a concrete light / dark, applies it to `state.mode`, and
+     * swaps neutral presets to their partner key if the resolved mode no
+     * longer matches the active preset's baked mode.
      *
-     * Color presets (no baked `mode`) keep their preset name; only the
-     * mode flips, leaving their hue/chroma untouched.
+     * Color presets stay untouched because they have no baked mode; only
+     * `state.mode` changes for them. Neutral presets must swap their key
+     * (e.g. zinc-dark -> zinc-light) so the dropdown's selected swatch
+     * stays consistent with the rendered palette.
      *
-     * Partner key is data-derived from the family prefix (the substring
-     * before the last `-`), matching the same convention used by
-     * `ThemeSelector`'s `NEUTRAL_FAMILIES` builder. Adding a future
-     * tinted-neutral pair to `THEME_PRESETS` therefore needs no reducer
-     * change.
+     * @example
+     * dispatch(setModePreference('light'))  // pin Light regardless of OS
+     * dispatch(setModePreference('system')) // follow OS appearance
      */
-    toggleMode: (state) => {
-      const next = state.mode === 'dark' ? 'light' : 'dark'
-      state.mode = next
-
-      const config = THEME_PRESETS[state.preset]
-      if (!config || !('mode' in config)) {
-        return
-      }
-
-      const lastDashIndex = state.preset.lastIndexOf('-')
-      // Defensive: a preset that bakes `mode` should always be named
-      // `<family>-<mode>`. If a future preset breaks this convention,
-      // skip the swap rather than guessing — the mode still flips.
-      if (lastDashIndex < 0) return
-      const family = state.preset.slice(0, lastDashIndex)
-      const partnerKey = `${family}-${next}` as ThemePresetName
-      if (partnerKey in THEME_PRESETS) {
-        state.preset = partnerKey
-      }
+    setModePreference: (state, action: PayloadAction<ModePreference>) => {
+      state.modePreference = action.payload
+      const resolved = resolveMode(action.payload)
+      state.mode = resolved
+      const partner = partnerForMode(state.preset, resolved)
+      if (partner) state.preset = partner
     },
   },
 })
 
-export const { setTheme, toggleMode } = themeSlice.actions
+export const { setTheme, setModePreference } = themeSlice.actions
 export default themeSlice.reducer

--- a/src/renderer/src/redux/store.test.ts
+++ b/src/renderer/src/redux/store.test.ts
@@ -5,10 +5,14 @@ import { COLOR_PRESET_CHROMA, THEME_PRESETS } from '@/shared/constants'
 import type { MigratableState } from './migrations'
 
 /**
- * Regression tests for the v0 → v1 theme migration in migrations.ts. Every
- * user upgrading from a pre-chroma release runs this path exactly once, and
- * a silent failure corrupts localStorage for that user forever. These tests
- * pin the contract so future theme refactors cannot regress it.
+ * Regression tests for the full theme migration chain. Every user upgrading
+ * from a pre-chroma release runs this path exactly once, and a silent
+ * failure corrupts localStorage for that user forever. These tests pin the
+ * end-state contract so future theme refactors cannot regress it.
+ *
+ * Each `migrate(state, 0)` call walks v0 → v1 → v2 → v3, so the expected
+ * shape below is the post-chain (v3) shape including `modePreference`,
+ * which v2 → v3 seeds from `state.mode`.
  */
 async function migrate(
   state: Record<string, unknown> | null | undefined,
@@ -18,8 +22,8 @@ async function migrate(
   return migrateState(state as MigratableState, oldVersion)
 }
 
-describe('migrateState (v0 → v1 theme)', () => {
-  it('migrates a valid color preset (cyan dark) to v1 shape', async () => {
+describe('migrateState (v0 → v3 theme chain)', () => {
+  it('migrates a valid color preset (cyan dark) to the latest shape', async () => {
     const state = {
       theme: {
         hue: 195,
@@ -33,11 +37,12 @@ describe('migrateState (v0 → v1 theme)', () => {
       hue: 195,
       chroma: COLOR_PRESET_CHROMA,
       mode: 'dark',
+      modePreference: 'dark',
       preset: 'cyan',
     })
   })
 
-  it('migrates a valid neutral preset (neutral-light) to v1 shape', async () => {
+  it('migrates a valid neutral preset (neutral-light) to the latest shape', async () => {
     const state = {
       theme: {
         hue: 0,
@@ -51,6 +56,7 @@ describe('migrateState (v0 → v1 theme)', () => {
       hue: 0,
       chroma: 0,
       mode: 'light',
+      modePreference: 'light',
       preset: 'neutral-light',
     })
   })
@@ -97,20 +103,22 @@ describe('migrateState (v0 → v1 theme)', () => {
     expect(result.theme).toBeUndefined()
   })
 
-  it('skips migration entirely when oldVersion >= 1', async () => {
+  it('skips migration entirely when oldVersion is already at the current schema version', async () => {
     // Storage-middleware guarantees migrate is only called when versions
     // differ, but if someone tampered with the stored `version` field we
-    // must not overwrite a valid v1 state with legacy defaults.
-    const v1State = {
+    // must not overwrite a valid current-schema state with legacy defaults.
+    const { PERSIST_STATE_VERSION } = await import('@/shared/constants')
+    const currentState = {
       theme: {
         hue: 195,
         chroma: 0.18,
         mode: 'dark',
+        modePreference: 'dark',
         preset: 'cyan',
       },
     }
-    const result = await migrate(v1State, 1)
-    expect(result.theme).toEqual(v1State.theme)
+    const result = await migrate(currentState, PERSIST_STATE_VERSION)
+    expect(result.theme).toEqual(currentState.theme)
   })
 
   it('coerces non-numeric hue to 0', async () => {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -22,8 +22,13 @@ export const PERSIST_STORAGE_KEY = 'skills-desktop-state'
  *    `minSize` grew (Quick Actions h: 2 → 3 with the row-height bump). Without
  *    this clamp, persisted layouts violate the new minSize and react-grid-layout
  *    silently re-clamps them mid-render, jolting saved positions.
+ *  - v2 → v3: theme gained `modePreference: 'light' | 'dark' | 'system'`.
+ *    Existing payloads only carry `mode`, so the migration seeds
+ *    `modePreference` from it (e.g. mode='dark' → modePreference='dark').
+ *    "system" is opt-in, never inherited from a pre-v3 user — they explicitly
+ *    picked light or dark before, so we keep that pin.
  */
-export const PERSIST_STATE_VERSION = 2
+export const PERSIST_STATE_VERSION = 3
 
 /**
  * Chroma value applied to OKLCH tokens for fully-saturated (color) presets.


### PR DESCRIPTION
## Summary

Replace the redundant 10-button theme dropdown with **Pattern 1 (Mode-First Compact)** — a 3-segment Light/Dark/Auto toggle, 17 accent swatches in a 6-column grid, and 5 tinted-neutral family swatches whose mode follows the segmented control. Adds an `'Auto'` mode that follows `prefers-color-scheme` at runtime.

### Before → After

| Before | After |
| --- | --- |
| 10 mode-locked buttons (5 families × 2 modes) + a "Toggle Mode" menuitem | Header (live preset name in mono) + Light/Dark/Auto segmented control + 17 accent swatches + 5 family swatches |
| `toggleMode` reducer | `setModePreference: 'light' \| 'dark' \| 'system'` reducer |
| `prefers-color-scheme` ignored | `matchMedia` `change` listener installed at hydrate; Auto users follow OS appearance live |

### Architecture changes

- **`themeSlice`**: introduce `ModePreference = 'light' \| 'dark' \| 'system'`. `mode` (DOM-resolved value) and `modePreference` (user choice) are now split. `setTheme` no longer touches `modePreference` so an Auto user picking Cyan keeps tracking the OS.
- **`migrations.ts`**: bump `PERSIST_STATE_VERSION` 2 → 3. `migrateV2ToV3` seeds `modePreference` from `state.mode` so legacy users keep their explicit Light/Dark pin (never inherit `'system'`).
- **`listener.ts`**: `isAnyOf(setTheme, setModePreference)` matcher applies CSS variables. `ACTION_HYDRATE_COMPLETE` installs a one-time `matchMedia('(prefers-color-scheme: dark)')` change subscription that re-resolves theme only when `modePreference === 'system'`.
- **`ThemeSelector.tsx`**: full rewrite. Uses Radix `ToggleGroup` for the segmented control, lucide `Sun`/`Moon`/`Monitor` icons, and inline arrow handlers for swatch grids (per `no-deopt-use-callback` lint rule). Family swatch click resolves to `\${family}-\${currentMode}` so picking Zinc in Dark gives `zinc-dark` without a surprise mode flip.

### Test coverage

| File | Suite |
| --- | --- |
| `themeSlice.test.ts` | 16 tests — light/dark/system resolution, neutral preset swap, color preset preserved, modePreference untouched by setTheme |
| `listener.test.ts` | 10 tests — `setModePreference` writes DOM classes, OS change re-applies theme only in Auto mode, sticky modes ignore OS flips |
| `migrations.test.ts` | 24 tests — v2→v3 dark/light seeding, null/invalid mode fallback, v0→v3 full chain |
| `ThemeSelector.browser.test.tsx` | 11 tests — 17 accent swatches, 5 family swatches, segmented control dispatches, family resolves to current mode |
| `store.test.ts` | Updated to assert v3 shape (`modePreference` included) |

## Known follow-up (out of scope)

When a `modePreference === 'system'` user has the OS flipped after their last session, the bootstrap script (which paints `<html>` before bundle load) still reads the persisted `mode` and produces a single-frame FOUC before the listener reconciles. Will be addressed in a follow-up PR that teaches the inline bootstrap to read `matchMedia` when `modePreference === 'system'`.

## Test plan

- [x] \`pnpm validate\` — 1088 tests pass (lint + test + typecheck + dead-code + dupes + health + storybook:build)
- [x] \`pnpm test:e2e\` — 43 Electron e2e specs pass
- [ ] Manual QA in dev build:
  - [ ] Open dropdown → segmented control reads current mode
  - [ ] Pick Light → \`<html>\` gets \`.light\`, persists across reload
  - [ ] Pick Auto + macOS Settings → flip Appearance Dark↔Light → app follows OS in real time
  - [ ] Pick Auto + Zinc → swatch resolves to current OS-driven mode
  - [ ] Upgrade from a v2 \`localStorage\` payload (\`mode: 'dark'\`) → loads as Dark, never as Auto

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * テーマに「モード選好(modePreference)」を導入し、Light/Dark/Systemを明示的に選択可能に
  * モード選択をセグメント切替へ改良し、ヘッダーに現在プリセット名＋モードを表示
  * ニュートラル系をファミリー単位の単一スウォッチへ集約し選択挙動を改善
  * System選択時はOSのダーク/ライト設定変化を反映するように

* **その他**
  * 永続化スキーマを v3 に更新（テーマ移行対応）

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/skills-desktop/pull/169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->