### PR TITLE
feat(filter): multi-select source-repo include filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,5 +65,8 @@ e2e/.snapshot/
 e2e/test-results/
 e2e/playwright-report/
 playwright/.cache/
+
+# understand-anything knowledge-graph cache (local tool artifact)
+.understand-anything/
 .claude/goal.json
 .claude/goal-notes.md

--- a/src/renderer/src/components/layout/MainContent.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.browser.test.tsx
@@ -4,7 +4,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
-import type { BulkDeleteResult, Skill, SkillName } from '@/shared/types'
+import type {
+  AgentId,
+  BulkDeleteResult,
+  Skill,
+  SkillName,
+  SymlinkInfo,
+} from '@/shared/types'
 import { repositoryId, tombstoneId } from '@/shared/types'
 
 const mockGetAll = vi.fn()
@@ -181,6 +187,34 @@ function makeSourceSkill(name: string, source: string): Skill {
     isOrphan: false,
     source: repositoryId(source),
     sourceUrl: `https://github.com/${source}.git`,
+  }
+}
+
+/**
+ * Build an agent-local skill (real folder under ~/.<agent>/skills/, no source
+ * repo) so repo-filter tests can exercise the "N local skills hidden" caveat.
+ * @param name - Visible skill name.
+ * @param agentId - Agent whose slot holds the local skill.
+ * @returns Skill row with one local symlink slot and no source metadata.
+ */
+function makeAgentLocalSkill(name: string, agentId: AgentId): Skill {
+  return {
+    name: name as SkillName,
+    description: '',
+    path: `/home/user/.${agentId}/skills/${name}` as never,
+    symlinkCount: 0,
+    symlinks: [
+      {
+        agentId,
+        agentName: agentId as SymlinkInfo['agentName'],
+        linkPath: `/home/user/.${agentId}/skills/${name}` as never,
+        targetPath: `/home/user/.${agentId}/skills/${name}` as never,
+        status: 'valid',
+        isLocal: true,
+      },
+    ],
+    isSource: false,
+    isOrphan: false,
   }
 }
 
@@ -469,6 +503,7 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
         skillNames: ['brainstorming' as SkillName, 'local-skill' as SkillName],
         agentId: null,
         agentName: null,
+        sourceSummary: null,
       }),
     )
 
@@ -706,14 +741,14 @@ describe('MainContent repo facet dropdown', () => {
       .getByRole('button', { name: /Filter by source repository/i })
       .click()
     await screen
-      .getByRole('menuitemradio', {
+      .getByRole('menuitemcheckbox', {
         name: /pbakaus\/impeccable, 1 skill/i,
       })
       .click()
 
-    expect(store.getState().ui.selectedSource).toBe(
+    expect(store.getState().ui.selectedSources).toEqual([
       repositoryId('pbakaus/impeccable'),
-    )
+    ])
   })
 })
 
