### PR TITLE
test: cover experimental dashboard widgets (AgentHeatmap, ActivityTimeline)

### DIFF
--- a/src/renderer/src/components/dashboard/widgets/ActivityTimelineWidget.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/widgets/ActivityTimelineWidget.browser.test.tsx
@@ -1,0 +1,129 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import { describe, expect, it } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import '@/renderer/src/styles/globals.css'
+import type { SyncExecuteResult, SyncResultItem } from '@/shared/types'
+
+/**
+ * Build a SyncExecuteResult from just the per-item `details` the widget renders.
+ * The summary counts (`created`/`replaced`/`skipped`/`errors`) are derived so
+ * the fixture stays internally consistent even though the widget ignores them.
+ * @param details - Per-item sync outcomes shown as timeline rows.
+ */
+function makeSyncResult(details: SyncResultItem[]): SyncExecuteResult {
+  const errors = details.flatMap((item) =>
+    item.action === 'error'
+      ? [
+          {
+            path: `/Users/test/.agents/skills/${item.skillName}`,
+            error: item.error,
+          },
+        ]
+      : [],
+  )
+  return {
+    success: errors.length === 0,
+    created: details.filter((item) => item.action === 'created').length,
+    replaced: details.filter((item) => item.action === 'replaced').length,
+    skipped: details.filter((item) => item.action === 'skipped').length,
+    errors,
+    details,
+  }
+}
+
+/**
+ * Seed `ui.syncResult` with the given result (or leave it null) and render the
+ * timeline inside a sized wrapper. Seeding via `executeSyncAction.fulfilled`
+ * avoids mocking the sync IPC call.
+ * @param syncResult - Result to seed, or null for the pristine "no activity" state.
+ */
+async function renderTimeline(syncResult: SyncExecuteResult | null) {
+  const [
+    { default: uiReducer, executeSyncAction },
+    { ActivityTimelineWidget },
+  ] = await Promise.all([
+    import('@/renderer/src/redux/slices/uiSlice'),
+    import('./ActivityTimelineWidget'),
+  ])
+  const store = configureStore({ reducer: { ui: uiReducer } })
+  if (syncResult) {
+    store.dispatch(
+      executeSyncAction.fulfilled(syncResult, 'req-sync', {
+        replaceConflicts: [],
+      }),
+    )
+  }
+
+  const screen = await render(
+    <Provider store={store}>
+      <div style={{ width: 320, height: 240 }}>
+        <ActivityTimelineWidget />
+      </div>
+    </Provider>,
+  )
+  return { screen, store }
+}
+
+describe('ActivityTimelineWidget', () => {
+  it('shows the no-activity hint before any sync has run', async () => {
+    // Arrange + Act: no sync result seeded into the store.
+    const { screen } = await renderTimeline(null)
+
+    // Assert
+    await expect.element(screen.getByText('No recent activity')).toBeVisible()
+    await expect
+      .element(screen.getByText('Run Sync to see per-item results here.'))
+      .toBeVisible()
+  })
+
+  it('lists each synced skill alongside its agent and action label', async () => {
+    // Arrange: three rows from one sync, distinct agents and actions.
+    const syncResult = makeSyncResult([
+      { skillName: 'alpha-skill', agentName: 'Claude Code', action: 'created' },
+      { skillName: 'beta-skill', agentName: 'Cursor', action: 'skipped' },
+      { skillName: 'gamma-skill', agentName: 'Codex', action: 'replaced' },
+    ])
+
+    // Act
+    const { screen } = await renderTimeline(syncResult)
+
+    // Assert: scope each assertion to its own row (`listitem`) so the test
+    // verifies same-row correspondence. A regression that scrambled which
+    // agent or action renders next to which skill would fail here, whereas a
+    // global text search would still pass. Rows render in sync-result order.
+    const rows = screen.getByRole('listitem')
+    await expect.element(rows.nth(0)).toHaveTextContent('alpha-skill')
+    await expect.element(rows.nth(0)).toHaveTextContent('Claude Code')
+    await expect.element(rows.nth(0)).toHaveTextContent('created')
+    await expect.element(rows.nth(1)).toHaveTextContent('beta-skill')
+    await expect.element(rows.nth(1)).toHaveTextContent('Cursor')
+    await expect.element(rows.nth(1)).toHaveTextContent('skipped')
+    await expect.element(rows.nth(2)).toHaveTextContent('gamma-skill')
+    await expect.element(rows.nth(2)).toHaveTextContent('Codex')
+    await expect.element(rows.nth(2)).toHaveTextContent('replaced')
+  })
+
+  it('shows the failure reason on an errored sync row', async () => {
+    // Arrange: a single errored row carrying a permission-denied message.
+    const syncResult = makeSyncResult([
+      {
+        skillName: 'delta-skill',
+        agentName: 'Claude Code',
+        action: 'error',
+        error: 'EACCES: permission denied',
+      },
+    ])
+
+    // Act
+    const { screen } = await renderTimeline(syncResult)
+
+    // Assert: the row shows the skill, the error label, and the reason text.
+    await expect.element(screen.getByText('delta-skill')).toBeVisible()
+    await expect.element(screen.getByText('error')).toBeVisible()
+    await expect
+      .element(screen.getByText('EACCES: permission denied'))
+      .toBeVisible()
+  })
+})

