### PR TITLE
fix(sidebar): hover-reveal bookmark Remove (X), align hover vocabulary

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -212,17 +212,17 @@ changing layout or meaning.
 
 | Type               | Visual height  | Hit target                          | Use                        |
 | ------------------ | -------------- | ----------------------------------- | -------------------------- |
-| Primary action     | 32-36px        | >= 36px, 44px when icon-only        | Install, sync, confirm     |
+| Primary action     | 32-36px        | >= 36px                             | Install, sync, confirm     |
 | Secondary action   | 30-34px        | >= 36px                             | Cancel, alternate actions  |
 | Small dense action | 28-32px        | May use expanded invisible hit area | Row tools, filters         |
-| Icon-only          | 28-32px visual | 44x44px target when standalone      | Close, settings, row tools |
+| Icon-only          | 24-32px visual | >= 24x24px (WCAG 2.5.8 AA floor)    | Close, settings, row tools |
 
 Rules:
 
 - If a button feels too tall, reduce the visual surface before reducing
   accessible hit area.
-- Use `size="icon"` only for standalone icon buttons that need the full 44px
-  target.
+- Size icon buttons to context: `size="icon"` for comfortable standalone
+  controls, `size-6` (24px, WCAG 2.5.8 AA floor) for dense row tools.
 - Prefer lucide icons for tool buttons.
 - Avoid multiple primary buttons in one region.
 - Destructive buttons should be visually explicit and never rely on icon alone.
@@ -291,11 +291,17 @@ Baseline:
 
 Target sizing:
 
-- Standalone icon buttons should keep a 44x44px target.
-- Dense row controls may have smaller visible icons if the clickable area is
-  padded or the row itself is the primary target.
-- Do not shrink destructive or confirmation controls below comfortable pointer
-  targets.
+This is a pointer-driven desktop app (mouse and trackpad), so the mobile 44px
+finger-target minimum does not apply. The floor is WCAG 2.5.8 AA: 24x24 CSS px
+(`size-6`). Comfortable standalone controls can still be larger.
+
+- Standalone icon buttons: 24x24px (`size-6`) meets the AA floor; size up toward
+  32px when the control is primary or isolated.
+- Dense row controls may show a smaller glyph inside a 24px-or-larger target. An
+  invisible `after:-inset-*` halo can extend the comfortable click area, but
+  never over a row that is itself clickable: `opacity-0` controls stay
+  pointer-active, so the halo would steal corner clicks meant for the row.
+- Do not shrink destructive or confirmation controls below the 24px floor.
 
 ## Responsive and Window Behavior
 
@@ -350,8 +356,8 @@ Likely app-safe improvements:
 
 - Compact default buttons from 36px toward 32-34px where the surrounding target
   remains comfortable.
-- Keep standalone icon buttons at 44px hit area, but use a smaller visible
-  glyph and subtle hover background.
+- Keep standalone icon buttons at a comfortable hit area (24px AA floor, larger
+  when isolated), but use a smaller visible glyph and subtle hover background.
 - Reduce ordinary card shadow intensity; reserve stronger shadows for toasts,
   dropdowns, and dialogs.
 - Add 120-180ms color/opacity transitions to selected rows and tabs.
@@ -373,9 +379,9 @@ Example prompt:
 
 ```text
 Polish the Settings sidebar using DESIGN.md. Keep the current layout and dark
-technical tone. Reduce visual button height if appropriate, preserve 44px
-standalone icon hit targets, normalize radius to 6-8px, and avoid decorative
-effects.
+technical tone. Reduce visual button height if appropriate, keep icon hit
+targets at or above the 24px WCAG AA floor, normalize radius to 6-8px, and
+avoid decorative effects.
 ```
 
 ## References