@@ -725,23 +760,23 @@ describe('MainContent filter pills (Agent + Source orthogonal)', () => {
 
   it('renders the Source pill with repo name and clears state on click', async () => {
     const { screen, store } = await renderMainContent()
-    const { setSelectedSource } =
+    const { setSelectedSources } =
       await import('@/renderer/src/redux/slices/uiSlice')
 
     // No source filter active: pill must not render.
     expect(screen.getByTestId('source-filter-pill').query()).toBeNull()
 
-    store.dispatch(setSelectedSource(repositoryId('vercel-labs/skills')))
+    store.dispatch(setSelectedSources([repositoryId('vercel-labs/skills')]))
 
     const pill = screen.getByTestId('source-filter-pill')
     await expect.element(pill).toBeInTheDocument()
-    await expect.element(pill).toHaveTextContent(/Showing skills from/)
+    await expect.element(pill).toHaveTextContent(/from/)
     await expect.element(pill).toHaveTextContent('vercel-labs/skills')
 
     // Clear button inside the pill resets the slice field.
     await pill.getByRole('button', { name: /Clear/i }).click()
 
-    await expect.poll(() => store.getState().ui.selectedSource).toBeNull()
+    await expect.poll(() => store.getState().ui.selectedSources).toEqual([])
     expect(screen.getByTestId('source-filter-pill').query()).toBeNull()
   })
 
@@ -749,7 +784,7 @@ describe('MainContent filter pills (Agent + Source orthogonal)', () => {
     const { screen, store } = await renderMainContent()
     const { fetchAgents } =
       await import('@/renderer/src/redux/slices/agentsSlice')
-    const { selectAgent, setSelectedSource } =
+    const { selectAgent, setSelectedSources } =
       await import('@/renderer/src/redux/slices/uiSlice')
 
     // Seed an agent fixture so MainContent's `agents.find(...)` resolves.
@@ -769,7 +804,7 @@ describe('MainContent filter pills (Agent + Source orthogonal)', () => {
       ),
     )
     store.dispatch(selectAgent('claude-code'))
-    store.dispatch(setSelectedSource(repositoryId('vercel-labs/skills')))
+    store.dispatch(setSelectedSources([repositoryId('vercel-labs/skills')]))
 
     await expect
       .element(screen.getByTestId('agent-filter-pill'))
@@ -783,7 +818,7 @@ describe('MainContent filter pills (Agent + Source orthogonal)', () => {
     const { screen, store } = await renderMainContent()
     const { fetchAgents } =
       await import('@/renderer/src/redux/slices/agentsSlice')
-    const { selectAgent, setSelectedSource } =
+    const { selectAgent, setSelectedSources } =
       await import('@/renderer/src/redux/slices/uiSlice')
 
     store.dispatch(
@@ -802,7 +837,7 @@ describe('MainContent filter pills (Agent + Source orthogonal)', () => {
       ),
     )
     store.dispatch(selectAgent('claude-code'))
-    store.dispatch(setSelectedSource(repositoryId('vercel-labs/skills')))
+    store.dispatch(setSelectedSources([repositoryId('vercel-labs/skills')]))
 
     // Clear ONLY the source pill.
     await screen
@@ -810,13 +845,74 @@ describe('MainContent filter pills (Agent + Source orthogonal)', () => {
       .getByRole('button', { name: /Clear/i })
       .click()
 
-    // Agent pill must still be rendered with its label intact; selectedSource
-    // must be null. This pins Issue 4 from the design review: source clear
+    // Agent pill must still be rendered with its label intact; selectedSources
+    // must be empty. This pins Issue 4 from the design review: source clear
     // does not bleed into agent state.
-    await expect.poll(() => store.getState().ui.selectedSource).toBeNull()
+    await expect.poll(() => store.getState().ui.selectedSources).toEqual([])
     expect(store.getState().ui.selectedAgentId).toBe('claude-code')
     await expect
       .element(screen.getByTestId('agent-filter-pill'))
       .toHaveTextContent('Claude Code')
+  })
+})
+
+describe('MainContent hidden-locals caveat', () => {
+  // The repo include-filter hides source-less local skills. This inline caveat
+  // tells the user how many were dropped so an empty-looking list is explained.
+
+  it('shows "N local skills hidden" when the repo filter suppresses source-less locals', async () => {
+    // Arrange — cursor view with one repo skill and two source-less locals
+    const { screen, store } = await renderMainContent()
+    const { fetchSkills } =
+      await import('@/renderer/src/redux/slices/skillsSlice')
+    const { selectAgent, setSelectedSources } =
+      await import('@/renderer/src/redux/slices/uiSlice')
+    store.dispatch(
+      fetchSkills.fulfilled(
+        [
+          makeSourceSkill('repo-skill', 'vercel-labs/skills'),
+          makeAgentLocalSkill('local-one', 'cursor'),
+          makeAgentLocalSkill('local-two', 'cursor'),
+        ],
+        'req-id',
+      ),
+    )
+    store.dispatch(selectAgent('cursor'))
+
+    // Act — turn on the repo include-filter
+    store.dispatch(setSelectedSources([repositoryId('vercel-labs/skills')]))
+
+    // Assert — both suppressed locals are reported, pluralized
+    await expect
+      .element(screen.getByText(/2 local skills hidden/))
+      .toBeInTheDocument()
+  })
+
+  it('omits the caveat when no repo filter is active', async () => {
+    // Arrange — same source-less locals in the cursor view, filter left empty
+    const { screen, store } = await renderMainContent()
+    const { fetchSkills } =
+      await import('@/renderer/src/redux/slices/skillsSlice')
+    const { selectAgent } = await import('@/renderer/src/redux/slices/uiSlice')
+    store.dispatch(
+      fetchSkills.fulfilled(
+        [
+          makeAgentLocalSkill('local-one', 'cursor'),
+          makeAgentLocalSkill('local-two', 'cursor'),
+        ],
+        'req-id',
+      ),
+    )
+    store.dispatch(selectAgent('cursor'))
+
+    // Anchor on the always-rendered trigger so the toolbar is known to be live…
+    await expect
+      .element(
+        screen.getByRole('button', { name: /Filter by source repository/i }),
+      )
+      .toBeInTheDocument()
+
+    // Assert — …then confirm the caveat is absent with nothing filtered out
+    expect(screen.getByText(/local skills hidden/).query()).toBeNull()
   })
 })

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -62,8 +62,10 @@ import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import {
   selectRepoFacetOptions,
   selectSelectedVisibleNames,
+  selectSourceFilterViewModel,
   selectVisibleSkillNames,
 } from '@/renderer/src/redux/selectors'
+import type { SourceFilterRow } from '@/renderer/src/redux/selectors'
 import { setPreviewSkill } from '@/renderer/src/redux/slices/marketplaceSlice'
 import {
   clearSelection,
@@ -77,7 +79,7 @@ import {
 import {
   clearBulkConfirm,
   clearExcludedSkillTypeFilters,
-  clearSelectedSource,
+  clearSelectedSources,
   clearUndoToast,
   enterBulkSelectMode,
   exitBulkSelectMode,
@@ -86,14 +88,14 @@ import {
   selectBulkConfirm,
   selectBulkSelectMode,
   selectExcludedSkillTypeFilters,
-  selectSelectedSource,
   setActiveTab,
   setBulkConfirm,
-  setSelectedSource,
+  setSelectedSources,
   setSkillTypeFilter,
   setUndoToast,
   toggleExcludedSkillTypeFilter,
   toggleSortOrder,
+  toggleSource,
 } from '@/renderer/src/redux/slices/uiSlice'
 import type {
   ActiveTab,
@@ -105,7 +107,10 @@ import { flashFailedRows } from '@/renderer/src/utils/bulkOpVisuals'
 import { errorToastDescription } from '@/renderer/src/utils/errorToastDescription'
 import { isEditableTarget } from '@/renderer/src/utils/isEditableTarget'
 import { pluralize } from '@/renderer/src/utils/pluralize'
-import { UNDO_WINDOW_MS } from '@/shared/constants'
+import {
+  SOURCE_FILTER_MAX_VISIBLE_REPOS,
+  UNDO_WINDOW_MS,
+} from '@/shared/constants'
 import { FEATURE_FLAGS } from '@/shared/featureFlags'
 import type {
   BulkDeleteItemResult,
@@ -137,20 +142,6 @@ const EXCLUDABLE_SKILL_TYPE_FILTER_OPTIONS = SKILL_TYPE_FILTER_OPTIONS.filter(
     dotClass?: string
   } => option.value !== 'all',
 )
-
-/**
- * Compress long repository slugs for toolbar triggers while preserving both
- * owner and repo clues. The full value remains in aria-labels and filter pills.
- * @param source - Repository slug, usually `owner/repo`.
- * @returns Short label safe for compact toolbar buttons.
- * @example
- * formatRepositoryFacetLabel('very-long-owner-name/extremely-long-repository')
- * // => "very-long-ow...ng-repository"
- */
-function formatRepositoryFacetLabel(source: RepositoryId): string {
-  if (source.length <= 28) return source
-  return `${source.slice(0, 12)}...${source.slice(-13)}`
-}
 
 /**
  * Explain why an exclude checkbox is unavailable for the current include mode.
@@ -190,7 +181,7 @@ export const MainContent = React.memo(
     const selectedAllNames = useAppSelector(selectSelectedSkillNames)
     const bulkConfirm = useAppSelector(selectBulkConfirm)
     const bulkSelectMode = useAppSelector(selectBulkSelectMode)
-    const selectedSource = useAppSelector(selectSelectedSource)
+    const sourceFilter = useAppSelector(selectSourceFilterViewModel)
     const repoFacetOptions = useAppSelector(selectRepoFacetOptions)
     const excludedSkillTypeFilters = useAppSelector(
       selectExcludedSkillTypeFilters,
@@ -206,16 +197,12 @@ export const MainContent = React.memo(
       excludedSkillTypeFilters.length === 0
         ? selectedSkillTypeLabel
         : `${selectedSkillTypeLabel} · ${excludedSkillTypeFilters.length} excluded`
-    const selectedSourceLabel = selectedSource
-      ? formatRepositoryFacetLabel(selectedSource)
-      : 'Source'
-
     const handleClearFilter = useCallback((): void => {
       dispatch(selectAgent(null))
     }, [dispatch])
 
     const handleClearSourceFilter = useCallback((): void => {
-      dispatch(clearSelectedSource())
+      dispatch(clearSelectedSources())
     }, [dispatch])
 
     const handleTabChange = useCallback(
@@ -317,15 +304,36 @@ export const MainContent = React.memo(
       [dispatch],
     )
 
-    const handleRepoFacetChange = useCallback(
-      (value: string): void => {
-        if (value === 'all') {
-          dispatch(clearSelectedSource())
-          return
-        }
-        dispatch(setSelectedSource(value as RepositoryId))
+    /**
+     * Tick/untick one repo in the source include-filter. Wired to each
+     * checkbox row in the repo facet dropdown; the menu stays open (via
+     * `handleKeepDropdownOpen`) so a multi-repo selection builds in one pass.
+     */
+    const handleToggleSource = useCallback(
+      (source: RepositoryId): void => {
+        dispatch(toggleSource(source))
       },
       [dispatch],
+    )
+
+    // "Show all repos" header item → clear the include-filter (show everything).
+    const handleSelectShowAllRepos = useCallback(
+      (event: Event): void => {
+        event.preventDefault()
+        dispatch(clearSelectedSources())
+      },
+      [dispatch],
+    )
+
+    // "Select all repos" header item → tick every repo in the current facet.
+    const handleSelectAllRepos = useCallback(
+      (event: Event): void => {
+        event.preventDefault()
+        dispatch(
+          setSelectedSources(repoFacetOptions.map((option) => option.source)),
+        )
+      },
+      [dispatch, repoFacetOptions],
     )
 
     const handleToggleExcludedSkillTypeFilter = useCallback(
@@ -407,15 +415,35 @@ export const MainContent = React.memo(
      */
     const handlePrimaryAction = useCallback((): void => {
       if (selectedVisibleNames.length === 0) return
+      // Snapshot the active repo-filter scope so the confirm dialog can state
+      // what the user is acting within, even if they change the filter before
+      // clicking confirm. Null when no repo is in scope and nothing is hidden
+      // — keeps the dialog copy unchanged in the common (unfiltered) case.
+      const sourceSummary =
+        sourceFilter.validRepoIds.length > 0 ||
+        sourceFilter.localHiddenCount > 0
+          ? {
+              repositoryIds: sourceFilter.validRepoIds,
+              localHiddenCount: sourceFilter.localHiddenCount,
+            }
+          : null
       dispatch(
         setBulkConfirm({
           kind: selectedAgentId ? 'unlink' : 'delete',
           skillNames: selectedVisibleNames,
           agentId: selectedAgentId,
           agentName: selectedAgent?.name ?? null,
+          sourceSummary,
         }),
       )
-    }, [dispatch, selectedAgentId, selectedAgent?.name, selectedVisibleNames])
+    }, [
+      dispatch,
+      selectedAgentId,
+      selectedAgent?.name,
+      selectedVisibleNames,
+      sourceFilter.validRepoIds,
+      sourceFilter.localHiddenCount,
+    ])
 
     /**
      * Invoked by the BulkConfirmDialog's primary button. Reads the pending
@@ -626,60 +654,63 @@ export const MainContent = React.memo(
                 )}
               </Button>
 
-              {/* Repo facet: exact source filter with counts from the current
-                  agent/type population, independent of the text query. */}
+              {/* Repo facet: multi-select source include-filter with counts
+                  from the current agent/type population, independent of the
+                  text query. Empty selection shows all repos (and local
+                  skills); ticking repos narrows to those sources. */}
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button
                     variant="ghost"
                     size="sm"
-                    aria-label={
-                      selectedSource
-                        ? `Filtering by source repository ${selectedSource}`
-                        : 'Filter by source repository'
-                    }
+                    aria-label={sourceFilter.triggerAriaLabel}
                     className={cn(
                       'shrink-0 gap-1.5 min-h-11 max-w-44',
-                      selectedSource
+                      sourceFilter.selectedSources.length > 0
                         ? 'text-primary'
                         : 'text-muted-foreground hover:text-foreground',
                     )}
                   >
                     <GitBranch className="h-4 w-4" />
                     <span className="max-w-32 truncate">
-                      {selectedSourceLabel}
+                      {sourceFilter.triggerLabel}
                     </span>
                     <ChevronDown className="h-3 w-3" />
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="w-72">
                   <DropdownMenuLabel>Source repository</DropdownMenuLabel>
-                  <DropdownMenuRadioGroup
-                    value={selectedSource ?? 'all'}
-                    onValueChange={handleRepoFacetChange}
-                  >
-                    <DropdownMenuRadioItem value="all">
-                      <span className="min-w-0 flex-1">All repos</span>
-                    </DropdownMenuRadioItem>
-                    {repoFacetOptions.map((option) => (
-                      <DropdownMenuRadioItem
-                        key={option.source}
-                        value={option.source}
-                        aria-label={`${option.source}, ${option.count} ${pluralize(
-                          option.count,
-                          'skill',
-                        )}`}
-                        className="gap-2"
+                  {sourceFilter.hasNoRepositories ? (
+                    <DropdownMenuItem disabled>
+                      No source repositories
+                    </DropdownMenuItem>
+                  ) : (
+                    <>
+                      {/* Bulk shortcuts mirror the multi-select pattern: clear
+                          the whole set, or tick every facet repo at once. */}
+                      <DropdownMenuItem
+                        disabled={sourceFilter.selectedSources.length === 0}
+                        onSelect={handleSelectShowAllRepos}
                       >
-                        <span className="min-w-0 flex-1 truncate">
-                          {option.source}
-                        </span>
-                        <span className="ml-auto text-xs text-muted-foreground">
-                          {option.count}
-                        </span>
-                      </DropdownMenuRadioItem>
-                    ))}
-                  </DropdownMenuRadioGroup>
+                        Show all repos
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        disabled={sourceFilter.isSelectAllDisabled}
+                        onSelect={handleSelectAllRepos}
+                      >
+                        Select all repos
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
+                      {sourceFilter.dropdownRows.map((row) => (
+                        <SourceFacetCheckboxRow
+                          key={row.source}
+                          row={row}
+                          onToggle={handleToggleSource}
+                          onKeepOpen={handleKeepDropdownOpen}
+                        />
+                      ))}
+                    </>
+                  )}
                 </DropdownMenuContent>
               </DropdownMenu>
 
@@ -833,20 +864,44 @@ export const MainContent = React.memo(
             )}
 
             {/* Source-repo filter indicator. Stacks orthogonally with the
-                Agent pill — the user can narrow by agent AND by repo at the
-                same time without one resetting the other. */}
-            {selectedSource && (
+                Agent pill — agent AND repo filters can be active at once. Up to
+                SOURCE_FILTER_MAX_VISIBLE_REPOS repos render as individual
+                clearable pills; beyond that a single collapsed pill clears the
+                whole set (DESIGN.md: avoid pill overload). The else branch maps
+                an empty array to nothing, covering the no-filter case too. */}
+            {sourceFilter.selectedSources.length >
+            SOURCE_FILTER_MAX_VISIBLE_REPOS ? (
               <FilterPill
                 label={
                   <>
                     from{' '}
-                    <strong className="text-primary">{selectedSource}</strong>
+                    <strong className="text-primary">
+                      {sourceFilter.selectedSources.length} repos
+                    </strong>
                   </>
                 }
                 onClear={handleClearSourceFilter}
                 testId="source-filter-pill"
               />
+            ) : (
+              sourceFilter.selectedSources.map((source) => (
+                <SourceFilterPill
+                  key={source}
+                  source={source}
+                  onClear={handleToggleSource}
+                />
+              ))
             )}
+
+            {/* Local-skills-hidden caveat — only while the repo filter is
+                actively suppressing source-less local skills. Plain metadata,
+                not a pill, so it reads as subordinate to the filter pills. */}
+            {sourceFilter.localHiddenCount > 0 ? (
+              <p className="px-4 py-2 border-b border-border text-xs text-muted-foreground shrink-0">
+                {sourceFilter.localHiddenCount}{' '}
+                {pluralize(sourceFilter.localHiddenCount, 'local skill')} hidden
+              </p>
+            ) : null}
 
             {/* Renders only when at least one skill is ticked. */}
             <SelectionToolbar
@@ -894,6 +949,7 @@ export const MainContent = React.memo(
                 {bulkConfirm?.kind === 'delete'
                   ? renderBulkDeleteDescription({
                       totalCount: bulkConfirm.skillNames.length,
+                      sourceSummary: bulkConfirm.sourceSummary,
                     })
                   : `This removes the symlinks in ${bulkConfirm?.agentName ?? 'this agent'}. The underlying skill files stay in your source directory.`}
               </DialogDescription>
@@ -917,3 +973,77 @@ export const MainContent = React.memo(
     )
   },
 )
+
+/**
+ * One repo row in the source-filter dropdown — wraps `DropdownMenuCheckboxItem`
+ * with a `useCallback` toggle so the memoized item isn't defeated by an inline
+ * arrow (which also trips `prefer-usecallback-might-work`). Mapped by MainContent.
+ * @param row - Facet row: repo id, visible-skill count, and ticked state.
+ * @param onToggle - Adds/removes this repo from the include filter.
+ * @param onKeepOpen - `onSelect` handler that keeps the menu open on activation.
+ * @returns A checkbox menu item labelling the repo id and its skill count.
+ * @example
+ * <SourceFacetCheckboxRow row={row} onToggle={handleToggleSource} onKeepOpen={handleKeepDropdownOpen} />
+ */
+const SourceFacetCheckboxRow = React.memo(function SourceFacetCheckboxRow({
+  row,
+  onToggle,
+  onKeepOpen,
+}: {
+  row: SourceFilterRow
+  onToggle: (source: RepositoryId) => void
+  onKeepOpen: (event: Event) => void
+}): React.ReactElement {
+  // Stable per-row toggle — re-created only when the row id or handler changes.
+  const handleCheckedChange = useCallback((): void => {
+    onToggle(row.source)
+  }, [onToggle, row.source])
+
+  return (
+    <DropdownMenuCheckboxItem
+      checked={row.checked}
+      onCheckedChange={handleCheckedChange}
+      onSelect={onKeepOpen}
+      aria-label={`${row.source}, ${row.count} ${pluralize(row.count, 'skill')}`}
+      className="gap-2"
+    >
+      <span className="min-w-0 flex-1 truncate">{row.source}</span>
+      <span className="ml-auto text-xs text-muted-foreground">{row.count}</span>
+    </DropdownMenuCheckboxItem>
+  )
+})
+
+/**
+ * One clearable "from <repo>" pill (shown when ≤ SOURCE_FILTER_MAX_VISIBLE_REPOS
+ * repos selected) — wraps the memoized `FilterPill` with a `useCallback` clear so
+ * an inline arrow doesn't re-render it / trip `prefer-usecallback-might-work`.
+ * @param source - The repository id this pill represents and clears.
+ * @param onClear - Removes `source` from the include filter (toggle off).
+ * @returns A FilterPill labelled `from <source>` wired to single-repo clear.
+ * @example
+ * <SourceFilterPill source={source} onClear={handleToggleSource} />
+ */
+const SourceFilterPill = React.memo(function SourceFilterPill({
+  source,
+  onClear,
+}: {
+  source: RepositoryId
+  onClear: (source: RepositoryId) => void
+}): React.ReactElement {
+  // Stable clear — toggles this exact repo off the include filter.
+  const handleClear = useCallback((): void => {
+    onClear(source)
+  }, [onClear, source])
+
+  return (
+    <FilterPill
+      label={
+        <>
+          from <strong className="text-primary">{source}</strong>
+        </>
+      }
+      onClear={handleClear}
+      testId="source-filter-pill"
+    />
+  )
+})

--- a/src/renderer/src/components/sidebar/SourceCard.tsx
+++ b/src/renderer/src/components/sidebar/SourceCard.tsx
@@ -25,6 +25,7 @@ import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import { fetchAgents } from '@/renderer/src/redux/slices/agentsSlice'
 import { fetchSkills } from '@/renderer/src/redux/slices/skillsSlice'
 import {
+  clearSelectedSources,
   fetchSourceStats,
   fetchSyncPreview,
   selectAgent,
@@ -70,6 +71,10 @@ export const SourceCard = React.memo(function SourceCard(): React.ReactElement {
     dispatch(setActiveTab('installed'))
     dispatch(selectAgent(null))
     dispatch(setSearchQuery(''))
+    // Drop the source-repo include filter too — the card's contract ("clear
+    // all filters and show all skills") was previously half-kept, leaving a
+    // repo narrow active after the click.
+    dispatch(clearSelectedSources())
   }, [dispatch])
 
   /**

--- a/src/renderer/src/components/skills/SkillItem.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillItem.browser.test.tsx
@@ -205,6 +205,8 @@ describe('SkillItem delete button', () => {
       skillNames: ['brainstorming'],
       agentId: null,
       agentName: null,
+      // Single-row delete carries no repo-filter scope, so the summary is null.
+      sourceSummary: null,
     })
   })
 
@@ -220,6 +222,8 @@ describe('SkillItem delete button', () => {
       skillNames: ['local-skill'],
       agentId: null,
       agentName: null,
+      // Single-row delete carries no repo-filter scope, so the summary is null.
+      sourceSummary: null,
     })
   })
 

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -177,6 +177,8 @@ export const SkillItem = React.memo(function SkillItem({
         skillNames: [skill.name],
         agentId: null,
         agentName: null,
+        // A single-row delete carries no repo-filter scope to report.
+        sourceSummary: null,
       }),
     )
   }

--- a/src/renderer/src/components/skills/SkillsList.tsx
+++ b/src/renderer/src/components/skills/SkillsList.tsx
@@ -14,7 +14,7 @@ import {
   selectExcludedSkillTypeFilters,
   selectSearchQuery,
   selectSelectedAgentId,
-  selectSelectedSource,
+  selectSelectedSources,
   selectSkillTypeFilter,
 } from '@/renderer/src/redux/slices/uiSlice'
 import type { Skill } from '@/shared/types'
@@ -69,7 +69,7 @@ export const SkillsList = React.memo(function SkillsList(): React.ReactElement {
   const selectedAgentId = useAppSelector(selectSelectedAgentId)
   const skillTypeFilter = useAppSelector(selectSkillTypeFilter)
   const searchQuery = useAppSelector(selectSearchQuery)
-  const selectedSource = useAppSelector(selectSelectedSource)
+  const selectedSources = useAppSelector(selectSelectedSources)
   const excludedSkillTypeFilters = useAppSelector(
     selectExcludedSkillTypeFilters,
   )
@@ -130,7 +130,7 @@ export const SkillsList = React.memo(function SkillsList(): React.ReactElement {
   if (filteredSkills.length === 0) {
     const emptyMessage = getEmptyListMessage({
       searchQuery,
-      selectedSource,
+      selectedSources,
       selectedAgentId,
       skillTypeFilter,
       excludedSkillTypeFilters,

--- a/src/renderer/src/components/skills/SourceLink.browser.test.tsx
+++ b/src/renderer/src/components/skills/SourceLink.browser.test.tsx
@@ -11,7 +11,7 @@ const REPO_HREF = 'https://github.com/pbakaus/impeccable'
 
 /**
  * Minimal store with only the `ui` slice — SourceLink's only Redux touchpoint
- * is `setSelectedSource`. Keeping the surface tight isolates the test from
+ * is `setSelectedSources`. Keeping the surface tight isolates the test from
  * unrelated reducer churn.
  */
 async function createStore() {
@@ -50,7 +50,7 @@ async function renderSourceLink(options: RenderOptions = {}) {
 }
 
 describe('SourceLink role split', () => {
-  it('clicking the repo text dispatches setSelectedSource', async () => {
+  it('clicking the repo text replaces the source filter with that repo', async () => {
     const { screen, store } = await renderSourceLink({
       source: REPO,
       sourceUrl: REPO_URL,
@@ -62,7 +62,7 @@ describe('SourceLink role split', () => {
       })
       .click()
 
-    await expect.poll(() => store.getState().ui.selectedSource).toBe(REPO)
+    await expect.poll(() => store.getState().ui.selectedSources).toEqual([REPO])
   })
 
   it('the icon anchor points at the .git-stripped GitHub URL with target=_blank', async () => {
@@ -92,7 +92,7 @@ describe('SourceLink role split', () => {
       .getByRole('button', { name: /Filter skills by repository/i })
       .click()
     expect(onParentClick).not.toHaveBeenCalled()
-    await expect.poll(() => store.getState().ui.selectedSource).toBe(REPO)
+    await expect.poll(() => store.getState().ui.selectedSources).toEqual([REPO])
 
     // Anchor click via dispatchEvent — Playwright's `.click()` on a
     // `target="_blank"` anchor would try to open a new browser context.

--- a/src/renderer/src/components/skills/SourceLink.tsx
+++ b/src/renderer/src/components/skills/SourceLink.tsx
@@ -2,7 +2,7 @@ import { ExternalLink } from 'lucide-react'
 import React from 'react'
 
 import { useAppDispatch } from '@/renderer/src/redux/hooks'
-import { setSelectedSource } from '@/renderer/src/redux/slices/uiSlice'
+import { setSelectedSources } from '@/renderer/src/redux/slices/uiSlice'
 import type { HttpUrl, RepositoryId } from '@/shared/types'
 
 import { getSourceLinkModel } from './sourceLinkHelpers'
@@ -17,8 +17,9 @@ interface SourceLinkProps {
  * - `local` — "Local" label, no interactive affordance.
  * - `text`  — source identifier, plain text (no URL to link to).
  * - `link`  — split affordances: a `<button>` that filters the skill list by
- *             repository (dispatches `setSelectedSource`) and a separate
- *             `<a target="_blank">` whose icon opens the repository on GitHub.
+ *             repository (dispatches `setSelectedSources([source])`, replacing
+ *             any active repo filter) and a separate `<a target="_blank">`
+ *             whose icon opens the repository on GitHub.
  *
  * Why split the `link` mode? Mixing a Redux-dispatch action and an external
  * navigation under one `<a>` was ambiguous — clicking the repo text used to
@@ -67,7 +68,9 @@ export const SourceLink = React.memo(function SourceLink({
     event: React.MouseEvent<HTMLButtonElement>,
   ): void => {
     event.stopPropagation()
-    dispatch(setSelectedSource(model.source))
+    // Replace any active repo filter with just this one — a SourceLink click is
+    // a focused "show me this repo" jump, not an additive toggle.
+    dispatch(setSelectedSources([model.source]))
   }
 
   const handleExternalClick = (

--- a/src/renderer/src/components/skills/bulkDeleteCopy.test.ts
+++ b/src/renderer/src/components/skills/bulkDeleteCopy.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest'
+
+import { repositoryId } from '@/shared/types'
+
+import { renderBulkDeleteDescription } from './bulkDeleteCopy'
+
+// The base trash + undo sentence the dialog always opens with (plural batch).
+const BASE_PLURAL =
+  'This moves the skills to the app trash and removes every symlink pointing to them. You can restore within 15 seconds from the notification.'
+
+describe('renderBulkDeleteDescription', () => {
+  it('returns the base trash-and-undo copy when no repo filter is active', () => {
+    // Arrange / Act
+    const description = renderBulkDeleteDescription({
+      totalCount: 3,
+      sourceSummary: null,
+    })
+
+    // Assert — no scope clause is appended
+    expect(description).toBe(BASE_PLURAL)
+  })
+
+  it('singularizes the base copy for a one-skill batch', () => {
+    // Arrange / Act
+    const description = renderBulkDeleteDescription({
+      totalCount: 1,
+      sourceSummary: null,
+    })
+
+    // Assert — "skill"/"it" instead of "skills"/"them"
+    expect(description).toBe(
+      'This moves the skill to the app trash and removes every symlink pointing to it. You can restore within 15 seconds from the notification.',
+    )
+  })
+
+  it('names the single in-scope repository', () => {
+    // Arrange / Act
+    const description = renderBulkDeleteDescription({
+      totalCount: 2,
+      sourceSummary: {
+        repositoryIds: [repositoryId('vercel-labs/skills')],
+        localHiddenCount: 0,
+      },
+    })
+
+    // Assert — the one repo is named verbatim
+    expect(description).toBe(
+      `${BASE_PLURAL} Only skills from vercel-labs/skills are in scope.`,
+    )
+  })
+
+  it('spells a long repository in full, not the truncated trigger label', () => {
+    // Arrange — a slug past the 28-char trigger-truncation threshold
+    const longRepo = repositoryId(
+      'very-long-owner-name/extremely-long-repository',
+    )
+
+    // Act
+    const description = renderBulkDeleteDescription({
+      totalCount: 2,
+      sourceSummary: {
+        repositoryIds: [longRepo],
+        localHiddenCount: 0,
+      },
+    })
+
+    // Assert — the destructive confirm shows the exact source, no middle ellipsis
+    expect(description).toBe(
+      `${BASE_PLURAL} Only skills from very-long-owner-name/extremely-long-repository are in scope.`,
+    )
+  })
+
+  it('summarizes multiple in-scope repositories by count', () => {
+    // Arrange / Act
+    const description = renderBulkDeleteDescription({
+      totalCount: 2,
+      sourceSummary: {
+        repositoryIds: [
+          repositoryId('vercel-labs/skills'),
+          repositoryId('pbakaus/impeccable'),
+        ],
+        localHiddenCount: 0,
+      },
+    })
+
+    // Assert — repos collapse to a count rather than a long list
+    expect(description).toBe(
+      `${BASE_PLURAL} Only skills from the 2 selected repositories are in scope.`,
+    )
+  })
+
+  it('notes that hidden local skills are not affected (plural)', () => {
+    // Arrange / Act
+    const description = renderBulkDeleteDescription({
+      totalCount: 2,
+      sourceSummary: {
+        repositoryIds: [],
+        localHiddenCount: 2,
+      },
+    })
+
+    // Assert — reassures the user the suppressed locals stay untouched
+    expect(description).toBe(
+      `${BASE_PLURAL} 2 local skills hidden by the source filter are not affected.`,
+    )
+  })
+
+  it('singularizes the hidden-locals note for a single local skill', () => {
+    // Arrange / Act
+    const description = renderBulkDeleteDescription({
+      totalCount: 2,
+      sourceSummary: {
+        repositoryIds: [],
+        localHiddenCount: 1,
+      },
+    })
+
+    // Assert — "1 local skill … is not affected"
+    expect(description).toBe(
+      `${BASE_PLURAL} 1 local skill hidden by the source filter is not affected.`,
+    )
+  })
+
+  it('appends both the repo scope and the hidden-locals note', () => {
+    // Arrange / Act
+    const description = renderBulkDeleteDescription({
+      totalCount: 2,
+      sourceSummary: {
+        repositoryIds: [repositoryId('vercel-labs/skills')],
+        localHiddenCount: 1,
+      },
+    })
+
+    // Assert — scope sentence first, then the hidden-locals reassurance
+    expect(description).toBe(
+      `${BASE_PLURAL} Only skills from vercel-labs/skills are in scope. 1 local skill hidden by the source filter is not affected.`,
+    )
+  })
+
+  it('falls back to the base copy when the summary carries neither repos nor hidden locals', () => {
+    // Defensive branch: a non-null summary with empty scope must not append a
+    // dangling space or empty sentence.
+    // Arrange / Act
+    const description = renderBulkDeleteDescription({
+      totalCount: 2,
+      sourceSummary: {
+        repositoryIds: [],
+        localHiddenCount: 0,
+      },
+    })
+
+    // Assert
+    expect(description).toBe(BASE_PLURAL)
+  })
+})

--- a/src/renderer/src/components/skills/bulkDeleteCopy.tsx
+++ b/src/renderer/src/components/skills/bulkDeleteCopy.tsx
@@ -1,5 +1,6 @@
 import type React from 'react'
 
+import type { SourceFilterSummary } from '@/renderer/src/redux/slices/uiSlice'
 import { pluralize } from '@/renderer/src/utils/pluralize'
 
 /**
@@ -9,20 +10,66 @@ import { pluralize } from '@/renderer/src/utils/pluralize'
  * trashed via `moveToTrash` with a 15s undo window. The CLI removal branch
  * was removed; lock-file entries are not rewritten by the desktop app.
  *
+ * When a source-repo include filter is active, `sourceSummary` appends a scope
+ * clause: which repositories the batch is drawn from, and how many source-less
+ * local skills the filter is hiding (so the user knows those stay untouched).
+ *
  * Extracted out of the JSX so the dialog render stays readable and so the
  * copy stays testable without mounting the full MainContent tree.
  *
- * @param totalCount - Total skills in the pending batch
- * @returns React node to drop into `<DialogDescription>`
+ * @param totalCount - Total skills in the pending batch.
+ * @param sourceSummary - Active repo-filter scope snapshot, or null when no
+ *   repo filter is active and no local skills are hidden.
+ * @returns
+ * - Base trash + undo sentence (always present).
+ * - `+ " Only skills from <repo> are in scope."` when ≥1 repo is in scope.
+ * - `+ " N local skills hidden by the source filter are not affected."` when
+ *   the filter suppresses source-less local skills.
  * @example
- * <DialogDescription>
- *   {renderBulkDeleteDescription({ totalCount: 3 })}
- * </DialogDescription>
+ * renderBulkDeleteDescription({ totalCount: 3, sourceSummary: null })
+ * // => "This moves the skills to the app trash ... from the notification."
+ * @example
+ * renderBulkDeleteDescription({
+ *   totalCount: 2,
+ *   sourceSummary: {
+ *     repositoryIds: [repositoryId('vercel-labs/skills')],
+ *     localHiddenCount: 1,
+ *   },
+ * })
+ * // => "... from the notification. Only skills from vercel-labs/skills are in
+ * //     scope. 1 local skill hidden by the source filter is not affected."
  */
 export const renderBulkDeleteDescription = ({
   totalCount,
+  sourceSummary,
 }: {
   totalCount: number
+  sourceSummary: SourceFilterSummary | null
 }): React.ReactNode => {
-  return `This moves the ${pluralize(totalCount, 'skill')} to the app trash and removes every symlink pointing to ${pluralize(totalCount, 'it', 'them')}. You can restore within 15 seconds from the notification.`
+  const base = `This moves the ${pluralize(totalCount, 'skill')} to the app trash and removes every symlink pointing to ${pluralize(totalCount, 'it', 'them')}. You can restore within 15 seconds from the notification.`
+
+  // No active repo filter (and nothing hidden) → the base copy is complete.
+  if (sourceSummary === null) return base
+
+  const scopeSentences: string[] = []
+  // Name the repositories the batch is drawn from. A single repo is spelled in
+  // full (NOT the truncated trigger label) — this is a destructive confirm, so
+  // the user must see the exact source; many repos collapse to a count.
+  if (sourceSummary.repositoryIds.length > 0) {
+    const repoScope =
+      sourceSummary.repositoryIds.length === 1
+        ? sourceSummary.repositoryIds[0]
+        : `the ${sourceSummary.repositoryIds.length} selected repositories`
+    scopeSentences.push(`Only skills from ${repoScope} are in scope.`)
+  }
+  // Reassure that source-less local skills the filter hides stay untouched.
+  if (sourceSummary.localHiddenCount > 0) {
+    const { localHiddenCount } = sourceSummary
+    scopeSentences.push(
+      `${localHiddenCount} local ${pluralize(localHiddenCount, 'skill')} hidden by the source filter ${pluralize(localHiddenCount, 'is', 'are')} not affected.`,
+    )
+  }
+
+  if (scopeSentences.length === 0) return base
+  return `${base} ${scopeSentences.join(' ')}`
 }

--- a/src/renderer/src/components/skills/skillsListHelpers.test.ts
+++ b/src/renderer/src/components/skills/skillsListHelpers.test.ts
@@ -11,22 +11,52 @@ describe('getEmptyListMessage', () => {
     expect(
       getEmptyListMessage({
         searchQuery: 'react',
-        selectedSource: repositoryId('vercel-labs/skills'),
+        selectedSources: [repositoryId('vercel-labs/skills')],
         selectedAgentId: 'cursor',
         skillTypeFilter: 'local',
       }),
     ).toBe('No skills match your search in vercel-labs/skills')
   })
 
-  it('returns the source message when only selectedSource is set', () => {
+  it('returns the source message when only a single source is selected', () => {
     expect(
       getEmptyListMessage({
         searchQuery: '',
-        selectedSource: repositoryId('vercel-labs/skills'),
+        selectedSources: [repositoryId('vercel-labs/skills')],
         selectedAgentId: null,
         skillTypeFilter: 'all',
       }),
     ).toBe('No skills from vercel-labs/skills')
+  })
+
+  it('collapses multiple selected sources to "the selected repositories"', () => {
+    // With >1 repo in the include filter, naming each would bloat the empty
+    // state; the helper summarizes instead of listing.
+    expect(
+      getEmptyListMessage({
+        searchQuery: '',
+        selectedSources: [
+          repositoryId('vercel-labs/skills'),
+          repositoryId('pbakaus/impeccable'),
+        ],
+        selectedAgentId: null,
+        skillTypeFilter: 'all',
+      }),
+    ).toBe('No skills from the selected repositories')
+  })
+
+  it('adds the multi-source summary to a search result', () => {
+    expect(
+      getEmptyListMessage({
+        searchQuery: 'react',
+        selectedSources: [
+          repositoryId('vercel-labs/skills'),
+          repositoryId('pbakaus/impeccable'),
+        ],
+        selectedAgentId: 'cursor',
+        skillTypeFilter: 'all',
+      }),
+    ).toBe('No skills match your search in the selected repositories')
   })
 
   it('source message wins over agent + type when both are set (search empty)', () => {
@@ -35,7 +65,7 @@ describe('getEmptyListMessage', () => {
     expect(
       getEmptyListMessage({
         searchQuery: '',
-        selectedSource: repositoryId('pbakaus/impeccable'),
+        selectedSources: [repositoryId('pbakaus/impeccable')],
         selectedAgentId: 'claude-code',
         skillTypeFilter: 'symlinked',
       }),
@@ -46,7 +76,7 @@ describe('getEmptyListMessage', () => {
     expect(
       getEmptyListMessage({
         searchQuery: 'trace',
-        selectedSource: repositoryId('laststance/skills'),
+        selectedSources: [repositoryId('laststance/skills')],
         selectedAgentId: 'cursor',
         skillTypeFilter: 'all',
       }),
@@ -57,7 +87,7 @@ describe('getEmptyListMessage', () => {
     expect(
       getEmptyListMessage({
         searchQuery: '',
-        selectedSource: null,
+        selectedSources: [],
         selectedAgentId: 'cursor',
         skillTypeFilter: 'local',
       }),
@@ -68,7 +98,7 @@ describe('getEmptyListMessage', () => {
     expect(
       getEmptyListMessage({
         searchQuery: '',
-        selectedSource: repositoryId('vercel-labs/skills'),
+        selectedSources: [repositoryId('vercel-labs/skills')],
         selectedAgentId: 'cursor',
         skillTypeFilter: 'all',
         excludedSkillTypeFilters: ['gstack', 'orphan'],
@@ -82,7 +112,7 @@ describe('getEmptyListMessage', () => {
     expect(
       getEmptyListMessage({
         searchQuery: '',
-        selectedSource: null,
+        selectedSources: [],
         selectedAgentId: 'cursor',
         skillTypeFilter: 'all',
         excludedSkillTypeFilters: ['local', 'gstack', 'orphan'],
@@ -96,7 +126,7 @@ describe('getEmptyListMessage', () => {
     expect(
       getEmptyListMessage({
         searchQuery: '',
-        selectedSource: null,
+        selectedSources: [],
         selectedAgentId: 'claude-code',
         skillTypeFilter: 'symlinked',
       }),
@@ -107,7 +137,7 @@ describe('getEmptyListMessage', () => {
     expect(
       getEmptyListMessage({
         searchQuery: '',
-        selectedSource: null,
+        selectedSources: [],
         selectedAgentId: 'cursor',
         skillTypeFilter: 'gstack',
       }),
@@ -118,7 +148,7 @@ describe('getEmptyListMessage', () => {
     expect(
       getEmptyListMessage({
         searchQuery: '',
-        selectedSource: null,
+        selectedSources: [],
         selectedAgentId: 'cursor',
         skillTypeFilter: 'all',
       }),
@@ -133,7 +163,7 @@ describe('getEmptyListMessage', () => {
     expect(
       getEmptyListMessage({
         searchQuery: '',
-        selectedSource: null,
+        selectedSources: [],
         selectedAgentId: null,
         skillTypeFilter: 'all',
       }),
@@ -148,7 +178,7 @@ describe('getEmptyListMessage', () => {
     expect(
       getEmptyListMessage({
         searchQuery: ' ',
-        selectedSource: null,
+        selectedSources: [],
         selectedAgentId: null,
         skillTypeFilter: 'all',
       }),

--- a/src/renderer/src/components/skills/skillsListHelpers.ts
+++ b/src/renderer/src/components/skills/skillsListHelpers.ts
@@ -8,7 +8,7 @@ import type { AgentId, RepositoryId } from '@/shared/types'
 
 interface EmptyMessageContext {
   searchQuery: string
-  selectedSource: RepositoryId | null
+  selectedSources: RepositoryId[]
   selectedAgentId: AgentId | null
   skillTypeFilter: SkillTypeFilter
   excludedSkillTypeFilters?: ExcludableSkillTypeFilter[]
@@ -68,17 +68,32 @@ function withExcludeContext(
 }
 
 /**
+ * Render the repo phrase for empty-state copy from the active include-filter.
+ * @param selectedSources - Active repository include-filter (non-empty when called).
+ * @returns
+ * - exactly 1 repo → the repo id, e.g. `"vercel-labs/skills"`
+ * - ≥2 repos → `"the selected repositories"`
+ * @example
+ * formatSelectedSourcesPhrase([repositoryId('vercel-labs/skills')])
+ * // => "vercel-labs/skills"
+ */
+function formatSelectedSourcesPhrase(selectedSources: RepositoryId[]): string {
+  if (selectedSources.length === 1) return selectedSources[0]
+  return 'the selected repositories'
+}
+
+/**
  * Compute the empty-state message for SkillsList based on which filters are
  * currently narrowing the result. The skills list participates in four
- * orthogonal filters (search query, source-repo pill, selected agent,
- * skill-type pill). When the intersection produces zero rows, the user
- * needs a message that names the *last action* they took, not a catch-all
- * "no skills match your filter."
+ * orthogonal filters (search query, source-repo include filter, selected
+ * agent, skill-type pill). When the intersection produces zero rows, the
+ * user needs a message that names the *last action* they took, not a
+ * catch-all "no skills match your filter."
  *
  * Priority order — search > source > (agent + type) > agent > fallback —
  * mirrors the user's mental model: "I just typed in the search box → the
- * search is what hid my rows." Source pill takes precedence over the agent
- * card because clicking a repo link from a skill card is a more recent,
+ * search is what hid my rows." The source filter takes precedence over the
+ * agent card because narrowing to specific repositories is a more recent,
  * more specific action than the persistent agent-tab selection.
  *
  * Why ts-pattern: the `match().with().otherwise()` chain forces the priority
@@ -89,7 +104,8 @@ function withExcludeContext(
  * @param ctx - Snapshot of the active filter values from Redux.
  * @returns
  * - When `searchQuery` is non-empty: `"No skills match your search"`
- * - When only `selectedSource` is set: `"No skills from <repo>"`
+ * - When `selectedSources` is non-empty: `"No skills from <repo>"` (or
+ *   `"the selected repositories"` when more than one repo is selected)
  * - When `selectedAgentId` is set AND `skillTypeFilter !== 'all'`:
  *   `"No <symlinked|local|G-Stack|orphan> skills for this agent"`
  * - When only `selectedAgentId` is set: `"No skills installed for this agent"`
@@ -99,7 +115,7 @@ function withExcludeContext(
  * @example
  * getEmptyListMessage({
  *   searchQuery: '',
- *   selectedSource: repositoryId('vercel-labs/skills'),
+ *   selectedSources: [repositoryId('vercel-labs/skills')],
  *   selectedAgentId: null,
  *   skillTypeFilter: 'all',
  *   excludedSkillTypeFilters: [],
@@ -109,7 +125,7 @@ function withExcludeContext(
  * @example
  * getEmptyListMessage({
  *   searchQuery: '',
- *   selectedSource: null,
+ *   selectedSources: [],
  *   selectedAgentId: 'cursor',
  *   skillTypeFilter: 'local',
  *   excludedSkillTypeFilters: ['gstack'],
@@ -119,18 +135,22 @@ function withExcludeContext(
 export function getEmptyListMessage(ctx: EmptyMessageContext): string {
   const baseMessage = match({
     hasSearchQuery: ctx.searchQuery.length > 0,
-    hasSelectedSource: ctx.selectedSource !== null,
+    hasSelectedSource: ctx.selectedSources.length > 0,
     hasSelectedAgent: ctx.selectedAgentId !== null,
     hasTypeNarrow: ctx.skillTypeFilter !== 'all',
   })
     .with(
       { hasSearchQuery: true, hasSelectedSource: true },
-      () => `No skills match your search in ${ctx.selectedSource}`,
+      () =>
+        `No skills match your search in ${formatSelectedSourcesPhrase(
+          ctx.selectedSources,
+        )}`,
     )
     .with({ hasSearchQuery: true }, () => 'No skills match your search')
     .with(
       { hasSelectedSource: true },
-      () => `No skills from ${ctx.selectedSource}`,
+      () =>
+        `No skills from ${formatSelectedSourcesPhrase(ctx.selectedSources)}`,
     )
     .with(
       { hasSelectedAgent: true, hasTypeNarrow: true },

--- a/src/renderer/src/redux/selectors.test.ts
+++ b/src/renderer/src/redux/selectors.test.ts
@@ -25,6 +25,7 @@ import {
   selectSelectedSkillNamesSet,
   selectSelectedVisibleCount,
   selectSelectedVisibleNames,
+  selectSourceFilterViewModel,
   selectVisibleSkillNames,
 } from './selectors'
 
@@ -34,7 +35,7 @@ function buildState(overrides: {
   searchQuery?: string
   searchScope?: 'name' | 'repo'
   selectedAgentId?: AgentId | null
-  selectedSource?: RepositoryId | null
+  selectedSources?: RepositoryId[]
   sortOrder?: 'asc' | 'desc'
   skillTypeFilter?: SkillTypeFilter
   excludedSkillTypeFilters?: ExcludableSkillTypeFilter[]
@@ -70,7 +71,7 @@ function buildState(overrides: {
       activeTab: 'installed' as const,
       searchQuery: overrides.searchQuery ?? '',
       searchScope: overrides.searchScope ?? ('name' as const),
-      selectedSource: overrides.selectedSource ?? null,
+      selectedSources: overrides.selectedSources ?? [],
       sourceStats: null,
       isRefreshing: false,
       selectedAgentId: overrides.selectedAgentId ?? null,
@@ -621,7 +622,7 @@ describe('selectFilteredSkills', () => {
     ]
     const state = buildState({
       skills,
-      selectedSource: repositoryId('vercel-labs/skills'),
+      selectedSources: [repositoryId('vercel-labs/skills')],
     })
     const result = selectFilteredSkills(state as never)
     expect(result.map((s) => s.name)).toEqual(['a', 'b'])
@@ -637,7 +638,7 @@ describe('selectFilteredSkills', () => {
     ]
     const state = buildState({
       skills,
-      selectedSource: repositoryId('vercel-labs/skills'),
+      selectedSources: [repositoryId('vercel-labs/skills')],
       searchQuery: 'alpha',
       searchScope: 'name',
     })
@@ -657,7 +658,7 @@ describe('selectFilteredSkills', () => {
     const state = buildState({
       skills,
       selectedAgentId: 'cursor',
-      selectedSource: repositoryId('vercel-labs/skills'),
+      selectedSources: [repositoryId('vercel-labs/skills')],
     })
     const result = selectFilteredSkills(state as never)
     expect(result.map((s) => s.name)).toEqual(['a'])
@@ -717,7 +718,7 @@ describe('selectFilteredSkills', () => {
     ]
     const state = buildState({
       skills,
-      selectedSource: repositoryId('vercel-labs/skills'),
+      selectedSources: [repositoryId('vercel-labs/skills')],
       searchQuery: 'vercel',
       searchScope: 'repo',
     })
@@ -736,7 +737,7 @@ describe('selectFilteredSkills', () => {
     ]
     const state = buildState({
       skills,
-      selectedSource: repositoryId('vercel-labs/skills'),
+      selectedSources: [repositoryId('vercel-labs/skills')],
       searchQuery: 'figma',
       searchScope: 'repo',
     })
@@ -755,7 +756,7 @@ describe('selectFilteredSkills', () => {
     const state = buildState({
       skills,
       selectedAgentId: 'cursor',
-      selectedSource: repositoryId('pbakaus/impeccable'),
+      selectedSources: [repositoryId('pbakaus/impeccable')],
       searchQuery: 'nothing matches',
       searchScope: 'repo',
     })
@@ -961,5 +962,185 @@ describe('selectSelectedSkillNamesSet', () => {
     const result1 = selectSelectedSkillNamesSet(state as never)
     const result2 = selectSelectedSkillNamesSet(state as never)
     expect(result1).toBe(result2)
+  })
+})
+
+describe('selectSourceFilterViewModel', () => {
+  it('shows the "All repos" trigger and a generic aria-label when nothing is ticked', () => {
+    // Arrange — one repo skill in the cursor view, but no include filter yet
+    const skills = [makeSkill('a', 'cursor', false, 'vercel-labs/skills')]
+    const state = buildState({
+      skills,
+      selectedAgentId: 'cursor',
+      selectedSources: [],
+    })
+
+    // Act
+    const viewModel = selectSourceFilterViewModel(state as never)
+
+    // Assert — empty-state defaults; the lone facet repo renders unchecked
+    expect(viewModel.triggerLabel).toBe('All repos')
+    expect(viewModel.triggerAriaLabel).toBe('Filter by source repository')
+    expect(viewModel.validRepoIds).toEqual([])
+    expect(viewModel.localHiddenCount).toBe(0)
+    expect(viewModel.dropdownRows).toEqual([
+      { source: repositoryId('vercel-labs/skills'), count: 1, checked: false },
+    ])
+  })
+
+  it('names the single ticked repo in the trigger, aria-label, and checkbox tick', () => {
+    // Arrange — two skills from one repo, that repo ticked
+    const skills = [
+      makeSkill('a', 'cursor', false, 'vercel-labs/skills'),
+      makeSkill('b', 'cursor', false, 'vercel-labs/skills'),
+    ]
+    const state = buildState({
+      skills,
+      selectedAgentId: 'cursor',
+      selectedSources: [repositoryId('vercel-labs/skills')],
+    })
+
+    // Act
+    const viewModel = selectSourceFilterViewModel(state as never)
+
+    // Assert — single-repo phrasing; row is checked and validRepoIds holds it
+    expect(viewModel.triggerLabel).toBe('vercel-labs/skills')
+    expect(viewModel.triggerAriaLabel).toBe(
+      'Filtering by source repository vercel-labs/skills',
+    )
+    expect(viewModel.validRepoIds).toEqual([repositoryId('vercel-labs/skills')])
+    expect(viewModel.dropdownRows).toEqual([
+      { source: repositoryId('vercel-labs/skills'), count: 2, checked: true },
+    ])
+  })
+
+  it('collapses the trigger to "N repos" and spells out the aria-label for multiple ticks', () => {
+    // Arrange — one skill per repo, both repos ticked
+    const skills = [
+      makeSkill('a', 'cursor', false, 'vercel-labs/skills'),
+      makeSkill('b', 'cursor', false, 'pbakaus/impeccable'),
+    ]
+    const state = buildState({
+      skills,
+      selectedAgentId: 'cursor',
+      selectedSources: [
+        repositoryId('vercel-labs/skills'),
+        repositoryId('pbakaus/impeccable'),
+      ],
+    })
+
+    // Act
+    const viewModel = selectSourceFilterViewModel(state as never)
+
+    // Assert — compact count label; aria spells each repo in selection order
+    expect(viewModel.triggerLabel).toBe('2 repos')
+    expect(viewModel.triggerAriaLabel).toBe(
+      'Filtering by 2 source repositories: vercel-labs/skills, pbakaus/impeccable',
+    )
+    // Every facet repo is ticked → "Select all" is pointless
+    expect(viewModel.isSelectAllDisabled).toBe(true)
+  })
+
+  it('keeps a ticked repo with zero remaining rows in the dropdown but out of validRepoIds', () => {
+    // A repo the user ticked that no longer backs any visible facet row (here a
+    // not-yet-pruned stale id) must still render — checked — so the user can
+    // untick it; but it must be excluded from the bulk-confirm scope snapshot.
+    // Arrange
+    const skills = [makeSkill('a', 'cursor', false, 'vercel-labs/skills')]
+    const state = buildState({
+      skills,
+      selectedAgentId: 'cursor',
+      selectedSources: [
+        repositoryId('vercel-labs/skills'),
+        repositoryId('stale/removed-repo'),
+      ],
+    })
+
+    // Act
+    const viewModel = selectSourceFilterViewModel(state as never)
+
+    // Assert — stale repo sorts first (alpha), count 0, still checked…
+    expect(viewModel.dropdownRows).toEqual([
+      { source: repositoryId('stale/removed-repo'), count: 0, checked: true },
+      { source: repositoryId('vercel-labs/skills'), count: 1, checked: true },
+    ])
+    // …but only the facet-backed repo survives into the actionable scope
+    expect(viewModel.validRepoIds).toEqual([repositoryId('vercel-labs/skills')])
+  })
+
+  it('counts source-less local skills suppressed by an active repo filter', () => {
+    // Arrange — cursor view: one repo skill plus two source-less local skills,
+    // repo filter active
+    const skills = [
+      makeSkill('linked', 'cursor', false, 'vercel-labs/skills'),
+      makeSkill('local-one', 'cursor', true),
+      makeSkill('local-two', 'cursor', true),
+    ]
+    const state = buildState({
+      skills,
+      selectedAgentId: 'cursor',
+      selectedSources: [repositoryId('vercel-labs/skills')],
+    })
+
+    // Act
+    const viewModel = selectSourceFilterViewModel(state as never)
+
+    // Assert — both locals are hidden by the include filter
+    expect(viewModel.localHiddenCount).toBe(2)
+  })
+
+  it('reports zero hidden locals when no repo filter is active', () => {
+    // Arrange — same source-less locals, but the include filter is empty
+    const skills = [
+      makeSkill('linked', 'cursor', false, 'vercel-labs/skills'),
+      makeSkill('local-one', 'cursor', true),
+    ]
+    const state = buildState({
+      skills,
+      selectedAgentId: 'cursor',
+      selectedSources: [],
+    })
+
+    // Act
+    const viewModel = selectSourceFilterViewModel(state as never)
+
+    // Assert — nothing is "hidden" because the filter is showing everything
+    expect(viewModel.localHiddenCount).toBe(0)
+  })
+
+  it('flags hasNoRepositories and an empty dropdown when no skill carries a source', () => {
+    // Arrange — only an agent-local skill exists, so the facet is empty
+    const skills = [makeSkill('local-only', 'cursor', true)]
+    const state = buildState({
+      skills,
+      selectedAgentId: 'cursor',
+      selectedSources: [],
+    })
+
+    // Act
+    const viewModel = selectSourceFilterViewModel(state as never)
+
+    // Assert — the component shows its "no repositories" empty state
+    expect(viewModel.hasNoRepositories).toBe(true)
+    expect(viewModel.dropdownRows).toEqual([])
+  })
+
+  it('leaves "Select all" enabled while at least one facet repo is unticked', () => {
+    // Arrange — two facet repos, only one ticked
+    const skills = [
+      makeSkill('a', 'cursor', false, 'vercel-labs/skills'),
+      makeSkill('b', 'cursor', false, 'pbakaus/impeccable'),
+    ]
+    const state = buildState({
+      skills,
+      selectedAgentId: 'cursor',
+      selectedSources: [repositoryId('vercel-labs/skills')],
+    })
+
+    // Act
+    const viewModel = selectSourceFilterViewModel(state as never)
+
+    // Assert — there is still a repo left to add, so the action stays live
+    expect(viewModel.isSelectAllDisabled).toBe(false)
   })
 })

--- a/src/renderer/src/redux/selectors.ts
+++ b/src/renderer/src/redux/selectors.ts
@@ -1,7 +1,9 @@
 import { createSelector } from '@reduxjs/toolkit'
 import { match } from 'ts-pattern'
 
+import { formatRepositoryFacetLabel } from '@/renderer/src/utils/formatRepositoryFacetLabel'
 import { isGStackManagedForAgent } from '@/renderer/src/utils/gstackSkill'
+import { SOURCE_FILTER_MAX_VISIBLE_REPOS } from '@/shared/constants'
 import type {
   AgentId,
   RepositoryId,
@@ -21,7 +23,7 @@ import {
   selectSearchQuery,
   selectSearchScope,
   selectSelectedAgentId,
-  selectSelectedSource,
+  selectSelectedSources,
   selectSkillTypeFilter,
   selectSortOrder,
 } from './slices/uiSlice'
@@ -138,8 +140,8 @@ function applyAgentAndTypeFilters(
 
 /**
  * Memoized selector for filtered and sorted skills list.
- * Applies (in order): agent/type include, type excludes, source-repo pill,
- * scope-aware search query, and name sort.
+ * Applies (in order): agent/type include, type excludes, source-repo include
+ * filter, scope-aware search query, and name sort.
  *
  * Search scope rules:
  * - `'name'` — case-insensitive substring match against `skill.name` (the
@@ -148,9 +150,11 @@ function applyAgentAndTypeFilters(
  *   with no `source` (Local-only skills) are excluded in this mode because
  *   they have no repo string to match.
  *
- * The source pill (`selectedSource`) is an exact-match filter applied
- * independently of the scope so users can stack "in repo X" with "name
- * containing Y".
+ * The source-repo include filter (`selectedSources`) keeps only skills whose
+ * `source` is in the ticked set; an empty set is a no-op (all repos shown).
+ * Source-less Local skills drop out whenever the set is non-empty. Applied
+ * independently of the search scope so users can stack "in repos X/Y" with
+ * "name containing Z".
  *
  * @returns Filtered + sorted skills array
  * @example
@@ -162,7 +166,7 @@ export const selectFilteredSkills = createSelector(
     selectSearchQuery,
     selectSearchScope,
     selectSelectedAgentId,
-    selectSelectedSource,
+    selectSelectedSources,
     selectSortOrder,
     selectSkillTypeFilter,
     selectExcludedSkillTypeFilters,
@@ -172,7 +176,7 @@ export const selectFilteredSkills = createSelector(
     searchQuery,
     searchScope,
     selectedAgentId,
-    selectedSource,
+    selectedSources,
     sortOrder,
     skillTypeFilter,
     excludedSkillTypeFilters,
@@ -184,10 +188,15 @@ export const selectFilteredSkills = createSelector(
       excludedSkillTypeFilters,
     )
 
-    // Source-repo filter pill — exact match. Local skills (source undefined)
-    // can never match a non-null pill value, so they drop out implicitly.
-    if (selectedSource) {
-      result = result.filter((skill) => skill.source === selectedSource)
+    // Source-repo include filter — keep only ticked repos. An empty set is a
+    // no-op. Local skills (source undefined) can never be in the set, so they
+    // drop out implicitly whenever the filter is active.
+    if (selectedSources.length > 0) {
+      const includedSources = new Set(selectedSources)
+      result = result.filter(
+        (skill) =>
+          skill.source !== undefined && includedSources.has(skill.source),
+      )
     }
 
     // Scope-aware search. ts-pattern + .exhaustive() makes adding a new
@@ -220,8 +229,9 @@ export const selectFilteredSkills = createSelector(
 
 /**
  * Exact repo choices for the Installed toolbar. It shares the agent/type gates
- * with `selectFilteredSkills`, but intentionally ignores the active source pill
- * and text query so users can recover from an over-narrowed filter.
+ * with `selectFilteredSkills`, but intentionally ignores the active source
+ * include filter and text query so users can recover from an over-narrowed
+ * filter.
  * @returns Sorted source options with matching row counts.
  * @example
  * const repoOptions = useAppSelector(selectRepoFacetOptions)
@@ -253,6 +263,169 @@ export const selectRepoFacetOptions = createSelector(
     return [...sourceCounts.entries()]
       .sort(([sourceA], [sourceB]) => sourceA.localeCompare(sourceB))
       .map(([source, count]) => ({ source, count }))
+  },
+)
+
+export interface SourceFilterRow {
+  source: RepositoryId
+  count: number
+  /** True when this repo is in `selectedSources` (drives the checkbox tick). */
+  checked: boolean
+}
+
+/**
+ * Everything the toolbar's source-repo filter UI needs, derived once so the
+ * trigger, dropdown, pills, hint, and bulk-confirm snapshot read from one
+ * consistent shape (no per-component recomputation or drift).
+ * - `selectedSources`: active include set (already pruned of dead ids at fetch
+ *   time); drives pills, the trigger count, and checkbox ticks.
+ * - `validRepoIds`: ticked ids that still back ≥1 visible row — snapshotted
+ *   into the bulk-confirm dialog so it states only scope the user can see.
+ * - `dropdownRows`: facet repos ∪ ticked repos, alpha-sorted; a ticked repo
+ *   narrowed to 0 rows by the type filter still renders (count 0, checked) so
+ *   the user can untick it.
+ * - `triggerLabel` / `triggerAriaLabel`: compact button text vs spelled SR copy.
+ * - `isSelectAllDisabled`: every facet repo already ticked (nothing to add).
+ * - `hasNoRepositories`: facet is empty → dropdown shows an empty state.
+ * - `localHiddenCount`: source-less Local skills suppressed by an active
+ *   include filter (drives the "N local skills hidden" hint); 0 when inactive.
+ *   Ignores the search query.
+ */
+interface SourceFilterViewModel {
+  selectedSources: RepositoryId[]
+  validRepoIds: RepositoryId[]
+  dropdownRows: SourceFilterRow[]
+  triggerLabel: string
+  triggerAriaLabel: string
+  isSelectAllDisabled: boolean
+  hasNoRepositories: boolean
+  localHiddenCount: number
+}
+
+/**
+ * Build the spelled aria-label for the source-repo filter trigger, naming up
+ * to `SOURCE_FILTER_MAX_VISIBLE_REPOS` repos then summarizing the remainder so
+ * screen-reader users hear the active scope without an unbounded list.
+ * @param selectedSources - The active repository include-filter.
+ * @returns
+ * - `[]` → "Filter by source repository"
+ * - 1 → "Filtering by source repository owner/repo"
+ * - ≤cap → "Filtering by N source repositories: a, b, c"
+ * - >cap → "Filtering by N source repositories: a, b, c, and M more"
+ * @example
+ * formatSourceFilterAriaLabel([]) // => "Filter by source repository"
+ */
+function formatSourceFilterAriaLabel(selectedSources: RepositoryId[]): string {
+  if (selectedSources.length === 0) return 'Filter by source repository'
+  if (selectedSources.length === 1) {
+    return `Filtering by source repository ${selectedSources[0]}`
+  }
+  const spelled = selectedSources
+    .slice(0, SOURCE_FILTER_MAX_VISIBLE_REPOS)
+    .join(', ')
+  const remainder = selectedSources.length - SOURCE_FILTER_MAX_VISIBLE_REPOS
+  const suffix = remainder > 0 ? `, and ${remainder} more` : ''
+  return `Filtering by ${selectedSources.length} source repositories: ${spelled}${suffix}`
+}
+
+/**
+ * Consolidated view-model for the Installed toolbar's source-repo include
+ * filter. Folds the active selection, the (agent/type-gated) facet options,
+ * and the hidden-local count into one memoized shape — see
+ * `SourceFilterViewModel` for field semantics. Recomputes the agent/type
+ * population internally for `localHiddenCount` rather than coupling
+ * `selectRepoFacetOptions` to that concern.
+ * @returns SourceFilterViewModel
+ * @example
+ * const sourceFilter = useAppSelector(selectSourceFilterViewModel)
+ * // sourceFilter.triggerLabel === '2 repos'
+ */
+export const selectSourceFilterViewModel = createSelector(
+  [
+    selectSkillsItems,
+    selectSelectedAgentId,
+    selectSkillTypeFilter,
+    selectExcludedSkillTypeFilters,
+    selectSelectedSources,
+    selectRepoFacetOptions,
+  ],
+  (
+    skills,
+    selectedAgentId,
+    skillTypeFilter,
+    excludedSkillTypeFilters,
+    selectedSources,
+    facetOptions,
+  ): SourceFilterViewModel => {
+    const facetSourceSet = new Set(facetOptions.map((option) => option.source))
+    const countBySource = new Map<RepositoryId, number>(
+      facetOptions.map((option): [RepositoryId, number] => [
+        option.source,
+        option.count,
+      ]),
+    )
+    const selectedSet = new Set(selectedSources)
+
+    // Dropdown render set = facet repos ∪ ticked repos. A repo the user ticked
+    // then narrowed to 0 rows via the type filter must still render (checked)
+    // so they can untick it — otherwise the include filter is stuck on.
+    const dropdownSourceSet = new Set<RepositoryId>([
+      ...facetSourceSet,
+      ...selectedSources,
+    ])
+    const dropdownRows: SourceFilterRow[] = [...dropdownSourceSet]
+      .sort((a, b) => a.localeCompare(b))
+      .map((source) => ({
+        source,
+        count: countBySource.get(source) ?? 0,
+        checked: selectedSet.has(source),
+      }))
+
+    // Ticked ids that still back ≥1 facet row. Snapshotted into the
+    // bulk-confirm dialog so it reflects only the scope the user can see.
+    const validRepoIds = selectedSources.filter((id) => facetSourceSet.has(id))
+
+    // Count source-less Local skills suppressed by an active include filter.
+    // Uses the SAME agent/type gate as the facet (ignores the search query) so
+    // it answers "how many local skills did the repo filter hide?".
+    let localHiddenCount = 0
+    if (selectedSources.length > 0) {
+      const population = applyAgentAndTypeFilters(
+        skills,
+        selectedAgentId,
+        skillTypeFilter,
+        excludedSkillTypeFilters,
+      )
+      for (const skill of population) {
+        if (!skill.source) localHiddenCount += 1
+      }
+    }
+
+    // Trigger text: compact for the button (CSS truncates further). 2-3 cases
+    // → plain branches per the ts-pattern threshold.
+    let triggerLabel: string
+    if (selectedSources.length === 0) {
+      triggerLabel = 'All repos'
+    } else if (selectedSources.length === 1) {
+      triggerLabel = formatRepositoryFacetLabel(selectedSources[0])
+    } else {
+      triggerLabel = `${selectedSources.length} repos`
+    }
+
+    return {
+      selectedSources,
+      validRepoIds,
+      dropdownRows,
+      triggerLabel,
+      triggerAriaLabel: formatSourceFilterAriaLabel(selectedSources),
+      // "Select all" is pointless once every facet repo is ticked; the empty
+      // facet case is handled by `hasNoRepositories` in the component.
+      isSelectAllDisabled:
+        facetOptions.length > 0 &&
+        facetOptions.every((option) => selectedSet.has(option.source)),
+      hasNoRepositories: facetOptions.length === 0,
+      localHiddenCount,
+    }
   },
 )
 

--- a/src/renderer/src/redux/slices/uiSlice.test.ts
+++ b/src/renderer/src/redux/slices/uiSlice.test.ts
@@ -6,6 +6,7 @@ import type {
   AgentId,
   BulkDeleteResult,
   BulkUnlinkResult,
+  Skill,
   SyncExecuteResult,
   SyncPreviewResult,
   TombstoneId,
@@ -690,6 +691,7 @@ describe('uiSlice atomic-clear contract on context switch', () => {
         skillNames: ['a'],
         agentId: null,
         agentName: null,
+        sourceSummary: null,
       }),
     )
   }
@@ -850,5 +852,142 @@ describe('uiSlice bulkSelectMode on rejection', () => {
     )
 
     expect(store.getState().ui.bulkSelectMode).toBe(false)
+  })
+})
+
+describe('uiSlice source filter (selectedSources)', () => {
+  /**
+   * Minimal source-bearing skill for the refetch-prune test. The prune reducer
+   * reads only `skill.source`; the remaining fields satisfy the `Skill` shape.
+   * @param name - Skill directory name.
+   * @param source - Repo slug; omit to model a source-less local skill.
+   * @returns A `Skill` carrying `source`/`sourceUrl` when a slug is provided.
+   */
+  function skillWithSource(name: string, source?: string): Skill {
+    return {
+      name,
+      description: `${name} skill`,
+      path: `/home/user/.agents/skills/${name}`,
+      symlinkCount: 0,
+      symlinks: [],
+      isSource: true,
+      isOrphan: false,
+      ...(source
+        ? {
+            source: repositoryId(source),
+            sourceUrl: `https://github.com/${source}.git`,
+          }
+        : {}),
+    }
+  }
+
+  it('starts with an empty source include-filter', async () => {
+    const store = await createTestStore()
+    expect(store.getState().ui.selectedSources).toEqual([])
+  })
+
+  it('toggleSource adds a repo to the empty include-filter', async () => {
+    // Arrange
+    const store = await createTestStore()
+    const { toggleSource } = await import('./uiSlice')
+
+    // Act
+    store.dispatch(toggleSource(repositoryId('vercel-labs/skills')))
+
+    // Assert
+    expect(store.getState().ui.selectedSources).toEqual([
+      repositoryId('vercel-labs/skills'),
+    ])
+  })
+
+  it('toggleSource is additive — a second repo joins rather than replacing the first', async () => {
+    // Arrange
+    const store = await createTestStore()
+    const { toggleSource } = await import('./uiSlice')
+
+    // Act
+    store.dispatch(toggleSource(repositoryId('vercel-labs/skills')))
+    store.dispatch(toggleSource(repositoryId('pbakaus/impeccable')))
+
+    // Assert — both repos coexist in selection order
+    expect(store.getState().ui.selectedSources).toEqual([
+      repositoryId('vercel-labs/skills'),
+      repositoryId('pbakaus/impeccable'),
+    ])
+  })
+
+  it('toggleSource removes a repo that is already ticked', async () => {
+    // Arrange
+    const store = await createTestStore()
+    const { toggleSource } = await import('./uiSlice')
+
+    // Act — tick then untick the same repo
+    store.dispatch(toggleSource(repositoryId('vercel-labs/skills')))
+    store.dispatch(toggleSource(repositoryId('vercel-labs/skills')))
+
+    // Assert
+    expect(store.getState().ui.selectedSources).toEqual([])
+  })
+
+  it('setSelectedSources replaces the whole include-filter in one shot', async () => {
+    // Arrange — start with an unrelated repo ticked
+    const store = await createTestStore()
+    const { toggleSource, setSelectedSources } = await import('./uiSlice')
+    store.dispatch(toggleSource(repositoryId('old/repo')))
+
+    // Act — bulk overwrite
+    store.dispatch(
+      setSelectedSources([
+        repositoryId('vercel-labs/skills'),
+        repositoryId('pbakaus/impeccable'),
+      ]),
+    )
+
+    // Assert — previous selection is gone, replaced wholesale
+    expect(store.getState().ui.selectedSources).toEqual([
+      repositoryId('vercel-labs/skills'),
+      repositoryId('pbakaus/impeccable'),
+    ])
+  })
+
+  it('clearSelectedSources empties the include-filter back to show-all', async () => {
+    // Arrange
+    const store = await createTestStore()
+    const { setSelectedSources, clearSelectedSources } =
+      await import('./uiSlice')
+    store.dispatch(setSelectedSources([repositoryId('vercel-labs/skills')]))
+
+    // Act
+    store.dispatch(clearSelectedSources())
+
+    // Assert
+    expect(store.getState().ui.selectedSources).toEqual([])
+  })
+
+  it('drops a ticked repo that no longer backs any skill after a refetch', async () => {
+    // The prune guards against a refetch (delete/sync/refresh) leaving a ticked
+    // repo that the new inventory no longer contains. Arrange — two ticked.
+    const store = await createTestStore()
+    const { setSelectedSources } = await import('./uiSlice')
+    const { fetchSkills } = await import('./skillsSlice')
+    store.dispatch(
+      setSelectedSources([
+        repositoryId('vercel-labs/skills'),
+        repositoryId('stale/removed-repo'),
+      ]),
+    )
+
+    // Act — the reload only carries vercel-labs/skills
+    store.dispatch(
+      fetchSkills.fulfilled(
+        [skillWithSource('task', 'vercel-labs/skills')],
+        'req-prune',
+      ),
+    )
+
+    // Assert — the orphaned id is pruned, the still-backed id survives
+    expect(store.getState().ui.selectedSources).toEqual([
+      repositoryId('vercel-labs/skills'),
+    ])
   })
 })

--- a/src/renderer/src/redux/slices/uiSlice.ts
+++ b/src/renderer/src/redux/slices/uiSlice.ts
@@ -19,7 +19,11 @@ import type {
   TombstoneId,
 } from '@/shared/types'
 
-import { deleteSelectedSkills, unlinkSelectedFromAgent } from './skillsSlice'
+import {
+  deleteSelectedSkills,
+  fetchSkills,
+  unlinkSelectedFromAgent,
+} from './skillsSlice'
 
 /** Bookmark with install status, used for the detail modal */
 export type BookmarkForDetail = BookmarkedSkill & { isInstalled: boolean }
@@ -62,6 +66,21 @@ interface UndoToastState {
 }
 
 /**
+ * Snapshot of the active repository include-filter, captured the instant a
+ * bulk delete/unlink is confirmed. Carried inside `BulkConfirmState` so the
+ * dialog copy can state the scope the user is acting within even if the live
+ * `ui` filter changes before they click confirm.
+ * - `repositoryIds`: the *visible* included repos (selectedSources ∩ facet
+ *   options) — stale ids that no longer match any skill are excluded.
+ * - `localHiddenCount`: source-less local skills suppressed by the active
+ *   include filter, surfaced as the "N local skills hidden" caveat.
+ */
+export interface SourceFilterSummary {
+  repositoryIds: RepositoryId[]
+  localHiddenCount: number
+}
+
+/**
  * Pending bulk confirmation payload. Populated by the SelectionToolbar's
  * primary-action handler when the user clicks Delete/Unlink; the
  * `BulkConfirmDialog` in MainContent reads this to render the Radix
@@ -71,12 +90,15 @@ interface UndoToastState {
  * - `skillNames`: the exact argument to pass to the thunk on confirm.
  * - `agentId` / `agentName`: carried through so the unlink thunk knows which
  *   agent to target, and the dialog copy can mention the agent by name.
+ * - `sourceSummary`: repository-filter scope snapshot, or null when no repo
+ *   filter is active and no local skills are hidden.
  */
 export interface BulkConfirmState {
   kind: 'delete' | 'unlink'
   skillNames: SkillName[]
   agentId: AgentId | null
   agentName: AgentName | null
+  sourceSummary: SourceFilterSummary | null
 }
 
 interface UiState {
@@ -89,11 +111,13 @@ interface UiState {
    */
   searchScope: SearchScope
   /**
-   * Repository filter pill. Set when the user clicks a SourceLink text;
-   * cleared from the FilterPill's "Clear" button. Orthogonal to the agent
-   * filter — both can be active simultaneously (skills in agent X from repo Y).
+   * Repository include-filter. Empty = show all repos (and local skills).
+   * Non-empty = show only skills whose `source` is in this set, hiding
+   * source-less local skills (surfaced via the "N local skills hidden" hint).
+   * Built up by ticking repos in the toolbar dropdown or clicking a SourceLink.
+   * Orthogonal to the agent filter — both can be active simultaneously.
    */
-  selectedSource: RepositoryId | null
+  selectedSources: RepositoryId[]
   sourceStats: SourceStats | null
   isRefreshing: boolean
   /** Currently selected agent filter (null = global/all-agents view). */
@@ -152,7 +176,7 @@ const initialState: UiState = {
   activeTab: 'installed',
   searchQuery: '',
   searchScope: 'name',
-  selectedSource: null,
+  selectedSources: [],
   sourceStats: null,
   isRefreshing: false,
   selectedAgentId: null,
@@ -258,27 +282,45 @@ const uiSlice = createSlice({
     },
     /**
      * Toggle which Skill field the search query matches.
-     * Does not clear `searchQuery` or `selectedSource` — the user is
+     * Does not clear `searchQuery` or `selectedSources` — the user is
      * narrowing intent, not abandoning the in-progress search.
      */
     setSearchScope: (state, action: PayloadAction<SearchScope>) => {
       state.searchScope = action.payload
     },
     /**
-     * Activate the repository filter pill. Dispatched when the user clicks
-     * a SourceLink's repo text on a skill row. Independent of the agent
-     * pill — both can render simultaneously.
+     * Toggle one repository in the include-filter (single-id additive writer).
+     * Dispatched per-checkbox in the toolbar dropdown and when the user clicks
+     * a SourceLink's repo text. Adds the id if absent, removes it if already
+     * ticked — mirrors `toggleExcludedSkillTypeFilter`, minus the availability
+     * guard since repo ids are free-form (not a fixed enum).
      */
-    setSelectedSource: (state, action: PayloadAction<RepositoryId>) => {
-      state.selectedSource = action.payload
+    toggleSource: (state, action: PayloadAction<RepositoryId>) => {
+      const currentIndex = state.selectedSources.indexOf(action.payload)
+      // Already ticked → untick (drop from the include set).
+      if (currentIndex >= 0) {
+        state.selectedSources.splice(currentIndex, 1)
+        return
+      }
+      // Not yet present → add to the include set.
+      state.selectedSources.push(action.payload)
     },
     /**
-     * Dismiss the repository filter pill. Wired to the FilterPill's "Clear"
-     * button. Does not touch `searchScope` or `searchQuery` — those remain
-     * as the user left them.
+     * Replace the entire include-filter in one shot (bulk writer). Wired to the
+     * dropdown's "Select all repos" action, which passes every facet repo id.
+     * Distinct from `toggleSource`: that mutates a single id additively, this
+     * overwrites the whole set.
      */
-    clearSelectedSource: (state) => {
-      state.selectedSource = null
+    setSelectedSources: (state, action: PayloadAction<RepositoryId[]>) => {
+      state.selectedSources = action.payload
+    },
+    /**
+     * Clear the include-filter back to "show all repos". Wired to the
+     * dropdown's "Show all repos" action and each FilterPill's "Clear" button.
+     * Does not touch `searchScope` or `searchQuery`.
+     */
+    clearSelectedSources: (state) => {
+      state.selectedSources = []
     },
     selectAgent: (state, action: PayloadAction<AgentId | null>) => {
       state.selectedAgentId = action.payload
@@ -475,6 +517,23 @@ const uiSlice = createSlice({
         state.bulkConfirm = null
         state.bulkSelectMode = false
       })
+      // ── Prune stale repo filter ids when the skill inventory reloads ─────
+      // After a refetch (delete, sync, manual refresh) a previously-ticked repo
+      // may no longer back any skill. Drop those ids from `selectedSources` so
+      // trigger counts, pills, and the bulk-confirm snapshot never reference a
+      // repo the user can no longer see. Prune against the RAW payload sources
+      // (the full inventory across all agents), not the agent/type-gated facet
+      // — an id valid under a different agent must survive an agent switch.
+      .addCase(fetchSkills.fulfilled, (state, action) => {
+        const survivingSources = new Set(
+          action.payload
+            .map((skill) => skill.source)
+            .filter((source): source is RepositoryId => Boolean(source)),
+        )
+        state.selectedSources = state.selectedSources.filter((id) =>
+          survivingSources.has(id),
+        )
+      })
   },
 })
 
@@ -482,8 +541,9 @@ export const {
   setActiveTab,
   setSearchQuery,
   setSearchScope,
-  setSelectedSource,
-  clearSelectedSource,
+  toggleSource,
+  setSelectedSources,
+  clearSelectedSources,
   selectAgent,
   toggleSortOrder,
   setSkillTypeFilter,
@@ -509,8 +569,8 @@ export const selectSearchQuery = (state: RootState): SearchQuery =>
   state.ui.searchQuery
 export const selectSearchScope = (state: RootState): SearchScope =>
   state.ui.searchScope
-export const selectSelectedSource = (state: RootState): RepositoryId | null =>
-  state.ui.selectedSource
+export const selectSelectedSources = (state: RootState): RepositoryId[] =>
+  state.ui.selectedSources
 export const selectSelectedAgentId = (state: RootState): AgentId | null =>
   state.ui.selectedAgentId
 export const selectIsRefreshing = (state: RootState): boolean =>

--- a/src/renderer/src/utils/formatRepositoryFacetLabel.test.ts
+++ b/src/renderer/src/utils/formatRepositoryFacetLabel.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import { repositoryId } from '@/shared/types'
+
+import { formatRepositoryFacetLabel } from './formatRepositoryFacetLabel'
+
+describe('formatRepositoryFacetLabel', () => {
+  it('returns the slug unchanged when it fits the compact trigger width', () => {
+    // Arrange — a typical owner/repo well under the 28-char threshold (18 chars)
+    const source = repositoryId('vercel-labs/skills')
+
+    // Act
+    const label = formatRepositoryFacetLabel(source)
+
+    // Assert — short slugs are shown verbatim
+    expect(label).toBe('vercel-labs/skills')
+  })
+
+  it('returns the slug unchanged at exactly the 28-char threshold', () => {
+    // Arrange — a slug whose length is exactly REPOSITORY_FACET_LABEL_MAX_CHARS
+    const source = repositoryId('owner-of-repos/the-repo-name')
+
+    // Act
+    const label = formatRepositoryFacetLabel(source)
+
+    // Assert — the boundary is inclusive, so no ellipsis at exactly 28
+    expect(label).toBe('owner-of-repos/the-repo-name')
+  })
+
+  it('middle-ellipsises an over-long slug, keeping owner head and repo tail', () => {
+    // Arrange — a 46-char slug past the threshold
+    const source = repositoryId(
+      'very-long-owner-name/extremely-long-repository',
+    )
+
+    // Act
+    const label = formatRepositoryFacetLabel(source)
+
+    // Assert — 12-char head + "..." + 13-char tail = 28 chars total
+    expect(label).toBe('very-long-ow...ng-repository')
+  })
+})

--- a/src/renderer/src/utils/formatRepositoryFacetLabel.ts
+++ b/src/renderer/src/utils/formatRepositoryFacetLabel.ts
@@ -11,8 +11,9 @@ import type { RepositoryId } from '@/shared/types'
  * @param source - Repository slug, usually `owner/repo`.
  * @returns
  * - `source` unchanged when ≤ `REPOSITORY_FACET_LABEL_MAX_CHARS` (28) chars.
- * - Otherwise a middle-ellipsis form `<12-char head>...<13-char tail>` whose
- *   total length is exactly 28.
+ * - Otherwise a middle-ellipsis form `<head>...<tail>` whose total length is
+ *   exactly `REPOSITORY_FACET_LABEL_MAX_CHARS`; head and tail are derived from
+ *   that constant (currently a 12-char head + "..." + 13-char tail = 28).
  * @example
  * formatRepositoryFacetLabel(repositoryId('vercel-labs/skills'))
  * // => "vercel-labs/skills"
@@ -21,6 +22,14 @@ import type { RepositoryId } from '@/shared/types'
  */
 export function formatRepositoryFacetLabel(source: RepositoryId): string {
   if (source.length <= REPOSITORY_FACET_LABEL_MAX_CHARS) return source
-  // 12-char head + "..." + 13-char tail = 28-char REPOSITORY_FACET_LABEL_MAX_CHARS.
-  return `${source.slice(0, 12)}...${source.slice(-13)}`
+  // Derive the head/tail split from the budget so the truncated label is always
+  // exactly REPOSITORY_FACET_LABEL_MAX_CHARS: changing the constant re-balances
+  // both halves instead of silently breaking the head + "..." + tail = MAX
+  // invariant. The head takes the floor so the tail keeps the odd remainder
+  // (12 + 3 + 13 = 28 today), matching the documented example.
+  const ellipsis = '...'
+  const visibleCharBudget = REPOSITORY_FACET_LABEL_MAX_CHARS - ellipsis.length
+  const headChars = Math.floor(visibleCharBudget / 2)
+  const tailChars = visibleCharBudget - headChars
+  return `${source.slice(0, headChars)}${ellipsis}${source.slice(-tailChars)}`
 }

--- a/src/renderer/src/utils/formatRepositoryFacetLabel.ts
+++ b/src/renderer/src/utils/formatRepositoryFacetLabel.ts
@@ -1,0 +1,26 @@
+import { REPOSITORY_FACET_LABEL_MAX_CHARS } from '@/shared/constants'
+import type { RepositoryId } from '@/shared/types'
+
+/**
+ * Compress a long repository slug for the COMPACT source-repo filter trigger
+ * label, preserving both owner and repo clues via a middle ellipsis. Used only
+ * by the trigger label (built in `selectSourceFilterViewModel`) — every
+ * precision-first surface (dropdown rows, filter pills, aria-labels, and the
+ * bulk-delete confirm dialog) shows the full untruncated value, because there
+ * width is not constrained and knowing the exact repo matters more.
+ * @param source - Repository slug, usually `owner/repo`.
+ * @returns
+ * - `source` unchanged when ≤ `REPOSITORY_FACET_LABEL_MAX_CHARS` (28) chars.
+ * - Otherwise a middle-ellipsis form `<12-char head>...<13-char tail>` whose
+ *   total length is exactly 28.
+ * @example
+ * formatRepositoryFacetLabel(repositoryId('vercel-labs/skills'))
+ * // => "vercel-labs/skills"
+ * formatRepositoryFacetLabel(repositoryId('very-long-owner-name/extremely-long-repository'))
+ * // => "very-long-ow...ng-repository"
+ */
+export function formatRepositoryFacetLabel(source: RepositoryId): string {
+  if (source.length <= REPOSITORY_FACET_LABEL_MAX_CHARS) return source
+  // 12-char head + "..." + 13-char tail = 28-char REPOSITORY_FACET_LABEL_MAX_CHARS.
+  return `${source.slice(0, 12)}...${source.slice(-13)}`
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -817,6 +817,30 @@ export const UNDO_WINDOW_MS = 15_000
 export const BULK_PROGRESS_THRESHOLD = 10
 
 /**
+ * Max number of source repositories enumerated individually before the
+ * source-repo filter collapses to a count summary. Drives BOTH the toolbar
+ * pills (≤ cap → one chip per repo; > cap → a single "from N repos" chip) and
+ * the trigger's spelled aria-label (names up to the cap, then ", and M more").
+ * One constant keeps the two surfaces' "too many to list" threshold in sync,
+ * honouring DESIGN.md's "avoid pill overload" guidance.
+ * @example
+ * selectedSources.length > SOURCE_FILTER_MAX_VISIBLE_REPOS // collapse pills
+ */
+export const SOURCE_FILTER_MAX_VISIBLE_REPOS = 3
+
+/**
+ * Length above which a repository slug is middle-ellipsised for the COMPACT
+ * source-repo filter trigger label only. Space-constrained surfaces (the
+ * toolbar trigger) truncate; precision-first surfaces (dropdown rows, filter
+ * pills, aria-labels, the bulk-delete confirm dialog) always show the full
+ * value. The truncated form is exactly this many chars (12-char head + "..." +
+ * 13-char tail = 28), so the label width stays bounded.
+ * @example
+ * 'very-long-owner-name/extremely-long-repository'.length > REPOSITORY_FACET_LABEL_MAX_CHARS // true → ellipsise
+ */
+export const REPOSITORY_FACET_LABEL_MAX_CHARS = 28
+
+/**
  * Minimum tap-target size (px) for interactive elements. Floor set by both
  * Apple HIG (44×44 pt) and WCAG 2.2 AA (target size 24 CSS px minimum, 44
  * recommended) — keeping a single source of truth here means adding a new


### PR DESCRIPTION
## What & why

Replaces the single-select source-repo filter (`selectedSource: RepositoryId | null`) with a **multi-select INCLUDE filter** (`selectedSources: RepositoryId[]`).

- **Empty selection** → show all skills, including source-less local skills (unchanged default).
- **Non-empty selection** → show only skills whose `source` is in the selection; source-less local skills are hidden.

When the filter hides local skills, an inline metadata hint surfaces the count ("N local skills hidden"), and the bulk-delete confirm dialog names the in-scope repositories plus reassures that hidden locals stay untouched.

## Key changes

- **`uiSlice`** — `selectedSources[]` with `setSelectedSources` / `toggleSource` / `clearSelectedSources`; the selection is pruned when its repos disappear. `SourceFilterSummary` (`repositoryIds` + `localHiddenCount`) feeds the bulk-delete confirm scope.
- **`selectors`** — `selectSourceFilterViewModel` builds the compact trigger label, dropdown rows, filter pills, and `localHiddenCount`, memoized via reselect.
- **`MainContent`** — dropdown migrated from `RadioGroup` → `DropdownMenuCheckboxItem` rows plus *Show all* / *Select all* items; pills collapse past `SOURCE_FILTER_MAX_VISIBLE_REPOS` into a "from N repos" summary.
- **`bulkDeleteCopy`** — appends a repo-scope sentence + hidden-locals reassurance to the destructive confirm.
- **`formatRepositoryFacetLabel`** — new util, middle-ellipsis past `REPOSITORY_FACET_LABEL_MAX_CHARS` (28), used by the compact trigger label **only**.

## Deliberate design decisions

1. **Single-row delete passes `sourceSummary: null`.** A single-row delete carries no repo-filter scope to surface — the confirm dialog stays focused on that one row, so it intentionally omits the multi-repo scope/hidden-locals sentences that the bulk path appends.
2. **`SourceLink` uses `setSelectedSources([source])` (replace, not toggle).** Clicking a skill's source link is a focused "show me this repo" jump — it *replaces* the active selection rather than additively toggling, matching the intent of navigating to a single repo's skills.

A matching nuance: the destructive bulk-delete confirm names a single repo **in full** (never the truncated trigger label) — width is unconstrained there and knowing the exact source matters most before a destructive action. Truncation is reserved for the space-constrained toolbar trigger.

## Quality gates

- `pnpm validate` — ✅ green (1123 tests across lint, test, typecheck, dead-code, dupes, health, storybook build)
- `pnpm test:e2e` — ✅ green (43 passed)

Version is intentionally **unchanged** — release version bumps are owned exclusively by `/electron-release` per project policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * リポジトリフィルターが複数選択に対応。複数リポジトリを同時に絞り込めます。
  * リポジトリ表示の短縮ラベル（長すぎる名前の省略表示）と表示上限を導入。

* **改善**
  * カードからのフィルタクリアで全スキル表示が確実に戻るよう修正。
  * 削除確認ダイアログの説明を強化し、フィルタ範囲やローカルスキルの影響を明確化。

* **テスト**
  * マルチ選択や削除文言などに対応したテストを追加・更新。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/skills-desktop/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->