### PR TITLE
chore(dashboard): remove inert after: halo deadcode in BookmarksWidget

### DIFF
--- a/src/renderer/src/components/dashboard/widgets/BookmarksWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/BookmarksWidget.tsx
@@ -59,7 +59,6 @@ const BookmarkRow = React.memo(function BookmarkRow({
           rounded-md text-muted-foreground hover:bg-destructive/10 hover:text-destructive
           opacity-0 group-hover:opacity-100 focus-visible:opacity-100
           transition-[opacity,background-color,color]
-          after:pointer-events-none after:absolute after:-inset-1.5 after:content-['']
           focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring
         "
       >


### PR DESCRIPTION
## What

Delete the four inert `after:*` classes from `BookmarkRow`'s remove button in `BookmarksWidget.tsx`:

```diff
- after:pointer-events-none after:absolute after:-inset-1.5 after:content-['']
```

## Why

`pointer-events-none` defeats the halo's only purpose — expanding the clickable hit area — so the pseudo-element was **inert dead code**: it did nothing. It was added during a PR #161 CodeRabbit exchange, but the combination is self-cancelling.

The `size-7` (28px) button already clears the **WCAG 2.5.8 AA 24px** target floor, so no halo is needed (acceptance criterion **(a)**, the simplest path).

A *real* `after:-inset-*` halo would actually be **harmful** here: it must never sit over a clickable row, because the still-pointer-active `opacity-0`/visible control would let the halo steal corner clicks meant for the surrounding `role="button"` row. So removal — not "fixing" the halo — is correct.

This was flagged out-of-scope during PR #173 and tracked as a follow-up.

## Verification

- ✅ `pnpm validate` — 1092 tests, lint, typecheck, dead-code all green
- ✅ `pnpm test:e2e` — 43 e2e tests passed
- ✅ `BookmarksWidget.browser.test.tsx` — long skill text stays visible + compact removal still dispatches

No behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * ブックマークウィジェットの削除ボタンのスタイルを調整しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/skills-desktop/pull/174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->