--- a/src/renderer/src/components/sidebar/BookmarkItem.tsx
+++ b/src/renderer/src/components/sidebar/BookmarkItem.tsx
@@ -94,8 +94,12 @@ export const BookmarkItem = React.memo(function BookmarkItem({
             <TooltipTrigger asChild>
               {/* Non-interactive status glyph — matches SkillItem's linked */}
               {/* check vocabulary (text-success/70), calmer than the X beside it. */}
-              <span aria-label="Installed" className="shrink-0 text-success/70">
-                <Check className="h-3.5 w-3.5" />
+              <span
+                role="img"
+                aria-label="Installed"
+                className="shrink-0 text-success/70"
+              >
+                <Check className="h-3.5 w-3.5" aria-hidden="true" />
               </span>
             </TooltipTrigger>
             <TooltipContent side="left">Installed</TooltipContent>
@@ -104,7 +108,7 @@ export const BookmarkItem = React.memo(function BookmarkItem({
           <button
             type="button"
             aria-label={`Install ${bookmark.name}`}
-            className="shrink-0 flex size-6 items-center justify-center rounded-md text-primary opacity-0 transition-[opacity,background-color,color] hover:bg-primary/10 hover:text-primary group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="shrink-0 flex size-6 items-center justify-center rounded-md text-primary opacity-0 transition-[opacity,background-color,color] hover:bg-primary/10 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             onClick={handleInstall}
             disabled={isInstalling}
           >

--- a/src/renderer/src/components/sidebar/BookmarkItem.tsx
+++ b/src/renderer/src/components/sidebar/BookmarkItem.tsx
@@ -18,9 +18,11 @@ interface BookmarkItemProps {
 }
 
 /**
- * Single bookmarked skill in the sidebar.
- * Shows skill name + repo. "Install" button or "Installed" badge.
- * X button removes from bookmarks.
+ * Single bookmarked skill row in the sidebar; opens the detail modal on click.
+ * Shows name + repo with an inline "Installed" check or hover-revealed Install.
+ * Remove (X) sits small in the top-right corner and fades in on hover
+ * (Sonner-style), keeping the resting row uncluttered so the title gets the
+ * widest possible space instead of a permanent 44px button slot.
  */
 export const BookmarkItem = React.memo(function BookmarkItem({
   bookmark,
@@ -65,32 +67,36 @@ export const BookmarkItem = React.memo(function BookmarkItem({
       tabIndex={0}
       aria-label={`View details for ${bookmark.name}`}
       className={cn(
-        'flex w-full items-center justify-between min-h-11 py-1.5 px-2 rounded-md transition-colors group cursor-pointer hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        'relative flex w-full items-center min-h-11 py-1.5 px-2 rounded-md transition-colors group cursor-pointer hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
       )}
       onClick={handleClick}
       onKeyDown={handleKeyDown}
     >
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <div className="flex flex-col min-w-0 flex-1">
-            <span className="text-sm truncate">{bookmark.name}</span>
-            <span className="text-xs text-muted-foreground truncate">
-              {bookmark.repo}
-            </span>
-          </div>
-        </TooltipTrigger>
-        <TooltipContent side="right">
-          <span>{bookmark.url}</span>
-        </TooltipContent>
-      </Tooltip>
+      {/* pr-7 reserves the top-right strip for the absolute Remove (X) below, */}
+      {/* so it never overlaps the title/status and the row doesn't shift on hover. */}
+      <div className="flex min-w-0 flex-1 items-center gap-2 pr-7">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div className="flex flex-col min-w-0 flex-1">
+              <span className="text-sm truncate">{bookmark.name}</span>
+              <span className="text-xs text-muted-foreground truncate">
+                {bookmark.repo}
+              </span>
+            </div>
+          </TooltipTrigger>
+          <TooltipContent side="right">
+            <span>{bookmark.url}</span>
+          </TooltipContent>
+        </Tooltip>
 
-      <div className="flex items-center gap-1 ml-2 shrink-0">
         {bookmark.isInstalled ? (
           <Tooltip>
             <TooltipTrigger asChild>
+              {/* Inline 16px status glyph — the row itself is the 44px hit */}
+              {/* target, so no padded button wrapper (DESIGN.md L295-297). */}
               <span
                 aria-label="Installed"
-                className="text-emerald-500 flex items-center justify-center min-h-11 min-w-11"
+                className="shrink-0 text-emerald-500"
               >
                 <Check className="h-4 w-4" />
               </span>
@@ -101,22 +107,25 @@ export const BookmarkItem = React.memo(function BookmarkItem({
           <button
             type="button"
             aria-label={`Install ${bookmark.name}`}
-            className="min-h-11 min-w-11 flex items-center justify-center text-primary hover:text-primary/80 transition-colors opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
+            className="shrink-0 flex h-6 w-6 items-center justify-center rounded-md text-primary opacity-0 transition hover:bg-accent hover:text-primary/80 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             onClick={handleInstall}
             disabled={isInstalling}
           >
             <Download className="h-4 w-4" />
           </button>
         )}
-        <button
-          type="button"
-          aria-label={`Remove ${bookmark.name} from bookmarks`}
-          className="min-h-11 min-w-11 flex items-center justify-center text-muted-foreground hover:text-destructive transition-colors opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
-          onClick={handleRemove}
-        >
-          <X className="h-3.5 w-3.5" />
-        </button>
       </div>
+
+      {/* Sonner-style remove: hidden at rest, fades in small at the top-right */}
+      {/* corner on row hover/focus. Absolute → frees the title's full width. */}
+      <button
+        type="button"
+        aria-label={`Remove ${bookmark.name} from bookmarks`}
+        className="absolute top-1 right-1 flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground opacity-0 transition hover:bg-accent hover:text-destructive group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        onClick={handleRemove}
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
     </div>
   )
 })

--- a/src/renderer/src/components/sidebar/BookmarkItem.tsx
+++ b/src/renderer/src/components/sidebar/BookmarkItem.tsx
@@ -20,9 +20,9 @@ interface BookmarkItemProps {
 /**
  * Single bookmarked skill row in the sidebar; opens the detail modal on click.
  * Shows name + repo with an inline "Installed" check or hover-revealed Install.
- * Remove (X) sits small in the top-right corner and fades in on hover
- * (Sonner-style), keeping the resting row uncluttered so the title gets the
- * widest possible space instead of a permanent 44px button slot.
+ * Remove (X) fades in small at the top-right on hover (Sonner-style), sharing
+ * the app's canonical remove vocabulary with BookmarksWidget — destructive-tint
+ * hover, not a gray box — so the title keeps full width with no permanent slot.
  */
 export const BookmarkItem = React.memo(function BookmarkItem({
   bookmark,
@@ -67,7 +67,7 @@ export const BookmarkItem = React.memo(function BookmarkItem({
       tabIndex={0}
       aria-label={`View details for ${bookmark.name}`}
       className={cn(
-        'relative flex w-full items-center min-h-11 py-1.5 px-2 rounded-md transition-colors group cursor-pointer hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        'relative flex w-full items-center py-1.5 px-2 rounded-md transition-colors group cursor-pointer hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
       )}
       onClick={handleClick}
       onKeyDown={handleKeyDown}
@@ -92,13 +92,10 @@ export const BookmarkItem = React.memo(function BookmarkItem({
         {bookmark.isInstalled ? (
           <Tooltip>
             <TooltipTrigger asChild>
-              {/* Inline 16px status glyph — the row itself is the 44px hit */}
-              {/* target, so no padded button wrapper (DESIGN.md L295-297). */}
-              <span
-                aria-label="Installed"
-                className="shrink-0 text-emerald-500"
-              >
-                <Check className="h-4 w-4" />
+              {/* Non-interactive status glyph — matches SkillItem's linked */}
+              {/* check vocabulary (text-success/70), calmer than the X beside it. */}
+              <span aria-label="Installed" className="shrink-0 text-success/70">
+                <Check className="h-3.5 w-3.5" />
               </span>
             </TooltipTrigger>
             <TooltipContent side="left">Installed</TooltipContent>
@@ -107,21 +104,22 @@ export const BookmarkItem = React.memo(function BookmarkItem({
           <button
             type="button"
             aria-label={`Install ${bookmark.name}`}
-            className="shrink-0 flex h-6 w-6 items-center justify-center rounded-md text-primary opacity-0 transition hover:bg-accent hover:text-primary/80 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="shrink-0 flex size-6 items-center justify-center rounded-md text-primary opacity-0 transition-[opacity,background-color,color] hover:bg-primary/10 hover:text-primary group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             onClick={handleInstall}
             disabled={isInstalling}
           >
-            <Download className="h-4 w-4" />
+            <Download className="h-3.5 w-3.5" />
           </button>
         )}
       </div>
 
       {/* Sonner-style remove: hidden at rest, fades in small at the top-right */}
-      {/* corner on row hover/focus. Absolute → frees the title's full width. */}
+      {/* corner on hover/focus (absolute → frees the title's full width). Shares */}
+      {/* BookmarksWidget's destructive-tint hover vocabulary; 24px meets WCAG 2.5.8 AA. */}
       <button
         type="button"
         aria-label={`Remove ${bookmark.name} from bookmarks`}
-        className="absolute top-1 right-1 flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground opacity-0 transition hover:bg-accent hover:text-destructive group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        className="absolute top-1 right-1 flex size-6 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-[opacity,background-color,color] hover:bg-destructive/10 hover:text-destructive group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         onClick={handleRemove}
       >
         <X className="h-3.5 w-3.5" />


### PR DESCRIPTION
## Why

Two passes, both driven by user feedback:

1. **Space.** The Remove (❌) on each sidebar bookmark row held a permanent
   **44px** slot, squeezing the skill title into a narrow column. We searched
   mobbin + the 21st.dev magic MCP tools for a better pattern; nothing beat the
   requested fallback, so we adopted the **Sonner-style hover-reveal** X.
2. **"なんかいまいち" (feels off).** The first pass shipped the X with a neutral
   gray `hover:bg-accent` box, which diverged from the app's **canonical remove
   vocabulary** already used in `BookmarksWidget` (destructive tint). This pass
   aligns the row's controls to that vocabulary and **abolishes the 44px
   touch-target rule**, which never applied to a pointer-driven desktop app.

## What changed

| File | Change |
| --- | --- |
| `src/renderer/src/components/sidebar/BookmarkItem.tsx` | Markup/CSS only, no logic change |
| `DESIGN.md` | Abolish the mobile 44px finger-target rule; document the WCAG floor |

### `BookmarkItem.tsx`

| | Before | After |
| --- | --- | --- |
| Remove (X) | permanent **44px** button in the flex row, gray `hover:bg-accent` | **24px** (`size-6`) `absolute top-1 right-1`, hidden at rest, fades in on hover/focus, **`hover:bg-destructive/10 hover:text-destructive`** (matches `BookmarksWidget`) |
| Title width | squeezed by the X slot | full row width (X is out of flow) |
| Install button | 44px `min-h-11 min-w-11`, `hover:bg-accent` | **24px** (`size-6`), **`hover:bg-primary/10 hover:text-primary`** |
| Installed check | loud `text-emerald-500`, 16px | calmer **`text-success/70`**, 14px glyph (matches `SkillItem`'s linked-check vocabulary) |
| Row | `min-h-11` (redundant 44px floor) | removed; two-line content (~48px) already exceeds it |
| Transition | `transition` / `transition-opacity` | unified `transition-[opacity,background-color,color]` on both controls |

A constant **`pr-7` (28px)** reserve on the content row keeps the absolute
corner X clear of the inline check / Install button, so the row never shifts
when the X fades in.

### `DESIGN.md`: 44px rule abolished

This is a pointer-driven desktop app (mouse + trackpad), so the mobile **44px
finger-target minimum does not apply**. The floor is now **WCAG 2.5.8 AA:
24×24 CSS px (`size-6`)**; comfortable standalone controls can still be larger.
Updated the Buttons table, the `size="icon"` guidance, the target-sizing block,
and the example prompt. Also documented a footgun: an `after:-inset-*` halo must
never sit over a clickable row, because `opacity-0` controls stay pointer-active
and the halo would steal corner clicks meant for the row.

## Accessibility

The 24px (`size-6`) controls meet **WCAG 2.5.8 AA** (24×24 CSS px) exactly.
This replaces the previous rationale ("the row's `min-h-11` is the 44px
target"), which is gone now that the rule is abolished and `min-h-11` removed.
The X keeps its `aria-label` and stays keyboard-reachable via
`focus-visible:opacity-100`.

## Follow-ups (out of scope, intentionally not done here)

- **No ripple edits to `SkillItem` / `AgentItem`.** Their density rules (e.g.
  `AgentItem`'s `min-h-11`) are about row height, not touch targets, and stay.
- **`BookmarksWidget` has inert dead code** (`after:pointer-events-none
  after:absolute after:-inset-1.5`): the `pointer-events-none` defeats the halo,
  so the pseudo-element does nothing. Worth a cleanup pass, but unrelated to this
  change.

## Testing

- ✅ `pnpm validate` — green (1092 tests; lint + test + typecheck + dead-code)
- ✅ `pnpm test:e2e` — green (43 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style（スタイル）  
  * サイドバーのブックマーク行は行全体クリックのまま維持しつつ、削除ボタンを右上に分離してレイアウト安定化  
  * インストール済み表示を小型で非インタラクティブな表現に統一しツールチップで状態を明示  
  * インストール／削除ボタンは通常は淡く隠れ、ホバー／フォーカスでフェード表示する挙動に変更

* **Documentation（ドキュメント）  
  * アイコンボタンの最小ヒットターゲットをWCAG準拠の24×24px基準に明確化し、指針を更新

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/skills-desktop/pull/173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
