### PR TITLE
refactor(marketplace): make InstallModal global-only install explicit (closes #177)

### DIFF
--- a/src/renderer/src/components/marketplace/InstallModal.tsx
+++ b/src/renderer/src/components/marketplace/InstallModal.tsx
@@ -34,7 +34,6 @@ export const InstallModal = React.memo(
     const [selectedAgents, setSelectedAgents] = useState<AgentId[]>([
       'claude-code',
     ])
-    const [isGlobal] = useState(true) // Always install globally for now
 
     const isInstalling = status === 'installing'
     const existingAgents = useMemo(
@@ -62,7 +61,10 @@ export const InstallModal = React.memo(
 
       const options: InstallOptions = {
         repo: selectedSkill.repo,
-        global: isGlobal,
+        // Marketplace installs are global-only by design — skills land in the
+        // shared ~/.agents/skills/ source dir. Per-project (local) scope was
+        // considered and deliberately not built (see #177).
+        global: true,
         agents: selectedAgents,
         skills: [selectedSkill.name],
       }
@@ -71,7 +73,7 @@ export const InstallModal = React.memo(
       // Refresh the skills list after installation
       dispatch(fetchSkills())
       handleClose()
-    }, [dispatch, handleClose, isGlobal, selectedAgents, selectedSkill])
+    }, [dispatch, handleClose, selectedAgents, selectedSkill])
 
     return (
       <Dialog open={!!selectedSkill} onOpenChange={handleClose}>

--- a/src/renderer/src/components/marketplace/SkillRowMarketplace.browser.test.tsx
+++ b/src/renderer/src/components/marketplace/SkillRowMarketplace.browser.test.tsx
@@ -117,7 +117,7 @@ describe('SkillRowMarketplace — installed row has no destructive action', () =
     // Static informational badge uses role="img" — `role="status"` is for
     // live regions that announce dynamic state changes, not labels. The
     // aria-label includes `--global` so the recipe matches how the app
-    // installs (InstallModal hardcodes isGlobal=true) and works when copied.
+    // installs (InstallModal installs globally by design) and works when copied.
     await expect
       .element(screen.getByRole('img', { name: /lint is installed/i }))
       .toBeInTheDocument()


### PR DESCRIPTION
## Summary

Resolves #177 with the **global-only** direction (Option 1 from the issue).

`InstallModal` carried a dead `const [isGlobal] = useState(true)` — a state
with no setter, so the value could never change. This made a deliberate
product decision look like a half-built local-scope toggle. This PR makes the
decision explicit:

- Remove the dead `isGlobal` state + `// Always install globally for now`
  comment.
- Pass `global: true` directly into `InstallOptions`, with a comment recording
  **why** marketplace installs are global-only: skills land in the shared
  `~/.agents/skills/` source dir. Per-project (local) scope was considered and
  intentionally not built — the desktop app has no "current project" concept,
  and the sidebar / symlink-status / uninstall-hint UI all assume global.
- Drop the now-constant `isGlobal` from the install `useCallback` deps.
- Refresh a `SkillRowMarketplace` test comment that named the removed variable.

**No behavior change** — installs were always global and remain global. This
closes the design question in #177 in favor of keeping the app global-first.

## Test plan

- `pnpm validate` — ✅ 85 files / 1135 tests; lint + typecheck + dead-code green
- `pnpm test:e2e` — ✅ 43 passed

Closes #177


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * マーケットプレイス経由でのエージェント・スキルのインストール処理を改善しました。インストール動作の一貫性が向上し、より安定した実行が期待できます。併せてテストスイートも更新し、品質保証を強化しています。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/skills-desktop/pull/181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->