### PR TITLE
feat(dashboard): rebuild WidgetPicker with live widget preview

### DIFF
--- a/src/renderer/src/components/dashboard/WidgetPicker.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/WidgetPicker.browser.test.tsx
@@ -23,11 +23,13 @@ async function renderPicker(
     { default: dashboardReducer, addPage, dismissWelcome },
     { default: skillsReducer },
     { default: agentsReducer },
+    { default: widgetPickerReducer },
     { WidgetPicker },
   ] = await Promise.all([
     import('@/renderer/src/redux/slices/dashboardSlice'),
     import('@/renderer/src/redux/slices/skillsSlice'),
     import('@/renderer/src/redux/slices/agentsSlice'),
+    import('@/renderer/src/redux/slices/widgetPickerSlice'),
     import('./WidgetPicker'),
   ])
 
@@ -36,6 +38,7 @@ async function renderPicker(
       dashboard: dashboardReducer,
       skills: skillsReducer,
       agents: agentsReducer,
+      widgetPicker: widgetPickerReducer,
     },
   })
   // One empty page so the clicked widget is placed via the common add path.

--- a/src/renderer/src/components/dashboard/WidgetPicker.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/WidgetPicker.browser.test.tsx
@@ -1,0 +1,129 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import { describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import '@/renderer/src/styles/globals.css'
+
+/**
+ * Render the WidgetPicker open, inside a real-reducer store seeded with one
+ * empty page so a clicked widget lands via the normal add path. dashboard /
+ * skills / agents are the only slices the default (Welcome) and Skill Stats
+ * previews read from — the preview mounts the REAL widget body.
+ * @param onOpenChange - Spy for the dialog's open-state callback.
+ * @param options - `welcomeDismissed` pre-dispatches `dismissWelcome()` to
+ *   simulate a returning user (Welcome's body then renders only a muted hint).
+ * @returns Render handle + the Redux store for state assertions.
+ */
+async function renderPicker(
+  onOpenChange: (open: boolean) => void,
+  options: { welcomeDismissed?: boolean } = {},
+) {
+  const [
+    { default: dashboardReducer, addPage, dismissWelcome },
+    { default: skillsReducer },
+    { default: agentsReducer },
+    { WidgetPicker },
+  ] = await Promise.all([
+    import('@/renderer/src/redux/slices/dashboardSlice'),
+    import('@/renderer/src/redux/slices/skillsSlice'),
+    import('@/renderer/src/redux/slices/agentsSlice'),
+    import('./WidgetPicker'),
+  ])
+
+  const store = configureStore({
+    reducer: {
+      dashboard: dashboardReducer,
+      skills: skillsReducer,
+      agents: agentsReducer,
+    },
+  })
+  // One empty page so the clicked widget is placed via the common add path.
+  store.dispatch(addPage({ name: 'Test Page' }))
+  // Simulate a returning user who already dismissed the Welcome card.
+  if (options.welcomeDismissed) store.dispatch(dismissWelcome())
+
+  const screen = await render(
+    <Provider store={store}>
+      <WidgetPicker open={true} onOpenChange={onOpenChange} />
+    </Provider>,
+  )
+  return { screen, store }
+}
+
+describe('WidgetPicker', () => {
+  it('previews the first widget live when the modal opens', async () => {
+    // Arrange + Act
+    const { screen } = await renderPicker(vi.fn())
+
+    // Assert: the real Welcome widget body renders in the preview stage. Its
+    // in-body heading is unique to the rendered component (the list shows only
+    // the short "Welcome" label), so finding it proves the live preview works.
+    await expect
+      .element(screen.getByText('Welcome to Skills Desktop'))
+      .toBeVisible()
+  })
+
+  it('seeds the open-default preview on the next widget when Welcome was already dismissed', async () => {
+    // Arrange + Act: returning user — Welcome is dismissed, so its body would
+    // render only a muted hint and make a useless first frame.
+    const { screen } = await renderPicker(vi.fn(), { welcomeDismissed: true })
+
+    // Assert: the stage opens on Skill Stats instead ("Linked" is one of its
+    // tiles)...
+    await expect
+      .element(screen.getByText('Linked', { exact: true }))
+      .toBeVisible()
+    // ...and the dismissed Welcome body is not what greets the user.
+    expect(screen.getByText('Welcome to Skills Desktop').query()).toBeNull()
+  })
+
+  it('swaps the preview to the live component of the hovered widget', async () => {
+    // Arrange
+    const { screen } = await renderPicker(vi.fn())
+
+    // Act: hover the Skill Stats row.
+    await screen.getByRole('button', { name: /skill stats/i }).hover()
+
+    // Assert: the Stats widget body now renders ("Linked" is one of its three
+    // stat tiles and appears nowhere else)...
+    await expect
+      .element(screen.getByText('Linked', { exact: true }))
+      .toBeVisible()
+    // ...and the previously-shown Welcome body is gone.
+    expect(screen.getByText('Welcome to Skills Desktop').query()).toBeNull()
+  })
+
+  it('adds the clicked widget to the page and closes the modal', async () => {
+    // Arrange
+    const onOpenChange = vi.fn()
+    const { screen, store } = await renderPicker(onOpenChange)
+
+    // Act: click the Skill Stats row (one-click-add).
+    await screen.getByRole('button', { name: /skill stats/i }).click()
+
+    // Assert: a stats widget was added to the page, and the modal was asked to
+    // close.
+    const pages = store.getState().dashboard.pages
+    expect(pages[0]?.widgets).toHaveLength(1)
+    expect(pages[0]?.widgets[0]?.type).toBe('stats')
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('updates the preview when a row receives keyboard focus', async () => {
+    // Arrange
+    const { screen } = await renderPicker(vi.fn())
+
+    // Act: move keyboard focus onto the Skill Stats row (no pointer involved).
+    const statsRow = screen
+      .getByRole('button', { name: /skill stats/i })
+      .element()
+    if (statsRow instanceof HTMLElement) statsRow.focus()
+
+    // Assert: focus alone drives the live preview, so keyboard users get the
+    // same preview as mouse users.
+    await expect
+      .element(screen.getByText('Linked', { exact: true }))
+      .toBeVisible()
+  })
+})

--- a/src/renderer/src/components/dashboard/WidgetPicker.tsx
+++ b/src/renderer/src/components/dashboard/WidgetPicker.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback, useMemo, useRef, useState } from 'react'
 
 import {
   Dialog,
@@ -7,12 +7,25 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/renderer/src/components/ui/dialog'
-import { useAppDispatch } from '@/renderer/src/redux/hooks'
-import { addWidget } from '@/renderer/src/redux/slices/dashboardSlice'
+import { cn } from '@/renderer/src/lib/utils'
+import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
+import {
+  addWidget,
+  selectWelcomeDismissed,
+} from '@/renderer/src/redux/slices/dashboardSlice'
 import { FEATURE_FLAGS } from '@/shared/featureFlags'
 
-import type { WidgetType } from './types'
-import { listAvailableWidgets } from './widgets/registry'
+import type { WidgetInstance, WidgetType } from './types'
+import { newWidgetInstanceId } from './utils/ids'
+import { widgetPreviewSize } from './utils/widgetPreviewSize'
+import { getWidgetDefinition, listAvailableWidgets } from './widgets/registry'
+import { WidgetShell } from './WidgetShell'
+
+// One stable id reused for whatever widget is previewed. Reuse is safe because
+// nothing keys off a preview instance's id — the object is never dispatched to
+// Redux. NOTE `inert` (see the wrapper below) only blocks pointer/focus/a11y,
+// not mount effects: Trending/What's New still fetch the leaderboard on preview.
+const PREVIEW_INSTANCE_ID = newWidgetInstanceId()
 
 interface WidgetPickerProps {
   open: boolean
@@ -20,13 +33,15 @@ interface WidgetPickerProps {
 }
 
 /**
- * Modal for adding a new widget to the current page.
+ * Modal for adding a new widget to the current page, with a live preview.
  *
- * Reads the visible widget catalog from the registry (filtered by the
- * `ENABLE_DASHBOARD_EXPERIMENTAL` flag so unfinished widgets stay hidden in
- * production builds). Clicking a widget dispatches `addWidget` — the reducer
- * finds the first empty grid slot on the current page, and auto-creates a
- * new page if the current one is full.
+ * Left: a compact list of every visible widget (catalog filtered by the
+ * `ENABLE_DASHBOARD_EXPERIMENTAL` flag). Right: the REAL widget body rendered
+ * on a neutral stage at its default-size aspect ratio, so the user sees exactly
+ * what they're adding — not just an icon + blurb. Hovering or keyboard-focusing
+ * a row swaps the preview; clicking a row adds the widget and closes the modal
+ * (one-click-add). The reducer finds the first empty grid slot on the current
+ * page, auto-creating a new page if the current one is full.
  *
  * @example
  * const [open, setOpen] = useState(false)
@@ -41,74 +56,186 @@ export const WidgetPicker = React.memo(function WidgetPicker({
     FEATURE_FLAGS.ENABLE_DASHBOARD_EXPERIMENTAL,
   )
 
+  // Welcome is first in the catalog, but once dismissed its body renders only a
+  // muted "already dismissed" hint (a GLOBAL flag, not per-instance). That makes
+  // a poor first frame for a live-preview modal, so returning users seed the
+  // open-default preview on the next widget. Welcome stays in the list and still
+  // previews truthfully when hovered.
+  const isWelcomeDismissed = useAppSelector(selectWelcomeDismissed)
+
+  // Which widget the preview shows. Driven by hover/focus; falls back to the
+  // default seed so the stage is never empty when the modal opens.
+  const [activePreviewType, setActivePreviewType] = useState<WidgetType | null>(
+    null,
+  )
+  const defaultPreviewType: WidgetType | undefined =
+    availableWidgets[0]?.type === 'welcome' && isWelcomeDismissed
+      ? availableWidgets[1]?.type
+      : availableWidgets[0]?.type
+  const previewType: WidgetType =
+    activePreviewType ?? defaultPreviewType ?? 'welcome'
+  const previewDefinition = getWidgetDefinition(previewType)
+
+  // Radix moves focus into the dialog on open. Left to its default it grabs the
+  // FIRST row, whose `onFocus` would override the seed — so for a returning user
+  // the stage would still open on the dismissed Welcome hint. We redirect that
+  // initial focus onto the seed row so the focused row and the preview always
+  // agree (and keyboard users land on the same widget the stage shows).
+  const seedRowRef = useRef<HTMLButtonElement>(null)
+  // Stable (refs never change identity) so the memoized DialogContent doesn't
+  // re-render on every keystroke-driven parent update.
+  const focusSeedRowOnOpen = useCallback((event: Event): void => {
+    if (!seedRowRef.current) return
+    event.preventDefault()
+    seedRowRef.current.focus()
+  }, [])
+  const previewBox = previewDefinition
+    ? widgetPreviewSize(previewDefinition.defaultSize)
+    : null
+
+  // Synthetic instance so the real widget body can render. The id is the
+  // constant PREVIEW_INSTANCE_ID (see above), reused because nothing keys off it.
+  const previewInstance = useMemo<WidgetInstance>(
+    () => ({
+      id: PREVIEW_INSTANCE_ID,
+      type: previewType,
+      x: 0,
+      y: 0,
+      w: previewDefinition?.defaultSize.w ?? 1,
+      h: previewDefinition?.defaultSize.h ?? 1,
+    }),
+    [previewType, previewDefinition],
+  )
+
+  // One-click-add must fire at most once per open: the close animation keeps the
+  // rows clickable for a frame, so a fast double-click could add the widget
+  // twice. The dialog stays mounted between sessions (the parent only toggles
+  // `open`), so this ref would persist — reset it when the dialog re-opens.
+  // Comparing the previous `open` during render is React's no-effect way to
+  // respond to a prop transition.
+  const hasAddedRef = useRef<boolean>(false)
+  const wasOpenRef = useRef<boolean>(open)
+  if (open && !wasOpenRef.current) {
+    hasAddedRef.current = false
+  }
+  wasOpenRef.current = open
+
   // Not wrapped in useCallback: each row already creates a new arrow in
   // `.map()`, so memoizing this helper offers zero stability benefit and
   // the lint rule `no-deopt-use-callback` correctly flags that pattern.
   const handleAddWidget = (widgetType: WidgetType): void => {
+    if (hasAddedRef.current) return
+    hasAddedRef.current = true
     dispatch(addWidget({ type: widgetType }))
     onOpenChange(false)
   }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl">
+      <DialogContent
+        className="max-w-3xl max-h-[85vh] overflow-y-auto"
+        onOpenAutoFocus={focusSeedRowOnOpen}
+      >
         <DialogHeader>
           <DialogTitle>Add Widget</DialogTitle>
           <DialogDescription>
-            Pick a widget to add to the current page. If the page is full, a new
-            one will be created automatically.
+            Hover a widget to preview it live, then click to add it to the
+            current page. If the page is full, a new one will be created
+            automatically.
           </DialogDescription>
         </DialogHeader>
-        <ul className="grid grid-cols-1 sm:grid-cols-2 gap-2 mt-2 max-h-[60vh] overflow-y-auto pr-1">
-          {availableWidgets.map((widgetDefinition) => {
-            const WidgetIcon = widgetDefinition.icon
-            return (
-              <li key={widgetDefinition.type}>
-                <button
-                  type="button"
-                  onClick={() => handleAddWidget(widgetDefinition.type)}
-                  className="
-                    group w-full min-h-18 flex items-start gap-3 p-3 rounded-lg
-                    border border-border bg-card text-left
-                    hover:bg-muted hover:border-border/80
-                    transition-colors focus-visible:outline-none
-                    focus-visible:ring-2 focus-visible:ring-ring
-                  "
-                >
-                  <span
-                    className="
-                      shrink-0 inline-flex items-center justify-center
-                      w-8 h-8 rounded-md bg-primary/10 text-primary
-                      group-hover:bg-primary/15
-                    "
+
+        <div className="flex gap-4 mt-2">
+          {/* Left: compact widget list. Hover/focus drives the preview;
+              clicking a row adds it immediately (one-click-add). */}
+          <ul className="w-56 shrink-0 flex flex-col gap-1 max-h-[60vh] overflow-y-auto pr-1">
+            {availableWidgets.map((widgetDefinition) => {
+              const WidgetIcon = widgetDefinition.icon
+              const isActive = widgetDefinition.type === previewType
+              // The seed row receives the dialog's initial focus (see
+              // `focusSeedRowOnOpen`) so focus and preview start in agreement.
+              const isSeedRow = widgetDefinition.type === defaultPreviewType
+              return (
+                <li key={widgetDefinition.type}>
+                  <button
+                    type="button"
+                    ref={isSeedRow ? seedRowRef : undefined}
+                    onClick={() => handleAddWidget(widgetDefinition.type)}
+                    onMouseEnter={() =>
+                      setActivePreviewType(widgetDefinition.type)
+                    }
+                    onFocus={() => setActivePreviewType(widgetDefinition.type)}
+                    aria-current={isActive ? 'true' : undefined}
+                    className={cn(
+                      `group w-full flex items-center gap-2.5 p-2 rounded-lg border
+                       text-left transition-colors focus-visible:outline-none
+                       focus-visible:ring-2 focus-visible:ring-ring`,
+                      isActive
+                        ? 'bg-muted border-border/80'
+                        : 'border-transparent hover:bg-muted hover:border-border/80',
+                    )}
                   >
-                    <WidgetIcon className="h-4 w-4" aria-hidden="true" />
-                  </span>
-                  <span className="flex-1 min-w-0 flex flex-col gap-0.5">
-                    <span className="text-sm font-semibold text-foreground flex items-center gap-1.5">
+                    <span className="shrink-0 inline-flex items-center justify-center w-7 h-7 rounded-md bg-primary/10 text-primary group-hover:bg-primary/15">
+                      <WidgetIcon className="h-4 w-4" aria-hidden="true" />
+                    </span>
+                    <span className="flex-1 min-w-0 text-sm font-medium text-foreground truncate flex items-center gap-1.5">
                       {widgetDefinition.label}
                       {widgetDefinition.experimental && (
                         <span
                           title="Experimental widget"
-                          className="
-                            text-[9px] font-mono uppercase tracking-wide
-                            text-amber-400 bg-amber-400/10
-                            px-1 py-0.5 rounded
-                          "
+                          className="shrink-0 text-[9px] font-mono uppercase tracking-wide text-amber-400 bg-amber-400/10 px-1 py-0.5 rounded"
                         >
                           exp
                         </span>
                       )}
                     </span>
-                    <span className="text-[11px] text-muted-foreground leading-relaxed">
-                      {widgetDefinition.description}
-                    </span>
-                  </span>
-                </button>
-              </li>
-            )
-          })}
-        </ul>
+                  </button>
+                </li>
+              )
+            })}
+          </ul>
+
+          {/* Right: live preview. The REAL widget body renders on a neutral
+              `--background` stage (the widget is `--card`, so the stage must
+              not be a card — no card-in-card per DESIGN.md). */}
+          <div className="flex-1 min-w-0 flex flex-col gap-3">
+            <div className="flex-1 min-h-[20rem] flex items-center justify-center rounded-lg border border-border bg-background p-4 overflow-hidden">
+              {previewDefinition && previewBox ? (
+                // `inert` removes the preview from tab order, the a11y tree, and
+                // pointer events in one declarative knob — the cloned widget's
+                // buttons/links can't be focused or clicked here. WidgetShell's
+                // root is already `h-full w-full`, so it fills this sized stage
+                // directly without an extra wrapper.
+                <div
+                  inert
+                  style={{
+                    width: previewBox.widthPx,
+                    aspectRatio: `${previewBox.widthPx} / ${previewBox.heightPx}`,
+                    maxWidth: '100%',
+                  }}
+                >
+                  <WidgetShell
+                    instance={previewInstance}
+                    definition={previewDefinition}
+                    isPreview
+                  />
+                </div>
+              ) : null}
+            </div>
+
+            {/* Name + blurb for the previewed widget (was per-card text). */}
+            {previewDefinition && (
+              <div className="px-0.5">
+                <p className="text-sm font-semibold text-foreground">
+                  {previewDefinition.label}
+                </p>
+                <p className="text-xs text-muted-foreground leading-relaxed">
+                  {previewDefinition.description}
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
       </DialogContent>
     </Dialog>
   )

--- a/src/renderer/src/components/dashboard/WidgetPicker.tsx
+++ b/src/renderer/src/components/dashboard/WidgetPicker.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useMemo, useRef } from 'react'
 
 import {
   Dialog,
@@ -13,10 +13,16 @@ import {
   addWidget,
   selectWelcomeDismissed,
 } from '@/renderer/src/redux/slices/dashboardSlice'
+import {
+  resetActivePreview,
+  selectActivePreviewType,
+  setActivePreviewType,
+} from '@/renderer/src/redux/slices/widgetPickerSlice'
 import { FEATURE_FLAGS } from '@/shared/featureFlags'
 
 import type { WidgetInstance, WidgetType } from './types'
 import { newWidgetInstanceId } from './utils/ids'
+import { resolveSeedPreviewType } from './utils/resolveSeedPreviewType'
 import { widgetPreviewSize } from './utils/widgetPreviewSize'
 import { getWidgetDefinition, listAvailableWidgets } from './widgets/registry'
 import { WidgetShell } from './WidgetShell'
@@ -56,24 +62,19 @@ export const WidgetPicker = React.memo(function WidgetPicker({
     FEATURE_FLAGS.ENABLE_DASHBOARD_EXPERIMENTAL,
   )
 
-  // Welcome is first in the catalog, but once dismissed its body renders only a
-  // muted "already dismissed" hint (a GLOBAL flag, not per-instance). That makes
-  // a poor first frame for a live-preview modal, so returning users seed the
-  // open-default preview on the next widget. Welcome stays in the list and still
-  // previews truthfully when hovered.
+  // Welcome dismissal feeds the seed-fallthrough rule in `resolveSeedPreviewType`.
   const isWelcomeDismissed = useAppSelector(selectWelcomeDismissed)
 
-  // Which widget the preview shows. Driven by hover/focus; falls back to the
-  // default seed so the stage is never empty when the modal opens.
-  const [activePreviewType, setActivePreviewType] = useState<WidgetType | null>(
-    null,
-  )
-  const defaultPreviewType: WidgetType | undefined =
-    availableWidgets[0]?.type === 'welcome' && isWelcomeDismissed
-      ? availableWidgets[1]?.type
-      : availableWidgets[0]?.type
+  // Live hover/focus state. Lives in `widgetPickerSlice` per the renderer rule
+  // that modal/dialog state is slice-owned (not local useState). `null` means
+  // the preview falls through to the seed widget.
+  const activePreviewType = useAppSelector(selectActivePreviewType)
+  const seedPreviewType = resolveSeedPreviewType({
+    availableWidgets,
+    isWelcomeDismissed,
+  })
   const previewType: WidgetType =
-    activePreviewType ?? defaultPreviewType ?? 'welcome'
+    activePreviewType ?? seedPreviewType ?? 'welcome'
   const previewDefinition = getWidgetDefinition(previewType)
 
   // Radix moves focus into the dialog on open. Left to its default it grabs the
@@ -82,13 +83,35 @@ export const WidgetPicker = React.memo(function WidgetPicker({
   // initial focus onto the seed row so the focused row and the preview always
   // agree (and keyboard users land on the same widget the stage shows).
   const seedRowRef = useRef<HTMLButtonElement>(null)
+
+  // One-click-add must fire at most once per open: the close animation keeps the
+  // rows clickable for a frame, so a fast double-click could add the widget
+  // twice. Reset on the open edge (via `onOpenAutoFocus`) and gate every
+  // `handleAddWidget` call against it.
+  const hasAddedRef = useRef<boolean>(false)
+
   // Stable (refs never change identity) so the memoized DialogContent doesn't
-  // re-render on every keystroke-driven parent update.
-  const focusSeedRowOnOpen = useCallback((event: Event): void => {
+  // re-render on every keystroke-driven parent update. Fires once per open
+  // cycle when Radix mounts focus on DialogContent, so it doubles as our
+  // open-edge event for resetting the one-click-add guard.
+  const handleOpenAutoFocus = useCallback((event: Event): void => {
+    hasAddedRef.current = false
     if (!seedRowRef.current) return
     event.preventDefault()
     seedRowRef.current.focus()
   }, [])
+
+  // Wrap `onOpenChange` so the close transition (Esc, overlay click, X button,
+  // or our own `handleAddWidget`) drops the hover override before forwarding.
+  // The parent only opens via `setIsPickerOpen(true)` and routes every close
+  // through this callback, so this covers every close path.
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean): void => {
+      if (!nextOpen) dispatch(resetActivePreview())
+      onOpenChange(nextOpen)
+    },
+    [dispatch, onOpenChange],
+  )
   const previewBox = previewDefinition
     ? widgetPreviewSize(previewDefinition.defaultSize)
     : null
@@ -107,34 +130,22 @@ export const WidgetPicker = React.memo(function WidgetPicker({
     [previewType, previewDefinition],
   )
 
-  // One-click-add must fire at most once per open: the close animation keeps the
-  // rows clickable for a frame, so a fast double-click could add the widget
-  // twice. The dialog stays mounted between sessions (the parent only toggles
-  // `open`), so this ref would persist — reset it when the dialog re-opens.
-  // Comparing the previous `open` during render is React's no-effect way to
-  // respond to a prop transition.
-  const hasAddedRef = useRef<boolean>(false)
-  const wasOpenRef = useRef<boolean>(open)
-  if (open && !wasOpenRef.current) {
-    hasAddedRef.current = false
-  }
-  wasOpenRef.current = open
-
   // Not wrapped in useCallback: each row already creates a new arrow in
   // `.map()`, so memoizing this helper offers zero stability benefit and
   // the lint rule `no-deopt-use-callback` correctly flags that pattern.
+  // Routes through `handleOpenChange` so the close-edge cleanup runs.
   const handleAddWidget = (widgetType: WidgetType): void => {
     if (hasAddedRef.current) return
     hasAddedRef.current = true
     dispatch(addWidget({ type: widgetType }))
-    onOpenChange(false)
+    handleOpenChange(false)
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
         className="max-w-3xl max-h-[85vh] overflow-y-auto"
-        onOpenAutoFocus={focusSeedRowOnOpen}
+        onOpenAutoFocus={handleOpenAutoFocus}
       >
         <DialogHeader>
           <DialogTitle>Add Widget</DialogTitle>
@@ -153,8 +164,8 @@ export const WidgetPicker = React.memo(function WidgetPicker({
               const WidgetIcon = widgetDefinition.icon
               const isActive = widgetDefinition.type === previewType
               // The seed row receives the dialog's initial focus (see
-              // `focusSeedRowOnOpen`) so focus and preview start in agreement.
-              const isSeedRow = widgetDefinition.type === defaultPreviewType
+              // `handleOpenAutoFocus`) so focus and preview start in agreement.
+              const isSeedRow = widgetDefinition.type === seedPreviewType
               return (
                 <li key={widgetDefinition.type}>
                   <button
@@ -162,9 +173,11 @@ export const WidgetPicker = React.memo(function WidgetPicker({
                     ref={isSeedRow ? seedRowRef : undefined}
                     onClick={() => handleAddWidget(widgetDefinition.type)}
                     onMouseEnter={() =>
-                      setActivePreviewType(widgetDefinition.type)
+                      dispatch(setActivePreviewType(widgetDefinition.type))
                     }
-                    onFocus={() => setActivePreviewType(widgetDefinition.type)}
+                    onFocus={() =>
+                      dispatch(setActivePreviewType(widgetDefinition.type))
+                    }
                     aria-current={isActive ? 'true' : undefined}
                     className={cn(
                       `group w-full flex items-center gap-2.5 p-2 rounded-lg border

--- a/src/renderer/src/components/dashboard/WidgetShell.tsx
+++ b/src/renderer/src/components/dashboard/WidgetShell.tsx
@@ -14,6 +14,12 @@ import { WIDGET_DRAG_HANDLE_CLASS } from './utils/gridConstants'
 interface WidgetShellProps {
   instance: WidgetInstance
   definition: WidgetDefinition
+  /**
+   * Render the widget's resting state for a non-interactive preview (e.g. the
+   * WidgetPicker live preview): the drag handle and remove button are always
+   * hidden even while the dashboard is in edit mode. Defaults to false.
+   */
+  isPreview?: boolean
 }
 
 /**
@@ -23,6 +29,8 @@ interface WidgetShellProps {
  *  - Title bar with icon + label (the draggable handle in edit mode).
  *  - Remove button (visible only in edit mode, 44×44 hit area per HIG).
  *  - Body slot where the widget's `Component` renders.
+ *  - In preview mode (`isPreview`), edit chrome is suppressed so the picker
+ *    shows exactly what the widget looks like at rest on the canvas.
  *
  * Intentionally dumb — the shell doesn't know what the widget is for, only
  * how to frame it. This keeps per-widget files small and uniform.
@@ -30,11 +38,15 @@ interface WidgetShellProps {
 export const WidgetShell = React.memo(function WidgetShell({
   instance,
   definition,
+  isPreview = false,
 }: WidgetShellProps): React.ReactElement {
   const dispatch = useAppDispatch()
   const isEditMode = useAppSelector(selectIsEditMode)
   const Icon = definition.icon
   const Body = definition.Component
+  // Edit affordances are gated on this rather than `isEditMode` directly so a
+  // preview never shows the drag handle / remove button mid-edit-session.
+  const showEditChrome = isEditMode && !isPreview
 
   const handleRemove = (event: React.MouseEvent): void => {
     event.stopPropagation()
@@ -48,12 +60,12 @@ export const WidgetShell = React.memo(function WidgetShell({
       <div
         className={cn(
           'flex items-center gap-2 px-3 h-9 border-b border-border shrink-0 bg-card/50',
-          isEditMode
+          showEditChrome
             ? `${WIDGET_DRAG_HANDLE_CLASS} cursor-grab active:cursor-grabbing`
             : '',
         )}
       >
-        {isEditMode && (
+        {showEditChrome && (
           <GripVertical
             className="h-3.5 w-3.5 text-muted-foreground shrink-0"
             aria-hidden="true"
@@ -67,7 +79,7 @@ export const WidgetShell = React.memo(function WidgetShell({
 
         {/* Remove button: only in edit mode.
             `onMouseDown` stops RGL from starting a drag when the user clicks it. */}
-        {isEditMode && (
+        {showEditChrome && (
           <button
             type="button"
             onClick={handleRemove}

--- a/src/renderer/src/components/dashboard/utils/resolveSeedPreviewType.test.ts
+++ b/src/renderer/src/components/dashboard/utils/resolveSeedPreviewType.test.ts
@@ -1,0 +1,103 @@
+import { Activity } from 'lucide-react'
+import { describe, expect, it } from 'vitest'
+
+import type { WidgetDefinition } from '@/renderer/src/components/dashboard/types'
+
+import { resolveSeedPreviewType } from './resolveSeedPreviewType'
+
+// Minimal placeholder used everywhere a WidgetDefinition is required but the
+// fields beyond `type` are irrelevant to the helper under test.
+const PLACEHOLDER_DEFINITION = {
+  label: '',
+  description: '',
+  icon: Activity,
+  defaultSize: { w: 1, h: 1 },
+  minSize: { w: 1, h: 1 },
+  Component: () => null,
+} as const
+
+function makeDefinition(type: WidgetDefinition['type']): WidgetDefinition {
+  return { ...PLACEHOLDER_DEFINITION, type }
+}
+
+describe('resolveSeedPreviewType', () => {
+  it('seeds on Welcome when it is first and the user has not dismissed it', () => {
+    // Arrange
+    const availableWidgets = [
+      makeDefinition('welcome'),
+      makeDefinition('stats'),
+    ]
+
+    // Act
+    const seed = resolveSeedPreviewType({
+      availableWidgets,
+      isWelcomeDismissed: false,
+    })
+
+    // Assert
+    expect(seed).toBe('welcome')
+  })
+
+  it('seeds on the next widget when Welcome is first but already dismissed', () => {
+    // Arrange
+    const availableWidgets = [
+      makeDefinition('welcome'),
+      makeDefinition('stats'),
+    ]
+
+    // Act
+    const seed = resolveSeedPreviewType({
+      availableWidgets,
+      isWelcomeDismissed: true,
+    })
+
+    // Assert
+    expect(seed).toBe('stats')
+  })
+
+  it('seeds on the first widget when Welcome is not at the head of the list', () => {
+    // Arrange — feature flag could reorder; the fallthrough rule only triggers
+    // when Welcome is literally first.
+    const availableWidgets = [
+      makeDefinition('stats'),
+      makeDefinition('welcome'),
+    ]
+
+    // Act
+    const seed = resolveSeedPreviewType({
+      availableWidgets,
+      isWelcomeDismissed: true,
+    })
+
+    // Assert
+    expect(seed).toBe('stats')
+  })
+
+  it('returns undefined when the catalog is empty', () => {
+    // Arrange
+    const availableWidgets: readonly WidgetDefinition[] = []
+
+    // Act
+    const seed = resolveSeedPreviewType({
+      availableWidgets,
+      isWelcomeDismissed: false,
+    })
+
+    // Assert
+    expect(seed).toBeUndefined()
+  })
+
+  it('returns undefined when Welcome is dismissed and there is no second widget', () => {
+    // Arrange
+    const availableWidgets = [makeDefinition('welcome')]
+
+    // Act
+    const seed = resolveSeedPreviewType({
+      availableWidgets,
+      isWelcomeDismissed: true,
+    })
+
+    // Assert
+    expect(seed).toBeUndefined()
+  })
+})

--- a/src/renderer/src/components/dashboard/utils/resolveSeedPreviewType.ts
+++ b/src/renderer/src/components/dashboard/utils/resolveSeedPreviewType.ts
@@ -1,0 +1,41 @@
+import type {
+  WidgetDefinition,
+  WidgetType,
+} from '@/renderer/src/components/dashboard/types'
+
+/**
+ * Pick which widget the live-preview stage should show by default — the seed.
+ * Welcome is first in the catalog, but once dismissed its body renders only a
+ * muted "already dismissed" hint (global flag, not per-instance). That makes a
+ * poor first frame, so returning users seed on the next widget. Welcome stays
+ * in the list and still previews truthfully when hovered.
+ *
+ * Pulled out of `WidgetPicker` so it's unit-testable without React Testing
+ * Library, per the renderer convention for conditional UI logic.
+ *
+ * @param availableWidgets - Visible picker rows (post feature-flag filter).
+ * @param isWelcomeDismissed - Whether the user has already dismissed Welcome.
+ * @returns The widget type to seed the stage with, or `undefined` when the
+ *   catalog is empty (caller falls back to `'welcome'`).
+ * @example
+ * resolveSeedPreviewType({
+ *   availableWidgets: [{ type: 'welcome', ... }, { type: 'stats', ... }],
+ *   isWelcomeDismissed: true,
+ * }) // => 'stats'
+ * resolveSeedPreviewType({
+ *   availableWidgets: [{ type: 'welcome', ... }, { type: 'stats', ... }],
+ *   isWelcomeDismissed: false,
+ * }) // => 'welcome'
+ */
+export function resolveSeedPreviewType({
+  availableWidgets,
+  isWelcomeDismissed,
+}: {
+  availableWidgets: readonly WidgetDefinition[]
+  isWelcomeDismissed: boolean
+}): WidgetType | undefined {
+  if (availableWidgets[0]?.type === 'welcome' && isWelcomeDismissed) {
+    return availableWidgets[1]?.type
+  }
+  return availableWidgets[0]?.type
+}

--- a/src/renderer/src/components/dashboard/utils/widgetPreviewSize.test.ts
+++ b/src/renderer/src/components/dashboard/utils/widgetPreviewSize.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import type { WidgetSize } from '@/renderer/src/components/dashboard/types'
+
+import { widgetPreviewSize } from './widgetPreviewSize'
+
+describe('widgetPreviewSize', () => {
+  it('sizes a default 3x2 widget to a wide preview box', () => {
+    // Arrange
+    const defaultSize: WidgetSize = { w: 3, h: 2 }
+
+    // Act
+    const box = widgetPreviewSize(defaultSize)
+
+    // Assert
+    expect(box).toEqual({ widthPx: 208, heightPx: 136 })
+  })
+
+  it('sizes a full-width 6x3 widget to a large preview box', () => {
+    // Arrange
+    const defaultSize: WidgetSize = { w: 6, h: 3 }
+
+    // Act
+    const box = widgetPreviewSize(defaultSize)
+
+    // Assert
+    expect(box).toEqual({ widthPx: 424, heightPx: 208 })
+  })
+
+  it('sizes a single 1x1 cell with no inter-cell margin', () => {
+    // Arrange
+    const defaultSize: WidgetSize = { w: 1, h: 1 }
+
+    // Act
+    const box = widgetPreviewSize(defaultSize)
+
+    // Assert
+    expect(box).toEqual({ widthPx: 64, heightPx: 64 })
+  })
+})

--- a/src/renderer/src/components/dashboard/utils/widgetPreviewSize.ts
+++ b/src/renderer/src/components/dashboard/utils/widgetPreviewSize.ts
@@ -1,0 +1,32 @@
+import type { WidgetSize } from '@/renderer/src/components/dashboard/types'
+import {
+  GRID_MARGIN_PX,
+  GRID_ROW_HEIGHT_PX,
+} from '@/renderer/src/components/dashboard/utils/gridConstants'
+
+/**
+ * Pixel dimensions for rendering a widget at its default grid footprint inside
+ * a static preview (the WidgetPicker live preview), so wide widgets look wide
+ * and compact ones look compact instead of all filling one generic box.
+ *
+ * Uses a square reference cell (`GRID_ROW_HEIGHT_PX`) for column width because
+ * the dashboard's column width ≈ its row height at the detail pane's typical
+ * width — that approximation keeps each widget's relative aspect ratio faithful
+ * without needing the live grid container width here.
+ *
+ * @param size - A widget's `defaultSize` in 6-col grid cells (`{ w, h }`).
+ * @returns Pixel box `{ widthPx, heightPx }`, inter-cell margins included.
+ * @example
+ * widgetPreviewSize({ w: 3, h: 2 }) // => { widthPx: 208, heightPx: 136 }
+ * widgetPreviewSize({ w: 6, h: 3 }) // => { widthPx: 424, heightPx: 208 }
+ */
+export function widgetPreviewSize(size: WidgetSize): {
+  widthPx: number
+  heightPx: number
+} {
+  const [marginPx] = GRID_MARGIN_PX
+  // n cells span n row-heights plus the (n-1) margins between them.
+  const cellSpanPx = (cells: number): number =>
+    cells * GRID_ROW_HEIGHT_PX + (cells - 1) * marginPx
+  return { widthPx: cellSpanPx(size.w), heightPx: cellSpanPx(size.h) }
+}

--- a/src/renderer/src/redux/slices/marketplaceSlice.test.ts
+++ b/src/renderer/src/redux/slices/marketplaceSlice.test.ts
@@ -327,4 +327,56 @@ describe('marketplaceSlice', () => {
     expect(lb?.error).toBe('Offline')
     expect(lb?.skills).toEqual([])
   })
+
+  it('loadLeaderboard fires a single fetch when two mounts request the same filter at once', async () => {
+    // Arrange: keep the first request in flight so the second sees it pending
+    let resolve!: (value: SkillSearchResult[]) => void
+    mockLeaderboard.mockReturnValue(
+      new Promise<SkillSearchResult[]>((r) => {
+        resolve = r
+      }),
+    )
+    const store = await createTestStore()
+    const { loadLeaderboard } = await import('./marketplaceSlice')
+
+    // Act: two widgets (e.g. Trending + What's New) dispatch the same filter
+    const first = store.dispatch(loadLeaderboard('trending'))
+    const second = store.dispatch(loadLeaderboard('trending'))
+
+    // Assert: the second is short-circuited by `condition` — only one IPC call
+    expect(mockLeaderboard).toHaveBeenCalledTimes(1)
+
+    resolve([sampleResult])
+    await Promise.all([first, second])
+  })
+
+  it('loadLeaderboard keeps already-loaded skills visible while refreshing', async () => {
+    // Arrange: first fetch populates the cache
+    mockLeaderboard.mockResolvedValueOnce([sampleResult])
+    const store = await createTestStore()
+    const { loadLeaderboard } = await import('./marketplaceSlice')
+    await store.dispatch(loadLeaderboard('trending'))
+
+    // Expire the cache so the next dispatch actually refetches
+    vi.useFakeTimers()
+    vi.setSystemTime(Date.now() + 31 * 60 * 1000)
+
+    // Act: a refresh starts but has not resolved yet
+    let resolve!: (value: SkillSearchResult[]) => void
+    mockLeaderboard.mockReturnValueOnce(
+      new Promise<SkillSearchResult[]>((r) => {
+        resolve = r
+      }),
+    )
+    const refresh = store.dispatch(loadLeaderboard('trending'))
+
+    // Assert: status is loading, but the stale skill is still on screen
+    const lb = store.getState().marketplace.leaderboard['trending']
+    expect(lb?.status).toBe('loading')
+    expect(lb?.skills).toHaveLength(1)
+
+    resolve([sampleResult])
+    await refresh
+    vi.useRealTimers()
+  })
 })

--- a/src/renderer/src/redux/slices/marketplaceSlice.test.ts
+++ b/src/renderer/src/redux/slices/marketplaceSlice.test.ts
@@ -357,26 +357,31 @@ describe('marketplaceSlice', () => {
     const { loadLeaderboard } = await import('./marketplaceSlice')
     await store.dispatch(loadLeaderboard('trending'))
 
-    // Expire the cache so the next dispatch actually refetches
+    // Expire the cache so the next dispatch actually refetches.
+    // try/finally guarantees real timers are restored even if an assertion
+    // throws — otherwise fake timers would leak into the next test.
     vi.useFakeTimers()
-    vi.setSystemTime(Date.now() + 31 * 60 * 1000)
+    try {
+      vi.setSystemTime(Date.now() + 31 * 60 * 1000)
 
-    // Act: a refresh starts but has not resolved yet
-    let resolve!: (value: SkillSearchResult[]) => void
-    mockLeaderboard.mockReturnValueOnce(
-      new Promise<SkillSearchResult[]>((r) => {
-        resolve = r
-      }),
-    )
-    const refresh = store.dispatch(loadLeaderboard('trending'))
+      // Act: a refresh starts but has not resolved yet
+      let resolve!: (value: SkillSearchResult[]) => void
+      mockLeaderboard.mockReturnValueOnce(
+        new Promise<SkillSearchResult[]>((r) => {
+          resolve = r
+        }),
+      )
+      const refresh = store.dispatch(loadLeaderboard('trending'))
 
-    // Assert: status is loading, but the stale skill is still on screen
-    const lb = store.getState().marketplace.leaderboard['trending']
-    expect(lb?.status).toBe('loading')
-    expect(lb?.skills).toHaveLength(1)
+      // Assert: status is loading, but the stale skill is still on screen
+      const lb = store.getState().marketplace.leaderboard['trending']
+      expect(lb?.status).toBe('loading')
+      expect(lb?.skills).toHaveLength(1)
 
-    resolve([sampleResult])
-    await refresh
-    vi.useRealTimers()
+      resolve([sampleResult])
+      await refresh
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/src/renderer/src/redux/slices/marketplaceSlice.ts
+++ b/src/renderer/src/redux/slices/marketplaceSlice.ts
@@ -81,30 +81,46 @@ export const installSkill = createAsyncThunk(
 
 /**
  * Fetch leaderboard data from skills.sh for a ranking filter.
- * Respects per-filter cache TTL: skips fetch if cached data is fresh.
+ *
+ * The `condition` gate runs before `pending` and aborts the thunk (dispatching
+ * nothing) when a fetch for this filter is already in flight or the cached data
+ * is still within its TTL. That bounds the work to one network call per filter
+ * even when several widgets mount at once — Trending and What's New both render
+ * `LeaderboardWidget`, so each fires this on mount.
  * @param filter - Ranking filter ('all-time' | 'trending' | 'hot')
- * @returns Skills array and filter, or null if cache is fresh
+ * @returns Skills array and the filter they belong to.
+ * @example
+ * dispatch(loadLeaderboard('trending')) // => { skills: [...], filter: 'trending' }
  */
 export const loadLeaderboard = createAsyncThunk(
   'marketplace/loadLeaderboard',
   async (
     filter: RankingFilter,
-    { getState },
-  ): Promise<{ skills: SkillSearchResult[]; filter: RankingFilter } | null> => {
-    const state = (getState() as { marketplace: MarketplaceState }).marketplace
-    const cached = state.leaderboard[filter]
-
-    // Skip fetch if cache is fresh
-    if (
-      cached &&
-      cached.status !== 'error' &&
-      Date.now() - cached.lastFetched < CACHE_TTL_MS
-    ) {
-      return null
-    }
-
+  ): Promise<{ skills: SkillSearchResult[]; filter: RankingFilter }> => {
     const skills = await window.electron.marketplace.leaderboard({ filter })
     return { skills, filter }
+  },
+  {
+    // Runs synchronously before `pending`; returning false aborts the thunk and
+    // (with dispatchConditionRejection:false) dispatches no actions at all.
+    condition: (filter: RankingFilter, { getState }) => {
+      const cached = (getState() as { marketplace: MarketplaceState })
+        .marketplace.leaderboard[filter]
+      // A fetch for this filter is already running — let it win, don't refetch.
+      if (cached?.status === 'loading') {
+        return false
+      }
+      // Cached data is still fresh — skip the network entirely.
+      if (
+        cached &&
+        cached.status !== 'error' &&
+        Date.now() - cached.lastFetched < CACHE_TTL_MS
+      ) {
+        return false
+      }
+      return true
+    },
+    dispatchConditionRejection: false,
   },
 )
 
@@ -187,19 +203,16 @@ const marketplaceSlice = createSlice({
       .addCase(loadLeaderboard.pending, (state, action) => {
         const filter = action.meta.arg
         const existing = state.leaderboard[filter]
-        // Only show loading if no cached data exists yet
-        if (!existing || existing.skills.length === 0) {
-          state.leaderboard[filter] = {
-            skills: [],
-            lastFetched: 0,
-            filter,
-            status: 'loading',
-          }
+        // Mark loading but keep any already-loaded skills on screen, so a
+        // background refresh of a populated tab doesn't flash an empty skeleton.
+        state.leaderboard[filter] = {
+          skills: existing?.skills ?? [],
+          lastFetched: existing?.lastFetched ?? 0,
+          filter,
+          status: 'loading',
         }
       })
       .addCase(loadLeaderboard.fulfilled, (state, action) => {
-        // null means cache was fresh, no update needed
-        if (action.payload === null) return
         const { skills, filter } = action.payload
         state.leaderboard[filter] = {
           skills,

--- a/src/renderer/src/redux/slices/widgetPickerSlice.test.ts
+++ b/src/renderer/src/redux/slices/widgetPickerSlice.test.ts
@@ -1,0 +1,66 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { describe, expect, it } from 'vitest'
+
+// Dynamic import per dashboardSlice.test.ts convention — keeps the slice out
+// of the module graph until each test needs it and yields a pristine reducer.
+async function createTestStore() {
+  const { default: widgetPickerReducer } = await import('./widgetPickerSlice')
+  return configureStore({ reducer: { widgetPicker: widgetPickerReducer } })
+}
+
+describe('widgetPickerSlice', () => {
+  describe('initial state', () => {
+    it('starts with no active preview override', async () => {
+      // Arrange / Act
+      const store = await createTestStore()
+
+      // Assert
+      expect(store.getState().widgetPicker.activePreviewType).toBeNull()
+    })
+  })
+
+  describe('setActivePreviewType', () => {
+    it('records the hovered widget so the preview stage can swap', async () => {
+      // Arrange
+      const { setActivePreviewType } = await import('./widgetPickerSlice')
+      const store = await createTestStore()
+
+      // Act
+      store.dispatch(setActivePreviewType('agent-heatmap'))
+
+      // Assert
+      expect(store.getState().widgetPicker.activePreviewType).toBe(
+        'agent-heatmap',
+      )
+    })
+
+    it('clears the override when dispatched with null', async () => {
+      // Arrange
+      const { setActivePreviewType } = await import('./widgetPickerSlice')
+      const store = await createTestStore()
+      store.dispatch(setActivePreviewType('trending'))
+
+      // Act
+      store.dispatch(setActivePreviewType(null))
+
+      // Assert
+      expect(store.getState().widgetPicker.activePreviewType).toBeNull()
+    })
+  })
+
+  describe('resetActivePreview', () => {
+    it('drops a previous hover so the next open starts on the seed widget', async () => {
+      // Arrange
+      const { setActivePreviewType, resetActivePreview } =
+        await import('./widgetPickerSlice')
+      const store = await createTestStore()
+      store.dispatch(setActivePreviewType('whats-new'))
+
+      // Act
+      store.dispatch(resetActivePreview())
+
+      // Assert
+      expect(store.getState().widgetPicker.activePreviewType).toBeNull()
+    })
+  })
+})

--- a/src/renderer/src/redux/slices/widgetPickerSlice.ts
+++ b/src/renderer/src/redux/slices/widgetPickerSlice.ts
@@ -1,0 +1,60 @@
+import type { PayloadAction } from '@reduxjs/toolkit'
+import { createSlice } from '@reduxjs/toolkit'
+
+import type { WidgetType } from '@/renderer/src/components/dashboard/types'
+import type { RootState } from '@/renderer/src/redux/store'
+
+/**
+ * Picker-only ephemeral state. Lives in Redux per the renderer convention that
+ * modal/dialog state is slice-owned, but is intentionally absent from the
+ * persistence list — a hover-driven preview type shouldn't survive an app
+ * restart. Read by `WidgetPicker` only.
+ */
+interface WidgetPickerState {
+  /**
+   * Widget the live-preview stage currently shows, or `null` to fall through
+   * to the seed widget. Updated on row hover / keyboard focus, cleared on
+   * picker close.
+   */
+  activePreviewType: WidgetType | null
+}
+
+const initialState: WidgetPickerState = {
+  activePreviewType: null,
+}
+
+const widgetPickerSlice = createSlice({
+  name: 'widgetPicker',
+  initialState,
+  reducers: {
+    /**
+     * Set the previewed widget. Called from `WidgetPicker` row onMouseEnter /
+     * onFocus. `null` releases the override so the seed widget takes over.
+     */
+    setActivePreviewType: (state, action: PayloadAction<WidgetType | null>) => {
+      state.activePreviewType = action.payload
+    },
+    /**
+     * Clear the override on picker close — next open starts on the seed
+     * widget instead of the last-hovered one. Dispatched from `WidgetPicker`
+     * on the open→closed transition.
+     */
+    resetActivePreview: (state) => {
+      state.activePreviewType = null
+    },
+  },
+})
+
+export const { setActivePreviewType, resetActivePreview } =
+  widgetPickerSlice.actions
+export default widgetPickerSlice.reducer
+
+/**
+ * Currently-previewed widget type, or `null` when no row is being hovered /
+ * focused (caller falls through to the seed widget).
+ * @example
+ * const activePreviewType = useAppSelector(selectActivePreviewType)
+ * // 'agent-heatmap' | null
+ */
+export const selectActivePreviewType = (state: RootState): WidgetType | null =>
+  state.widgetPicker.activePreviewType

--- a/src/renderer/src/redux/store.ts
+++ b/src/renderer/src/redux/store.ts
@@ -15,6 +15,7 @@ import skillsReducer from './slices/skillsSlice'
 import themeReducer from './slices/themeSlice'
 import uiReducer from './slices/uiSlice'
 import updateReducer from './slices/updateSlice'
+import widgetPickerReducer from './slices/widgetPickerSlice'
 
 const rootReducer = combineReducers({
   theme: themeReducer,
@@ -25,6 +26,9 @@ const rootReducer = combineReducers({
   update: updateReducer,
   marketplace: marketplaceReducer,
   dashboard: dashboardReducer,
+  // Picker hover/focus preview state. Intentionally NOT persisted — last-hovered
+  // widget shouldn't survive an app restart.
+  widgetPicker: widgetPickerReducer,
   // Mirrors main-process settings.json. Intentionally NOT listed in
   // the redux-storage-middleware `slices` array — persistence is owned
   // by main, so layering localStorage here would create a dual-write race.


### PR DESCRIPTION
## Summary

Rebuild the **Add Widget** picker into a list + **live preview** pane: the right side renders the real widget body on a neutral stage at its default aspect ratio, so users see exactly what they're adding before clicking. One-click-add wires straight through to `addWidget`; the reducer finds the first empty slot (auto-creating a page if the current one is full).

## What changed

### `WidgetPicker.tsx` — full rebuild
- **Left** list of every visible widget (filtered by `ENABLE_DASHBOARD_EXPERIMENTAL`).
- **Right** stage clones the real `WidgetShell` body at the widget's default `{w,h}` aspect ratio (`widgetPreviewSize` util), with `inert` removing the cloned subtree from tab order, the a11y tree, and pointer events so its buttons/links are inert.
- **Seed behavior**: Welcome stays in the list, but for returning users (`welcomeDismissed`) the open-default preview falls through to the next widget so the stage isn't a muted "already dismissed" hint. The dialog's `onOpenAutoFocus` is redirected to the seed row so focus and preview always agree.
- **One-click-add guard**: a `hasAddedRef` prevents a fast double-click during the close animation from dispatching `addWidget` twice. The dialog stays mounted between sessions (parent only toggles `open`), so the guard is reset on `open` rising-edge via the "compare prev open during render" no-effect pattern.

### `WidgetShell.tsx`
- New `isPreview` prop gates edit chrome (remove/resize) so the staged clone doesn't show edit affordances even in edit mode.

### `marketplaceSlice.ts` — `loadLeaderboard` dedup
- Added `createAsyncThunk` `condition` gate + `dispatchConditionRejection: false`: aborts the thunk (dispatches no actions) when a fetch for this filter is in-flight or cached data is within TTL. Trending and What's New both render `LeaderboardWidget` — adding the live preview compounded the fan-out and the duplicate fetch became visible.

### New utility — `widgetPreviewSize.ts`
- Pure cell→px conversion using `GRID_ROW_HEIGHT_PX` + `GRID_MARGIN_PX`. One util per file, with `@example`. Sized the stage so the preview matches the widget's real default geometry.

### `DialogContent`
- `max-h-[85vh] overflow-y-auto` so the live stage can't push the picker off-screen on short viewports.

## Tests

- `widgetPreviewSize.test.ts` — 3 unit tests covering 1×1, 3×2, 6×3.
- `WidgetPicker.browser.test.tsx` — **5** browser-mode tests (Chromium lane) covering: first-widget preview, seed-on-next-widget when Welcome dismissed, hover swap, click→add+close, keyboard-focus swap.
- `marketplaceSlice.test.ts` — regression tests for dedup + stale-while-revalidate.

## Quality gate

`pnpm validate` ✅ (lint / test / typecheck / dead-code) — 89 files, 1152 tests passing including the browser lane.

## Review trail

- `/review` Fix-First: 4 informational items applied (`inert` wrapper comment accuracy, `loadLeaderboard` dedup + tests, dialog `max-h-[85vh]`, one-click-add guard).
- `/simplify`: removed redundant `<div inert>` wrapper around `<WidgetShell>` since `WidgetShell`'s root is already `h-full w-full`; `inert` moved up to the styled aspect-ratio div. One fewer DOM layer, identical behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ウィジェット追加モーダルを一覧＋ライブプレビューに刷新。ホバー／キーボードで即時プレビュー切替、プレビューは編集操作（ドラッグ・削除）を非表示化。

* **Bug Fixes**
  * リーダーボードの重複リクエスト抑制とキャッシュ挙動を改善。読み込み中も既存データを表示して空表示を防止。

* **Tests**
  * ウィジェットピッカー、プレビューサイズ、初期プレビュー選定ロジック等の自動テストを追加。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/skills-desktop/pull/184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->