### PR TITLE
feat(settings): wire Auto Updates pane to real updater config

### DIFF
--- a/.storybook/stories/Settings.stories.tsx
+++ b/.storybook/stories/Settings.stories.tsx
@@ -10,7 +10,6 @@ import { AutoUpdates } from '@/renderer/settings/sections/AutoUpdates'
 import { General } from '@/renderer/settings/sections/General'
 import { Keybindings } from '@/renderer/settings/sections/Keybindings'
 import {
-  MockControl,
   SectionFrame,
   SectionRow,
 } from '@/renderer/settings/sections/SectionFrame'
@@ -64,20 +63,16 @@ export const SectionPanes: Story = {
 
 export const SectionFrameParts: Story = {
   render: () => (
-    <StoryCard label="SectionFrame / SectionRow / MockControl">
+    <StoryCard label="SectionFrame / SectionRow">
       <SectionFrame
         title="Storybook Section"
         description="A compact settings section using the shared settings chrome."
       >
         <SectionRow
           label="Preview control"
-          description="Disabled controls still explain their future state."
+          description="A trailing control sits flush-right against its row label."
         >
-          <MockControl>
-            <Button size="sm" disabled>
-              Coming soon
-            </Button>
-          </MockControl>
+          <Button size="sm">Preview action</Button>
         </SectionRow>
       </SectionFrame>
     </StoryCard>

--- a/src/main/ipc/ipc-schemas.test.ts
+++ b/src/main/ipc/ipc-schemas.test.ts
@@ -118,6 +118,16 @@ describe('settings:set lockstep with SettingsSchema', () => {
     )
   })
 
+  it('accepts the auto-download preference boolean', () => {
+    expect(schema.safeParse([{ autoDownloadUpdates: true }]).success).toBe(true)
+  })
+
+  it('rejects a non-boolean autoDownloadUpdates at the IPC boundary', () => {
+    expect(schema.safeParse([{ autoDownloadUpdates: 'yes' }]).success).toBe(
+      false,
+    )
+  })
+
   it('rejects an unknown enum value for preferredTerminal', () => {
     expect(
       schema.safeParse([{ preferredTerminal: 'fish-shell' }]).success,
@@ -172,6 +182,16 @@ describe('settings:set lockstep with SettingsSchema', () => {
   it('parsing a partial without windowBackgroundBlurRadius does NOT inject a default', () => {
     const parsed = schema.parse([{ defaultSkillTab: 'info' }]) as [object]
     expect('windowBackgroundBlurRadius' in parsed[0]).toBe(false)
+  })
+
+  it('parsing a partial without autoDownloadUpdates does NOT inject its default', () => {
+    // Same wipe-on-every-write guard as hiddenAgentIds/blur: the IPC schema
+    // declares the toggle as a bare `z.boolean().optional()` rather than
+    // chaining `.optional()` over the disk schema's `.default(false)`. If it
+    // re-inherited the default, every unrelated settings:set would parse to
+    // `{ autoDownloadUpdates: false }` and clobber a user's persisted opt-in.
+    const parsed = schema.parse([{ defaultSkillTab: 'info' }]) as [object]
+    expect('autoDownloadUpdates' in parsed[0]).toBe(false)
   })
 
   it('accepts an explicit hiddenAgentIds array on settings:set', () => {

--- a/src/main/ipc/ipc-schemas.ts
+++ b/src/main/ipc/ipc-schemas.ts
@@ -305,6 +305,14 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
           .array(z.enum(AGENT_IDS))
           .max(AGENT_IDS.length)
           .optional(),
+        // Auto-download preference. Declared as plain `z.boolean().optional()`
+        // rather than chaining `.optional()` off `SettingsSchema.shape.*`
+        // (which carries `.default(false)`): the same default-materialization
+        // footgun as hiddenAgentIds above — an omitted key would parse to
+        // `false` and clobber the persisted value on every unrelated
+        // settings:set. A bare boolean has no constraint that can drift, so
+        // there's nothing to keep in lockstep beyond the type itself.
+        autoDownloadUpdates: z.boolean().optional(),
       })
       .strict(),
   ]),

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -1,6 +1,7 @@
 import { getMainWindow } from '@/main/services/mainWindowState'
 import { getSettings, saveSettings } from '@/main/services/settings'
 import { createOrFocusSettingsWindow } from '@/main/services/settingsWindow'
+import { applyUpdaterPreferences } from '@/main/updater'
 import { applyWindowBackgroundBlur } from '@/main/utils/windowBackgroundBlur'
 import { IPC_CHANNELS } from '@/shared/ipc-channels'
 
@@ -46,6 +47,13 @@ export function registerSettingsHandlers(): void {
         if (mainWindow !== null) {
           applyWindowBackgroundBlur(mainWindow, next.windowBackgroundBlurRadius)
         }
+      }
+      // Push the auto-download preference onto the live updater so a
+      // mid-session toggle takes effect on the next check without an app
+      // restart. Harmless when the updater is inactive (dev / unpackaged):
+      // it only mutates config on the electron-updater singleton.
+      if (next.autoDownloadUpdates !== before.autoDownloadUpdates) {
+        applyUpdaterPreferences(next)
       }
       broadcastTypedEvent(IPC_CHANNELS.SETTINGS_CHANGED, next)
     }

--- a/src/main/services/settings.test.ts
+++ b/src/main/services/settings.test.ts
@@ -18,6 +18,7 @@ describe('areSettingsEqual', () => {
     preferredTerminal: 'terminal',
     windowBackgroundBlurRadius: 0,
     hiddenAgentIds: [],
+    autoDownloadUpdates: false,
   }
 
   it('returns true for identical primitive-only settings', () => {

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Mutable stand-in for the electron-updater singleton. `applyUpdaterPreferences`
+ * writes the config values onto it; the tests read them back. `autoInstallOnAppQuit`
+ * starts `true` to mirror electron-updater's real default so the consent-pin
+ * assertion below is meaningful.
+ */
+const mockAutoUpdater = vi.hoisted(() => ({
+  autoDownload: false,
+  autoInstallOnAppQuit: true,
+}))
+
+vi.mock('electron-updater', () => ({
+  autoUpdater: mockAutoUpdater,
+}))
+
+// updater.ts transitively imports `electron` via typedSend (BrowserWindow)
+// and the settings service (app). Neither is touched by the unit under test,
+// so a minimal surface keeps the import graph from throwing at load time.
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn(() => '/tmp') },
+  BrowserWindow: { getAllWindows: vi.fn(() => []) },
+}))
+
+import { applyUpdaterPreferences } from './updater'
+
+describe('applyUpdaterPreferences', () => {
+  beforeEach(() => {
+    mockAutoUpdater.autoDownload = false
+    mockAutoUpdater.autoInstallOnAppQuit = true
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('enables background downloads on the updater when the user opts in', () => {
+    // Arrange + Act
+    applyUpdaterPreferences({ autoDownloadUpdates: true })
+
+    // Assert
+    expect(mockAutoUpdater.autoDownload).toBe(true)
+  })
+
+  it('restores manual downloads when the user turns the toggle back off', () => {
+    // Arrange — simulate a prior opt-in that the user then turned back off.
+    mockAutoUpdater.autoDownload = true
+
+    // Act
+    applyUpdaterPreferences({ autoDownloadUpdates: false })
+
+    // Assert
+    expect(mockAutoUpdater.autoDownload).toBe(false)
+  })
+
+  it('pins autoInstallOnAppQuit to false so a downloaded update never installs without UI consent', () => {
+    // Arrange — electron-updater defaults this to true, which would silently
+    // install a downloaded update on the next quit, bypassing the
+    // confirm-via-UI install flow.
+
+    // Act
+    applyUpdaterPreferences({ autoDownloadUpdates: true })
+
+    // Assert
+    expect(mockAutoUpdater.autoInstallOnAppQuit).toBe(false)
+  })
+})

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -1,17 +1,46 @@
 import { autoUpdater } from 'electron-updater'
 
 import { IPC_CHANNELS } from '@/shared/ipc-channels'
+import type { Settings } from '@/shared/settings'
 import { semanticVersion } from '@/shared/types'
 
 import { broadcastTypedEvent as broadcastEvent } from './ipc/typedSend'
+import { getSettings } from './services/settings'
+
+/**
+ * Push the user's persisted update preference onto the live
+ * `electron-updater` singleton. Called once at init (so the boot-time
+ * update check honors the saved value) and again from the `settings:set`
+ * IPC handler whenever `autoDownloadUpdates` flips, so a mid-session change
+ * takes effect on the next check without an app restart.
+ *
+ * Also pins `autoInstallOnAppQuit` to `false`: electron-updater defaults it
+ * to `true`, which would silently install an already-downloaded update on the
+ * next quit and bypass the app's explicit confirm-via-UI install flow. Pinning
+ * it here (idempotently re-applied on every preference change) keeps installs
+ * user-initiated regardless of the auto-download setting.
+ * @param preferences - The `autoDownloadUpdates` slice of Settings.
+ * @example
+ * applyUpdaterPreferences({ autoDownloadUpdates: true })
+ * // autoUpdater.autoDownload === true, autoUpdater.autoInstallOnAppQuit === false
+ */
+export function applyUpdaterPreferences(
+  preferences: Pick<Settings, 'autoDownloadUpdates'>,
+): void {
+  autoUpdater.autoDownload = preferences.autoDownloadUpdates
+  // Never auto-install on quit — install stays user-initiated via the UI.
+  autoUpdater.autoInstallOnAppQuit = false
+}
 
 /**
  * Initialize auto updater with IPC-based UI notifications
  * Replaces native dialogs with in-app toast notifications
  */
 export function initAutoUpdater(): void {
-  // Disable auto download - user should confirm via UI
-  autoUpdater.autoDownload = false
+  // Seed the updater from the persisted user preference. The default keeps
+  // autoDownload off (manual confirm-via-UI flow) until the user opts in
+  // via Settings → Auto Updates.
+  applyUpdaterPreferences(getSettings())
 
   autoUpdater.on('checking-for-update', () => {
     console.log('Checking for updates...')

--- a/src/renderer/settings/sections/AutoUpdates.browser.test.tsx
+++ b/src/renderer/settings/sections/AutoUpdates.browser.test.tsx
@@ -1,0 +1,98 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import { DEFAULT_SETTINGS, type Settings } from '@/shared/settings'
+
+const mockSettingsSet = vi.fn()
+
+beforeEach(() => {
+  mockSettingsSet.mockReset()
+  mockSettingsSet.mockResolvedValue(undefined)
+  // Browser mode has no preload bridge; Auto Updates only needs settings.set.
+  vi.stubGlobal('electron', {
+    settings: { set: mockSettingsSet },
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+/**
+ * Build a settings-only store for the Auto Updates pane.
+ * @param overrides - Settings fields to layer over DEFAULT_SETTINGS.
+ * @returns Redux store with settings preloaded.
+ */
+async function createStore(
+  overrides: Partial<Settings> = {},
+): Promise<ReturnType<typeof configureStore>> {
+  const { default: settingsReducer } =
+    await import('@/renderer/src/redux/slices/settingsSlice')
+  return configureStore({
+    reducer: {
+      settings: settingsReducer,
+    },
+    preloadedState: {
+      settings: { ...DEFAULT_SETTINGS, ...overrides },
+    },
+  })
+}
+
+describe('Settings → Auto Updates', () => {
+  it('persists opting into automatic background downloads', async () => {
+    const store = await createStore()
+    const { AutoUpdates } = await import('./AutoUpdates')
+    const screen = await render(
+      <Provider store={store}>
+        <AutoUpdates />
+      </Provider>,
+    )
+
+    await screen
+      .getByRole('checkbox', { name: /Download updates automatically/i })
+      .click()
+
+    await expect.poll(() => mockSettingsSet.mock.calls.length).toBe(1)
+    expect(mockSettingsSet).toHaveBeenCalledWith({ autoDownloadUpdates: true })
+  })
+
+  it('persists turning automatic background downloads back off', async () => {
+    // Pin the `checked === true` coercion's false-path: an already-checked
+    // box, when clicked, must persist `false` — never the indeterminate
+    // sentinel Radix can report.
+    const store = await createStore({ autoDownloadUpdates: true })
+    const { AutoUpdates } = await import('./AutoUpdates')
+    const screen = await render(
+      <Provider store={store}>
+        <AutoUpdates />
+      </Provider>,
+    )
+
+    await screen
+      .getByRole('checkbox', { name: /Download updates automatically/i })
+      .click()
+
+    await expect.poll(() => mockSettingsSet.mock.calls.length).toBe(1)
+    expect(mockSettingsSet).toHaveBeenCalledWith({ autoDownloadUpdates: false })
+  })
+
+  it('reflects a persisted opt-in as an already-checked box', async () => {
+    const store = await createStore({ autoDownloadUpdates: true })
+    const { AutoUpdates } = await import('./AutoUpdates')
+    const screen = await render(
+      <Provider store={store}>
+        <AutoUpdates />
+      </Provider>,
+    )
+
+    await expect
+      .element(
+        screen.getByRole('checkbox', {
+          name: /Download updates automatically/i,
+        }),
+      )
+      .toBeChecked()
+  })
+})

--- a/src/renderer/settings/sections/AutoUpdates.tsx
+++ b/src/renderer/settings/sections/AutoUpdates.tsx
@@ -1,22 +1,35 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 
 import { Checkbox } from '@/renderer/src/components/ui/checkbox'
+import { useUpdateSettings } from '@/renderer/src/hooks/useUpdateSettings'
+import { useAppSelector } from '@/renderer/src/redux/hooks'
 
-import { MockControl, SectionFrame, SectionRow } from './SectionFrame'
+import { SectionFrame, SectionRow } from './SectionFrame'
 
 /**
- * Auto Updates pane — visual stub for v0.15.0.
+ * Auto Updates pane — wired to the real `electron-updater` config.
  *
- * Real updater behavior (auto-download, install-on-quit) is owned by
- * `electron-updater` in `src/main/updater.ts`. Wiring user-facing
- * toggles requires propagating values into that module's runtime
- * config (`autoUpdater.autoDownload`, `allowPrerelease`). That
- * roundtrip is out of scope for the v0.15.0 Settings shell — see the
- * "Out of scope" list in the plan. The "Check for Updates" trigger
- * lives in the About pane and IS wired to the real updater.
+ * One persisted boolean drives the updater at boot and live (mirrors the
+ * `windowBackgroundBlurRadius` flow): `autoDownloadUpdates` →
+ * `autoUpdater.autoDownload`. The settings round-trip (optimistic dispatch +
+ * `settings:set` IPC) is owned by `useUpdateSettings`; the main process
+ * applies the value in `src/main/updater.ts`. The "Check for Updates" trigger
+ * lives in the About pane and is wired to the same updater instance.
  */
 export const AutoUpdates = React.memo(
   function AutoUpdates(): React.ReactElement {
+    const settings = useAppSelector((state) => state.settings)
+    const updateSettings = useUpdateSettings()
+
+    // Radix Checkbox reports `boolean | 'indeterminate'`; coerce to a strict
+    // boolean so we never persist the indeterminate sentinel.
+    const handleAutoDownloadChange = useCallback(
+      (checked: boolean | 'indeterminate'): void => {
+        updateSettings({ autoDownloadUpdates: checked === true })
+      },
+      [updateSettings],
+    )
+
     return (
       <SectionFrame
         title="Auto Updates"
@@ -26,23 +39,14 @@ export const AutoUpdates = React.memo(
           label="Auto-download updates"
           description="Download in the background when a new version ships."
         >
-          <MockControl>
-            <label className="flex items-center gap-2 text-sm">
-              <Checkbox disabled />
-              <span>Download updates automatically</span>
-            </label>
-          </MockControl>
-        </SectionRow>
-        <SectionRow
-          label="Beta channel"
-          description="Receive pre-release builds before stable promotion."
-        >
-          <MockControl>
-            <label className="flex items-center gap-2 text-sm">
-              <Checkbox disabled />
-              <span>Opt into beta releases</span>
-            </label>
-          </MockControl>
+          <label className="flex w-fit items-center gap-2 text-sm">
+            <Checkbox
+              checked={settings.autoDownloadUpdates}
+              onCheckedChange={handleAutoDownloadChange}
+              aria-label="Download updates automatically"
+            />
+            <span>Download updates automatically</span>
+          </label>
         </SectionRow>
       </SectionFrame>
     )

--- a/src/renderer/settings/sections/SectionFrame.tsx
+++ b/src/renderer/settings/sections/SectionFrame.tsx
@@ -1,11 +1,6 @@
 import React from 'react'
 
 import { Separator } from '@/renderer/src/components/ui/separator'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@/renderer/src/components/ui/tooltip'
 
 interface SectionFrameProps {
   title: string
@@ -72,40 +67,5 @@ export const SectionRow = React.memo(function SectionRow({
       </div>
       <div>{children}</div>
     </div>
-  )
-})
-
-interface MockControlProps {
-  children: React.ReactNode
-}
-
-/**
- * Wraps a disabled control + its label with a "Coming in a future
- * release" tooltip. Used by the Appearance / Auto Updates panes to
- * communicate that the controls are visual stubs.
- *
- * Why a wrapper, not the control itself: Radix Tooltip's
- * `TooltipTrigger asChild` forwards events to its child, but a
- * disabled `<button>` / `<input>` does not fire pointer events. The
- * tooltip would silently not show. Wrapping in a focusable `<div>`
- * captures hover/focus so the tooltip works while the inner control
- * stays unambiguously disabled (50% opacity, cursor-not-allowed).
- */
-export const MockControl = React.memo(function MockControl({
-  children,
-}: MockControlProps): React.ReactElement {
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <div
-          tabIndex={0}
-          aria-disabled="true"
-          className="inline-flex w-fit cursor-not-allowed items-center gap-3 rounded-md opacity-60"
-        >
-          {children}
-        </div>
-      </TooltipTrigger>
-      <TooltipContent side="top">Coming in a future release</TooltipContent>
-    </Tooltip>
   )
 })

--- a/src/shared/settings.test.ts
+++ b/src/shared/settings.test.ts
@@ -89,6 +89,22 @@ describe('SettingsSchema', () => {
     expect(DEFAULT_SETTINGS).toEqual(SettingsSchema.parse({}))
   })
 
+  it('defaults autoDownloadUpdates to off so a fresh install keeps manual confirm-via-UI downloads', () => {
+    const parsed = SettingsSchema.parse({})
+    expect(parsed.autoDownloadUpdates).toBe(false)
+  })
+
+  it('persists opting into background downloads', () => {
+    const parsed = SettingsSchema.parse({
+      autoDownloadUpdates: true,
+    })
+    expect(parsed.autoDownloadUpdates).toBe(true)
+  })
+
+  it('rejects a non-boolean autoDownloadUpdates', () => {
+    expect(() => SettingsSchema.parse({ autoDownloadUpdates: 'yes' })).toThrow()
+  })
+
   it('windowSize is optional and defaults to undefined', () => {
     const parsed = SettingsSchema.parse({})
     expect(parsed.windowSize).toBeUndefined()

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -169,13 +169,17 @@ const HIDDEN_AGENT_IDS_SCHEMA = z
  *   Validated against `AGENT_IDS` so a stale id from a prior version
  *   (e.g. an agent removed upstream by `/cli-upgrade`) is silently
  *   dropped on parse rather than surfacing as a phantom hidden entry.
+ * - `autoDownloadUpdates`: when `true`, `electron-updater` downloads a new
+ *   release in the background as soon as it is detected. Default `false`
+ *   preserves the app's manual confirm-via-UI flow (`src/main/updater.ts`
+ *   keeps `autoUpdater.autoDownload` in sync with this field).
  *
  * Adding a field here requires widening `IPC_ARG_SCHEMAS['settings:set']`
  * in `src/main/ipc/ipc-schemas.ts` in lockstep — that schema is `.strict()`
  * so unknown keys are rejected at the IPC boundary (defense in depth).
  *
  * @example
- * SettingsSchema.parse({}) // { defaultSkillTab: 'files', preferredTerminal: 'terminal', windowBackgroundBlurRadius: 0, hiddenAgentIds: [] }
+ * SettingsSchema.parse({}) // { defaultSkillTab: 'files', preferredTerminal: 'terminal', windowBackgroundBlurRadius: 0, hiddenAgentIds: [], autoDownloadUpdates: false }
  */
 export const SettingsSchema = z.object({
   defaultSkillTab: z.enum(['files', 'info']).default('files'),
@@ -186,6 +190,10 @@ export const SettingsSchema = z.object({
     WINDOW_BACKGROUND_BLUR_MIN_RADIUS,
   ),
   hiddenAgentIds: HIDDEN_AGENT_IDS_SCHEMA,
+  // Auto-download preference surfaced in Settings → Auto Updates. Defaults
+  // to false so the manual confirm-via-UI download flow is preserved unless
+  // the user opts in.
+  autoDownloadUpdates: z.boolean().default(false),
 })
 
 /**
@@ -207,4 +215,5 @@ export const DEFAULT_SETTINGS: Settings = {
   preferredTerminal: 'terminal',
   windowBackgroundBlurRadius: WINDOW_BACKGROUND_BLUR_MIN_RADIUS,
   hiddenAgentIds: [],
+  autoDownloadUpdates: false,
 }


### PR DESCRIPTION
## Summary

Wires the **Settings → Auto Updates** pane (previously a visual stub of
`<Checkbox disabled />` + `MockControl`) to the real `electron-updater`
config, following the existing wired-settings pattern
(`windowBackgroundBlurRadius`, `preferredTerminal`):

- **Auto-download updates** → `autoUpdater.autoDownload`, persisted as
  `autoDownloadUpdates` and applied at boot and live on every change.
- Pins `autoUpdater.autoInstallOnAppQuit = false` so a downloaded update never
  installs silently on quit — install stays **user-initiated via the UI**,
  preserving the confirm-via-UI flow regardless of the auto-download setting.
- Removes the now-unused `MockControl` stub from `SectionFrame`.

## Beta channel — deferred to #179 (intentional scope reduction)

#176 also asked for a **Beta channel** (`allowPrerelease`) toggle. It is
**not** in this PR: the release pipeline produces no pre-release builds today
(no `channel` in `electron-builder.yml`, `/electron-release` never passes
`--prerelease`, no `beta-mac.yml` is uploaded). An `allowPrerelease` toggle
with no beta feed is a dead switch — `electron-updater` would just resolve to
the same stable `latest-mac.yml`. Shipping it would fail review.

The pipeline work (cut + upload a pre-release feed) must land first; the
UI/settings wiring then follows. Tracked in #179.

## Changes

- `src/shared/settings.ts` — add `autoDownloadUpdates: boolean`
  (`.default(false)`) to `SettingsSchema` + `DEFAULT_SETTINGS`.
- `src/main/ipc/ipc-schemas.ts` — widen the `.strict()` `settings:set` schema
  with a bare optional boolean (no `.default()` inheritance — avoids the
  clobber-on-every-write footgun).
- `src/main/updater.ts` — `applyUpdaterPreferences()` reads the setting onto
  `autoUpdater.autoDownload` + pins `autoInstallOnAppQuit = false`; seeded at
  boot from persisted settings.
- `src/main/ipc/settings.ts` — propagate a mid-session change to the live
  updater.
- `src/renderer/settings/sections/AutoUpdates.tsx` — real checkbox bound to
  Redux + `useUpdateSettings()`.
- `src/renderer/settings/sections/SectionFrame.tsx` — drop unused `MockControl`.
- Tests: schema, IPC schema (incl. no-default-injection guard), updater unit
  (incl. `autoInstallOnAppQuit` consent pin), and a browser-lane test for the
  pane (opt-in, opt-out coercion, persisted reflection).

## Test plan

- `pnpm validate` — ✅ 85 files / 1135 tests; lint + typecheck + dead-code green
- `pnpm test:e2e` — ✅ 43 passed

Closes #176


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 自動更新ダウンロード設定機能を追加しました。ユーザーは設定画面で自動ダウンロード機能のオン/オフを制御できるようになります。設定はアプリ再起動後に反映されます。

* **Tests**
  * 自動更新設定の動作を検証するテストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/skills-desktop/pull/180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->