--- a/src/renderer/src/components/dashboard/widgets/AgentHeatmapWidget.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/widgets/AgentHeatmapWidget.browser.test.tsx
@@ -1,0 +1,216 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import { describe, expect, it } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import '@/renderer/src/styles/globals.css'
+import type {
+  Agent,
+  AgentId,
+  AgentName,
+  Skill,
+  SymlinkInfo,
+  SymlinkStatus,
+} from '@/shared/types'
+
+/**
+ * Build a minimal Agent fixture. Only `id`/`name`/`exists` matter to the
+ * heatmap (columns come from installed agents); the rest are plausible filler.
+ * @param id - Agent state id (e.g. "claude-code").
+ * @param name - Display name driving the column header abbreviation.
+ * @param exists - Whether the agent's skills dir is on disk (gates the column).
+ */
+function makeAgent(id: AgentId, name: AgentName, exists: boolean): Agent {
+  return {
+    id,
+    name,
+    path: `/Users/test/.${id}/skills`,
+    exists,
+    skillCount: 0,
+    localSkillCount: 0,
+  }
+}
+
+/**
+ * Build a SymlinkInfo fixture for one (skill × agent) slot.
+ * @param agentId - Owning agent id.
+ * @param agentName - Owning agent display name (appears in the cell label).
+ * @param status - valid / broken / missing.
+ * @param isLocal - True when the slot is a real local folder, not a symlink.
+ */
+function makeSymlink(
+  agentId: AgentId,
+  agentName: AgentName,
+  status: SymlinkStatus,
+  isLocal = false,
+): SymlinkInfo {
+  return {
+    agentId,
+    agentName,
+    status,
+    linkPath: `/Users/test/.${agentId}/skills/${agentName}`,
+    isLocal,
+  }
+}
+
+/**
+ * Build a Skill fixture. `symlinkCount` is derived from the valid links so the
+ * row-sorting input stays internally consistent.
+ * @param name - Skill name (also the heatmap row label).
+ * @param symlinks - Per-agent symlink slots for this skill.
+ */
+function makeSkill(name: string, symlinks: SymlinkInfo[]): Skill {
+  return {
+    name,
+    description: `${name} description`,
+    path: `/Users/test/.agents/skills/${name}`,
+    symlinkCount: symlinks.filter((link) => link.status === 'valid').length,
+    symlinks,
+    isSource: true,
+    isOrphan: false,
+  }
+}
+
+/**
+ * Seed a store with the given skills/agents and render the heatmap inside a
+ * sized wrapper (the widget is `h-full w-full`, so it needs a box to fill).
+ * Seeding via each thunk's `fulfilled` action avoids mocking the IPC layer.
+ */
+async function renderHeatmap(skills: Skill[], agents: Agent[]) {
+  const [
+    { default: skillsReducer, fetchSkills },
+    { default: agentsReducer, fetchAgents },
+    { AgentHeatmapWidget },
+  ] = await Promise.all([
+    import('@/renderer/src/redux/slices/skillsSlice'),
+    import('@/renderer/src/redux/slices/agentsSlice'),
+    import('./AgentHeatmapWidget'),
+  ])
+  const store = configureStore({
+    reducer: { skills: skillsReducer, agents: agentsReducer },
+  })
+  store.dispatch(fetchSkills.fulfilled(skills, 'req-skills'))
+  store.dispatch(fetchAgents.fulfilled(agents, 'req-agents'))
+
+  const screen = await render(
+    <Provider store={store}>
+      <div style={{ width: 320, height: 240 }}>
+        <AgentHeatmapWidget />
+      </div>
+    </Provider>,
+  )
+  return { screen, store }
+}
+
+describe('AgentHeatmapWidget', () => {
+  it('shows the not-enough-data hint when no agents are installed', async () => {
+    // Arrange: a skill exists, but every agent is uninstalled (exists: false).
+    const skills = [makeSkill('alpha-skill', [])]
+    const agents = [
+      makeAgent('claude-code', 'Claude Code', false),
+      makeAgent('cursor', 'Cursor', false),
+    ]
+
+    // Act
+    const { screen } = await renderHeatmap(skills, agents)
+
+    // Assert
+    await expect
+      .element(screen.getByText('Not enough data for a heatmap yet'))
+      .toBeVisible()
+  })
+
+  it('renders a two-letter column header for each installed agent and omits not-installed agents', async () => {
+    // Arrange: Claude Code + Cursor are installed; Codex is not.
+    const skills = [
+      makeSkill('alpha-skill', [
+        makeSymlink('claude-code', 'Claude Code', 'valid'),
+      ]),
+    ]
+    const agents = [
+      makeAgent('claude-code', 'Claude Code', true),
+      makeAgent('cursor', 'Cursor', true),
+      makeAgent('codex', 'Codex', false),
+    ]
+
+    // Act
+    const { screen } = await renderHeatmap(skills, agents)
+
+    // Assert: installed agents get an uppercased two-letter header...
+    await expect.element(screen.getByText('CC', { exact: true })).toBeVisible()
+    await expect.element(screen.getByText('CU', { exact: true })).toBeVisible()
+    // ...and the uninstalled Codex column never renders.
+    expect(screen.getByText('CO', { exact: true }).query()).toBeNull()
+  })
+
+  it('labels each heatmap cell with its per-agent symlink status', async () => {
+    // Arrange: one skill linked valid to Claude Code and broken to Cursor;
+    // Codex is installed but has no link for this skill, so it reads "missing".
+    const skills = [
+      makeSkill('alpha-skill', [
+        makeSymlink('claude-code', 'Claude Code', 'valid'),
+        makeSymlink('cursor', 'Cursor', 'broken'),
+      ]),
+    ]
+    const agents = [
+      makeAgent('claude-code', 'Claude Code', true),
+      makeAgent('cursor', 'Cursor', true),
+      makeAgent('codex', 'Codex', true),
+    ]
+
+    // Act
+    const { screen } = await renderHeatmap(skills, agents)
+
+    // Assert: each cell exposes "<skill> — <status> in <agent>" as its
+    // accessible label. (We assert presence, not visibility: the cells are
+    // empty colored squares whose Tailwind size utilities aren't generated in
+    // the test CSS bundle, so a labeled-but-zero-size cell is expected here.)
+    expect(
+      screen
+        .getByRole('img', {
+          name: 'alpha-skill — valid in Claude Code',
+          exact: true,
+        })
+        .query(),
+    ).not.toBeNull()
+    expect(
+      screen
+        .getByRole('img', {
+          name: 'alpha-skill — broken in Cursor',
+          exact: true,
+        })
+        .query(),
+    ).not.toBeNull()
+    expect(
+      screen
+        .getByRole('img', {
+          name: 'alpha-skill — missing in Codex',
+          exact: true,
+        })
+        .query(),
+    ).not.toBeNull()
+  })
+
+  it('labels a local folder slot as local to its agent', async () => {
+    // Arrange: the skill is present as a real local folder in Claude Code.
+    const skills = [
+      makeSkill('gamma-skill', [
+        makeSymlink('claude-code', 'Claude Code', 'valid', true),
+      ]),
+    ]
+    const agents = [makeAgent('claude-code', 'Claude Code', true)]
+
+    // Act
+    const { screen } = await renderHeatmap(skills, agents)
+
+    // Assert: local slots read "local to <agent>", not a status verb.
+    expect(
+      screen
+        .getByRole('img', {
+          name: 'gamma-skill — local to Claude Code',
+          exact: true,
+        })
+        .query(),
+    ).not.toBeNull()
+  })
+})

