### PR TITLE
fix(marketplace): wrap long skill names to 2 lines (closes #171)

### DIFF
--- a/src/renderer/src/components/marketplace/SkillRowMarketplace.tsx
+++ b/src/renderer/src/components/marketplace/SkillRowMarketplace.tsx
@@ -19,13 +19,22 @@ interface SkillRowMarketplaceProps {
   isInstalled?: boolean
 }
 
+// Fixed widths for the three right-hand grid columns; the name column is the
+// flexible `minmax(0, 1fr)` that absorbs whatever is left. Kept tight on purpose
+// (VL-001 / #171): at the ~1400px default window the 3-pane layout leaves the
+// list only ~510px, so every pixel reserved here is one the skill name — the
+// primary identifier a user scans to decide what to install — loses. Bookmark
+// stays 44px to preserve the 44×44 touch target (DESIGN.md target sizing).
 const BOOKMARK_COLUMN_WIDTH_PX = 44
-const INSTALL_COUNT_COLUMN_WIDTH_PX = 96
-const ACTION_COLUMN_WIDTH_PX = 160
+const INSTALL_COUNT_COLUMN_WIDTH_PX = 80
+const ACTION_COLUMN_WIDTH_PX = 128
 
 /**
- * Single skill row in marketplace search results
- * Design: 72px height, rank badge, install count, install button (or installed badge)
+ * Single skill row in marketplace search results.
+ * Min height 76px (min-h-19); long skill names wrap to 2 lines (line-clamp-2 +
+ * break-words) so they stay readable in the ~510px center column (VL-001 / #171)
+ * instead of truncating — break-words keeps the line-clamp ellipsis working for
+ * rare unbroken names; short names keep the 76px baseline, badge stays centered.
  */
 export const SkillRowMarketplace = React.memo(function SkillRowMarketplace({
   skill,
@@ -61,7 +70,7 @@ export const SkillRowMarketplace = React.memo(function SkillRowMarketplace({
 
   return (
     <div
-      className="grid items-center gap-4 p-4 rounded-lg bg-card h-19 min-w-0 border border-card hover:border-primary/50 transition-colors"
+      className="grid items-center gap-4 p-4 rounded-lg bg-card min-h-19 min-w-0 border border-card hover:border-primary/50 transition-colors"
       style={{
         gridTemplateColumns: `minmax(0, 1fr) ${BOOKMARK_COLUMN_WIDTH_PX}px ${INSTALL_COUNT_COLUMN_WIDTH_PX}px ${ACTION_COLUMN_WIDTH_PX}px`,
       }}
@@ -76,7 +85,7 @@ export const SkillRowMarketplace = React.memo(function SkillRowMarketplace({
           {skill.rank}
         </div>
         <div className="flex-1 min-w-0 flex flex-col gap-1">
-          <span className="font-semibold text-[15px] text-foreground truncate">
+          <span className="font-semibold text-[15px] text-foreground line-clamp-2 leading-snug break-words">
             {skill.name}
           </span>
           <span className="font-mono text-xs text-muted-foreground truncate">


### PR DESCRIPTION
## Summary

Fixes **VL-001** (#171): in the Marketplace ranked skill list, long skill **names** — the primary identifier a user scans to decide what to install — truncated to ~8 characters in the default browse view.

## Root cause

At the ~1400 CSS px default window, the 3-pane layout (agents sidebar │ skill list │ right rail) leaves the center list only ~510px. Each row in `SkillRowMarketplace.tsx` is a 4-column grid whose fixed right columns (`44 + 96 + 160 = 300px`) + gaps + padding left the flexible `minmax(0, 1fr)` name column only ~80–100px (~8 chars), and the name span carried `truncate` → mid-name ellipsis (`vercel-r…`, `web-des…`).

## Fix

`src/renderer/src/components/marketplace/SkillRowMarketplace.tsx`:

- Name span `truncate` → `line-clamp-2 leading-snug break-words` — long names wrap to 2 lines instead of clipping. `break-words` keeps the line-clamp ellipsis working for rare unbroken tokens (an adversarial review catch).
- Row `h-19` → `min-h-19` — single-line rows keep the 76px baseline; wrapped rows grow to ~95px (the list isn't virtualized, so variable row height is safe).
- Tightened the two widest right columns: install-count `96 → 80px`, action `160 → 128px`, recovering ~48px for the name. Bookmark stays `44px` to preserve the 44×44 touch target (DESIGN.md).

Implements the top two candidate fixes from #171 (relax right columns + wrap to 2 lines).

## Verification

- Measured at the exact **1400×941** viewport the issue flags as critical (not just a wide monitor) via playwright-cli CDP: wrapped rows grow to 95px, single-line rows stay 76px, rank badge stays vertically centered (0px offset → no `items-start` needed), name line-height 20.625px.
- `pnpm validate` green (lint + 1092 tests + typecheck + dead-code + dupes + health + storybook build).
- `pnpm test:e2e` green (43 passed).

Closes #171


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * マーケットプレイスのスキル行レイアウトを改善しました。スキル名が長い場合、2行まで表示されるようになり、読みやすくなりました。
  * スキル行の高さの柔軟性が向上し、コンテンツに応じた表示が可能になりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/skills-desktop/pull/172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->