--- a/src/renderer/src/components/dashboard/widgets/AgentHeatmapWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/AgentHeatmapWidget.tsx
@@ -50,11 +50,13 @@ function buildSymlinkIndex(skills: readonly Skill[]): Map<string, SymlinkInfo> {
 /**
  * Abbreviate an agent name for the column header. We show two letters so the
  * heatmap stays narrow enough that 6–10 agents fit without horizontal scroll.
- * "Claude Code" → "CC", "Cursor" → "Cu", "Codex" → "Co".
+ * Multi-word names take the first two words' initials; single-word names take
+ * the first two characters. Either way the result is fully uppercased.
  * @param name - Full agent display name
  * @returns Two-letter abbreviation, uppercased
- * @example abbreviateAgentName("Claude Code") // => "CC"
- * @example abbreviateAgentName("Cursor")       // => "Cu"
+ * @example abbreviateAgentName("Claude Code") // => "CC" (two-word initials)
+ * @example abbreviateAgentName("Cursor")      // => "CU" (first two chars, uppercased)
+ * @example abbreviateAgentName("Codex")       // => "CO"
  */
 function abbreviateAgentName(name: string): string {
   const parts = name.trim().split(/\s+/)


### PR DESCRIPTION
## What

Adds Vitest browser-mode test coverage for the two experimental dashboard widgets that shipped without tests — `AgentHeatmapWidget` and `ActivityTimelineWidget` — and corrects a stale `abbreviateAgentName` docstring.

Both widgets are gated behind the disabled `ENABLE_DASHBOARD_EXPERIMENTAL` flag, so a regression in either is currently invisible. `BookmarksWidget` (the third dashboard widget) already has coverage; this closes the gap.

## Tests added

**`AgentHeatmapWidget.browser.test.tsx`** (4 tests)
- Empty-state hint when no agents are installed
- A two-letter column header per installed agent, and omission of uninstalled agents
- Per-cell symlink-status accessible labels (`valid` / `broken` / `missing`)
- Local-folder slot labeling (`local to <agent>`)

**`ActivityTimelineWidget.browser.test.tsx`** (3 tests)
- No-activity hint before any sync has run
- Per-item rows surfacing skill name, **agent name**, and action label
- Error-row failure-reason rendering

## Docstring fix

`abbreviateAgentName`'s `@example`s claimed `"Cursor" → "Cu"` / `"Codex" → "Co"`, but the implementation calls `.toUpperCase()`, so it actually returns `"CU"` / `"CO"`. Corrected the examples and tightened the prose ("the first two words' initials", not "each word's initial" — the impl only uses the first two words). Doc-only; no behavior change.

## Notes for reviewers

- Heatmap cell assertions check the **accessible label** (`getByRole('img', { name })`) rather than visibility. The cells are empty colored squares whose Tailwind size utilities (`h-3.5 w-3.5`) aren't emitted into the browser-test CSS bundle, so a labeled-but-zero-size cell is expected there — the behavior under test is the label, not the painted box.

## Quality gate

- `pnpm validate` — 1142 tests, lint, typecheck, dead-code, dupes, health, Storybook build ✅
- `pnpm test:e2e` ✅
- `/review` — Testing + Maintainability specialists + Claude & Codex adversarial passes. Two review-driven refinements applied (agent-name assertion in the timeline test; docstring prose precision). Both adversarial passes returned "ship" with no production-reachable findings.

Closes #182


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Tests**
  * アクティビティタイムラインウィジェットのブラウザ表示テストを追加（未実行・成功系・エラー表示を検証）
  * エージェントヒートマップウィジェットのブラウザ表示テストを追加（列ヘッダー、セルのラベル、ローカル表示を検証）

* **Documentation**
  * エージェント名の省略表示ルール説明を明確化

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/skills-desktop/pull/183?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->