### PR TITLE
Fix symlink cleanup identity and deletion safety

### DIFF
--- a/.storybook/storybook-utils.tsx
+++ b/.storybook/storybook-utils.tsx
@@ -436,12 +436,24 @@ export function installStorybookElectronMock(): void {
       createSymlinks: async () => createSymlinksResult,
       copyToAgents: async () => ({ success: true, copied: 1, failures: [] }),
       deleteSkills: async () => deleteResult,
-      clearOrphanSymlinks: async () => ({ items: [] }),
-      clearBrokenSymlinkSlots: async () => ({
-        items: unlinkResult.items.map((item) => ({
-          ...item,
-          agentId: 'cursor',
-          linkPath: '/Users/test/.cursor/skills/story-skill',
+      clearOrphanSymlinks: async (options) => ({
+        // Echo the requested rows 1:1 so stories reflect exactly what was
+        // selected, preserving skill identity and order.
+        items: options.items.map((item) => ({
+          skillName: item.skillName,
+          outcome: 'orphan-cleared' as const,
+          symlinksRemoved: item.agents.length,
+          cascadeAgents: item.agents.map((agent) => agent.agentId),
+        })),
+      }),
+      clearBrokenSymlinkSlots: async (options) => ({
+        // Echo each requested slot 1:1, keeping the caller's agent + link path
+        // instead of substituting a hardcoded fixture.
+        items: options.items.map((item) => ({
+          agentId: item.agentId,
+          skillName: item.linkName,
+          linkPath: item.linkPath,
+          outcome: 'unlinked' as const,
         })),
       }),
       unlinkManyFromAgent: async () => unlinkResult,

--- a/.storybook/storybook-utils.tsx
+++ b/.storybook/storybook-utils.tsx
@@ -436,6 +436,14 @@ export function installStorybookElectronMock(): void {
       createSymlinks: async () => createSymlinksResult,
       copyToAgents: async () => ({ success: true, copied: 1, failures: [] }),
       deleteSkills: async () => deleteResult,
+      clearOrphanSymlinks: async () => ({ items: [] }),
+      clearBrokenSymlinkSlots: async () => ({
+        items: unlinkResult.items.map((item) => ({
+          ...item,
+          agentId: 'cursor',
+          linkPath: '/Users/test/.cursor/skills/story-skill',
+        })),
+      }),
       unlinkManyFromAgent: async () => unlinkResult,
       restoreDeletedSkill: async () => restoreResult,
       onDeleteProgress: () => cleanup,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ PRs are ready to ship only when `validate` and e2e both pass in that order.
 | --------- | -------------------- | -------------------------------------------------------------- |
 | Skill     | `~/.agents/skills/`  | Directory with SKILL.md                                        |
 | Agent     | `~/.<agent>/skills/` | AI agents (count = `AGENT_DEFINITIONS.length` in `src/shared/constants.ts`) |
-| Symlink   | Agent→Skill          | `valid` / `broken` / `missing`                                 |
+| Symlink   | Agent→Skill          | `valid` / `broken` / `inaccessible` / `missing`                  |
 | Universal | `~/.agents/skills/`  | 13 agents share this source dir (see `UNIVERSAL_AGENT_IDS` in `src/shared/constants.ts`) |
 
 ### Skills CLI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,3 +135,33 @@ typography, spacing, radius, elevation, motion, component styling,
 accessibility, responsive behavior, and visual-polish guardrails. Keep design
 guidance there so agents and design tools have one place to read before
 changing UI.
+
+## Design Review Principles
+
+When running `/design-review` (or any visual critique), apply two standing
+principles **in addition to** DESIGN.md compliance:
+
+### 1. Benchmark against top-tier apps
+
+Don't grade UI only by "does it match DESIGN.md" — grade it against the bar set
+by best-in-class products: **Linear, Notion, Dia (The Browser Company), the
+Codex desktop app**, and peers (Warp, Raycast, VS Code). For every finding ask:
+*how would Linear / Notion / Dia / Codex handle this?* Surface where the app
+falls short of that bar, not just where it breaks a written rule. The goal is
+parity with top-tier craft, not mere rule-compliance.
+
+### 2. DESIGN.md is a living document — refine it, don't just obey it
+
+Using "DESIGN.md compliance" as the quality baseline only works if DESIGN.md
+actually encodes the rules needed for excellent UI/UX. It is almost certainly
+still incomplete. So a design review is **also an audit of DESIGN.md itself**:
+
+- When the top-tier benchmark (principle 1) surfaces a quality gap that DESIGN.md
+  has no rule for, that gap is a **DESIGN.md deficiency**, not just a one-off fix.
+- Propose the missing rule and fold it into DESIGN.md so the next review inherits
+  it.
+- Expanding/refining DESIGN.md is an expected, recurring part of the
+  design-review workflow — not a separate task.
+
+DESIGN.md stays the binding visual source of truth; these two principles are how
+it earns and keeps that authority.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -250,6 +250,19 @@ Rules:
   spatial placement.
 - Hover should clarify clickability through tint, not depth.
 - Selected rows need stronger contrast than hover rows.
+- Row and card corner actions follow a visibility asymmetry by intent — match
+  the affordance to whether the action helps or harms:
+  - Destructive actions (delete, unlink) stay hover/focus-revealed
+    (`opacity-0 group-hover:opacity-100 focus-visible:opacity-100`). They must
+    not advertise themselves at rest; a quiet corner avoids accidental clicks
+    and visual noise. (Linear, Finder, VS Code, GitHub issue rows.)
+  - Non-destructive value-add actions (bookmark, pin, copy) keep a quiet
+    always-visible rest state (`opacity-40`) that lifts to full on hover/focus.
+    For an action the user benefits from finding, discoverability outranks
+    restraint — hidden-until-hover hurts it. (Notion, GitHub favorite/star.)
+  - Reserve overlay space with padding so revealing a corner action never
+    shifts the row's content (zero-layout-shift); align overlays to the title
+    row, not the card's raw top edge.
 
 ### Cards and Widgets
 
@@ -302,6 +315,18 @@ finger-target minimum does not apply. The floor is WCAG 2.5.8 AA: 24x24 CSS px
   never over a row that is itself clickable: `opacity-0` controls stay
   pointer-active, so the halo would steal corner clicks meant for the row.
 - Do not shrink destructive or confirmation controls below the 24px floor.
+
+Quiet resting affordances:
+
+When a non-destructive action uses a muted always-visible rest state (see Lists
+and Rows), the resting treatment must not become an accessibility gap.
+
+- Keep the resting opacity high enough that the control never reads as disabled;
+  `opacity-40` is the practical floor for a muted-but-discoverable icon.
+- Restore full strength on BOTH hover and `focus-visible` — never hover alone.
+- The keyboard path must surface the control at full contrast (visible focus
+  ring plus full-opacity glyph), so a muted rest state is never the only way a
+  keyboard or low-vision user perceives the action.
 
 ## Responsive and Window Behavior
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Download the latest release from [GitHub Releases](https://github.com/laststance
 ### Prerequisites
 
 - Node.js 20+
-- pnpm 9+
+- pnpm 10+
 
 ### Setup
 
@@ -103,7 +103,7 @@ APPLE_KEYCHAIN_PROFILE=skills-desktop pnpm build:mac
 
 | Component | Technology                                           |
 | --------- | ---------------------------------------------------- |
-| Framework | Electron 41                                          |
+| Framework | Electron 42                                          |
 | Frontend  | React 19 + TypeScript                                |
 | State     | Redux Toolkit + @laststance/redux-storage-middleware |
 | Styling   | Tailwind CSS + shadcn/ui                             |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Skills Desktop provides a GUI to manage and monitor skills installed via [`npx s
 ## Features
 
 - **54 AI Agents Supported** - Auto-detects Claude Code, Cursor, Codex, Gemini CLI, and more
-- **Symlink Status Visualization** - Valid (✓), Broken (◐), Missing (○) indicators
+- **Symlink Status Visualization** - Valid (✓), Broken (◐), Inaccessible (!), Missing (○) indicators
 - **44 Themes** - 34 OKLCH color themes (17 hues × light/dark) + 2 pure neutral + 8 tinted neutral
 - **Auto Update** - Automatic updates via GitHub Releases
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -123,7 +123,7 @@ Agent definitions are synced with [vercel-labs/skills CLI](https://github.com/ve
 - [x] Auto-detect installed AI agents (54 agents)
 - [x] List all installed skills with metadata
 - [x] Show symlink status per skill per agent
-- [x] Validate symlink integrity (valid/broken/missing)
+- [x] Validate symlink integrity (valid/broken/inaccessible/missing)
 - [x] Local skills support with visual distinction
 
 ### Skills Marketplace
@@ -137,11 +137,12 @@ GUI wrapper for `npx skills` CLI commands:
 
 ### Symlink Status
 
-| Status  | Symbol | Color           | Description                               |
-| ------- | ------ | --------------- | ----------------------------------------- |
-| Valid   | `✓`    | Cyan (#22D3EE)  | Symlink exists and points to valid target |
-| Broken  | `◐`    | Amber (#F59E0B) | Symlink exists but target is missing      |
-| Missing | `○`    | Gray (#475569)  | No symlink for this agent                 |
+| Status       | Symbol | Color           | Description                               |
+| ------------ | ------ | --------------- | ----------------------------------------- |
+| Valid        | `✓`    | Cyan (#22D3EE)  | Symlink exists and points to valid target |
+| Broken       | `◐`    | Amber (#F59E0B) | Symlink exists but target is missing      |
+| Inaccessible | `!`    | Red (#EF4444)   | Symlink target could not be probed safely |
+| Missing      | `○`    | Gray (#475569)  | No symlink for this agent                 |
 
 **Orphan skill** is a separate concept layered on top of these states: a
 skill record whose source directory under `~/.agents/skills/` was deleted
@@ -182,14 +183,14 @@ interface Agent {
 
 ### Skill Types
 
-Skills fall into two categories based on their installation path. The distinction drives deletion UX (irreversible CLI remove vs trash-with-undo):
+Skills fall into two categories based on their installation path. Both in-app delete paths require reviewed filesystem identity and move the selected source/local folder to the app trash with a 15-second undo window:
 
-| Type        | Installation                   | Lock file tracked                  | Uninstall path                      |
+| Type        | Installation                   | Lock file tracked                  | In-app delete path                  |
 | ----------- | ------------------------------ | ---------------------------------- | ----------------------------------- |
-| CLI-managed | `npx skills add <owner/repo>`  | Yes (`~/.agents/.skill-lock.json`) | `npx skills remove` (irreversible)  |
+| CLI-managed | `npx skills add <owner/repo>`  | Yes (`~/.agents/.skill-lock.json`) | Move to app trash (undo within 15s) |
 | Plain       | Created directly in skills dir | No                                 | Move to app trash (undo within 15s) |
 
-The app detects CLI-managed skills by the `source` field on the Skill record (populated during scan from the lock file). The in-app delete button and bulk-delete flow route each skill through the matching path.
+The app detects CLI-managed skills by the `source` field on the Skill record (populated during scan from the lock file). The in-app delete button and bulk-delete flow route both CLI-managed and plain skills through reviewed app-trash deletion; CLI uninstall hints are used only in Marketplace install/uninstall copy.
 
 ### Orphan Skill Cleanup
 
@@ -228,14 +229,14 @@ Each skill displays:
 
 ### Actions
 
-| Action                 | Status  | Notes                                                                                                                                          |
-| ---------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| View skill details     | ✅ Done | -                                                                                                                                              |
-| View symlink status    | ✅ Done | -                                                                                                                                              |
-| Search skills          | ✅ Done | Marketplace tab                                                                                                                                |
-| Install skill          | ✅ Done | With agent selection                                                                                                                           |
-| Uninstall skill        | ✅ Done | Delete button and bulk-delete route CLI-managed skills through `npx skills remove` (irreversible, no undo); plain skills go to trash with undo |
-| Repair broken symlinks | ✅ Done | Dashboard Symlink Health cleanup reviews and removes safe orphan/broken symlink issues without deleting live source skills                     |
+| Action                 | Status  | Notes                                                                                                                                                 |
+| ---------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| View skill details     | ✅ Done | -                                                                                                                                                     |
+| View symlink status    | ✅ Done | -                                                                                                                                                     |
+| Search skills          | ✅ Done | Marketplace tab                                                                                                                                       |
+| Install skill          | ✅ Done | With agent selection                                                                                                                                  |
+| Uninstall skill        | ✅ Done | Delete button and bulk-delete move reviewed CLI-managed/plain skills to app trash with undo; Marketplace hints still use `npx skills remove --global` |
+| Repair broken symlinks | ✅ Done | Dashboard Symlink Health cleanup reviews and removes safe orphan/broken symlink issues without deleting live source skills                            |
 
 ## Tech Stack
 
@@ -515,7 +516,7 @@ interface SymlinkInfo {
   isLocal: boolean
 }
 
-type SymlinkStatus = 'valid' | 'broken' | 'missing'
+type SymlinkStatus = 'valid' | 'broken' | 'inaccessible' | 'missing'
 
 interface SourceStats {
   path: string

--- a/SPEC.md
+++ b/SPEC.md
@@ -213,6 +213,7 @@ When a skill source directory is deleted (e.g. `rm -rf ~/.agents/skills/foo`) bu
 | Per-skill unlink         | Skill row's action menu → "Unlink..."      | Removes one orphan skill from one or more selected agents    |
 | Per-agent cleanup dialog | Sidebar agent context menu → "Clean up..." | Previews and executes all orphan removals for a single agent |
 | Global cleanup           | Sidebar footer "Clean up orphan symlinks"  | Removes all orphan symlinks across every agent               |
+| Symlink Health cleanup   | Dashboard widget → "Scan issues"           | Reviews and removes orphan records plus broken agent links   |
 
 The per-agent dialog uses the scoped sync IPC (`sync:preview` / `sync:execute` accept an optional `agentId`) so both the preview and execution stay restricted to the targeted agent. When the dialog opens with no actionable orphans (only conflicts to acknowledge), it surfaces a "conflicts skipped" hint instead of an empty success.
 
@@ -227,14 +228,14 @@ Each skill displays:
 
 ### Actions
 
-| Action                 | Status     | Notes                                                                                                                                          |
-| ---------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| View skill details     | ✅ Done    | -                                                                                                                                              |
-| View symlink status    | ✅ Done    | -                                                                                                                                              |
-| Search skills          | ✅ Done    | Marketplace tab                                                                                                                                |
-| Install skill          | ✅ Done    | With agent selection                                                                                                                           |
-| Uninstall skill        | ✅ Done    | Delete button and bulk-delete route CLI-managed skills through `npx skills remove` (irreversible, no undo); plain skills go to trash with undo |
-| Repair broken symlinks | 🚧 Planned | -                                                                                                                                              |
+| Action                 | Status  | Notes                                                                                                                                          |
+| ---------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| View skill details     | ✅ Done | -                                                                                                                                              |
+| View symlink status    | ✅ Done | -                                                                                                                                              |
+| Search skills          | ✅ Done | Marketplace tab                                                                                                                                |
+| Install skill          | ✅ Done | With agent selection                                                                                                                           |
+| Uninstall skill        | ✅ Done | Delete button and bulk-delete route CLI-managed skills through `npx skills remove` (irreversible, no undo); plain skills go to trash with undo |
+| Repair broken symlinks | ✅ Done | Dashboard Symlink Health cleanup reviews and removes safe orphan/broken symlink issues without deleting live source skills                     |
 
 ## Tech Stack
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -141,7 +141,7 @@ GUI wrapper for `npx skills` CLI commands:
 | ------------ | ------ | --------------- | ----------------------------------------- |
 | Valid        | `✓`    | Cyan (#22D3EE)  | Symlink exists and points to valid target |
 | Broken       | `◐`    | Amber (#F59E0B) | Symlink exists but target is missing      |
-| Inaccessible | `!`    | Red (#EF4444)   | Symlink target could not be probed safely |
+| Inaccessible | `!`    | Amber (#F59E0B) | Symlink target needs manual review        |
 | Missing      | `○`    | Gray (#475569)  | No symlink for this agent                 |
 
 **Orphan skill** is a separate concept layered on top of these states: a
@@ -486,6 +486,7 @@ interface Skill {
   name: string
   description: string
   path: string
+  filesystemIdentity?: FilesystemEntryIdentity
   symlinkCount: number
   symlinks: SymlinkInfo[]
   /** True when the skill lives under SOURCE_DIR (`~/.agents/skills/`); false for agent-local-only skills. */
@@ -505,15 +506,27 @@ interface Agent {
   exists: boolean
   skillCount: number
   localSkillCount: number
+  filesystemIdentity?: FilesystemEntryIdentity
+}
+
+interface FilesystemEntryIdentity {
+  kind: 'directory' | 'symlink' | 'file' | 'other'
+  dev: number
+  ino: number
+  size: number
+  ctimeMs: number
+  mtimeMs: number
 }
 
 interface SymlinkInfo {
   agentId: string
   agentName: string
   status: SymlinkStatus
-  targetPath: string
+  targetPath?: string
   linkPath: string
   isLocal: boolean
+  filesystemIdentity?: FilesystemEntryIdentity
+  skillMdSymlinkTarget?: string
 }
 
 type SymlinkStatus = 'valid' | 'broken' | 'inaccessible' | 'missing'

--- a/TODOS.md
+++ b/TODOS.md
@@ -916,6 +916,54 @@ Deferred items captured during planning. Pick up when scope and bandwidth allow.
 
 **Fix direction:** Attach `filesystemIdentity` to local slots returned by `checkSkillSymlinks()` and add coverage proving local source-agent slot unlink passes the reviewed identity.
 
+### P2. Offline snapshot skip must not hide self-staged destructive E2Es
+
+**Status:** Fixed after second-round subagent review.
+
+**Finding:** `e2e/spec/delete.e2e.ts` skips the whole file when the global azure snapshot is offline. The local-only delete and orphan cleanup tests stage their own Codex fixtures, so they should still run in offline/smoke mode.
+
+**Fix direction:** Move `isSnapshotOffline()` gating to only azure-dependent source-backed delete/restore/TTL tests, leaving self-staged destructive tests active against an empty isolated HOME.
+
+### P2. Bulk confirm state must require reviewed destructive snapshots
+
+**Status:** Fixed after second-round subagent review.
+
+**Finding:** `BulkConfirmState` still allows optional `deleteTargets` / `unlinkTargets`, and `MainContent` can rebuild targets from live rows at confirm time. That leaves a stale same-name replacement bypass path for future callers that omit the snapshot.
+
+**Fix direction:** Make `BulkConfirmState` a discriminated union with required reviewed delete/unlink snapshots, and remove live-row recompute fallbacks from dialog rendering and confirm execution.
+
+### P2. Source/local stale delete rows must not use orphan rescan copy
+
+**Status:** Fixed after second-round subagent review.
+
+**Finding:** Non-orphan source/local rows missing `filesystemIdentity` are currently stored in `orphanErrors`, so dialog copy can label a stale source/local row as an orphan cleanup rescan case.
+
+**Fix direction:** Split generic stale delete preflight errors from orphan cleanup preflight errors, render separate source/local rescan copy, and keep only orphan cleanup names in orphan-specific retry suppression.
+
+### P2. Deletion spec must stop claiming CLI-managed deletes are irreversible CLI removals
+
+**Status:** Fixed after second-round subagent review.
+
+**Finding:** `SPEC.md` still says CLI-managed skills are uninstalled with irreversible `npx skills remove`, but current delete flows move reviewed source/local skill folders to the app trash with undo.
+
+**Fix direction:** Update the Skill Types and Actions docs to describe reviewed app-trash delete/undo for both CLI-managed and plain skills; keep CLI uninstall wording only for marketplace uninstall hints.
+
+### P2. Status docs must include inaccessible symlink state
+
+**Status:** Fixed after second-round subagent review.
+
+**Finding:** README, SPEC, CLAUDE guidance, and symlinkChecker comments still document only `valid` / `broken` / `missing`, even though the branch adds `inaccessible` for manual-review symlinks.
+
+**Fix direction:** Update user/docs and code comments/type snippets to include `inaccessible` as distinct from broken and missing.
+
+### P2. Source scan must tolerate vanished source directories
+
+**Status:** Fixed after Codex CLI review during second-round subagent review.
+
+**Finding:** `scanSourceSkills()` lists valid source skill directories, then later captures `lstat(dir.path)` inside a per-row `Promise.all`. If another process deletes one source directory between listing/stat and identity capture, that single `ENOENT` rejects the whole scan and hides otherwise valid skills.
+
+**Fix direction:** Catch missing-path filesystem races per source row, drop only the vanished source skill from the scan result, and keep non-missing errors fatal.
+
 ## Orphan filter follow-ups (2026-05-09)
 
 ### 1. Source-view orphan visibility

--- a/TODOS.md
+++ b/TODOS.md
@@ -420,6 +420,102 @@ Deferred items captured during planning. Pick up when scope and bandwidth allow.
 
 **Fix direction:** Call `refreshAllData(dispatch)` in the mixed rejection path after restoring unresolved selection.
 
+### P1. Agent-view bulk Unlink must not bypass reviewed cleanup
+
+**Status:** Fixed after sixth post-fix subagent review follow-up.
+
+**Finding:** Per-row Unlink is hidden for broken/inaccessible agent rows, but bulk selection still allows those rows and `MainContent` routes agent bulk actions through name-only `unlinkSelectedFromAgent`. That bypasses reviewed `linkPath`/`targetPath` revalidation and can remove a symlink that became live after scan.
+
+**Fix direction:** Exclude broken/inaccessible non-local rows from agent-view bulk-select names and checkbox rendering, with selector/browser coverage.
+
+### P1. Name-rescan orphan delete must not direct-unlink stale links
+
+**Status:** Fixed after sixth post-fix subagent review follow-up.
+
+**Finding:** `moveToTrash` orphan branch still scans by name and then `fs.unlink(orphan.linkPath)` directly. If the target/source is restored between scan and unlink, a live symlink can be removed outside the guarded cleanup path.
+
+**Fix direction:** Carry resolved reviewed target identity from orphan scan and commit through the same guarded rename/revalidate/unlink model, returning `ESTALE` when the target is restored.
+
+### P1. Restore loop must not abort after source restore when one symlink parent is missing
+
+**Status:** Fixed after sixth post-fix subagent review follow-up.
+
+**Finding:** `restoreSourceBacked` calls `resolveRawSymlinkTarget` before ensuring the agent skills directory exists and lets resolver failures escape the per-link skip loop. A missing agent dir can abort restore after the source has already been moved back.
+
+**Fix direction:** Resolve absolute targets without parent realpath, create the agent skills dir before relative resolution, and treat per-link resolver failures as skipped symlinks.
+
+### P1. Guarded stale cleanup needs E2E coverage
+
+**Status:** Fixed after sixth post-fix subagent review follow-up.
+
+**Finding:** E2E covers immediate cleanup but not the stale-after-review case where the selected slot changes before mutation. The lower-level race tests do not prove the UI preserves replacements and asks for rescan.
+
+**Fix direction:** Add an Electron E2E that opens Symlink Health cleanup, mutates the selected slot, clicks Clean, and asserts rescan/error copy plus preserved replacement.
+
+### P1. Orphan-only Delete rejection must refresh and restore retry state
+
+**Status:** Fixed after sixth post-fix subagent review follow-up.
+
+**Finding:** If `clearSelectedOrphanSymlinks` rejects before per-item results and no source delete ran, `MainContent` shows a toast and returns without refresh or re-entering bulk mode.
+
+**Fix direction:** On orphan cleanup thunk rejection with no prior delete items, reselect unresolved orphan rows, refresh all data, and add browser coverage.
+
+### P2. Broken cleanup thunk must update Redux busy state
+
+**Status:** Fixed after sixth post-fix subagent review follow-up.
+
+**Finding:** `clearSelectedBrokenSymlinkSlots` is dispatched by Symlink Cleanup but has no pending/fulfilled/rejected reducers, so global busy/error/ephemeral UI state can remain stale during broken-only cleanup.
+
+**Fix direction:** Add reducer and UI pending handling mirroring unlink cleanup state, with slice tests.
+
+### P2. Stale-only orphan confirm must not enable a no-op destructive Delete
+
+**Status:** Fixed after sixth post-fix subagent review follow-up.
+
+**Finding:** A selection containing only stale orphan rows shows "No selected orphan skills are cleanup-ready" but still enables the destructive Delete button. Clicking it does nothing because `deleteItems.length === 0`.
+
+**Fix direction:** Disable the confirm primary action when there are no source deletes and no cleanup-ready orphan records.
+
+### P2. Refresh-failed Rescan should preserve auxiliary refresh failure warning
+
+**Status:** Fixed after sixth post-fix subagent review follow-up.
+
+**Finding:** `runScan({ refreshDashboard: true })` now ignores `fetchAgents`/`fetchSourceStats` rejection when `fetchSkills` succeeds. That avoids a hard error but can make the stale-dashboard warning disappear.
+
+**Fix direction:** Keep the scan usable while surfacing an auxiliary refresh failure message and keeping a Rescan affordance.
+
+### P2. Inaccessible destination labels must not say "broken link"
+
+**Status:** Fixed after sixth post-fix subagent review follow-up.
+
+**Finding:** Add/Copy modal occupancy maps inaccessible destinations to the same `broken link` label, collapsing manual-review and cleanup-ready states.
+
+**Fix direction:** Add an `inaccessible` occupancy reason and label it as manual review required.
+
+### P2. Orphan cleanup needs route-specific guarded-race coverage
+
+**Status:** Fixed after sixth post-fix subagent review follow-up.
+
+**Finding:** Broken-slot guarded races are covered, but orphan cleanup has its own source/local-copy blocker and lacks analogous integration tests.
+
+**Fix direction:** Add orphan cleanup tests for target restored, local folder/source appearing, and commit-time replacement preservation.
+
+### P2. Symlink Cleanup orphan-record path needs E2E coverage
+
+**Status:** Fixed after sixth post-fix subagent review follow-up.
+
+**Finding:** Symlink Cleanup E2E covers broken slots, not source-absent orphan-record cleanup, busy controls, or no-undo/tombstone behavior.
+
+**Fix direction:** Add an Electron E2E with a dangling agent symlink and no source, asserting cleanup removes the orphan without creating undo affordance.
+
+### P2. Inaccessible/manual-review affordances need E2E coverage
+
+**Status:** Fixed after sixth post-fix subagent review follow-up.
+
+**Finding:** Unit/browser tests cover hidden Add/Copy/Unlink, but E2E does not assert the manual-review surface and absence of destructive affordances.
+
+**Fix direction:** Add or extend E2E coverage for inaccessible state if a stable fixture can create it without touching protected user paths.
+
 ## Orphan filter follow-ups (2026-05-09)
 
 ### 1. Source-view orphan visibility

--- a/TODOS.md
+++ b/TODOS.md
@@ -212,6 +212,78 @@ Deferred items captured during planning. Pick up when scope and bandwidth allow.
 
 **Fix direction:** Add cleanup channel cases to the malicious skill-name table and add required/absolute `targetPath` schema tests for orphan and broken-slot cleanup payloads.
 
+### P1. Scanner orphan rows must carry reviewed target identity
+
+**Status:** Fixed after second post-fix subagent review follow-up.
+
+**Finding:** Real scanner-created orphan slots only carry `status` and `linkPath`, while cleanup eligibility now requires `targetPath`. Fixture-based tests passed because they manually populated `targetPath`, but real orphan rows can disappear from Symlink Health cleanup and global orphan Delete can fall into the rescan-required preflight error.
+
+**Fix direction:** Carry resolved `targetPath` through agent symlink status hits into `scanOrphanSymlinks`, and add scanner-to-plan regression coverage.
+
+### P1. Quarantine cleanup must restore non-symlink replacements
+
+**Status:** Fixed after second post-fix subagent review follow-up.
+
+**Finding:** Atomic quarantine currently restores only after `readlink` succeeds. If a reviewed symlink is replaced by a local folder or regular file between precheck and `rename`, cleanup can move that replacement to `.cleanup-*`, throw stale, and leave the original slot missing.
+
+**Fix direction:** Restore quarantined non-symlink entries back to the reviewed path on validation failure when possible, and cover the swap-before-rename race.
+
+### P1. Cleanup mutation success must not become cleanup failure after refresh failure
+
+**Status:** Fixed after second post-fix subagent review follow-up.
+
+**Finding:** `SymlinkCleanupDialog` runs destructive cleanup and post-cleanup refresh in the same `try`. If cleanup succeeds but `fetchSkills`, `fetchAgents`, or `fetchSourceStats` later rejects, the dialog reports `Cleanup failed`, encouraging a retry of a mutation that already happened.
+
+**Fix direction:** Finalize cleanup results first, refresh with `Promise.allSettled`, preserve success/partial-failure state, and surface refresh failures as secondary copy.
+
+### P1. Global orphan Delete confirm copy must not promise trash undo
+
+**Status:** Fixed after second post-fix subagent review follow-up.
+
+**Finding:** Global Delete confirmation still says rows move to app trash and can be restored within 15 seconds, but orphan rows now call orphan symlink cleanup and return no tombstone or undo path.
+
+**Fix direction:** Derive confirmation copy from the selected delete/orphan split, advertise undo only for tombstoned rows, and describe orphan rows as dangling symlink cleanup with no undo window.
+
+### P2. Agent-only inaccessible symlinks must stay visible
+
+**Status:** Fixed after second post-fix subagent review follow-up.
+
+**Finding:** Agent-only `inaccessible` symlink hits are dropped because linked scan keeps only `valid` and orphan scan keeps only `broken`. A manual-review symlink with no source skill can disappear from Health/manual-review UI.
+
+**Fix direction:** Group agent-only inaccessible symlinks into visible non-orphan skill records with inaccessible slots and no cleanup action, plus scanner coverage.
+
+### P2. Cleanup rows must expose full reviewed path identity
+
+**Status:** Fixed after second post-fix subagent review follow-up.
+
+**Finding:** Cleanup rows truncate the path detail and orphan checkbox labels omit the exact paths. Long links that differ only near the end can look identical, and screen-reader users cannot audit the reviewed destructive identity.
+
+**Fix direction:** Render full wrapped `linkPath -> targetPath` details, include orphan agent path pairs, and connect details to the checkbox via accessible description.
+
+### P2. E2E ambient cleanup contract must include targetPath
+
+**Status:** Fixed after second post-fix subagent review follow-up.
+
+**Finding:** `e2e/types.d.ts` still types `clearOrphanSymlinks` agent records without `targetPath`, even though shared IPC types and Zod require it.
+
+**Fix direction:** Update the E2E ambient type or reuse the shared contract so Playwright `page.evaluate` cleanup calls cannot type-check with stale payloads.
+
+### P3. Broken-slot cleanup request should name link identity explicitly
+
+**Status:** Fixed after second post-fix subagent review follow-up.
+
+**Finding:** `ClearBrokenSymlinkSlotsOptions.skillName` is semantically the agent-side link basename, not necessarily the visible source skill name. Future callers can reasonably pass the display skill name and trigger a false stale-path rejection.
+
+**Fix direction:** Rename the request field to `linkName` or derive it from `linkPath` in main; keep result identity backward-compatible where useful.
+
+### P3. Scan failure states need a retry affordance
+
+**Status:** Fixed after second post-fix subagent review follow-up.
+
+**Finding:** Initial scan failures show an error body but only Cancel plus disabled Clean; Rescan is gated to stale-plan states.
+
+**Fix direction:** Show Rescan for error states as well, especially when no actionable plan is available.
+
 ## Orphan filter follow-ups (2026-05-09)
 
 ### 1. Source-view orphan visibility

--- a/TODOS.md
+++ b/TODOS.md
@@ -596,6 +596,30 @@ Deferred items captured during planning. Pick up when scope and bandwidth allow.
 
 **Fix direction:** Stage the regular-file fixture directly and invoke IPC without waiting for pre-existing scanned skills.
 
+### P1. Source-backed cascade abort must roll back earlier symlinks
+
+**Status:** Fixed after ninth post-fix subagent review follow-up.
+
+**Finding:** `moveSourceBackedToTrash` rolls back symlinks if the source move fails, but a fatal symlink-removal error during the earlier source-backed cascade throws before rollback. If agent A was already unlinked and agent B then hits a quarantine restore failure, the source stays in place while agent A's symlink is lost without a tombstone or Undo path.
+
+**Fix direction:** Roll back all previously recorded symlinks before throwing from fatal cascade-removal failures, and add a multi-agent regression where an earlier removed symlink is restored after a later agent aborts.
+
+### P1. Unlink-agent E2E must support `E2E_SKIP_INSTALL`
+
+**Status:** Fixed after ninth post-fix subagent review follow-up.
+
+**Finding:** `unlink-agent.e2e.ts` still assumes snapshot-installed `azure-ai` / populated `SOURCE_DIR` in a few tests. With `E2E_SKIP_INSTALL=1`, the file can fail before reaching the deletion-safety assertions.
+
+**Fix direction:** Make snapshot-dependent tests skip on explicit fixture absence or stage their own fixture data, and remove `waitForInitialScan()` from direct-IPC tests that do not need scanned renderer state.
+
+### P2. Toolbar primary copy must count visible action targets
+
+**Status:** Fixed after ninth post-fix subagent review follow-up.
+
+**Finding:** The selection toolbar labels the destructive primary action with the total selected count, while `MainContent` acts on only selected rows that remain visible. With filtered selections, the button can say `Delete 5 skills` while the confirmation and IPC operate on 2 visible targets.
+
+**Fix direction:** Derive primary labels and aria labels from `visibleCount`, keeping the separate selected/hidden summary as the source of total-selection context.
+
 ## Orphan filter follow-ups (2026-05-09)
 
 ### 1. Source-view orphan visibility

--- a/TODOS.md
+++ b/TODOS.md
@@ -860,6 +860,62 @@ Deferred items captured during planning. Pick up when scope and bandwidth allow.
 
 **Fix direction:** Reuse the absolute-path schema for the single-agent unlink payload and add IPC schema regression coverage.
 
+### P2. Source delete `ESTALE` must not be labeled as orphan cleanup rescan
+
+**Status:** Fixed after second parallel subagent review.
+
+**Finding:** `isRescanRequiredDeleteError` treated every `ESTALE` as an orphan-cleanup rescan. Source/local delete identity mismatches also return `ESTALE`, so stale source deletes could show orphan-specific copy and be dropped from retry selection.
+
+**Fix direction:** Pass the reviewed orphan cleanup candidate names into mixed-delete reconciliation, and only exclude/describe `ESTALE` rows as orphan rescans when they came from orphan cleanup or orphan preflight errors.
+
+### P1. Source trash move must revalidate identity at commit time
+
+**Status:** Fixed after second parallel subagent review.
+
+**Finding:** Source-backed delete validates the reviewed source directory before cascading agent symlink removal, then later moves `sourcePath` into the app trash by path. A same-path replacement between those steps can be the folder actually tombstoned.
+
+**Fix direction:** Carry the reviewed filesystem identity into the source trash move, validate the staged trash entry after rename/copy, and roll back symlink removals plus source staging when the staged identity differs.
+
+### P1. Local-only delete must not sweep same-basename agent folders
+
+**Status:** Fixed after second parallel subagent review and Codex review.
+
+**Finding:** Agent-local delete validates the reviewed local folder, then scans every agent for the same folder basename and moves all matches. That can delete unreviewed same-basename local skills and misses same-metadata skills under different folder basenames.
+
+**Fix direction:** Execute local-only delete from the exact reviewed local folder snapshot and filesystem identity, not from a fresh basename scan, and verify the staged directory identity before manifest write.
+
+### P1. Single local-folder unlink must be guarded through OS Trash commit
+
+**Status:** Fixed after second parallel subagent review.
+
+**Finding:** Single-agent local-folder unlink checks `reviewedDirectoryIdentity`, validates `SKILL.md`, then calls `shell.trashItem(derivedLinkPath)` by path. A same-path replacement between validation and OS Trash can move an unreviewed folder.
+
+**Fix direction:** Rename the reviewed directory to a private same-directory quarantine path, verify the quarantined entry identity, then call `shell.trashItem` on the quarantined path; restore on mismatch or trash failure.
+
+### P1. Remove-all-agent must require reviewed agent directory identity
+
+**Status:** Fixed after second parallel subagent review.
+
+**Finding:** `skills:removeAllFromAgent` accepts only `agentId + agentPath`, then trashes the whole selected skills directory by path. A stale confirm can trash a same-path replacement agent directory.
+
+**Fix direction:** Populate `Agent.filesystemIdentity` during agent scan, require it in remove-all IPC options/schema, verify the current directory identity, and use the same quarantine-then-trash commit path.
+
+### P2. Generic symlink unlink must bind reviewed target identity
+
+**Status:** Fixed after second parallel subagent review.
+
+**Finding:** Generic single/bulk unlink validates that `linkPath` is in the selected agent directory, but removes the current symlink by path without checking that it still points at the reviewed target. A stale confirm can unlink a replacement symlink in the same slot.
+
+**Fix direction:** Carry reviewed `targetPath` for symlink unlink payloads and verify the current resolved target before unlinking with guarded same-directory quarantine.
+
+### P2. Local source-agent slots must expose filesystem identity
+
+**Status:** Fixed after Codex review.
+
+**Finding:** Source skill rows can include a real local folder in an agent slot, but `checkSkillSymlinks()` does not attach `filesystemIdentity` for that local slot. The new local-folder unlink guard then rejects the supported Delete-from-Agent flow.
+
+**Fix direction:** Attach `filesystemIdentity` to local slots returned by `checkSkillSymlinks()` and add coverage proving local source-agent slot unlink passes the reviewed identity.
+
 ## Orphan filter follow-ups (2026-05-09)
 
 ### 1. Source-view orphan visibility

--- a/TODOS.md
+++ b/TODOS.md
@@ -684,6 +684,38 @@ Deferred items captured during planning. Pick up when scope and bandwidth allow.
 
 **Fix direction:** Separate filtered-hidden counts from visible-but-ineligible counts or clear/reconcile ineligible selections before rendering toolbar copy.
 
+### P2. Cleanup-dialog stale-plan return must clear list selection
+
+**Status:** Fixed after twelfth post-fix subagent review.
+
+**Finding:** `SymlinkCleanupDialog` clears Installed-list selection only after the fresh plan still matches. If the plan is stale, the dialog returns before clearing stale row ticks, so closing the dialog can resurrect actionable selection.
+
+**Fix direction:** Clear list selection immediately after entering the cleaning phase, before fresh-scan stale checks can return.
+
+### P1. Source-backed manifest rollback must preserve stranded source recovery path
+
+**Status:** Fixed after twelfth post-fix subagent review.
+
+**Finding:** On source-backed manifest-write failure, rollback can fail to restore the source from the trash entry. The catch path still removes `entryDir`, deleting the `entrySourceDir` path mentioned as the manual recovery location.
+
+**Fix direction:** Only remove `entryDir` when source rollback succeeded; if rollback failed, preserve the trash entry and surface the stranded `entrySourceDir` path.
+
+### P1. Local-only partial restore must not delete skipped staged copies
+
+**Status:** Fixed after twelfth post-fix subagent review.
+
+**Finding:** `restoreLocalOnly()` skips occupied, invalid, unknown-agent, or failed copy restores but then finalizes the tombstone, deleting the whole `local-copies/` tree and any skipped staged folders.
+
+**Fix direction:** Treat skipped local-only restore copies as partial restore requiring manual recovery: keep the trash entry, cancel the evict timer, and return skipped counts without deleting staged copies.
+
+### P2. Single-agent unlink must allow metadata name and slot basename mismatch
+
+**Status:** Fixed after Codex built-in review during twelfth subagent review.
+
+**Finding:** `skills:unlinkFromAgent` derives the reviewed link path from `skillName`, but renderer `skill.name` can come from `SKILL.md` metadata while the actual agent-side slot basename is carried by `symlink.linkPath`. A valid unlink can be rejected when those differ.
+
+**Fix direction:** Validate the reviewed `linkPath` as a direct child of the selected agent path instead of deriving it from the display skill name, while still rejecting source paths and other-agent paths.
+
 ## Orphan filter follow-ups (2026-05-09)
 
 ### 1. Source-view orphan visibility

--- a/TODOS.md
+++ b/TODOS.md
@@ -164,6 +164,54 @@ Deferred items captured during planning. Pick up when scope and bandwidth allow.
 
 **Fix direction:** Show the agent-side `linkName` first and include the metadata display name when it differs; add browser coverage for the mismatch case.
 
+### P1. Global orphan Delete must use reviewed target identity
+
+**Status:** Fixed after post-fix subagent review.
+
+**Finding:** The global orphan row Delete / bulk delete path still routes through `deleteSelectedSkills(skillName)`, which rescans by name and calls `clearOrphanSymlinks` from fresh name matches. That bypasses the reviewed `linkPath + targetPath` identity now used by the Symlink Health dialog.
+
+**Fix direction:** Route selected global orphan deletes through the exact reviewed orphan cleanup IPC payload (`skillName`, `agentId`, `linkPath`, `targetPath`) and never fall back to name-only orphan sweeping for orphan rows. Added MainContent browser coverage for the IPC payload and deleteSkills bypass.
+
+### P2. Symlink cleanup should avoid check-then-unlink races
+
+**Status:** Fixed after post-fix subagent review.
+
+**Finding:** Broken-slot and orphan cleanup now revalidate the reviewed target immediately before unlinking, but the unlink is still a separate filesystem operation. A concurrent replacement between check and unlink could still remove a slot that was not reviewed.
+
+**Fix direction:** Use an atomic same-directory quarantine/rename cleanup path that validates the quarantined symlink and unlinks that exact entry, with conservative restoration behavior when validation fails.
+
+### P2. HealthWidget must distinguish cleanup-ready and manual-review counts
+
+**Status:** Fixed after post-fix subagent review.
+
+**Finding:** Mixed health states compress cleanup-ready `broken` slots and non-cleanup-safe `inaccessible` slots into one "needs review" count, while the cleanup dialog only shows cleanup-eligible broken rows. Users can see a higher widget count than the dialog can clean without an explanation.
+
+**Fix direction:** Split the widget footer/accessible copy into cleanup issue and manual-review counts while keeping the dialog button scoped to cleanup-ready rows. Added mixed-state browser coverage.
+
+### P2. E2E must assert removed symlink paths with `lstat`
+
+**Status:** Fixed after post-fix subagent review.
+
+**Finding:** The destructive cleanup E2E asserts removed symlink paths with `existsSync`, which follows symlinks. A broken symlink also returns false, so the test can pass when the symlink itself remains.
+
+**Fix direction:** Assert `lstatSync(path)` throws `ENOENT` after cleanup for both Devin and Codex cleanup E2E paths.
+
+### P2. Mismatched cleanup-row browser test must assert destructive payload
+
+**Status:** Fixed after post-fix subagent review.
+
+**Finding:** The mismatch test checks that the row label shows `linkName` first, but it does not prove the cleanup IPC payload uses that destructive link identity.
+
+**Fix direction:** Extend the browser test to click cleanup and assert `clearBrokenSymlinkSlots` receives the exact `skillName`, `linkPath`, and `targetPath` from the reviewed row.
+
+### P3. IPC schema tests must cover cleanup target paths
+
+**Status:** Fixed after post-fix subagent review.
+
+**Finding:** `ipc-schemas.test.ts` does not include the new cleanup IPC channels in the skill-name rejection coverage, and does not verify that cleanup `targetPath` values are required absolute paths.
+
+**Fix direction:** Add cleanup channel cases to the malicious skill-name table and add required/absolute `targetPath` schema tests for orphan and broken-slot cleanup payloads.
+
 ## Orphan filter follow-ups (2026-05-09)
 
 ### 1. Source-view orphan visibility

--- a/TODOS.md
+++ b/TODOS.md
@@ -1036,6 +1036,30 @@ Deferred items captured during planning. Pick up when scope and bandwidth allow.
 
 **Fix direction:** Update README prerequisites / tech stack and the one-line `SymlinkInfo.status` comment.
 
+### P1. Restore rollback directory moves must not overwrite empty-directory replacements
+
+**Status:** Fixed after final re-run gstack-review subagent review.
+
+**Finding:** Restore and rollback paths use `fs.rename(source, destination)` after a previous destination-free check. On macOS, renaming a directory over an existing empty directory can replace it, so another process recreating the destination after the check can still be clobbered.
+
+**Fix direction:** Use no-overwrite directory copy plus source removal for restore-direction moves, preserve staged recovery entries on destination collisions, and add regressions for source-backed and local-only restore races.
+
+### P3. Website public copy must include inaccessible symlink state
+
+**Status:** Fixed after final re-run gstack-review subagent review.
+
+**Finding:** `website/src/components/Features.tsx` and `website/public/llms.txt` still described only valid/broken/missing symlink states after the app added `inaccessible` manual-review status.
+
+**Fix direction:** Update website feature and LLM copy to mention inaccessible/manual-review symlink status.
+
+### P2. Directory restore copies must preserve relative symlink bytes
+
+**Status:** Fixed after final re-run gstack-review subagent review.
+
+**Finding:** `copyDirectoryNoOverwrite()` uses `fs.cp(..., { recursive: true, force: false, errorOnExist: true })` without `verbatimSymlinks: true`. Restore/rollback copies can therefore rewrite relative symlink targets inside a skill directory instead of restoring the bytes the user had before deletion.
+
+**Fix direction:** Copy directory restores with `verbatimSymlinks: true` and add a local-only restore regression that asserts an internal relative symlink target stays relative.
+
 ### P2. Undo toast E2E must not depend on snapshot-installed azure-ai
 
 **Status:** Fixed after final gstack-review subagent review.

--- a/TODOS.md
+++ b/TODOS.md
@@ -636,6 +636,54 @@ Deferred items captured during planning. Pick up when scope and bandwidth allow.
 
 **Fix direction:** Remove the file-level offline skip and move the snapshot/offline guard into the single `azure-ai`-dependent test.
 
+### P1. Quarantine rollback tests must assert recovered symlink identity
+
+**Status:** Fixed after eleventh post-fix subagent review.
+
+**Finding:** `trashService.orphanRace.test.ts` only asserts that a `.cleanup-*` entry exists after rollback failure. The test can pass even if the quarantined leftover is not the original reviewed symlink.
+
+**Fix direction:** Capture the exact cleanup entry, assert it is still a symlink, and assert `readlink()` points to the original source path in both rollback-failure regressions.
+
+### P1. Global orphan Delete must not seed source-delete undo state
+
+**Status:** Fixed after eleventh post-fix subagent review.
+
+**Finding:** `MainContent.browser.test.tsx` verifies that global orphan Delete routes to reviewed orphan cleanup IPC and bypasses `deleteSkills`, but does not assert that the orphan-only path leaves no source-delete undo/tombstone state.
+
+**Fix direction:** Add a post-confirm assertion that `ui.undoToast` remains `null` after orphan-only cleanup succeeds.
+
+### P2. IPC integration fs mocks must be unmocked after cleanup-target tests
+
+**Status:** Fixed after eleventh post-fix subagent review.
+
+**Finding:** The cleanup target identity integration describe in `skills.clearOrphanSymlinks.integration.test.ts` mocks `node:fs/promises` but does not unmock it in `afterEach`, which can leak module state into later tests.
+
+**Fix direction:** Mirror the first describe's cleanup and call `vi.doUnmock('node:fs/promises')` in the second describe `afterEach`.
+
+### P1. Broken selected-agent rows must not expose Add or Copy affordances
+
+**Status:** Fixed after eleventh post-fix subagent review.
+
+**Finding:** `getSkillItemVisibility()` treats a broken selected-agent symlink as "present", enabling Add/Copy controls while the normal unlink control is hidden. Broken non-orphan rows can look actionable through the wrong flow instead of requiring cleanup/manual review.
+
+**Fix direction:** Derive Add/Copy visibility from a usable selected-agent slot (`local` or `valid`) rather than any selected-agent slot, and cover broken-slot visibility with focused tests.
+
+### P2. Cleanup-dialog bulk cleanup must not resurrect stale row selection
+
+**Status:** Fixed after eleventh post-fix subagent review.
+
+**Finding:** Cleanup thunks close bulk-select chrome on `.pending` but preserve `selectedSkillNames` for retry semantics. When cleanup starts from `SymlinkCleanupDialog`, stale list selection can later reappear when the user re-enters Select.
+
+**Fix direction:** Clear list selection only for the dashboard cleanup-dialog entry point, while preserving the existing fulfilled-time retry narrowing used by `MainContent` bulk actions.
+
+### P3. Selection toolbar must distinguish hidden rows from visible ineligible rows
+
+**Status:** Fixed after eleventh post-fix subagent review.
+
+**Finding:** `SelectionToolbar` reports selected rows outside `selectBulkSelectableVisibleSkillNames` as hidden by filter. Visible but ineligible rows, such as broken/manual-review rows, can be described as hidden even though they are on screen.
+
+**Fix direction:** Separate filtered-hidden counts from visible-but-ineligible counts or clear/reconcile ineligible selections before rendering toolbar copy.
+
 ## Orphan filter follow-ups (2026-05-09)
 
 ### 1. Source-view orphan visibility

--- a/TODOS.md
+++ b/TODOS.md
@@ -2,6 +2,128 @@
 
 Deferred items captured during planning. Pick up when scope and bandwidth allow.
 
+## Symlink Health cleanup subagent review follow-ups (2026-05-28)
+
+### P0. Orphan cleanup must not reuse source skill deletion
+
+**Status:** Fixed in this branch.
+
+**Finding:** The Symlink Health dialog currently calls the generic source-delete flow for orphan cleanup. If a source skill is restored between scan and cleanup, or if the reviewed display name does not match the destructive link name, cleanup can delete a live source skill instead of unlinking only dangling agent links.
+
+**Fix direction:** Add an orphan-only main-process IPC path that revalidates selected dangling symlink paths, refuses when source/local copies exist, and only unlinks confirmed orphan agent links.
+
+### P0. Stale-plan guard must compare reviewed cleanup snapshots
+
+**Status:** Fixed in this branch.
+
+**Finding:** The stale-plan check only verifies that selected item IDs still exist. The same ID can later represent a different agent/link path/target, so cleanup can act on rows the user did not review.
+
+**Fix direction:** Compare full selected snapshots against the fresh plan before mutation, and execute from the fresh matched rows.
+
+### P1. Inaccessible symlink targets must not be treated as cleanup-ready broken links
+
+**Status:** Fixed in this branch.
+
+**Finding:** `access()` failures are all classified as `broken`, including `EACCES`, `EPERM`, and `ELOOP`. The cleanup UI can then offer a symlink to a real but inaccessible target for unlinking.
+
+**Fix direction:** Classify only `ENOENT` and `ENOTDIR` as cleanup-eligible broken targets. Represent other access failures as non-cleanup-safe and exclude them from cleanup.
+
+### P1. Relative target resolution must match between scan and destructive cleanup
+
+**Status:** Fixed in this branch.
+
+**Finding:** The scanner resolves relative readlink targets against the physical parent directory, but the orphan sweep in `trashService` still resolves against the logical symlink path parent. Under symlinked parents, scan and cleanup can disagree.
+
+**Fix direction:** Share the physical-parent resolver between scanner and cleanup code and cover it with a real filesystem test.
+
+### P1. Add missing destructive-flow regression tests
+
+**Status:** Fixed in this branch.
+
+**Finding:** Current E2E covers a valid Devin symlink under symlinked `~/.config` and a generic cleanup unlink, but not the combined case: broken Devin symlink under symlinked `~/.config` cleaned through the UI.
+
+**Fix direction:** Add E2E coverage that cleans a broken Devin slot under symlinked `~/.config`, preserves the source skill, preserves the `~/.config` symlink, and removes only the selected agent link.
+
+### P1. Add stale-plan and partial-failure dialog coverage
+
+**Status:** Fixed in this branch.
+
+**Finding:** Stale plan and partial failure branches are destructive-flow guards, but dialog-level tests do not cover them.
+
+**Fix direction:** Add browser/component tests proving stale cleanup does not call destructive IPC, and partial failure keeps failed rows selected with visible row errors.
+
+### P2. Dialog state and accessibility polish
+
+**Status:** Fixed in this branch.
+
+**Finding:** Partial failure renders from the old plan after refresh, scans are not generation-guarded, the close button remains focusable during cleaning, close autofocus can fall through when the trigger disappears, and the live region wraps the whole interactive body.
+
+**Fix direction:** Rebuild error state from fresh plan, guard late scan results, hide/disable the close affordance while cleaning, always prevent close autofocus with a stable fallback target, and move live announcements to status/error-only nodes.
+
+### P0. Broken-slot cleanup must revalidate exact reviewed symlink in main
+
+**Status:** Fixed in follow-up amend.
+
+**Finding:** The post-fix subagent review found that non-orphan broken-slot cleanup still called generic `unlinkManyFromAgent` with only `agentId + linkName`. A source/target restored after renderer fresh-scan could turn a reviewed dangling slot into a live symlink before main unlinks it.
+
+**Fix direction:** Add a broken-slot cleanup IPC that receives exact `agentId`, `linkName`, `linkPath`, and `targetPath`, then main revalidates slot path, symlink kind, resolved target equality, and missing-target error before unlinking.
+
+### P1. Partial-failure retry state must compare fresh row snapshots
+
+**Status:** Fixed in follow-up amend.
+
+**Finding:** Partial failure rendering rebuilt from fresh plan but only retained failed row IDs. If the same ID now represented a different path/target, row errors and retry selection could attach to the wrong target.
+
+**Fix direction:** Compare failed attempted rows against the post-cleanup plan with the same full snapshot matcher; stale out if any failed row no longer matches.
+
+### P2. Inaccessible-only health state must not say Healthy
+
+**Status:** Fixed in follow-up amend.
+
+**Finding:** HealthWidget counted inaccessible slots in the amber/degraded health ratio but still rendered `Healthy` when `broken === 0`.
+
+**Fix direction:** Render a non-cleanup manual-review state for inaccessible-only attention and add browser coverage.
+
+### P0. Missing-path helper must not parse path text for ENOENT
+
+**Status:** Fixed after second subagent review.
+
+**Finding:** `isMissingPathError` falls back to `error.message.includes('ENOENT')`, so an `EACCES`/`EPERM` path containing the text `ENOENT` can be misclassified as a missing target and become cleanup-eligible.
+
+**Fix direction:** Trust Node filesystem `error.code` only, and add a regression where `code: 'EACCES'` plus an `ENOENT` path returns inaccessible/manual-review.
+
+### P0. Broken-slot cleanup results must preserve reviewed row identity
+
+**Status:** Fixed after second subagent review.
+
+**Finding:** `skills:clearBrokenSymlinkSlots` returns only `skillName`, and the dialog reconstructs failed row ownership with `find(linkName)`. Two agents with the same broken basename can attach an error/retry selection to the wrong row.
+
+**Fix direction:** Return `agentId` and `linkPath` for each broken-slot result and group renderer summaries by the returned agent identity, not by skill name.
+
+### P1. Inaccessible slots must not render as unlinked in skill views
+
+**Status:** Fixed after second subagent review.
+
+**Finding:** `SkillItem` and `SkillDetail` count only `valid` and `broken`, so a skill with only `inaccessible` slots can say `Not linked to any agent` and under-report the manual-review state.
+
+**Fix direction:** Count and display inaccessible slots as their own amber/manual-review status in both summary and detail views.
+
+### P2. Dialog live-region and pending-cleaning coverage
+
+**Status:** Fixed after second subagent review.
+
+**Finding:** The ready live region is always mounted, including scan/clean phases, and browser tests do not hold cleanup pending to assert the cleaning state.
+
+**Fix direction:** Render the ready announcement only while the review list is shown, and add a deferred-IPC browser test for pending cleanup UI.
+
+### P1. HealthWidget must not label inaccessible slots as broken
+
+**Status:** Fixed after final subagent review.
+
+**Finding:** The HealthWidget footer correctly says `Manual review` for inaccessible-only state, but the health bar aria-label and legend still aggregate `broken + inaccessible` under the word `broken`.
+
+**Fix direction:** Use neutral `needs review` wording for the amber segment and add browser coverage so inaccessible-only state is not announced as broken.
+
 ## Orphan filter follow-ups (2026-05-09)
 
 ### 1. Source-view orphan visibility

--- a/TODOS.md
+++ b/TODOS.md
@@ -516,6 +516,70 @@ Deferred items captured during planning. Pick up when scope and bandwidth allow.
 
 **Fix direction:** Add or extend E2E coverage for inaccessible state if a stable fixture can create it without touching protected user paths.
 
+### P1. Legacy single unlink must derive the agent slot in main
+
+**Status:** Fixed after seventh post-fix subagent review follow-up.
+
+**Finding:** `skills:unlinkFromAgent` validates the renderer-supplied `linkPath` against broad allowed bases, so a tampered renderer can request a source path or another agent slot while presenting a different `agentId`.
+
+**Fix direction:** Resolve `agentId + skillName` in the main process, require the supplied `linkPath` to match that exact slot, and operate on the derived path only.
+
+### P1. Remove-all agent deletion must derive the agent path in main
+
+**Status:** Fixed after seventh post-fix subagent review follow-up.
+
+**Finding:** `skills:removeAllFromAgent` validates the renderer-supplied `agentPath` against all agent bases, so a tampered renderer can delete a different non-shared agent folder than the selected `agentId`.
+
+**Fix direction:** Resolve the selected agent by `agentId`, require the supplied `agentPath` to match the selected agent path exactly, and call `trashItem` only on the derived path.
+
+### P1. Guarded stale cleanup E2E must hit the main IPC commit guard
+
+**Status:** Fixed after seventh post-fix subagent review follow-up.
+
+**Finding:** The stale cleanup E2E mutates before the renderer fresh-scan, so it verifies the renderer `Plan changed` guard but not the main-process guarded cleanup path.
+
+**Fix direction:** Exercise the real renderer-to-main cleanup IPC with a reviewed stale payload after UI review, then assert the replacement survives and main returns an `ESTALE` cleanup result.
+
+### P2. Source-backed delete cascade must verify symlink target identity
+
+**Status:** Fixed after seventh post-fix subagent review follow-up.
+
+**Finding:** Source-backed deletion removes same-name agent symlinks without verifying that those symlinks point to the source being deleted.
+
+**Fix direction:** Resolve each candidate symlink target and skip stale or mismatched links instead of unlinking links that belong to another source.
+
+### P2. Refresh-failed ready scan must preserve the warning
+
+**Status:** Fixed after seventh post-fix subagent review follow-up.
+
+**Finding:** `runScan({ refreshDashboard: true })` preserves auxiliary refresh errors only for the no-safe-cleanup state. A fresh scan that still has cleanup items drops the warning and the Rescan affordance.
+
+**Fix direction:** Carry auxiliary refresh failure messages into the ready state and keep Rescan available while the dashboard refresh warning is present.
+
+### P2. Destructive E2Es must not depend on pre-existing snapshot skills
+
+**Status:** Fixed after seventh post-fix subagent review follow-up.
+
+**Finding:** Several symlink cleanup E2Es call `waitForInitialScan()` before arranging their throwaway fixture data, so an empty or skipped-install snapshot can timeout before the test reaches the intended path.
+
+**Fix direction:** Arrange the fixture first, then drive `refreshSkillsState()` or a direct scan so the test owns the data it needs.
+
+### P2. Agent-view toolbar bulk unlink needs real integration coverage
+
+**Status:** Fixed after seventh post-fix subagent review follow-up.
+
+**Finding:** `MainContent.browser.test.tsx` mocks `SelectionToolbar`, so the real toolbar Select all and Unlink path is not proving that broken or inaccessible rows are excluded from destructive bulk payloads.
+
+**Fix direction:** Add browser coverage with the real `SelectionToolbar`, select all visible agent rows, and assert the unlink payload contains only cleanup-safe valid rows.
+
+### P3. Inaccessible manual-review state needs health-surface E2E coverage
+
+**Status:** Fixed after seventh post-fix subagent review follow-up.
+
+**Finding:** The inaccessible E2E verifies row affordances but not the HealthWidget / scan-issues surface that tells users the item needs manual review rather than cleanup.
+
+**Fix direction:** Extend the inaccessible E2E to assert the manual-review health copy and absence of cleanup-ready scan issues.
+
 ## Orphan filter follow-ups (2026-05-09)
 
 ### 1. Source-view orphan visibility

--- a/TODOS.md
+++ b/TODOS.md
@@ -1084,6 +1084,14 @@ Deferred items captured during planning. Pick up when scope and bandwidth allow.
 
 **Fix direction:** Add `verbatimSymlinks: true` to the IPC quarantine directory copy and add a rollback regression that asserts an internal relative symlink target stays relative.
 
+### P3. Remaining public copy and theme docs must match current counts
+
+**Status:** Fixed after final re-run gstack-review subagent review.
+
+**Finding:** `Hero.tsx`, `layout.tsx`, and the top of `llms.txt` still said 21 AI agents. `ThemePresetName` docs still described 12 OKLCH hues and 2 neutral variants.
+
+**Fix direction:** Update the remaining website/SEO/LLM copy to 54 agents and update the theme type comment to 17 OKLCH hues, 2 pure neutrals, and 8 tinted neutrals.
+
 ### P2. Undo toast E2E must not depend on snapshot-installed azure-ai
 
 **Status:** Fixed after final gstack-review subagent review.

--- a/TODOS.md
+++ b/TODOS.md
@@ -620,6 +620,22 @@ Deferred items captured during planning. Pick up when scope and bandwidth allow.
 
 **Fix direction:** Derive primary labels and aria labels from `visibleCount`, keeping the separate selected/hidden summary as the source of total-selection context.
 
+### P3. Hidden-only toolbar selection needs explicit zero-visible copy
+
+**Status:** Fixed after tenth post-fix subagent review follow-up.
+
+**Finding:** After switching primary labels to visible action targets, a hidden-only selection collapses to the single-item variant. The disabled button can still say `Delete skill` or `Unlink from Cursor` even though zero visible rows can be acted on.
+
+**Fix direction:** Add an explicit zero-visible toolbar state with disabled copy and aria labels that say no visible selected skills can be deleted or unlinked.
+
+### P2. Unlink-agent offline skip must not hide fixture-owned safety tests
+
+**Status:** Fixed after tenth post-fix subagent review follow-up.
+
+**Finding:** `unlink-agent.e2e.ts` has a file-level offline skip even though only the first `azure-ai` test depends on snapshot-installed skills. When the snapshot is genuinely offline/empty, the self-staged IPC and Trash safety tests are skipped unnecessarily.
+
+**Fix direction:** Remove the file-level offline skip and move the snapshot/offline guard into the single `azure-ai`-dependent test.
+
 ## Orphan filter follow-ups (2026-05-09)
 
 ### 1. Source-view orphan visibility

--- a/TODOS.md
+++ b/TODOS.md
@@ -316,6 +316,46 @@ Deferred items captured during planning. Pick up when scope and bandwidth allow.
 
 **Fix direction:** Count only cleanup-ready orphan records as orphan cleanup and add a separate rescan warning for stale orphan rows.
 
+### P1. Reviewed cleanup must revalidate immediately before unlink
+
+**Status:** Fixed after fourth post-fix subagent review follow-up.
+
+**Finding:** `unlinkReviewedDanglingSymlink` verifies the reviewed symlink and missing target, then awaits blocker probes before unlinking by path. A same-path symlink replacement or target restore during that window can make cleanup remove a slot that is no longer the reviewed dangling entry.
+
+**Fix direction:** Re-read `lstat + readlink + targetPath` immediately before unlink and repeat the missing-target probe, with integration tests for symlink-to-symlink replacement and target restore after the first probe.
+
+### P1. Refresh-failed cleanup Rescan must retry every failed dashboard source
+
+**Status:** Fixed after fourth post-fix subagent review follow-up.
+
+**Finding:** The complete-but-refresh-failed footer shows `Rescan`, but that action only reruns `fetchSkills`; if `fetchAgents` or `fetchSourceStats` failed, the dashboard state can remain stale after the advertised retry.
+
+**Fix direction:** In refresh-failed complete state, make Rescan retry `fetchSkills`, `fetchAgents`, and `fetchSourceStats` before rebuilding the cleanup plan.
+
+### P1. Stale orphan preflight failures must not become retry loops
+
+**Status:** Fixed after fourth post-fix subagent review follow-up.
+
+**Finding:** Global Delete mixes preflight `orphanErrors` into normal failed rows and reselects them. A stale orphan that requires rescan can stay selected and fail repeatedly, while the toast summary hides the rescan requirement.
+
+**Fix direction:** Separate rescan-required orphan failures from retryable failures, exclude them from retry selection, and append explicit rescan-required copy to the post-action summary.
+
+### P1. Mixed Delete rejection must restore unresolved selection
+
+**Status:** Fixed after fourth post-fix subagent review follow-up.
+
+**Finding:** If source delete rejects at the thunk level in a mixed source+orphan batch, the handler returns before orphan cleanup and does not restore source/orphan selection for retry.
+
+**Fix direction:** On rejected source delete with orphan cleanup involved, re-enter bulk mode and reselect unresolved source names plus not-yet-run cleanup-ready orphan records.
+
+### P1. Delete reducer must treat orphan-cleared as successful removal
+
+**Status:** Fixed after fourth post-fix subagent review follow-up.
+
+**Finding:** `deleteSelectedSkills.fulfilled` removes only `deleted` names from selection. If main returns `orphan-cleared`, a ghost selected row and anchor can remain until another context switch.
+
+**Fix direction:** Treat both `deleted` and `orphan-cleared` as successful removal outcomes in selection and anchor reconciliation, with reducer coverage.
+
 ## Orphan filter follow-ups (2026-05-09)
 
 ### 1. Source-view orphan visibility

--- a/TODOS.md
+++ b/TODOS.md
@@ -1060,6 +1060,30 @@ Deferred items captured during planning. Pick up when scope and bandwidth allow.
 
 **Fix direction:** Copy directory restores with `verbatimSymlinks: true` and add a local-only restore regression that asserts an internal relative symlink target stays relative.
 
+### P1. Manifest write rollback must not overwrite same-device source replacements
+
+**Status:** Fixed after final re-run gstack-review subagent review.
+
+**Finding:** Manifest write rollback still used `fs.rename(entrySourceDir, sourcePath)`. A same-device empty directory recreated at `sourcePath` after the restore check could be overwritten before the delete failure is surfaced.
+
+**Fix direction:** Route manifest rollback through the same no-overwrite directory restore helper and add a same-device rollback collision regression.
+
+### P3. Website public copy must match current agent and theme counts
+
+**Status:** Fixed after final re-run gstack-review subagent review.
+
+**Finding:** Website feature and LLM copy still said 21 agents and 26 theme presets, while current README/SPEC/constants document 54 agents and 27 presets.
+
+**Fix direction:** Update website feature and LLM copy to the current counts.
+
+### P1. Quarantine directory restore must preserve relative symlink bytes
+
+**Status:** Fixed after final re-run gstack-review subagent review.
+
+**Finding:** `restoreQuarantinedPath()` copies quarantined local skill folders without `verbatimSymlinks: true`. A local-folder delete rollback could restore internal relative symlinks as absolute paths pointing into the quarantine directory that is then removed.
+
+**Fix direction:** Add `verbatimSymlinks: true` to the IPC quarantine directory copy and add a rollback regression that asserts an internal relative symlink target stays relative.
+
 ### P2. Undo toast E2E must not depend on snapshot-installed azure-ai
 
 **Status:** Fixed after final gstack-review subagent review.

--- a/TODOS.md
+++ b/TODOS.md
@@ -580,6 +580,22 @@ Deferred items captured during planning. Pick up when scope and bandwidth allow.
 
 **Fix direction:** Extend the inaccessible E2E to assert the manual-review health copy and absence of cleanup-ready scan issues.
 
+### P1. Source-backed quarantine restore failure must abort delete
+
+**Status:** Fixed after eighth post-fix subagent review follow-up.
+
+**Finding:** Source-backed cascade catches every `ESTALE` from `unlinkReviewedSourceSymlink` as a safe skip. If the reviewed symlink is quarantined, validation fails, and restoring the quarantined entry also fails because the original slot became occupied, that restore failure is also `ESTALE`. The source delete can then continue and leave an unmanifested `.cleanup-*` entry behind.
+
+**Fix direction:** Distinguish stale-skip with successful restore from quarantine restore failure. Restore failure must abort source-backed delete before moving the source into trash and be covered by a race test.
+
+### P2. Unlink regular-file E2E must not depend on snapshot install
+
+**Status:** Fixed after eighth post-fix subagent review follow-up.
+
+**Finding:** The adjusted `unlinkFromAgent` regular-file E2E still calls `waitForInitialScan()` before staging its own fixture. With `E2E_SKIP_INSTALL=1`, an empty snapshot can timeout before the deletion-safety assertion runs.
+
+**Fix direction:** Stage the regular-file fixture directly and invoke IPC without waiting for pre-existing scanned skills.
+
 ## Orphan filter follow-ups (2026-05-09)
 
 ### 1. Source-view orphan visibility

--- a/TODOS.md
+++ b/TODOS.md
@@ -964,6 +964,78 @@ Deferred items captured during planning. Pick up when scope and bandwidth allow.
 
 **Fix direction:** Catch missing-path filesystem races per source row, drop only the vanished source skill from the scan result, and keep non-missing errors fatal.
 
+### P1. Quarantine restore must not overwrite same-path replacements
+
+**Status:** Fixed after final gstack-review subagent review.
+
+**Finding:** `restoreQuarantinedPath()` used `fs.rename(quarantinePath, originalPath)`. If a file, symlink, or folder appeared at the original reviewed path after quarantine, rollback could overwrite that replacement.
+
+**Fix direction:** Restore quarantined entries with no-clobber behavior, refuse occupied original paths, preserve the quarantine for manual recovery, and surface the quarantine path in the error.
+
+### P1. EXDEV fallback copies must not overwrite recovery destinations
+
+**Status:** Fixed after final gstack-review subagent review.
+
+**Finding:** `fs.cp(source, destination, { recursive: true })` defaults to overwrite. Cross-device restore/rollback could copy into a destination that appeared after the previous existence check.
+
+**Fix direction:** Use no-overwrite copy options (`force: false`, `errorOnExist: true`) for EXDEV fallback copies and preserve staged trash/manual-recovery entries on destination collisions.
+
+### P1. Missing-identity unlink integration test must expect schema rejection
+
+**Status:** Fixed after Codex CLI review during final subagent review.
+
+**Finding:** After tightening `skills:unlinkFromAgent` to a symlink-vs-local schema union, the missing `reviewedDirectoryIdentity` case throws in `typedHandle` before the handler returns, but the integration test still expected `{ success: false }`.
+
+**Fix direction:** Assert the IPC validation rejection directly, then keep filesystem and trash-call assertions proving the unsafe local folder remains untouched.
+
+### P2. Undo toast E2E must not depend on snapshot-installed azure-ai
+
+**Status:** Fixed after final gstack-review subagent review.
+
+**Finding:** `e2e/spec/undo-toast.e2e.ts` skipped the whole UI bulk-delete to Undo restore flow when the snapshot was offline, even though the spec can stage its own source skill and agent symlink.
+
+**Fix direction:** Stage a throwaway source skill and symlink inside the isolated HOME, remove the blanket snapshot skip, and keep the renderer click-chain restore assertion active in offline runs.
+
+### P2. Regression E2E offline skip must not hide self-staged destructive safety tests
+
+**Status:** Fixed after final gstack-review subagent review.
+
+**Finding:** `e2e/spec/regression.e2e.ts` skipped the entire file when the azure snapshot was offline, hiding self-staged remove-all and cleanup safety regressions that do not need azure fixture data.
+
+**Fix direction:** Move snapshot gating into only azure-dependent tests, and make self-staged destructive tests own their source/local fixtures.
+
+### P2. Unlink-agent E2E must assert removed symlinks with lstat
+
+**Status:** Fixed after final gstack-review subagent review.
+
+**Finding:** `unlink-agent.e2e.ts` used `existsSync(path) === false` to prove symlink removal. A dangling symlink left behind at the same path also returns false.
+
+**Fix direction:** Add an `lstatSync`-based missing-path assertion and use it for every agent symlink expected to be removed.
+
+### P2. Single unlink IPC schema must require destructive identity variant fields
+
+**Status:** Fixed after final gstack-review subagent review.
+
+**Finding:** `UnlinkFromAgentOptions` and the Zod schema kept `targetPath` and `reviewedDirectoryIdentity` optional. Main rejected unsafe local deletes, but renderer/preload could still send a local delete without identity and show a failed mutation instead of a rescan-required preflight.
+
+**Fix direction:** Make the single unlink payload a symlink-vs-local discriminated union, require `targetPath` for symlink unlink and `reviewedDirectoryIdentity` for confirmed local folder delete, and add renderer preflight for missing identity.
+
+### P3. Inaccessible status spec color must match UI amber treatment
+
+**Status:** Fixed after final gstack-review subagent review.
+
+**Finding:** `SPEC.md` documented inaccessible status as red, while the UI renders inaccessible with the same amber/manual-review treatment used by broken status.
+
+**Fix direction:** Update the spec table to amber/manual-review copy unless the product intentionally adds a separate red variant.
+
+### P3. SPEC type snippets must include reviewed identity fields
+
+**Status:** Fixed after final gstack-review subagent review.
+
+**Finding:** `SPEC.md` still showed `SymlinkInfo.targetPath` as required and omitted `filesystemIdentity` / `skillMdSymlinkTarget`, despite destructive flows now depending on those reviewed identities.
+
+**Fix direction:** Update the type snippets to mirror `src/shared/types.ts` for `Skill`, `Agent`, and `SymlinkInfo`.
+
 ## Orphan filter follow-ups (2026-05-09)
 
 ### 1. Source-view orphan visibility

--- a/TODOS.md
+++ b/TODOS.md
@@ -1140,6 +1140,24 @@ Deferred items captured during planning. Pick up when scope and bandwidth allow.
 
 **Fix direction:** Update the type snippets to mirror `src/shared/types.ts` for `Skill`, `Agent`, and `SymlinkInfo`.
 
+## Design review follow-ups (2026-05-29)
+
+### P1. Skill row Add action must not be part of the heading
+
+**Status:** Fixed after gstack-design-review.
+
+**Finding:** The Installed list renders the `Add` button inside the row `<h3>`, so the accessibility tree exposes headings like `auto Add`. The action also uses a 20px-tall target, below the compact desktop 24px control floor in `DESIGN.md`.
+
+**Fix direction:** Split the title and row action into a header flex row, keep the `<h3>` to skill identity only, and size the compact `Add` button to at least 24px tall.
+
+### P1. Symlink cleanup dialog must make destructive path identity readable
+
+**Status:** Fixed after gstack-design-review.
+
+**Finding:** The cleanup dialog shows the exact `linkPath -> targetPath` identity in 11px muted monospace text. For a deletion-adjacent flow, that evidence is critical but visually recedes behind the row label and red action.
+
+**Fix direction:** Promote the path evidence into a compact tinted block with higher contrast, 12px monospace text, and wrapping that preserves long path inspection.
+
 ## Orphan filter follow-ups (2026-05-09)
 
 ### 1. Source-view orphan visibility

--- a/TODOS.md
+++ b/TODOS.md
@@ -716,6 +716,38 @@ Deferred items captured during planning. Pick up when scope and bandwidth allow.
 
 **Fix direction:** Validate the reviewed `linkPath` as a direct child of the selected agent path instead of deriving it from the display skill name, while still rejecting source paths and other-agent paths.
 
+### P1. Startup trash cleanup must preserve manual-recovery entries
+
+**Status:** Fixed after thirteenth post-fix subagent review.
+
+**Finding:** Preserved tombstone entries that require manual recovery can still be swept by `startupCleanup()` after the 24h trash TTL. The recovery path is preserved during the failed operation, but restart-time cleanup can later delete it without checking that the entry is intentionally stranded.
+
+**Fix direction:** Mark stranded/manual-recovery trash entries and teach `startupCleanup()` to skip marked entries instead of evicting them by age.
+
+### P1. Cross-device fallback failures must not delete staged recovery copies
+
+**Status:** Fixed after thirteenth post-fix subagent review.
+
+**Finding:** The EXDEV fallback paths copy into the trash entry before removing the original path. If the copy succeeds but the remove fails, the current fatal rollback cleanup can delete the staged copy, which may be the only complete recovery copy.
+
+**Fix direction:** Track when a cross-device fallback has staged data in the trash entry, preserve that entry on fallback failure, and mark it for manual recovery.
+
+### P1. Source delete must use reviewed source path when metadata name differs
+
+**Status:** Fixed after thirteenth post-fix subagent review.
+
+**Finding:** Bulk source delete still sends only `skillName`, so main derives `SOURCE_DIR/<skillName>`. If `Skill.name` comes from `SKILL.md` metadata and differs from the actual source folder basename, delete can miss the selected folder or tombstone the wrong folder when a same-name folder exists.
+
+**Fix direction:** Pass the reviewed `Skill.path` through delete IPC and have main prefer that path as the filesystem identity after validating it under allowed skill directories.
+
+### P2. Bulk agent unlink must use reviewed link path when metadata name differs
+
+**Status:** Fixed after thirteenth post-fix subagent review.
+
+**Finding:** Bulk unlink still sends only `skillName`, so main derives `agent.path/skillName`. A selected row whose display metadata name differs from the actual agent slot basename can report success while leaving the reviewed slot untouched.
+
+**Fix direction:** Pass reviewed per-row `symlink.linkPath` through bulk unlink IPC and have main validate/remove that exact direct child of the selected agent directory.
+
 ## Orphan filter follow-ups (2026-05-09)
 
 ### 1. Source-view orphan visibility

--- a/TODOS.md
+++ b/TODOS.md
@@ -748,6 +748,62 @@ Deferred items captured during planning. Pick up when scope and bandwidth allow.
 
 **Fix direction:** Pass reviewed per-row `symlink.linkPath` through bulk unlink IPC and have main validate/remove that exact direct child of the selected agent directory.
 
+### P1. Reviewed-path source delete needs Electron E2E coverage
+
+**Status:** Fixed in this branch.
+
+**Finding:** `e2e/types.d.ts` and the current delete E2E still model `deleteSkills` items as `{ skillName }` only. Service and browser tests cover metadata-name vs folder-basename deletion, but the Electron IPC path can regress without an E2E failure.
+
+**Fix direction:** Update the E2E bridge type and add an Electron E2E that deletes a `metadata-title` row via reviewed `skillPath` pointing at `folder-basename`, while a decoy `metadata-title` folder remains untouched.
+
+### P1. Reviewed-link bulk unlink needs Electron E2E coverage
+
+**Status:** Fixed in this branch.
+
+**Finding:** `e2e/types.d.ts` and the current bulk unlink E2E still model `unlinkManyFromAgent` items as `{ skillName }` only. Main and renderer tests cover metadata-name vs slot-basename unlink, but the full Electron destructive flow does not.
+
+**Fix direction:** Update the E2E bridge type and add an Electron E2E that unlinks the reviewed `folder-basename` slot while a decoy `metadata-title` slot and the source directory remain intact.
+
+### P0. Destructive delete IPC must require reviewed skill paths
+
+**Status:** Fixed in this branch.
+
+**Finding:** `skills:deleteSkill` and `skills:deleteSkills` still accept payloads without `skillPath`, preserving the old name-derived `SOURCE_DIR/<skillName>` delete path for any stale renderer, preload caller, or test harness.
+
+**Fix direction:** Make reviewed `skillPath` mandatory in the shared contract, Zod IPC schemas, renderer thunk targets, and E2E bridge types so destructive source delete cannot fall back to a display-name-derived path.
+
+### P0. Agent-local delete must not collapse to a source-folder delete
+
+**Status:** Fixed in this branch.
+
+**Finding:** A reviewed agent-local folder path such as `~/.claude/skills/folder-basename` resolves to `SOURCE_DIR/folder-basename`; if a source folder with the same basename exists, delete can tombstone the unreviewed source instead of the reviewed local copy.
+
+**Fix direction:** Preserve source-backed and reviewed agent-local delete identities as separate branches. Agent-local deletes must require the exact reviewed local folder to still exist, then use the local-only trash flow without probing or moving a source folder.
+
+### P1. Bulk unlink IPC must require reviewed link paths
+
+**Status:** Fixed in this branch.
+
+**Finding:** `skills:unlinkManyFromAgent` still allows `linkPath` to be omitted and falls back to `removeFromAgent(agent.path, skillName)`, keeping the old display-name-derived unlink behavior reachable.
+
+**Fix direction:** Make `linkPath` mandatory for every bulk unlink item in shared types, schemas, renderer thunk targets, and E2E bridge types, then remove the name-derived fallback in main.
+
+### P1. Bulk agent unlink must exclude local folders
+
+**Status:** Fixed in this branch.
+
+**Finding:** `selectBulkSelectableVisibleSkillNames` treats selected-agent local folders as bulk unlink eligible, but bulk unlink is now reviewed-symlink-only and refuses real directories. The toolbar can offer a doomed destructive action.
+
+**Fix direction:** In selected-agent view, bulk unlink should select only valid non-local symlink rows until a separate reviewed local-delete batch flow exists.
+
+### P1. Source-backed delete must remove metadata-named agent links
+
+**Status:** Fixed in this branch.
+
+**Finding:** When `SKILL.md` metadata name differs from the source folder basename, renderer add/sync flows can create agent links at `agent.path/<metadataName>`. Source-backed delete only probes `agent.path/<sourceFolderName>`, leaving metadata-named links dangling after the source is moved to trash.
+
+**Fix direction:** Source-backed delete should remove reviewed source symlinks for both the display skill name and source folder basename, validating each link still resolves to the reviewed source before unlinking.
+
 ## Orphan filter follow-ups (2026-05-09)
 
 ### 1. Source-view orphan visibility

--- a/TODOS.md
+++ b/TODOS.md
@@ -124,6 +124,46 @@ Deferred items captured during planning. Pick up when scope and bandwidth allow.
 
 **Fix direction:** Use neutral `needs review` wording for the amber segment and add browser coverage so inaccessible-only state is not announced as broken.
 
+### P1. Orphan cleanup must revalidate reviewed target identity
+
+**Status:** Fixed after final parallel subagent review.
+
+**Finding:** Orphan cleanup sends only `agentId + linkPath` for each reviewed agent link. If that same slot is replaced with a different dangling symlink before cleanup, main still unlinks it because the current target is missing.
+
+**Fix direction:** Carry reviewed orphan `targetPath` through the cleanup plan, IPC schema, shared contract, and main handler, then reject cleanup when the current resolved target differs from the reviewed target.
+
+### P1. Inaccessible agent slots must not use the normal unlink affordance
+
+**Status:** Fixed after final parallel subagent review.
+
+**Finding:** In agent view, `inaccessible` symlinks still qualify for the row X button and `UnlinkDialog` falls through to the valid-link copy. Users can be told the removal is a normal safe unlink even though the target could not be verified.
+
+**Fix direction:** Keep inaccessible slots visible as amber manual-review state, hide the normal unlink button for non-local inaccessible links, and make `UnlinkDialog` treat inaccessible as a separate manual-review variant if it is ever reached defensively.
+
+### P1. Stale and partial-failure dialog tests must cover same-id snapshot drift
+
+**Status:** Fixed after final parallel subagent review.
+
+**Finding:** Browser tests cover disappearing rows and matching failed rows, but not the fixed guard where a row keeps the same id while `linkPath`, `targetPath`, or preserved source identity changes.
+
+**Fix direction:** Add dialog browser tests where the second/final scan keeps the same row id but changes `targetPath`; stale cleanup must not call destructive IPC and partial failure must switch to rescan-required state.
+
+### P2. Pending destructive cleanup must prove close affordances are blocked
+
+**Status:** Fixed after final parallel subagent review.
+
+**Finding:** Pending-cleanup coverage asserts the loading title and disabled buttons, but not the corner close button or Escape/outside dismissal guards.
+
+**Fix direction:** While cleanup IPC is unresolved, assert the close button is hidden and Escape leaves the dialog in the cleaning phase.
+
+### P2. Broken-slot cleanup rows must show destructive link identity first
+
+**Status:** Fixed after final parallel subagent review.
+
+**Finding:** When metadata skill name differs from the agent-side link basename, cleanup row labels and checkbox accessible names use only the display skill name, while main unlinks by the link basename.
+
+**Fix direction:** Show the agent-side `linkName` first and include the metadata display name when it differs; add browser coverage for the mismatch case.
+
 ## Orphan filter follow-ups (2026-05-09)
 
 ### 1. Source-view orphan visibility

--- a/TODOS.md
+++ b/TODOS.md
@@ -988,6 +988,54 @@ Deferred items captured during planning. Pick up when scope and bandwidth allow.
 
 **Fix direction:** Assert the IPC validation rejection directly, then keep filesystem and trash-call assertions proving the unsafe local folder remains untouched.
 
+### P1. Cleanup rollback must restore moved candidates without overwrite-prone rename
+
+**Status:** Fixed after re-run gstack-review subagent review.
+
+**Finding:** `restoreMovedCleanupCandidate()` checked that `linkPath` was absent and then restored with `fs.rename(movedPath, linkPath)`. Another process could recreate `linkPath` after the check but before rename, allowing rollback to overwrite the replacement.
+
+**Fix direction:** Restore moved symlinks by recreating the symlink, restore directories/files with no-overwrite copy, remove the moved candidate only after success, and leave the moved path in place when restoration collides.
+
+### P1. Quarantine restore must recover regular-file replacements
+
+**Status:** Fixed after re-run gstack-review subagent review.
+
+**Finding:** `restoreQuarantinedPath()` restored symlinks and directories but returned `false` for regular files. If a reviewed symlink slot was replaced by a file between lstat and quarantine rename, the replacement could be stranded as `.unlink-*`.
+
+**Fix direction:** Add no-overwrite regular-file restoration and cover the race where unlink review sees a symlink but the quarantined entry is a regular file.
+
+### P1. Azure-backed E2E skip must detect empty skip-install snapshots
+
+**Status:** Fixed after re-run gstack-review subagent review.
+
+**Finding:** Azure-dependent E2E skip helpers only checked `snapshot.offline`; `E2E_SKIP_INSTALL=1` writes `offline: false` while leaving the snapshot empty, causing azure-backed tests to time out instead of skipping.
+
+**Fix direction:** Treat the azure fixture as unavailable when the snapshot is offline or `~/.agents/skills/azure-ai` is absent in the isolated HOME, while keeping self-staged destructive tests active.
+
+### P2. Source restore must treat dangling source-path symlinks as occupied
+
+**Status:** Fixed after re-run gstack-review subagent review.
+
+**Finding:** Source-backed undo used `fs.stat(manifest.sourcePath)` to check whether the original source path was free. A dangling symlink at that path returns `ENOENT` through `stat`, so restore could overwrite an occupied directory entry.
+
+**Fix direction:** Use `lstat` for the source-path occupancy gate and add a restore regression where a dangling symlink occupies the original source path.
+
+### P2. Restore E2E must assert recreated symlink targets
+
+**Status:** Fixed after re-run gstack-review subagent review.
+
+**Finding:** Undo/restore E2E asserted that agent entries exist and are symlinks, but not that they point back to the reviewed restored source. A wrong-target symlink restore could still pass.
+
+**Fix direction:** Assert `realpathSync.native(symlink.linkPath) === realpathSync.native(expectedSourcePath)` after restore in both IPC and UI undo coverage.
+
+### P3. README tool versions and SymlinkInfo docs must match current code
+
+**Status:** Fixed after re-run gstack-review subagent review.
+
+**Finding:** README still said `pnpm 9+` / Electron 41, while the repo pins pnpm 10 and Electron 42. `SymlinkInfo.status` docs also omitted the `inaccessible` state.
+
+**Fix direction:** Update README prerequisites / tech stack and the one-line `SymlinkInfo.status` comment.
+
 ### P2. Undo toast E2E must not depend on snapshot-installed azure-ai
 
 **Status:** Fixed after final gstack-review subagent review.

--- a/TODOS.md
+++ b/TODOS.md
@@ -804,6 +804,62 @@ Deferred items captured during planning. Pick up when scope and bandwidth allow.
 
 **Fix direction:** Source-backed delete should remove reviewed source symlinks for both the display skill name and source folder basename, validating each link still resolves to the reviewed source before unlinking.
 
+### P1. Delete IPC must reject same-path filesystem replacements
+
+**Status:** Fixed in follow-up after parallel subagent review.
+
+**Finding:** Reviewed delete payloads carried `skillPath`, but main re-statted the current path without binding it to the entry the user reviewed. A stale payload replay could delete a replacement folder created at the same path after review.
+
+**Fix direction:** Capture scan-time filesystem identity for source and local skill directories, require it in single and bulk delete IPC payloads, and revalidate `lstat` identity plus `SKILL.md` validity before moving anything to trash.
+
+### P1. Single-agent local folder unlink must require reviewed directory identity
+
+**Status:** Fixed in follow-up after parallel subagent review.
+
+**Finding:** `skills:unlinkFromAgent` protected local folder deletion with `confirmedLocalDirectoryDelete`, but did not bind that confirmation to the reviewed directory. A stale or malicious renderer payload could trash a different direct child local skill folder.
+
+**Fix direction:** Pass `reviewedDirectoryIdentity` for local-folder unlink, reject missing or mismatched identities in main, and verify the current directory is still a valid skill before `shell.trashItem`.
+
+### P1. Bulk confirm must snapshot reviewed destructive targets
+
+**Status:** Fixed in follow-up after parallel subagent review.
+
+**Finding:** `BulkConfirmState` stored only names. If `fetchSkills` refreshed while the dialog was open, confirm rebuilt delete/unlink paths from live rows instead of the rows the user reviewed.
+
+**Fix direction:** Store reviewed delete targets, orphan cleanup records, orphan preflight errors, and unlink targets in `BulkConfirmState`; confirm now executes from that snapshot and only falls back to live reconstruction for legacy/test state.
+
+### P1. `moveToTrash` must validate reviewed paths are valid skill directories
+
+**Status:** Fixed in follow-up after parallel subagent review.
+
+**Finding:** `moveToTrash` accepted any direct child under a known skills directory. It did not revalidate that the reviewed path was still a real, non-symlink skill directory with `SKILL.md`.
+
+**Fix direction:** Add shared reviewed-directory validation that uses `lstat`, filesystem identity comparison, and `isValidSkillDir` before both source-backed and agent-local trash moves.
+
+### P1. Delete E2E must assert removed symlink entries with `lstat`
+
+**Status:** Fixed in follow-up after parallel subagent review.
+
+**Finding:** The source-backed delete E2E used `existsSync` on symlink paths. Since `existsSync` follows links, a leftover dangling symlink can look absent and make the test pass.
+
+**Fix direction:** Assert removal with `lstatSync` expecting `ENOENT`, so a dangling symlink left on disk fails the test.
+
+### P2. Bulk delete aria copy must not promise permanent deletion
+
+**Status:** Fixed in follow-up after parallel subagent review.
+
+**Finding:** Bulk delete accessibility copy said selected skills would be deleted permanently, even though source-backed delete moves files to app trash with an undo window.
+
+**Fix direction:** Change the label to "Move ... to app trash" so screen-reader copy matches the actual reversible behavior.
+
+### P2. Single-agent unlink path schema must require absolute reviewed paths
+
+**Status:** Fixed in follow-up after parallel subagent review.
+
+**Finding:** `skills:unlinkFromAgent.linkPath` was still validated as a non-empty string, leaving relative reviewed paths accepted at the IPC schema boundary.
+
+**Fix direction:** Reuse the absolute-path schema for the single-agent unlink payload and add IPC schema regression coverage.
+
 ## Orphan filter follow-ups (2026-05-09)
 
 ### 1. Source-view orphan visibility

--- a/TODOS.md
+++ b/TODOS.md
@@ -284,6 +284,38 @@ Deferred items captured during planning. Pick up when scope and bandwidth allow.
 
 **Fix direction:** Show Rescan for error states as well, especially when no actionable plan is available.
 
+### P1. Mixed global Delete must preserve failed source rows
+
+**Status:** Fixed after third post-fix subagent review follow-up.
+
+**Finding:** Mixed global delete batches that include orphan cleanup clear selection and leave bulk mode before source-backed deletion resolves. If a source delete fails, the failed row no longer stays selected for retry.
+
+**Fix direction:** Clear selection eagerly only for true orphan-only batches, or reconcile final selection after both source delete and orphan cleanup so failed source rows remain selected.
+
+### P1. Complete-but-stale cleanup state needs a Rescan action
+
+**Status:** Fixed after third post-fix subagent review follow-up.
+
+**Finding:** When destructive cleanup succeeds but the post-cleanup dashboard refresh fails, the dialog says `Rescan to refresh the dashboard state` but the footer exposes only `Done`.
+
+**Fix direction:** Surface `Rescan` in the complete footer when the summary contains a post-cleanup refresh failure.
+
+### P1. Reviewed cleanup must not quarantine an unreviewed replacement
+
+**Status:** Fixed after third post-fix subagent review follow-up.
+
+**Finding:** The atomic quarantine path renames whatever currently occupies `linkPath` before proving it is still the reviewed symlink. If another process swaps in a local folder, a crash or restore failure can strand the user's folder under `.cleanup-*`.
+
+**Fix direction:** Avoid rename-first cleanup for paths that can become non-symlinks. Revalidate the reviewed symlink target immediately before unlinking, and treat non-symlink unlink failures as stale/manual rescan.
+
+### P2. Global Delete confirm copy must separate stale orphan rows
+
+**Status:** Fixed after third post-fix subagent review follow-up.
+
+**Finding:** The global delete confirmation counts preflight `orphanErrors` as actionable orphan cleanup, so stale orphan rows can be described as if they will remove reviewed dangling symlinks.
+
+**Fix direction:** Count only cleanup-ready orphan records as orphan cleanup and add a separate rescan warning for stale orphan rows.
+
 ## Orphan filter follow-ups (2026-05-09)
 
 ### 1. Source-view orphan visibility

--- a/TODOS.md
+++ b/TODOS.md
@@ -356,6 +356,70 @@ Deferred items captured during planning. Pick up when scope and bandwidth allow.
 
 **Fix direction:** Treat both `deleted` and `orphan-cleared` as successful removal outcomes in selection and anchor reconciliation, with reducer coverage.
 
+### P1. Cleanup commit must not path-unlink a post-validation replacement
+
+**Status:** Fixed in `fix: close symlink cleanup fifth-review findings`.
+
+**Finding:** Final symlink/target revalidation still commits with `fs.unlink(linkPath)`. A replacement after final validation but before unlink can delete an unreviewed same-path symlink/file.
+
+**Fix direction:** Use a guarded commit step: rename the reviewed slot to a private same-directory path, revalidate that moved entry and missing target, restore on mismatch/stale target, and unlink only the verified temp entry.
+
+### P1. Restore must resolve relative symlink targets through physical parents
+
+**Status:** Fixed in `fix: close symlink cleanup fifth-review findings`.
+
+**Finding:** Undo restore resolves recorded relative symlink targets against the logical `linkPath` parent. For Devin under symlinked `~/.config`, this can resolve to `/Users/.agents/...` and skip restoring the symlink.
+
+**Fix direction:** Use `resolveRawSymlinkTarget(link.linkPath, link.target)` during restore and add a real filesystem symlinked-`.config` restore regression.
+
+### P1. Agent-row broken cleanup must not use generic unlink
+
+**Status:** Fixed in `fix: close symlink cleanup fifth-review findings`.
+
+**Finding:** Agent view exposes normal unlink for broken non-local rows, routing through generic `unlinkFromAgent` without reviewed `targetPath` revalidation. A broken row that becomes live after scan can be removed as if still broken.
+
+**Fix direction:** Hide the normal unlink affordance for non-local broken rows unless routed through `clearBrokenSymlinkSlots`; add browser/helper coverage.
+
+### P2. CopyToAgents must resolve symlinked-parent relative targets physically
+
+**Status:** Fixed in `fix: close symlink cleanup fifth-review findings`.
+
+**Finding:** `copyToAgents` resolves a source symlink's raw target with `resolve(dirname(sourcePath), rawTarget)`, reproducing the symlinked `~/.config` physical-parent bug for valid Devin links.
+
+**Fix direction:** Use `resolveRawSymlinkTarget(sourcePath, rawTarget)` and add an integration test for copying a valid Devin symlink under symlinked `.config`.
+
+### P2. Orphan cleanup thunk must set bulk busy state
+
+**Status:** Fixed in `fix: close symlink cleanup fifth-review findings`.
+
+**Finding:** Global orphan-only Delete dispatches `clearSelectedOrphanSymlinks`, but the slice never sets `bulkDeleting` or `inFlightDeleteNames`; toolbar controls stay enabled and duplicate submissions are possible.
+
+**Fix direction:** Add pending/fulfilled/rejected reducers and UI pending handling for `clearSelectedOrphanSymlinks`.
+
+### P2. Inaccessible rows must not expose Add or Copy fan-out
+
+**Status:** Fixed in `fix: close symlink cleanup fifth-review findings`.
+
+**Finding:** Inaccessible symlinks are manual-review rows but still expose Add/Copy actions, allowing the UI to replicate a target the app could not verify.
+
+**Fix direction:** Gate Add/Copy on `!isInaccessibleSkill` and add helper/browser coverage.
+
+### P2. Refresh-failed Rescan must not lose dashboard retry context
+
+**Status:** Fixed in `fix: close symlink cleanup fifth-review findings`.
+
+**Finding:** If the first refresh-failed Rescan retries `fetchAgents`/`fetchSourceStats` and one fails again, the dialog enters error state; future Rescan calls become skills-only.
+
+**Fix direction:** Treat auxiliary dashboard refresh failures as secondary when `fetchSkills` succeeds, keeping the scan result usable and avoiding downgrade to skills-only retry.
+
+### P2. Mixed Delete rejection must refresh sticky error state
+
+**Status:** Fixed in `fix: close symlink cleanup fifth-review findings`.
+
+**Finding:** Mixed Delete source thunk rejection restores selection but does not refetch, leaving `skills.error` set and hiding the restored retry state behind the SkillsList error view.
+
+**Fix direction:** Call `refreshAllData(dispatch)` in the mixed rejection path after restoring unresolved selection.
+
 ## Orphan filter follow-ups (2026-05-09)
 
 ### 1. Source-view orphan visibility

--- a/e2e/spec/bulk-delete.e2e.ts
+++ b/e2e/spec/bulk-delete.e2e.ts
@@ -22,6 +22,45 @@ interface DeleteProgressPayload {
   total: number
 }
 
+interface E2EFilesystemIdentity {
+  kind: 'directory' | 'symlink' | 'file' | 'other'
+  dev: number
+  ino: number
+  size: number
+  ctimeMs: number
+  mtimeMs: number
+}
+
+interface DeleteSkillItem {
+  skillName: string
+  skillPath: string
+  filesystemIdentity: E2EFilesystemIdentity
+}
+
+/**
+ * Build the reviewed directory identity expected by destructive delete IPC.
+ * @param path - Reviewed source/local skill folder.
+ * @returns Serializable identity copied from Node lstat metadata.
+ * @example filesystemIdentityForPath('/tmp/home/.agents/skills/task')
+ */
+function filesystemIdentityForPath(path: string): E2EFilesystemIdentity {
+  const stats = lstatSync(path)
+  return {
+    kind: stats.isSymbolicLink()
+      ? 'symlink'
+      : stats.isDirectory()
+        ? 'directory'
+        : stats.isFile()
+          ? 'file'
+          : 'other',
+    dev: stats.dev,
+    ino: stats.ino,
+    size: stats.size,
+    ctimeMs: stats.ctimeMs,
+    mtimeMs: stats.mtimeMs,
+  }
+}
+
 /**
  * Pre-stage `count` source-backed dummy skills under the isolated HOME's
  * universal source dir (`~/.agents/skills/<name>`). Each skill gets a minimal
@@ -59,10 +98,14 @@ function preStageDummySkills(
  * @example deleteItemsFor(home, ['task'])
  */
 function deleteItemsFor(isolatedHome: string, skillNames: string[]) {
-  return skillNames.map((skillName) => ({
-    skillName,
-    skillPath: join(isolatedHome, '.agents', 'skills', skillName),
-  }))
+  return skillNames.map((skillName) => {
+    const skillPath = join(isolatedHome, '.agents', 'skills', skillName)
+    return {
+      skillName,
+      skillPath,
+      filesystemIdentity: filesystemIdentityForPath(skillPath),
+    }
+  })
 }
 
 /**
@@ -101,7 +144,7 @@ test('bulk deleteSkills below BULK_PROGRESS_THRESHOLD (N=9) skips progress event
   await clearIpcEvents(appWindow)
 
   const result = await appWindow.evaluate(
-    async (items: Array<{ skillName: string; skillPath: string }>) =>
+    async (items: DeleteSkillItem[]) =>
       window.electron.skills.deleteSkills({ items }),
     deleteItemsFor(isolatedHome, skillNames),
   )
@@ -155,7 +198,7 @@ test('bulk deleteSkills at BULK_PROGRESS_THRESHOLD (N=10) emits sequential progr
   await clearIpcEvents(appWindow)
 
   const result = await appWindow.evaluate(
-    async (items: Array<{ skillName: string; skillPath: string }>) =>
+    async (items: DeleteSkillItem[]) =>
       window.electron.skills.deleteSkills({ items }),
     deleteItemsFor(isolatedHome, skillNames),
   )
@@ -221,6 +264,7 @@ test('bulk deleteSkills with one missing source returns per-item error and conti
   // that aborts as soon as the first error fires.
   const failingIndex = 5
   const failingSkillName = skillNames[failingIndex]
+  const deleteItems = deleteItemsFor(isolatedHome, skillNames)
   rmSync(join(isolatedHome, '.agents', 'skills', failingSkillName), {
     recursive: true,
     force: true,
@@ -231,9 +275,9 @@ test('bulk deleteSkills with one missing source returns per-item error and conti
   await clearIpcEvents(appWindow)
 
   const result = await appWindow.evaluate(
-    async (items: Array<{ skillName: string; skillPath: string }>) =>
+    async (items: DeleteSkillItem[]) =>
       window.electron.skills.deleteSkills({ items }),
-    deleteItemsFor(isolatedHome, skillNames),
+    deleteItems,
   )
 
   expect(result.items).toHaveLength(10)
@@ -247,7 +291,7 @@ test('bulk deleteSkills with one missing source returns per-item error and conti
       expect(item.outcome).toBe('error')
       if (item.outcome === 'error') {
         expect(item.error.code).toBe('ENOENT')
-        expect(item.error.message).toMatch(/Reviewed skill source not found/)
+        expect(item.error.message).toMatch(/Reviewed skill folder not found/)
       }
     } else {
       expect(item.skillName).toBe(skillNames[index])
@@ -310,9 +354,13 @@ test('bulk deleteSkills uses reviewed skillPath when metadata name differs from 
 
   // Act
   const result = await appWindow.evaluate(
-    async (item: { skillName: string; skillPath: string }) =>
+    async (item: DeleteSkillItem) =>
       window.electron.skills.deleteSkills({ items: [item] }),
-    { skillName: metadataName, skillPath: sourcePath },
+    {
+      skillName: metadataName,
+      skillPath: sourcePath,
+      filesystemIdentity: filesystemIdentityForPath(sourcePath),
+    },
   )
 
   // Assert

--- a/e2e/spec/bulk-delete.e2e.ts
+++ b/e2e/spec/bulk-delete.e2e.ts
@@ -1,9 +1,11 @@
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
   readdirSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs'
 import { join } from 'node:path'
@@ -50,6 +52,20 @@ function preStageDummySkills(
 }
 
 /**
+ * Build reviewed delete IPC items from source skill names in the isolated HOME.
+ * @param isolatedHome - E2E fixture HOME.
+ * @param skillNames - Source folder basenames to delete.
+ * @returns Payload items with mandatory reviewed source paths.
+ * @example deleteItemsFor(home, ['task'])
+ */
+function deleteItemsFor(isolatedHome: string, skillNames: string[]) {
+  return skillNames.map((skillName) => ({
+    skillName,
+    skillPath: join(isolatedHome, '.agents', 'skills', skillName),
+  }))
+}
+
+/**
  * Phase-2 spec covering the `BULK_PROGRESS_THRESHOLD` boundary in
  * `SKILLS_DELETE_BATCH`. The handler emits one `skills:deleteProgress` event
  * per item ONLY when the batch size meets or exceeds the threshold (10) —
@@ -85,9 +101,9 @@ test('bulk deleteSkills below BULK_PROGRESS_THRESHOLD (N=9) skips progress event
   await clearIpcEvents(appWindow)
 
   const result = await appWindow.evaluate(
-    async (items: Array<{ skillName: string }>) =>
+    async (items: Array<{ skillName: string; skillPath: string }>) =>
       window.electron.skills.deleteSkills({ items }),
-    skillNames.map((skillName) => ({ skillName })),
+    deleteItemsFor(isolatedHome, skillNames),
   )
 
   expect(result.items).toHaveLength(9)
@@ -139,9 +155,9 @@ test('bulk deleteSkills at BULK_PROGRESS_THRESHOLD (N=10) emits sequential progr
   await clearIpcEvents(appWindow)
 
   const result = await appWindow.evaluate(
-    async (items: Array<{ skillName: string }>) =>
+    async (items: Array<{ skillName: string; skillPath: string }>) =>
       window.electron.skills.deleteSkills({ items }),
-    skillNames.map((skillName) => ({ skillName })),
+    deleteItemsFor(isolatedHome, skillNames),
   )
 
   expect(result.items).toHaveLength(10)
@@ -215,9 +231,9 @@ test('bulk deleteSkills with one missing source returns per-item error and conti
   await clearIpcEvents(appWindow)
 
   const result = await appWindow.evaluate(
-    async (items: Array<{ skillName: string }>) =>
+    async (items: Array<{ skillName: string; skillPath: string }>) =>
       window.electron.skills.deleteSkills({ items }),
-    skillNames.map((skillName) => ({ skillName })),
+    deleteItemsFor(isolatedHome, skillNames),
   )
 
   expect(result.items).toHaveLength(10)
@@ -231,7 +247,7 @@ test('bulk deleteSkills with one missing source returns per-item error and conti
       expect(item.outcome).toBe('error')
       if (item.outcome === 'error') {
         expect(item.error.code).toBe('ENOENT')
-        expect(item.error.message).toMatch(/Skill not found/)
+        expect(item.error.message).toMatch(/Reviewed skill source not found/)
       }
     } else {
       expect(item.skillName).toBe(skillNames[index])
@@ -267,4 +283,63 @@ test('bulk deleteSkills with one missing source returns per-item error and conti
   expect(
     trashEntries.some((entry) => entry.includes(`-${failingSkillName}-`)),
   ).toBe(false)
+})
+
+test('bulk deleteSkills uses reviewed skillPath when metadata name differs from folder basename', async ({
+  appWindow,
+  isolatedHome,
+}) => {
+  const metadataName = 'metadata-title-e2e'
+  const folderName = 'folder-basename-e2e'
+  const sourceDir = join(isolatedHome, '.agents', 'skills')
+  const sourcePath = join(sourceDir, folderName)
+  const decoySourcePath = join(sourceDir, metadataName)
+  const cursorSkillsDir = join(isolatedHome, '.cursor', 'skills')
+  const folderLinkPath = join(cursorSkillsDir, folderName)
+  const metadataLinkPath = join(cursorSkillsDir, metadataName)
+
+  // Arrange
+  mkdirSync(sourcePath, { recursive: true })
+  mkdirSync(decoySourcePath, { recursive: true })
+  mkdirSync(cursorSkillsDir, { recursive: true })
+  writeFileSync(join(sourcePath, 'SKILL.md'), `name: ${metadataName}\n`)
+  writeFileSync(join(decoySourcePath, 'SKILL.md'), `# decoy\n`)
+  symlinkSync(sourcePath, folderLinkPath)
+  symlinkSync(sourcePath, metadataLinkPath)
+  await waitForInitialScan(appWindow)
+
+  // Act
+  const result = await appWindow.evaluate(
+    async (item: { skillName: string; skillPath: string }) =>
+      window.electron.skills.deleteSkills({ items: [item] }),
+    { skillName: metadataName, skillPath: sourcePath },
+  )
+
+  // Assert
+  expect(result.items).toEqual([
+    {
+      skillName: metadataName,
+      outcome: 'deleted',
+      tombstoneId: expect.stringMatching(
+        /^\d+-metadata-title-e2e-[0-9a-f]{8}$/,
+      ),
+      symlinksRemoved: 2,
+      cascadeAgents: ['cursor'],
+    },
+  ])
+  expect(existsSync(sourcePath)).toBe(false)
+  expect(existsSync(decoySourcePath)).toBe(true)
+  expect(() => lstatSync(folderLinkPath)).toThrow(/ENOENT/)
+  expect(() => lstatSync(metadataLinkPath)).toThrow(/ENOENT/)
+  const trashDir = join(isolatedHome, '.agents', '.trash')
+  const [trashEntry] = readdirSync(trashDir).filter((entry) =>
+    entry.includes('-metadata-title-e2e-'),
+  )
+  expect(trashEntry).toBeDefined()
+  if (!trashEntry) throw new Error('Expected metadata-title tombstone entry')
+  const manifest = JSON.parse(
+    readFileSync(join(trashDir, trashEntry, 'manifest.json'), 'utf-8'),
+  ) as { skillName: string; sourcePath: string }
+  expect(manifest.skillName).toBe(metadataName)
+  expect(manifest.sourcePath).toBe(sourcePath)
 })

--- a/e2e/spec/delete.e2e.ts
+++ b/e2e/spec/delete.e2e.ts
@@ -51,6 +51,58 @@ interface SourceBackedManifest {
 
 const AZURE_AI_NAME = 'azure-ai'
 
+interface E2EFilesystemIdentity {
+  kind: 'directory' | 'symlink' | 'file' | 'other'
+  dev: number
+  ino: number
+  size: number
+  ctimeMs: number
+  mtimeMs: number
+}
+
+interface DeleteSkillPayload {
+  skillName: string
+  skillPath: string
+  filesystemIdentity: E2EFilesystemIdentity
+}
+
+/**
+ * Assert a path entry itself is gone; unlike existsSync, this detects dangling symlinks.
+ * @param path - Filesystem path expected to have no directory entry.
+ * @returns void after asserting lstat throws ENOENT.
+ * @example expectPathEntryMissing('/tmp/link')
+ */
+function expectPathEntryMissing(path: string): void {
+  expect(
+    () => lstatSync(path),
+    `expected ${path} directory entry to be removed`,
+  ).toThrow(/ENOENT/)
+}
+
+/**
+ * Build the reviewed directory identity expected by destructive delete IPC.
+ * @param path - Reviewed source/local skill folder.
+ * @returns Serializable identity copied from Node lstat metadata.
+ * @example filesystemIdentityForPath('/tmp/home/.agents/skills/task')
+ */
+function filesystemIdentityForPath(path: string): E2EFilesystemIdentity {
+  const stats = lstatSync(path)
+  return {
+    kind: stats.isSymbolicLink()
+      ? 'symlink'
+      : stats.isDirectory()
+        ? 'directory'
+        : stats.isFile()
+          ? 'file'
+          : 'other',
+    dev: stats.dev,
+    ino: stats.ino,
+    size: stats.size,
+    ctimeMs: stats.ctimeMs,
+    mtimeMs: stats.mtimeMs,
+  }
+}
+
 /**
  * Build the mandatory reviewed-path delete payload for E2E direct IPC calls.
  * @param isolatedHome - E2E fixture HOME.
@@ -64,7 +116,11 @@ function deleteSkillPayload(
   skillName: string,
   reviewedPath = join(isolatedHome, '.agents', 'skills', skillName),
 ) {
-  return { skillName, skillPath: reviewedPath }
+  return {
+    skillName,
+    skillPath: reviewedPath,
+    filesystemIdentity: filesystemIdentityForPath(reviewedPath),
+  }
 }
 
 /**
@@ -157,7 +213,7 @@ test('deleteSkill moves source-backed skill into trash and unlinks every agent s
   ).toBeGreaterThan(0)
 
   const ipcResult = await appWindow.evaluate(
-    async (payload: { skillName: string; skillPath: string }) =>
+    async (payload: DeleteSkillPayload) =>
       window.electron.skills.deleteSkill(payload),
     deleteSkillPayload(isolatedHome, AZURE_AI_NAME),
   )
@@ -173,10 +229,7 @@ test('deleteSkill moves source-backed skill into trash and unlinks every agent s
   // FS — source gone, every cascading symlink unlinked.
   expect(existsSync(expectedSourcePath)).toBe(false)
   for (const symlink of initial.validSymlinks) {
-    expect(
-      existsSync(symlink.linkPath),
-      `expected ${symlink.linkPath} to be unlinked after deleteSkill`,
-    ).toBe(false)
+    expectPathEntryMissing(symlink.linkPath)
   }
 
   // FS — trash entry exists with the expected layout. Entry basename matches
@@ -232,7 +285,7 @@ test('restoreDeletedSkill recovers a source-backed deletion within the undo wind
   expect(initial.validSymlinks.length).toBeGreaterThan(0)
 
   const deleteResult = await appWindow.evaluate(
-    async (payload: { skillName: string; skillPath: string }) =>
+    async (payload: DeleteSkillPayload) =>
       window.electron.skills.deleteSkill(payload),
     deleteSkillPayload(isolatedHome, AZURE_AI_NAME),
   )
@@ -342,7 +395,7 @@ test('deleteSkill moves a local-only skill into trash with kind="local-only" man
   await waitForInitialScan(appWindow)
 
   const ipcResult = await appWindow.evaluate(
-    async (payload: { skillName: string; skillPath: string }) =>
+    async (payload: DeleteSkillPayload) =>
       window.electron.skills.deleteSkill(payload),
     deleteSkillPayload(isolatedHome, skillName, codexAgentDir),
   )
@@ -524,7 +577,7 @@ test('source-backed delete entry is auto-evicted after UNDO_WINDOW_MS', async ({
   expect(initial.hasAzure).toBe(true)
 
   const deleteResult = await appWindow.evaluate(
-    async (payload: { skillName: string; skillPath: string }) =>
+    async (payload: DeleteSkillPayload) =>
       window.electron.skills.deleteSkill(payload),
     deleteSkillPayload(isolatedHome, AZURE_AI_NAME),
   )

--- a/e2e/spec/delete.e2e.ts
+++ b/e2e/spec/delete.e2e.ts
@@ -4,6 +4,7 @@ import {
   mkdirSync,
   readFileSync,
   readdirSync,
+  realpathSync,
   symlinkSync,
   writeFileSync,
 } from 'node:fs'
@@ -178,14 +179,16 @@ const azureSnapshotSelector = (state: unknown): AzureSnapshot => {
  */
 
 /**
- * Skip only specs that depend on the azure skill snapshot installed by global setup.
+ * Skip specs that depend on the azure skill snapshot installed by global setup.
+ * @param isolatedHome - E2E fixture HOME to inspect for the azure source dir.
  * @returns void; Playwright marks the current test as skipped when offline.
- * @example skipWhenAzureSnapshotOffline()
+ * @example skipWhenAzureSnapshotUnavailable('/tmp/home')
  */
-function skipWhenAzureSnapshotOffline(): void {
+function skipWhenAzureSnapshotUnavailable(isolatedHome: string): void {
   test.skip(
-    isSnapshotOffline(),
-    'azure-* skills required for this suite; runner is offline (global-setup wrote snapshot.offline=true)',
+    isSnapshotOffline() ||
+      !existsSync(join(isolatedHome, '.agents', 'skills', AZURE_AI_NAME)),
+    'azure-* skills required for this suite; snapshot is offline or install was skipped',
   )
 }
 
@@ -193,7 +196,7 @@ test('deleteSkill moves source-backed skill into trash and unlinks every agent s
   appWindow,
   isolatedHome,
 }) => {
-  skipWhenAzureSnapshotOffline()
+  skipWhenAzureSnapshotUnavailable(isolatedHome)
   await waitForInitialScan(appWindow)
 
   const expectedSourcePath = join(
@@ -272,7 +275,7 @@ test('restoreDeletedSkill recovers a source-backed deletion within the undo wind
   appWindow,
   isolatedHome,
 }) => {
-  skipWhenAzureSnapshotOffline()
+  skipWhenAzureSnapshotUnavailable(isolatedHome)
   await waitForInitialScan(appWindow)
 
   const expectedSourcePath = join(
@@ -328,6 +331,9 @@ test('restoreDeletedSkill recovers a source-backed deletion within the undo wind
     expect(existsSync(symlink.linkPath)).toBe(true)
     const stat = lstatSync(symlink.linkPath)
     expect(stat.isSymbolicLink()).toBe(true)
+    expect(realpathSync.native(symlink.linkPath)).toBe(
+      realpathSync.native(expectedSourcePath),
+    )
   }
 
   // FS — trash entry cleaned up by finalizeRestore (rm + cancel TTL timer).
@@ -565,7 +571,7 @@ test('source-backed delete entry is auto-evicted after UNDO_WINDOW_MS', async ({
   appWindow,
   isolatedHome,
 }) => {
-  skipWhenAzureSnapshotOffline()
+  skipWhenAzureSnapshotUnavailable(isolatedHome)
   test.setTimeout(45_000)
 
   await waitForInitialScan(appWindow)

--- a/e2e/spec/delete.e2e.ts
+++ b/e2e/spec/delete.e2e.ts
@@ -177,21 +177,23 @@ const azureSnapshotSelector = (state: unknown): AzureSnapshot => {
  * eviction live in dedicated tests below the source-backed pair.
  */
 
-// Every test in this file deletes / restores `azure-ai` from the snapshot
-// SOURCE_DIR. When global-setup is offline the snapshot is empty and the
-// `hasAzure: true` precondition would fail with a confusing renderer error
-// instead of a clean skip.
-test.beforeEach(() => {
+/**
+ * Skip only specs that depend on the azure skill snapshot installed by global setup.
+ * @returns void; Playwright marks the current test as skipped when offline.
+ * @example skipWhenAzureSnapshotOffline()
+ */
+function skipWhenAzureSnapshotOffline(): void {
   test.skip(
     isSnapshotOffline(),
     'azure-* skills required for this suite; runner is offline (global-setup wrote snapshot.offline=true)',
   )
-})
+}
 
 test('deleteSkill moves source-backed skill into trash and unlinks every agent symlink', async ({
   appWindow,
   isolatedHome,
 }) => {
+  skipWhenAzureSnapshotOffline()
   await waitForInitialScan(appWindow)
 
   const expectedSourcePath = join(
@@ -270,6 +272,7 @@ test('restoreDeletedSkill recovers a source-backed deletion within the undo wind
   appWindow,
   isolatedHome,
 }) => {
+  skipWhenAzureSnapshotOffline()
   await waitForInitialScan(appWindow)
 
   const expectedSourcePath = join(
@@ -562,6 +565,7 @@ test('source-backed delete entry is auto-evicted after UNDO_WINDOW_MS', async ({
   appWindow,
   isolatedHome,
 }) => {
+  skipWhenAzureSnapshotOffline()
   test.setTimeout(45_000)
 
   await waitForInitialScan(appWindow)

--- a/e2e/spec/delete.e2e.ts
+++ b/e2e/spec/delete.e2e.ts
@@ -52,6 +52,22 @@ interface SourceBackedManifest {
 const AZURE_AI_NAME = 'azure-ai'
 
 /**
+ * Build the mandatory reviewed-path delete payload for E2E direct IPC calls.
+ * @param isolatedHome - E2E fixture HOME.
+ * @param skillName - Display skill name to delete.
+ * @param reviewedPath - Optional reviewed source/local folder path override.
+ * @returns Payload accepted by `skills:deleteSkill`.
+ * @example deleteSkillPayload(home, 'azure-ai')
+ */
+function deleteSkillPayload(
+  isolatedHome: string,
+  skillName: string,
+  reviewedPath = join(isolatedHome, '.agents', 'skills', skillName),
+) {
+  return { skillName, skillPath: reviewedPath }
+}
+
+/**
  * Single snapshot selector for azure-ai used by every test in this file.
  *
  * `getStoreState` serializes this function via `Function.prototype.toString`
@@ -141,9 +157,9 @@ test('deleteSkill moves source-backed skill into trash and unlinks every agent s
   ).toBeGreaterThan(0)
 
   const ipcResult = await appWindow.evaluate(
-    async (skillName: string) =>
-      window.electron.skills.deleteSkill({ skillName }),
-    AZURE_AI_NAME,
+    async (payload: { skillName: string; skillPath: string }) =>
+      window.electron.skills.deleteSkill(payload),
+    deleteSkillPayload(isolatedHome, AZURE_AI_NAME),
   )
 
   expect(ipcResult.success).toBe(true)
@@ -216,9 +232,9 @@ test('restoreDeletedSkill recovers a source-backed deletion within the undo wind
   expect(initial.validSymlinks.length).toBeGreaterThan(0)
 
   const deleteResult = await appWindow.evaluate(
-    async (skillName: string) =>
-      window.electron.skills.deleteSkill({ skillName }),
-    AZURE_AI_NAME,
+    async (payload: { skillName: string; skillPath: string }) =>
+      window.electron.skills.deleteSkill(payload),
+    deleteSkillPayload(isolatedHome, AZURE_AI_NAME),
   )
   expect(deleteResult.success).toBe(true)
 
@@ -326,9 +342,9 @@ test('deleteSkill moves a local-only skill into trash with kind="local-only" man
   await waitForInitialScan(appWindow)
 
   const ipcResult = await appWindow.evaluate(
-    async (name: string) =>
-      window.electron.skills.deleteSkill({ skillName: name }),
-    skillName,
+    async (payload: { skillName: string; skillPath: string }) =>
+      window.electron.skills.deleteSkill(payload),
+    deleteSkillPayload(isolatedHome, skillName, codexAgentDir),
   )
 
   expect(ipcResult.success).toBe(true)
@@ -370,25 +386,17 @@ test('deleteSkill moves a local-only skill into trash with kind="local-only" man
 })
 
 /**
- * Orphan-cleared delete branch (issue #71 PR-1) — exercises the third arm of
- * `moveToTrash`'s dispatcher in `trashService.ts:moveToTrash`. Both the source
- * dir AND every agent's local copy are absent; the only remaining records are
- * dangling symlinks. The handler must:
+ * Orphan cleanup branch (issue #71 PR-1) — exercises the exact reviewed
+ * `clearOrphanSymlinks` IPC path. Both the source dir AND every agent's local
+ * copy are absent; the only remaining records are dangling symlinks. The
+ * handler must:
  *
- *   1. Probe `~/.agents/skills/<name>` → ENOENT, NOT throw.
- *   2. `scanLocalCopies` → empty (no real folders anywhere).
- *   3. `scanOrphanSymlinkPaths` → finds the dangling links.
- *   4. `clearOrphanSymlinks` unlinks each, returns `kind: 'orphan-cleared'`.
- *   5. NO trash entry, NO manifest, NO TTL timer — the source is gone, so
+ *   1. Revalidate the exact reviewed `linkPath + targetPath`.
+ *   2. `clearOrphanSymlinks` unlinks each dangling link.
+ *   3. NO trash entry, NO manifest, NO TTL timer — the source is gone, so
  *      "undo" would only restore broken links.
- *
- * The single-delete IPC `SKILLS_DELETE` strips `kind` and `tombstoneId` from
- * the result (see `src/main/ipc/skills.ts:SKILLS_DELETE`); only the bulk-delete
- * path discriminates on `outcome`. So this test asserts only the common-shape
- * fields (`success`, `symlinksRemoved`, `cascadeAgents`) plus the FS invariants
- * — link gone, trash dir untouched.
  */
-test('deleteSkill clears orphan (broken) symlinks with no trash entry', async ({
+test('clearOrphanSymlinks removes reviewed broken symlinks with no trash entry', async ({
   appWindow,
   isolatedHome,
 }) => {
@@ -410,16 +418,36 @@ test('deleteSkill clears orphan (broken) symlinks with no trash entry', async ({
   await waitForInitialScan(appWindow)
 
   const ipcResult = await appWindow.evaluate(
-    async (name: string) =>
-      window.electron.skills.deleteSkill({ skillName: name }),
-    skillName,
+    async (payload: {
+      items: Array<{
+        skillName: string
+        agents: Array<{ agentId: string; linkPath: string; targetPath: string }>
+      }>
+    }) => window.electron.skills.clearOrphanSymlinks(payload),
+    {
+      items: [
+        {
+          skillName,
+          agents: [
+            {
+              agentId: 'codex',
+              linkPath: orphanLinkPath,
+              targetPath: phantomSourcePath,
+            },
+          ],
+        },
+      ],
+    },
   )
 
-  expect(ipcResult.success).toBe(true)
-  // Common-shape fields work for both kinds. orphan-cleared returns the
-  // unlinked count and the agents whose links were swept.
-  expect(ipcResult.symlinksRemoved).toBe(1)
-  expect(ipcResult.cascadeAgents).toEqual(['codex'])
+  expect(ipcResult.items).toEqual([
+    {
+      skillName,
+      outcome: 'orphan-cleared',
+      symlinksRemoved: 1,
+      cascadeAgents: ['codex'],
+    },
+  ])
 
   // FS — the dangling symlink itself is gone (lstat throws ENOENT). Using
   // lstat (not stat) because stat follows symlinks and would have thrown
@@ -496,9 +524,9 @@ test('source-backed delete entry is auto-evicted after UNDO_WINDOW_MS', async ({
   expect(initial.hasAzure).toBe(true)
 
   const deleteResult = await appWindow.evaluate(
-    async (skillName: string) =>
-      window.electron.skills.deleteSkill({ skillName }),
-    AZURE_AI_NAME,
+    async (payload: { skillName: string; skillPath: string }) =>
+      window.electron.skills.deleteSkill(payload),
+    deleteSkillPayload(isolatedHome, AZURE_AI_NAME),
   )
   expect(deleteResult.success).toBe(true)
 

--- a/e2e/spec/regression.e2e.ts
+++ b/e2e/spec/regression.e2e.ts
@@ -41,14 +41,16 @@ interface E2EFilesystemIdentity {
 const AZURE_AI_NAME = 'azure-ai'
 
 /**
- * Skip only tests whose assertion target comes from the snapshot install.
+ * Skip tests whose assertion target comes from the snapshot install.
+ * @param isolatedHome - E2E fixture HOME to inspect for the azure source dir.
  * @returns void; Playwright marks the current test skipped when offline.
- * @example skipWhenAzureSnapshotOffline()
+ * @example skipWhenAzureSnapshotUnavailable('/tmp/home')
  */
-function skipWhenAzureSnapshotOffline(): void {
+function skipWhenAzureSnapshotUnavailable(isolatedHome: string): void {
   test.skip(
-    isSnapshotOffline(),
-    'azure-* skills required for this test; runner is offline (global-setup wrote snapshot.offline=true)',
+    isSnapshotOffline() ||
+      !existsSync(join(isolatedHome, '.agents', 'skills', AZURE_AI_NAME)),
+    'azure-* skills required for this test; snapshot is offline or install was skipped',
   )
 }
 
@@ -116,8 +118,9 @@ function filesystemIdentityForPath(path: string): E2EFilesystemIdentity {
 
 test('selection survives no further than a tab switch or agent switch (regression 2f05684)', async ({
   appWindow,
+  isolatedHome,
 }) => {
-  skipWhenAzureSnapshotOffline()
+  skipWhenAzureSnapshotUnavailable(isolatedHome)
   await waitForInitialScan(appWindow)
 
   // Tab-switch leg — toggle one azure-* skill into the selection, flip the
@@ -189,8 +192,9 @@ test('selection survives no further than a tab switch or agent switch (regressio
  */
 test('selection clears on fetchSyncPreview.pending — third listener-matcher leg (regression 2f05684 follow-up)', async ({
   appWindow,
+  isolatedHome,
 }) => {
-  skipWhenAzureSnapshotOffline()
+  skipWhenAzureSnapshotUnavailable(isolatedHome)
   await waitForInitialScan(appWindow)
 
   // Tick one azure-* skill so the listener has something to clear. Leg-1/-2
@@ -250,7 +254,7 @@ test('cline/warp do NOT report universal source skills as their own local skills
   appWindow,
   isolatedHome,
 }) => {
-  skipWhenAzureSnapshotOffline()
+  skipWhenAzureSnapshotUnavailable(isolatedHome)
   await waitForInitialScan(appWindow)
 
   // FS truth — universal source has azure-ai but neither cline nor warp's
@@ -869,8 +873,9 @@ test('sidebar inner ScrollArea wrapper does not inflate beyond aside width (regr
  */
 test('skills list scroll position survives a background refetch (regression 5619bb7)', async ({
   appWindow,
+  isolatedHome,
 }) => {
-  skipWhenAzureSnapshotOffline()
+  skipWhenAzureSnapshotUnavailable(isolatedHome)
   await waitForInitialScan(appWindow)
 
   const itemCount = await getStoreState(appWindow, (state) => {

--- a/e2e/spec/regression.e2e.ts
+++ b/e2e/spec/regression.e2e.ts
@@ -41,6 +41,32 @@ interface E2EFilesystemIdentity {
 const AZURE_AI_NAME = 'azure-ai'
 
 /**
+ * Skip only tests whose assertion target comes from the snapshot install.
+ * @returns void; Playwright marks the current test skipped when offline.
+ * @example skipWhenAzureSnapshotOffline()
+ */
+function skipWhenAzureSnapshotOffline(): void {
+  test.skip(
+    isSnapshotOffline(),
+    'azure-* skills required for this test; runner is offline (global-setup wrote snapshot.offline=true)',
+  )
+}
+
+/**
+ * Stage a minimal source skill inside the isolated HOME before renderer scans.
+ * @param isolatedHome - Test HOME from the Electron fixture.
+ * @param skillName - Skill folder name to create under ~/.agents/skills.
+ * @returns Absolute source skill directory path.
+ * @example stageSourceSkill('/tmp/home', 'fixture-skill')
+ */
+function stageSourceSkill(isolatedHome: string, skillName: string): string {
+  const sourcePath = join(isolatedHome, '.agents', 'skills', skillName)
+  mkdirSync(sourcePath, { recursive: true })
+  writeFileSync(join(sourcePath, 'SKILL.md'), `# ${skillName}\n`)
+  return sourcePath
+}
+
+/**
  * Build the reviewed directory identity required by removeAllFromAgent IPC.
  * @param path - Reviewed agent skills path.
  * @returns Serializable identity copied from Node lstat metadata.
@@ -88,21 +114,10 @@ function filesystemIdentityForPath(path: string): E2EFilesystemIdentity {
  * one regression silently mask another.
  */
 
-// Every test in this file reads `~/.agents/skills/azure-ai` from the snapshot
-// (selection regressions dispatch `payload: AZURE_AI_NAME`; the IRON-RULE
-// suite walks the symlink chain rooted at the snapshot's SOURCE_DIR). When
-// global-setup is offline, SOURCE_DIR is empty and the renderer surfaces an
-// empty skill list, which would silently drop the assertion target.
-test.beforeEach(() => {
-  test.skip(
-    isSnapshotOffline(),
-    'azure-* skills required for this suite; runner is offline (global-setup wrote snapshot.offline=true)',
-  )
-})
-
 test('selection survives no further than a tab switch or agent switch (regression 2f05684)', async ({
   appWindow,
 }) => {
+  skipWhenAzureSnapshotOffline()
   await waitForInitialScan(appWindow)
 
   // Tab-switch leg — toggle one azure-* skill into the selection, flip the
@@ -175,6 +190,7 @@ test('selection survives no further than a tab switch or agent switch (regressio
 test('selection clears on fetchSyncPreview.pending — third listener-matcher leg (regression 2f05684 follow-up)', async ({
   appWindow,
 }) => {
+  skipWhenAzureSnapshotOffline()
   await waitForInitialScan(appWindow)
 
   // Tick one azure-* skill so the listener has something to clear. Leg-1/-2
@@ -234,6 +250,7 @@ test('cline/warp do NOT report universal source skills as their own local skills
   appWindow,
   isolatedHome,
 }) => {
+  skipWhenAzureSnapshotOffline()
   await waitForInitialScan(appWindow)
 
   // FS truth — universal source has azure-ai but neither cline nor warp's
@@ -326,7 +343,9 @@ test('removeAllFromAgent refuses on a multi-agent shared scanDir (.config/agents
   const sentinelPath = join(sharedScanDir, 'iron-rule-sentinel.md')
   writeFileSync(sentinelPath, '# sentinel\n')
 
-  await waitForInitialScan(appWindow)
+  await appWindow.waitForFunction(() =>
+    Boolean(window.electron?.skills?.removeAllFromAgent),
+  )
 
   const result = await appWindow.evaluate(
     async (args: {
@@ -381,12 +400,10 @@ test('removeAllFromAgent refusal leaves both aliased symlinks and local skill by
   const sharedScanDir = join(isolatedHome, '.config', 'agents', 'skills')
   mkdirSync(sharedScanDir, { recursive: true })
 
-  // Source skill the alias points at — the global-setup scan creates this.
-  const aliasTargetPath = join(isolatedHome, '.agents', 'skills', AZURE_AI_NAME)
-  expect(
-    existsSync(aliasTargetPath),
-    `expected snapshot SOURCE_DIR to contain ${AZURE_AI_NAME}; global-setup may have changed`,
-  ).toBe(true)
+  // Source skill the alias points at. This test owns the fixture so the safety
+  // check stays active even when the global snapshot install is offline.
+  const aliasSkillName = 'b1-source-alias-fixture'
+  const aliasTargetPath = stageSourceSkill(isolatedHome, aliasSkillName)
 
   // Pre-stage mixed contents inside the shared dir.
   const aliasLinkPath = join(sharedScanDir, 'b1-azure-alias')
@@ -459,6 +476,7 @@ test('removeAllFromAgent refusal still fires when SOURCE_DIR itself is a symlink
   appWindow,
   isolatedHome,
 }) => {
+  stageSourceSkill(isolatedHome, 'firmlink-source-fixture')
   // Wait for the renderer's initial scan BEFORE renaming SOURCE_DIR.
   // The scanner reads SOURCE_DIR's contents; renaming mid-scan would race
   // and could surface as a flaky ENOENT in the renderer's fetchSkills
@@ -478,7 +496,7 @@ test('removeAllFromAgent refusal still fires when SOURCE_DIR itself is a symlink
     `expected ${realSourceDirParent} to be absent — isolated home leaked across tests`,
   ).toBe(false)
 
-  // Step 1: relocate the snapshot's source bytes to .agents-real/skills/.
+  // Step 1: relocate the staged source bytes to .agents-real/skills/.
   // renameSync is sound here because cp -al -based snapshots create real
   // directories (only files are hardlinked); moving the directory entry
   // doesn't touch the file inodes underneath.
@@ -505,7 +523,7 @@ test('removeAllFromAgent refusal still fires when SOURCE_DIR itself is a symlink
   const realSourceContentsBefore = readdirSync(realSourceDir).sort()
   expect(
     realSourceContentsBefore.length,
-    'expected the relocated SOURCE_DIR to retain the snapshot contents',
+    'expected the relocated SOURCE_DIR to retain staged source contents',
   ).toBeGreaterThan(0)
 
   const result = await appWindow.evaluate(
@@ -566,7 +584,7 @@ test('removeAllFromAgent refusal still fires when SOURCE_DIR itself is a symlink
  *      slot would silently break the renderer's broken-vs-missing badge
  *      logic without surfacing in a sourced-skill assertion.
  *
- * Negative control on a real source (azure-ai) in the same store state
+ * Negative control on a self-staged real source in the same store state
  * confirms the orphan flag did NOT broaden across all rows — the previous
  * three assertions alone could pass while every row got `isOrphan: true`.
  */
@@ -574,6 +592,7 @@ test('scanSkills surfaces broken symlinks as orphan skills (regression #127)', a
   appWindow,
   isolatedHome,
 }) => {
+  stageSourceSkill(isolatedHome, 'source-control-fixture')
   await waitForInitialScan(appWindow)
 
   // Stage the orphan condition: a non-universal agent dir containing a
@@ -668,18 +687,16 @@ test('scanSkills surfaces broken symlinks as orphan skills (regression #127)', a
   )
   expect(claudeRow?.status).toBe('missing')
 
-  // Negative control — a real source skill (azure-ai) MUST NOT be flagged
+  // Negative control — a real source skill MUST NOT be flagged
   // as orphan. A regression that broadened the orphan branch (e.g. moving
   // `isOrphan: true` outside the orphan-scan block in scanSkills.ts) would
   // pass the orphan-row assertions above but flip every source skill into
   // `isOrphan: true`, hiding their delete/unlink buttons across the UI.
-  // The file-level `test.beforeEach` already skips this entire suite when
-  // the snapshot is offline, so azure-ai is guaranteed to be installed.
+  // This spec stages the control source itself so it remains active offline.
   // `getStoreState` re-evaluates the selector inside the renderer via
-  // `Function.toString`, so closure-scope identifiers like `AZURE_AI_NAME`
-  // would resolve to `undefined` at runtime. Inline the literal — same
-  // pattern delete.e2e.ts uses for `'azure-ai'` in azureSnapshotSelector.
-  const azureRecord = await getStoreState(
+  // `Function.toString`, so closure-scope identifiers would resolve to
+  // `undefined` at runtime. Inline the literal string.
+  const sourceRecord = await getStoreState(
     appWindow,
     (state): { isOrphan: boolean; isSource: boolean } | null => {
       const root = state as {
@@ -687,18 +704,20 @@ test('scanSkills surfaces broken symlinks as orphan skills (regression #127)', a
           items: Array<{ name: string; isOrphan: boolean; isSource: boolean }>
         }
       }
-      const azure = root.skills.items.find((skill) => skill.name === 'azure-ai')
-      return azure
-        ? { isOrphan: azure.isOrphan, isSource: azure.isSource }
+      const source = root.skills.items.find(
+        (skill) => skill.name === 'source-control-fixture',
+      )
+      return source
+        ? { isOrphan: source.isOrphan, isSource: source.isSource }
         : null
     },
   )
   expect(
-    azureRecord,
-    'azure-ai (real source) must remain in skills.items alongside the orphan',
+    sourceRecord,
+    'source-control-fixture (real source) must remain in skills.items alongside the orphan',
   ).not.toBeNull()
-  expect(azureRecord?.isOrphan).toBe(false)
-  expect(azureRecord?.isSource).toBe(true)
+  expect(sourceRecord?.isOrphan).toBe(false)
+  expect(sourceRecord?.isSource).toBe(true)
 })
 
 /**
@@ -741,15 +760,14 @@ test('scanSkills surfaces broken symlinks as orphan skills (regression #127)', a
  *      wrapper width assertion ever loses precision against a future Radix
  *      version.
  *
- * This test does not depend on the snapshot's azure-* skills — it only needs
- * the Sidebar mounted with the SourceCard visible. The file-level
- * `test.beforeEach` skip-gate against `isSnapshotOffline()` is irrelevant here
- * but harmless; we accept the false-positive skip on offline runs to keep the
- * suite uniform.
+ * This test does not depend on the snapshot's azure-* skills — it stages one
+ * minimal source so the Sidebar mounts with the SourceCard visible offline.
  */
 test('sidebar inner ScrollArea wrapper does not inflate beyond aside width (regression a541de9)', async ({
   appWindow,
+  isolatedHome,
 }) => {
+  stageSourceSkill(isolatedHome, 'sidebar-sourcecard-fixture')
   await waitForInitialScan(appWindow)
 
   const aside = appWindow.locator('aside[aria-label="Agent sidebar"]')
@@ -852,6 +870,7 @@ test('sidebar inner ScrollArea wrapper does not inflate beyond aside width (regr
 test('skills list scroll position survives a background refetch (regression 5619bb7)', async ({
   appWindow,
 }) => {
+  skipWhenAzureSnapshotOffline()
   await waitForInitialScan(appWindow)
 
   const itemCount = await getStoreState(appWindow, (state) => {

--- a/e2e/spec/regression.e2e.ts
+++ b/e2e/spec/regression.e2e.ts
@@ -29,7 +29,40 @@ interface SymlinkSnapshot {
   linkPath: string
 }
 
+interface E2EFilesystemIdentity {
+  kind: 'directory' | 'symlink' | 'file' | 'other'
+  dev: number
+  ino: number
+  size: number
+  ctimeMs: number
+  mtimeMs: number
+}
+
 const AZURE_AI_NAME = 'azure-ai'
+
+/**
+ * Build the reviewed directory identity required by removeAllFromAgent IPC.
+ * @param path - Reviewed agent skills path.
+ * @returns Serializable identity copied from Node lstat metadata.
+ * @example filesystemIdentityForPath('/tmp/home/.config/agents/skills')
+ */
+function filesystemIdentityForPath(path: string): E2EFilesystemIdentity {
+  const stats = lstatSync(path)
+  return {
+    kind: stats.isSymbolicLink()
+      ? 'symlink'
+      : stats.isDirectory()
+        ? 'directory'
+        : stats.isFile()
+          ? 'file'
+          : 'other',
+    dev: stats.dev,
+    ino: stats.ino,
+    size: stats.size,
+    ctimeMs: stats.ctimeMs,
+    mtimeMs: stats.mtimeMs,
+  }
+}
 
 /**
  * Phase-2 final spec — three regressions, each guarding a separate fix that
@@ -296,9 +329,16 @@ test('removeAllFromAgent refuses on a multi-agent shared scanDir (.config/agents
   await waitForInitialScan(appWindow)
 
   const result = await appWindow.evaluate(
-    async (args: { agentId: string; agentPath: string }) =>
-      window.electron.skills.removeAllFromAgent(args),
-    { agentId: 'amp', agentPath: sharedScanDir },
+    async (args: {
+      agentId: string
+      agentPath: string
+      filesystemIdentity: E2EFilesystemIdentity
+    }) => window.electron.skills.removeAllFromAgent(args),
+    {
+      agentId: 'amp',
+      agentPath: sharedScanDir,
+      filesystemIdentity: filesystemIdentityForPath(sharedScanDir),
+    },
   )
 
   expectIronRuleRefusal(result)
@@ -360,9 +400,16 @@ test('removeAllFromAgent refusal leaves both aliased symlinks and local skill by
   await waitForInitialScan(appWindow)
 
   const result = await appWindow.evaluate(
-    async (args: { agentId: string; agentPath: string }) =>
-      window.electron.skills.removeAllFromAgent(args),
-    { agentId: 'amp', agentPath: sharedScanDir },
+    async (args: {
+      agentId: string
+      agentPath: string
+      filesystemIdentity: E2EFilesystemIdentity
+    }) => window.electron.skills.removeAllFromAgent(args),
+    {
+      agentId: 'amp',
+      agentPath: sharedScanDir,
+      filesystemIdentity: filesystemIdentityForPath(sharedScanDir),
+    },
   )
 
   expectIronRuleRefusal(result)
@@ -462,9 +509,16 @@ test('removeAllFromAgent refusal still fires when SOURCE_DIR itself is a symlink
   ).toBeGreaterThan(0)
 
   const result = await appWindow.evaluate(
-    async (args: { agentId: string; agentPath: string }) =>
-      window.electron.skills.removeAllFromAgent(args),
-    { agentId: 'cursor', agentPath: cursorAgentPath },
+    async (args: {
+      agentId: string
+      agentPath: string
+      filesystemIdentity: E2EFilesystemIdentity
+    }) => window.electron.skills.removeAllFromAgent(args),
+    {
+      agentId: 'cursor',
+      agentPath: cursorAgentPath,
+      filesystemIdentity: filesystemIdentityForPath(cursorAgentPath),
+    },
   )
 
   expectIronRuleRefusal(result)

--- a/e2e/spec/symlinked-config-cleanup.e2e.ts
+++ b/e2e/spec/symlinked-config-cleanup.e2e.ts
@@ -232,7 +232,7 @@ symlinkedConfigTest(
     expect(existsSync(join(sourcePath, 'SKILL.md'))).toBe(true)
     expect(lstatSync(logicalConfigDir).isSymbolicLink()).toBe(true)
     expect(existsSync(physicalConfigDir)).toBe(true)
-    expect(existsSync(devinLinkPath)).toBe(false)
+    expect(() => lstatSync(devinLinkPath)).toThrow(/ENOENT/)
   },
 )
 
@@ -282,5 +282,5 @@ test('Symlink Health cleanup unlinks a broken agent slot without deleting the so
   await expect(appWindow.getByText('Cleaned up 1 symlink issue')).toBeVisible()
   expect(existsSync(sourcePath)).toBe(true)
   expect(existsSync(join(sourcePath, 'SKILL.md'))).toBe(true)
-  expect(existsSync(codexLinkPath)).toBe(false)
+  expect(() => lstatSync(codexLinkPath)).toThrow(/ENOENT/)
 })

--- a/e2e/spec/symlinked-config-cleanup.e2e.ts
+++ b/e2e/spec/symlinked-config-cleanup.e2e.ts
@@ -1,0 +1,286 @@
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, relative } from 'node:path'
+
+import { test, expect } from '../fixtures/electron-app'
+import {
+  getStoreState,
+  refreshSkillsState,
+  waitForInitialScan,
+} from '../helpers/redux'
+
+interface SymlinkSnapshot {
+  agentId: string
+  status: 'valid' | 'broken' | 'inaccessible' | 'missing'
+  isLocal: boolean
+  linkPath: string
+}
+
+interface SkillWithDevinSlot {
+  name: string
+  symlinks: SymlinkSnapshot[]
+}
+
+const SYMLINKED_CONFIG_DEVIN_SKILL_NAME = 'valid-devin-symlink-parent-fixture'
+const CLEANUP_UI_SOURCE_PRESERVED_SKILL_NAME =
+  'cleanup-ui-source-preserved-fixture'
+const BROKEN_DEVIN_CLEANUP_SKILL_NAME = 'broken-devin-cleanup-fixture'
+
+const symlinkedConfigTest = test.extend({
+  // Playwright inspects fixture parameter names; the empty object must remain.
+  // eslint-disable-next-line no-empty-pattern
+  isolatedHome: async ({}, use) => {
+    const home = realpathSync.native(
+      mkdtempSync(join(tmpdir(), 'skills-desktop-e2e-symlinked-config-')),
+    )
+
+    try {
+      seedSymlinkedConfigDevinHome(home)
+      // Playwright's fixture callback is named `use`; this is not a React Hook.
+      // react-doctor-disable-next-line react-hooks/rules-of-hooks
+      await use(home)
+    } finally {
+      rmSync(home, { recursive: true, force: true })
+    }
+  },
+})
+
+/**
+ * Build the production Devin topology before Electron starts so scans read a
+ * symlinked ~/.config from first paint.
+ * @param home - Isolated HOME owned by this Playwright worker
+ * @returns Paths are created on disk; callers recompute them from HOME
+ * @example seedSymlinkedConfigDevinHome('/tmp/e2e-home')
+ */
+function seedSymlinkedConfigDevinHome(home: string): void {
+  const logicalConfigDir = join(home, '.config')
+  const physicalConfigDir = join(home, 'dotfiles', '.config')
+  const sourcePath = join(
+    home,
+    '.agents',
+    'skills',
+    SYMLINKED_CONFIG_DEVIN_SKILL_NAME,
+  )
+  const devinSkillsDir = join(logicalConfigDir, 'devin', 'skills')
+  const devinLinkPath = join(devinSkillsDir, SYMLINKED_CONFIG_DEVIN_SKILL_NAME)
+  const relativeTarget = `../../../../.agents/skills/${SYMLINKED_CONFIG_DEVIN_SKILL_NAME}`
+
+  mkdirSync(sourcePath, { recursive: true })
+  writeFileSync(
+    join(sourcePath, 'SKILL.md'),
+    [
+      '---',
+      `name: ${SYMLINKED_CONFIG_DEVIN_SKILL_NAME}`,
+      'description: E2E fixture for symlinked parent cleanup regression',
+      '---',
+      '',
+    ].join('\n'),
+  )
+
+  // Keep the test focused on Devin: no snapshot copy, no sibling .config
+  // agent symlinks that would create unrelated broken-count noise.
+  mkdirSync(physicalConfigDir, { recursive: true })
+  symlinkSync(physicalConfigDir, logicalConfigDir)
+  mkdirSync(devinSkillsDir, { recursive: true })
+  symlinkSync(relativeTarget, devinLinkPath)
+}
+
+symlinkedConfigTest(
+  'valid Devin symlink under symlinked .config parent is not offered to cleanup',
+  async ({ appWindow, isolatedHome }) => {
+    await waitForInitialScan(appWindow)
+
+    // Arrange: recompute fixture paths from HOME so assertions match main
+    // process paths exactly, including macOS /private/var canonicalization.
+    const sourcePath = join(
+      isolatedHome,
+      '.agents',
+      'skills',
+      SYMLINKED_CONFIG_DEVIN_SKILL_NAME,
+    )
+    const devinLinkPath = join(
+      isolatedHome,
+      '.config',
+      'devin',
+      'skills',
+      SYMLINKED_CONFIG_DEVIN_SKILL_NAME,
+    )
+
+    // Act: read the post-boot scan result that powers Symlink Health cleanup.
+    const snapshot = await getStoreState(
+      appWindow,
+      (state, name): SkillWithDevinSlot | null => {
+        const root = state as { skills: { items: SkillWithDevinSlot[] } }
+        return root.skills.items.find((skill) => skill.name === name) ?? null
+      },
+      SYMLINKED_CONFIG_DEVIN_SKILL_NAME,
+    )
+
+    expect(snapshot, 'source skill should be visible after scan').not.toBeNull()
+    if (!snapshot) return
+
+    const devinSlot = snapshot.symlinks.find(
+      (symlink) => symlink.agentId === 'devin',
+    )
+    expect(devinSlot, 'Devin slot must exist for every skill row').toBeDefined()
+
+    // Assert: the filesystem, renderer store, and destructive cleanup affordance
+    // agree this symlink is valid and should not be unlinked.
+    expect(lstatSync(devinLinkPath).isSymbolicLink()).toBe(true)
+    expect(realpathSync.native(devinLinkPath)).toBe(
+      realpathSync.native(sourcePath),
+    )
+    expect(devinSlot?.status).toBe('valid')
+    expect(devinSlot?.isLocal).toBe(false)
+    expect(devinSlot?.linkPath).toBe(devinLinkPath)
+
+    const health = await getStoreState(appWindow, (state) => {
+      const root = state as {
+        skills: {
+          items: Array<{
+            symlinks: Array<{ status: 'valid' | 'broken' | 'missing' }>
+          }>
+        }
+      }
+      return root.skills.items.reduce(
+        (totals, skill) => {
+          for (const symlink of skill.symlinks) {
+            if (symlink.status === 'valid') totals.valid++
+            if (symlink.status === 'broken') totals.broken++
+          }
+          return totals
+        },
+        { valid: 0, broken: 0 },
+      )
+    })
+
+    expect(health.broken).toBe(0)
+    await expect(
+      appWindow.getByRole('button', { name: 'Scan issues' }),
+    ).toHaveCount(0)
+    await expect(appWindow.getByText('Healthy')).toBeVisible()
+  },
+)
+
+symlinkedConfigTest(
+  'Symlink Health cleanup unlinks a broken Devin slot under symlinked .config without deleting the source skill',
+  async ({ appWindow, isolatedHome }) => {
+    await waitForInitialScan(appWindow)
+
+    // Arrange: source exists, but Devin has a stale agent-side symlink under
+    // ~/.config -> dotfiles/.config. Cleanup must remove only that link.
+    const sourcePath = join(
+      isolatedHome,
+      '.agents',
+      'skills',
+      BROKEN_DEVIN_CLEANUP_SKILL_NAME,
+    )
+    const logicalConfigDir = join(isolatedHome, '.config')
+    const physicalConfigDir = join(isolatedHome, 'dotfiles', '.config')
+    const physicalDevinSkillsDir = join(physicalConfigDir, 'devin', 'skills')
+    const devinLinkPath = join(
+      logicalConfigDir,
+      'devin',
+      'skills',
+      BROKEN_DEVIN_CLEANUP_SKILL_NAME,
+    )
+    const relativeMissingTarget = relative(
+      physicalDevinSkillsDir,
+      join(isolatedHome, '.agents', 'skills', 'missing-devin-cleanup-target'),
+    )
+
+    mkdirSync(sourcePath, { recursive: true })
+    writeFileSync(
+      join(sourcePath, 'SKILL.md'),
+      [
+        '---',
+        `name: ${BROKEN_DEVIN_CLEANUP_SKILL_NAME}`,
+        'description: E2E fixture for broken Devin cleanup under symlinked config',
+        '---',
+        '',
+      ].join('\n'),
+    )
+    symlinkSync(relativeMissingTarget, devinLinkPath)
+    await refreshSkillsState(appWindow)
+
+    // Act: drive the real destructive cleanup path from Symlink Health.
+    await appWindow.getByRole('button', { name: 'Scan issues' }).click()
+    await expect(
+      appWindow.getByRole('heading', { name: 'Symlink cleanup' }),
+    ).toBeVisible()
+    await expect(
+      appWindow
+        .getByLabel('Symlink cleanup')
+        .getByText('Devin for Terminal', { exact: true }),
+    ).toBeVisible()
+    await appWindow.getByRole('button', { name: 'Clean 1 selected' }).click()
+
+    // Assert: source and ~/.config alias survive; only the stale Devin link is gone.
+    await expect(
+      appWindow.getByText('Cleaned up 1 symlink issue'),
+    ).toBeVisible()
+    expect(existsSync(sourcePath)).toBe(true)
+    expect(existsSync(join(sourcePath, 'SKILL.md'))).toBe(true)
+    expect(lstatSync(logicalConfigDir).isSymbolicLink()).toBe(true)
+    expect(existsSync(physicalConfigDir)).toBe(true)
+    expect(existsSync(devinLinkPath)).toBe(false)
+  },
+)
+
+test('Symlink Health cleanup unlinks a broken agent slot without deleting the source skill', async ({
+  appWindow,
+  isolatedHome,
+}) => {
+  await waitForInitialScan(appWindow)
+
+  // Arrange: one live source skill plus one dangling non-protected agent slot.
+  const sourcePath = join(
+    isolatedHome,
+    '.agents',
+    'skills',
+    CLEANUP_UI_SOURCE_PRESERVED_SKILL_NAME,
+  )
+  const codexSkillsDir = join(isolatedHome, '.codex', 'skills')
+  const codexLinkPath = join(
+    codexSkillsDir,
+    CLEANUP_UI_SOURCE_PRESERVED_SKILL_NAME,
+  )
+
+  mkdirSync(sourcePath, { recursive: true })
+  writeFileSync(
+    join(sourcePath, 'SKILL.md'),
+    [
+      '---',
+      `name: ${CLEANUP_UI_SOURCE_PRESERVED_SKILL_NAME}`,
+      'description: E2E fixture for Symlink Health cleanup source preservation',
+      '---',
+      '',
+    ].join('\n'),
+  )
+  mkdirSync(codexSkillsDir, { recursive: true })
+  symlinkSync('../missing-target-for-cleanup-ui', codexLinkPath)
+  await refreshSkillsState(appWindow)
+
+  // Act: drive the actual dialog entry point and clean the selected broken slot.
+  await appWindow.getByRole('button', { name: 'Scan issues' }).click()
+  await expect(
+    appWindow.getByRole('heading', { name: 'Symlink cleanup' }),
+  ).toBeVisible()
+  await expect(appWindow.getByText('Broken agent links')).toBeVisible()
+  await appWindow.getByRole('button', { name: 'Clean 1 selected' }).click()
+
+  // Assert: UI reports success, the broken agent symlink is gone, and source remains.
+  await expect(appWindow.getByText('Cleaned up 1 symlink issue')).toBeVisible()
+  expect(existsSync(sourcePath)).toBe(true)
+  expect(existsSync(join(sourcePath, 'SKILL.md'))).toBe(true)
+  expect(existsSync(codexLinkPath)).toBe(false)
+})

--- a/e2e/spec/symlinked-config-cleanup.e2e.ts
+++ b/e2e/spec/symlinked-config-cleanup.e2e.ts
@@ -34,6 +34,11 @@ const SYMLINKED_CONFIG_DEVIN_SKILL_NAME = 'valid-devin-symlink-parent-fixture'
 const CLEANUP_UI_SOURCE_PRESERVED_SKILL_NAME =
   'cleanup-ui-source-preserved-fixture'
 const BROKEN_DEVIN_CLEANUP_SKILL_NAME = 'broken-devin-cleanup-fixture'
+const STALE_CLEANUP_PRESERVES_REPLACEMENT_SKILL_NAME =
+  'stale-cleanup-preserves-replacement-fixture'
+const ORPHAN_CLEANUP_UI_SKILL_NAME = 'orphan-cleanup-ui-fixture'
+const INACCESSIBLE_MANUAL_REVIEW_SKILL_NAME =
+  'inaccessible-manual-review-fixture'
 
 const symlinkedConfigTest = test.extend({
   // Playwright inspects fixture parameter names; the empty object must remain.
@@ -283,4 +288,161 @@ test('Symlink Health cleanup unlinks a broken agent slot without deleting the so
   expect(existsSync(sourcePath)).toBe(true)
   expect(existsSync(join(sourcePath, 'SKILL.md'))).toBe(true)
   expect(() => lstatSync(codexLinkPath)).toThrow(/ENOENT/)
+})
+
+test('Symlink Health cleanup refuses a reviewed broken slot that becomes valid before Clean', async ({
+  appWindow,
+  isolatedHome,
+}) => {
+  await waitForInitialScan(appWindow)
+
+  // Arrange: the review plan sees a broken Codex slot for a live source skill.
+  const sourcePath = join(
+    isolatedHome,
+    '.agents',
+    'skills',
+    STALE_CLEANUP_PRESERVES_REPLACEMENT_SKILL_NAME,
+  )
+  const codexSkillsDir = join(isolatedHome, '.codex', 'skills')
+  const codexLinkPath = join(
+    codexSkillsDir,
+    STALE_CLEANUP_PRESERVES_REPLACEMENT_SKILL_NAME,
+  )
+
+  mkdirSync(sourcePath, { recursive: true })
+  writeFileSync(
+    join(sourcePath, 'SKILL.md'),
+    [
+      '---',
+      `name: ${STALE_CLEANUP_PRESERVES_REPLACEMENT_SKILL_NAME}`,
+      'description: E2E fixture for stale cleanup replacement preservation',
+      '---',
+      '',
+    ].join('\n'),
+  )
+  mkdirSync(codexSkillsDir, { recursive: true })
+  symlinkSync('../missing-target-for-stale-cleanup-ui', codexLinkPath)
+  await refreshSkillsState(appWindow)
+
+  await appWindow.getByRole('button', { name: 'Scan issues' }).click()
+  await expect(
+    appWindow.getByRole('heading', { name: 'Symlink cleanup' }),
+  ).toBeVisible()
+  await expect(
+    appWindow.getByText(STALE_CLEANUP_PRESERVES_REPLACEMENT_SKILL_NAME),
+  ).toBeVisible()
+
+  // Act: replace the reviewed dangling symlink with a valid symlink before
+  // the user commits cleanup.
+  rmSync(codexLinkPath, { force: true })
+  symlinkSync(sourcePath, codexLinkPath)
+  await appWindow.getByRole('button', { name: 'Clean 1 selected' }).click()
+
+  // Assert: the UI asks for rescan and preserves the replacement link.
+  await expect(
+    appWindow.getByText('Plan changed', { exact: true }),
+  ).toBeVisible()
+  await expect(
+    appWindow.getByText('Plan changed. Rescan required.'),
+  ).toBeVisible()
+  expect(lstatSync(codexLinkPath).isSymbolicLink()).toBe(true)
+  expect(realpathSync.native(codexLinkPath)).toBe(
+    realpathSync.native(sourcePath),
+  )
+})
+
+test('Symlink Health cleanup removes orphan records without creating an Undo affordance', async ({
+  appWindow,
+  isolatedHome,
+}) => {
+  await waitForInitialScan(appWindow)
+
+  // Arrange: no source skill exists; Codex owns only a dangling agent symlink.
+  const codexSkillsDir = join(isolatedHome, '.codex', 'skills')
+  const orphanLinkPath = join(codexSkillsDir, ORPHAN_CLEANUP_UI_SKILL_NAME)
+  const missingSourcePath = join(
+    isolatedHome,
+    '.agents',
+    'skills',
+    ORPHAN_CLEANUP_UI_SKILL_NAME,
+  )
+  mkdirSync(codexSkillsDir, { recursive: true })
+  symlinkSync(missingSourcePath, orphanLinkPath)
+  await refreshSkillsState(appWindow)
+
+  // Act: clean the orphan-record path from the Symlink Health dialog.
+  await appWindow.getByRole('button', { name: 'Scan issues' }).click()
+  await expect(
+    appWindow.getByRole('heading', { name: 'Symlink cleanup' }),
+  ).toBeVisible()
+  await expect(appWindow.getByText('Orphan records')).toBeVisible()
+  await expect(
+    appWindow.getByText(ORPHAN_CLEANUP_UI_SKILL_NAME, { exact: true }),
+  ).toBeVisible()
+  await appWindow.getByRole('button', { name: 'Clean 1 selected' }).click()
+
+  // Assert: only the dangling symlink is removed; no trash/undo path appears.
+  await expect(appWindow.getByText('Cleaned up 1 symlink issue')).toBeVisible()
+  await expect(appWindow.getByText('1 orphan symlink removed')).toBeVisible()
+  expect(() => lstatSync(orphanLinkPath)).toThrow(/ENOENT/)
+  expect(existsSync(missingSourcePath)).toBe(false)
+  await expect(appWindow.getByRole('button', { name: /^Undo$/ })).toHaveCount(0)
+})
+
+test('inaccessible agent symlinks stay visible for manual review without destructive row affordances', async ({
+  appWindow,
+  isolatedHome,
+}) => {
+  await waitForInitialScan(appWindow)
+
+  // Arrange: a self-referential Codex symlink produces ELOOP, which the app
+  // treats as inaccessible/manual-review rather than cleanup-ready broken.
+  const codexSkillsDir = join(isolatedHome, '.codex', 'skills')
+  const loopLinkPath = join(
+    codexSkillsDir,
+    INACCESSIBLE_MANUAL_REVIEW_SKILL_NAME,
+  )
+  mkdirSync(codexSkillsDir, { recursive: true })
+  symlinkSync(loopLinkPath, loopLinkPath)
+  await refreshSkillsState(appWindow)
+
+  // Act: open the Codex-scoped view where row Add/Unlink affordances render.
+  await appWindow.evaluate(() => {
+    const store = window.__store__ ?? window.__store
+    if (!store) throw new Error('Redux store unavailable in E2E build')
+    store.dispatch({ type: 'ui/selectAgent', payload: 'codex' })
+  })
+
+  // Assert: the row is visible as manual review and does not expose Add/Unlink.
+  await expect(
+    appWindow.getByText(INACCESSIBLE_MANUAL_REVIEW_SKILL_NAME),
+  ).toBeVisible()
+  await expect(
+    appWindow.getByLabel('Inaccessible link - manual review required'),
+  ).toBeVisible()
+  await expect(appWindow.getByRole('button', { name: /^Add$/ })).toHaveCount(0)
+  await expect(
+    appWindow.getByRole('button', {
+      name: `Unlink ${INACCESSIBLE_MANUAL_REVIEW_SKILL_NAME} from Codex`,
+    }),
+  ).toHaveCount(0)
+
+  const inaccessibleSnapshot = await getStoreState(
+    appWindow,
+    (state, name): string | undefined => {
+      const root = state as {
+        skills: {
+          items: Array<{
+            name: string
+            symlinks: Array<{ agentId: string; status: string }>
+          }>
+        }
+      }
+      return root.skills.items
+        .find((skill) => skill.name === name)
+        ?.symlinks.find((symlink) => symlink.agentId === 'codex')?.status
+    },
+    INACCESSIBLE_MANUAL_REVIEW_SKILL_NAME,
+  )
+  expect(inaccessibleSnapshot).toBe('inaccessible')
 })

--- a/e2e/spec/symlinked-config-cleanup.e2e.ts
+++ b/e2e/spec/symlinked-config-cleanup.e2e.ts
@@ -245,8 +245,6 @@ test('Symlink Health cleanup unlinks a broken agent slot without deleting the so
   appWindow,
   isolatedHome,
 }) => {
-  await waitForInitialScan(appWindow)
-
   // Arrange: one live source skill plus one dangling non-protected agent slot.
   const sourcePath = join(
     isolatedHome,
@@ -290,12 +288,10 @@ test('Symlink Health cleanup unlinks a broken agent slot without deleting the so
   expect(() => lstatSync(codexLinkPath)).toThrow(/ENOENT/)
 })
 
-test('Symlink Health cleanup refuses a reviewed broken slot that becomes valid before Clean', async ({
+test('Symlink Health cleanup IPC refuses a reviewed broken slot that becomes valid after review', async ({
   appWindow,
   isolatedHome,
 }) => {
-  await waitForInitialScan(appWindow)
-
   // Arrange: the review plan sees a broken Codex slot for a live source skill.
   const sourcePath = join(
     isolatedHome,
@@ -329,22 +325,53 @@ test('Symlink Health cleanup refuses a reviewed broken slot that becomes valid b
     appWindow.getByRole('heading', { name: 'Symlink cleanup' }),
   ).toBeVisible()
   await expect(
-    appWindow.getByText(STALE_CLEANUP_PRESERVES_REPLACEMENT_SKILL_NAME),
+    appWindow
+      .getByLabel('Symlink cleanup')
+      .getByText(STALE_CLEANUP_PRESERVES_REPLACEMENT_SKILL_NAME, {
+        exact: true,
+      }),
   ).toBeVisible()
 
-  // Act: replace the reviewed dangling symlink with a valid symlink before
-  // the user commits cleanup.
+  const reviewedTargetPath = join(
+    isolatedHome,
+    '.codex',
+    'missing-target-for-stale-cleanup-ui',
+  )
+
+  // Act: mutate after the UI review, then invoke the real renderer→main IPC
+  // with the reviewed stale payload so the main commit guard is exercised.
   rmSync(codexLinkPath, { force: true })
   symlinkSync(sourcePath, codexLinkPath)
-  await appWindow.getByRole('button', { name: 'Clean 1 selected' }).click()
+  const result = await appWindow.evaluate(
+    async ({ linkPath, targetPath, skillName }) => {
+      return window.electron.skills.clearBrokenSymlinkSlots({
+        items: [
+          {
+            agentId: 'codex',
+            linkName: skillName,
+            linkPath,
+            targetPath,
+          },
+        ],
+      })
+    },
+    {
+      linkPath: codexLinkPath,
+      targetPath: reviewedTargetPath,
+      skillName: STALE_CLEANUP_PRESERVES_REPLACEMENT_SKILL_NAME,
+    },
+  )
 
-  // Assert: the UI asks for rescan and preserves the replacement link.
-  await expect(
-    appWindow.getByText('Plan changed', { exact: true }),
-  ).toBeVisible()
-  await expect(
-    appWindow.getByText('Plan changed. Rescan required.'),
-  ).toBeVisible()
+  // Assert: main rejects the stale commit and preserves the replacement link.
+  expect(result.items).toEqual([
+    expect.objectContaining({
+      agentId: 'codex',
+      skillName: STALE_CLEANUP_PRESERVES_REPLACEMENT_SKILL_NAME,
+      linkPath: codexLinkPath,
+      outcome: 'error',
+      error: expect.objectContaining({ code: 'ESTALE' }),
+    }),
+  ])
   expect(lstatSync(codexLinkPath).isSymbolicLink()).toBe(true)
   expect(realpathSync.native(codexLinkPath)).toBe(
     realpathSync.native(sourcePath),
@@ -355,8 +382,6 @@ test('Symlink Health cleanup removes orphan records without creating an Undo aff
   appWindow,
   isolatedHome,
 }) => {
-  await waitForInitialScan(appWindow)
-
   // Arrange: no source skill exists; Codex owns only a dangling agent symlink.
   const codexSkillsDir = join(isolatedHome, '.codex', 'skills')
   const orphanLinkPath = join(codexSkillsDir, ORPHAN_CLEANUP_UI_SKILL_NAME)
@@ -393,8 +418,6 @@ test('inaccessible agent symlinks stay visible for manual review without destruc
   appWindow,
   isolatedHome,
 }) => {
-  await waitForInitialScan(appWindow)
-
   // Arrange: a self-referential Codex symlink produces ELOOP, which the app
   // treats as inaccessible/manual-review rather than cleanup-ready broken.
   const codexSkillsDir = join(isolatedHome, '.codex', 'skills')
@@ -405,6 +428,11 @@ test('inaccessible agent symlinks stay visible for manual review without destruc
   mkdirSync(codexSkillsDir, { recursive: true })
   symlinkSync(loopLinkPath, loopLinkPath)
   await refreshSkillsState(appWindow)
+
+  await expect(appWindow.getByText('Manual review')).toBeVisible()
+  await expect(
+    appWindow.getByRole('button', { name: 'Scan issues' }),
+  ).toHaveCount(0)
 
   // Act: open the Codex-scoped view where row Add/Unlink affordances render.
   await appWindow.evaluate(() => {

--- a/e2e/spec/undo-toast.e2e.ts
+++ b/e2e/spec/undo-toast.e2e.ts
@@ -1,8 +1,14 @@
-import { existsSync, lstatSync, readdirSync } from 'node:fs'
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
 import { join } from 'node:path'
 
 import { test, expect } from '../fixtures/electron-app'
-import { isSnapshotOffline } from '../fixtures/isolated-home'
 import {
   getStoreState,
   refreshSkillsState,
@@ -16,22 +22,50 @@ interface SymlinkSnapshot {
   linkPath: string
 }
 
-interface AzureSnapshot {
-  hasAzure: boolean
+interface UndoFixtureSnapshot {
+  hasFixture: boolean
   sourcePath: string | null
   validSymlinks: SymlinkSnapshot[]
 }
 
-const AZURE_AI_NAME = 'azure-ai'
+const UNDO_TOAST_FIXTURE_NAME = 'undo-toast-fixture'
 
 /**
- * Snapshot selector for azure-ai. Mirrors `azureSnapshotSelector` in
- * delete.e2e.ts. Inlined here (rather than imported from a shared helper)
+ * Create the source skill and one agent symlink this undo spec owns.
+ * @param isolatedHome - Test HOME from the Electron fixture.
+ * @returns Source and agent-link paths for the staged skill.
+ * @example stageUndoToastSkillFixture('/tmp/home')
+ */
+function stageUndoToastSkillFixture(isolatedHome: string): {
+  sourcePath: string
+  linkPath: string
+} {
+  const sourcePath = join(
+    isolatedHome,
+    '.agents',
+    'skills',
+    UNDO_TOAST_FIXTURE_NAME,
+  )
+  const cursorSkillsDir = join(isolatedHome, '.cursor', 'skills')
+  const linkPath = join(cursorSkillsDir, UNDO_TOAST_FIXTURE_NAME)
+  mkdirSync(sourcePath, { recursive: true })
+  mkdirSync(cursorSkillsDir, { recursive: true })
+  writeFileSync(
+    join(sourcePath, 'SKILL.md'),
+    '# Undo Toast Fixture\n\nRestored by E2E.\n',
+  )
+  symlinkSync(sourcePath, linkPath)
+  return { sourcePath, linkPath }
+}
+
+/**
+ * Snapshot selector for the self-staged undo fixture. Inlined here (rather than
+ * imported from a shared helper)
  * because `getStoreState` serializes the function via `Function.prototype.toString`
  * — the body must NOT close over outer-scope identifiers, so the literal
- * `'azure-ai'` is hard-coded inside.
+ * `'undo-toast-fixture'` is hard-coded inside.
  */
-const azureSnapshotSelector = (state: unknown): AzureSnapshot => {
+const undoToastFixtureSelector = (state: unknown): UndoFixtureSnapshot => {
   const root = state as {
     skills: {
       items: Array<{
@@ -41,12 +75,14 @@ const azureSnapshotSelector = (state: unknown): AzureSnapshot => {
       }>
     }
   }
-  const azure = root.skills.items.find((skill) => skill.name === 'azure-ai')
+  const fixture = root.skills.items.find(
+    (skill) => skill.name === 'undo-toast-fixture',
+  )
   return {
-    hasAzure: Boolean(azure),
-    sourcePath: azure?.path ?? null,
+    hasFixture: Boolean(fixture),
+    sourcePath: fixture?.path ?? null,
     validSymlinks:
-      azure?.symlinks.filter((symlink) => symlink.status === 'valid') ?? [],
+      fixture?.symlinks.filter((symlink) => symlink.status === 'valid') ?? [],
   }
 }
 
@@ -74,31 +110,21 @@ const azureSnapshotSelector = (state: unknown): AzureSnapshot => {
  * delete.e2e.ts owns the bulk-delete IPC contract.
  */
 
-test.beforeEach(() => {
-  test.skip(
-    isSnapshotOffline(),
-    'azure-ai required from snapshot; runner is offline (global-setup wrote snapshot.offline=true)',
-  )
-})
-
-test('UI: clicking Undo on the bulk-delete toast restores azure-ai files and symlinks', async ({
+test('UI: clicking Undo on the bulk-delete toast restores staged source files and symlinks', async ({
   appWindow,
   isolatedHome,
 }) => {
+  const { sourcePath: expectedSourcePath } =
+    stageUndoToastSkillFixture(isolatedHome)
   await waitForInitialScan(appWindow)
 
-  const expectedSourcePath = join(
-    isolatedHome,
-    '.agents',
-    'skills',
-    AZURE_AI_NAME,
-  )
   const trashDir = join(isolatedHome, '.agents', '.trash')
 
-  const initial = await getStoreState(appWindow, azureSnapshotSelector)
-  expect(initial.hasAzure, 'azure-ai should be installed by global-setup').toBe(
-    true,
-  )
+  const initial = await getStoreState(appWindow, undoToastFixtureSelector)
+  expect(
+    initial.hasFixture,
+    'undo-toast-fixture should be staged by this spec before scan',
+  ).toBe(true)
   expect(initial.sourcePath).toBe(expectedSourcePath)
   expect(
     initial.validSymlinks.length,
@@ -117,7 +143,10 @@ test('UI: clicking Undo on the bulk-delete toast restores azure-ai files and sym
   await appWindow.evaluate(() => {
     const store = window.__store__ ?? window.__store
     store?.dispatch({ type: 'ui/enterBulkSelectMode' })
-    store?.dispatch({ type: 'skills/toggleSelection', payload: 'azure-ai' })
+    store?.dispatch({
+      type: 'skills/toggleSelection',
+      payload: 'undo-toast-fixture',
+    })
   })
 
   // Toolbar primary button — global view, single skill selected. The label is
@@ -202,7 +231,7 @@ test('UI: clicking Undo on the bulk-delete toast restores azure-ai files and sym
   // A residual entry would leave a phantom undo target around indefinitely.
   const residualTrashEntries = existsSync(trashDir)
     ? readdirSync(trashDir).filter((entry) =>
-        entry.includes(`-${AZURE_AI_NAME}-`),
+        entry.includes(`-${UNDO_TOAST_FIXTURE_NAME}-`),
       )
     : []
   expect(
@@ -210,7 +239,7 @@ test('UI: clicking Undo on the bulk-delete toast restores azure-ai files and sym
     'restore must remove the trash entry — leftover would leak undo targets',
   ).toEqual([])
 
-  // Redux — azure-ai is back with the same set of valid symlinks. Comparing
+  // Redux — the staged skill is back with the same set of valid symlinks. Comparing
   // the agentId set (not the snapshot identity) is enough: status booleans
   // for restored agents land on `valid` because the source dir exists and
   // the symlink target resolves. `refreshSkillsState` is needed because the
@@ -218,9 +247,9 @@ test('UI: clicking Undo on the bulk-delete toast restores azure-ai files and sym
   // the renderer's listener races the test's evaluation; an explicit refresh
   // collapses the race.
   await refreshSkillsState(appWindow)
-  const restored = await getStoreState(appWindow, azureSnapshotSelector)
+  const restored = await getStoreState(appWindow, undoToastFixtureSelector)
 
-  expect(restored.hasAzure).toBe(true)
+  expect(restored.hasFixture).toBe(true)
   expect(restored.sourcePath).toBe(expectedSourcePath)
   expect(
     restored.validSymlinks.map((symlink) => symlink.agentId).sort(),

--- a/e2e/spec/undo-toast.e2e.ts
+++ b/e2e/spec/undo-toast.e2e.ts
@@ -3,6 +3,7 @@ import {
   lstatSync,
   mkdirSync,
   readdirSync,
+  realpathSync,
   symlinkSync,
   writeFileSync,
 } from 'node:fs'
@@ -225,6 +226,9 @@ test('UI: clicking Undo on the bulk-delete toast restores staged source files an
       lstatSync(symlink.linkPath).isSymbolicLink(),
       `expected ${symlink.linkPath} to be a symlink after Undo (not a regular file)`,
     ).toBe(true)
+    expect(realpathSync.native(symlink.linkPath)).toBe(
+      realpathSync.native(expectedSourcePath),
+    )
   }
 
   // Trash entry cleaned up by `finalizeRestore` (rm + cancel TTL timer).

--- a/e2e/spec/undo-toast.e2e.ts
+++ b/e2e/spec/undo-toast.e2e.ts
@@ -126,7 +126,7 @@ test('UI: clicking Undo on the bulk-delete toast restores azure-ai files and sym
   // resilient to visual-label tweaks ("Delete skill" → "Remove skill") that
   // would not change the underlying intent.
   await appWindow
-    .getByRole('button', { name: 'Delete selected skill permanently' })
+    .getByRole('button', { name: 'Move selected skill to app trash' })
     .click()
 
   // Confirm dialog mounts via Radix `<Dialog>`. The title is dynamic

--- a/e2e/spec/unlink-agent.e2e.ts
+++ b/e2e/spec/unlink-agent.e2e.ts
@@ -102,19 +102,6 @@ function preStageLinkedSkills(
  * tests.
  */
 
-// Several tests in this file consume the snapshot's azure-* skills directly,
-// while others share the same isolated-home contract that assumes SOURCE_DIR
-// is populated. When global-setup classifies the runner as offline, the
-// snapshot is empty and any spec that lstats `~/.agents/skills/azure-ai` will
-// fail with confusing renderer errors. File-level skip is the simplest
-// guarantee that the suite degrades gracefully.
-test.beforeEach(() => {
-  test.skip(
-    isSnapshotOffline(),
-    'azure-* skills required for this suite; runner is offline (global-setup wrote snapshot.offline=true)',
-  )
-})
-
 test('unlinkFromAgent removes one valid azure-ai symlink without touching the source or other agents', async ({
   appWindow,
   isolatedHome,
@@ -126,7 +113,7 @@ test('unlinkFromAgent removes one valid azure-ai symlink without touching the so
     AZURE_AI_NAME,
   )
   test.skip(
-    !existsSync(expectedSourcePath),
+    isSnapshotOffline() || !existsSync(expectedSourcePath),
     'azure-ai snapshot skill is required for this snapshot-backed unlink test',
   )
 

--- a/e2e/spec/unlink-agent.e2e.ts
+++ b/e2e/spec/unlink-agent.e2e.ts
@@ -137,6 +137,24 @@ function unlinkItemsFor(agentPath: string, skillNames: string[]) {
 }
 
 /**
+ * Assert a path is absent without letting dangling symlinks pass as removed.
+ * @param path - Filesystem path expected to have no directory entry.
+ * @returns void when lstat reports ENOENT.
+ * @example expectPathMissing('/tmp/home/.cursor/skills/task')
+ */
+function expectPathMissing(path: string): void {
+  try {
+    const stats = lstatSync(path)
+    throw new Error(
+      `expected ${path} to be absent, but lstat found ${stats.isSymbolicLink() ? 'a symlink' : 'an entry'}`,
+    )
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return
+    throw error
+  }
+}
+
+/**
  * Phase-2 spec covering the three unlink-style IPCs that operate on agent-side
  * link paths without writing to trash:
  *   - `SKILLS_UNLINK_FROM_AGENT`        (single)
@@ -195,6 +213,11 @@ test('unlinkFromAgent removes one valid azure-ai symlink without touching the so
     'expected at least one valid azure-ai symlink — adjust global-setup if --global no longer creates per-agent links',
   ).toBeTruthy()
   if (!target) return
+  expect(
+    target.targetPath,
+    'valid symlink rows must include a reviewed targetPath for single unlink',
+  ).toBeTruthy()
+  if (!target.targetPath) return
 
   // Other valid symlinks act as the "untouched" control set — none of them
   // should be removed by a single-agent unlink.
@@ -208,7 +231,7 @@ test('unlinkFromAgent removes one valid azure-ai symlink without touching the so
       skillName: string
       agentId: string
       linkPath: string
-      targetPath?: string
+      targetPath: string
     }) => window.electron.skills.unlinkFromAgent(args),
     {
       skillName: AZURE_AI_NAME,
@@ -225,7 +248,7 @@ test('unlinkFromAgent removes one valid azure-ai symlink without touching the so
   // present. The third assertion is the load-bearing one: a regression that
   // unlinks too aggressively (e.g. cascading the realpath target) would wipe
   // every agent in this loop and the diff would be obvious.
-  expect(existsSync(target.linkPath)).toBe(false)
+  expectPathMissing(target.linkPath)
   expect(existsSync(expectedSourcePath)).toBe(true)
   expect(existsSync(join(expectedSourcePath, 'SKILL.md'))).toBe(true)
   for (const other of otherValidSymlinks) {
@@ -293,15 +316,20 @@ test('unlinkFromAgent treats a missing linkPath as an idempotent success', async
   // Sanity — confirm the path is genuinely absent before the IPC fires. A
   // false positive here would silently test the normal unlink path instead of
   // the idempotent missing-path branch.
-  expect(existsSync(missingLinkPath)).toBe(false)
+  expectPathMissing(missingLinkPath)
 
   const ipcResult = await appWindow.evaluate(
-    async (args: { skillName: string; agentId: string; linkPath: string }) =>
-      window.electron.skills.unlinkFromAgent(args),
+    async (args: {
+      skillName: string
+      agentId: string
+      linkPath: string
+      targetPath: string
+    }) => window.electron.skills.unlinkFromAgent(args),
     {
       skillName: 'never-existed',
       agentId: 'claude-code',
       linkPath: missingLinkPath,
+      targetPath: join(isolatedHome, '.agents', 'skills', 'never-existed'),
     },
   )
 
@@ -327,12 +355,17 @@ test('unlinkFromAgent refuses a regular file with the structured kind-mismatch e
   expect(stagedStat.isDirectory()).toBe(false)
 
   const ipcResult = await appWindow.evaluate(
-    async (args: { skillName: string; agentId: string; linkPath: string }) =>
-      window.electron.skills.unlinkFromAgent(args),
+    async (args: {
+      skillName: string
+      agentId: string
+      linkPath: string
+      targetPath: string
+    }) => window.electron.skills.unlinkFromAgent(args),
     {
       skillName: 'not-a-skill.txt',
       agentId: 'claude-code',
       linkPath: regularFilePath,
+      targetPath: join(isolatedHome, '.agents', 'skills', 'not-a-skill.txt'),
     },
   )
 
@@ -396,7 +429,7 @@ test('unlinkManyFromAgent removes every pre-staged symlink and leaves source dir
   // a regression that hard-rms the realpath target (instead of just the
   // symlink) would surface here as missing source dirs.
   for (const name of skillNames) {
-    expect(existsSync(join(claudeAgentPath, name))).toBe(false)
+    expectPathMissing(join(claudeAgentPath, name))
     const sourcePath = join(isolatedHome, '.agents', 'skills', name)
     expect(existsSync(sourcePath)).toBe(true)
     expect(existsSync(join(sourcePath, 'SKILL.md'))).toBe(true)
@@ -444,7 +477,7 @@ test('unlinkManyFromAgent uses reviewed linkPath when metadata name differs from
   expect(result.items).toEqual([
     { skillName: metadataName, outcome: 'unlinked' },
   ])
-  expect(existsSync(reviewedLinkPath)).toBe(false)
+  expectPathMissing(reviewedLinkPath)
   expect(lstatSync(decoyLinkPath).isSymbolicLink()).toBe(true)
   expect(existsSync(sourcePath)).toBe(true)
   expect(existsSync(join(sourcePath, 'SKILL.md'))).toBe(true)
@@ -558,7 +591,7 @@ test('unlinkManyFromAgent aggregates per-item failures without short-circuiting 
       expect(existsSync(join(poisonedLinkPath, 'SKILL.md'))).toBe(true)
       expect(lstatSync(poisonedLinkPath).isDirectory()).toBe(true)
     } else {
-      expect(existsSync(join(claudeAgentPath, name))).toBe(false)
+      expectPathMissing(join(claudeAgentPath, name))
     }
   }
 })
@@ -742,7 +775,7 @@ test('removeAllFromAgent moves a non-shared agent dir to OS Trash and reports th
     // FS — the agent dir is gone from its original location and every source
     // dir is intact. trashItem moves only the agent path itself; per-skill
     // source bytes under SOURCE_DIR must not be touched (unlink is benign).
-    expect(existsSync(clineAgentPath)).toBe(false)
+    expectPathMissing(clineAgentPath)
     for (const name of skillNames) {
       const sourcePath = join(isolatedHome, '.agents', 'skills', name)
       expect(existsSync(sourcePath)).toBe(true)

--- a/e2e/spec/unlink-agent.e2e.ts
+++ b/e2e/spec/unlink-agent.e2e.ts
@@ -34,9 +34,43 @@ interface SymlinkSnapshot {
   status: 'valid' | 'broken' | 'missing'
   isLocal: boolean
   linkPath: string
+  targetPath?: string
+}
+
+interface E2EFilesystemIdentity {
+  kind: 'directory' | 'symlink' | 'file' | 'other'
+  dev: number
+  ino: number
+  size: number
+  ctimeMs: number
+  mtimeMs: number
 }
 
 const AZURE_AI_NAME = 'azure-ai'
+
+/**
+ * Build the reviewed directory identity expected by destructive agent-folder IPC.
+ * @param path - Reviewed directory path.
+ * @returns Serializable identity copied from Node lstat metadata.
+ * @example filesystemIdentityForPath('/tmp/home/.cline/skills')
+ */
+function filesystemIdentityForPath(path: string): E2EFilesystemIdentity {
+  const stats = lstatSync(path)
+  return {
+    kind: stats.isSymbolicLink()
+      ? 'symlink'
+      : stats.isDirectory()
+        ? 'directory'
+        : stats.isFile()
+          ? 'file'
+          : 'other',
+    dev: stats.dev,
+    ino: stats.ino,
+    size: stats.size,
+    ctimeMs: stats.ctimeMs,
+    mtimeMs: stats.mtimeMs,
+  }
+}
 
 /**
  * Pre-stage `count` source-backed dummy skills under the isolated HOME's
@@ -93,6 +127,12 @@ function unlinkItemsFor(agentPath: string, skillNames: string[]) {
   return skillNames.map((skillName) => ({
     skillName,
     linkPath: join(agentPath, skillName),
+    targetPath: join(
+      dirname(dirname(agentPath)),
+      '.agents',
+      'skills',
+      skillName,
+    ),
   }))
 }
 
@@ -164,12 +204,17 @@ test('unlinkFromAgent removes one valid azure-ai symlink without touching the so
   )
 
   const ipcResult = await appWindow.evaluate(
-    async (args: { skillName: string; agentId: string; linkPath: string }) =>
-      window.electron.skills.unlinkFromAgent(args),
+    async (args: {
+      skillName: string
+      agentId: string
+      linkPath: string
+      targetPath?: string
+    }) => window.electron.skills.unlinkFromAgent(args),
     {
       skillName: AZURE_AI_NAME,
       agentId: target.agentId,
       linkPath: target.linkPath,
+      targetPath: target.targetPath,
     },
   )
 
@@ -333,7 +378,7 @@ test('unlinkManyFromAgent removes every pre-staged symlink and leaves source dir
   const result = await appWindow.evaluate(
     async (args: {
       agentId: string
-      items: Array<{ skillName: string; linkPath: string }>
+      items: Array<{ skillName: string; linkPath: string; targetPath: string }>
     }) => window.electron.skills.unlinkManyFromAgent(args),
     {
       agentId: 'claude-code',
@@ -381,11 +426,17 @@ test('unlinkManyFromAgent uses reviewed linkPath when metadata name differs from
   const result = await appWindow.evaluate(
     async (args: {
       agentId: string
-      items: Array<{ skillName: string; linkPath: string }>
+      items: Array<{ skillName: string; linkPath: string; targetPath: string }>
     }) => window.electron.skills.unlinkManyFromAgent(args),
     {
       agentId: 'claude-code',
-      items: [{ skillName: metadataName, linkPath: reviewedLinkPath }],
+      items: [
+        {
+          skillName: metadataName,
+          linkPath: reviewedLinkPath,
+          targetPath: sourcePath,
+        },
+      ],
     },
   )
 
@@ -468,7 +519,7 @@ test('unlinkManyFromAgent aggregates per-item failures without short-circuiting 
   const result = await appWindow.evaluate(
     async (args: {
       agentId: string
-      items: Array<{ skillName: string; linkPath: string }>
+      items: Array<{ skillName: string; linkPath: string; targetPath: string }>
     }) => window.electron.skills.unlinkManyFromAgent(args),
     {
       agentId: 'claude-code',
@@ -548,9 +599,16 @@ test('removeAllFromAgent refuses when the agent path is a symlink alias to the u
   expect(sourceContentsBefore).toContain(sentinelSourceName)
 
   const result = await appWindow.evaluate(
-    async (args: { agentId: string; agentPath: string }) =>
-      window.electron.skills.removeAllFromAgent(args),
-    { agentId: 'cursor', agentPath: cursorAgentPath },
+    async (args: {
+      agentId: string
+      agentPath: string
+      filesystemIdentity: E2EFilesystemIdentity
+    }) => window.electron.skills.removeAllFromAgent(args),
+    {
+      agentId: 'cursor',
+      agentPath: cursorAgentPath,
+      filesystemIdentity: filesystemIdentityForPath(cursorAgentPath),
+    },
   )
 
   expectIronRuleRefusal(result)
@@ -651,9 +709,16 @@ test('removeAllFromAgent moves a non-shared agent dir to OS Trash and reports th
   let createdTrashEntryPaths: string[] = []
   try {
     const result = await appWindow.evaluate(
-      async (args: { agentId: string; agentPath: string }) =>
-        window.electron.skills.removeAllFromAgent(args),
-      { agentId: 'cline', agentPath: clineAgentPath },
+      async (args: {
+        agentId: string
+        agentPath: string
+        filesystemIdentity: E2EFilesystemIdentity
+      }) => window.electron.skills.removeAllFromAgent(args),
+      {
+        agentId: 'cline',
+        agentPath: clineAgentPath,
+        filesystemIdentity: filesystemIdentityForPath(clineAgentPath),
+      },
     )
 
     // Diff ~/.Trash IMMEDIATELY after the IPC call returns, then narrow
@@ -787,9 +852,16 @@ test('removeAllFromAgent surfaces structured failure when shell.trashItem reject
   let regressionTrashEntryPaths: string[] = []
   try {
     const result = await appWindow.evaluate(
-      async (args: { agentId: string; agentPath: string }) =>
-        window.electron.skills.removeAllFromAgent(args),
-      { agentId: 'cline', agentPath: clineAgentPath },
+      async (args: {
+        agentId: string
+        agentPath: string
+        filesystemIdentity: E2EFilesystemIdentity
+      }) => window.electron.skills.removeAllFromAgent(args),
+      {
+        agentId: 'cline',
+        agentPath: clineAgentPath,
+        filesystemIdentity: filesystemIdentityForPath(clineAgentPath),
+      },
     )
 
     const { newPaths } = diffUserTrash(trashEntriesBefore)

--- a/e2e/spec/unlink-agent.e2e.ts
+++ b/e2e/spec/unlink-agent.e2e.ts
@@ -119,14 +119,18 @@ test('unlinkFromAgent removes one valid azure-ai symlink without touching the so
   appWindow,
   isolatedHome,
 }) => {
-  await waitForInitialScan(appWindow)
-
   const expectedSourcePath = join(
     isolatedHome,
     '.agents',
     'skills',
     AZURE_AI_NAME,
   )
+  test.skip(
+    !existsSync(expectedSourcePath),
+    'azure-ai snapshot skill is required for this snapshot-backed unlink test',
+  )
+
+  await waitForInitialScan(appWindow)
 
   // Selector source is re-evaluated in renderer context (see redux.ts:23) so
   // closures over module-level constants are NOT preserved — `'azure-ai'`
@@ -233,8 +237,6 @@ test('unlinkFromAgent treats a missing linkPath as an idempotent success', async
   appWindow,
   isolatedHome,
 }) => {
-  await waitForInitialScan(appWindow)
-
   // Pre-create the parent agent dir so validatePath's allowed-bases check
   // succeeds. Without this, validatePath could throw before lstat runs and
   // we'd be testing the wrong failure branch.
@@ -484,18 +486,20 @@ test('removeAllFromAgent refuses when the agent path is a symlink alias to the u
     existsSync(cursorAgentPath),
     `cursor scanDir ${cursorAgentPath} unexpectedly exists pre-stage — global-setup or skills-cli behavior changed`,
   ).toBe(false)
+  const sentinelSourceName = `shared-source-refusal-${randomBytes(4).toString('hex')}`
+  const sentinelSourcePath = join(sourceDir, sentinelSourceName)
+  mkdirSync(sentinelSourcePath, { recursive: true })
+  writeFileSync(
+    join(sentinelSourcePath, 'SKILL.md'),
+    '# Shared source refusal fixture\n',
+  )
   mkdirSync(dirname(cursorAgentPath), { recursive: true })
   symlinkSync(sourceDir, cursorAgentPath)
 
   // Capture the SOURCE_DIR contents pre-call so we can assert nothing inside
   // it moved when the refusal path fires.
   const sourceContentsBefore = readdirSync(sourceDir).sort()
-  expect(
-    sourceContentsBefore.length,
-    'expected the snapshot source dir to be populated by global-setup',
-  ).toBeGreaterThan(0)
-
-  await waitForInitialScan(appWindow)
+  expect(sourceContentsBefore).toContain(sentinelSourceName)
 
   const result = await appWindow.evaluate(
     async (args: { agentId: string; agentPath: string }) =>

--- a/e2e/spec/unlink-agent.e2e.ts
+++ b/e2e/spec/unlink-agent.e2e.ts
@@ -83,6 +83,20 @@ function preStageLinkedSkills(
 }
 
 /**
+ * Build reviewed bulk-unlink IPC items for a selected agent directory.
+ * @param agentPath - Selected agent skills directory.
+ * @param skillNames - Agent slot basenames to unlink.
+ * @returns Payload items with mandatory reviewed link paths.
+ * @example unlinkItemsFor('/Users/me/.claude/skills', ['task'])
+ */
+function unlinkItemsFor(agentPath: string, skillNames: string[]) {
+  return skillNames.map((skillName) => ({
+    skillName,
+    linkPath: join(agentPath, skillName),
+  }))
+}
+
+/**
  * Phase-2 spec covering the three unlink-style IPCs that operate on agent-side
  * link paths without writing to trash:
  *   - `SKILLS_UNLINK_FROM_AGENT`        (single)
@@ -317,11 +331,13 @@ test('unlinkManyFromAgent removes every pre-staged symlink and leaves source dir
   }
 
   const result = await appWindow.evaluate(
-    async (args: { agentId: string; items: Array<{ skillName: string }> }) =>
-      window.electron.skills.unlinkManyFromAgent(args),
+    async (args: {
+      agentId: string
+      items: Array<{ skillName: string; linkPath: string }>
+    }) => window.electron.skills.unlinkManyFromAgent(args),
     {
       agentId: 'claude-code',
-      items: skillNames.map((skillName) => ({ skillName })),
+      items: unlinkItemsFor(claudeAgentPath, skillNames),
     },
   )
 
@@ -340,6 +356,47 @@ test('unlinkManyFromAgent removes every pre-staged symlink and leaves source dir
     expect(existsSync(sourcePath)).toBe(true)
     expect(existsSync(join(sourcePath, 'SKILL.md'))).toBe(true)
   }
+})
+
+test('unlinkManyFromAgent uses reviewed linkPath when metadata name differs from slot basename', async ({
+  appWindow,
+  isolatedHome,
+}) => {
+  const metadataName = 'metadata-title-unlink-e2e'
+  const slotName = 'folder-basename-unlink-e2e'
+  const sourcePath = join(isolatedHome, '.agents', 'skills', slotName)
+  const claudeAgentPath = join(isolatedHome, '.claude', 'skills')
+  const reviewedLinkPath = join(claudeAgentPath, slotName)
+  const decoyLinkPath = join(claudeAgentPath, metadataName)
+
+  // Arrange
+  mkdirSync(sourcePath, { recursive: true })
+  mkdirSync(claudeAgentPath, { recursive: true })
+  writeFileSync(join(sourcePath, 'SKILL.md'), `name: ${metadataName}\n`)
+  symlinkSync(sourcePath, reviewedLinkPath)
+  symlinkSync(sourcePath, decoyLinkPath)
+  await waitForInitialScan(appWindow)
+
+  // Act
+  const result = await appWindow.evaluate(
+    async (args: {
+      agentId: string
+      items: Array<{ skillName: string; linkPath: string }>
+    }) => window.electron.skills.unlinkManyFromAgent(args),
+    {
+      agentId: 'claude-code',
+      items: [{ skillName: metadataName, linkPath: reviewedLinkPath }],
+    },
+  )
+
+  // Assert
+  expect(result.items).toEqual([
+    { skillName: metadataName, outcome: 'unlinked' },
+  ])
+  expect(existsSync(reviewedLinkPath)).toBe(false)
+  expect(lstatSync(decoyLinkPath).isSymbolicLink()).toBe(true)
+  expect(existsSync(sourcePath)).toBe(true)
+  expect(existsSync(join(sourcePath, 'SKILL.md'))).toBe(true)
 })
 
 /**
@@ -409,11 +466,13 @@ test('unlinkManyFromAgent aggregates per-item failures without short-circuiting 
   expect(lstatSync(poisonedLinkPath).isSymbolicLink()).toBe(false)
 
   const result = await appWindow.evaluate(
-    async (args: { agentId: string; items: Array<{ skillName: string }> }) =>
-      window.electron.skills.unlinkManyFromAgent(args),
+    async (args: {
+      agentId: string
+      items: Array<{ skillName: string; linkPath: string }>
+    }) => window.electron.skills.unlinkManyFromAgent(args),
     {
       agentId: 'claude-code',
-      items: skillNames.map((skillName) => ({ skillName })),
+      items: unlinkItemsFor(claudeAgentPath, skillNames),
     },
   )
 

--- a/e2e/spec/unlink-agent.e2e.ts
+++ b/e2e/spec/unlink-agent.e2e.ts
@@ -261,11 +261,9 @@ test('unlinkFromAgent treats a missing linkPath as an idempotent success', async
 })
 
 test('unlinkFromAgent refuses a regular file with the structured kind-mismatch error', async ({
-  appWindow,
   isolatedHome,
+  appWindow,
 }) => {
-  await waitForInitialScan(appWindow)
-
   const claudeAgentPath = join(isolatedHome, '.claude', 'skills')
   mkdirSync(claudeAgentPath, { recursive: true })
   const regularFilePath = join(claudeAgentPath, 'not-a-skill.txt')

--- a/e2e/spec/unlink-agent.e2e.ts
+++ b/e2e/spec/unlink-agent.e2e.ts
@@ -284,7 +284,7 @@ test('unlinkFromAgent refuses a regular file with the structured kind-mismatch e
     async (args: { skillName: string; agentId: string; linkPath: string }) =>
       window.electron.skills.unlinkFromAgent(args),
     {
-      skillName: 'not-a-skill',
+      skillName: 'not-a-skill.txt',
       agentId: 'claude-code',
       linkPath: regularFilePath,
     },

--- a/e2e/types.d.ts
+++ b/e2e/types.d.ts
@@ -101,7 +101,11 @@ declare global {
         clearOrphanSymlinks: (options: {
           items: Array<{
             skillName: string
-            agents: Array<{ agentId: string; linkPath: string }>
+            agents: Array<{
+              agentId: string
+              linkPath: string
+              targetPath: string
+            }>
           }>
         }) => Promise<{
           items: Array<
@@ -121,7 +125,7 @@ declare global {
         clearBrokenSymlinkSlots: (options: {
           items: Array<{
             agentId: string
-            skillName: string
+            linkName: string
             linkPath: string
             targetPath: string
           }>

--- a/e2e/types.d.ts
+++ b/e2e/types.d.ts
@@ -167,12 +167,17 @@ declare global {
           skillName: string
           agentId: string
           linkPath: string
+          targetPath?: string
           confirmedLocalDirectoryDelete?: boolean
           reviewedDirectoryIdentity?: FilesystemEntryIdentity
         }) => Promise<{ success: boolean; error?: string }>
         unlinkManyFromAgent: (options: {
           agentId: string
-          items: Array<{ skillName: string; linkPath: string }>
+          items: Array<{
+            skillName: string
+            linkPath: string
+            targetPath: string
+          }>
         }) => Promise<{
           items: Array<
             | { skillName: string; outcome: 'unlinked' }
@@ -186,6 +191,7 @@ declare global {
         removeAllFromAgent: (options: {
           agentId: string
           agentPath: string
+          filesystemIdentity: FilesystemEntryIdentity
         }) => Promise<{
           success: boolean
           removedCount: number

--- a/e2e/types.d.ts
+++ b/e2e/types.d.ts
@@ -60,7 +60,10 @@ declare global {
           copied: number
           failures: Array<{ agentId: string; error: string }>
         }>
-        deleteSkill: (options: { skillName: string }) => Promise<{
+        deleteSkill: (options: {
+          skillName: string
+          skillPath: string
+        }) => Promise<{
           success: boolean
           symlinksRemoved: number
           cascadeAgents: string[]
@@ -75,7 +78,7 @@ declare global {
           | { outcome: 'error'; error: { message: string; code?: string } }
         >
         deleteSkills: (options: {
-          items: Array<{ skillName: string }>
+          items: Array<{ skillName: string; skillPath: string }>
         }) => Promise<{
           items: Array<
             | {
@@ -153,7 +156,7 @@ declare global {
         }) => Promise<{ success: boolean; error?: string }>
         unlinkManyFromAgent: (options: {
           agentId: string
-          items: Array<{ skillName: string }>
+          items: Array<{ skillName: string; linkPath: string }>
         }) => Promise<{
           items: Array<
             | { skillName: string; outcome: 'unlinked' }

--- a/e2e/types.d.ts
+++ b/e2e/types.d.ts
@@ -29,6 +29,15 @@ interface ExposedReduxStore {
 }
 
 declare global {
+  interface FilesystemEntryIdentity {
+    kind: 'directory' | 'symlink' | 'file' | 'other'
+    dev: number
+    ino: number
+    size: number
+    ctimeMs: number
+    mtimeMs: number
+  }
+
   interface Window {
     __store?: ExposedReduxStore
     __store__?: ExposedReduxStore
@@ -63,6 +72,7 @@ declare global {
         deleteSkill: (options: {
           skillName: string
           skillPath: string
+          filesystemIdentity: FilesystemEntryIdentity
         }) => Promise<{
           success: boolean
           symlinksRemoved: number
@@ -78,7 +88,11 @@ declare global {
           | { outcome: 'error'; error: { message: string; code?: string } }
         >
         deleteSkills: (options: {
-          items: Array<{ skillName: string; skillPath: string }>
+          items: Array<{
+            skillName: string
+            skillPath: string
+            filesystemIdentity: FilesystemEntryIdentity
+          }>
         }) => Promise<{
           items: Array<
             | {
@@ -153,6 +167,8 @@ declare global {
           skillName: string
           agentId: string
           linkPath: string
+          confirmedLocalDirectoryDelete?: boolean
+          reviewedDirectoryIdentity?: FilesystemEntryIdentity
         }) => Promise<{ success: boolean; error?: string }>
         unlinkManyFromAgent: (options: {
           agentId: string

--- a/e2e/types.d.ts
+++ b/e2e/types.d.ts
@@ -163,14 +163,25 @@ declare global {
               }
           >
         }>
-        unlinkFromAgent: (options: {
-          skillName: string
-          agentId: string
-          linkPath: string
-          targetPath?: string
-          confirmedLocalDirectoryDelete?: boolean
-          reviewedDirectoryIdentity?: FilesystemEntryIdentity
-        }) => Promise<{ success: boolean; error?: string }>
+        unlinkFromAgent: (
+          options:
+            | {
+                skillName: string
+                agentId: string
+                linkPath: string
+                targetPath: string
+                confirmedLocalDirectoryDelete?: false
+                reviewedDirectoryIdentity?: never
+              }
+            | {
+                skillName: string
+                agentId: string
+                linkPath: string
+                confirmedLocalDirectoryDelete: true
+                reviewedDirectoryIdentity: FilesystemEntryIdentity
+                targetPath?: never
+              },
+        ) => Promise<{ success: boolean; error?: string }>
         unlinkManyFromAgent: (options: {
           agentId: string
           items: Array<{

--- a/e2e/types.d.ts
+++ b/e2e/types.d.ts
@@ -87,6 +87,56 @@ declare global {
               }
             | {
                 skillName: string
+                outcome: 'orphan-cleared'
+                symlinksRemoved: number
+                cascadeAgents: string[]
+              }
+            | {
+                skillName: string
+                outcome: 'error'
+                error: { message: string; code?: string }
+              }
+          >
+        }>
+        clearOrphanSymlinks: (options: {
+          items: Array<{
+            skillName: string
+            agents: Array<{ agentId: string; linkPath: string }>
+          }>
+        }) => Promise<{
+          items: Array<
+            | {
+                skillName: string
+                outcome: 'orphan-cleared'
+                symlinksRemoved: number
+                cascadeAgents: string[]
+              }
+            | {
+                skillName: string
+                outcome: 'error'
+                error: { message: string; code?: string }
+              }
+          >
+        }>
+        clearBrokenSymlinkSlots: (options: {
+          items: Array<{
+            agentId: string
+            skillName: string
+            linkPath: string
+            targetPath: string
+          }>
+        }) => Promise<{
+          items: Array<
+            | {
+                agentId: string
+                skillName: string
+                linkPath: string
+                outcome: 'unlinked'
+              }
+            | {
+                agentId: string
+                skillName: string
+                linkPath: string
                 outcome: 'error'
                 error: { message: string; code?: string }
               }

--- a/src/main/ipc/ipc-schemas.test.ts
+++ b/src/main/ipc/ipc-schemas.test.ts
@@ -43,6 +43,7 @@ describe('skillNameString consistency across channels', () => {
           skillName: malicious,
           agentId: 'cursor',
           linkPath: '/tmp/x',
+          targetPath: '/tmp/target',
         },
       },
       {
@@ -221,6 +222,7 @@ describe('reviewed destructive path schemas', () => {
       skillName: 'task',
       agentId: 'cursor',
       linkPath: 'relative/link',
+      targetPath: '/tmp/target',
     }
 
     // Act
@@ -228,6 +230,53 @@ describe('reviewed destructive path schemas', () => {
 
     // Assert
     expect(result.success).toBe(false)
+  })
+
+  it('requires targetPath for single-agent symlink unlink', () => {
+    // Arrange
+    const missingTargetPath = {
+      skillName: 'task',
+      agentId: 'cursor',
+      linkPath: '/tmp/task',
+    }
+    const relativeTargetPath = {
+      skillName: 'task',
+      agentId: 'cursor',
+      linkPath: '/tmp/task',
+      targetPath: 'relative/target',
+    }
+    const validSymlinkUnlink = {
+      skillName: 'task',
+      agentId: 'cursor',
+      linkPath: '/tmp/task',
+      targetPath: '/tmp/target',
+    }
+
+    // Act / Assert
+    expect(unlinkSchema.safeParse([missingTargetPath]).success).toBe(false)
+    expect(unlinkSchema.safeParse([relativeTargetPath]).success).toBe(false)
+    expect(unlinkSchema.safeParse([validSymlinkUnlink]).success).toBe(true)
+  })
+
+  it('requires reviewed identity for confirmed single-agent local delete', () => {
+    // Arrange
+    const missingIdentity = {
+      skillName: 'local-task',
+      agentId: 'cursor',
+      linkPath: '/tmp/local-task',
+      confirmedLocalDirectoryDelete: true,
+    }
+    const validLocalDelete = {
+      skillName: 'local-task',
+      agentId: 'cursor',
+      linkPath: '/tmp/local-task',
+      confirmedLocalDirectoryDelete: true,
+      reviewedDirectoryIdentity: directoryIdentity,
+    }
+
+    // Act / Assert
+    expect(unlinkSchema.safeParse([missingIdentity]).success).toBe(false)
+    expect(unlinkSchema.safeParse([validLocalDelete]).success).toBe(true)
   })
 
   it('requires a reviewed filesystem identity for single delete', () => {

--- a/src/main/ipc/ipc-schemas.test.ts
+++ b/src/main/ipc/ipc-schemas.test.ts
@@ -36,7 +36,16 @@ describe('skillNameString consistency across channels', () => {
           linkPath: '/tmp/x',
         },
       },
-      { channel: 'skills:deleteSkill', payload: { skillName: malicious } },
+      {
+        channel: 'skills:deleteSkill',
+        payload: { skillName: malicious, skillPath: '/tmp/x' },
+      },
+      {
+        channel: 'skills:deleteSkills',
+        payload: {
+          items: [{ skillName: malicious, skillPath: '/tmp/x' }],
+        },
+      },
       {
         channel: 'skills:createSymlinks',
         payload: {
@@ -81,6 +90,13 @@ describe('skillNameString consistency across channels', () => {
               targetPath: '/tmp/target',
             },
           ],
+        },
+      },
+      {
+        channel: 'skills:unlinkManyFromAgent',
+        payload: {
+          agentId: 'cursor',
+          items: [{ skillName: malicious, linkPath: '/tmp/link' }],
         },
       },
     ]
@@ -166,6 +182,60 @@ describe('cleanup IPC target path schemas', () => {
         },
       ]).success,
     ).toBe(false)
+  })
+})
+
+describe('destructive reviewed-path IPC schemas', () => {
+  const singleDeleteSchema = IPC_ARG_SCHEMAS['skills:deleteSkill']!
+  const batchDeleteSchema = IPC_ARG_SCHEMAS['skills:deleteSkills']!
+  const batchUnlinkSchema = IPC_ARG_SCHEMAS['skills:unlinkManyFromAgent']!
+
+  it('requires an absolute skillPath for every delete request', () => {
+    expect(singleDeleteSchema.safeParse([{ skillName: 'task' }]).success).toBe(
+      false,
+    )
+    expect(
+      singleDeleteSchema.safeParse([
+        { skillName: 'task', skillPath: 'relative/path' },
+      ]).success,
+    ).toBe(false)
+    expect(
+      batchDeleteSchema.safeParse([{ items: [{ skillName: 'task' }] }]).success,
+    ).toBe(false)
+    expect(
+      batchDeleteSchema.safeParse([
+        { items: [{ skillName: 'task', skillPath: 'relative/path' }] },
+      ]).success,
+    ).toBe(false)
+    expect(
+      batchDeleteSchema.safeParse([
+        { items: [{ skillName: 'task', skillPath: '/tmp/task' }] },
+      ]).success,
+    ).toBe(true)
+  })
+
+  it('requires an absolute linkPath for every bulk unlink request', () => {
+    expect(
+      batchUnlinkSchema.safeParse([
+        { agentId: 'cursor', items: [{ skillName: 'task' }] },
+      ]).success,
+    ).toBe(false)
+    expect(
+      batchUnlinkSchema.safeParse([
+        {
+          agentId: 'cursor',
+          items: [{ skillName: 'task', linkPath: 'relative/path' }],
+        },
+      ]).success,
+    ).toBe(false)
+    expect(
+      batchUnlinkSchema.safeParse([
+        {
+          agentId: 'cursor',
+          items: [{ skillName: 'task', linkPath: '/tmp/task' }],
+        },
+      ]).success,
+    ).toBe(true)
   })
 })
 

--- a/src/main/ipc/ipc-schemas.test.ts
+++ b/src/main/ipc/ipc-schemas.test.ts
@@ -7,6 +7,15 @@ import {
 
 import { IPC_ARG_SCHEMAS } from './ipc-schemas'
 
+const directoryIdentity = {
+  kind: 'directory' as const,
+  dev: 1,
+  ino: 2,
+  size: 96,
+  ctimeMs: 3,
+  mtimeMs: 4,
+}
+
 /**
  * Runtime validation tests for IPC boundary schemas.
  *
@@ -38,12 +47,22 @@ describe('skillNameString consistency across channels', () => {
       },
       {
         channel: 'skills:deleteSkill',
-        payload: { skillName: malicious, skillPath: '/tmp/x' },
+        payload: {
+          skillName: malicious,
+          skillPath: '/tmp/x',
+          filesystemIdentity: directoryIdentity,
+        },
       },
       {
         channel: 'skills:deleteSkills',
         payload: {
-          items: [{ skillName: malicious, skillPath: '/tmp/x' }],
+          items: [
+            {
+              skillName: malicious,
+              skillPath: '/tmp/x',
+              filesystemIdentity: directoryIdentity,
+            },
+          ],
         },
       },
       {
@@ -185,6 +204,54 @@ describe('cleanup IPC target path schemas', () => {
   })
 })
 
+describe('reviewed destructive path schemas', () => {
+  const unlinkSchema = IPC_ARG_SCHEMAS['skills:unlinkFromAgent']!
+  const deleteSchema = IPC_ARG_SCHEMAS['skills:deleteSkill']!
+  const deleteBatchSchema = IPC_ARG_SCHEMAS['skills:deleteSkills']!
+
+  it('requires an absolute linkPath for single-agent unlink', () => {
+    // Arrange
+    const payload = {
+      skillName: 'task',
+      agentId: 'cursor',
+      linkPath: 'relative/link',
+    }
+
+    // Act
+    const result = unlinkSchema.safeParse([payload])
+
+    // Assert
+    expect(result.success).toBe(false)
+  })
+
+  it('requires a reviewed filesystem identity for single delete', () => {
+    // Arrange
+    const payload = {
+      skillName: 'task',
+      skillPath: '/tmp/task',
+    }
+
+    // Act
+    const result = deleteSchema.safeParse([payload])
+
+    // Assert
+    expect(result.success).toBe(false)
+  })
+
+  it('requires a reviewed filesystem identity for batch delete items', () => {
+    // Arrange
+    const payload = {
+      items: [{ skillName: 'task', skillPath: '/tmp/task' }],
+    }
+
+    // Act
+    const result = deleteBatchSchema.safeParse([payload])
+
+    // Assert
+    expect(result.success).toBe(false)
+  })
+})
+
 describe('destructive reviewed-path IPC schemas', () => {
   const singleDeleteSchema = IPC_ARG_SCHEMAS['skills:deleteSkill']!
   const batchDeleteSchema = IPC_ARG_SCHEMAS['skills:deleteSkills']!
@@ -196,7 +263,11 @@ describe('destructive reviewed-path IPC schemas', () => {
     )
     expect(
       singleDeleteSchema.safeParse([
-        { skillName: 'task', skillPath: 'relative/path' },
+        {
+          skillName: 'task',
+          skillPath: 'relative/path',
+          filesystemIdentity: directoryIdentity,
+        },
       ]).success,
     ).toBe(false)
     expect(
@@ -209,7 +280,15 @@ describe('destructive reviewed-path IPC schemas', () => {
     ).toBe(false)
     expect(
       batchDeleteSchema.safeParse([
-        { items: [{ skillName: 'task', skillPath: '/tmp/task' }] },
+        {
+          items: [
+            {
+              skillName: 'task',
+              skillPath: '/tmp/task',
+              filesystemIdentity: directoryIdentity,
+            },
+          ],
+        },
       ]).success,
     ).toBe(true)
   })

--- a/src/main/ipc/ipc-schemas.test.ts
+++ b/src/main/ipc/ipc-schemas.test.ts
@@ -115,7 +115,13 @@ describe('skillNameString consistency across channels', () => {
         channel: 'skills:unlinkManyFromAgent',
         payload: {
           agentId: 'cursor',
-          items: [{ skillName: malicious, linkPath: '/tmp/link' }],
+          items: [
+            {
+              skillName: malicious,
+              linkPath: '/tmp/link',
+              targetPath: '/tmp/target',
+            },
+          ],
         },
       },
     ]
@@ -275,7 +281,15 @@ describe('destructive reviewed-path IPC schemas', () => {
     ).toBe(false)
     expect(
       batchDeleteSchema.safeParse([
-        { items: [{ skillName: 'task', skillPath: 'relative/path' }] },
+        {
+          items: [
+            {
+              skillName: 'task',
+              skillPath: 'relative/path',
+              filesystemIdentity: directoryIdentity,
+            },
+          ],
+        },
       ]).success,
     ).toBe(false)
     expect(
@@ -303,7 +317,13 @@ describe('destructive reviewed-path IPC schemas', () => {
       batchUnlinkSchema.safeParse([
         {
           agentId: 'cursor',
-          items: [{ skillName: 'task', linkPath: 'relative/path' }],
+          items: [
+            {
+              skillName: 'task',
+              linkPath: 'relative/path',
+              targetPath: '/tmp/target',
+            },
+          ],
         },
       ]).success,
     ).toBe(false)
@@ -311,7 +331,51 @@ describe('destructive reviewed-path IPC schemas', () => {
       batchUnlinkSchema.safeParse([
         {
           agentId: 'cursor',
-          items: [{ skillName: 'task', linkPath: '/tmp/task' }],
+          items: [
+            {
+              skillName: 'task',
+              linkPath: '/tmp/task',
+              targetPath: 'relative/target',
+            },
+          ],
+        },
+      ]).success,
+    ).toBe(false)
+    expect(
+      batchUnlinkSchema.safeParse([
+        {
+          agentId: 'cursor',
+          items: [
+            {
+              skillName: 'task',
+              linkPath: '/tmp/task',
+              targetPath: '/tmp/target',
+            },
+          ],
+        },
+      ]).success,
+    ).toBe(true)
+  })
+
+  it('requires remove-all agent path and directory identity', () => {
+    const removeAllSchema = IPC_ARG_SCHEMAS['skills:removeAllFromAgent']!
+
+    expect(
+      removeAllSchema.safeParse([
+        { agentId: 'cursor', agentPath: 'relative/path' },
+      ]).success,
+    ).toBe(false)
+    expect(
+      removeAllSchema.safeParse([
+        { agentId: 'cursor', agentPath: '/tmp/.cursor/skills' },
+      ]).success,
+    ).toBe(false)
+    expect(
+      removeAllSchema.safeParse([
+        {
+          agentId: 'cursor',
+          agentPath: '/tmp/.cursor/skills',
+          filesystemIdentity: directoryIdentity,
         },
       ]).success,
     ).toBe(true)

--- a/src/main/ipc/ipc-schemas.test.ts
+++ b/src/main/ipc/ipc-schemas.test.ts
@@ -76,7 +76,7 @@ describe('skillNameString consistency across channels', () => {
           items: [
             {
               agentId: 'cursor',
-              skillName: malicious,
+              linkName: malicious,
               linkPath: '/tmp/link',
               targetPath: '/tmp/target',
             },
@@ -145,7 +145,7 @@ describe('cleanup IPC target path schemas', () => {
           items: [
             {
               agentId: 'cursor',
-              skillName: 'task',
+              linkName: 'task',
               linkPath: '/tmp/link',
             },
           ],
@@ -158,7 +158,7 @@ describe('cleanup IPC target path schemas', () => {
           items: [
             {
               agentId: 'cursor',
-              skillName: 'task',
+              linkName: 'task',
               linkPath: '/tmp/link',
               targetPath: 'relative/target',
             },

--- a/src/main/ipc/ipc-schemas.test.ts
+++ b/src/main/ipc/ipc-schemas.test.ts
@@ -23,39 +23,149 @@ describe('skillNameString consistency across channels', () => {
   // and forgets to use skillNameString, this will not catch it directly
   // but the `../` rejections above will (all channels share the refinement).
   it('rejects "../etc/passwd" across every skill-name-accepting channel', () => {
-    const channels: Array<keyof typeof IPC_ARG_SCHEMAS> = [
-      'skills:unlinkFromAgent',
-      'skills:deleteSkill',
-      'skills:createSymlinks',
-      'skills:copyToAgents',
+    const malicious = '../etc/passwd'
+    const channelCases: Array<{
+      channel: keyof typeof IPC_ARG_SCHEMAS
+      payload: unknown
+    }> = [
+      {
+        channel: 'skills:unlinkFromAgent',
+        payload: {
+          skillName: malicious,
+          agentId: 'cursor',
+          linkPath: '/tmp/x',
+        },
+      },
+      { channel: 'skills:deleteSkill', payload: { skillName: malicious } },
+      {
+        channel: 'skills:createSymlinks',
+        payload: {
+          skillName: malicious,
+          skillPath: '/tmp/x',
+          agentIds: ['cursor'],
+        },
+      },
+      {
+        channel: 'skills:copyToAgents',
+        payload: {
+          skillName: malicious,
+          sourcePath: '/tmp/x',
+          targetAgentIds: ['cursor'],
+        },
+      },
+      {
+        channel: 'skills:clearOrphanSymlinks',
+        payload: {
+          items: [
+            {
+              skillName: malicious,
+              agents: [
+                {
+                  agentId: 'cursor',
+                  linkPath: '/tmp/link',
+                  targetPath: '/tmp/target',
+                },
+              ],
+            },
+          ],
+        },
+      },
+      {
+        channel: 'skills:clearBrokenSymlinkSlots',
+        payload: {
+          items: [
+            {
+              agentId: 'cursor',
+              skillName: malicious,
+              linkPath: '/tmp/link',
+              targetPath: '/tmp/target',
+            },
+          ],
+        },
+      },
     ]
 
-    const malicious = '../etc/passwd'
-    for (const channel of channels) {
+    for (const { channel, payload } of channelCases) {
       const schema = IPC_ARG_SCHEMAS[channel]!
-      // Build a minimally-valid payload but inject the malicious skillName.
-      // This avoids asserting the exact shape of each channel (too brittle)
-      // while still exercising the skillName refinement.
-      const payload: { skillName: string; [k: string]: unknown } = {
-        skillName: malicious,
-      }
-      // Supply the other required fields for schemas that need them.
-      if (channel === 'skills:unlinkFromAgent') {
-        payload.agentId = 'cursor'
-        payload.linkPath = '/tmp/x'
-      } else if (channel === 'skills:createSymlinks') {
-        payload.skillPath = '/tmp/x'
-        payload.agentIds = ['cursor']
-      } else if (channel === 'skills:copyToAgents') {
-        payload.sourcePath = '/tmp/x'
-        payload.targetAgentIds = ['cursor']
-      }
       const result = schema.safeParse([payload])
       expect(
         result.success,
         `channel ${channel} should reject ${malicious}`,
       ).toBe(false)
     }
+  })
+})
+
+describe('cleanup IPC target path schemas', () => {
+  const orphanSchema = IPC_ARG_SCHEMAS['skills:clearOrphanSymlinks']!
+  const brokenSchema = IPC_ARG_SCHEMAS['skills:clearBrokenSymlinkSlots']!
+
+  it('requires an absolute targetPath for orphan cleanup records', () => {
+    expect(
+      orphanSchema.safeParse([
+        {
+          items: [
+            {
+              skillName: 'abandoned',
+              agents: [
+                {
+                  agentId: 'cursor',
+                  linkPath: '/tmp/link',
+                },
+              ],
+            },
+          ],
+        },
+      ]).success,
+    ).toBe(false)
+    expect(
+      orphanSchema.safeParse([
+        {
+          items: [
+            {
+              skillName: 'abandoned',
+              agents: [
+                {
+                  agentId: 'cursor',
+                  linkPath: '/tmp/link',
+                  targetPath: 'relative/target',
+                },
+              ],
+            },
+          ],
+        },
+      ]).success,
+    ).toBe(false)
+  })
+
+  it('requires an absolute targetPath for broken-slot cleanup records', () => {
+    expect(
+      brokenSchema.safeParse([
+        {
+          items: [
+            {
+              agentId: 'cursor',
+              skillName: 'task',
+              linkPath: '/tmp/link',
+            },
+          ],
+        },
+      ]).success,
+    ).toBe(false)
+    expect(
+      brokenSchema.safeParse([
+        {
+          items: [
+            {
+              agentId: 'cursor',
+              skillName: 'task',
+              linkPath: '/tmp/link',
+              targetPath: 'relative/target',
+            },
+          ],
+        },
+      ]).success,
+    ).toBe(false)
   })
 })
 

--- a/src/main/ipc/ipc-schemas.ts
+++ b/src/main/ipc/ipc-schemas.ts
@@ -195,6 +195,7 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
   'skills:deleteSkill': z.tuple([
     z.object({
       skillName: skillNameString,
+      skillPath: absolutePathArg.optional(),
     }),
   ]),
   'skills:createSymlinks': z.tuple([
@@ -216,7 +217,12 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
   'skills:deleteSkills': z.tuple([
     z.object({
       items: z
-        .array(z.object({ skillName: skillNameString }))
+        .array(
+          z.object({
+            skillName: skillNameString,
+            skillPath: absolutePathArg.optional(),
+          }),
+        )
         .min(1, 'At least one skill required for batch delete'),
     }),
   ]),
@@ -258,7 +264,12 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
     z.object({
       agentId: nonEmptyString,
       items: z
-        .array(z.object({ skillName: skillNameString }))
+        .array(
+          z.object({
+            skillName: skillNameString,
+            linkPath: absolutePathArg.optional(),
+          }),
+        )
         .min(1, 'At least one skill required for batch unlink'),
     }),
   ]),

--- a/src/main/ipc/ipc-schemas.ts
+++ b/src/main/ipc/ipc-schemas.ts
@@ -195,7 +195,7 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
   'skills:deleteSkill': z.tuple([
     z.object({
       skillName: skillNameString,
-      skillPath: absolutePathArg.optional(),
+      skillPath: absolutePathArg,
     }),
   ]),
   'skills:createSymlinks': z.tuple([
@@ -220,7 +220,7 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
         .array(
           z.object({
             skillName: skillNameString,
-            skillPath: absolutePathArg.optional(),
+            skillPath: absolutePathArg,
           }),
         )
         .min(1, 'At least one skill required for batch delete'),
@@ -267,7 +267,7 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
         .array(
           z.object({
             skillName: skillNameString,
-            linkPath: absolutePathArg.optional(),
+            linkPath: absolutePathArg,
           }),
         )
         .min(1, 'At least one skill required for batch unlink'),

--- a/src/main/ipc/ipc-schemas.ts
+++ b/src/main/ipc/ipc-schemas.ts
@@ -189,14 +189,24 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
 
   // Skills operations
   'skills:unlinkFromAgent': z.tuple([
-    z.object({
-      skillName: skillNameString,
-      agentId: nonEmptyString,
-      linkPath: absolutePathArg,
-      targetPath: absolutePathArg.optional(),
-      confirmedLocalDirectoryDelete: z.boolean().optional(),
-      reviewedDirectoryIdentity: filesystemEntryIdentitySchema.optional(),
-    }),
+    z.union([
+      z.object({
+        skillName: skillNameString,
+        agentId: nonEmptyString,
+        linkPath: absolutePathArg,
+        targetPath: absolutePathArg,
+        confirmedLocalDirectoryDelete: z.literal(false).optional(),
+        reviewedDirectoryIdentity: z.undefined().optional(),
+      }),
+      z.object({
+        skillName: skillNameString,
+        agentId: nonEmptyString,
+        linkPath: absolutePathArg,
+        confirmedLocalDirectoryDelete: z.literal(true),
+        reviewedDirectoryIdentity: filesystemEntryIdentitySchema,
+        targetPath: z.undefined().optional(),
+      }),
+    ]),
   ]),
   'skills:removeAllFromAgent': z.tuple([
     z.object({

--- a/src/main/ipc/ipc-schemas.ts
+++ b/src/main/ipc/ipc-schemas.ts
@@ -38,6 +38,16 @@ const absolutePathArg = z
   .refine((p) => p.startsWith('/'), {
     message: 'Path must be absolute (start with /)',
   })
+
+/** Serializable lstat identity captured when a destructive row was reviewed. */
+const filesystemEntryIdentitySchema = z.object({
+  kind: z.enum(['directory', 'symlink', 'file', 'other']),
+  dev: z.number().finite(),
+  ino: z.number().finite(),
+  size: z.number().finite(),
+  ctimeMs: z.number().finite(),
+  mtimeMs: z.number().finite(),
+})
 /**
  * Skill name must not contain path separators (prevents `../` traversal) or
  * null bytes (defense in depth: some libc wrappers truncate at `\0`, which
@@ -182,8 +192,9 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
     z.object({
       skillName: skillNameString,
       agentId: nonEmptyString,
-      linkPath: nonEmptyString,
+      linkPath: absolutePathArg,
       confirmedLocalDirectoryDelete: z.boolean().optional(),
+      reviewedDirectoryIdentity: filesystemEntryIdentitySchema.optional(),
     }),
   ]),
   'skills:removeAllFromAgent': z.tuple([
@@ -196,6 +207,7 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
     z.object({
       skillName: skillNameString,
       skillPath: absolutePathArg,
+      filesystemIdentity: filesystemEntryIdentitySchema,
     }),
   ]),
   'skills:createSymlinks': z.tuple([
@@ -221,6 +233,7 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
           z.object({
             skillName: skillNameString,
             skillPath: absolutePathArg,
+            filesystemIdentity: filesystemEntryIdentitySchema,
           }),
         )
         .min(1, 'At least one skill required for batch delete'),

--- a/src/main/ipc/ipc-schemas.ts
+++ b/src/main/ipc/ipc-schemas.ts
@@ -246,7 +246,7 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
         .array(
           z.object({
             agentId: nonEmptyString,
-            skillName: skillNameString,
+            linkName: skillNameString,
             linkPath: absolutePathArg,
             targetPath: absolutePathArg,
           }),

--- a/src/main/ipc/ipc-schemas.ts
+++ b/src/main/ipc/ipc-schemas.ts
@@ -193,6 +193,7 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
       skillName: skillNameString,
       agentId: nonEmptyString,
       linkPath: absolutePathArg,
+      targetPath: absolutePathArg.optional(),
       confirmedLocalDirectoryDelete: z.boolean().optional(),
       reviewedDirectoryIdentity: filesystemEntryIdentitySchema.optional(),
     }),
@@ -200,7 +201,8 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
   'skills:removeAllFromAgent': z.tuple([
     z.object({
       agentId: nonEmptyString,
-      agentPath: nonEmptyString,
+      agentPath: absolutePathArg,
+      filesystemIdentity: filesystemEntryIdentitySchema,
     }),
   ]),
   'skills:deleteSkill': z.tuple([
@@ -281,6 +283,7 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
           z.object({
             skillName: skillNameString,
             linkPath: absolutePathArg,
+            targetPath: absolutePathArg,
           }),
         )
         .min(1, 'At least one skill required for batch unlink'),

--- a/src/main/ipc/ipc-schemas.ts
+++ b/src/main/ipc/ipc-schemas.ts
@@ -231,6 +231,7 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
                 z.object({
                   agentId: nonEmptyString,
                   linkPath: absolutePathArg,
+                  targetPath: absolutePathArg,
                 }),
               )
               .min(1, 'At least one orphan symlink required'),

--- a/src/main/ipc/ipc-schemas.ts
+++ b/src/main/ipc/ipc-schemas.ts
@@ -220,6 +220,39 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
         .min(1, 'At least one skill required for batch delete'),
     }),
   ]),
+  'skills:clearOrphanSymlinks': z.tuple([
+    z.object({
+      items: z
+        .array(
+          z.object({
+            skillName: skillNameString,
+            agents: z
+              .array(
+                z.object({
+                  agentId: nonEmptyString,
+                  linkPath: absolutePathArg,
+                }),
+              )
+              .min(1, 'At least one orphan symlink required'),
+          }),
+        )
+        .min(1, 'At least one orphan record required'),
+    }),
+  ]),
+  'skills:clearBrokenSymlinkSlots': z.tuple([
+    z.object({
+      items: z
+        .array(
+          z.object({
+            agentId: nonEmptyString,
+            skillName: skillNameString,
+            linkPath: absolutePathArg,
+            targetPath: absolutePathArg,
+          }),
+        )
+        .min(1, 'At least one broken symlink slot required'),
+    }),
+  ]),
   'skills:unlinkManyFromAgent': z.tuple([
     z.object({
       agentId: nonEmptyString,

--- a/src/main/ipc/skills.clearOrphanSymlinks.integration.test.ts
+++ b/src/main/ipc/skills.clearOrphanSymlinks.integration.test.ts
@@ -1,0 +1,424 @@
+import { lstat, mkdir, mkdtemp, rm, symlink } from 'node:fs/promises'
+import type * as NodeOs from 'node:os'
+import { tmpdir } from 'node:os'
+import { join, relative } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const handleMock = vi.fn()
+const trashItemMock = vi.fn()
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (...args: unknown[]) => handleMock(...args),
+  },
+  shell: {
+    trashItem: (...args: unknown[]) => trashItemMock(...args),
+  },
+}))
+
+/**
+ * Returns a registered skills cleanup IPC handler from the Electron mock.
+ * @param channel - IPC invoke channel to find.
+ * @returns Registered handler callable with test event and options.
+ * @example
+ * const handler = getRegisteredHandler('skills:clearOrphanSymlinks')
+ */
+function getRegisteredHandler(channel: string): (
+  event: unknown,
+  arg: {
+    items: Array<{
+      skillName: string
+      agents?: Array<{ agentId: string; linkPath: string }>
+      agentId?: string
+      linkPath?: string
+      targetPath?: string
+    }>
+  },
+) => Promise<unknown> {
+  const registration = handleMock.mock.calls.find(([name]) => name === channel)
+  if (!registration) {
+    throw new Error(`No handler registered for ${channel}`)
+  }
+  return registration[1] as (
+    event: unknown,
+    arg: {
+      items: Array<{
+        skillName: string
+        agents?: Array<{ agentId: string; linkPath: string }>
+        agentId?: string
+        linkPath?: string
+        targetPath?: string
+      }>
+    },
+  ) => Promise<unknown>
+}
+
+describe('skills:clearOrphanSymlinks handler', () => {
+  let tempHome = ''
+
+  beforeEach(async () => {
+    vi.resetModules()
+    handleMock.mockReset()
+    trashItemMock.mockReset()
+    tempHome = await mkdtemp(join(tmpdir(), 'skills-desktop-orphan-ipc-'))
+    vi.doMock('os', async () => {
+      const actual = await vi.importActual<typeof NodeOs>('os')
+      return {
+        ...actual,
+        homedir: () => tempHome,
+      }
+    })
+    vi.doMock('node:os', async () => {
+      const actual = await vi.importActual<typeof NodeOs>('node:os')
+      return {
+        ...actual,
+        homedir: () => tempHome,
+      }
+    })
+  })
+
+  afterEach(async () => {
+    vi.doUnmock('os')
+    vi.doUnmock('node:os')
+    await rm(tempHome, { recursive: true, force: true })
+  })
+
+  it('unlinks a reviewed orphan symlink without creating a source-delete tombstone', async () => {
+    // Arrange
+    const skillName = 'abandoned'
+    const codexSkillsDir = join(tempHome, '.codex', 'skills')
+    const linkPath = join(codexSkillsDir, skillName)
+    await mkdir(codexSkillsDir, { recursive: true })
+    await symlink(join(tempHome, '.agents', 'skills', skillName), linkPath)
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+    const handler = getRegisteredHandler('skills:clearOrphanSymlinks')
+
+    // Act
+    const result = await handler(
+      {},
+      {
+        items: [
+          {
+            skillName,
+            agents: [{ agentId: 'codex', linkPath }],
+          },
+        ],
+      },
+    )
+
+    // Assert
+    expect(result).toEqual({
+      items: [
+        {
+          skillName,
+          outcome: 'orphan-cleared',
+          symlinksRemoved: 1,
+          cascadeAgents: ['codex'],
+        },
+      ],
+    })
+    await expect(lstat(linkPath)).rejects.toThrow(/ENOENT/)
+    expect(trashItemMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses orphan cleanup when a source skill was restored before mutation', async () => {
+    // Arrange
+    const skillName = 'restored-source'
+    const sourceDir = join(tempHome, '.agents', 'skills', skillName)
+    const codexSkillsDir = join(tempHome, '.codex', 'skills')
+    const linkPath = join(codexSkillsDir, skillName)
+    await mkdir(sourceDir, { recursive: true })
+    await mkdir(codexSkillsDir, { recursive: true })
+    await symlink(sourceDir, linkPath)
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+    const handler = getRegisteredHandler('skills:clearOrphanSymlinks')
+
+    // Act
+    const result = await handler(
+      {},
+      {
+        items: [
+          {
+            skillName,
+            agents: [{ agentId: 'codex', linkPath }],
+          },
+        ],
+      },
+    )
+
+    // Assert
+    expect(result).toEqual({
+      items: [
+        {
+          skillName,
+          outcome: 'error',
+          error: {
+            message: 'Source skill exists. Rescan before cleanup.',
+            code: 'ESTALE',
+          },
+        },
+      ],
+    })
+    expect((await lstat(linkPath)).isSymbolicLink()).toBe(true)
+  })
+
+  it('resolves broken targets through a symlinked Devin config parent before unlinking', async () => {
+    // Arrange
+    const skillName = 'devin-orphan'
+    const physicalConfigDir = join(tempHome, 'dotfiles', '.config')
+    const logicalConfigDir = join(tempHome, '.config')
+    const devinSkillsDir = join(logicalConfigDir, 'devin', 'skills')
+    const physicalDevinSkillsDir = join(physicalConfigDir, 'devin', 'skills')
+    const linkPath = join(devinSkillsDir, skillName)
+    await mkdir(physicalDevinSkillsDir, { recursive: true })
+    await symlink(physicalConfigDir, logicalConfigDir)
+    const relativeMissingTarget = relative(
+      physicalDevinSkillsDir,
+      join(tempHome, '.agents', 'skills', skillName),
+    )
+    await symlink(relativeMissingTarget, linkPath)
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+    const handler = getRegisteredHandler('skills:clearOrphanSymlinks')
+
+    // Act
+    const result = await handler(
+      {},
+      {
+        items: [
+          {
+            skillName,
+            agents: [{ agentId: 'devin', linkPath }],
+          },
+        ],
+      },
+    )
+
+    // Assert
+    expect(result).toEqual({
+      items: [
+        {
+          skillName,
+          outcome: 'orphan-cleared',
+          symlinksRemoved: 1,
+          cascadeAgents: ['devin'],
+        },
+      ],
+    })
+    await expect(lstat(linkPath)).rejects.toThrow(/ENOENT/)
+    expect((await lstat(logicalConfigDir)).isSymbolicLink()).toBe(true)
+  })
+})
+
+describe('skills:clearBrokenSymlinkSlots handler', () => {
+  let tempHome = ''
+
+  beforeEach(async () => {
+    vi.resetModules()
+    handleMock.mockReset()
+    trashItemMock.mockReset()
+    tempHome = await mkdtemp(join(tmpdir(), 'skills-desktop-broken-ipc-'))
+    vi.doMock('os', async () => {
+      const actual = await vi.importActual<typeof NodeOs>('os')
+      return {
+        ...actual,
+        homedir: () => tempHome,
+      }
+    })
+    vi.doMock('node:os', async () => {
+      const actual = await vi.importActual<typeof NodeOs>('node:os')
+      return {
+        ...actual,
+        homedir: () => tempHome,
+      }
+    })
+  })
+
+  afterEach(async () => {
+    vi.doUnmock('os')
+    vi.doUnmock('node:os')
+    await rm(tempHome, { recursive: true, force: true })
+  })
+
+  it('unlinks a reviewed broken slot only when the exact target is still missing', async () => {
+    // Arrange
+    const skillName = 'stale-source-slot'
+    const codexSkillsDir = join(tempHome, '.codex', 'skills')
+    const targetPath = join(tempHome, '.agents', 'skills', skillName)
+    const linkPath = join(codexSkillsDir, skillName)
+    await mkdir(codexSkillsDir, { recursive: true })
+    await symlink(targetPath, linkPath)
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+    const handler = getRegisteredHandler('skills:clearBrokenSymlinkSlots')
+
+    // Act
+    const result = await handler(
+      {},
+      {
+        items: [
+          {
+            skillName,
+            agentId: 'codex',
+            linkPath,
+            targetPath,
+          },
+        ],
+      },
+    )
+
+    // Assert
+    expect(result).toEqual({
+      items: [{ agentId: 'codex', skillName, linkPath, outcome: 'unlinked' }],
+    })
+    await expect(lstat(linkPath)).rejects.toThrow(/ENOENT/)
+  })
+
+  it('refuses to unlink a reviewed broken slot when its target was restored', async () => {
+    // Arrange
+    const skillName = 'restored-target-slot'
+    const codexSkillsDir = join(tempHome, '.codex', 'skills')
+    const targetPath = join(tempHome, '.agents', 'skills', skillName)
+    const linkPath = join(codexSkillsDir, skillName)
+    await mkdir(codexSkillsDir, { recursive: true })
+    await mkdir(targetPath, { recursive: true })
+    await symlink(targetPath, linkPath)
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+    const handler = getRegisteredHandler('skills:clearBrokenSymlinkSlots')
+
+    // Act
+    const result = await handler(
+      {},
+      {
+        items: [
+          {
+            skillName,
+            agentId: 'codex',
+            linkPath,
+            targetPath,
+          },
+        ],
+      },
+    )
+
+    // Assert
+    expect(result).toEqual({
+      items: [
+        {
+          skillName,
+          agentId: 'codex',
+          linkPath,
+          outcome: 'error',
+          error: {
+            message:
+              'Reviewed broken link target now exists. Rescan before cleanup.',
+            code: 'ESTALE',
+          },
+        },
+      ],
+    })
+    expect((await lstat(linkPath)).isSymbolicLink()).toBe(true)
+  })
+
+  it('refuses to unlink when the reviewed link path no longer matches the agent slot', async () => {
+    // Arrange
+    const skillName = 'path-swapped-slot'
+    const codexSkillsDir = join(tempHome, '.codex', 'skills')
+    const targetPath = join(tempHome, '.agents', 'skills', skillName)
+    const linkPath = join(codexSkillsDir, skillName)
+    const reviewedLinkPath = join(codexSkillsDir, 'other-slot')
+    await mkdir(codexSkillsDir, { recursive: true })
+    await symlink(targetPath, linkPath)
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+    const handler = getRegisteredHandler('skills:clearBrokenSymlinkSlots')
+
+    // Act
+    const result = await handler(
+      {},
+      {
+        items: [
+          {
+            skillName,
+            agentId: 'codex',
+            linkPath: reviewedLinkPath,
+            targetPath,
+          },
+        ],
+      },
+    )
+
+    // Assert
+    expect(result).toEqual({
+      items: [
+        {
+          agentId: 'codex',
+          skillName,
+          linkPath: reviewedLinkPath,
+          outcome: 'error',
+          error: {
+            message: 'Reviewed broken link path no longer matches agent slot',
+            code: 'ESTALE',
+          },
+        },
+      ],
+    })
+    expect((await lstat(linkPath)).isSymbolicLink()).toBe(true)
+  })
+
+  it('refuses to unlink when the reviewed broken slot target changed', async () => {
+    // Arrange
+    const skillName = 'target-swapped-slot'
+    const codexSkillsDir = join(tempHome, '.codex', 'skills')
+    const reviewedTargetPath = join(tempHome, '.agents', 'skills', skillName)
+    const currentTargetPath = join(
+      tempHome,
+      '.agents',
+      'skills',
+      'other-target',
+    )
+    const linkPath = join(codexSkillsDir, skillName)
+    await mkdir(codexSkillsDir, { recursive: true })
+    await symlink(currentTargetPath, linkPath)
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+    const handler = getRegisteredHandler('skills:clearBrokenSymlinkSlots')
+
+    // Act
+    const result = await handler(
+      {},
+      {
+        items: [
+          {
+            skillName,
+            agentId: 'codex',
+            linkPath,
+            targetPath: reviewedTargetPath,
+          },
+        ],
+      },
+    )
+
+    // Assert
+    expect(result).toEqual({
+      items: [
+        {
+          agentId: 'codex',
+          skillName,
+          linkPath,
+          outcome: 'error',
+          error: {
+            message:
+              'Reviewed broken link target changed. Rescan before cleanup.',
+            code: 'ESTALE',
+          },
+        },
+      ],
+    })
+    expect((await lstat(linkPath)).isSymbolicLink()).toBe(true)
+  })
+})

--- a/src/main/ipc/skills.clearOrphanSymlinks.integration.test.ts
+++ b/src/main/ipc/skills.clearOrphanSymlinks.integration.test.ts
@@ -1,4 +1,12 @@
-import { lstat, mkdir, mkdtemp, realpath, rm, symlink } from 'node:fs/promises'
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readlink,
+  realpath,
+  rm,
+  symlink,
+} from 'node:fs/promises'
 import type * as NodeFsPromises from 'node:fs/promises'
 import type * as NodeOs from 'node:os'
 import { tmpdir } from 'node:os'
@@ -547,5 +555,139 @@ describe('skills:clearBrokenSymlinkSlots handler', () => {
       ],
     })
     expect((await lstat(linkPath)).isDirectory()).toBe(true)
+  })
+
+  it('refuses when a reviewed link becomes a different symlink before final unlink', async () => {
+    // Arrange
+    const skillName = 'replacement-symlink-race'
+    const codexSkillsDir = join(tempHome, '.codex', 'skills')
+    const targetPath = join(tempHome, '.agents', 'skills', skillName)
+    const replacementTargetPath = join(
+      tempHome,
+      '.agents',
+      'skills',
+      'other-target',
+    )
+    const linkPath = join(codexSkillsDir, skillName)
+    await mkdir(codexSkillsDir, { recursive: true })
+    await symlink(targetPath, linkPath)
+    let targetProbeCount = 0
+    vi.doMock('node:fs/promises', async () => {
+      const actual =
+        await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
+      return {
+        ...actual,
+        access: async (path: string): Promise<void> => {
+          if (String(path) === targetPath) {
+            targetProbeCount += 1
+            if (targetProbeCount === 1) {
+              await actual.rm(linkPath, { force: true })
+              await actual.symlink(replacementTargetPath, linkPath)
+            }
+            throw Object.assign(new Error('missing target'), { code: 'ENOENT' })
+          }
+          return actual.access(path)
+        },
+      }
+    })
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+    const handler = getRegisteredHandler('skills:clearBrokenSymlinkSlots')
+
+    // Act
+    const result = await handler(
+      {},
+      {
+        items: [
+          {
+            agentId: 'codex',
+            linkName: skillName,
+            linkPath,
+            targetPath,
+          },
+        ],
+      },
+    )
+
+    // Assert
+    expect(result).toEqual({
+      items: [
+        {
+          agentId: 'codex',
+          skillName,
+          linkPath,
+          outcome: 'error',
+          error: {
+            message:
+              'Reviewed broken link target changed. Rescan before cleanup.',
+            code: 'ESTALE',
+          },
+        },
+      ],
+    })
+    expect(await readlink(linkPath)).toBe(replacementTargetPath)
+  })
+
+  it('refuses when the reviewed target is restored before final unlink', async () => {
+    // Arrange
+    const skillName = 'restored-target-race'
+    const codexSkillsDir = join(tempHome, '.codex', 'skills')
+    const targetPath = join(tempHome, '.agents', 'skills', skillName)
+    const linkPath = join(codexSkillsDir, skillName)
+    await mkdir(codexSkillsDir, { recursive: true })
+    await symlink(targetPath, linkPath)
+    let targetProbeCount = 0
+    vi.doMock('node:fs/promises', async () => {
+      const actual =
+        await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
+      return {
+        ...actual,
+        access: async (path: string): Promise<void> => {
+          if (String(path) === targetPath && targetProbeCount === 0) {
+            targetProbeCount += 1
+            await actual.mkdir(targetPath, { recursive: true })
+            throw Object.assign(new Error('missing target'), { code: 'ENOENT' })
+          }
+          return actual.access(path)
+        },
+      }
+    })
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+    const handler = getRegisteredHandler('skills:clearBrokenSymlinkSlots')
+
+    // Act
+    const result = await handler(
+      {},
+      {
+        items: [
+          {
+            agentId: 'codex',
+            linkName: skillName,
+            linkPath,
+            targetPath,
+          },
+        ],
+      },
+    )
+
+    // Assert
+    expect(result).toEqual({
+      items: [
+        {
+          agentId: 'codex',
+          skillName,
+          linkPath,
+          outcome: 'error',
+          error: {
+            message:
+              'Reviewed broken link target now exists. Rescan before cleanup.',
+            code: 'ESTALE',
+          },
+        },
+      ],
+    })
+    expect((await lstat(linkPath)).isSymbolicLink()).toBe(true)
+    expect((await lstat(targetPath)).isDirectory()).toBe(true)
   })
 })

--- a/src/main/ipc/skills.clearOrphanSymlinks.integration.test.ts
+++ b/src/main/ipc/skills.clearOrphanSymlinks.integration.test.ts
@@ -490,7 +490,7 @@ describe('skills:clearBrokenSymlinkSlots handler', () => {
     expect((await lstat(linkPath)).isSymbolicLink()).toBe(true)
   })
 
-  it('restores a local replacement quarantined by a swap before rename', async () => {
+  it('keeps a local replacement when a reviewed link becomes a folder before unlink', async () => {
     // Arrange
     const skillName = 'replacement-race-slot'
     const codexSkillsDir = join(tempHome, '.codex', 'skills')
@@ -503,12 +503,12 @@ describe('skills:clearBrokenSymlinkSlots handler', () => {
         await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
       return {
         ...actual,
-        rename: async (oldPath: string, newPath: string): Promise<void> => {
-          if (String(oldPath) === linkPath) {
+        unlink: async (path: string): Promise<void> => {
+          if (String(path) === linkPath) {
             await actual.rm(linkPath, { recursive: true, force: true })
             await actual.mkdir(linkPath, { recursive: true })
           }
-          return actual.rename(oldPath, newPath)
+          return actual.unlink(path)
         },
       }
     })

--- a/src/main/ipc/skills.clearOrphanSymlinks.integration.test.ts
+++ b/src/main/ipc/skills.clearOrphanSymlinks.integration.test.ts
@@ -498,7 +498,7 @@ describe('skills:clearBrokenSymlinkSlots handler', () => {
     expect((await lstat(linkPath)).isSymbolicLink()).toBe(true)
   })
 
-  it('keeps a local replacement when a reviewed link becomes a folder before unlink', async () => {
+  it('keeps a local replacement when a reviewed link becomes a folder before guarded commit', async () => {
     // Arrange
     const skillName = 'replacement-race-slot'
     const codexSkillsDir = join(tempHome, '.codex', 'skills')
@@ -511,12 +511,12 @@ describe('skills:clearBrokenSymlinkSlots handler', () => {
         await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
       return {
         ...actual,
-        unlink: async (path: string): Promise<void> => {
-          if (String(path) === linkPath) {
+        rename: async (oldPath: string, newPath: string): Promise<void> => {
+          if (String(oldPath) === linkPath) {
             await actual.rm(linkPath, { recursive: true, force: true })
             await actual.mkdir(linkPath, { recursive: true })
           }
-          return actual.unlink(path)
+          return actual.rename(oldPath, newPath)
         },
       }
     })
@@ -555,6 +555,132 @@ describe('skills:clearBrokenSymlinkSlots handler', () => {
       ],
     })
     expect((await lstat(linkPath)).isDirectory()).toBe(true)
+  })
+
+  it('keeps a symlink replacement that appears during guarded commit rename', async () => {
+    // Arrange
+    const skillName = 'replacement-during-rename'
+    const codexSkillsDir = join(tempHome, '.codex', 'skills')
+    const targetPath = join(tempHome, '.agents', 'skills', skillName)
+    const replacementTargetPath = join(
+      tempHome,
+      '.agents',
+      'skills',
+      'rename-replacement-target',
+    )
+    const linkPath = join(codexSkillsDir, skillName)
+    await mkdir(codexSkillsDir, { recursive: true })
+    await symlink(targetPath, linkPath)
+    vi.doMock('node:fs/promises', async () => {
+      const actual =
+        await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
+      return {
+        ...actual,
+        rename: async (oldPath: string, newPath: string): Promise<void> => {
+          if (String(oldPath) === linkPath) {
+            await actual.rm(linkPath, { force: true })
+            await actual.symlink(replacementTargetPath, linkPath)
+          }
+          return actual.rename(oldPath, newPath)
+        },
+      }
+    })
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+    const handler = getRegisteredHandler('skills:clearBrokenSymlinkSlots')
+
+    // Act
+    const result = await handler(
+      {},
+      {
+        items: [
+          {
+            agentId: 'codex',
+            linkName: skillName,
+            linkPath,
+            targetPath,
+          },
+        ],
+      },
+    )
+
+    // Assert
+    expect(result).toEqual({
+      items: [
+        {
+          agentId: 'codex',
+          skillName,
+          linkPath,
+          outcome: 'error',
+          error: {
+            message:
+              'Reviewed broken link target changed. Rescan before cleanup.',
+            code: 'ESTALE',
+          },
+        },
+      ],
+    })
+    expect(await readlink(linkPath)).toBe(replacementTargetPath)
+  })
+
+  it('restores the reviewed symlink when its target reappears during guarded commit rename', async () => {
+    // Arrange
+    const skillName = 'target-restore-during-rename'
+    const codexSkillsDir = join(tempHome, '.codex', 'skills')
+    const targetPath = join(tempHome, '.agents', 'skills', skillName)
+    const linkPath = join(codexSkillsDir, skillName)
+    await mkdir(codexSkillsDir, { recursive: true })
+    await symlink(targetPath, linkPath)
+    vi.doMock('node:fs/promises', async () => {
+      const actual =
+        await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
+      return {
+        ...actual,
+        rename: async (oldPath: string, newPath: string): Promise<void> => {
+          if (String(oldPath) === linkPath) {
+            await actual.mkdir(targetPath, { recursive: true })
+          }
+          return actual.rename(oldPath, newPath)
+        },
+      }
+    })
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+    const handler = getRegisteredHandler('skills:clearBrokenSymlinkSlots')
+
+    // Act
+    const result = await handler(
+      {},
+      {
+        items: [
+          {
+            agentId: 'codex',
+            linkName: skillName,
+            linkPath,
+            targetPath,
+          },
+        ],
+      },
+    )
+
+    // Assert
+    expect(result).toEqual({
+      items: [
+        {
+          agentId: 'codex',
+          skillName,
+          linkPath,
+          outcome: 'error',
+          error: {
+            message:
+              'Reviewed broken link target now exists. Rescan before cleanup.',
+            code: 'ESTALE',
+          },
+        },
+      ],
+    })
+    expect((await lstat(linkPath)).isSymbolicLink()).toBe(true)
+    expect((await lstat(targetPath)).isDirectory()).toBe(true)
   })
 
   it('refuses when a reviewed link becomes a different symlink before final unlink', async () => {

--- a/src/main/ipc/skills.clearOrphanSymlinks.integration.test.ts
+++ b/src/main/ipc/skills.clearOrphanSymlinks.integration.test.ts
@@ -316,6 +316,7 @@ describe('skills:clearBrokenSymlinkSlots handler', () => {
   afterEach(async () => {
     vi.doUnmock('os')
     vi.doUnmock('node:os')
+    vi.doUnmock('node:fs/promises')
     await rm(tempHome, { recursive: true, force: true })
   })
 

--- a/src/main/ipc/skills.clearOrphanSymlinks.integration.test.ts
+++ b/src/main/ipc/skills.clearOrphanSymlinks.integration.test.ts
@@ -1,4 +1,5 @@
 import { lstat, mkdir, mkdtemp, realpath, rm, symlink } from 'node:fs/promises'
+import type * as NodeFsPromises from 'node:fs/promises'
 import type * as NodeOs from 'node:os'
 import { tmpdir } from 'node:os'
 import { join, relative } from 'node:path'
@@ -28,7 +29,8 @@ function getRegisteredHandler(channel: string): (
   event: unknown,
   arg: {
     items: Array<{
-      skillName: string
+      skillName?: string
+      linkName?: string
       agents?: Array<{ agentId: string; linkPath: string; targetPath: string }>
       agentId?: string
       linkPath?: string
@@ -44,7 +46,8 @@ function getRegisteredHandler(channel: string): (
     event: unknown,
     arg: {
       items: Array<{
-        skillName: string
+        skillName?: string
+        linkName?: string
         agents?: Array<{
           agentId: string
           linkPath: string
@@ -85,6 +88,7 @@ describe('skills:clearOrphanSymlinks handler', () => {
   afterEach(async () => {
     vi.doUnmock('os')
     vi.doUnmock('node:os')
+    vi.doUnmock('node:fs/promises')
     await rm(tempHome, { recursive: true, force: true })
   })
 
@@ -325,8 +329,8 @@ describe('skills:clearBrokenSymlinkSlots handler', () => {
       {
         items: [
           {
-            skillName,
             agentId: 'codex',
+            linkName: skillName,
             linkPath,
             targetPath,
           },
@@ -360,8 +364,8 @@ describe('skills:clearBrokenSymlinkSlots handler', () => {
       {
         items: [
           {
-            skillName,
             agentId: 'codex',
+            linkName: skillName,
             linkPath,
             targetPath,
           },
@@ -407,8 +411,8 @@ describe('skills:clearBrokenSymlinkSlots handler', () => {
       {
         items: [
           {
-            skillName,
             agentId: 'codex',
+            linkName: skillName,
             linkPath: reviewedLinkPath,
             targetPath,
           },
@@ -458,8 +462,8 @@ describe('skills:clearBrokenSymlinkSlots handler', () => {
       {
         items: [
           {
-            skillName,
             agentId: 'codex',
+            linkName: skillName,
             linkPath,
             targetPath: reviewedTargetPath,
           },
@@ -484,5 +488,64 @@ describe('skills:clearBrokenSymlinkSlots handler', () => {
       ],
     })
     expect((await lstat(linkPath)).isSymbolicLink()).toBe(true)
+  })
+
+  it('restores a local replacement quarantined by a swap before rename', async () => {
+    // Arrange
+    const skillName = 'replacement-race-slot'
+    const codexSkillsDir = join(tempHome, '.codex', 'skills')
+    const targetPath = join(tempHome, '.agents', 'skills', skillName)
+    const linkPath = join(codexSkillsDir, skillName)
+    await mkdir(codexSkillsDir, { recursive: true })
+    await symlink(targetPath, linkPath)
+    vi.doMock('node:fs/promises', async () => {
+      const actual =
+        await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
+      return {
+        ...actual,
+        rename: async (oldPath: string, newPath: string): Promise<void> => {
+          if (String(oldPath) === linkPath) {
+            await actual.rm(linkPath, { recursive: true, force: true })
+            await actual.mkdir(linkPath, { recursive: true })
+          }
+          return actual.rename(oldPath, newPath)
+        },
+      }
+    })
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+    const handler = getRegisteredHandler('skills:clearBrokenSymlinkSlots')
+
+    // Act
+    const result = await handler(
+      {},
+      {
+        items: [
+          {
+            agentId: 'codex',
+            linkName: skillName,
+            linkPath,
+            targetPath,
+          },
+        ],
+      },
+    )
+
+    // Assert
+    expect(result).toEqual({
+      items: [
+        {
+          agentId: 'codex',
+          skillName,
+          linkPath,
+          outcome: 'error',
+          error: {
+            message: 'Reviewed cleanup slot is no longer a symlink',
+            code: 'ESTALE',
+          },
+        },
+      ],
+    })
+    expect((await lstat(linkPath)).isDirectory()).toBe(true)
   })
 })

--- a/src/main/ipc/skills.clearOrphanSymlinks.integration.test.ts
+++ b/src/main/ipc/skills.clearOrphanSymlinks.integration.test.ts
@@ -1,4 +1,4 @@
-import { lstat, mkdir, mkdtemp, rm, symlink } from 'node:fs/promises'
+import { lstat, mkdir, mkdtemp, realpath, rm, symlink } from 'node:fs/promises'
 import type * as NodeOs from 'node:os'
 import { tmpdir } from 'node:os'
 import { join, relative } from 'node:path'
@@ -29,7 +29,7 @@ function getRegisteredHandler(channel: string): (
   arg: {
     items: Array<{
       skillName: string
-      agents?: Array<{ agentId: string; linkPath: string }>
+      agents?: Array<{ agentId: string; linkPath: string; targetPath: string }>
       agentId?: string
       linkPath?: string
       targetPath?: string
@@ -45,7 +45,11 @@ function getRegisteredHandler(channel: string): (
     arg: {
       items: Array<{
         skillName: string
-        agents?: Array<{ agentId: string; linkPath: string }>
+        agents?: Array<{
+          agentId: string
+          linkPath: string
+          targetPath: string
+        }>
         agentId?: string
         linkPath?: string
         targetPath?: string
@@ -88,9 +92,10 @@ describe('skills:clearOrphanSymlinks handler', () => {
     // Arrange
     const skillName = 'abandoned'
     const codexSkillsDir = join(tempHome, '.codex', 'skills')
+    const targetPath = join(tempHome, '.agents', 'skills', skillName)
     const linkPath = join(codexSkillsDir, skillName)
     await mkdir(codexSkillsDir, { recursive: true })
-    await symlink(join(tempHome, '.agents', 'skills', skillName), linkPath)
+    await symlink(targetPath, linkPath)
     const { registerSkillsHandlers } = await import('./skills')
     registerSkillsHandlers()
     const handler = getRegisteredHandler('skills:clearOrphanSymlinks')
@@ -102,7 +107,7 @@ describe('skills:clearOrphanSymlinks handler', () => {
         items: [
           {
             skillName,
-            agents: [{ agentId: 'codex', linkPath }],
+            agents: [{ agentId: 'codex', linkPath, targetPath }],
           },
         ],
       },
@@ -128,6 +133,7 @@ describe('skills:clearOrphanSymlinks handler', () => {
     const skillName = 'restored-source'
     const sourceDir = join(tempHome, '.agents', 'skills', skillName)
     const codexSkillsDir = join(tempHome, '.codex', 'skills')
+    const targetPath = sourceDir
     const linkPath = join(codexSkillsDir, skillName)
     await mkdir(sourceDir, { recursive: true })
     await mkdir(codexSkillsDir, { recursive: true })
@@ -143,7 +149,7 @@ describe('skills:clearOrphanSymlinks handler', () => {
         items: [
           {
             skillName,
-            agents: [{ agentId: 'codex', linkPath }],
+            agents: [{ agentId: 'codex', linkPath, targetPath }],
           },
         ],
       },
@@ -179,6 +185,10 @@ describe('skills:clearOrphanSymlinks handler', () => {
       physicalDevinSkillsDir,
       join(tempHome, '.agents', 'skills', skillName),
     )
+    const targetPath = join(
+      await realpath(physicalDevinSkillsDir),
+      relativeMissingTarget,
+    )
     await symlink(relativeMissingTarget, linkPath)
     const { registerSkillsHandlers } = await import('./skills')
     registerSkillsHandlers()
@@ -191,7 +201,7 @@ describe('skills:clearOrphanSymlinks handler', () => {
         items: [
           {
             skillName,
-            agents: [{ agentId: 'devin', linkPath }],
+            agents: [{ agentId: 'devin', linkPath, targetPath }],
           },
         ],
       },
@@ -210,6 +220,60 @@ describe('skills:clearOrphanSymlinks handler', () => {
     })
     await expect(lstat(linkPath)).rejects.toThrow(/ENOENT/)
     expect((await lstat(logicalConfigDir)).isSymbolicLink()).toBe(true)
+  })
+
+  it('refuses orphan cleanup when the reviewed target changed before unlink', async () => {
+    // Arrange
+    const skillName = 'orphan-target-swapped'
+    const codexSkillsDir = join(tempHome, '.codex', 'skills')
+    const reviewedTargetPath = join(tempHome, '.agents', 'skills', skillName)
+    const currentTargetPath = join(
+      tempHome,
+      '.agents',
+      'skills',
+      'other-orphan-target',
+    )
+    const linkPath = join(codexSkillsDir, skillName)
+    await mkdir(codexSkillsDir, { recursive: true })
+    await symlink(currentTargetPath, linkPath)
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+    const handler = getRegisteredHandler('skills:clearOrphanSymlinks')
+
+    // Act
+    const result = await handler(
+      {},
+      {
+        items: [
+          {
+            skillName,
+            agents: [
+              {
+                agentId: 'codex',
+                linkPath,
+                targetPath: reviewedTargetPath,
+              },
+            ],
+          },
+        ],
+      },
+    )
+
+    // Assert
+    expect(result).toEqual({
+      items: [
+        {
+          skillName,
+          outcome: 'error',
+          error: {
+            message:
+              'Reviewed orphan link target changed. Rescan before cleanup.',
+            code: 'ESTALE',
+          },
+        },
+      ],
+    })
+    expect((await lstat(linkPath)).isSymbolicLink()).toBe(true)
   })
 })
 

--- a/src/main/ipc/skills.copyToAgents.integration.test.ts
+++ b/src/main/ipc/skills.copyToAgents.integration.test.ts
@@ -4,13 +4,14 @@ import {
   mkdtemp,
   readFile,
   readlink,
+  realpath,
   rm,
   symlink,
   writeFile,
 } from 'node:fs/promises'
 import type * as NodeOs from 'node:os'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, relative } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -158,5 +159,50 @@ describe('skills:copyToAgents handler', () => {
         'utf-8',
       ),
     ).resolves.toBe('nested guide')
+  })
+
+  it('copies a Devin symlink under symlinked .config using its physical relative target', async () => {
+    // Arrange
+    const skillName = 'devin-copy'
+    const targetPath = join(tempHome, '.agents', 'skills', skillName)
+    const physicalConfigDir = join(tempHome, 'dotfiles', '.config')
+    const physicalDevinSkillsDir = join(physicalConfigDir, 'devin', 'skills')
+    const logicalConfigDir = join(tempHome, '.config')
+    const sourcePath = join(logicalConfigDir, 'devin', 'skills', skillName)
+    const rawTarget = relative(physicalDevinSkillsDir, targetPath)
+    await mkdir(targetPath, { recursive: true })
+    await writeFile(join(targetPath, 'SKILL.md'), '# Devin copy\n')
+    await mkdir(physicalDevinSkillsDir, { recursive: true })
+    await symlink(physicalConfigDir, logicalConfigDir)
+    await symlink(rawTarget, sourcePath)
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+    const copyToAgentsHandler = getRegisteredHandler('skills:copyToAgents')
+
+    // Act
+    const result = (await copyToAgentsHandler(
+      {},
+      {
+        skillName,
+        sourcePath,
+        targetAgentIds: ['cursor'],
+      },
+    )) as {
+      success: boolean
+      copied: number
+      failures: unknown[]
+    }
+
+    // Assert
+    expect(result).toEqual({
+      success: true,
+      copied: 1,
+      failures: [],
+    })
+    const copiedLinkPath = join(tempHome, '.cursor', 'skills', skillName)
+    expect((await lstat(copiedLinkPath)).isSymbolicLink()).toBe(true)
+    await expect(readlink(copiedLinkPath)).resolves.toBe(
+      await realpath(targetPath),
+    )
   })
 })

--- a/src/main/ipc/skills.removeAllFromAgent.integration.test.ts
+++ b/src/main/ipc/skills.removeAllFromAgent.integration.test.ts
@@ -1,9 +1,12 @@
-import { mkdir, mkdtemp, rm, symlink } from 'node:fs/promises'
+import { lstat, mkdir, mkdtemp, rm, symlink } from 'node:fs/promises'
 import type * as NodeOs from 'node:os'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { filesystemIdentityFromStats } from '@/main/services/filesystemIdentity'
+import type { FilesystemEntryIdentity } from '@/shared/types'
 
 const handleMock = vi.fn()
 const trashItemMock = vi.fn()
@@ -26,7 +29,11 @@ vi.mock('electron', () => ({
  */
 function getRegisteredHandler(channel: string): (
   event: unknown,
-  arg: { agentId: string; agentPath: string },
+  arg: {
+    agentId: string
+    agentPath: string
+    filesystemIdentity?: FilesystemEntryIdentity
+  },
 ) => Promise<{
   success: boolean
   removedCount: number
@@ -38,12 +45,28 @@ function getRegisteredHandler(channel: string): (
   }
   return registration[1] as (
     event: unknown,
-    arg: { agentId: string; agentPath: string },
+    arg: {
+      agentId: string
+      agentPath: string
+      filesystemIdentity?: FilesystemEntryIdentity
+    },
   ) => Promise<{
     success: boolean
     removedCount: number
     error?: string
   }>
+}
+
+/**
+ * Capture the reviewed directory identity expected by removeAllFromAgent.
+ * @param path - Agent skills directory reviewed by the user.
+ * @returns Serializable filesystem identity for the IPC payload.
+ * @example reviewedIdentity('/tmp/home/.cursor/skills')
+ */
+async function reviewedIdentity(
+  path: string,
+): Promise<FilesystemEntryIdentity> {
+  return filesystemIdentityFromStats(await lstat(path))
 }
 
 describe('skills:removeAllFromAgent handler', () => {
@@ -95,7 +118,14 @@ describe('skills:removeAllFromAgent handler', () => {
     registerSkillsHandlers()
 
     const handler = getRegisteredHandler('skills:removeAllFromAgent')
-    const result = await handler({}, { agentId: 'cline', agentPath: sourceDir })
+    const result = await handler(
+      {},
+      {
+        agentId: 'cline',
+        agentPath: sourceDir,
+        filesystemIdentity: await reviewedIdentity(sourceDir),
+      },
+    )
 
     expect(result.success).toBe(false)
     expect(result.error).toMatch(
@@ -116,9 +146,14 @@ describe('skills:removeAllFromAgent handler', () => {
     registerSkillsHandlers()
 
     const handler = getRegisteredHandler('skills:removeAllFromAgent')
+    const sourceIdentity = await reviewedIdentity(sourceDir)
     const result = await handler(
       {},
-      { agentId: 'cline', agentPath: sourceDir + '/' },
+      {
+        agentId: 'cline',
+        agentPath: sourceDir + '/',
+        filesystemIdentity: sourceIdentity,
+      },
     )
 
     expect(result.success).toBe(false)
@@ -132,8 +167,10 @@ describe('skills:removeAllFromAgent handler', () => {
   // fs.rm({force:true}) this handler used to call). Pre-checking with
   // fs.access lets double-clicks and out-of-band deletes resolve cleanly.
   it('returns success with 0 count when agent dir does not exist', async () => {
-    // Never mkdir — the .cursor/skills dir is absent.
     const cursorDir = join(tempHome, '.cursor', 'skills')
+    await mkdir(cursorDir, { recursive: true })
+    const staleIdentity = await reviewedIdentity(cursorDir)
+    await rm(cursorDir, { recursive: true, force: true })
 
     const { registerSkillsHandlers } = await import('./skills')
     registerSkillsHandlers()
@@ -141,7 +178,11 @@ describe('skills:removeAllFromAgent handler', () => {
     const handler = getRegisteredHandler('skills:removeAllFromAgent')
     const result = await handler(
       {},
-      { agentId: 'cursor', agentPath: cursorDir },
+      {
+        agentId: 'cursor',
+        agentPath: cursorDir,
+        filesystemIdentity: staleIdentity,
+      },
     )
 
     expect(result).toEqual({ success: true, removedCount: 0 })
@@ -162,7 +203,11 @@ describe('skills:removeAllFromAgent handler', () => {
     const handler = getRegisteredHandler('skills:removeAllFromAgent')
     const result = await handler(
       {},
-      { agentId: 'cursor', agentPath: claudeDir },
+      {
+        agentId: 'cursor',
+        agentPath: claudeDir,
+        filesystemIdentity: await reviewedIdentity(claudeDir),
+      },
     )
 
     // Assert
@@ -182,11 +227,49 @@ describe('skills:removeAllFromAgent handler', () => {
     const handler = getRegisteredHandler('skills:removeAllFromAgent')
     const result = await handler(
       {},
-      { agentId: 'cursor', agentPath: cursorDir },
+      {
+        agentId: 'cursor',
+        agentPath: cursorDir,
+        filesystemIdentity: await reviewedIdentity(cursorDir),
+      },
     )
 
     expect(result).toEqual({ success: true, removedCount: 2 })
     expect(trashItemMock).toHaveBeenCalledTimes(1)
+    expect(String(trashItemMock.mock.calls[0][0])).toContain(
+      join(tempHome, '.cursor', 'skills.trash-'),
+    )
+  })
+
+  it('rejects a same-path replacement before moving the agent dir to OS Trash', async () => {
+    // Arrange
+    const cursorDir = join(tempHome, '.cursor', 'skills')
+    await mkdir(join(cursorDir, 'reviewed-skill'), { recursive: true })
+    const staleIdentity = await reviewedIdentity(cursorDir)
+    await rm(cursorDir, { recursive: true, force: true })
+    await mkdir(join(cursorDir, 'replacement-skill'), { recursive: true })
+
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+
+    // Act
+    const handler = getRegisteredHandler('skills:removeAllFromAgent')
+    const result = await handler(
+      {},
+      {
+        agentId: 'cursor',
+        agentPath: cursorDir,
+        filesystemIdentity: staleIdentity,
+      },
+    )
+
+    // Assert
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/changed since review/i)
+    await expect(
+      lstat(join(cursorDir, 'replacement-skill')),
+    ).resolves.toBeDefined()
+    expect(trashItemMock).not.toHaveBeenCalled()
   })
 
   // Exercises the `realpathSync.native` fallback inside isSharedAgentPath.
@@ -205,7 +288,14 @@ describe('skills:removeAllFromAgent handler', () => {
     registerSkillsHandlers()
 
     const handler = getRegisteredHandler('skills:removeAllFromAgent')
-    const result = await handler({}, { agentId: 'cursor', agentPath: aliasDir })
+    const result = await handler(
+      {},
+      {
+        agentId: 'cursor',
+        agentPath: aliasDir,
+        filesystemIdentity: await reviewedIdentity(aliasDir),
+      },
+    )
 
     expect(result.success).toBe(false)
     expect(result.error).toMatch(/shared skills folder/)

--- a/src/main/ipc/skills.removeAllFromAgent.integration.test.ts
+++ b/src/main/ipc/skills.removeAllFromAgent.integration.test.ts
@@ -245,9 +245,18 @@ describe('skills:removeAllFromAgent handler', () => {
     // Arrange
     const cursorDir = join(tempHome, '.cursor', 'skills')
     await mkdir(join(cursorDir, 'reviewed-skill'), { recursive: true })
-    const staleIdentity = await reviewedIdentity(cursorDir)
     await rm(cursorDir, { recursive: true, force: true })
     await mkdir(join(cursorDir, 'replacement-skill'), { recursive: true })
+    // Synthesize the reviewed identity from the replacement dir but with a
+    // distinct ctime. This deterministically simulates an in-place same-path
+    // replacement (dev+ino reused as ext4 does, fresh ctime) without depending
+    // on the host filesystem's ctime granularity, which can otherwise let the
+    // recreated dir reuse the captured ctime and make the test flaky.
+    const replacementIdentity = await reviewedIdentity(cursorDir)
+    const staleIdentity: FilesystemEntryIdentity = {
+      ...replacementIdentity,
+      ctimeMs: replacementIdentity.ctimeMs - 60_000,
+    }
 
     const { registerSkillsHandlers } = await import('./skills')
     registerSkillsHandlers()

--- a/src/main/ipc/skills.removeAllFromAgent.integration.test.ts
+++ b/src/main/ipc/skills.removeAllFromAgent.integration.test.ts
@@ -98,7 +98,9 @@ describe('skills:removeAllFromAgent handler', () => {
     const result = await handler({}, { agentId: 'cline', agentPath: sourceDir })
 
     expect(result.success).toBe(false)
-    expect(result.error).toMatch(/shared skills folder|path traversal/i)
+    expect(result.error).toMatch(
+      /shared skills folder|path traversal|does not match the selected agent slot/i,
+    )
     expect(trashItemMock).not.toHaveBeenCalled()
   })
 
@@ -120,7 +122,9 @@ describe('skills:removeAllFromAgent handler', () => {
     )
 
     expect(result.success).toBe(false)
-    expect(result.error).toMatch(/shared skills folder|path traversal/i)
+    expect(result.error).toMatch(
+      /shared skills folder|path traversal|does not match the selected agent slot/i,
+    )
     expect(trashItemMock).not.toHaveBeenCalled()
   })
 
@@ -141,6 +145,29 @@ describe('skills:removeAllFromAgent handler', () => {
     )
 
     expect(result).toEqual({ success: true, removedCount: 0 })
+    expect(trashItemMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a renderer path for a different agent than the selected agentId', async () => {
+    // Arrange
+    const cursorDir = join(tempHome, '.cursor', 'skills')
+    const claudeDir = join(tempHome, '.claude', 'skills')
+    await mkdir(cursorDir, { recursive: true })
+    await mkdir(claudeDir, { recursive: true })
+
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+
+    // Act
+    const handler = getRegisteredHandler('skills:removeAllFromAgent')
+    const result = await handler(
+      {},
+      { agentId: 'cursor', agentPath: claudeDir },
+    )
+
+    // Assert
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/does not match the selected agent slot/i)
     expect(trashItemMock).not.toHaveBeenCalled()
   })
 

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -6,18 +6,27 @@ import type { IpcMainInvokeEvent } from 'electron'
 import { shell } from 'electron'
 import { match } from 'ts-pattern'
 
-import { AGENTS, findAgentById, isSharedAgentPath } from '@/main/constants'
+import {
+  AGENTS,
+  SOURCE_DIR,
+  findAgentById,
+  isSharedAgentPath,
+} from '@/main/constants'
 import { getAllowedBases, validatePath } from '@/main/services/pathValidation'
 import { scanSkills } from '@/main/services/skillScanner'
+import { resolveRawSymlinkTarget } from '@/main/services/symlinkChecker'
 import { moveToTrash, restore, TrashError } from '@/main/services/trashService'
-import { errorCode } from '@/main/utils/errorCode'
+import { errorCode, isMissingPathError } from '@/main/utils/errorCode'
 import { extractErrorMessage } from '@/main/utils/errors'
 import { BULK_PROGRESS_THRESHOLD } from '@/shared/constants'
 import { IPC_CHANNELS } from '@/shared/ipc-channels'
 import type {
   AbsolutePath,
+  AgentId,
   BulkDeleteItemResult,
   BulkDeleteResult,
+  ClearBrokenSymlinkSlotItemResult,
+  ClearOrphanSymlinkItemResult,
   BulkUnlinkItemResult,
   BulkUnlinkResult,
   RestoreDeletedSkillResult,
@@ -119,6 +128,268 @@ async function removeFromAgent(
       success: false,
       error: extractErrorMessage(error),
       code: errorCode(error),
+    }
+  }
+}
+
+/**
+ * Removes one reviewed broken symlink slot after rechecking exact slot path and target identity.
+ * @param item - Reviewed broken-slot target from Symlink Health cleanup.
+ * @returns Per-slot unlink result.
+ * @example
+ * await clearReviewedBrokenSymlinkSlot({ agentId: 'codex', skillName: 'task', linkPath: '/Users/me/.codex/skills/task', targetPath: '/Users/me/.agents/skills/task' })
+ */
+async function clearReviewedBrokenSymlinkSlot(item: {
+  agentId: AgentId
+  skillName: SkillName
+  linkPath: AbsolutePath
+  targetPath: AbsolutePath
+}): Promise<ClearBrokenSymlinkSlotItemResult> {
+  try {
+    const agent = findAgentById(item.agentId)
+    if (!agent) throw new TrashError('Agent not found', 'ENOENT')
+
+    const expectedLinkPath = resolve(agent.path, item.skillName)
+    if (resolve(item.linkPath) !== expectedLinkPath) {
+      throw new TrashError(
+        'Reviewed broken link path no longer matches agent slot',
+        'ESTALE',
+      )
+    }
+
+    validatePath(dirname(item.linkPath), [agent.path])
+
+    let stats: Stats
+    try {
+      stats = await fs.lstat(item.linkPath)
+    } catch (error) {
+      if (isMissingPathError(error)) {
+        return {
+          agentId: item.agentId,
+          skillName: item.skillName,
+          linkPath: item.linkPath,
+          outcome: 'unlinked',
+        }
+      }
+      throw new TrashError(extractErrorMessage(error), errorCode(error))
+    }
+
+    if (!stats.isSymbolicLink()) {
+      throw new TrashError(
+        'Reviewed broken slot is no longer a symlink',
+        'ESTALE',
+      )
+    }
+
+    const rawTarget = await fs.readlink(item.linkPath)
+    const resolvedTarget = await resolveRawSymlinkTarget(
+      item.linkPath,
+      rawTarget,
+    )
+    if (resolve(resolvedTarget) !== resolve(item.targetPath)) {
+      throw new TrashError(
+        'Reviewed broken link target changed. Rescan before cleanup.',
+        'ESTALE',
+      )
+    }
+
+    try {
+      await fs.access(resolvedTarget)
+      throw new TrashError(
+        'Reviewed broken link target now exists. Rescan before cleanup.',
+        'ESTALE',
+      )
+    } catch (error) {
+      if (error instanceof TrashError) throw error
+      if (!isMissingPathError(error)) {
+        throw new TrashError(
+          `Cannot verify broken link target: ${extractErrorMessage(error)}`,
+          errorCode(error),
+        )
+      }
+    }
+
+    await fs.unlink(item.linkPath)
+    return {
+      agentId: item.agentId,
+      skillName: item.skillName,
+      linkPath: item.linkPath,
+      outcome: 'unlinked',
+    }
+  } catch (error) {
+    const message =
+      error instanceof TrashError ? error.message : extractErrorMessage(error)
+    const code = error instanceof TrashError ? error.code : errorCode(error)
+    return {
+      agentId: item.agentId,
+      skillName: item.skillName,
+      linkPath: item.linkPath,
+      outcome: 'error',
+      error: code ? { message, code } : { message },
+    }
+  }
+}
+
+/**
+ * Finds live filesystem entries that make orphan-only cleanup unsafe for one skill name.
+ * @param skillName - Agent-side skill directory name selected in the cleanup dialog.
+ * @returns Null when only symlinks/missing slots remain; otherwise a user-facing stale-plan reason.
+ * @example
+ * await findOrphanCleanupBlocker('abandoned') // => null
+ */
+async function findOrphanCleanupBlocker(
+  skillName: SkillName,
+): Promise<string | null> {
+  const sourcePath = join(SOURCE_DIR, skillName)
+  try {
+    await fs.lstat(sourcePath)
+    return 'Source skill exists. Rescan before cleanup.'
+  } catch (error) {
+    if (!isMissingPathError(error)) {
+      return `Cannot verify source skill: ${extractErrorMessage(error)}`
+    }
+  }
+
+  for (const agent of AGENTS) {
+    const agentSkillPath = join(agent.path, skillName)
+    try {
+      const stats = await fs.lstat(agentSkillPath)
+      if (stats.isSymbolicLink()) continue
+      if (stats.isDirectory()) {
+        return `${agent.name} has a local skill folder. Rescan before cleanup.`
+      }
+      return `${agent.name} has a non-symlink entry. Rescan before cleanup.`
+    } catch (error) {
+      if (isMissingPathError(error)) continue
+      return `Cannot verify ${agent.name}: ${extractErrorMessage(error)}`
+    }
+  }
+
+  return null
+}
+
+/**
+ * Removes one reviewed orphan symlink after rechecking the exact agent slot and dangling target.
+ * @param skillName - Skill name whose source is expected to be absent.
+ * @param reviewedLink - Agent and link path reviewed by the renderer.
+ * @returns Removed agent id when the link was unlinked or already gone.
+ * @example
+ * await clearReviewedOrphanLink('abandoned', { agentId: 'codex', linkPath: '/Users/me/.codex/skills/abandoned' })
+ */
+async function clearReviewedOrphanLink(
+  skillName: SkillName,
+  reviewedLink: { agentId: AgentId; linkPath: AbsolutePath },
+): Promise<AgentId> {
+  const agent = findAgentById(reviewedLink.agentId)
+  if (!agent) {
+    throw new TrashError('Agent not found', 'ENOENT')
+  }
+
+  const expectedLinkPath = resolve(agent.path, skillName)
+  if (resolve(reviewedLink.linkPath) !== expectedLinkPath) {
+    throw new TrashError(
+      'Reviewed link path no longer matches agent slot',
+      'ESTALE',
+    )
+  }
+
+  validatePath(dirname(reviewedLink.linkPath), [agent.path])
+
+  let stats: Stats
+  try {
+    stats = await fs.lstat(reviewedLink.linkPath)
+  } catch (error) {
+    if (isMissingPathError(error)) return agent.id
+    throw new TrashError(extractErrorMessage(error), errorCode(error))
+  }
+  if (!stats.isSymbolicLink()) {
+    throw new TrashError(
+      'Reviewed orphan slot is no longer a symlink',
+      'ESTALE',
+    )
+  }
+
+  let rawTarget: string
+  try {
+    rawTarget = await fs.readlink(reviewedLink.linkPath)
+  } catch (error) {
+    if (isMissingPathError(error)) return agent.id
+    throw new TrashError(extractErrorMessage(error), errorCode(error))
+  }
+  const resolvedTarget = await resolveRawSymlinkTarget(
+    reviewedLink.linkPath,
+    rawTarget,
+  )
+  try {
+    await fs.access(resolvedTarget)
+    throw new TrashError(
+      'Reviewed orphan link target now exists. Rescan before cleanup.',
+      'ESTALE',
+    )
+  } catch (error) {
+    if (error instanceof TrashError) throw error
+    if (!isMissingPathError(error)) {
+      throw new TrashError(
+        `Cannot verify orphan target: ${extractErrorMessage(error)}`,
+        errorCode(error),
+      )
+    }
+  }
+
+  const blocker = await findOrphanCleanupBlocker(skillName)
+  if (blocker) {
+    throw new TrashError(blocker, 'ESTALE')
+  }
+
+  try {
+    await fs.unlink(reviewedLink.linkPath)
+  } catch (error) {
+    if (!isMissingPathError(error)) {
+      throw new TrashError(extractErrorMessage(error), errorCode(error))
+    }
+  }
+
+  return agent.id
+}
+
+/**
+ * Clears one reviewed orphan record without ever calling source-delete paths.
+ * @param item - Skill name plus the exact orphan agent links selected in the dialog.
+ * @returns Per-item cleanup outcome for the dialog summary.
+ * @example
+ * await clearReviewedOrphanRecord({ skillName: 'abandoned', agents: [{ agentId: 'codex', linkPath: '/Users/me/.codex/skills/abandoned' }] })
+ */
+async function clearReviewedOrphanRecord(item: {
+  skillName: SkillName
+  agents: Array<{ agentId: AgentId; linkPath: AbsolutePath }>
+}): Promise<ClearOrphanSymlinkItemResult> {
+  try {
+    const blocker = await findOrphanCleanupBlocker(item.skillName)
+    if (blocker) {
+      throw new TrashError(blocker, 'ESTALE')
+    }
+
+    const cascadeAgents: AgentId[] = []
+    for (const reviewedLink of item.agents) {
+      cascadeAgents.push(
+        await clearReviewedOrphanLink(item.skillName, reviewedLink),
+      )
+    }
+
+    return {
+      skillName: item.skillName,
+      outcome: 'orphan-cleared',
+      symlinksRemoved: cascadeAgents.length,
+      cascadeAgents,
+    }
+  } catch (error) {
+    const message =
+      error instanceof TrashError ? error.message : extractErrorMessage(error)
+    const code = error instanceof TrashError ? error.code : errorCode(error)
+    return {
+      skillName: item.skillName,
+      outcome: 'error',
+      error: code ? { message, code } : { message },
     }
   }
 }
@@ -343,6 +614,41 @@ export function registerSkillsHandlers(): void {
 
       const result: BulkDeleteResult = { items: results }
       return result
+    },
+  )
+
+  /**
+   * Clear reviewed orphan symlinks without calling the source-delete path.
+   * Revalidates the exact agent slots in main so a stale renderer plan cannot
+   * delete live source skills or unrelated local folders.
+   * @param options - orphan records and exact agent link paths reviewed by the user
+   * @returns Per-orphan cleanup outcomes with no tombstones
+   * @example clearOrphanSymlinks({ items: [{ skillName: 'abandoned', agents: [...] }] })
+   */
+  typedHandle(IPC_CHANNELS.SKILLS_CLEAR_ORPHAN_SYMLINKS, async (_, options) => {
+    const results: ClearOrphanSymlinkItemResult[] = []
+    for (const item of options.items) {
+      results.push(await clearReviewedOrphanRecord(item))
+    }
+    return { items: results }
+  })
+
+  /**
+   * Clear reviewed broken symlink slots with exact main-process revalidation.
+   * Unlike generic unlink, this cleanup-only path refuses live, changed, or
+   * inaccessible targets so restored user links are never removed.
+   * @param options - exact broken slots selected in Symlink Health cleanup
+   * @returns Per-slot unlink outcomes
+   * @example clearBrokenSymlinkSlots({ items: [{ agentId: 'codex', skillName: 'task', linkPath, targetPath }] })
+   */
+  typedHandle(
+    IPC_CHANNELS.SKILLS_CLEAR_BROKEN_SYMLINK_SLOTS,
+    async (_, options) => {
+      const results: ClearBrokenSymlinkSlotItemResult[] = []
+      for (const item of options.items) {
+        results.push(await clearReviewedBrokenSymlinkSlot(item))
+      }
+      return { items: results }
     },
   )
 

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -124,24 +124,6 @@ async function removeLinkPathByKind(
 }
 
 /**
- * Unlink or remove a single link-path inside an agent directory. Shared by the
- * single-unlink handler and the batch-unlink handler so both behave identically.
- * @param agentPath - Validated agent skills directory (trust root)
- * @param skillName - Validated skill name (no separators)
- * @returns { success: boolean, error?: string; code?: string }
- * @example removeFromAgent('/Users/me/.cursor/skills', 'task')
- */
-async function removeFromAgent(
-  agentPath: AbsolutePath,
-  skillName: SkillName,
-): Promise<
-  { success: true } | { success: false; error: string; code?: string }
-> {
-  const linkPath = join(agentPath, skillName) as AbsolutePath
-  return removeReviewedPathFromAgent(agentPath, linkPath)
-}
-
-/**
  * Remove the exact reviewed agent slot after validating it belongs to selected agent.
  * @param agentPath - Selected agent skills directory from main constants.
  * @param linkPath - Renderer-reviewed slot path to remove.
@@ -574,9 +556,9 @@ export function registerSkillsHandlers(): void {
    * Delete a single skill by delegating to trashService so the single-delete
    * path shares the same trash/undo/eviction code as batch delete.
    *
-   * `moveToTrash(skillName, skillPath)` validates the reviewed row path when
-   * present so metadata names cannot redirect deletion to a same-name folder.
-   * @param options - { skillName, skillPath? }
+   * `moveToTrash(skillName, skillPath)` validates the reviewed row path so
+   * metadata names cannot redirect deletion to a same-name folder.
+   * @param options - { skillName, skillPath }
    * @returns DeleteSkillResult with symlinksRemoved + cascadeAgents
    */
   typedHandle(IPC_CHANNELS.SKILLS_DELETE, async (_, options) => {
@@ -612,7 +594,7 @@ export function registerSkillsHandlers(): void {
    * Progress: emits \`skills:deleteProgress\` after each item when N >= 10 so the
    * SelectionToolbar can show "Deleting 3 of 12". Smaller batches skip the
    * event to avoid toast churn.
-   * @param options - items: Array<{ skillName, skillPath? }>
+   * @param options - items: Array<{ skillName, skillPath }>
    * @returns BulkDeleteResult with per-item discriminated outcome
    */
   typedHandle(
@@ -626,25 +608,13 @@ export function registerSkillsHandlers(): void {
       for (const [itemIndex, { skillName, skillPath }] of items.entries()) {
         try {
           const moveResult = await moveToTrash(skillName, skillPath)
-          // Discriminate on `kind` so the renderer can tell apart "this row has
-          // a tombstone, wire it into the Undo toast" from "this row is just a
-          // broken-symlink sweep with no undo path".
-          if (moveResult.kind === 'tombstoned') {
-            results.push({
-              skillName,
-              outcome: 'deleted',
-              tombstoneId: moveResult.tombstoneId,
-              symlinksRemoved: moveResult.symlinksRemoved,
-              cascadeAgents: moveResult.cascadeAgents,
-            })
-          } else {
-            results.push({
-              skillName,
-              outcome: 'orphan-cleared',
-              symlinksRemoved: moveResult.symlinksRemoved,
-              cascadeAgents: moveResult.cascadeAgents,
-            })
-          }
+          results.push({
+            skillName,
+            outcome: 'deleted',
+            tombstoneId: moveResult.tombstoneId,
+            symlinksRemoved: moveResult.symlinksRemoved,
+            cascadeAgents: moveResult.cascadeAgents,
+          })
         } catch (error) {
           const message =
             error instanceof TrashError
@@ -736,9 +706,7 @@ export function registerSkillsHandlers(): void {
       }
 
       for (const { skillName, linkPath } of items) {
-        const outcome = linkPath
-          ? await removeReviewedPathFromAgent(agent.path, linkPath)
-          : await removeFromAgent(agent.path, skillName)
+        const outcome = await removeReviewedPathFromAgent(agent.path, linkPath)
         if (outcome.success) {
           results.push({ skillName, outcome: 'unlinked' })
         } else {

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import type { Stats } from 'node:fs'
 import * as fs from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
@@ -122,6 +123,85 @@ async function assertReviewedTargetMissing(
 }
 
 /**
+ * Restore a moved cleanup candidate when post-rename validation proves it is stale.
+ * @param linkPath - Original agent slot path reviewed by the user.
+ * @param movedPath - Same-directory temporary path created by guarded rename.
+ * @returns void after the moved entry is back at the reviewed slot when possible.
+ * @example
+ * await restoreMovedCleanupCandidate('/agent/task', '/agent/task.cleanup-1')
+ */
+async function restoreMovedCleanupCandidate(
+  linkPath: AbsolutePath,
+  movedPath: AbsolutePath,
+): Promise<void> {
+  try {
+    await fs.lstat(linkPath)
+    throw new TrashError(
+      `Cleanup stopped after the reviewed slot changed. Moved entry left at ${movedPath} because ${linkPath} is occupied.`,
+      'ESTALE',
+    )
+  } catch (error) {
+    if (error instanceof TrashError) throw error
+    if (!isMissingPathError(error)) {
+      throw new TrashError(
+        `Cleanup stopped, but ${linkPath} could not be checked before restoring the moved entry: ${extractErrorMessage(error)}`,
+        errorCode(error),
+      )
+    }
+  }
+
+  try {
+    await fs.rename(movedPath, linkPath)
+  } catch (error) {
+    throw new TrashError(
+      `Cleanup stopped, but the moved entry could not be restored at ${linkPath}: ${extractErrorMessage(error)}`,
+      errorCode(error),
+    )
+  }
+}
+
+/**
+ * Commit cleanup by moving the candidate, validating the moved entry, then unlinking it.
+ * @param options - Reviewed path and target messages for final validation.
+ * @returns void after the moved, verified symlink is removed.
+ * @example
+ * await commitReviewedDanglingSymlink({ linkPath, targetPath, targetChangedMessage, targetExistsMessage, targetProbePrefix })
+ */
+async function commitReviewedDanglingSymlink(options: {
+  linkPath: AbsolutePath
+  targetPath: AbsolutePath
+  targetChangedMessage: string
+  targetExistsMessage: string
+  targetProbePrefix: string
+}): Promise<void> {
+  const movedPath =
+    `${options.linkPath}.cleanup-${randomUUID()}` as AbsolutePath
+  try {
+    await fs.rename(options.linkPath, movedPath)
+  } catch (error) {
+    if (isMissingPathError(error)) return
+    throw new TrashError(extractErrorMessage(error), errorCode(error))
+  }
+
+  try {
+    const movedReviewed = await readReviewedDanglingSymlink({
+      linkPath: movedPath,
+      targetPath: options.targetPath,
+      targetChangedMessage: options.targetChangedMessage,
+    })
+    await assertReviewedTargetMissing(
+      movedReviewed.resolvedTarget,
+      options.targetExistsMessage,
+      options.targetProbePrefix,
+    )
+    await fs.unlink(movedPath)
+  } catch (error) {
+    await restoreMovedCleanupCandidate(options.linkPath, movedPath)
+    throw error
+  }
+}
+
+/**
  * Revalidate and unlink one reviewed dangling symlink without moving replacements.
  * @param options - Exact reviewed path/target plus messages for stale-target cases.
  * @returns `missing` when the slot was already gone; otherwise `unlinked`.
@@ -154,7 +234,7 @@ async function unlinkReviewedDanglingSymlink(options: {
       options.targetProbePrefix,
     )
 
-    await fs.unlink(options.linkPath)
+    await commitReviewedDanglingSymlink(options)
   } catch (error) {
     if (isMissingPathError(error)) return 'missing'
     if (error instanceof TrashError) throw error
@@ -899,11 +979,13 @@ export function registerSkillsHandlers(): void {
       })
         .with({ isSymlink: true }, async () => {
           // `readlink` returns the raw target, which can be relative to the
-          // symlink's own directory. Resolve it against `dirname(sourcePath)`
-          // so validation and replication see an absolute filesystem path
-          // rather than a cwd-relative string.
+          // symlink's physical parent. Resolve through realpath(dirname) so
+          // symlinked config roots like Devin's ~/.config stay valid.
           const rawTarget = await fs.readlink(sourcePath)
-          const resolvedTarget = resolve(dirname(sourcePath), rawTarget)
+          const resolvedTarget = await resolveRawSymlinkTarget(
+            sourcePath,
+            rawTarget,
+          )
           // Validate the resolved symlink target is within allowed bases.
           // After the CREATE_SYMLINKS fix, symlinks may legitimately point at
           // either SOURCE_DIR (source skills) or another agent's dir (local

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import type { Stats } from 'node:fs'
 import * as fs from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
@@ -39,6 +40,104 @@ import { typedSend } from './typedSend'
 type AgentPathRemovalResult =
   | { success: true }
   | { success: false; error: string; code?: string }
+
+/**
+ * Recreate a reviewed symlink after a quarantined cleanup validation fails.
+ * @param linkPath - Original reviewed agent slot path.
+ * @param quarantinePath - Temporary path holding the reviewed symlink.
+ * @param rawTarget - Verbatim readlink target to restore.
+ * @returns void after the original path points at the reviewed target again.
+ * @example
+ * await restoreReviewedSymlink('/agent/task', '/agent/task.cleanup-1', '../source/task')
+ */
+async function restoreReviewedSymlink(
+  linkPath: AbsolutePath,
+  quarantinePath: AbsolutePath,
+  rawTarget: string,
+): Promise<void> {
+  try {
+    // symlink() fails with EEXIST instead of overwriting a concurrent
+    // replacement at the reviewed path.
+    await fs.symlink(rawTarget, linkPath)
+    await fs.unlink(quarantinePath).catch(() => {
+      // The reviewed path is restored; leftover quarantine cleanup is best-effort.
+    })
+  } catch (error) {
+    const code = errorCode(error) ?? 'ESTALE'
+    throw new TrashError(
+      `Cleanup stopped, but the reviewed link could not be restored at ${linkPath}: ${extractErrorMessage(error)}`,
+      code,
+    )
+  }
+}
+
+/**
+ * Atomically quarantine, revalidate, and unlink one reviewed dangling symlink.
+ * @param options - Exact reviewed path/target plus messages for stale-target cases.
+ * @returns `missing` when the slot was already gone; otherwise `unlinked`.
+ * @example
+ * await unlinkReviewedDanglingSymlink({ linkPath, targetPath, targetChangedMessage, targetExistsMessage, targetProbePrefix })
+ */
+async function unlinkReviewedDanglingSymlink(options: {
+  linkPath: AbsolutePath
+  targetPath: AbsolutePath
+  targetChangedMessage: string
+  targetExistsMessage: string
+  targetProbePrefix: string
+  beforeTargetProbe?: () => Promise<void>
+}): Promise<'missing' | 'unlinked'> {
+  const quarantinePath =
+    `${options.linkPath}.cleanup-${randomUUID()}` as AbsolutePath
+  try {
+    await fs.rename(options.linkPath, quarantinePath)
+  } catch (error) {
+    if (isMissingPathError(error)) return 'missing'
+    throw new TrashError(extractErrorMessage(error), errorCode(error))
+  }
+
+  let rawTarget: string | null = null
+  try {
+    const stats = await fs.lstat(quarantinePath)
+    if (!stats.isSymbolicLink()) {
+      throw new TrashError(
+        'Reviewed cleanup slot is no longer a symlink',
+        'ESTALE',
+      )
+    }
+
+    rawTarget = await fs.readlink(quarantinePath)
+    const resolvedTarget = await resolveRawSymlinkTarget(
+      quarantinePath,
+      rawTarget,
+    )
+    if (resolve(resolvedTarget) !== resolve(options.targetPath)) {
+      throw new TrashError(options.targetChangedMessage, 'ESTALE')
+    }
+
+    await options.beforeTargetProbe?.()
+
+    try {
+      await fs.access(resolvedTarget)
+      throw new TrashError(options.targetExistsMessage, 'ESTALE')
+    } catch (error) {
+      if (error instanceof TrashError) throw error
+      if (!isMissingPathError(error)) {
+        throw new TrashError(
+          `${options.targetProbePrefix}: ${extractErrorMessage(error)}`,
+          errorCode(error),
+        )
+      }
+    }
+
+    await fs.unlink(quarantinePath)
+    return 'unlinked'
+  } catch (error) {
+    if (rawTarget !== null) {
+      await restoreReviewedSymlink(options.linkPath, quarantinePath, rawTarget)
+    }
+    throw error
+  }
+}
 
 /**
  * Remove an agent symlink path after the caller has already validated and
@@ -181,35 +280,15 @@ async function clearReviewedBrokenSymlinkSlot(item: {
       )
     }
 
-    const rawTarget = await fs.readlink(item.linkPath)
-    const resolvedTarget = await resolveRawSymlinkTarget(
-      item.linkPath,
-      rawTarget,
-    )
-    if (resolve(resolvedTarget) !== resolve(item.targetPath)) {
-      throw new TrashError(
+    await unlinkReviewedDanglingSymlink({
+      linkPath: item.linkPath,
+      targetPath: item.targetPath,
+      targetChangedMessage:
         'Reviewed broken link target changed. Rescan before cleanup.',
-        'ESTALE',
-      )
-    }
-
-    try {
-      await fs.access(resolvedTarget)
-      throw new TrashError(
+      targetExistsMessage:
         'Reviewed broken link target now exists. Rescan before cleanup.',
-        'ESTALE',
-      )
-    } catch (error) {
-      if (error instanceof TrashError) throw error
-      if (!isMissingPathError(error)) {
-        throw new TrashError(
-          `Cannot verify broken link target: ${extractErrorMessage(error)}`,
-          errorCode(error),
-        )
-      }
-    }
-
-    await fs.unlink(item.linkPath)
+      targetProbePrefix: 'Cannot verify broken link target',
+    })
     return {
       agentId: item.agentId,
       skillName: item.skillName,
@@ -313,52 +392,21 @@ async function clearReviewedOrphanLink(
     )
   }
 
-  let rawTarget: string
-  try {
-    rawTarget = await fs.readlink(reviewedLink.linkPath)
-  } catch (error) {
-    if (isMissingPathError(error)) return agent.id
-    throw new TrashError(extractErrorMessage(error), errorCode(error))
-  }
-  const resolvedTarget = await resolveRawSymlinkTarget(
-    reviewedLink.linkPath,
-    rawTarget,
-  )
-  if (resolve(resolvedTarget) !== resolve(reviewedLink.targetPath)) {
-    throw new TrashError(
+  await unlinkReviewedDanglingSymlink({
+    linkPath: reviewedLink.linkPath,
+    targetPath: reviewedLink.targetPath,
+    targetChangedMessage:
       'Reviewed orphan link target changed. Rescan before cleanup.',
-      'ESTALE',
-    )
-  }
-
-  const blocker = await findOrphanCleanupBlocker(skillName)
-  if (blocker) {
-    throw new TrashError(blocker, 'ESTALE')
-  }
-
-  try {
-    await fs.access(resolvedTarget)
-    throw new TrashError(
+    targetExistsMessage:
       'Reviewed orphan link target now exists. Rescan before cleanup.',
-      'ESTALE',
-    )
-  } catch (error) {
-    if (error instanceof TrashError) throw error
-    if (!isMissingPathError(error)) {
-      throw new TrashError(
-        `Cannot verify orphan target: ${extractErrorMessage(error)}`,
-        errorCode(error),
-      )
-    }
-  }
-
-  try {
-    await fs.unlink(reviewedLink.linkPath)
-  } catch (error) {
-    if (!isMissingPathError(error)) {
-      throw new TrashError(extractErrorMessage(error), errorCode(error))
-    }
-  }
+    targetProbePrefix: 'Cannot verify orphan target',
+    beforeTargetProbe: async () => {
+      const blocker = await findOrphanCleanupBlocker(skillName)
+      if (blocker) {
+        throw new TrashError(blocker, 'ESTALE')
+      }
+    },
+  })
 
   return agent.id
 }

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto'
 import type { Stats } from 'node:fs'
 import * as fs from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
@@ -42,75 +41,7 @@ type AgentPathRemovalResult =
   | { success: false; error: string; code?: string }
 
 /**
- * Recreate a reviewed symlink after a quarantined cleanup validation fails.
- * @param linkPath - Original reviewed agent slot path.
- * @param quarantinePath - Temporary path holding the reviewed symlink.
- * @param rawTarget - Verbatim readlink target to restore.
- * @returns void after the original path points at the reviewed target again.
- * @example
- * await restoreReviewedSymlink('/agent/task', '/agent/task.cleanup-1', '../source/task')
- */
-async function restoreReviewedSymlink(
-  linkPath: AbsolutePath,
-  quarantinePath: AbsolutePath,
-  rawTarget: string,
-): Promise<void> {
-  try {
-    // symlink() fails with EEXIST instead of overwriting a concurrent
-    // replacement at the reviewed path.
-    await fs.symlink(rawTarget, linkPath)
-    await fs.unlink(quarantinePath).catch(() => {
-      // The reviewed path is restored; leftover quarantine cleanup is best-effort.
-    })
-  } catch (error) {
-    const code = errorCode(error) ?? 'ESTALE'
-    throw new TrashError(
-      `Cleanup stopped, but the reviewed link could not be restored at ${linkPath}: ${extractErrorMessage(error)}`,
-      code,
-    )
-  }
-}
-
-/**
- * Move a quarantined non-reviewed entry back after validation proves it was not the reviewed symlink.
- * @param linkPath - Original reviewed agent slot path.
- * @param quarantinePath - Temporary path holding the entry moved by rename.
- * @returns void after the quarantined entry is restored or a detailed stale error is thrown.
- * @example
- * await restoreQuarantinedEntry('/agent/task', '/agent/task.cleanup-1')
- */
-async function restoreQuarantinedEntry(
-  linkPath: AbsolutePath,
-  quarantinePath: AbsolutePath,
-): Promise<void> {
-  try {
-    await fs.lstat(linkPath)
-    throw new TrashError(
-      `Cleanup stopped after the reviewed slot changed. Quarantined entry left at ${quarantinePath} because ${linkPath} is occupied.`,
-      'ESTALE',
-    )
-  } catch (error) {
-    if (error instanceof TrashError) throw error
-    if (!isMissingPathError(error)) {
-      throw new TrashError(
-        `Cleanup stopped, but ${linkPath} could not be checked before restoring quarantine: ${extractErrorMessage(error)}`,
-        errorCode(error),
-      )
-    }
-  }
-
-  try {
-    await fs.rename(quarantinePath, linkPath)
-  } catch (error) {
-    throw new TrashError(
-      `Cleanup stopped, but the quarantined entry could not be restored at ${linkPath}: ${extractErrorMessage(error)}`,
-      errorCode(error),
-    )
-  }
-}
-
-/**
- * Atomically quarantine, revalidate, and unlink one reviewed dangling symlink.
+ * Revalidate and unlink one reviewed dangling symlink without moving replacements.
  * @param options - Exact reviewed path/target plus messages for stale-target cases.
  * @returns `missing` when the slot was already gone; otherwise `unlinked`.
  * @example
@@ -124,59 +55,71 @@ async function unlinkReviewedDanglingSymlink(options: {
   targetProbePrefix: string
   beforeTargetProbe?: () => Promise<void>
 }): Promise<'missing' | 'unlinked'> {
-  const quarantinePath =
-    `${options.linkPath}.cleanup-${randomUUID()}` as AbsolutePath
+  let stats: Stats
   try {
-    await fs.rename(options.linkPath, quarantinePath)
+    stats = await fs.lstat(options.linkPath)
   } catch (error) {
     if (isMissingPathError(error)) return 'missing'
     throw new TrashError(extractErrorMessage(error), errorCode(error))
   }
 
-  let rawTarget: string | null = null
+  if (!stats.isSymbolicLink()) {
+    throw new TrashError(
+      'Reviewed cleanup slot is no longer a symlink',
+      'ESTALE',
+    )
+  }
+
+  let rawTarget: string
   try {
-    const stats = await fs.lstat(quarantinePath)
-    if (!stats.isSymbolicLink()) {
+    rawTarget = await fs.readlink(options.linkPath)
+  } catch (error) {
+    if (isMissingPathError(error)) return 'missing'
+    throw new TrashError(
+      'Reviewed cleanup slot is no longer a symlink',
+      'ESTALE',
+    )
+  }
+
+  const resolvedTarget = await resolveRawSymlinkTarget(
+    options.linkPath,
+    rawTarget,
+  )
+  if (resolve(resolvedTarget) !== resolve(options.targetPath)) {
+    throw new TrashError(options.targetChangedMessage, 'ESTALE')
+  }
+
+  await options.beforeTargetProbe?.()
+
+  try {
+    await fs.access(resolvedTarget)
+    throw new TrashError(options.targetExistsMessage, 'ESTALE')
+  } catch (error) {
+    if (error instanceof TrashError) throw error
+    if (!isMissingPathError(error)) {
+      throw new TrashError(
+        `${options.targetProbePrefix}: ${extractErrorMessage(error)}`,
+        errorCode(error),
+      )
+    }
+  }
+
+  try {
+    await fs.unlink(options.linkPath)
+  } catch (error) {
+    if (isMissingPathError(error)) return 'missing'
+    const code = errorCode(error)
+    // A concurrent folder replacement should never be moved or removed.
+    if (code === 'EISDIR' || code === 'EPERM' || code === 'EINVAL') {
       throw new TrashError(
         'Reviewed cleanup slot is no longer a symlink',
         'ESTALE',
       )
     }
-
-    rawTarget = await fs.readlink(quarantinePath)
-    const resolvedTarget = await resolveRawSymlinkTarget(
-      quarantinePath,
-      rawTarget,
-    )
-    if (resolve(resolvedTarget) !== resolve(options.targetPath)) {
-      throw new TrashError(options.targetChangedMessage, 'ESTALE')
-    }
-
-    await options.beforeTargetProbe?.()
-
-    try {
-      await fs.access(resolvedTarget)
-      throw new TrashError(options.targetExistsMessage, 'ESTALE')
-    } catch (error) {
-      if (error instanceof TrashError) throw error
-      if (!isMissingPathError(error)) {
-        throw new TrashError(
-          `${options.targetProbePrefix}: ${extractErrorMessage(error)}`,
-          errorCode(error),
-        )
-      }
-    }
-
-    await fs.unlink(quarantinePath)
-    return 'unlinked'
-  } catch (error) {
-    if (rawTarget !== null) {
-      await restoreReviewedSymlink(options.linkPath, quarantinePath, rawTarget)
-    } else {
-      await restoreQuarantinedEntry(options.linkPath, quarantinePath)
-    }
-    throw error
+    throw new TrashError(extractErrorMessage(error), code)
   }
+
+  return 'unlinked'
 }
 
 /**

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -12,8 +12,10 @@ import {
   findAgentById,
   isSharedAgentPath,
 } from '@/main/constants'
+import { isSameFilesystemIdentity } from '@/main/services/filesystemIdentity'
 import { getAllowedBases, validatePath } from '@/main/services/pathValidation'
 import { scanSkills } from '@/main/services/skillScanner'
+import { isValidSkillDir } from '@/main/services/skillValidation'
 import { resolveRawSymlinkTarget } from '@/main/services/symlinkChecker'
 import {
   moveToTrash,
@@ -455,6 +457,27 @@ export function registerSkillsHandlers(): void {
               'Refusing to delete a local skill without explicit confirmation.',
           }
         }
+        if (!options.reviewedDirectoryIdentity) {
+          return {
+            success: false,
+            error:
+              'Refusing to delete a local skill without reviewed directory identity.',
+          }
+        }
+        if (
+          !isSameFilesystemIdentity(stats, options.reviewedDirectoryIdentity)
+        ) {
+          return {
+            success: false,
+            error: 'Reviewed local skill folder changed since review.',
+          }
+        }
+        if (!(await isValidSkillDir(derivedLinkPath))) {
+          return {
+            success: false,
+            error: 'Reviewed local skill folder is no longer a valid skill.',
+          }
+        }
 
         // Local skill deletion arrives from UnlinkDialog's destructive confirm
         // action. Move to OS Trash instead of recursively deleting bytes so a
@@ -556,9 +579,10 @@ export function registerSkillsHandlers(): void {
    * Delete a single skill by delegating to trashService so the single-delete
    * path shares the same trash/undo/eviction code as batch delete.
    *
-   * `moveToTrash(skillName, skillPath)` validates the reviewed row path so
-   * metadata names cannot redirect deletion to a same-name folder.
-   * @param options - { skillName, skillPath }
+   * `moveToTrash(skillName, skillPath, filesystemIdentity)` validates the
+   * reviewed row path so metadata names cannot redirect deletion to a same-name
+   * folder or same-path replacement.
+   * @param options - Reviewed skill name, path, and filesystem identity.
    * @returns DeleteSkillResult with symlinksRemoved + cascadeAgents
    */
   typedHandle(IPC_CHANNELS.SKILLS_DELETE, async (_, options) => {
@@ -567,6 +591,7 @@ export function registerSkillsHandlers(): void {
       const { cascadeAgents, symlinksRemoved } = await moveToTrash(
         skillName,
         skillPath,
+        options.filesystemIdentity,
       )
       return {
         success: true,
@@ -605,9 +630,16 @@ export function registerSkillsHandlers(): void {
       const emitProgress = total >= BULK_PROGRESS_THRESHOLD
       const results: BulkDeleteItemResult[] = []
 
-      for (const [itemIndex, { skillName, skillPath }] of items.entries()) {
+      for (const [
+        itemIndex,
+        { skillName, skillPath, filesystemIdentity },
+      ] of items.entries()) {
         try {
-          const moveResult = await moveToTrash(skillName, skillPath)
+          const moveResult = await moveToTrash(
+            skillName,
+            skillPath,
+            filesystemIdentity,
+          )
           results.push({
             skillName,
             outcome: 'deleted',

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -137,14 +137,32 @@ async function removeFromAgent(
 ): Promise<
   { success: true } | { success: false; error: string; code?: string }
 > {
-  const linkPath = join(agentPath, skillName)
+  const linkPath = join(agentPath, skillName) as AbsolutePath
+  return removeReviewedPathFromAgent(agentPath, linkPath)
+}
+
+/**
+ * Remove the exact reviewed agent slot after validating it belongs to selected agent.
+ * @param agentPath - Selected agent skills directory from main constants.
+ * @param linkPath - Renderer-reviewed slot path to remove.
+ * @returns Structured IPC result for bulk unlink reporting.
+ * @example removeReviewedPathFromAgent('/Users/me/.cursor/skills', '/Users/me/.cursor/skills/folder-name')
+ */
+async function removeReviewedPathFromAgent(
+  agentPath: AbsolutePath,
+  linkPath: AbsolutePath,
+): Promise<
+  { success: true } | { success: false; error: string; code?: string }
+> {
+  let reviewedLinkPath: AbsolutePath
   try {
+    reviewedLinkPath = assertAgentSlotPath(linkPath, agentPath)
     // Use getAllowedBases() instead of [agentPath] because validatePath
     // realpath-follows linkPath. For a legitimate agent symlink the realpath
     // lands in SOURCE_DIR (source-backed) or another agent dir (cross-agent
     // copy), both of which are valid bases. Restricting to [agentPath] alone
     // would false-positive every symlinked-skill unlink.
-    validatePath(linkPath, getAllowedBases())
+    validatePath(reviewedLinkPath, getAllowedBases())
   } catch (error) {
     return {
       success: false,
@@ -153,7 +171,7 @@ async function removeFromAgent(
   }
   let stats: Stats
   try {
-    stats = await fs.lstat(linkPath)
+    stats = await fs.lstat(reviewedLinkPath)
   } catch (error) {
     const code = errorCode(error)
     if (code === 'ENOENT') {
@@ -168,7 +186,7 @@ async function removeFromAgent(
   }
 
   try {
-    return await removeLinkPathByKind(linkPath, stats)
+    return await removeLinkPathByKind(reviewedLinkPath, stats)
   } catch (error) {
     return {
       success: false,
@@ -556,16 +574,18 @@ export function registerSkillsHandlers(): void {
    * Delete a single skill by delegating to trashService so the single-delete
    * path shares the same trash/undo/eviction code as batch delete.
    *
-   * `moveToTrash(skillName)` derives + validates `sourcePath` internally and
-   * also handles the local-only case (skill lives in agent dirs only with no
-   * `~/.agents/skills/<name>` source). The renderer never passes a path.
-   * @param options - { skillName }
+   * `moveToTrash(skillName, skillPath)` validates the reviewed row path when
+   * present so metadata names cannot redirect deletion to a same-name folder.
+   * @param options - { skillName, skillPath? }
    * @returns DeleteSkillResult with symlinksRemoved + cascadeAgents
    */
   typedHandle(IPC_CHANNELS.SKILLS_DELETE, async (_, options) => {
-    const { skillName } = options
+    const { skillName, skillPath } = options
     try {
-      const { cascadeAgents, symlinksRemoved } = await moveToTrash(skillName)
+      const { cascadeAgents, symlinksRemoved } = await moveToTrash(
+        skillName,
+        skillPath,
+      )
       return {
         success: true,
         symlinksRemoved,
@@ -592,7 +612,7 @@ export function registerSkillsHandlers(): void {
    * Progress: emits \`skills:deleteProgress\` after each item when N >= 10 so the
    * SelectionToolbar can show "Deleting 3 of 12". Smaller batches skip the
    * event to avoid toast churn.
-   * @param options - items: Array<{ skillName }>
+   * @param options - items: Array<{ skillName, skillPath? }>
    * @returns BulkDeleteResult with per-item discriminated outcome
    */
   typedHandle(
@@ -603,9 +623,9 @@ export function registerSkillsHandlers(): void {
       const emitProgress = total >= BULK_PROGRESS_THRESHOLD
       const results: BulkDeleteItemResult[] = []
 
-      for (const [itemIndex, { skillName }] of items.entries()) {
+      for (const [itemIndex, { skillName, skillPath }] of items.entries()) {
         try {
-          const moveResult = await moveToTrash(skillName)
+          const moveResult = await moveToTrash(skillName, skillPath)
           // Discriminate on `kind` so the renderer can tell apart "this row has
           // a tombstone, wire it into the Undo toast" from "this row is just a
           // broken-symlink sweep with no undo path".
@@ -715,8 +735,10 @@ export function registerSkillsHandlers(): void {
         return result
       }
 
-      for (const { skillName } of items) {
-        const outcome = await removeFromAgent(agent.path, skillName)
+      for (const { skillName, linkPath } of items) {
+        const outcome = linkPath
+          ? await removeReviewedPathFromAgent(agent.path, linkPath)
+          : await removeFromAgent(agent.path, skillName)
         if (outcome.success) {
           results.push({ skillName, outcome: 'unlinked' })
         } else {

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -13,7 +13,10 @@ import {
   findAgentById,
   isSharedAgentPath,
 } from '@/main/constants'
-import { isSameFilesystemIdentity } from '@/main/services/filesystemIdentity'
+import {
+  isReviewedEntryUnchanged,
+  isSameFilesystemIdentity,
+} from '@/main/services/filesystemIdentity'
 import { getAllowedBases, validatePath } from '@/main/services/pathValidation'
 import { scanSkills } from '@/main/services/skillScanner'
 import { isValidSkillDir } from '@/main/services/skillValidation'
@@ -647,8 +650,10 @@ export function registerSkillsHandlers(): void {
               'Refusing to delete a local skill without explicit confirmation.',
           }
         }
+        // Pre-rename gate: catch a same-path replacement before quarantining,
+        // including the reused-inode case dev+ino alone misses on ext4/CI.
         if (
-          !isSameFilesystemIdentity(stats, options.reviewedDirectoryIdentity)
+          !isReviewedEntryUnchanged(stats, options.reviewedDirectoryIdentity)
         ) {
           return {
             success: false,
@@ -755,7 +760,9 @@ export function registerSkillsHandlers(): void {
           error: 'Reviewed agent skills path is no longer a real directory.',
         }
       }
-      if (!isSameFilesystemIdentity(stats, options.filesystemIdentity)) {
+      // Pre-rename gate: catch a same-path replacement before quarantining,
+      // including the reused-inode case dev+ino alone misses on ext4/CI.
+      if (!isReviewedEntryUnchanged(stats, options.filesystemIdentity)) {
         return {
           success: false,
           removedCount: 0,

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -146,6 +146,7 @@ async function restoreQuarantinedPath(
         recursive: true,
         force: false,
         errorOnExist: true,
+        verbatimSymlinks: true,
       })
       await fs.rm(quarantinePath, { recursive: true, force: true })
       return true

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto'
 import type { Stats } from 'node:fs'
 import * as fs from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
@@ -16,7 +15,12 @@ import {
 import { getAllowedBases, validatePath } from '@/main/services/pathValidation'
 import { scanSkills } from '@/main/services/skillScanner'
 import { resolveRawSymlinkTarget } from '@/main/services/symlinkChecker'
-import { moveToTrash, restore, TrashError } from '@/main/services/trashService'
+import {
+  moveToTrash,
+  restore,
+  TrashError,
+  unlinkReviewedDanglingSymlink,
+} from '@/main/services/trashService'
 import { errorCode, isMissingPathError } from '@/main/utils/errorCode'
 import { extractErrorMessage } from '@/main/utils/errors'
 import { BULK_PROGRESS_THRESHOLD } from '@/shared/constants'
@@ -40,217 +44,6 @@ import { typedSend } from './typedSend'
 type AgentPathRemovalResult =
   | { success: true }
   | { success: false; error: string; code?: string }
-
-/**
- * Read and verify the exact reviewed symlink target at the destructive slot.
- * @param options - Reviewed link path, target path, and stale-target message.
- * @returns Raw and resolved target for the still-reviewed symlink.
- * @example
- * await readReviewedDanglingSymlink({ linkPath, targetPath, targetChangedMessage })
- */
-async function readReviewedDanglingSymlink(options: {
-  linkPath: AbsolutePath
-  targetPath: AbsolutePath
-  targetChangedMessage: string
-}): Promise<{ rawTarget: string; resolvedTarget: AbsolutePath }> {
-  let stats: Stats
-  try {
-    stats = await fs.lstat(options.linkPath)
-  } catch (error) {
-    if (isMissingPathError(error)) {
-      throw new TrashError('Reviewed cleanup slot is already missing', 'ENOENT')
-    }
-    throw new TrashError(extractErrorMessage(error), errorCode(error))
-  }
-
-  if (!stats.isSymbolicLink()) {
-    throw new TrashError(
-      'Reviewed cleanup slot is no longer a symlink',
-      'ESTALE',
-    )
-  }
-
-  let rawTarget: string
-  try {
-    rawTarget = await fs.readlink(options.linkPath)
-  } catch (error) {
-    if (isMissingPathError(error)) {
-      throw new TrashError('Reviewed cleanup slot is already missing', 'ENOENT')
-    }
-    throw new TrashError(
-      'Reviewed cleanup slot is no longer a symlink',
-      'ESTALE',
-    )
-  }
-
-  const resolvedTarget = await resolveRawSymlinkTarget(
-    options.linkPath,
-    rawTarget,
-  )
-  if (resolve(resolvedTarget) !== resolve(options.targetPath)) {
-    throw new TrashError(options.targetChangedMessage, 'ESTALE')
-  }
-
-  return { rawTarget, resolvedTarget }
-}
-
-/**
- * Assert the reviewed symlink target is still absent and cleanup-safe.
- * @param resolvedTarget - Absolute target path resolved from the reviewed symlink.
- * @param targetExistsMessage - Stale message when the source target reappears.
- * @param targetProbePrefix - Prefix for non-missing probe failures.
- * @returns void when the target remains missing.
- * @example
- * await assertReviewedTargetMissing('/Users/me/.agents/skills/task', 'Target exists', 'Cannot verify target')
- */
-async function assertReviewedTargetMissing(
-  resolvedTarget: AbsolutePath,
-  targetExistsMessage: string,
-  targetProbePrefix: string,
-): Promise<void> {
-  try {
-    await fs.access(resolvedTarget)
-    throw new TrashError(targetExistsMessage, 'ESTALE')
-  } catch (error) {
-    if (error instanceof TrashError) throw error
-    if (!isMissingPathError(error)) {
-      throw new TrashError(
-        `${targetProbePrefix}: ${extractErrorMessage(error)}`,
-        errorCode(error),
-      )
-    }
-  }
-}
-
-/**
- * Restore a moved cleanup candidate when post-rename validation proves it is stale.
- * @param linkPath - Original agent slot path reviewed by the user.
- * @param movedPath - Same-directory temporary path created by guarded rename.
- * @returns void after the moved entry is back at the reviewed slot when possible.
- * @example
- * await restoreMovedCleanupCandidate('/agent/task', '/agent/task.cleanup-1')
- */
-async function restoreMovedCleanupCandidate(
-  linkPath: AbsolutePath,
-  movedPath: AbsolutePath,
-): Promise<void> {
-  try {
-    await fs.lstat(linkPath)
-    throw new TrashError(
-      `Cleanup stopped after the reviewed slot changed. Moved entry left at ${movedPath} because ${linkPath} is occupied.`,
-      'ESTALE',
-    )
-  } catch (error) {
-    if (error instanceof TrashError) throw error
-    if (!isMissingPathError(error)) {
-      throw new TrashError(
-        `Cleanup stopped, but ${linkPath} could not be checked before restoring the moved entry: ${extractErrorMessage(error)}`,
-        errorCode(error),
-      )
-    }
-  }
-
-  try {
-    await fs.rename(movedPath, linkPath)
-  } catch (error) {
-    throw new TrashError(
-      `Cleanup stopped, but the moved entry could not be restored at ${linkPath}: ${extractErrorMessage(error)}`,
-      errorCode(error),
-    )
-  }
-}
-
-/**
- * Commit cleanup by moving the candidate, validating the moved entry, then unlinking it.
- * @param options - Reviewed path and target messages for final validation.
- * @returns void after the moved, verified symlink is removed.
- * @example
- * await commitReviewedDanglingSymlink({ linkPath, targetPath, targetChangedMessage, targetExistsMessage, targetProbePrefix })
- */
-async function commitReviewedDanglingSymlink(options: {
-  linkPath: AbsolutePath
-  targetPath: AbsolutePath
-  targetChangedMessage: string
-  targetExistsMessage: string
-  targetProbePrefix: string
-}): Promise<void> {
-  const movedPath =
-    `${options.linkPath}.cleanup-${randomUUID()}` as AbsolutePath
-  try {
-    await fs.rename(options.linkPath, movedPath)
-  } catch (error) {
-    if (isMissingPathError(error)) return
-    throw new TrashError(extractErrorMessage(error), errorCode(error))
-  }
-
-  try {
-    const movedReviewed = await readReviewedDanglingSymlink({
-      linkPath: movedPath,
-      targetPath: options.targetPath,
-      targetChangedMessage: options.targetChangedMessage,
-    })
-    await assertReviewedTargetMissing(
-      movedReviewed.resolvedTarget,
-      options.targetExistsMessage,
-      options.targetProbePrefix,
-    )
-    await fs.unlink(movedPath)
-  } catch (error) {
-    await restoreMovedCleanupCandidate(options.linkPath, movedPath)
-    throw error
-  }
-}
-
-/**
- * Revalidate and unlink one reviewed dangling symlink without moving replacements.
- * @param options - Exact reviewed path/target plus messages for stale-target cases.
- * @returns `missing` when the slot was already gone; otherwise `unlinked`.
- * @example
- * await unlinkReviewedDanglingSymlink({ linkPath, targetPath, targetChangedMessage, targetExistsMessage, targetProbePrefix })
- */
-async function unlinkReviewedDanglingSymlink(options: {
-  linkPath: AbsolutePath
-  targetPath: AbsolutePath
-  targetChangedMessage: string
-  targetExistsMessage: string
-  targetProbePrefix: string
-  beforeTargetProbe?: () => Promise<void>
-}): Promise<'missing' | 'unlinked'> {
-  try {
-    const reviewed = await readReviewedDanglingSymlink(options)
-
-    await options.beforeTargetProbe?.()
-
-    await assertReviewedTargetMissing(
-      reviewed.resolvedTarget,
-      options.targetExistsMessage,
-      options.targetProbePrefix,
-    )
-
-    const finalReviewed = await readReviewedDanglingSymlink(options)
-    await assertReviewedTargetMissing(
-      finalReviewed.resolvedTarget,
-      options.targetExistsMessage,
-      options.targetProbePrefix,
-    )
-
-    await commitReviewedDanglingSymlink(options)
-  } catch (error) {
-    if (isMissingPathError(error)) return 'missing'
-    if (error instanceof TrashError) throw error
-    const code = errorCode(error)
-    // A concurrent folder replacement should never be moved or removed.
-    if (code === 'EISDIR' || code === 'EPERM' || code === 'EINVAL') {
-      throw new TrashError(
-        'Reviewed cleanup slot is no longer a symlink',
-        'ESTALE',
-      )
-    }
-    throw new TrashError(extractErrorMessage(error), code)
-  }
-
-  return 'unlinked'
-}
 
 /**
  * Remove an agent symlink path after the caller has already validated and

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -72,6 +72,44 @@ async function restoreReviewedSymlink(
 }
 
 /**
+ * Move a quarantined non-reviewed entry back after validation proves it was not the reviewed symlink.
+ * @param linkPath - Original reviewed agent slot path.
+ * @param quarantinePath - Temporary path holding the entry moved by rename.
+ * @returns void after the quarantined entry is restored or a detailed stale error is thrown.
+ * @example
+ * await restoreQuarantinedEntry('/agent/task', '/agent/task.cleanup-1')
+ */
+async function restoreQuarantinedEntry(
+  linkPath: AbsolutePath,
+  quarantinePath: AbsolutePath,
+): Promise<void> {
+  try {
+    await fs.lstat(linkPath)
+    throw new TrashError(
+      `Cleanup stopped after the reviewed slot changed. Quarantined entry left at ${quarantinePath} because ${linkPath} is occupied.`,
+      'ESTALE',
+    )
+  } catch (error) {
+    if (error instanceof TrashError) throw error
+    if (!isMissingPathError(error)) {
+      throw new TrashError(
+        `Cleanup stopped, but ${linkPath} could not be checked before restoring quarantine: ${extractErrorMessage(error)}`,
+        errorCode(error),
+      )
+    }
+  }
+
+  try {
+    await fs.rename(quarantinePath, linkPath)
+  } catch (error) {
+    throw new TrashError(
+      `Cleanup stopped, but the quarantined entry could not be restored at ${linkPath}: ${extractErrorMessage(error)}`,
+      errorCode(error),
+    )
+  }
+}
+
+/**
  * Atomically quarantine, revalidate, and unlink one reviewed dangling symlink.
  * @param options - Exact reviewed path/target plus messages for stale-target cases.
  * @returns `missing` when the slot was already gone; otherwise `unlinked`.
@@ -134,6 +172,8 @@ async function unlinkReviewedDanglingSymlink(options: {
   } catch (error) {
     if (rawTarget !== null) {
       await restoreReviewedSymlink(options.linkPath, quarantinePath, rawTarget)
+    } else {
+      await restoreQuarantinedEntry(options.linkPath, quarantinePath)
     }
     throw error
   }
@@ -236,11 +276,11 @@ async function removeFromAgent(
  * @param item - Reviewed broken-slot target from Symlink Health cleanup.
  * @returns Per-slot unlink result.
  * @example
- * await clearReviewedBrokenSymlinkSlot({ agentId: 'codex', skillName: 'task', linkPath: '/Users/me/.codex/skills/task', targetPath: '/Users/me/.agents/skills/task' })
+ * await clearReviewedBrokenSymlinkSlot({ agentId: 'codex', linkName: 'task', linkPath: '/Users/me/.codex/skills/task', targetPath: '/Users/me/.agents/skills/task' })
  */
 async function clearReviewedBrokenSymlinkSlot(item: {
   agentId: AgentId
-  skillName: SkillName
+  linkName: SkillName
   linkPath: AbsolutePath
   targetPath: AbsolutePath
 }): Promise<ClearBrokenSymlinkSlotItemResult> {
@@ -248,7 +288,7 @@ async function clearReviewedBrokenSymlinkSlot(item: {
     const agent = findAgentById(item.agentId)
     if (!agent) throw new TrashError('Agent not found', 'ENOENT')
 
-    const expectedLinkPath = resolve(agent.path, item.skillName)
+    const expectedLinkPath = resolve(agent.path, item.linkName)
     if (resolve(item.linkPath) !== expectedLinkPath) {
       throw new TrashError(
         'Reviewed broken link path no longer matches agent slot',
@@ -265,7 +305,7 @@ async function clearReviewedBrokenSymlinkSlot(item: {
       if (isMissingPathError(error)) {
         return {
           agentId: item.agentId,
-          skillName: item.skillName,
+          skillName: item.linkName,
           linkPath: item.linkPath,
           outcome: 'unlinked',
         }
@@ -291,7 +331,7 @@ async function clearReviewedBrokenSymlinkSlot(item: {
     })
     return {
       agentId: item.agentId,
-      skillName: item.skillName,
+      skillName: item.linkName,
       linkPath: item.linkPath,
       outcome: 'unlinked',
     }
@@ -301,7 +341,7 @@ async function clearReviewedBrokenSymlinkSlot(item: {
     const code = error instanceof TrashError ? error.code : errorCode(error)
     return {
       agentId: item.agentId,
-      skillName: item.skillName,
+      skillName: item.linkName,
       linkPath: item.linkPath,
       outcome: 'error',
       error: code ? { message, code } : { message },
@@ -702,7 +742,7 @@ export function registerSkillsHandlers(): void {
    * inaccessible targets so restored user links are never removed.
    * @param options - exact broken slots selected in Symlink Health cleanup
    * @returns Per-slot unlink outcomes
-   * @example clearBrokenSymlinkSlots({ items: [{ agentId: 'codex', skillName: 'task', linkPath, targetPath }] })
+   * @example clearBrokenSymlinkSlots({ items: [{ agentId: 'codex', linkName: 'task', linkPath, targetPath }] })
    */
   typedHandle(
     IPC_CHANNELS.SKILLS_CLEAR_BROKEN_SYMLINK_SLOTS,

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -111,7 +111,9 @@ function buildQuarantinePath(
 }
 
 /**
- * Restore a quarantined path after validation or OS Trash fails without clobbering replacements.
+ * Restore a quarantined path after validation or OS Trash fails. The lstat
+ * pre-check + per-type guards prevent clobbering a recreated file/symlink or a
+ * non-empty directory; only an empty dir recreated in the race can be replaced.
  * @param quarantinePath - Hidden same-directory path currently holding the entry.
  * @param originalPath - Original reviewed path to restore.
  * @returns true when restoration succeeds or the quarantine is already gone.
@@ -146,12 +148,15 @@ async function restoreQuarantinedPath(
 
     if (quarantineStats.isDirectory()) {
       // Atomic same-directory restore (buildQuarantinePath keeps both paths in
-      // the same dir, so rename can't hit EXDEV). Replaces the previous
-      // cp+rm, which could leave a half-copied tree at originalPath on a
-      // mid-copy failure (ENOSPC/EACCES). The L124-129 pre-check already
-      // guarantees originalPath is absent; if a concurrent process recreated a
-      // *non-empty* dir in the race window, rename fails ENOTEMPTY → caught →
-      // false, so the no-clobber guarantee survives for the dangerous case.
+      // the same dir, so rename can't hit EXDEV). Replaces the previous cp+rm,
+      // which could leave a half-copied tree at originalPath on a mid-copy
+      // failure (ENOSPC/EACCES). The lstat pre-check makes originalPath absent
+      // in the common case. In the narrow race where another process recreates
+      // it first: a *non-empty* dir makes rename fail ENOTEMPTY → caught →
+      // false (no-clobber preserved); an *empty* dir is silently replaced, but
+      // it holds no data so nothing is lost. POSIX rename has no portable
+      // no-replace flag (renameat2/renamex_np need native bindings), and
+      // cp+rm's partial-tree failure is strictly worse, so rename stands.
       await fs.rename(quarantinePath, originalPath)
       return true
     }

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -568,13 +568,15 @@ async function clearReviewedOrphanRecord(item: {
     targetPath: AbsolutePath
   }>
 }): Promise<ClearOrphanSymlinkItemResult> {
+  // Hoisted above the try so a mid-loop throw (e.g. source reappears between
+  // adjacent agent unlinks) still reports the unlinks already committed to disk.
+  const cascadeAgents: AgentId[] = []
   try {
     const blocker = await findOrphanCleanupBlocker(item.skillName)
     if (blocker) {
       throw new TrashError(blocker, 'ESTALE')
     }
 
-    const cascadeAgents: AgentId[] = []
     for (const reviewedLink of item.agents) {
       cascadeAgents.push(
         await clearReviewedOrphanLink(item.skillName, reviewedLink),
@@ -591,10 +593,15 @@ async function clearReviewedOrphanRecord(item: {
     const message =
       error instanceof TrashError ? error.message : extractErrorMessage(error)
     const code = error instanceof TrashError ? error.code : errorCode(error)
+    // Surface any partial cleanup so the summary mirrors disk state instead of
+    // reporting zero removed when N-1 of N agents already unlinked.
     return {
       skillName: item.skillName,
       outcome: 'error',
       error: code ? { message, code } : { message },
+      ...(cascadeAgents.length > 0
+        ? { symlinksRemoved: cascadeAgents.length, cascadeAgents }
+        : {}),
     }
   }
 }

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -46,6 +46,27 @@ type AgentPathRemovalResult =
   | { success: false; error: string; code?: string }
 
 /**
+ * Require a renderer path to name the same slot the main process derives.
+ * @param rendererPath - Path supplied over IPC for backward-compatible callers
+ * @param derivedPath - Path calculated from validated main-process state
+ * @param subject - Human-readable path kind for error messages
+ * @returns Derived path after exact normalized equality passes
+ * @example assertDerivedPathMatch('/a/b', '/a/b/', 'agent path')
+ */
+function assertDerivedPathMatch(
+  rendererPath: AbsolutePath,
+  derivedPath: AbsolutePath,
+  subject: string,
+): AbsolutePath {
+  if (resolve(rendererPath) !== resolve(derivedPath)) {
+    throw new Error(
+      `Renderer ${subject} does not match the selected agent slot.`,
+    )
+  }
+  return derivedPath
+}
+
+/**
  * Remove an agent symlink path after the caller has already validated and
  * lstat'd it. Directories are refused here so destructive local-folder removal
  * remains isolated to the single-unlink confirmation path.
@@ -377,17 +398,33 @@ export function registerSkillsHandlers(): void {
    * @returns UnlinkResult with success status and optional error
    */
   typedHandle(IPC_CHANNELS.SKILLS_UNLINK_FROM_AGENT, async (_, options) => {
-    const { linkPath, confirmedLocalDirectoryDelete = false } = options
+    const {
+      agentId,
+      skillName,
+      linkPath,
+      confirmedLocalDirectoryDelete = false,
+    } = options
 
     try {
+      const agent = findAgentById(agentId)
+      if (!agent) {
+        return { success: false, error: 'Agent not found' }
+      }
+
+      const derivedLinkPath = assertDerivedPathMatch(
+        linkPath,
+        join(agent.path, skillName) as AbsolutePath,
+        'link path',
+      )
+
       // Allow agent dirs (for local skills) AND SOURCE_DIR (for symlinked skills).
       // validatePath calls realpathSync, which follows the symlink to its source
       // in ~/.agents/skills/. Without SOURCE_DIR in the allowed bases, every
       // symlinked-skill unlink fails with "Path traversal attempt detected".
-      validatePath(linkPath, getAllowedBases())
+      validatePath(derivedLinkPath, getAllowedBases())
       let stats: Stats
       try {
-        stats = await fs.lstat(linkPath)
+        stats = await fs.lstat(derivedLinkPath)
       } catch (error) {
         if (errorCode(error) === 'ENOENT') {
           // Already gone — match bulk unlink's idempotent no-op behavior.
@@ -408,11 +445,11 @@ export function registerSkillsHandlers(): void {
         // Local skill deletion arrives from UnlinkDialog's destructive confirm
         // action. Move to OS Trash instead of recursively deleting bytes so a
         // mistaken confirmation is still recoverable at the filesystem level.
-        await shell.trashItem(linkPath)
+        await shell.trashItem(derivedLinkPath)
         return { success: true }
       }
 
-      return await removeLinkPathByKind(linkPath, stats)
+      return await removeLinkPathByKind(derivedLinkPath, stats)
     } catch (error) {
       return { success: false, error: extractErrorMessage(error) }
     }
@@ -431,20 +468,35 @@ export function registerSkillsHandlers(): void {
    * @returns RemoveAllFromAgentResult with item count removed
    */
   typedHandle(IPC_CHANNELS.SKILLS_REMOVE_ALL_FROM_AGENT, async (_, options) => {
-    const { agentPath } = options
+    const { agentId, agentPath } = options
 
     try {
+      const agent = findAgentById(agentId)
+      if (!agent) {
+        return {
+          success: false,
+          removedCount: 0,
+          error: 'Agent not found',
+        }
+      }
+
+      const derivedAgentPath = assertDerivedPathMatch(
+        agentPath,
+        agent.path as AbsolutePath,
+        'agent path',
+      )
+
       const agentBases = AGENTS.map((a) => a.path)
       // validatePath throws on traversal attempts. We discard the return
       // value intentionally: SHARED_AGENT_PATHS is keyed by the resolve()-
       // normalized join() form, NOT by realpath, to avoid macOS firmlink
       // (/var → /private/var) false negatives. isSharedAgentPath handles
-      // symlink aliases itself via its realpathSync fallback. Using
-      // agentPath (not the realpath'd form) for trashItem is also safer:
-      // trashItem on a symlink moves the symlink, not its target.
-      validatePath(agentPath, agentBases)
+      // symlink aliases itself via its realpathSync fallback. Using the
+      // derived raw agent path for trashItem is also safer: trashItem on a
+      // symlink moves the symlink, not its target.
+      validatePath(derivedAgentPath, agentBases)
 
-      if (isSharedAgentPath(agentPath)) {
+      if (isSharedAgentPath(derivedAgentPath)) {
         return {
           success: false,
           removedCount: 0,
@@ -458,7 +510,7 @@ export function registerSkillsHandlers(): void {
       // Short-circuit when the dir is already gone so double-clicks and
       // out-of-band deletes don't surface as errors.
       try {
-        await fs.access(agentPath)
+        await fs.access(derivedAgentPath)
       } catch {
         return { success: true, removedCount: 0 }
       }
@@ -466,7 +518,7 @@ export function registerSkillsHandlers(): void {
       // Count entries before deletion for reporting
       let removedCount = 0
       try {
-        const entries = await fs.readdir(agentPath)
+        const entries = await fs.readdir(derivedAgentPath)
         removedCount = entries.length
       } catch {
         // Directory may be unreadable (permissions) — proceed to trash anyway
@@ -474,7 +526,7 @@ export function registerSkillsHandlers(): void {
 
       // Move to OS trash instead of hard-rm so accidents can be restored from
       // Finder > Trash.
-      await shell.trashItem(agentPath)
+      await shell.trashItem(derivedAgentPath)
 
       return { success: true, removedCount }
     } catch (error) {

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -278,7 +278,11 @@ async function findOrphanCleanupBlocker(
  */
 async function clearReviewedOrphanLink(
   skillName: SkillName,
-  reviewedLink: { agentId: AgentId; linkPath: AbsolutePath },
+  reviewedLink: {
+    agentId: AgentId
+    linkPath: AbsolutePath
+    targetPath: AbsolutePath
+  },
 ): Promise<AgentId> {
   const agent = findAgentById(reviewedLink.agentId)
   if (!agent) {
@@ -320,6 +324,18 @@ async function clearReviewedOrphanLink(
     reviewedLink.linkPath,
     rawTarget,
   )
+  if (resolve(resolvedTarget) !== resolve(reviewedLink.targetPath)) {
+    throw new TrashError(
+      'Reviewed orphan link target changed. Rescan before cleanup.',
+      'ESTALE',
+    )
+  }
+
+  const blocker = await findOrphanCleanupBlocker(skillName)
+  if (blocker) {
+    throw new TrashError(blocker, 'ESTALE')
+  }
+
   try {
     await fs.access(resolvedTarget)
     throw new TrashError(
@@ -334,11 +350,6 @@ async function clearReviewedOrphanLink(
         errorCode(error),
       )
     }
-  }
-
-  const blocker = await findOrphanCleanupBlocker(skillName)
-  if (blocker) {
-    throw new TrashError(blocker, 'ESTALE')
   }
 
   try {
@@ -357,11 +368,15 @@ async function clearReviewedOrphanLink(
  * @param item - Skill name plus the exact orphan agent links selected in the dialog.
  * @returns Per-item cleanup outcome for the dialog summary.
  * @example
- * await clearReviewedOrphanRecord({ skillName: 'abandoned', agents: [{ agentId: 'codex', linkPath: '/Users/me/.codex/skills/abandoned' }] })
+ * await clearReviewedOrphanRecord({ skillName: 'abandoned', agents: [{ agentId: 'codex', linkPath: '/Users/me/.codex/skills/abandoned', targetPath: '/Users/me/.agents/skills/abandoned' }] })
  */
 async function clearReviewedOrphanRecord(item: {
   skillName: SkillName
-  agents: Array<{ agentId: AgentId; linkPath: AbsolutePath }>
+  agents: Array<{
+    agentId: AgentId
+    linkPath: AbsolutePath
+    targetPath: AbsolutePath
+  }>
 }): Promise<ClearOrphanSymlinkItemResult> {
   try {
     const blocker = await findOrphanCleanupBlocker(item.skillName)

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -145,16 +145,22 @@ async function restoreQuarantinedPath(
     }
 
     if (quarantineStats.isDirectory()) {
-      await fs.cp(quarantinePath, originalPath, {
-        recursive: true,
-        force: false,
-        errorOnExist: true,
-        verbatimSymlinks: true,
-      })
-      await fs.rm(quarantinePath, { recursive: true, force: true })
+      // Atomic same-directory restore (buildQuarantinePath keeps both paths in
+      // the same dir, so rename can't hit EXDEV). Replaces the previous
+      // cp+rm, which could leave a half-copied tree at originalPath on a
+      // mid-copy failure (ENOSPC/EACCES). The L124-129 pre-check already
+      // guarantees originalPath is absent; if a concurrent process recreated a
+      // *non-empty* dir in the race window, rename fails ENOTEMPTY → caught →
+      // false, so the no-clobber guarantee survives for the dangerous case.
+      await fs.rename(quarantinePath, originalPath)
       return true
     }
 
+    // File and symlink restores intentionally keep copy-then-unlink with
+    // COPYFILE_EXCL / symlink's implicit EEXIST: there is a real
+    // (if narrow) race where originalPath is recreated as a file/symlink after
+    // the pre-check, and plain rename would SILENTLY overwrite it — exactly the
+    // same-path replacement this PR exists to defend against.
     if (quarantineStats.isFile()) {
       await fs.copyFile(quarantinePath, originalPath, constants.COPYFILE_EXCL)
       await fs.unlink(quarantinePath)
@@ -398,7 +404,7 @@ async function clearReviewedBrokenSymlinkSlot(item: {
       )
     }
 
-    validatePath(dirname(item.linkPath), [agent.path])
+    assertAgentSlotPath(item.linkPath, agent.path)
 
     let stats: Stats
     try {
@@ -518,7 +524,7 @@ async function clearReviewedOrphanLink(
     )
   }
 
-  validatePath(dirname(reviewedLink.linkPath), [agent.path])
+  assertAgentSlotPath(reviewedLink.linkPath, agent.path)
 
   let stats: Stats
   try {

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -108,7 +108,7 @@ function buildQuarantinePath(
 }
 
 /**
- * Restore a quarantined path after validation or OS Trash fails.
+ * Restore a quarantined path after validation or OS Trash fails without clobbering replacements.
  * @param quarantinePath - Hidden same-directory path currently holding the entry.
  * @param originalPath - Original reviewed path to restore.
  * @returns true when restoration succeeds or the quarantine is already gone.
@@ -119,10 +119,40 @@ async function restoreQuarantinedPath(
   originalPath: AbsolutePath,
 ): Promise<boolean> {
   try {
-    await fs.rename(quarantinePath, originalPath)
-    return true
+    await fs.lstat(originalPath)
+    return false
+  } catch (error) {
+    if (!isMissingPathError(error)) return false
+  }
+
+  let quarantineStats: Stats
+  try {
+    quarantineStats = await fs.lstat(quarantinePath)
   } catch (error) {
     if (errorCode(error) === 'ENOENT') return true
+    return false
+  }
+
+  try {
+    if (quarantineStats.isSymbolicLink()) {
+      const target = await fs.readlink(quarantinePath)
+      await fs.symlink(target, originalPath)
+      await fs.unlink(quarantinePath)
+      return true
+    }
+
+    if (quarantineStats.isDirectory()) {
+      await fs.cp(quarantinePath, originalPath, {
+        recursive: true,
+        force: false,
+        errorOnExist: true,
+      })
+      await fs.rm(quarantinePath, { recursive: true, force: true })
+      return true
+    }
+
+    return false
+  } catch {
     return false
   }
 }
@@ -181,7 +211,12 @@ async function trashReviewedDirectory(
 
     await shell.trashItem(quarantinePath)
   } catch (error) {
-    await restoreQuarantinedPath(quarantinePath, directoryPath)
+    const restored = await restoreQuarantinedPath(quarantinePath, directoryPath)
+    if (!restored) {
+      throw new Error(
+        `${extractErrorMessage(error)}; quarantined folder could not be restored from ${quarantinePath}`,
+      )
+    }
     throw error
   }
 }
@@ -242,7 +277,12 @@ async function removeLinkPathByKind(
         }
         await fs.unlink(quarantinePath)
       } catch (error) {
-        await restoreQuarantinedPath(quarantinePath, linkPath)
+        const restored = await restoreQuarantinedPath(quarantinePath, linkPath)
+        if (!restored) {
+          throw new Error(
+            `${extractErrorMessage(error)}; quarantined symlink could not be restored from ${quarantinePath}`,
+          )
+        }
         throw error
       }
       return { success: true } as const
@@ -563,7 +603,7 @@ export function registerSkillsHandlers(): void {
    * @returns UnlinkResult with success status and optional error
    */
   typedHandle(IPC_CHANNELS.SKILLS_UNLINK_FROM_AGENT, async (_, options) => {
-    const { agentId, linkPath, confirmedLocalDirectoryDelete = false } = options
+    const { agentId, linkPath } = options
 
     try {
       const agent = findAgentById(agentId)
@@ -593,18 +633,11 @@ export function registerSkillsHandlers(): void {
       }
 
       if (stats.isDirectory() && !stats.isSymbolicLink()) {
-        if (!confirmedLocalDirectoryDelete) {
+        if (options.confirmedLocalDirectoryDelete !== true) {
           return {
             success: false,
             error:
               'Refusing to delete a local skill without explicit confirmation.',
-          }
-        }
-        if (!options.reviewedDirectoryIdentity) {
-          return {
-            success: false,
-            error:
-              'Refusing to delete a local skill without reviewed directory identity.',
           }
         }
         if (
@@ -638,7 +671,9 @@ export function registerSkillsHandlers(): void {
       return await removeLinkPathByKind(
         derivedLinkPath,
         stats,
-        options.targetPath,
+        options.confirmedLocalDirectoryDelete === true
+          ? undefined
+          : options.targetPath,
       )
     } catch (error) {
       return { success: false, error: extractErrorMessage(error) }

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import type { Stats } from 'node:fs'
+import { constants, type Stats } from 'node:fs'
 import * as fs from 'node:fs/promises'
 import { basename, dirname, join, resolve } from 'node:path'
 
@@ -148,6 +148,12 @@ async function restoreQuarantinedPath(
         errorOnExist: true,
       })
       await fs.rm(quarantinePath, { recursive: true, force: true })
+      return true
+    }
+
+    if (quarantineStats.isFile()) {
+      await fs.copyFile(quarantinePath, originalPath, constants.COPYFILE_EXCL)
+      await fs.unlink(quarantinePath)
       return true
     }
 

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -46,7 +46,7 @@ type AgentPathRemovalResult =
   | { success: false; error: string; code?: string }
 
 /**
- * Require a renderer path to name the same slot the main process derives.
+ * Require a renderer path to name the same derived main-process path.
  * @param rendererPath - Path supplied over IPC for backward-compatible callers
  * @param derivedPath - Path calculated from validated main-process state
  * @param subject - Human-readable path kind for error messages
@@ -64,6 +64,26 @@ function assertDerivedPathMatch(
     )
   }
   return derivedPath
+}
+
+/**
+ * Require a reviewed linkPath to be one direct child of the selected agent skills dir.
+ * @param rendererPath - Agent-side slot path reviewed in the renderer.
+ * @param agentPath - Selected agent skills directory from main-process constants.
+ * @returns Normalized rendererPath once its parent matches the selected agent dir.
+ * @example assertAgentSlotPath('/Users/me/.cursor/skills/slot', '/Users/me/.cursor/skills')
+ */
+function assertAgentSlotPath(
+  rendererPath: AbsolutePath,
+  agentPath: AbsolutePath,
+): AbsolutePath {
+  const normalizedPath = resolve(rendererPath)
+  if (dirname(normalizedPath) !== resolve(agentPath)) {
+    throw new Error(
+      'Renderer link path does not match the selected agent slot.',
+    )
+  }
+  return normalizedPath as AbsolutePath
 }
 
 /**
@@ -398,12 +418,7 @@ export function registerSkillsHandlers(): void {
    * @returns UnlinkResult with success status and optional error
    */
   typedHandle(IPC_CHANNELS.SKILLS_UNLINK_FROM_AGENT, async (_, options) => {
-    const {
-      agentId,
-      skillName,
-      linkPath,
-      confirmedLocalDirectoryDelete = false,
-    } = options
+    const { agentId, linkPath, confirmedLocalDirectoryDelete = false } = options
 
     try {
       const agent = findAgentById(agentId)
@@ -411,10 +426,9 @@ export function registerSkillsHandlers(): void {
         return { success: false, error: 'Agent not found' }
       }
 
-      const derivedLinkPath = assertDerivedPathMatch(
+      const derivedLinkPath = assertAgentSlotPath(
         linkPath,
-        join(agent.path, skillName) as AbsolutePath,
-        'link path',
+        agent.path as AbsolutePath,
       )
 
       // Allow agent dirs (for local skills) AND SOURCE_DIR (for symlinked skills).

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -1,6 +1,7 @@
+import { randomUUID } from 'node:crypto'
 import type { Stats } from 'node:fs'
 import * as fs from 'node:fs/promises'
-import { dirname, join, resolve } from 'node:path'
+import { basename, dirname, join, resolve } from 'node:path'
 
 import type { IpcMainInvokeEvent } from 'electron'
 import { shell } from 'electron'
@@ -37,6 +38,7 @@ import type {
   BulkUnlinkItemResult,
   BulkUnlinkResult,
   RestoreDeletedSkillResult,
+  FilesystemEntryIdentity,
   SkillName,
 } from '@/shared/types'
 
@@ -89,25 +91,160 @@ function assertAgentSlotPath(
 }
 
 /**
+ * Build a hidden sibling path for identity-bound destructive OS Trash commits.
+ * @param reviewedPath - Original reviewed path that will be quarantined.
+ * @param label - Operation label used in the hidden basename.
+ * @returns Hidden same-directory path for atomic rename before commit.
+ * @example buildQuarantinePath('/Users/me/.cursor/skills/task', 'unlink')
+ */
+function buildQuarantinePath(
+  reviewedPath: AbsolutePath,
+  label: string,
+): AbsolutePath {
+  return join(
+    dirname(reviewedPath),
+    `${basename(reviewedPath)}.${label}-${randomUUID()}`,
+  ) as AbsolutePath
+}
+
+/**
+ * Restore a quarantined path after validation or OS Trash fails.
+ * @param quarantinePath - Hidden same-directory path currently holding the entry.
+ * @param originalPath - Original reviewed path to restore.
+ * @returns true when restoration succeeds or the quarantine is already gone.
+ * @example restoreQuarantinedPath('/Users/me/.cursor/skills/.task.unlink-id', '/Users/me/.cursor/skills/task')
+ */
+async function restoreQuarantinedPath(
+  quarantinePath: AbsolutePath,
+  originalPath: AbsolutePath,
+): Promise<boolean> {
+  try {
+    await fs.rename(quarantinePath, originalPath)
+    return true
+  } catch (error) {
+    if (errorCode(error) === 'ENOENT') return true
+    return false
+  }
+}
+
+/**
+ * Move a reviewed directory to OS Trash only after quarantined identity revalidation.
+ * @param directoryPath - Reviewed directory path to trash.
+ * @param reviewedIdentity - Filesystem identity captured at review time.
+ * @param options - Human-readable stale error and optional skill-directory validation.
+ * @returns void when the quarantined reviewed directory reaches OS Trash.
+ * @example
+ * await trashReviewedDirectory('/Users/me/.cursor/skills/task', identity, { staleMessage: 'Reviewed local skill folder changed since review', validateSkillDirectory: true })
+ */
+async function trashReviewedDirectory(
+  directoryPath: AbsolutePath,
+  reviewedIdentity: FilesystemEntryIdentity,
+  options: {
+    staleMessage: string
+    validateSkillDirectory: boolean
+  },
+): Promise<void> {
+  const quarantinePath = buildQuarantinePath(directoryPath, 'trash')
+  await fs.rename(directoryPath, quarantinePath)
+
+  try {
+    const quarantinedStats = await fs.lstat(quarantinePath)
+    if (
+      !quarantinedStats.isDirectory() ||
+      quarantinedStats.isSymbolicLink() ||
+      !isSameFilesystemIdentity(quarantinedStats, reviewedIdentity)
+    ) {
+      const restored = await restoreQuarantinedPath(
+        quarantinePath,
+        directoryPath,
+      )
+      throw new Error(
+        restored
+          ? options.staleMessage
+          : `${options.staleMessage}; quarantined folder could not be restored from ${quarantinePath}`,
+      )
+    }
+    if (
+      options.validateSkillDirectory &&
+      !(await isValidSkillDir(quarantinePath))
+    ) {
+      const restored = await restoreQuarantinedPath(
+        quarantinePath,
+        directoryPath,
+      )
+      throw new Error(
+        restored
+          ? 'Reviewed local skill folder is no longer a valid skill.'
+          : `Reviewed local skill folder is no longer a valid skill; quarantined folder could not be restored from ${quarantinePath}`,
+      )
+    }
+
+    await shell.trashItem(quarantinePath)
+  } catch (error) {
+    await restoreQuarantinedPath(quarantinePath, directoryPath)
+    throw error
+  }
+}
+
+/**
  * Remove an agent symlink path after the caller has already validated and
  * lstat'd it. Directories are refused here so destructive local-folder removal
  * remains isolated to the single-unlink confirmation path.
  * @param linkPath - Validated path inside an agent skills directory
  * @param stats - `lstat` result for linkPath
+ * @param reviewedTargetPath - Target path captured when the symlink row was reviewed.
  * @returns Structured IPC result for renderer toast handling
  * @example
- * removeLinkPathByKind('/Users/me/.cursor/skills/task', stats)
+ * removeLinkPathByKind('/Users/me/.cursor/skills/task', stats, '/Users/me/.agents/skills/task')
  */
 async function removeLinkPathByKind(
   linkPath: AbsolutePath,
   stats: Stats,
+  reviewedTargetPath?: AbsolutePath,
 ): Promise<AgentPathRemovalResult> {
   return match({
     isSymlink: stats.isSymbolicLink(),
     isDirectory: stats.isDirectory(),
   })
     .with({ isSymlink: true }, async () => {
-      await fs.unlink(linkPath)
+      if (!reviewedTargetPath) {
+        return {
+          success: false as const,
+          error: 'Refusing to unlink a symlink without reviewed target path.',
+          code: 'ESTALE',
+        }
+      }
+      const quarantinePath = buildQuarantinePath(linkPath, 'unlink')
+      try {
+        await fs.rename(linkPath, quarantinePath)
+      } catch (error) {
+        if (errorCode(error) === 'ENOENT') return { success: true } as const
+        throw error
+      }
+      try {
+        const rawTarget = await fs.readlink(quarantinePath)
+        const resolvedTarget = await resolveRawSymlinkTarget(
+          quarantinePath,
+          rawTarget,
+        )
+        if (resolve(resolvedTarget) !== resolve(reviewedTargetPath)) {
+          const restored = await restoreQuarantinedPath(
+            quarantinePath,
+            linkPath,
+          )
+          return {
+            success: false as const,
+            error: restored
+              ? 'Reviewed symlink target changed since review.'
+              : `Reviewed symlink target changed since review; quarantined symlink could not be restored from ${quarantinePath}`,
+            code: 'ESTALE',
+          }
+        }
+        await fs.unlink(quarantinePath)
+      } catch (error) {
+        await restoreQuarantinedPath(quarantinePath, linkPath)
+        throw error
+      }
       return { success: true } as const
     })
     .with(
@@ -129,12 +266,14 @@ async function removeLinkPathByKind(
  * Remove the exact reviewed agent slot after validating it belongs to selected agent.
  * @param agentPath - Selected agent skills directory from main constants.
  * @param linkPath - Renderer-reviewed slot path to remove.
+ * @param reviewedTargetPath - Renderer-reviewed symlink target path, required when current slot is a symlink.
  * @returns Structured IPC result for bulk unlink reporting.
- * @example removeReviewedPathFromAgent('/Users/me/.cursor/skills', '/Users/me/.cursor/skills/folder-name')
+ * @example removeReviewedPathFromAgent('/Users/me/.cursor/skills', '/Users/me/.cursor/skills/folder-name', '/Users/me/.agents/skills/folder-name')
  */
 async function removeReviewedPathFromAgent(
   agentPath: AbsolutePath,
   linkPath: AbsolutePath,
+  reviewedTargetPath?: AbsolutePath,
 ): Promise<
   { success: true } | { success: false; error: string; code?: string }
 > {
@@ -170,7 +309,11 @@ async function removeReviewedPathFromAgent(
   }
 
   try {
-    return await removeLinkPathByKind(reviewedLinkPath, stats)
+    return await removeLinkPathByKind(
+      reviewedLinkPath,
+      stats,
+      reviewedTargetPath,
+    )
   } catch (error) {
     return {
       success: false,
@@ -479,14 +622,24 @@ export function registerSkillsHandlers(): void {
           }
         }
 
-        // Local skill deletion arrives from UnlinkDialog's destructive confirm
-        // action. Move to OS Trash instead of recursively deleting bytes so a
-        // mistaken confirmation is still recoverable at the filesystem level.
-        await shell.trashItem(derivedLinkPath)
+        // Quarantine before OS Trash so the commit acts on the reviewed folder,
+        // not a same-path replacement created after the dialog opened.
+        await trashReviewedDirectory(
+          derivedLinkPath,
+          options.reviewedDirectoryIdentity,
+          {
+            staleMessage: 'Reviewed local skill folder changed since review.',
+            validateSkillDirectory: true,
+          },
+        )
         return { success: true }
       }
 
-      return await removeLinkPathByKind(derivedLinkPath, stats)
+      return await removeLinkPathByKind(
+        derivedLinkPath,
+        stats,
+        options.targetPath,
+      )
     } catch (error) {
       return { success: false, error: extractErrorMessage(error) }
     }
@@ -501,7 +654,7 @@ export function registerSkillsHandlers(): void {
    * would wipe `~/.agents/skills` and cascade into every universal agent —
    * the exact v0.13.0 regression that motivated this handler rewrite.
    *
-   * @param options - agentId, agentPath
+   * @param options - agentId, agentPath, and reviewed directory identity.
    * @returns RemoveAllFromAgentResult with item count removed
    */
   typedHandle(IPC_CHANNELS.SKILLS_REMOVE_ALL_FROM_AGENT, async (_, options) => {
@@ -542,14 +695,30 @@ export function registerSkillsHandlers(): void {
         }
       }
 
-      // Idempotent missing-dir handling: `shell.trashItem` throws ENOENT,
-      // unlike the old `fs.rm({ force: true })` this handler used to call.
-      // Short-circuit when the dir is already gone so double-clicks and
-      // out-of-band deletes don't surface as errors.
+      // Idempotent missing-dir handling: lstat first because shell.trashItem
+      // throws ENOENT and follows no reviewed identity by itself.
+      let stats: Stats
       try {
-        await fs.access(derivedAgentPath)
-      } catch {
-        return { success: true, removedCount: 0 }
+        stats = await fs.lstat(derivedAgentPath)
+      } catch (error) {
+        if (errorCode(error) === 'ENOENT') {
+          return { success: true, removedCount: 0 }
+        }
+        throw error
+      }
+      if (!stats.isDirectory() || stats.isSymbolicLink()) {
+        return {
+          success: false,
+          removedCount: 0,
+          error: 'Reviewed agent skills path is no longer a real directory.',
+        }
+      }
+      if (!isSameFilesystemIdentity(stats, options.filesystemIdentity)) {
+        return {
+          success: false,
+          removedCount: 0,
+          error: 'Reviewed agent skills folder changed since review.',
+        }
       }
 
       // Count entries before deletion for reporting
@@ -561,9 +730,16 @@ export function registerSkillsHandlers(): void {
         // Directory may be unreadable (permissions) — proceed to trash anyway
       }
 
-      // Move to OS trash instead of hard-rm so accidents can be restored from
-      // Finder > Trash.
-      await shell.trashItem(derivedAgentPath)
+      // Move to OS trash instead of hard-rm, but only after quarantining the
+      // exact reviewed skills folder to close same-path replacement races.
+      await trashReviewedDirectory(
+        derivedAgentPath,
+        options.filesystemIdentity,
+        {
+          staleMessage: 'Reviewed agent skills folder changed since review.',
+          validateSkillDirectory: false,
+        },
+      )
 
       return { success: true, removedCount }
     } catch (error) {
@@ -713,7 +889,7 @@ export function registerSkillsHandlers(): void {
    * Batch unlink N skills from a single agent. Unlink is benign (it only
    * removes one symlink/folder, doesn't touch the source), so no trash entry
    * is created. Runs serially for predictable error reporting.
-   * @param options - agentId, items
+   * @param options - agentId and reviewed linkPath+targetPath items.
    * @returns BulkUnlinkResult with per-item discriminated outcome
    */
   typedHandle(
@@ -737,8 +913,12 @@ export function registerSkillsHandlers(): void {
         return result
       }
 
-      for (const { skillName, linkPath } of items) {
-        const outcome = await removeReviewedPathFromAgent(agent.path, linkPath)
+      for (const { skillName, linkPath, targetPath } of items) {
+        const outcome = await removeReviewedPathFromAgent(
+          agent.path,
+          linkPath,
+          targetPath,
+        )
         if (outcome.success) {
           results.push({ skillName, outcome: 'unlinked' })
         } else {

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -41,25 +41,24 @@ type AgentPathRemovalResult =
   | { success: false; error: string; code?: string }
 
 /**
- * Revalidate and unlink one reviewed dangling symlink without moving replacements.
- * @param options - Exact reviewed path/target plus messages for stale-target cases.
- * @returns `missing` when the slot was already gone; otherwise `unlinked`.
+ * Read and verify the exact reviewed symlink target at the destructive slot.
+ * @param options - Reviewed link path, target path, and stale-target message.
+ * @returns Raw and resolved target for the still-reviewed symlink.
  * @example
- * await unlinkReviewedDanglingSymlink({ linkPath, targetPath, targetChangedMessage, targetExistsMessage, targetProbePrefix })
+ * await readReviewedDanglingSymlink({ linkPath, targetPath, targetChangedMessage })
  */
-async function unlinkReviewedDanglingSymlink(options: {
+async function readReviewedDanglingSymlink(options: {
   linkPath: AbsolutePath
   targetPath: AbsolutePath
   targetChangedMessage: string
-  targetExistsMessage: string
-  targetProbePrefix: string
-  beforeTargetProbe?: () => Promise<void>
-}): Promise<'missing' | 'unlinked'> {
+}): Promise<{ rawTarget: string; resolvedTarget: AbsolutePath }> {
   let stats: Stats
   try {
     stats = await fs.lstat(options.linkPath)
   } catch (error) {
-    if (isMissingPathError(error)) return 'missing'
+    if (isMissingPathError(error)) {
+      throw new TrashError('Reviewed cleanup slot is already missing', 'ENOENT')
+    }
     throw new TrashError(extractErrorMessage(error), errorCode(error))
   }
 
@@ -74,7 +73,9 @@ async function unlinkReviewedDanglingSymlink(options: {
   try {
     rawTarget = await fs.readlink(options.linkPath)
   } catch (error) {
-    if (isMissingPathError(error)) return 'missing'
+    if (isMissingPathError(error)) {
+      throw new TrashError('Reviewed cleanup slot is already missing', 'ENOENT')
+    }
     throw new TrashError(
       'Reviewed cleanup slot is no longer a symlink',
       'ESTALE',
@@ -89,25 +90,74 @@ async function unlinkReviewedDanglingSymlink(options: {
     throw new TrashError(options.targetChangedMessage, 'ESTALE')
   }
 
-  await options.beforeTargetProbe?.()
+  return { rawTarget, resolvedTarget }
+}
 
+/**
+ * Assert the reviewed symlink target is still absent and cleanup-safe.
+ * @param resolvedTarget - Absolute target path resolved from the reviewed symlink.
+ * @param targetExistsMessage - Stale message when the source target reappears.
+ * @param targetProbePrefix - Prefix for non-missing probe failures.
+ * @returns void when the target remains missing.
+ * @example
+ * await assertReviewedTargetMissing('/Users/me/.agents/skills/task', 'Target exists', 'Cannot verify target')
+ */
+async function assertReviewedTargetMissing(
+  resolvedTarget: AbsolutePath,
+  targetExistsMessage: string,
+  targetProbePrefix: string,
+): Promise<void> {
   try {
     await fs.access(resolvedTarget)
-    throw new TrashError(options.targetExistsMessage, 'ESTALE')
+    throw new TrashError(targetExistsMessage, 'ESTALE')
   } catch (error) {
     if (error instanceof TrashError) throw error
     if (!isMissingPathError(error)) {
       throw new TrashError(
-        `${options.targetProbePrefix}: ${extractErrorMessage(error)}`,
+        `${targetProbePrefix}: ${extractErrorMessage(error)}`,
         errorCode(error),
       )
     }
   }
+}
 
+/**
+ * Revalidate and unlink one reviewed dangling symlink without moving replacements.
+ * @param options - Exact reviewed path/target plus messages for stale-target cases.
+ * @returns `missing` when the slot was already gone; otherwise `unlinked`.
+ * @example
+ * await unlinkReviewedDanglingSymlink({ linkPath, targetPath, targetChangedMessage, targetExistsMessage, targetProbePrefix })
+ */
+async function unlinkReviewedDanglingSymlink(options: {
+  linkPath: AbsolutePath
+  targetPath: AbsolutePath
+  targetChangedMessage: string
+  targetExistsMessage: string
+  targetProbePrefix: string
+  beforeTargetProbe?: () => Promise<void>
+}): Promise<'missing' | 'unlinked'> {
   try {
+    const reviewed = await readReviewedDanglingSymlink(options)
+
+    await options.beforeTargetProbe?.()
+
+    await assertReviewedTargetMissing(
+      reviewed.resolvedTarget,
+      options.targetExistsMessage,
+      options.targetProbePrefix,
+    )
+
+    const finalReviewed = await readReviewedDanglingSymlink(options)
+    await assertReviewedTargetMissing(
+      finalReviewed.resolvedTarget,
+      options.targetExistsMessage,
+      options.targetProbePrefix,
+    )
+
     await fs.unlink(options.linkPath)
   } catch (error) {
     if (isMissingPathError(error)) return 'missing'
+    if (error instanceof TrashError) throw error
     const code = errorCode(error)
     // A concurrent folder replacement should never be moved or removed.
     if (code === 'EISDIR' || code === 'EPERM' || code === 'EINVAL') {

--- a/src/main/ipc/skills.unlinkFromAgent.integration.test.ts
+++ b/src/main/ipc/skills.unlinkFromAgent.integration.test.ts
@@ -216,7 +216,7 @@ describe('skills:unlinkFromAgent handler', () => {
     const handler = getRegisteredInvokeHandler<
       {
         agentId: AgentId
-        items: Array<{ skillName: SkillName; linkPath?: AbsolutePath }>
+        items: Array<{ skillName: SkillName; linkPath: AbsolutePath }>
       },
       BulkUnlinkResult
     >('skills:unlinkManyFromAgent')

--- a/src/main/ipc/skills.unlinkFromAgent.integration.test.ts
+++ b/src/main/ipc/skills.unlinkFromAgent.integration.test.ts
@@ -139,4 +139,36 @@ describe('skills:unlinkFromAgent handler', () => {
     await expect(lstat(claudeLinkPath)).resolves.toBeDefined()
     expect(trashItemMock).not.toHaveBeenCalled()
   })
+
+  it('unlinks the reviewed slot when metadata name differs from the folder basename', async () => {
+    // Arrange
+    const metadataName = 'metadata-title'
+    const slotName = 'folder-basename'
+    const sourcePath = join(tempHome, '.agents', 'skills', slotName)
+    const cursorLinkPath = join(tempHome, '.cursor', 'skills', slotName)
+    await mkdir(sourcePath, { recursive: true })
+    await mkdir(join(tempHome, '.cursor', 'skills'), { recursive: true })
+    await writeFile(join(sourcePath, 'SKILL.md'), `name: ${metadataName}\n`)
+    await symlink(sourcePath, cursorLinkPath)
+
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+
+    // Act
+    const handler = getRegisteredHandler('skills:unlinkFromAgent')
+    const result = await handler(
+      {},
+      {
+        skillName: metadataName,
+        agentId: 'cursor',
+        linkPath: cursorLinkPath,
+      },
+    )
+
+    // Assert
+    expect(result.success).toBe(true)
+    await expect(lstat(cursorLinkPath)).rejects.toThrow(/ENOENT/)
+    await expect(lstat(sourcePath)).resolves.toBeDefined()
+    expect(trashItemMock).not.toHaveBeenCalled()
+  })
 })

--- a/src/main/ipc/skills.unlinkFromAgent.integration.test.ts
+++ b/src/main/ipc/skills.unlinkFromAgent.integration.test.ts
@@ -5,10 +5,12 @@ import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { filesystemIdentityFromStats } from '@/main/services/filesystemIdentity'
 import type {
   AbsolutePath,
   AgentId,
   BulkUnlinkResult,
+  FilesystemEntryIdentity,
   SkillName,
 } from '@/shared/types'
 
@@ -36,7 +38,9 @@ function getRegisteredHandler(channel: string): (
     skillName: string
     agentId: string
     linkPath: string
+    targetPath?: string
     confirmedLocalDirectoryDelete?: boolean
+    reviewedDirectoryIdentity?: FilesystemEntryIdentity
   },
 ) => Promise<{ success: boolean; error?: string }> {
   const registration = handleMock.mock.calls.find(([name]) => name === channel)
@@ -49,7 +53,9 @@ function getRegisteredHandler(channel: string): (
       skillName: string
       agentId: string
       linkPath: string
+      targetPath?: string
       confirmedLocalDirectoryDelete?: boolean
+      reviewedDirectoryIdentity?: FilesystemEntryIdentity
     },
   ) => Promise<{ success: boolean; error?: string }>
 }
@@ -185,6 +191,7 @@ describe('skills:unlinkFromAgent handler', () => {
         skillName: metadataName,
         agentId: 'cursor',
         linkPath: cursorLinkPath,
+        targetPath: sourcePath,
       },
     )
 
@@ -216,7 +223,11 @@ describe('skills:unlinkFromAgent handler', () => {
     const handler = getRegisteredInvokeHandler<
       {
         agentId: AgentId
-        items: Array<{ skillName: SkillName; linkPath: AbsolutePath }>
+        items: Array<{
+          skillName: SkillName
+          linkPath: AbsolutePath
+          targetPath: AbsolutePath
+        }>
       },
       BulkUnlinkResult
     >('skills:unlinkManyFromAgent')
@@ -224,7 +235,13 @@ describe('skills:unlinkFromAgent handler', () => {
       {},
       {
         agentId: 'cursor' as AgentId,
-        items: [{ skillName: metadataName, linkPath: cursorLinkPath }],
+        items: [
+          {
+            skillName: metadataName,
+            linkPath: cursorLinkPath,
+            targetPath: sourcePath as AbsolutePath,
+          },
+        ],
       },
     )
 
@@ -236,5 +253,101 @@ describe('skills:unlinkFromAgent handler', () => {
     await expect(lstat(decoyLinkPath)).resolves.toBeDefined()
     await expect(lstat(sourcePath)).resolves.toBeDefined()
     expect(trashItemMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects local folder delete without reviewed directory identity', async () => {
+    // Arrange
+    const skillName = 'local-missing-identity'
+    const localPath = join(tempHome, '.cursor', 'skills', skillName)
+    await mkdir(localPath, { recursive: true })
+    await writeFile(join(localPath, 'SKILL.md'), `name: ${skillName}\n`)
+
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+
+    // Act
+    const handler = getRegisteredHandler('skills:unlinkFromAgent')
+    const result = await handler(
+      {},
+      {
+        skillName,
+        agentId: 'cursor',
+        linkPath: localPath,
+        confirmedLocalDirectoryDelete: true,
+      },
+    )
+
+    // Assert
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/reviewed directory identity/i)
+    await expect(lstat(localPath)).resolves.toBeDefined()
+    expect(trashItemMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects local folder delete when same path was replaced after review', async () => {
+    // Arrange
+    const skillName = 'local-stale-identity'
+    const localPath = join(tempHome, '.cursor', 'skills', skillName)
+    await mkdir(localPath, { recursive: true })
+    await writeFile(join(localPath, 'SKILL.md'), `name: ${skillName}\n`)
+    const reviewedIdentity = filesystemIdentityFromStats(await lstat(localPath))
+    await rm(localPath, { recursive: true, force: true })
+    await mkdir(localPath, { recursive: true })
+    await writeFile(join(localPath, 'SKILL.md'), `name: ${skillName}\n`)
+
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+
+    // Act
+    const handler = getRegisteredHandler('skills:unlinkFromAgent')
+    const result = await handler(
+      {},
+      {
+        skillName,
+        agentId: 'cursor',
+        linkPath: localPath,
+        confirmedLocalDirectoryDelete: true,
+        reviewedDirectoryIdentity: reviewedIdentity,
+      },
+    )
+
+    // Assert
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/changed since review/i)
+    await expect(lstat(localPath)).resolves.toBeDefined()
+    expect(trashItemMock).not.toHaveBeenCalled()
+  })
+
+  it('trashes the quarantined reviewed local folder when identity still matches', async () => {
+    // Arrange
+    const skillName = 'local-reviewed-trash'
+    const localPath = join(tempHome, '.cursor', 'skills', skillName)
+    await mkdir(localPath, { recursive: true })
+    await writeFile(join(localPath, 'SKILL.md'), `name: ${skillName}\n`)
+    const reviewedIdentity = filesystemIdentityFromStats(await lstat(localPath))
+
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+
+    // Act
+    const handler = getRegisteredHandler('skills:unlinkFromAgent')
+    const result = await handler(
+      {},
+      {
+        skillName,
+        agentId: 'cursor',
+        linkPath: localPath,
+        confirmedLocalDirectoryDelete: true,
+        reviewedDirectoryIdentity: reviewedIdentity,
+      },
+    )
+
+    // Assert
+    expect(result.success).toBe(true)
+    await expect(lstat(localPath)).rejects.toThrow(/ENOENT/)
+    expect(trashItemMock).toHaveBeenCalledTimes(1)
+    expect(String(trashItemMock.mock.calls[0][0])).toContain(
+      join(tempHome, '.cursor', 'skills', 'local-reviewed-trash.trash-'),
+    )
   })
 })

--- a/src/main/ipc/skills.unlinkFromAgent.integration.test.ts
+++ b/src/main/ipc/skills.unlinkFromAgent.integration.test.ts
@@ -5,6 +5,13 @@ import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type {
+  AbsolutePath,
+  AgentId,
+  BulkUnlinkResult,
+  SkillName,
+} from '@/shared/types'
+
 const handleMock = vi.fn()
 const trashItemMock = vi.fn()
 
@@ -45,6 +52,22 @@ function getRegisteredHandler(channel: string): (
       confirmedLocalDirectoryDelete?: boolean
     },
   ) => Promise<{ success: boolean; error?: string }>
+}
+
+/**
+ * Return a typed IPC handler from the mocked Electron registry.
+ * @param channel - IPC channel name to locate.
+ * @returns Handler registered by registerSkillsHandlers().
+ * @example getRegisteredInvokeHandler('skills:unlinkManyFromAgent')
+ */
+function getRegisteredInvokeHandler<TArg, TResult>(
+  channel: string,
+): (event: unknown, arg: TArg) => Promise<TResult> {
+  const registration = handleMock.mock.calls.find(([name]) => name === channel)
+  if (!registration) {
+    throw new Error(`No handler registered for ${channel}`)
+  }
+  return registration[1] as (event: unknown, arg: TArg) => Promise<TResult>
 }
 
 describe('skills:unlinkFromAgent handler', () => {
@@ -168,6 +191,49 @@ describe('skills:unlinkFromAgent handler', () => {
     // Assert
     expect(result.success).toBe(true)
     await expect(lstat(cursorLinkPath)).rejects.toThrow(/ENOENT/)
+    await expect(lstat(sourcePath)).resolves.toBeDefined()
+    expect(trashItemMock).not.toHaveBeenCalled()
+  })
+
+  it('bulk unlink removes reviewed slot when metadata name differs from folder basename', async () => {
+    // Arrange
+    const metadataName = 'metadata-title-bulk' as SkillName
+    const slotName = 'folder-basename-bulk'
+    const sourcePath = join(tempHome, '.agents', 'skills', slotName)
+    const cursorSkillsDir = join(tempHome, '.cursor', 'skills')
+    const cursorLinkPath = join(cursorSkillsDir, slotName) as AbsolutePath
+    const decoyLinkPath = join(cursorSkillsDir, metadataName)
+    await mkdir(sourcePath, { recursive: true })
+    await mkdir(cursorSkillsDir, { recursive: true })
+    await writeFile(join(sourcePath, 'SKILL.md'), `name: ${metadataName}\n`)
+    await symlink(sourcePath, cursorLinkPath)
+    await symlink(sourcePath, decoyLinkPath)
+
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+
+    // Act
+    const handler = getRegisteredInvokeHandler<
+      {
+        agentId: AgentId
+        items: Array<{ skillName: SkillName; linkPath?: AbsolutePath }>
+      },
+      BulkUnlinkResult
+    >('skills:unlinkManyFromAgent')
+    const result = await handler(
+      {},
+      {
+        agentId: 'cursor' as AgentId,
+        items: [{ skillName: metadataName, linkPath: cursorLinkPath }],
+      },
+    )
+
+    // Assert
+    expect(result.items).toEqual([
+      { skillName: metadataName, outcome: 'unlinked' },
+    ])
+    await expect(lstat(cursorLinkPath)).rejects.toThrow(/ENOENT/)
+    await expect(lstat(decoyLinkPath)).resolves.toBeDefined()
     await expect(lstat(sourcePath)).resolves.toBeDefined()
     expect(trashItemMock).not.toHaveBeenCalled()
   })

--- a/src/main/ipc/skills.unlinkFromAgent.integration.test.ts
+++ b/src/main/ipc/skills.unlinkFromAgent.integration.test.ts
@@ -1,0 +1,142 @@
+import { lstat, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import type * as NodeOs from 'node:os'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const handleMock = vi.fn()
+const trashItemMock = vi.fn()
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (...args: unknown[]) => handleMock(...args),
+  },
+  shell: {
+    trashItem: (...args: unknown[]) => trashItemMock(...args),
+  },
+}))
+
+/**
+ * Return the registered unlink IPC handler from the mocked Electron registry.
+ * @param channel - IPC channel name to locate.
+ * @returns Handler registered by registerSkillsHandlers().
+ * @example getRegisteredHandler('skills:unlinkFromAgent')
+ */
+function getRegisteredHandler(channel: string): (
+  event: unknown,
+  arg: {
+    skillName: string
+    agentId: string
+    linkPath: string
+    confirmedLocalDirectoryDelete?: boolean
+  },
+) => Promise<{ success: boolean; error?: string }> {
+  const registration = handleMock.mock.calls.find(([name]) => name === channel)
+  if (!registration) {
+    throw new Error(`No handler registered for ${channel}`)
+  }
+  return registration[1] as (
+    event: unknown,
+    arg: {
+      skillName: string
+      agentId: string
+      linkPath: string
+      confirmedLocalDirectoryDelete?: boolean
+    },
+  ) => Promise<{ success: boolean; error?: string }>
+}
+
+describe('skills:unlinkFromAgent handler', () => {
+  let tempHome = ''
+
+  beforeEach(async () => {
+    vi.resetModules()
+    handleMock.mockReset()
+    trashItemMock.mockReset()
+    trashItemMock.mockResolvedValue(undefined)
+    tempHome = await mkdtemp(join(tmpdir(), 'skills-desktop-unlink-'))
+    vi.doMock('os', async () => {
+      const actual = await vi.importActual<typeof NodeOs>('os')
+      return {
+        ...actual,
+        homedir: () => tempHome,
+      }
+    })
+    vi.doMock('node:os', async () => {
+      const actual = await vi.importActual<typeof NodeOs>('node:os')
+      return {
+        ...actual,
+        homedir: () => tempHome,
+      }
+    })
+  })
+
+  afterEach(async () => {
+    vi.doUnmock('os')
+    vi.doUnmock('node:os')
+    await rm(tempHome, { recursive: true, force: true })
+  })
+
+  it('rejects a source path when the selected agent is Cursor', async () => {
+    // Arrange
+    const skillName = 'unlink-source-path-guard-fixture'
+    const sourcePath = join(tempHome, '.agents', 'skills', skillName)
+    await mkdir(sourcePath, { recursive: true })
+    await writeFile(join(sourcePath, 'SKILL.md'), `name: ${skillName}\n`)
+
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+
+    // Act
+    const handler = getRegisteredHandler('skills:unlinkFromAgent')
+    const result = await handler(
+      {},
+      {
+        skillName,
+        agentId: 'cursor',
+        linkPath: sourcePath,
+      },
+    )
+
+    // Assert
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/does not match the selected agent slot/i)
+    await expect(lstat(sourcePath)).resolves.toBeDefined()
+    expect(trashItemMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects another agent slot when the selected agent is Cursor', async () => {
+    // Arrange
+    const skillName = 'unlink-other-agent-path-guard-fixture'
+    const sourcePath = join(tempHome, '.agents', 'skills', skillName)
+    const cursorLinkPath = join(tempHome, '.cursor', 'skills', skillName)
+    const claudeLinkPath = join(tempHome, '.claude', 'skills', skillName)
+    await mkdir(sourcePath, { recursive: true })
+    await mkdir(join(tempHome, '.cursor', 'skills'), { recursive: true })
+    await mkdir(join(tempHome, '.claude', 'skills'), { recursive: true })
+    await symlink(sourcePath, cursorLinkPath)
+    await symlink(sourcePath, claudeLinkPath)
+
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+
+    // Act
+    const handler = getRegisteredHandler('skills:unlinkFromAgent')
+    const result = await handler(
+      {},
+      {
+        skillName,
+        agentId: 'cursor',
+        linkPath: claudeLinkPath,
+      },
+    )
+
+    // Assert
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/does not match the selected agent slot/i)
+    await expect(lstat(cursorLinkPath)).resolves.toBeDefined()
+    await expect(lstat(claudeLinkPath)).resolves.toBeDefined()
+    expect(trashItemMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ipc/skills.unlinkFromAgent.integration.test.ts
+++ b/src/main/ipc/skills.unlinkFromAgent.integration.test.ts
@@ -1,4 +1,13 @@
-import { lstat, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises'
 import type * as NodeOs from 'node:os'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -125,6 +134,7 @@ describe('skills:unlinkFromAgent handler', () => {
         skillName,
         agentId: 'cursor',
         linkPath: sourcePath,
+        targetPath: sourcePath,
       },
     )
 
@@ -158,6 +168,7 @@ describe('skills:unlinkFromAgent handler', () => {
         skillName,
         agentId: 'cursor',
         linkPath: claudeLinkPath,
+        targetPath: sourcePath,
       },
     )
 
@@ -255,7 +266,7 @@ describe('skills:unlinkFromAgent handler', () => {
     expect(trashItemMock).not.toHaveBeenCalled()
   })
 
-  it('rejects local folder delete without reviewed directory identity', async () => {
+  it('rejects local folder delete at IPC validation without reviewed directory identity', async () => {
     // Arrange
     const skillName = 'local-missing-identity'
     const localPath = join(tempHome, '.cursor', 'skills', skillName)
@@ -265,21 +276,50 @@ describe('skills:unlinkFromAgent handler', () => {
     const { registerSkillsHandlers } = await import('./skills')
     registerSkillsHandlers()
 
-    // Act
+    // Act / Assert
     const handler = getRegisteredHandler('skills:unlinkFromAgent')
-    const result = await handler(
-      {},
-      {
-        skillName,
-        agentId: 'cursor',
-        linkPath: localPath,
-        confirmedLocalDirectoryDelete: true,
-      },
-    )
+    await expect(
+      handler(
+        {},
+        {
+          skillName,
+          agentId: 'cursor',
+          linkPath: localPath,
+          confirmedLocalDirectoryDelete: true,
+        },
+      ),
+    ).rejects.toThrow(/IPC validation failed/)
 
     // Assert
-    expect(result.success).toBe(false)
-    expect(result.error).toMatch(/reviewed directory identity/i)
+    await expect(lstat(localPath)).resolves.toBeDefined()
+    expect(trashItemMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects local folder delete without explicit confirmation', async () => {
+    // Arrange
+    const skillName = 'local-missing-confirmation'
+    const localPath = join(tempHome, '.cursor', 'skills', skillName)
+    await mkdir(localPath, { recursive: true })
+    await writeFile(join(localPath, 'SKILL.md'), `name: ${skillName}\n`)
+    const reviewedIdentity = filesystemIdentityFromStats(await lstat(localPath))
+
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+
+    // Act / Assert
+    const handler = getRegisteredHandler('skills:unlinkFromAgent')
+    await expect(
+      handler(
+        {},
+        {
+          skillName,
+          agentId: 'cursor',
+          linkPath: localPath,
+          targetPath: localPath,
+          reviewedDirectoryIdentity: reviewedIdentity,
+        },
+      ),
+    ).rejects.toThrow(/IPC validation failed/)
     await expect(lstat(localPath)).resolves.toBeDefined()
     expect(trashItemMock).not.toHaveBeenCalled()
   })
@@ -349,5 +389,60 @@ describe('skills:unlinkFromAgent handler', () => {
     expect(String(trashItemMock.mock.calls[0][0])).toContain(
       join(tempHome, '.cursor', 'skills', 'local-reviewed-trash.trash-'),
     )
+  })
+
+  it('preserves quarantined local folder when restore path is occupied after trash failure', async () => {
+    // Arrange
+    const skillName = 'local-restore-collision'
+    const cursorSkillsDir = join(tempHome, '.cursor', 'skills')
+    const localPath = join(cursorSkillsDir, skillName)
+    await mkdir(localPath, { recursive: true })
+    await writeFile(join(localPath, 'SKILL.md'), `# original ${skillName}\n`)
+    const reviewedIdentity = filesystemIdentityFromStats(await lstat(localPath))
+    trashItemMock.mockImplementationOnce(async () => {
+      await mkdir(localPath, { recursive: true })
+      await writeFile(
+        join(localPath, 'SKILL.md'),
+        `# replacement ${skillName}\n`,
+      )
+      const error = new Error('forced trash failure') as NodeJS.ErrnoException
+      error.code = 'EACCES'
+      throw error
+    })
+
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+
+    // Act
+    const handler = getRegisteredHandler('skills:unlinkFromAgent')
+    const result = await handler(
+      {},
+      {
+        skillName,
+        agentId: 'cursor',
+        linkPath: localPath,
+        confirmedLocalDirectoryDelete: true,
+        reviewedDirectoryIdentity: reviewedIdentity,
+      },
+    )
+
+    // Assert
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/quarantined folder could not be restored/i)
+    expect(await readFile(join(localPath, 'SKILL.md'), 'utf-8')).toBe(
+      `# replacement ${skillName}\n`,
+    )
+    const entries = await readdir(cursorSkillsDir)
+    const quarantineEntry = entries.find((entry) =>
+      entry.startsWith(`${skillName}.trash-`),
+    )
+    expect(quarantineEntry).toBeDefined()
+    if (!quarantineEntry) return
+    expect(
+      await readFile(
+        join(cursorSkillsDir, quarantineEntry, 'SKILL.md'),
+        'utf-8',
+      ),
+    ).toBe(`# original ${skillName}\n`)
   })
 })

--- a/src/main/ipc/skills.unlinkFromAgent.integration.test.ts
+++ b/src/main/ipc/skills.unlinkFromAgent.integration.test.ts
@@ -8,6 +8,7 @@ import {
   symlink,
   writeFile,
 } from 'node:fs/promises'
+import type * as NodeFsPromises from 'node:fs/promises'
 import type * as NodeOs from 'node:os'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -113,6 +114,7 @@ describe('skills:unlinkFromAgent handler', () => {
   afterEach(async () => {
     vi.doUnmock('os')
     vi.doUnmock('node:os')
+    vi.doUnmock('node:fs/promises')
     await rm(tempHome, { recursive: true, force: true })
   })
 
@@ -264,6 +266,59 @@ describe('skills:unlinkFromAgent handler', () => {
     await expect(lstat(decoyLinkPath)).resolves.toBeDefined()
     await expect(lstat(sourcePath)).resolves.toBeDefined()
     expect(trashItemMock).not.toHaveBeenCalled()
+  })
+
+  it('restores a same-path replacement file when a reviewed symlink changes during unlink', async () => {
+    // Arrange
+    const skillName = 'unlink-race-file-replacement'
+    const sourcePath = join(tempHome, '.agents', 'skills', skillName)
+    const cursorLinkPath = join(tempHome, '.cursor', 'skills', skillName)
+    await mkdir(sourcePath, { recursive: true })
+    await mkdir(join(tempHome, '.cursor', 'skills'), { recursive: true })
+    await writeFile(join(sourcePath, 'SKILL.md'), `name: ${skillName}\n`)
+    await symlink(sourcePath, cursorLinkPath)
+    vi.doMock('node:fs/promises', async () => {
+      const actual =
+        await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
+      return {
+        ...actual,
+        rename: async (oldPath: string, newPath: string): Promise<void> => {
+          if (oldPath === cursorLinkPath && newPath.includes('.unlink-')) {
+            await actual.unlink(oldPath)
+            await actual.writeFile(
+              oldPath,
+              `replacement ${skillName}\n`,
+              'utf-8',
+            )
+          }
+          return actual.rename(oldPath, newPath)
+        },
+      }
+    })
+
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+
+    // Act
+    const handler = getRegisteredHandler('skills:unlinkFromAgent')
+    const result = await handler(
+      {},
+      {
+        skillName,
+        agentId: 'cursor',
+        linkPath: cursorLinkPath,
+        targetPath: sourcePath,
+      },
+    )
+
+    // Assert
+    expect(result.success).toBe(false)
+    expect(await readFile(cursorLinkPath, 'utf-8')).toBe(
+      `replacement ${skillName}\n`,
+    )
+    const leftovers = await readdir(join(tempHome, '.cursor', 'skills'))
+    expect(leftovers.some((entry) => entry.includes('.unlink-'))).toBe(false)
+    await expect(lstat(sourcePath)).resolves.toBeDefined()
   })
 
   it('rejects local folder delete at IPC validation without reviewed directory identity', async () => {

--- a/src/main/ipc/skills.unlinkFromAgent.integration.test.ts
+++ b/src/main/ipc/skills.unlinkFromAgent.integration.test.ts
@@ -386,10 +386,20 @@ describe('skills:unlinkFromAgent handler', () => {
     const localPath = join(tempHome, '.cursor', 'skills', skillName)
     await mkdir(localPath, { recursive: true })
     await writeFile(join(localPath, 'SKILL.md'), `name: ${skillName}\n`)
-    const reviewedIdentity = filesystemIdentityFromStats(await lstat(localPath))
     await rm(localPath, { recursive: true, force: true })
     await mkdir(localPath, { recursive: true })
     await writeFile(join(localPath, 'SKILL.md'), `name: ${skillName}\n`)
+    // Synthesize the reviewed identity from the replacement folder but with a
+    // distinct ctime so the rejection is deterministic regardless of the host
+    // filesystem's ctime granularity (ext4 can reuse the freed inode number,
+    // which would otherwise let the recreated folder pass the dev+ino check).
+    const replacementIdentity = filesystemIdentityFromStats(
+      await lstat(localPath),
+    )
+    const reviewedIdentity: FilesystemEntryIdentity = {
+      ...replacementIdentity,
+      ctimeMs: replacementIdentity.ctimeMs - 60_000,
+    }
 
     const { registerSkillsHandlers } = await import('./skills')
     registerSkillsHandlers()

--- a/src/main/ipc/skills.unlinkFromAgent.integration.test.ts
+++ b/src/main/ipc/skills.unlinkFromAgent.integration.test.ts
@@ -4,6 +4,7 @@ import {
   mkdtemp,
   readdir,
   readFile,
+  readlink,
   rm,
   symlink,
   writeFile,
@@ -499,5 +500,45 @@ describe('skills:unlinkFromAgent handler', () => {
         'utf-8',
       ),
     ).toBe(`# original ${skillName}\n`)
+  })
+
+  it('preserves relative symlinks inside a quarantined local folder after trash failure rollback', async () => {
+    // Arrange
+    const skillName = 'local-restore-relative-symlink'
+    const localPath = join(tempHome, '.cursor', 'skills', skillName)
+    await mkdir(join(localPath, 'links'), { recursive: true })
+    await mkdir(join(localPath, 'target'), { recursive: true })
+    await writeFile(join(localPath, 'target', 'SKILL.md'), '# target\n')
+    await symlink('../target', join(localPath, 'links', 'target-link'))
+    const reviewedIdentity = filesystemIdentityFromStats(await lstat(localPath))
+    trashItemMock.mockRejectedValueOnce(
+      Object.assign(new Error('forced trash failure'), { code: 'EACCES' }),
+    )
+
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+
+    // Act
+    const handler = getRegisteredHandler('skills:unlinkFromAgent')
+    const result = await handler(
+      {},
+      {
+        skillName,
+        agentId: 'cursor',
+        linkPath: localPath,
+        confirmedLocalDirectoryDelete: true,
+        reviewedDirectoryIdentity: reviewedIdentity,
+      },
+    )
+
+    // Assert
+    expect(result.success).toBe(false)
+    await expect(
+      readlink(join(localPath, 'links', 'target-link')),
+    ).resolves.toBe('../target')
+    const entries = await readdir(join(tempHome, '.cursor', 'skills'))
+    expect(
+      entries.some((entry) => entry.startsWith(`${skillName}.trash-`)),
+    ).toBe(false)
   })
 })

--- a/src/main/services/agentScanner.test.ts
+++ b/src/main/services/agentScanner.test.ts
@@ -27,10 +27,12 @@ function createDirent(
 
 const readdirMock = vi.fn()
 const accessMock = vi.fn()
+const lstatMock = vi.fn()
 
 vi.mock('fs/promises', () => ({
   readdir: readdirMock,
   access: accessMock,
+  lstat: lstatMock,
 }))
 
 const checkSymlinkStatusMock = vi.fn()
@@ -59,6 +61,16 @@ vi.mock('../constants', () => ({
 describe('scanAgents', () => {
   beforeEach(() => {
     vi.resetAllMocks()
+    lstatMock.mockResolvedValue({
+      isSymbolicLink: () => false,
+      isDirectory: () => true,
+      isFile: () => false,
+      dev: 1,
+      ino: 2,
+      size: 96,
+      ctimeMs: 3,
+      mtimeMs: 4,
+    })
   })
 
   it('counts only valid symlinks, excluding broken ones', async () => {

--- a/src/main/services/agentScanner.ts
+++ b/src/main/services/agentScanner.ts
@@ -1,9 +1,10 @@
-import { access, readdir } from 'fs/promises'
+import { access, lstat, readdir } from 'fs/promises'
 import { join } from 'path'
 
 import { AGENTS } from '@/main/constants'
 import type { Agent } from '@/shared/types'
 
+import { filesystemIdentityFromStats } from './filesystemIdentity'
 import { checkSymlinkStatus } from './symlinkChecker'
 
 /**
@@ -42,6 +43,11 @@ export async function scanAgents(): Promise<Agent[]> {
             countLocalSkills(agent.path),
           ])
         : [0, 0]
+      const filesystemIdentity = exists
+        ? await lstat(agent.path)
+            .then((stats) => filesystemIdentityFromStats(stats))
+            .catch(() => undefined)
+        : undefined
 
       return {
         id: agent.id,
@@ -50,6 +56,7 @@ export async function scanAgents(): Promise<Agent[]> {
         exists,
         skillCount,
         localSkillCount,
+        filesystemIdentity,
       }
     }),
   )

--- a/src/main/services/filesystemIdentity.test.ts
+++ b/src/main/services/filesystemIdentity.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest'
+
+import type { FilesystemEntryIdentity } from '@/shared/types'
+
+import {
+  isReviewedEntryUnchangedIdentity,
+  isSameFilesystemEntryIdentity,
+} from './filesystemIdentity'
+
+/**
+ * These specs lock in the same-path-replacement guard at the identity level so
+ * the contract holds on every platform — including CI Linux/ext4, which recycles
+ * inode numbers and where the integration tests originally regressed. Building
+ * identities by hand (rather than touching a real filesystem) lets us simulate
+ * inode reuse, which APFS on the dev machine never produces on its own.
+ */
+describe('filesystem identity guards for destructive deletes', () => {
+  // A reviewed source/local skill directory as captured at scan time.
+  const reviewedDirectory: FilesystemEntryIdentity = {
+    kind: 'directory',
+    dev: 16777233,
+    ino: 99,
+    size: 96,
+    ctimeMs: 1_000,
+    mtimeMs: 2_000,
+  }
+
+  describe('isReviewedEntryUnchangedIdentity (strict pre-operation gate)', () => {
+    it('treats a reused-inode same-path replacement as changed so the wrong folder is not deleted', () => {
+      // Arrange: rm+mkdir recycled the inode number, so dev/ino/size/mtime all
+      // collide; only the freshly initialized ctime gives the replacement away.
+      const recreatedWithSameInode: FilesystemEntryIdentity = {
+        kind: 'directory',
+        dev: 16777233,
+        ino: 99,
+        size: 96,
+        ctimeMs: 1_500,
+        mtimeMs: 2_000,
+      }
+
+      // Act
+      const isUnchanged = isReviewedEntryUnchangedIdentity(
+        recreatedWithSameInode,
+        reviewedDirectory,
+      )
+
+      // Assert
+      expect(isUnchanged).toBe(false)
+    })
+
+    it('keeps an untouched reviewed folder deletable when every field matches', () => {
+      // Arrange: same object, nothing changed since review.
+      const unchanged: FilesystemEntryIdentity = {
+        kind: 'directory',
+        dev: 16777233,
+        ino: 99,
+        size: 96,
+        ctimeMs: 1_000,
+        mtimeMs: 2_000,
+      }
+
+      // Act
+      const isUnchanged = isReviewedEntryUnchangedIdentity(
+        unchanged,
+        reviewedDirectory,
+      )
+
+      // Assert
+      expect(isUnchanged).toBe(true)
+    })
+
+    it('rejects a different inode appearing at the reviewed path', () => {
+      // Arrange: a genuinely different object now occupies the path.
+      const differentInode: FilesystemEntryIdentity = {
+        kind: 'directory',
+        dev: 16777233,
+        ino: 100,
+        size: 96,
+        ctimeMs: 1_000,
+        mtimeMs: 2_000,
+      }
+
+      // Act
+      const isUnchanged = isReviewedEntryUnchangedIdentity(
+        differentInode,
+        reviewedDirectory,
+      )
+
+      // Assert
+      expect(isUnchanged).toBe(false)
+    })
+
+    it('rejects when the reviewed directory was replaced by a symlink', () => {
+      // Arrange: kind flipped from directory to symlink.
+      const symlinkAtSamePath: FilesystemEntryIdentity = {
+        kind: 'symlink',
+        dev: 16777233,
+        ino: 99,
+        size: 96,
+        ctimeMs: 1_000,
+        mtimeMs: 2_000,
+      }
+
+      // Act
+      const isUnchanged = isReviewedEntryUnchangedIdentity(
+        symlinkAtSamePath,
+        reviewedDirectory,
+      )
+
+      // Assert
+      expect(isUnchanged).toBe(false)
+    })
+
+    it('rejects a fresh-ctime replacement on a filesystem that reports no inode', () => {
+      // Arrange: dev=ino=0 (no inode support) so identity falls back to
+      // size+ctime+mtime; a replacement bumps ctime even here.
+      const reviewedNoInode: FilesystemEntryIdentity = {
+        kind: 'directory',
+        dev: 0,
+        ino: 0,
+        size: 96,
+        ctimeMs: 1_000,
+        mtimeMs: 2_000,
+      }
+      const replacedNoInode: FilesystemEntryIdentity = {
+        kind: 'directory',
+        dev: 0,
+        ino: 0,
+        size: 96,
+        ctimeMs: 1_500,
+        mtimeMs: 2_000,
+      }
+
+      // Act
+      const isUnchanged = isReviewedEntryUnchangedIdentity(
+        replacedNoInode,
+        reviewedNoInode,
+      )
+
+      // Assert
+      expect(isUnchanged).toBe(false)
+    })
+  })
+
+  describe('isSameFilesystemEntryIdentity (rename-stable post-rename check)', () => {
+    it('still matches a reused-inode entry whose ctime moved, so our own quarantine rename is not flagged stale', () => {
+      // Arrange: rename preserves dev+ino but bumps ctime; the post-rename
+      // re-check must ignore ctime or every legitimate delete would fail.
+      const renamedSameInode: FilesystemEntryIdentity = {
+        kind: 'directory',
+        dev: 16777233,
+        ino: 99,
+        size: 96,
+        ctimeMs: 1_500,
+        mtimeMs: 2_000,
+      }
+
+      // Act
+      const isSame = isSameFilesystemEntryIdentity(
+        renamedSameInode,
+        reviewedDirectory,
+      )
+
+      // Assert
+      expect(isSame).toBe(true)
+    })
+
+    it('rejects a different inode at the reviewed path', () => {
+      // Arrange: different object, different inode.
+      const differentInode: FilesystemEntryIdentity = {
+        kind: 'directory',
+        dev: 16777233,
+        ino: 100,
+        size: 96,
+        ctimeMs: 1_000,
+        mtimeMs: 2_000,
+      }
+
+      // Act
+      const isSame = isSameFilesystemEntryIdentity(
+        differentInode,
+        reviewedDirectory,
+      )
+
+      // Assert
+      expect(isSame).toBe(false)
+    })
+  })
+})

--- a/src/main/services/filesystemIdentity.ts
+++ b/src/main/services/filesystemIdentity.ts
@@ -61,7 +61,15 @@ export function isSameFilesystemEntryIdentity(
 ): boolean {
   if (currentIdentity.kind !== reviewed.kind) return false
 
-  if (currentIdentity.dev !== 0 || currentIdentity.ino !== 0) {
+  // Only trust the dev+ino fast path when BOTH sides carry a real inode. A
+  // 0/0 sentinel means inode info was unavailable at capture; comparing it
+  // would spuriously fail (or pass) so fall back to the stat heuristic below.
+  if (
+    currentIdentity.dev !== 0 &&
+    currentIdentity.ino !== 0 &&
+    reviewed.dev !== 0 &&
+    reviewed.ino !== 0
+  ) {
     return (
       currentIdentity.dev === reviewed.dev &&
       currentIdentity.ino === reviewed.ino

--- a/src/main/services/filesystemIdentity.ts
+++ b/src/main/services/filesystemIdentity.ts
@@ -1,0 +1,71 @@
+import type { Stats } from 'node:fs'
+
+import type { FilesystemEntryIdentity } from '@/shared/types'
+
+/**
+ * Convert Node fs.Stats into the small identity payload reviewed by destructive UI.
+ * @param stats - lstat/stat result for the reviewed filesystem entry.
+ * @returns Serializable identity used to reject same-path replacements.
+ * @example filesystemIdentityFromStats(await fs.lstat('/path/to/skill'))
+ */
+export function filesystemIdentityFromStats(
+  stats: Stats,
+): FilesystemEntryIdentity {
+  return {
+    kind: stats.isSymbolicLink()
+      ? 'symlink'
+      : stats.isDirectory()
+        ? 'directory'
+        : stats.isFile()
+          ? 'file'
+          : 'other',
+    dev: stats.dev,
+    ino: stats.ino,
+    size: stats.size,
+    ctimeMs: stats.ctimeMs,
+    mtimeMs: stats.mtimeMs,
+  }
+}
+
+/**
+ * Check whether current lstat metadata still names the reviewed filesystem entry.
+ * @param current - Current lstat/stat result for the destructive path.
+ * @param reviewed - Identity captured when the user reviewed the row.
+ * @returns True when the same path still points at the reviewed object.
+ * @example isSameFilesystemIdentity(await fs.lstat(path), reviewedIdentity)
+ */
+export function isSameFilesystemIdentity(
+  current: Stats,
+  reviewed: FilesystemEntryIdentity,
+): boolean {
+  const currentIdentity = filesystemIdentityFromStats(current)
+  return isSameFilesystemEntryIdentity(currentIdentity, reviewed)
+}
+
+/**
+ * Compare two serialized filesystem identities without requiring a live Stats object.
+ * @param current - Current serialized filesystem identity.
+ * @param reviewed - Reviewed serialized filesystem identity.
+ * @returns True when both records describe the same filesystem entry.
+ * @example isSameFilesystemEntryIdentity(currentIdentity, reviewedIdentity)
+ */
+export function isSameFilesystemEntryIdentity(
+  currentIdentity: FilesystemEntryIdentity,
+  reviewed: FilesystemEntryIdentity,
+): boolean {
+  if (currentIdentity.kind !== reviewed.kind) return false
+
+  if (currentIdentity.dev !== 0 || currentIdentity.ino !== 0) {
+    return (
+      currentIdentity.dev === reviewed.dev &&
+      currentIdentity.ino === reviewed.ino
+    )
+  }
+
+  return (
+    currentIdentity.dev === reviewed.dev &&
+    currentIdentity.size === reviewed.size &&
+    currentIdentity.ctimeMs === reviewed.ctimeMs &&
+    currentIdentity.mtimeMs === reviewed.mtimeMs
+  )
+}

--- a/src/main/services/filesystemIdentity.ts
+++ b/src/main/services/filesystemIdentity.ts
@@ -28,7 +28,12 @@ export function filesystemIdentityFromStats(
 }
 
 /**
- * Check whether current lstat metadata still names the reviewed filesystem entry.
+ * Rename-stable identity check (device + inode) used AFTER we have renamed the
+ * reviewed entry into a quarantine/stage path — rename preserves dev+ino but
+ * bumps ctime, so a timestamp-strict check would false-positive there.
+ * Does NOT catch a same-path rm+mkdir replacement on filesystems that recycle
+ * inode numbers (ext4 / CI Linux); use {@link isReviewedEntryUnchanged} at
+ * pre-operation gates where an in-place replacement must be rejected.
  * @param current - Current lstat/stat result for the destructive path.
  * @param reviewed - Identity captured when the user reviewed the row.
  * @returns True when the same path still points at the reviewed object.
@@ -43,7 +48,8 @@ export function isSameFilesystemIdentity(
 }
 
 /**
- * Compare two serialized filesystem identities without requiring a live Stats object.
+ * Serialized-identity form of {@link isSameFilesystemIdentity} (rename-stable,
+ * dev+ino). See that function for when to use the lenient vs strict check.
  * @param current - Current serialized filesystem identity.
  * @param reviewed - Reviewed serialized filesystem identity.
  * @returns True when both records describe the same filesystem entry.
@@ -67,5 +73,50 @@ export function isSameFilesystemEntryIdentity(
     currentIdentity.size === reviewed.size &&
     currentIdentity.ctimeMs === reviewed.ctimeMs &&
     currentIdentity.mtimeMs === reviewed.mtimeMs
+  )
+}
+
+/**
+ * Strict pre-operation gate: the reviewed path is still the same object AND was
+ * not replaced in place since review. Exists because dev+ino alone is defeated
+ * by inode-number reuse — ext4 (and thus GitHub Actions Linux) recycles a freed
+ * inode number on `rm`+`mkdir`, so a same-path replacement can otherwise pass
+ * the dev+ino check and get the wrong directory deleted. A recreated inode
+ * always carries a fresh ctime (the kernel reinitializes it on allocation),
+ * so adding ctime equality catches the replacement on every filesystem.
+ * MUST be called BEFORE any rename — `rename` bumps ctime and would
+ * false-positive; post-rename re-checks use {@link isSameFilesystemIdentity}.
+ * @param current - Current lstat/stat result for the still-original reviewed path.
+ * @param reviewed - Identity captured when the user reviewed the row.
+ * @returns True only when both the dev+ino identity and ctime match the review.
+ * @example isReviewedEntryUnchanged(await fs.lstat(reviewedPath), reviewedIdentity)
+ */
+export function isReviewedEntryUnchanged(
+  current: Stats,
+  reviewed: FilesystemEntryIdentity,
+): boolean {
+  return isReviewedEntryUnchangedIdentity(
+    filesystemIdentityFromStats(current),
+    reviewed,
+  )
+}
+
+/**
+ * Serialized-identity form of {@link isReviewedEntryUnchanged}. Layers a ctime
+ * check on top of the rename-stable identity so a reused-inode replacement is
+ * rejected; the dev=ino=0 fallback already compares ctime, so this only adds
+ * the guard to the inode-present branch.
+ * @param currentIdentity - Current serialized identity of the still-original path.
+ * @param reviewed - Reviewed serialized filesystem identity.
+ * @returns True only when the entry is the reviewed object and its ctime is unchanged.
+ * @example isReviewedEntryUnchangedIdentity(currentIdentity, reviewedIdentity)
+ */
+export function isReviewedEntryUnchangedIdentity(
+  currentIdentity: FilesystemEntryIdentity,
+  reviewed: FilesystemEntryIdentity,
+): boolean {
+  return (
+    isSameFilesystemEntryIdentity(currentIdentity, reviewed) &&
+    currentIdentity.ctimeMs === reviewed.ctimeMs
   )
 }

--- a/src/main/services/skillScanner.test.ts
+++ b/src/main/services/skillScanner.test.ts
@@ -277,6 +277,65 @@ describe('scanSkills agent-only linked symlink surfacing', () => {
     })
     expect(cursor).toMatchObject({ status: 'missing', isLocal: false })
   })
+
+  it('surfaces inaccessible agent-only symlinks for manual review instead of dropping them', async () => {
+    // Arrange: Codex has a symlink whose target can be read but not safely
+    // probed. It has no source skill, so it must still appear in the inventory.
+    readdirMock.mockImplementation(async (path: string) => {
+      if (path === '/mock/source/skills') return []
+      if (path === '/mock/agents/codex/skills') {
+        return [
+          createDirent('secure-review', {
+            isDirectory: false,
+            isSymbolicLink: true,
+          }),
+        ]
+      }
+      return []
+    })
+    accessMock.mockRejectedValue(new Error('ENOENT'))
+    statMock.mockRejectedValue(new Error('ENOENT'))
+    checkSymlinkTargetFromKnownLinkMock.mockImplementation(
+      async (linkPath: string) => {
+        if (linkPath === '/mock/agents/codex/skills/secure-review') {
+          return 'inaccessible'
+        }
+        return 'missing'
+      },
+    )
+    readSymlinkTargetIfPresentMock.mockImplementation(
+      async (linkPath: string) => {
+        if (linkPath === '/mock/agents/codex/skills/secure-review') {
+          return '/mock/secure/skills/secure-review'
+        }
+        return undefined
+      },
+    )
+
+    const { scanSkills } = await import('./skillScanner')
+    const skills = await scanSkills()
+
+    expect(skills).toHaveLength(1)
+    const manualReview = skills[0]
+    expect(manualReview.name).toBe('secure-review')
+    expect(manualReview.description).toBe(
+      'Inaccessible symlink — target cannot be verified',
+    )
+    expect(manualReview.path).toBe('/mock/secure/skills/secure-review')
+    expect(manualReview.symlinkCount).toBe(0)
+    expect(manualReview.isSource).toBe(false)
+    expect(manualReview.isOrphan).toBe(false)
+
+    const codex = manualReview.symlinks.find((s) => s.agentId === 'codex')
+    const cursor = manualReview.symlinks.find((s) => s.agentId === 'cursor')
+    expect(codex).toMatchObject({
+      status: 'inaccessible',
+      isLocal: false,
+      linkPath: '/mock/agents/codex/skills/secure-review',
+      targetPath: '/mock/secure/skills/secure-review',
+    })
+    expect(cursor).toMatchObject({ status: 'missing', isLocal: false })
+  })
 })
 
 describe('scanSkills orphan symlink surfacing (issue #127)', () => {
@@ -313,6 +372,14 @@ describe('scanSkills orphan symlink surfacing (issue #127)', () => {
         return 'missing'
       },
     )
+    readSymlinkTargetIfPresentMock.mockImplementation(
+      async (linkPath: string) => {
+        if (linkPath === '/mock/agents/codex/skills/connect-chrome') {
+          return '/mock/source/skills/connect-chrome'
+        }
+        return undefined
+      },
+    )
 
     const { scanSkills } = await import('./skillScanner')
     const skills = await scanSkills()
@@ -327,7 +394,11 @@ describe('scanSkills orphan symlink surfacing (issue #127)', () => {
 
     const codex = orphan.symlinks.find((s) => s.agentId === 'codex')
     const cursor = orphan.symlinks.find((s) => s.agentId === 'cursor')
-    expect(codex).toMatchObject({ status: 'broken', isLocal: false })
+    expect(codex).toMatchObject({
+      status: 'broken',
+      isLocal: false,
+      targetPath: '/mock/source/skills/connect-chrome',
+    })
     expect(cursor).toMatchObject({ status: 'missing', isLocal: false })
   })
 

--- a/src/main/services/skillScanner.test.ts
+++ b/src/main/services/skillScanner.test.ts
@@ -57,6 +57,20 @@ function createDirectoryStats(seed: number): {
 }
 
 /**
+ * Build an fs-like error with a Node `code` field for branch-specific scanner tests.
+ * @param message - Human-readable failure message.
+ * @param code - Node-style errno code.
+ * @returns Error object carrying the requested code.
+ * @example createFsError('missing', 'ENOENT')
+ */
+function createFsError(
+  message: string,
+  code: string,
+): Error & { code: string } {
+  return Object.assign(new Error(message), { code })
+}
+
+/**
  * Mock lstat for reviewed skill directories that the scanner should accept.
  * @param paths - Directory paths expected to survive scanner identity capture.
  * @returns void after configuring the shared lstat mock.
@@ -530,6 +544,58 @@ describe('scanSkills orphan symlink surfacing (issue #127)', () => {
     expect(skills).toHaveLength(1)
     expect(skills[0].name).toBe('theme-generator')
     expect(skills[0].isSource).toBe(true)
+  })
+
+  it('skips a source skill directory that disappears after the directory listing', async () => {
+    // Arrange: `listValidSourceSkillDirs()` sees two valid dirs because SKILL.md
+    // stat succeeded, then the second dir vanishes before scanSourceSkills()
+    // captures its reviewed filesystem identity.
+    readdirMock.mockImplementation(async (path: string) => {
+      if (path === '/mock/source/skills') {
+        return [
+          createDirent('live-source', {
+            isDirectory: true,
+            isSymbolicLink: false,
+          }),
+          createDirent('vanished-source', {
+            isDirectory: true,
+            isSymbolicLink: false,
+          }),
+        ]
+      }
+      return []
+    })
+    statMock.mockImplementation(async (path: string) => {
+      if (
+        path === '/mock/source/skills/live-source/SKILL.md' ||
+        path === '/mock/source/skills/vanished-source/SKILL.md'
+      ) {
+        return { isFile: () => true }
+      }
+      throw createFsError(`ENOENT: ${path}`, 'ENOENT')
+    })
+    lstatMock.mockImplementation(async (path: string) => {
+      if (path === '/mock/source/skills/live-source') {
+        return createDirectoryStats(10)
+      }
+      if (path === '/mock/source/skills/vanished-source') {
+        throw createFsError(`ENOENT: ${path}`, 'ENOENT')
+      }
+      throw createFsError(`ENOENT: ${path}`, 'ENOENT')
+    })
+
+    const { scanSkills } = await import('./skillScanner')
+
+    // Act
+    const skills = await scanSkills()
+
+    // Assert: one stale source row is dropped instead of rejecting the whole scan.
+    expect(skills).toHaveLength(1)
+    expect(skills[0]).toMatchObject({
+      name: 'live-source',
+      path: '/mock/source/skills/live-source',
+      isSource: true,
+    })
   })
 
   it('merges orphan broken slots into a same-named local skill (regression for #127 follow-up)', async () => {

--- a/src/main/services/skillScanner.test.ts
+++ b/src/main/services/skillScanner.test.ts
@@ -26,11 +26,55 @@ function createDirent(
 const readdirMock = vi.fn()
 const accessMock = vi.fn()
 const statMock = vi.fn()
+const lstatMock = vi.fn()
+
+/**
+ * Build the subset of fs.Stats consumed by filesystem identity guards.
+ * @param seed - Stable number that makes mocked inodes distinct enough for tests.
+ * @returns Directory-shaped stats object with identity fields.
+ * @example createDirectoryStats(7).isDirectory() // => true
+ */
+function createDirectoryStats(seed: number): {
+  isDirectory: () => boolean
+  isSymbolicLink: () => boolean
+  isFile: () => boolean
+  dev: number
+  ino: number
+  size: number
+  ctimeMs: number
+  mtimeMs: number
+} {
+  return {
+    isDirectory: () => true,
+    isSymbolicLink: () => false,
+    isFile: () => false,
+    dev: 1,
+    ino: seed,
+    size: 96,
+    ctimeMs: seed,
+    mtimeMs: seed,
+  }
+}
+
+/**
+ * Mock lstat for reviewed skill directories that the scanner should accept.
+ * @param paths - Directory paths expected to survive scanner identity capture.
+ * @returns void after configuring the shared lstat mock.
+ * @example mockLstatDirectories(['/mock/agents/codex/skills/task'])
+ */
+function mockLstatDirectories(paths: readonly string[]): void {
+  const validPaths = new Set(paths)
+  lstatMock.mockImplementation(async (path: string) => {
+    if (validPaths.has(path)) return createDirectoryStats(path.length)
+    throw new Error(`ENOENT: ${path}`)
+  })
+}
 
 vi.mock('fs/promises', () => ({
   readdir: readdirMock,
   access: accessMock,
   stat: statMock,
+  lstat: lstatMock,
 }))
 
 vi.mock('../constants', () => ({
@@ -71,6 +115,7 @@ describe('scanSkills local skill aggregation', () => {
   beforeEach(() => {
     readdirMock.mockReset()
     accessMock.mockReset()
+    lstatMock.mockReset()
     checkSymlinkTargetFromKnownLinkMock.mockReset()
     checkSymlinkTargetFromKnownLinkMock.mockResolvedValue('missing')
     readSymlinkTargetIfPresentMock.mockReset()
@@ -126,6 +171,10 @@ describe('scanSkills local skill aggregation', () => {
 
       throw new Error(`ENOENT: ${path}`)
     })
+    mockLstatDirectories([
+      join('/mock/agents/codex/skills', 'frontend-design'),
+      join('/mock/agents/cursor/skills', 'frontend-design'),
+    ])
   })
 
   it('keeps same local skill as valid for multiple agents', async () => {
@@ -215,6 +264,8 @@ describe('scanSkills agent-only linked symlink surfacing', () => {
     readdirMock.mockReset()
     accessMock.mockReset()
     statMock.mockReset()
+    lstatMock.mockReset()
+    lstatMock.mockRejectedValue(new Error('ENOENT'))
     checkSymlinkTargetFromKnownLinkMock.mockReset()
     readSymlinkTargetIfPresentMock.mockReset()
     readSymlinkTargetIfPresentMock.mockResolvedValue(undefined)
@@ -343,6 +394,8 @@ describe('scanSkills orphan symlink surfacing (issue #127)', () => {
     readdirMock.mockReset()
     accessMock.mockReset()
     statMock.mockReset()
+    lstatMock.mockReset()
+    lstatMock.mockRejectedValue(new Error('ENOENT'))
     checkSymlinkTargetFromKnownLinkMock.mockReset()
     readSymlinkTargetIfPresentMock.mockReset()
     readSymlinkTargetIfPresentMock.mockResolvedValue(undefined)
@@ -467,6 +520,7 @@ describe('scanSkills orphan symlink surfacing (issue #127)', () => {
       }
       throw new Error(`ENOENT: ${path}`)
     })
+    mockLstatDirectories(['/mock/source/skills/theme-generator'])
     checkSymlinkTargetFromKnownLinkMock.mockResolvedValue('broken')
 
     const { scanSkills } = await import('./skillScanner')
@@ -514,6 +568,7 @@ describe('scanSkills orphan symlink surfacing (issue #127)', () => {
       }
       throw new Error(`ENOENT: ${path}`)
     })
+    mockLstatDirectories(['/mock/agents/cursor/skills/frontend-design'])
     checkSymlinkTargetFromKnownLinkMock.mockImplementation(
       async (linkPath: string) => {
         if (linkPath === '/mock/agents/codex/skills/frontend-design')

--- a/src/main/services/skillScanner.ts
+++ b/src/main/services/skillScanner.ts
@@ -3,6 +3,7 @@ import { homedir } from 'os'
 import { join } from 'path'
 
 import { AGENTS, SOURCE_DIR } from '@/main/constants'
+import { isMissingPathError } from '@/main/utils/errorCode'
 import { formatBytes } from '@/shared/fileTypes'
 import { repositoryId } from '@/shared/types'
 import type {
@@ -270,27 +271,34 @@ async function scanSourceSkills(): Promise<Skill[]> {
   const validDirs = await listValidSourceSkillDirs()
 
   const skills = await Promise.all(
-    validDirs.map(async (dir) => {
-      const [metadata, symlinks, stats] = await Promise.all([
-        parseSkillMetadata(dir.path),
-        checkSkillSymlinks(dir.name),
-        lstat(dir.path),
-      ])
+    validDirs.map(async (dir): Promise<Skill | null> => {
+      try {
+        const [metadata, symlinks, stats] = await Promise.all([
+          parseSkillMetadata(dir.path),
+          checkSkillSymlinks(dir.name),
+          lstat(dir.path),
+        ])
 
-      return {
-        name: metadata.name,
-        description: metadata.description,
-        path: dir.path,
-        filesystemIdentity: filesystemIdentityFromStats(stats),
-        symlinkCount: countValidSymlinks(symlinks),
-        symlinks,
-        isSource: true,
-        isOrphan: false,
+        return {
+          name: metadata.name,
+          description: metadata.description,
+          path: dir.path,
+          filesystemIdentity: filesystemIdentityFromStats(stats),
+          symlinkCount: countValidSymlinks(symlinks),
+          symlinks,
+          isSource: true,
+          isOrphan: false,
+        }
+      } catch (error) {
+        // Race: another process deleted the source dir after readdir/stat but
+        // before identity capture. Drop only that stale row; keep the scan alive.
+        if (isMissingPathError(error)) return null
+        throw error
       }
     }),
   )
 
-  return skills
+  return skills.filter((skill): skill is Skill => skill !== null)
 }
 
 /**

--- a/src/main/services/skillScanner.ts
+++ b/src/main/services/skillScanner.ts
@@ -62,6 +62,7 @@ interface AgentSymlinkStatusHit {
   name: SkillName
   linkPath: AbsolutePath
   status: SymlinkStatus
+  targetPath?: AbsolutePath
 }
 
 /**
@@ -128,8 +129,11 @@ async function scanAgentSymlinkStatusHits(
         return Promise.all(
           candidates.map(async (link) => {
             const linkPath = join(agent.path, link.name) as AbsolutePath
-            const status = await checkSymlinkTargetFromKnownLink(linkPath)
-            return { agent, name: link.name, linkPath, status }
+            const [status, targetPath] = await Promise.all([
+              checkSymlinkTargetFromKnownLink(linkPath),
+              readSymlinkTargetIfPresent(linkPath),
+            ])
+            return { agent, name: link.name, linkPath, status, targetPath }
           }),
         )
       } catch {
@@ -298,7 +302,7 @@ async function scanSourceSkills(): Promise<Skill[]> {
  * address the actual path under the selected agent.
  *
  * @param sourceNames - Source skill names already represented by `scanSourceSkills`.
- * @returns Agent-only linked skills with valid non-local symlink slots.
+ * @returns Agent-only linked skills with valid or manual-review non-local symlink slots.
  * @example
  * // ~/.codex/skills/gstack-browse -> ~/gstack/.agents/skills/gstack-browse
  * scanAgentLinkedSymlinks(new Set())
@@ -310,14 +314,21 @@ async function scanAgentLinkedSymlinks(
   const linkedHits = (
     await Promise.all(
       (await scanAgentSymlinkStatusHits(sourceNames))
-        .filter((hit) => hit.status === 'valid')
+        .filter(
+          (hit) => hit.status === 'valid' || hit.status === 'inaccessible',
+        )
         .map(async (hit) => {
-          try {
-            const targetPath = await readSymlinkTargetIfPresent(hit.linkPath)
-            if (!targetPath) return null
+          if (hit.status === 'inaccessible') {
+            return {
+              ...hit,
+              metadata: null,
+            }
+          }
 
-            const metadata = await parseSkillMetadata(targetPath)
-            return { ...hit, targetPath, metadata }
+          try {
+            if (!hit.targetPath) return null
+            const metadata = await parseSkillMetadata(hit.targetPath)
+            return { ...hit, metadata }
           } catch {
             return null
           }
@@ -326,23 +337,37 @@ async function scanAgentLinkedSymlinks(
   ).filter((item): item is NonNullable<typeof item> => item !== null)
 
   const linkedSkillsByName = new Map<SkillName, Skill>()
-  for (const { agent, name, linkPath, targetPath, metadata } of linkedHits) {
+  for (const {
+    agent,
+    name,
+    linkPath,
+    status,
+    targetPath,
+    metadata,
+  } of linkedHits) {
     let skill = linkedSkillsByName.get(name)
     if (!skill) {
       skill = {
         name,
-        description: metadata.description,
-        path: targetPath,
+        description:
+          metadata?.description ??
+          'Inaccessible symlink — target cannot be verified',
+        path: targetPath ?? linkPath,
         symlinkCount: 0,
         symlinks: createMissingSymlinkSlots(name),
         isSource: false,
         isOrphan: false,
       }
       linkedSkillsByName.set(name, skill)
+    } else if (metadata) {
+      // If an inaccessible slot was seen before a valid sibling, upgrade the
+      // display metadata to the readable skill target.
+      skill.description = metadata.description
+      skill.path = targetPath ?? skill.path
     }
 
     updateAgentSymlinkSlot(skill, agent.id, {
-      status: 'valid',
+      status,
       targetPath,
       linkPath,
       isLocal: false,
@@ -382,7 +407,7 @@ async function scanOrphanSymlinks(
   // template (every agent 'missing'), subsequent sightings flip that agent's
   // slot to 'broken'. Single branch, no existing/new split.
   const orphansByName = new Map<SkillName, Skill>()
-  for (const { agent, name, linkPath } of brokenLinks) {
+  for (const { agent, name, linkPath, targetPath } of brokenLinks) {
     let skill = orphansByName.get(name)
     if (!skill) {
       skill = {
@@ -399,6 +424,7 @@ async function scanOrphanSymlinks(
     updateAgentSymlinkSlot(skill, agent.id, {
       status: 'broken',
       linkPath,
+      targetPath,
     })
   }
 

--- a/src/main/services/skillScanner.ts
+++ b/src/main/services/skillScanner.ts
@@ -1,4 +1,4 @@
-import { readdir, readFile, stat } from 'fs/promises'
+import { lstat, readdir, readFile, stat } from 'fs/promises'
 import { homedir } from 'os'
 import { join } from 'path'
 
@@ -17,6 +17,7 @@ import type {
 } from '@/shared/types'
 
 import { listValidSourceSkillDirs } from './dirScanner'
+import { filesystemIdentityFromStats } from './filesystemIdentity'
 import { parseSkillMetadata } from './metadataParser'
 import { isValidSkillDir } from './skillValidation'
 import {
@@ -270,15 +271,17 @@ async function scanSourceSkills(): Promise<Skill[]> {
 
   const skills = await Promise.all(
     validDirs.map(async (dir) => {
-      const [metadata, symlinks] = await Promise.all([
+      const [metadata, symlinks, stats] = await Promise.all([
         parseSkillMetadata(dir.path),
         checkSkillSymlinks(dir.name),
+        lstat(dir.path),
       ])
 
       return {
         name: metadata.name,
         description: metadata.description,
         path: dir.path,
+        filesystemIdentity: filesystemIdentityFromStats(stats),
         symlinkCount: countValidSymlinks(symlinks),
         symlinks,
         isSource: true,
@@ -465,16 +468,20 @@ async function scanAllLocalSkills(): Promise<Skill[]> {
               // gstack source tree (~/.claude/skills/gstack/<name>/SKILL.md).
               // Capturing that target lets the renderer display the G-Stack
               // badge on every gstack-managed skill, not just the parent.
-              const [metadata, skillMdSymlinkTarget] = await Promise.all([
-                parseSkillMetadata(skillPath),
-                readSymlinkTargetIfPresent(
-                  join(skillPath, 'SKILL.md') as AbsolutePath,
-                ),
-              ])
+              const [metadata, skillMdSymlinkTarget, stats] = await Promise.all(
+                [
+                  parseSkillMetadata(skillPath),
+                  readSymlinkTargetIfPresent(
+                    join(skillPath, 'SKILL.md') as AbsolutePath,
+                  ),
+                  lstat(skillPath),
+                ],
+              )
               return {
                 agent,
                 dirName: dir.name,
                 skillPath,
+                filesystemIdentity: filesystemIdentityFromStats(stats),
                 metadata,
                 skillMdSymlinkTarget,
               }
@@ -501,6 +508,7 @@ async function scanAllLocalSkills(): Promise<Skill[]> {
     agent,
     dirName,
     skillPath,
+    filesystemIdentity,
     metadata,
     skillMdSymlinkTarget,
   } of localHits) {
@@ -510,6 +518,7 @@ async function scanAllLocalSkills(): Promise<Skill[]> {
         name: metadata.name,
         description: metadata.description,
         path: skillPath,
+        filesystemIdentity,
         symlinkCount: 0, // Local skills have 0 symlinks
         symlinks: createMissingSymlinkSlots(dirName),
         isSource: false,
@@ -521,6 +530,7 @@ async function scanAllLocalSkills(): Promise<Skill[]> {
       status: 'valid',
       linkPath: join(agent.path, dirName) as AbsolutePath,
       isLocal: true,
+      filesystemIdentity,
       skillMdSymlinkTarget,
     })
   }

--- a/src/main/services/symlinkChecker.realfs.test.ts
+++ b/src/main/services/symlinkChecker.realfs.test.ts
@@ -1,0 +1,68 @@
+import {
+  mkdir,
+  mkdtemp,
+  readlink,
+  realpath as realpathFs,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import type { AbsolutePath } from '@/shared/types'
+
+import {
+  checkSymlinkStatus,
+  checkSymlinkTargetFromKnownLink,
+  readSymlinkTargetIfPresent,
+} from './symlinkChecker'
+
+describe('symlinkChecker real filesystem behavior', () => {
+  it('keeps a valid relative symlink valid when the parent directory is symlinked', async () => {
+    // Arrange
+    const temporaryRoot = await mkdtemp(
+      join(tmpdir(), 'skills-desktop-symlink-parent-'),
+    )
+
+    try {
+      const homeDir = join(temporaryRoot, 'home')
+      const physicalConfigDir = join(homeDir, 'dotfiles', '.config')
+      const logicalConfigDir = join(homeDir, '.config')
+      const physicalAgentSkillsDir = join(physicalConfigDir, 'devin', 'skills')
+      const sourceSkillDir = join(homeDir, '.agents', 'skills', 'qa-skill')
+      const relativeTarget = '../../../../.agents/skills/qa-skill'
+      const linkPath = join(
+        logicalConfigDir,
+        'devin',
+        'skills',
+        'qa-skill',
+      ) as AbsolutePath
+
+      await mkdir(physicalAgentSkillsDir, { recursive: true })
+      await mkdir(sourceSkillDir, { recursive: true })
+      await writeFile(join(sourceSkillDir, 'SKILL.md'), 'name: qa-skill\n')
+      await symlink(physicalConfigDir, logicalConfigDir)
+      await symlink(relativeTarget, linkPath)
+      const physicalSourceSkillDir = await realpathFs(sourceSkillDir)
+
+      // Act
+      const slowStatus = await checkSymlinkStatus(linkPath)
+      const fastStatus = await checkSymlinkTargetFromKnownLink(linkPath)
+      const displayedTarget = await readSymlinkTargetIfPresent(linkPath)
+
+      // Assert
+      expect(await readlink(linkPath)).toBe(relativeTarget)
+      expect(slowStatus).toBe('valid')
+      expect(fastStatus).toBe('valid')
+      expect(displayedTarget).toBe(physicalSourceSkillDir)
+      expect(displayedTarget).not.toBe(
+        join(temporaryRoot, '.agents', 'skills', 'qa-skill'),
+      )
+    } finally {
+      await rm(temporaryRoot, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/main/services/symlinkChecker.realfs.test.ts
+++ b/src/main/services/symlinkChecker.realfs.test.ts
@@ -18,6 +18,7 @@ import {
   checkSymlinkStatus,
   checkSymlinkTargetFromKnownLink,
   readSymlinkTargetIfPresent,
+  resolveRawSymlinkTarget,
 } from './symlinkChecker'
 
 describe('symlinkChecker real filesystem behavior', () => {
@@ -61,6 +62,27 @@ describe('symlinkChecker real filesystem behavior', () => {
       expect(displayedTarget).not.toBe(
         join(temporaryRoot, '.agents', 'skills', 'qa-skill'),
       )
+    } finally {
+      await rm(temporaryRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('resolves absolute symlink targets without requiring the link parent to exist', async () => {
+    // Arrange
+    const temporaryRoot = await mkdtemp(
+      join(tmpdir(), 'skills-desktop-absolute-target-'),
+    )
+
+    try {
+      const removedParent = join(temporaryRoot, 'missing-agent', 'skills')
+      const linkPath = join(removedParent, 'qa-skill')
+      const target = join(temporaryRoot, '.agents', 'skills', 'qa-skill')
+
+      // Act
+      const resolvedTarget = await resolveRawSymlinkTarget(linkPath, target)
+
+      // Assert
+      expect(resolvedTarget).toBe(target)
     } finally {
       await rm(temporaryRoot, { recursive: true, force: true })
     }

--- a/src/main/services/symlinkChecker.test.ts
+++ b/src/main/services/symlinkChecker.test.ts
@@ -16,10 +16,22 @@ function createStats(options: {
 }): {
   isSymbolicLink: () => boolean
   isDirectory: () => boolean
+  isFile: () => boolean
+  dev: number
+  ino: number
+  size: number
+  ctimeMs: number
+  mtimeMs: number
 } {
   return {
     isSymbolicLink: () => options.isSymbolicLink,
     isDirectory: () => options.isDirectory,
+    isFile: () => false,
+    dev: 1,
+    ino: 2,
+    size: 96,
+    ctimeMs: 3,
+    mtimeMs: 4,
   }
 }
 
@@ -279,6 +291,14 @@ describe('checkSkillSymlinks', () => {
       expect(r.status).toBe('valid')
       expect(r.isLocal).toBe(true)
       expect(r.targetPath).toBeUndefined()
+      expect(r.filesystemIdentity).toEqual({
+        kind: 'directory',
+        dev: 1,
+        ino: 2,
+        size: 96,
+        ctimeMs: 3,
+        mtimeMs: 4,
+      })
     }
   })
 

--- a/src/main/services/symlinkChecker.test.ts
+++ b/src/main/services/symlinkChecker.test.ts
@@ -23,14 +23,26 @@ function createStats(options: {
   }
 }
 
+/**
+ * Build a Node-style filesystem error with a stable `code` field.
+ * @param code - Errno code the production helper branches on.
+ * @returns Error object shaped like fs/promises rejections.
+ * @example makeFsError('ENOENT').code // => 'ENOENT'
+ */
+function makeFsError(code: string): Error & { code: string } {
+  return Object.assign(new Error(code), { code })
+}
+
 const lstatMock = vi.fn()
 const readlinkMock = vi.fn()
 const accessMock = vi.fn()
+const realpathMock = vi.fn()
 
 vi.mock('fs/promises', () => ({
   lstat: lstatMock,
   readlink: readlinkMock,
   access: accessMock,
+  realpath: realpathMock,
 }))
 
 vi.mock('../constants', () => ({
@@ -48,6 +60,7 @@ vi.mock('../constants', () => ({
 describe('checkSymlinkStatus', () => {
   beforeEach(() => {
     vi.resetAllMocks()
+    realpathMock.mockImplementation(async (path: string) => path)
   })
 
   it('returns valid when symlink exists and target is accessible', async () => {
@@ -76,7 +89,7 @@ describe('checkSymlinkStatus', () => {
       createStats({ isSymbolicLink: true, isDirectory: false }),
     )
     readlinkMock.mockResolvedValue('/mock/source/skills/deleted-skill')
-    accessMock.mockRejectedValue(new Error('ENOENT'))
+    accessMock.mockRejectedValue(makeFsError('ENOENT'))
 
     const { checkSymlinkStatus } = await import('./symlinkChecker')
     const result = await checkSymlinkStatus(
@@ -86,8 +99,25 @@ describe('checkSymlinkStatus', () => {
     expect(result).toBe('broken')
   })
 
+  it('returns inaccessible when symlink target cannot be probed safely', async () => {
+    lstatMock.mockResolvedValue(
+      createStats({ isSymbolicLink: true, isDirectory: false }),
+    )
+    readlinkMock.mockResolvedValue('/mock/source/skills/locked-skill')
+    accessMock.mockRejectedValue(
+      Object.assign(new Error('EPERM'), { code: 'EPERM' }),
+    )
+
+    const { checkSymlinkStatus } = await import('./symlinkChecker')
+    const result = await checkSymlinkStatus(
+      '/mock/agents/claude/skills/locked-skill',
+    )
+
+    expect(result).toBe('inaccessible')
+  })
+
   it('returns missing when path does not exist (lstat throws ENOENT)', async () => {
-    lstatMock.mockRejectedValue(new Error('ENOENT'))
+    lstatMock.mockRejectedValue(makeFsError('ENOENT'))
 
     const { checkSymlinkStatus } = await import('./symlinkChecker')
     const result = await checkSymlinkStatus(
@@ -128,11 +158,39 @@ describe('checkSymlinkStatus', () => {
     expect(result).toBe('valid')
     expect(accessMock).toHaveBeenCalledWith(expectedResolved)
   })
+
+  it('keeps relative symlink valid when parent directory is itself symlinked', async () => {
+    // Arrange
+    const linkPath = '/Users/raphtalia/.config/devin/skills/analyze-app'
+    const relativeTarget = '../../../../.agents/skills/analyze-app'
+    const physicalParent = '/Users/raphtalia/dotfiles/.config/devin/skills'
+    const expectedPhysicalTarget = '/Users/raphtalia/.agents/skills/analyze-app'
+
+    lstatMock.mockResolvedValue(
+      createStats({ isSymbolicLink: true, isDirectory: false }),
+    )
+    readlinkMock.mockResolvedValue(relativeTarget)
+    realpathMock.mockResolvedValue(physicalParent)
+    accessMock.mockResolvedValue(undefined)
+
+    // Act
+    const { checkSymlinkStatus } = await import('./symlinkChecker')
+    const result = await checkSymlinkStatus(linkPath)
+
+    // Assert
+    expect(result).toBe('valid')
+    expect(realpathMock).toHaveBeenCalledWith(dirname(linkPath))
+    expect(accessMock).toHaveBeenCalledWith(expectedPhysicalTarget)
+    expect(accessMock).not.toHaveBeenCalledWith(
+      '/Users/.agents/skills/analyze-app',
+    )
+  })
 })
 
 describe('checkSkillSymlinks', () => {
   beforeEach(() => {
     vi.resetAllMocks()
+    realpathMock.mockImplementation(async (path: string) => path)
   })
 
   it('returns correct status for each agent with broken symlink', async () => {
@@ -143,14 +201,14 @@ describe('checkSkillSymlinks', () => {
       if (path === join('/mock/agents/cursor/skills', 'my-skill')) {
         return createStats({ isSymbolicLink: true, isDirectory: false })
       }
-      throw new Error('ENOENT')
+      throw makeFsError('ENOENT')
     })
 
     readlinkMock.mockResolvedValue('/mock/source/skills/my-skill')
 
     accessMock.mockImplementation(async (path: string) => {
       if (path === '/mock/source/skills/my-skill') {
-        throw new Error('ENOENT')
+        throw makeFsError('ENOENT')
       }
     })
 
@@ -172,11 +230,11 @@ describe('checkSkillSymlinks', () => {
         return createStats({ isSymbolicLink: true, isDirectory: false })
       }
       // Cursor has no entry
-      throw new Error('ENOENT')
+      throw makeFsError('ENOENT')
     })
 
     readlinkMock.mockResolvedValue('/mock/source/skills/deleted-target')
-    accessMock.mockRejectedValue(new Error('ENOENT'))
+    accessMock.mockRejectedValue(makeFsError('ENOENT'))
 
     const { checkSkillSymlinks } = await import('./symlinkChecker')
     const results = await checkSkillSymlinks('partial-skill')
@@ -225,7 +283,7 @@ describe('checkSkillSymlinks', () => {
   })
 
   it('returns missing for all agents when no entries exist', async () => {
-    lstatMock.mockRejectedValue(new Error('ENOENT'))
+    lstatMock.mockRejectedValue(makeFsError('ENOENT'))
 
     const { checkSkillSymlinks } = await import('./symlinkChecker')
     const results = await checkSkillSymlinks('nonexistent-skill')
@@ -269,8 +327,37 @@ describe('checkSkillSymlinks', () => {
     }
   })
 
+  it('reports physical targetPath for relative symlinks under a symlinked parent directory', async () => {
+    // Arrange
+    const relativeTarget = '../../../../.agents/skills/good-skill'
+    const physicalParent = '/Users/raphtalia/dotfiles/.config/devin/skills'
+    const expectedPhysicalTarget = '/Users/raphtalia/.agents/skills/good-skill'
+
+    lstatMock.mockResolvedValue(
+      createStats({ isSymbolicLink: true, isDirectory: false }),
+    )
+    readlinkMock.mockResolvedValue(relativeTarget)
+    realpathMock.mockResolvedValue(physicalParent)
+    accessMock.mockResolvedValue(undefined)
+
+    // Act
+    const { checkSkillSymlinks } = await import('./symlinkChecker')
+    const results = await checkSkillSymlinks('good-skill')
+
+    // Assert
+    expect(results).toHaveLength(2)
+    for (const result of results) {
+      expect(result.status).toBe('valid')
+      expect(result.isLocal).toBe(false)
+      expect(result.targetPath).toBe(expectedPhysicalTarget)
+    }
+    expect(accessMock).not.toHaveBeenCalledWith(
+      '/Users/.agents/skills/good-skill',
+    )
+  })
+
   it('populates linkPath for each agent correctly', async () => {
-    lstatMock.mockRejectedValue(new Error('ENOENT'))
+    lstatMock.mockRejectedValue(makeFsError('ENOENT'))
 
     const { checkSkillSymlinks } = await import('./symlinkChecker')
     const results = await checkSkillSymlinks('any-skill')
@@ -290,6 +377,7 @@ describe('checkSkillSymlinks', () => {
 describe('readSymlinkTargetIfPresent', () => {
   beforeEach(() => {
     vi.resetAllMocks()
+    realpathMock.mockImplementation(async (path: string) => path)
   })
 
   it('returns resolved absolute target when path is a symlink with absolute target', async () => {
@@ -376,7 +464,7 @@ describe('readSymlinkTargetIfPresent', () => {
   })
 
   it('returns undefined when path does not exist (lstat throws)', async () => {
-    lstatMock.mockRejectedValue(new Error('ENOENT'))
+    lstatMock.mockRejectedValue(makeFsError('ENOENT'))
 
     const { readSymlinkTargetIfPresent } = await import('./symlinkChecker')
     const result = await readSymlinkTargetIfPresent('/mock/missing/SKILL.md')
@@ -388,7 +476,7 @@ describe('readSymlinkTargetIfPresent', () => {
     lstatMock.mockResolvedValue(
       createStats({ isSymbolicLink: true, isDirectory: false }),
     )
-    readlinkMock.mockRejectedValue(new Error('ENOENT'))
+    readlinkMock.mockRejectedValue(makeFsError('ENOENT'))
 
     const { readSymlinkTargetIfPresent } = await import('./symlinkChecker')
     const result = await readSymlinkTargetIfPresent(

--- a/src/main/services/symlinkChecker.ts
+++ b/src/main/services/symlinkChecker.ts
@@ -27,7 +27,7 @@ interface LinkOrLocalResult {
  * Check if a path is a symlink or local folder
  * @param path - Path to check
  * @returns
- * - Symlink: { status: 'valid'|'broken', isLocal: false }
+ * - Symlink: { status: 'valid'|'broken'|'inaccessible', isLocal: false }
  * - Local folder: { status: 'valid', isLocal: true }
  * - Missing: { status: 'missing', isLocal: false }
  * @example
@@ -147,7 +147,7 @@ export async function checkSkillSymlinks(
 /**
  * Check the status of a single symlink
  * @param linkPath - Path to the potential symlink
- * @returns Status: 'valid' | 'broken' | 'missing'
+ * @returns Status: 'valid' | 'broken' | 'inaccessible' | 'missing'
  * @example
  * checkSymlinkStatus('/Users/.claude/skills/foo')
  * // => 'valid' (if symlink exists and target exists)
@@ -176,8 +176,8 @@ export async function checkSymlinkStatus(
  * across all agent dirs during a full scan.
  *
  * @param linkPath - Path that is known (by the caller) to be a symbolic link
- * @returns 'valid' if target exists, 'broken' if dangling, 'missing' if the
- * link itself disappeared between the readdir snapshot and the lookup
+ * @returns 'valid' if target exists, 'broken' if dangling, 'inaccessible' if
+ * probe is unsafe, or 'missing' if the link disappeared during lookup
  * @example
  * // Inside a readdir loop where entry.isSymbolicLink() === true:
  * await checkSymlinkTargetFromKnownLink(join(dir, entry.name))
@@ -253,7 +253,7 @@ export async function resolveRawSymlinkTarget(
  * Shared core: read the symlink, resolve it relative to its physical parent, then probe for existence.
  * Centralizing this makes the slow-path and fast-path identical in meaning.
  * @param linkPath - Symlink path whose raw target should be checked.
- * @returns `valid` when the target exists, otherwise `broken`.
+ * @returns `valid` when target exists, `broken` when missing, or `inaccessible` when probing is unsafe.
  * @example
  * resolveSymlinkTarget('/Users/me/.config/devin/skills/foo')
  * // => 'valid'

--- a/src/main/services/symlinkChecker.ts
+++ b/src/main/services/symlinkChecker.ts
@@ -1,5 +1,5 @@
 import { lstat, readlink, access, realpath } from 'fs/promises'
-import { dirname, join, resolve } from 'path'
+import { dirname, isAbsolute, join, resolve } from 'path'
 
 import { match } from 'ts-pattern'
 
@@ -230,6 +230,9 @@ export async function resolveRawSymlinkTarget(
   linkPath: string,
   target: string,
 ): Promise<AbsolutePath> {
+  if (isAbsolute(target)) {
+    return resolve(target) as AbsolutePath
+  }
   const physicalParent = await realpath(dirname(linkPath))
   return resolve(physicalParent, target) as AbsolutePath
 }

--- a/src/main/services/symlinkChecker.ts
+++ b/src/main/services/symlinkChecker.ts
@@ -7,10 +7,13 @@ import { AGENTS } from '@/main/constants'
 import { isMissingPathError } from '@/main/utils/errorCode'
 import type {
   AbsolutePath,
+  FilesystemEntryIdentity,
   SkillName,
   SymlinkInfo,
   SymlinkStatus,
 } from '@/shared/types'
+
+import { filesystemIdentityFromStats } from './filesystemIdentity'
 
 /**
  * Result from checking if a path is a symlink or local folder
@@ -101,6 +104,7 @@ export async function checkSkillSymlinks(
       // against the physical symlink parent, mirroring checkSymlinkStatus.
       let targetPath: AbsolutePath | undefined
       let skillMdSymlinkTarget: AbsolutePath | undefined
+      let filesystemIdentity: FilesystemEntryIdentity | undefined
       if (status !== 'missing' && !isLocal) {
         try {
           const target = await readlink(linkPath)
@@ -112,9 +116,16 @@ export async function checkSkillSymlinks(
         // Local folder: probe the SKILL.md inside it for a gstack-managed
         // symlink. Per-agent so the renderer's badge attribution is bound to
         // THIS slot, not to a sibling agent that happens to share the name.
-        skillMdSymlinkTarget = await readSymlinkTargetIfPresent(
-          join(linkPath, 'SKILL.md') as AbsolutePath,
-        )
+        const [skillMdTarget, localStats] = await Promise.all([
+          readSymlinkTargetIfPresent(
+            join(linkPath, 'SKILL.md') as AbsolutePath,
+          ),
+          lstat(linkPath).catch(() => undefined),
+        ])
+        skillMdSymlinkTarget = skillMdTarget
+        filesystemIdentity = localStats
+          ? filesystemIdentityFromStats(localStats)
+          : undefined
       }
 
       return {
@@ -124,6 +135,7 @@ export async function checkSkillSymlinks(
         targetPath,
         linkPath,
         isLocal,
+        filesystemIdentity,
         skillMdSymlinkTarget,
       }
     }),

--- a/src/main/services/symlinkChecker.ts
+++ b/src/main/services/symlinkChecker.ts
@@ -1,9 +1,10 @@
-import { lstat, readlink, access } from 'fs/promises'
+import { lstat, readlink, access, realpath } from 'fs/promises'
 import { dirname, join, resolve } from 'path'
 
 import { match } from 'ts-pattern'
 
 import { AGENTS } from '@/main/constants'
+import { isMissingPathError } from '@/main/utils/errorCode'
 import type {
   AbsolutePath,
   SkillName,
@@ -44,15 +45,17 @@ async function checkLinkOrLocal(path: string): Promise<LinkOrLocalResult> {
       isDirectory: stats.isDirectory(),
     })
       .with({ isSymlink: true }, async (): Promise<LinkOrLocalResult> => {
-        // resolve() handles both absolute and relative targets correctly:
-        // absolute target → returned as-is, relative → resolved from symlink's directory
+        // Resolve through the physical parent so symlinked agent dirs mirror OS behavior.
         const target = await readlink(path)
-        const resolvedTarget = resolve(dirname(path), target)
+        const resolvedTarget = await resolveRawSymlinkTarget(path, target)
         try {
           await access(resolvedTarget)
           return { status: 'valid', isLocal: false }
-        } catch {
-          return { status: 'broken', isLocal: false }
+        } catch (error) {
+          return {
+            status: isMissingPathError(error) ? 'broken' : 'inaccessible',
+            isLocal: false,
+          }
         }
       })
       .with(
@@ -95,13 +98,13 @@ export async function checkSkillSymlinks(
       // readlink() returns the raw stored target string — relative when the
       // symlink was created with a relative target (`ln -s ../foo bar`). The
       // `AbsolutePath` contract requires an absolute path, so resolve it
-      // against the symlink's parent directory, mirroring checkSymlinkStatus.
+      // against the physical symlink parent, mirroring checkSymlinkStatus.
       let targetPath: AbsolutePath | undefined
       let skillMdSymlinkTarget: AbsolutePath | undefined
       if (status !== 'missing' && !isLocal) {
         try {
           const target = await readlink(linkPath)
-          targetPath = resolve(dirname(linkPath), target) as AbsolutePath
+          targetPath = await resolveRawSymlinkTarget(linkPath, target)
         } catch {
           // Leave undefined — the link disappeared between lstat and readlink
         }
@@ -178,9 +181,9 @@ export async function checkSymlinkTargetFromKnownLink(
 }
 
 /**
- * Read the resolved target of a symbolic link if (and only if) the given path
- * is itself a symlink. Returns `undefined` when the path is a regular file or
- * directory, when it does not exist, or when readlink races with deletion.
+ * Read the OS-resolved target of a symbolic link if the given path is itself a symlink.
+ * Returns `undefined` when the path is a regular file or directory, when it
+ * does not exist, or when readlink races with deletion.
  *
  * Used by the skill scanner to capture where a `SKILL.md` symlink points —
  * gstack-managed sibling skills (e.g. `~/.claude/skills/ship/`) have a real
@@ -190,8 +193,8 @@ export async function checkSymlinkTargetFromKnownLink(
  *
  * @param path - Absolute path that *may or may not* be a symbolic link
  * @returns
- * - Path is a symlink: resolved absolute target (handles both absolute and
- *   relative `readlink(2)` results by anchoring relatives to the link's dir)
+ * - Path is a symlink: resolved absolute target (anchors relative targets to
+ *   the link's physical parent directory)
  * - Path is a regular file/directory, missing, or fails mid-syscall: `undefined`
  * @example
  * await readSymlinkTargetIfPresent('/Users/me/.claude/skills/ship/SKILL.md')
@@ -206,32 +209,50 @@ export async function readSymlinkTargetIfPresent(
     const stats = await lstat(path)
     if (!stats.isSymbolicLink()) return undefined
 
-    // readlink(2) returns the raw stored target — absolute when the link was
-    // created with an absolute target, relative otherwise. resolve(dirname,
-    // target) is a no-op for absolute targets and the correct anchor for
-    // relative ones, mirroring the resolveSymlinkTarget() helper above.
+    // Resolve through the physical parent so symlinked agent dirs mirror OS behavior.
     const target = await readlink(path)
-    return resolve(dirname(path), target) as AbsolutePath
+    return await resolveRawSymlinkTarget(path, target)
   } catch {
     return undefined
   }
 }
 
 /**
- * Shared core: read the symlink, resolve it relative to its own directory
- * (handles both absolute and relative targets), then probe for existence.
+ * Resolve readlink's raw target exactly as the OS does when parent dirs include symlinks.
+ * @param linkPath - Logical path to the symlink being inspected.
+ * @param target - Raw `readlink` target, absolute or relative.
+ * @returns Absolute target path anchored at the physical symlink parent.
+ * @example
+ * resolveRawSymlinkTarget('/home/me/.config/devin/skills/foo', '../../../../.agents/skills/foo')
+ * // => '/home/me/.agents/skills/foo' when `.config` points into dotfiles
+ */
+export async function resolveRawSymlinkTarget(
+  linkPath: string,
+  target: string,
+): Promise<AbsolutePath> {
+  const physicalParent = await realpath(dirname(linkPath))
+  return resolve(physicalParent, target) as AbsolutePath
+}
+
+/**
+ * Shared core: read the symlink, resolve it relative to its physical parent, then probe for existence.
  * Centralizing this makes the slow-path and fast-path identical in meaning.
+ * @param linkPath - Symlink path whose raw target should be checked.
+ * @returns `valid` when the target exists, otherwise `broken`.
+ * @example
+ * resolveSymlinkTarget('/Users/me/.config/devin/skills/foo')
+ * // => 'valid'
  */
 async function resolveSymlinkTarget(
   linkPath: AbsolutePath,
 ): Promise<SymlinkStatus> {
   const target = await readlink(linkPath)
-  const resolvedTarget = resolve(dirname(linkPath), target)
+  const resolvedTarget = await resolveRawSymlinkTarget(linkPath, target)
   try {
     await access(resolvedTarget)
     return 'valid'
-  } catch {
-    return 'broken'
+  } catch (error) {
+    return isMissingPathError(error) ? 'broken' : 'inaccessible'
   }
 }
 

--- a/src/main/services/trashService.integration.test.ts
+++ b/src/main/services/trashService.integration.test.ts
@@ -548,6 +548,29 @@ describe('trashService (integration)', () => {
     await stat(orphanLocal)
   })
 
+  it('source-backed delete skips same-name symlinks that point to another source', async () => {
+    const { moveToTrash } = await trashServicePromise
+
+    // Arrange
+    const skillName = 'source-cascade-target-identity'
+    const sourcePath = await makeSourceSkill(skillName)
+    const otherSourcePath = await makeSourceSkill('other-cascade-owner')
+    const cursorLinkPath = join(sharedAgentCursor, skillName)
+    await symlink(otherSourcePath, cursorLinkPath)
+
+    // Act
+    const deleteResult = await moveToTrash(skillName)
+    assertTombstoned(deleteResult)
+
+    // Assert
+    expect(deleteResult.symlinksRemoved).toBe(0)
+    expect(deleteResult.cascadeAgents).not.toContain('cursor')
+    await expect(stat(sourcePath)).rejects.toThrow()
+    await expect(stat(otherSourcePath)).resolves.toBeDefined()
+    await expect(lstat(cursorLinkPath)).resolves.toBeDefined()
+    expect(await readlink(cursorLinkPath)).toBe(otherSourcePath)
+  })
+
   it('regression: moveToTrash no longer throws "already deleted" when only an agent-side local folder exists', async () => {
     // Direct repro of the user-reported bug. Pre-fix, the IPC handler called
     // moveToTrash with sourcePath = SOURCE_DIR/<name>, which didn't exist for

--- a/src/main/services/trashService.integration.test.ts
+++ b/src/main/services/trashService.integration.test.ts
@@ -2,7 +2,6 @@ import { mkdtempSync, realpathSync } from 'node:fs'
 import {
   lstat,
   mkdir,
-  readdir,
   readFile,
   readlink,
   rm,
@@ -79,15 +78,13 @@ const trashServicePromise = (async () => {
 
 /**
  * Narrow a `MoveToTrashResult` to the `tombstoned` variant for the rest of the
- * caller's scope. Every existing test in this file exercises a source-backed
- * or local-only path, both of which produce `kind: 'tombstoned'`. The new
- * `'orphan-cleared'` arm (added in PR-1 of issue #71) has its own dedicated
- * test below — for the legacy tests we just need to assert and continue.
+ * caller's scope. This file exercises reviewed source-backed and local-only
+ * delete paths, both of which produce `kind: 'tombstoned'`.
  *
  * @param result - Result returned by `moveToTrash` under test
  * @throws Error if the result is not a tombstoned variant
  * @example
- * const deleteResult = await moveToTrash(skillName)
+ * const deleteResult = await moveToTrash(skillName, reviewedSkillPath)
  * assertTombstoned(deleteResult)
  * // deleteResult.tombstoneId is now type-safe to access
  */
@@ -173,22 +170,45 @@ describe('trashService (integration)', () => {
   }
 
   /**
-   * Create a broken symlink in an agent dir: the link is well-formed but its
-   * target — `sharedSourceDir/<name>` — was never created (or was deleted),
-   * so `fs.access(target)` fails with ENOENT. This is exactly the disk shape
-   * the orphan branch of `moveToTrash` is meant to clean up.
-   * @param skillName - Skill name (target basename under SOURCE_DIR)
-   * @param agentBaseDir - Absolute path to the agent's skills dir
-   * @returns Absolute path to the dangling symlink
+   * Call moveToTrash with the reviewed source path used by real renderer deletes.
+   * @param moveToTrash - trashService function under test.
+   * @param skillName - Source folder basename under the mocked SOURCE_DIR.
+   * @returns moveToTrash result for the reviewed source row.
+   * @example await moveReviewedSource(moveToTrash, 'task')
    */
-  async function makeBrokenSymlink(
+  async function moveReviewedSource(
+    moveToTrash: (
+      skillName: SkillName,
+      reviewedSkillPath: AbsolutePath,
+    ) => Promise<MoveToTrashResult>,
+    skillName: string,
+  ): Promise<MoveToTrashResult> {
+    return moveToTrash(
+      skillName as SkillName,
+      join(sharedSourceDir, skillName) as AbsolutePath,
+    )
+  }
+
+  /**
+   * Call moveToTrash with a reviewed agent-local path instead of a source path.
+   * @param moveToTrash - trashService function under test.
+   * @param skillName - Local folder basename inside the agent skills directory.
+   * @param agentBaseDir - Agent skills directory holding the local folder.
+   * @returns moveToTrash result for the reviewed local row.
+   * @example await moveReviewedLocal(moveToTrash, 'local-task', sharedAgentClaude)
+   */
+  async function moveReviewedLocal(
+    moveToTrash: (
+      skillName: SkillName,
+      reviewedSkillPath: AbsolutePath,
+    ) => Promise<MoveToTrashResult>,
     skillName: string,
     agentBaseDir: string,
-  ): Promise<string> {
-    const linkPath = join(agentBaseDir, skillName)
-    const danglingTarget = join(sharedSourceDir, skillName)
-    await symlink(danglingTarget, linkPath)
-    return linkPath
+  ): Promise<MoveToTrashResult> {
+    return moveToTrash(
+      skillName as SkillName,
+      join(agentBaseDir, skillName) as AbsolutePath,
+    )
   }
 
   it('round-trip: moves source and agent symlink into trash, then restores both', async () => {
@@ -202,7 +222,7 @@ describe('trashService (integration)', () => {
     await stat(sourcePath)
     await stat(linkPath)
 
-    const deleteResult = await moveToTrash(skillName)
+    const deleteResult = await moveReviewedSource(moveToTrash, skillName)
     assertTombstoned(deleteResult)
     // With both `os` and `node:os` mocked, `AGENTS` paths resolve under
     // `sharedHome` so the cursor symlink we created above is actually
@@ -249,13 +269,15 @@ describe('trashService (integration)', () => {
     const folderName = 'folder-basename-source'
     const sourcePath = await makeSourceSkill(folderName)
     const decoyPath = await makeSourceSkill(metadataName)
-    const linkPath = join(sharedAgentCursor, folderName)
+    const folderLinkPath = join(sharedAgentCursor, folderName)
+    const metadataLinkPath = join(sharedAgentCursor, metadataName)
     await writeFile(
       join(sourcePath, 'SKILL.md'),
       `name: ${metadataName}\n`,
       'utf-8',
     )
-    await symlink(sourcePath, linkPath)
+    await symlink(sourcePath, folderLinkPath)
+    await symlink(sourcePath, metadataLinkPath)
 
     // Act
     const deleteResult = await moveToTrash(
@@ -265,9 +287,10 @@ describe('trashService (integration)', () => {
     assertTombstoned(deleteResult)
 
     // Assert
-    expect(deleteResult.symlinksRemoved).toBe(1)
+    expect(deleteResult.symlinksRemoved).toBe(2)
     await expect(stat(sourcePath)).rejects.toThrow()
-    await expect(stat(linkPath)).rejects.toThrow()
+    await expect(lstat(folderLinkPath)).rejects.toThrow()
+    await expect(lstat(metadataLinkPath)).rejects.toThrow()
     await expect(stat(decoyPath)).resolves.toBeDefined()
     const manifestRaw = await readFile(
       join(sharedTrashDir, deleteResult.tombstoneId, 'manifest.json'),
@@ -279,6 +302,41 @@ describe('trashService (integration)', () => {
     }
     expect(manifest.skillName).toBe(metadataName)
     expect(manifest.sourcePath).toBe(sourcePath)
+  })
+
+  it('moveToTrash deletes reviewed agent-local folder without tombstoning same-basename source', async () => {
+    const { moveToTrash } = await trashServicePromise
+
+    // Arrange
+    const skillName = 'local-source-decoy'
+    const sourceDecoyPath = await makeSourceSkill(skillName)
+    const localPath = await makeLocalSkill(skillName, sharedAgentClaude)
+
+    // Act
+    const deleteResult = await moveReviewedLocal(
+      moveToTrash,
+      skillName,
+      sharedAgentClaude,
+    )
+    assertTombstoned(deleteResult)
+
+    // Assert
+    await expect(stat(sourceDecoyPath)).resolves.toBeDefined()
+    await expect(stat(localPath)).rejects.toThrow()
+    const manifestRaw = await readFile(
+      join(sharedTrashDir, deleteResult.tombstoneId, 'manifest.json'),
+      'utf-8',
+    )
+    const manifest = JSON.parse(manifestRaw) as {
+      kind: string
+      localCopies?: Array<{ agentId: string; linkPath: string }>
+      sourcePath?: string
+    }
+    expect(manifest.kind).toBe('local-only')
+    expect(manifest.sourcePath).toBeUndefined()
+    expect(manifest.localCopies).toEqual([
+      { agentId: 'claude-code', linkPath: localPath },
+    ])
   })
 
   it('evict: idempotent — calling evict on a missing entry does not throw', async () => {
@@ -299,7 +357,7 @@ describe('trashService (integration)', () => {
 
     const skillName = 'manifest-corrupt-skill'
     await makeSourceSkill(skillName)
-    const result = await moveToTrash(skillName)
+    const result = await moveReviewedSource(moveToTrash, skillName)
     assertTombstoned(result)
 
     // Corrupt the manifest.
@@ -324,7 +382,7 @@ describe('trashService (integration)', () => {
 
     const skillName = 'collision-skill'
     const sourcePath = await makeSourceSkill(skillName)
-    const result = await moveToTrash(skillName)
+    const result = await moveReviewedSource(moveToTrash, skillName)
     assertTombstoned(result)
 
     // Recreate something at the original source path to simulate a reinstall
@@ -347,7 +405,9 @@ describe('trashService (integration)', () => {
     // so we just verify the missing-everywhere case still surfaces ENOENT.
     const skillName = 'ghost-skill'
 
-    await expect(moveToTrash(skillName)).rejects.toThrow(/already deleted/i)
+    await expect(moveReviewedSource(moveToTrash, skillName)).rejects.toThrow(
+      /already changed/i,
+    )
   })
 
   it('produces unique tombstone ids when two calls happen in the same ms', async () => {
@@ -355,11 +415,11 @@ describe('trashService (integration)', () => {
     const [a, b] = await Promise.all([
       (async () => {
         await makeSourceSkill('race-a')
-        return moveToTrash('race-a')
+        return moveReviewedSource(moveToTrash, 'race-a')
       })(),
       (async () => {
         await makeSourceSkill('race-b')
-        return moveToTrash('race-b')
+        return moveReviewedSource(moveToTrash, 'race-b')
       })(),
     ])
     assertTombstoned(a)
@@ -373,7 +433,7 @@ describe('trashService (integration)', () => {
     // Fresh entry: should survive the sweep.
     const skillName = 'sweep-recent'
     await makeSourceSkill(skillName)
-    const recent = await moveToTrash(skillName)
+    const recent = await moveReviewedSource(moveToTrash, skillName)
     assertTombstoned(recent)
 
     // Planted ancient entry: must be swept.
@@ -396,7 +456,7 @@ describe('trashService (integration)', () => {
 
     const skillName = 'evict-then-restore'
     await makeSourceSkill(skillName)
-    const result = await moveToTrash(skillName)
+    const result = await moveReviewedSource(moveToTrash, skillName)
     assertTombstoned(result)
 
     await evict(result.tombstoneId)
@@ -417,7 +477,7 @@ describe('trashService (integration)', () => {
 
     const skillName = 'manifest-check'
     const sourcePath = await makeSourceSkill(skillName)
-    const result = await moveToTrash(skillName)
+    const result = await moveReviewedSource(moveToTrash, skillName)
     assertTombstoned(result)
 
     const manifestPath = join(
@@ -447,7 +507,7 @@ describe('trashService (integration)', () => {
 
     const skillName = 'nested-source'
     await makeSourceSkill(skillName)
-    const result = await moveToTrash(skillName)
+    const result = await moveReviewedSource(moveToTrash, skillName)
     assertTombstoned(result)
 
     // The moved source must live under entry/source.
@@ -479,7 +539,11 @@ describe('trashService (integration)', () => {
     await stat(localPath)
     await expect(stat(join(sharedSourceDir, skillName))).rejects.toThrow()
 
-    const deleteResult = await moveToTrash(skillName)
+    const deleteResult = await moveReviewedLocal(
+      moveToTrash,
+      skillName,
+      sharedAgentClaude,
+    )
     assertTombstoned(deleteResult)
     expect(deleteResult.cascadeAgents).toContain('claude-code')
     // The local copy is staged under entryDir/local-copies — count it for parity
@@ -526,7 +590,11 @@ describe('trashService (integration)', () => {
     const skillName = 'local-round-trip'
     const localPath = await makeLocalSkill(skillName, sharedAgentClaude)
 
-    const deleteResult = await moveToTrash(skillName)
+    const deleteResult = await moveReviewedLocal(
+      moveToTrash,
+      skillName,
+      sharedAgentClaude,
+    )
     assertTombstoned(deleteResult)
     await expect(stat(localPath)).rejects.toThrow()
 
@@ -562,7 +630,7 @@ describe('trashService (integration)', () => {
     // local copy must be left alone untouched.
     const orphanLocal = await makeLocalSkill(skillName, sharedAgentClaude)
 
-    const deleteResult = await moveToTrash(skillName)
+    const deleteResult = await moveReviewedSource(moveToTrash, skillName)
     assertTombstoned(deleteResult)
 
     // Source went into trash entry under /source.
@@ -601,7 +669,7 @@ describe('trashService (integration)', () => {
     await symlink(otherSourcePath, cursorLinkPath)
 
     // Act
-    const deleteResult = await moveToTrash(skillName)
+    const deleteResult = await moveReviewedSource(moveToTrash, skillName)
     assertTombstoned(deleteResult)
 
     // Assert
@@ -625,80 +693,12 @@ describe('trashService (integration)', () => {
     const skillName = 'regression-local-only'
     await makeLocalSkill(skillName, sharedAgentClaude)
 
-    await expect(moveToTrash(skillName)).resolves.toMatchObject({
+    await expect(
+      moveReviewedLocal(moveToTrash, skillName, sharedAgentClaude),
+    ).resolves.toMatchObject({
       cascadeAgents: ['claude-code'],
       symlinksRemoved: 1,
     })
-  })
-
-  // ---------------------------------------------------------------------
-  // Orphan-branch tests (issue #71 PR-1). When the source skill is gone
-  // and no agent has a real local copy, every remaining record is a broken
-  // symlink. moveToTrash sweeps them with no manifest/no undo, returning
-  // `kind: 'orphan-cleared'`. The renderer's bulkDelete summary counts these
-  // as success rows even though they have no `tombstoneId`.
-  // ---------------------------------------------------------------------
-
-  it('moveToTrash: pure orphan returns orphan-cleared and unlinks the dangling symlink', async () => {
-    const { moveToTrash } = await trashServicePromise
-
-    const skillName = 'pure-orphan-skill'
-    const linkPath = await makeBrokenSymlink(skillName, sharedAgentCursor)
-    // Sanity: lstat sees the symlink itself; access on the target fails
-    // (target was never created), confirming the orphan disk shape.
-    const linkStats = await lstat(linkPath)
-    expect(linkStats.isSymbolicLink()).toBe(true)
-
-    const result = await moveToTrash(skillName)
-    expect(result.kind).toBe('orphan-cleared')
-    if (result.kind === 'orphan-cleared') {
-      expect(result.cascadeAgents).toEqual(['cursor'])
-      expect(result.symlinksRemoved).toBe(1)
-    }
-
-    // The symlink itself is gone (lstat throws ENOENT now).
-    await expect(lstat(linkPath)).rejects.toThrow()
-  })
-
-  it('moveToTrash: orphan branch sweeps broken symlinks across multiple agents', async () => {
-    const { moveToTrash } = await trashServicePromise
-
-    const skillName = 'multi-agent-orphan'
-    const cursorLink = await makeBrokenSymlink(skillName, sharedAgentCursor)
-    const claudeLink = await makeBrokenSymlink(skillName, sharedAgentClaude)
-
-    const result = await moveToTrash(skillName)
-    expect(result.kind).toBe('orphan-cleared')
-    if (result.kind === 'orphan-cleared') {
-      expect(result.symlinksRemoved).toBe(2)
-      // Cascade order follows AGENTS table iteration; assert membership rather
-      // than exact order so a future reordering of AGENTS doesn't break this.
-      expect(result.cascadeAgents).toContain('cursor')
-      expect(result.cascadeAgents).toContain('claude-code')
-    }
-
-    await expect(lstat(cursorLink)).rejects.toThrow()
-    await expect(lstat(claudeLink)).rejects.toThrow()
-  })
-
-  it('moveToTrash: orphan branch writes no tombstone (no undo for orphan)', async () => {
-    // The whole point of the orphan-cleared variant: there is nothing
-    // meaningful to restore (resurrected symlinks would still be broken),
-    // so we skip the manifest/TTL/evict timer machinery entirely.
-    const { moveToTrash } = await trashServicePromise
-
-    const skillName = 'orphan-no-tombstone'
-    await makeBrokenSymlink(skillName, sharedAgentCursor)
-
-    const result = await moveToTrash(skillName)
-    expect(result.kind).toBe('orphan-cleared')
-
-    // Trash dir is wiped in afterEach, so any entry here was created by THIS
-    // call. An orphan-cleared run must leave it empty (or the dir absent).
-    const trashEntries = await readdir(sharedTrashDir).catch(
-      () => [] as string[],
-    )
-    expect(trashEntries).toEqual([])
   })
 })
 

--- a/src/main/services/trashService.integration.test.ts
+++ b/src/main/services/trashService.integration.test.ts
@@ -23,6 +23,8 @@ import {
   vi,
 } from 'vitest'
 
+import type { AbsolutePath, SkillName } from '@/shared/types'
+
 import type { MoveToTrashResult } from './trashService'
 
 // sharedHome is stamped SYNCHRONOUSLY at module load so that the vi.mock
@@ -237,6 +239,46 @@ describe('trashService (integration)', () => {
     }
     // Source is back on disk.
     await stat(sourcePath)
+  })
+
+  it('moveToTrash deletes the reviewed source folder when metadata name differs from basename', async () => {
+    const { moveToTrash } = await trashServicePromise
+
+    // Arrange
+    const metadataName = 'metadata-title-source' as SkillName
+    const folderName = 'folder-basename-source'
+    const sourcePath = await makeSourceSkill(folderName)
+    const decoyPath = await makeSourceSkill(metadataName)
+    const linkPath = join(sharedAgentCursor, folderName)
+    await writeFile(
+      join(sourcePath, 'SKILL.md'),
+      `name: ${metadataName}\n`,
+      'utf-8',
+    )
+    await symlink(sourcePath, linkPath)
+
+    // Act
+    const deleteResult = await moveToTrash(
+      metadataName,
+      sourcePath as AbsolutePath,
+    )
+    assertTombstoned(deleteResult)
+
+    // Assert
+    expect(deleteResult.symlinksRemoved).toBe(1)
+    await expect(stat(sourcePath)).rejects.toThrow()
+    await expect(stat(linkPath)).rejects.toThrow()
+    await expect(stat(decoyPath)).resolves.toBeDefined()
+    const manifestRaw = await readFile(
+      join(sharedTrashDir, deleteResult.tombstoneId, 'manifest.json'),
+      'utf-8',
+    )
+    const manifest = JSON.parse(manifestRaw) as {
+      skillName: string
+      sourcePath: string
+    }
+    expect(manifest.skillName).toBe(metadataName)
+    expect(manifest.sourcePath).toBe(sourcePath)
   })
 
   it('evict: idempotent — calling evict on a missing entry does not throw', async () => {

--- a/src/main/services/trashService.integration.test.ts
+++ b/src/main/services/trashService.integration.test.ts
@@ -360,6 +360,75 @@ describe('trashService (integration)', () => {
     ])
   })
 
+  it('moveToTrash rejects a same-path source replacement and preserves the replacement folder', async () => {
+    const { moveToTrash } = await trashServicePromise
+
+    // Arrange
+    const skillName = 'source-same-path-replacement'
+    const sourcePath = (await makeSourceSkill(skillName)) as AbsolutePath
+    const reviewedIdentity = filesystemIdentityFromStats(
+      await lstat(sourcePath),
+    )
+    await rm(sourcePath, { recursive: true, force: true })
+    await mkdir(sourcePath, { recursive: true })
+    await writeFile(join(sourcePath, 'SKILL.md'), '# replacement\n', 'utf-8')
+
+    // Act + Assert
+    await expect(
+      moveToTrash(skillName as SkillName, sourcePath, reviewedIdentity),
+    ).rejects.toMatchObject({ code: 'ESTALE' })
+    await expect(readFile(join(sourcePath, 'SKILL.md'), 'utf-8')).resolves.toBe(
+      '# replacement\n',
+    )
+    await expect(lstat(sharedTrashDir)).rejects.toThrow(/ENOENT/)
+  })
+
+  it('moveToTrash rejects a same-path local replacement and preserves the replacement folder', async () => {
+    const { moveToTrash } = await trashServicePromise
+
+    // Arrange
+    const skillName = 'local-same-path-replacement'
+    const localPath = (await makeLocalSkill(
+      skillName,
+      sharedAgentClaude,
+    )) as AbsolutePath
+    const reviewedIdentity = filesystemIdentityFromStats(await lstat(localPath))
+    await rm(localPath, { recursive: true, force: true })
+    await mkdir(localPath, { recursive: true })
+    await writeFile(join(localPath, 'SKILL.md'), '# replacement\n', 'utf-8')
+
+    // Act + Assert
+    await expect(
+      moveToTrash(skillName as SkillName, localPath, reviewedIdentity),
+    ).rejects.toMatchObject({ code: 'ESTALE' })
+    await expect(readFile(join(localPath, 'SKILL.md'), 'utf-8')).resolves.toBe(
+      '# replacement\n',
+    )
+    await expect(lstat(sharedTrashDir)).rejects.toThrow(/ENOENT/)
+  })
+
+  it('moveToTrash deletes only the reviewed local folder when another agent has the same basename', async () => {
+    const { moveToTrash } = await trashServicePromise
+
+    // Arrange
+    const skillName = 'same-basename-local'
+    const reviewedLocalPath = await makeLocalSkill(skillName, sharedAgentClaude)
+    const siblingLocalPath = await makeLocalSkill(skillName, sharedAgentCursor)
+
+    // Act
+    const deleteResult = await moveReviewedLocal(
+      moveToTrash,
+      skillName,
+      sharedAgentClaude,
+    )
+
+    // Assert
+    assertTombstoned(deleteResult)
+    expect(deleteResult.cascadeAgents).toEqual(['claude-code'])
+    await expect(lstat(reviewedLocalPath)).rejects.toThrow(/ENOENT/)
+    await expect(lstat(siblingLocalPath)).resolves.toBeDefined()
+  })
+
   it('evict: idempotent — calling evict on a missing entry does not throw', async () => {
     const { evict, tombstoneId } = await (async () => {
       const mod = await trashServicePromise

--- a/src/main/services/trashService.integration.test.ts
+++ b/src/main/services/trashService.integration.test.ts
@@ -22,9 +22,23 @@ import {
   vi,
 } from 'vitest'
 
-import type { AbsolutePath, SkillName } from '@/shared/types'
+import type {
+  AbsolutePath,
+  FilesystemEntryIdentity,
+  SkillName,
+} from '@/shared/types'
 
+import { filesystemIdentityFromStats } from './filesystemIdentity'
 import type { MoveToTrashResult } from './trashService'
+
+const missingDirectoryIdentity: FilesystemEntryIdentity = {
+  kind: 'directory',
+  dev: 1,
+  ino: 1,
+  size: 96,
+  ctimeMs: 1,
+  mtimeMs: 1,
+}
 
 // sharedHome is stamped SYNCHRONOUSLY at module load so that the vi.mock
 // factory below captures a defined value by the time `trashService` is
@@ -180,12 +194,15 @@ describe('trashService (integration)', () => {
     moveToTrash: (
       skillName: SkillName,
       reviewedSkillPath: AbsolutePath,
+      reviewedIdentity: ReturnType<typeof filesystemIdentityFromStats>,
     ) => Promise<MoveToTrashResult>,
     skillName: string,
   ): Promise<MoveToTrashResult> {
+    const reviewedSkillPath = join(sharedSourceDir, skillName) as AbsolutePath
     return moveToTrash(
       skillName as SkillName,
-      join(sharedSourceDir, skillName) as AbsolutePath,
+      reviewedSkillPath,
+      filesystemIdentityFromStats(await lstat(reviewedSkillPath)),
     )
   }
 
@@ -201,13 +218,16 @@ describe('trashService (integration)', () => {
     moveToTrash: (
       skillName: SkillName,
       reviewedSkillPath: AbsolutePath,
+      reviewedIdentity: ReturnType<typeof filesystemIdentityFromStats>,
     ) => Promise<MoveToTrashResult>,
     skillName: string,
     agentBaseDir: string,
   ): Promise<MoveToTrashResult> {
+    const reviewedSkillPath = join(agentBaseDir, skillName) as AbsolutePath
     return moveToTrash(
       skillName as SkillName,
-      join(agentBaseDir, skillName) as AbsolutePath,
+      reviewedSkillPath,
+      filesystemIdentityFromStats(await lstat(reviewedSkillPath)),
     )
   }
 
@@ -283,6 +303,7 @@ describe('trashService (integration)', () => {
     const deleteResult = await moveToTrash(
       metadataName,
       sourcePath as AbsolutePath,
+      filesystemIdentityFromStats(await lstat(sourcePath)),
     )
     assertTombstoned(deleteResult)
 
@@ -405,9 +426,13 @@ describe('trashService (integration)', () => {
     // so we just verify the missing-everywhere case still surfaces ENOENT.
     const skillName = 'ghost-skill'
 
-    await expect(moveReviewedSource(moveToTrash, skillName)).rejects.toThrow(
-      /already changed/i,
-    )
+    await expect(
+      moveToTrash(
+        skillName,
+        join(sharedSourceDir, skillName) as AbsolutePath,
+        missingDirectoryIdentity,
+      ),
+    ).rejects.toThrow(/already changed/i)
   })
 
   it('produces unique tombstone ids when two calls happen in the same ms', async () => {

--- a/src/main/services/trashService.orphanRace.test.ts
+++ b/src/main/services/trashService.orphanRace.test.ts
@@ -3,6 +3,7 @@ import {
   mkdtemp,
   lstat,
   readdir,
+  readFile,
   readlink,
   rm,
   symlink,
@@ -320,6 +321,18 @@ describe('trashService orphan cleanup guarded commit', () => {
           }
           return actual.rm(path, options)
         },
+        cp: async (
+          source: string,
+          destination: string,
+          options?: Parameters<typeof actual.cp>[2],
+        ): Promise<void> => {
+          expect(options).toMatchObject({
+            recursive: true,
+            force: false,
+            errorOnExist: true,
+          })
+          return actual.cp(source, destination, options)
+        },
       }
     })
     const { __getTrashDirForTests, moveToTrash } =
@@ -339,6 +352,91 @@ describe('trashService orphan cleanup guarded commit', () => {
     expect(trashEntries).toHaveLength(1)
     const entryDir = join(__getTrashDirForTests(), trashEntries[0]!)
     expect((await lstat(join(entryDir, 'source'))).isDirectory()).toBe(true)
+    await expect(
+      lstat(join(entryDir, '.manual-recovery')),
+    ).resolves.toBeDefined()
+  })
+
+  it('does not overwrite a replacement during manifest rollback EXDEV restore', async () => {
+    // Arrange
+    const skillName = 'source-manifest-exdev-collision'
+    const sourcePath = join(tempHome, '.agents', 'skills', skillName)
+    const cursorSkillsDir = join(tempHome, '.cursor', 'skills')
+    const linkPath = join(cursorSkillsDir, skillName)
+    await mkdir(sourcePath, { recursive: true })
+    await writeFile(
+      join(sourcePath, 'SKILL.md'),
+      `# original ${skillName}\n`,
+      'utf-8',
+    )
+    await mkdir(cursorSkillsDir, { recursive: true })
+    await symlink(sourcePath, linkPath)
+    vi.doMock('node:fs/promises', async () => {
+      const actual =
+        await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
+      return {
+        ...actual,
+        rename: async (oldPath: string, newPath: string): Promise<void> => {
+          if (
+            oldPath.includes('/.agents/.trash/') &&
+            oldPath.endsWith('/source') &&
+            newPath === sourcePath
+          ) {
+            await actual.mkdir(sourcePath, { recursive: true })
+            await actual.writeFile(
+              join(sourcePath, 'SKILL.md'),
+              `# replacement ${skillName}\n`,
+              'utf-8',
+            )
+            const error = new Error(
+              'forced cross-device source rollback collision',
+            ) as NodeJS.ErrnoException
+            error.code = 'EXDEV'
+            throw error
+          }
+          return actual.rename(oldPath, newPath)
+        },
+        writeFile: async (
+          path: string,
+          data: Parameters<typeof actual.writeFile>[1],
+          options?: Parameters<typeof actual.writeFile>[2],
+        ): Promise<void> => {
+          if (
+            path.includes('/.agents/.trash/') &&
+            path.endsWith('/manifest.json')
+          ) {
+            const error = new Error(
+              'forced manifest write failure',
+            ) as NodeJS.ErrnoException
+            error.code = 'EACCES'
+            throw error
+          }
+          return actual.writeFile(path, data, options)
+        },
+      }
+    })
+    const { __getTrashDirForTests, moveToTrash } =
+      await import('./trashService')
+
+    // Act / Assert
+    await expect(
+      moveToTrash(
+        skillName,
+        sourcePath,
+        await reviewedIdentityForPath(sourcePath),
+      ),
+    ).rejects.toThrow(/source is stranded/i)
+    expect(await readFile(join(sourcePath, 'SKILL.md'), 'utf-8')).toBe(
+      `# replacement ${skillName}\n`,
+    )
+    expect((await lstat(linkPath)).isSymbolicLink()).toBe(true)
+    expect(await readlink(linkPath)).toBe(sourcePath)
+    const trashEntries = await readdir(__getTrashDirForTests())
+    expect(trashEntries).toHaveLength(1)
+    const entryDir = join(__getTrashDirForTests(), trashEntries[0]!)
+    expect(await readFile(join(entryDir, 'source', 'SKILL.md'), 'utf-8')).toBe(
+      `# original ${skillName}\n`,
+    )
     await expect(
       lstat(join(entryDir, '.manual-recovery')),
     ).resolves.toBeDefined()
@@ -378,6 +476,18 @@ describe('trashService orphan cleanup guarded commit', () => {
             throw error
           }
           return actual.rm(path, options)
+        },
+        cp: async (
+          source: string,
+          destination: string,
+          options?: Parameters<typeof actual.cp>[2],
+        ): Promise<void> => {
+          expect(options).toMatchObject({
+            recursive: true,
+            force: false,
+            errorOnExist: true,
+          })
+          return actual.cp(source, destination, options)
         },
       }
     })

--- a/src/main/services/trashService.orphanRace.test.ts
+++ b/src/main/services/trashService.orphanRace.test.ts
@@ -222,4 +222,72 @@ describe('trashService orphan cleanup guarded commit', () => {
     expect(await readlink(cleanupPath)).toBe(sourcePath)
     expect(await readdir(__getTrashDirForTests())).toEqual([])
   })
+
+  it('preserves trash source directory when manifest rollback cannot restore source', async () => {
+    // Arrange
+    const skillName = 'source-manifest-stranded'
+    const sourcePath = join(tempHome, '.agents', 'skills', skillName)
+    const cursorSkillsDir = join(tempHome, '.cursor', 'skills')
+    const linkPath = join(cursorSkillsDir, skillName)
+    await mkdir(sourcePath, { recursive: true })
+    await writeFile(join(sourcePath, 'SKILL.md'), `# ${skillName}\n`, 'utf-8')
+    await mkdir(cursorSkillsDir, { recursive: true })
+    await symlink(sourcePath, linkPath)
+    vi.doMock('node:fs/promises', async () => {
+      const actual =
+        await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
+      return {
+        ...actual,
+        rename: async (oldPath: string, newPath: string): Promise<void> => {
+          if (
+            oldPath.includes('/.agents/.trash/') &&
+            oldPath.endsWith('/source') &&
+            newPath === sourcePath
+          ) {
+            const error = new Error(
+              'forced source rollback failure',
+            ) as NodeJS.ErrnoException
+            error.code = 'EACCES'
+            throw error
+          }
+          return actual.rename(oldPath, newPath)
+        },
+        writeFile: async (
+          path: string,
+          data: Parameters<typeof actual.writeFile>[1],
+          options?: Parameters<typeof actual.writeFile>[2],
+        ): Promise<void> => {
+          if (
+            path.includes('/.agents/.trash/') &&
+            path.endsWith('/manifest.json')
+          ) {
+            const error = new Error(
+              'forced manifest write failure',
+            ) as NodeJS.ErrnoException
+            error.code = 'EACCES'
+            throw error
+          }
+          return actual.writeFile(path, data, options)
+        },
+      }
+    })
+    const { __getTrashDirForTests, moveToTrash } =
+      await import('./trashService')
+
+    // Act / Assert
+    await expect(moveToTrash(skillName)).rejects.toThrow(/source is stranded/i)
+    await expect(lstat(sourcePath)).rejects.toThrow()
+    expect((await lstat(linkPath)).isSymbolicLink()).toBe(true)
+    expect(await readlink(linkPath)).toBe(sourcePath)
+    const trashEntries = await readdir(__getTrashDirForTests())
+    expect(trashEntries).toHaveLength(1)
+    expect(
+      (
+        await lstat(join(__getTrashDirForTests(), trashEntries[0]!, 'source'))
+      ).isDirectory(),
+    ).toBe(true)
+    await expect(
+      lstat(join(__getTrashDirForTests(), trashEntries[0]!, 'manifest.json')),
+    ).rejects.toThrow()
+  })
 })

--- a/src/main/services/trashService.orphanRace.test.ts
+++ b/src/main/services/trashService.orphanRace.test.ts
@@ -290,4 +290,144 @@ describe('trashService orphan cleanup guarded commit', () => {
       lstat(join(__getTrashDirForTests(), trashEntries[0]!, 'manifest.json')),
     ).rejects.toThrow()
   })
+
+  it('startupCleanup preserves old entries marked for manual recovery', async () => {
+    // Arrange
+    const { __getTrashDirForTests, startupCleanup } =
+      await import('./trashService')
+    const trashDir = __getTrashDirForTests()
+    const oldMs = Date.now() - 25 * 60 * 60 * 1000
+    const manualEntry = join(trashDir, `${oldMs}-manual-recovery-aaaaaaaa`)
+    const sweepEntry = join(trashDir, `${oldMs}-safe-sweep-bbbbbbbb`)
+    await mkdir(manualEntry, { recursive: true })
+    await mkdir(sweepEntry, { recursive: true })
+    await writeFile(
+      join(manualEntry, '.manual-recovery'),
+      'manual recovery required\n',
+      'utf-8',
+    )
+
+    // Act
+    await startupCleanup()
+
+    // Assert
+    await expect(lstat(manualEntry)).resolves.toBeDefined()
+    await expect(lstat(sweepEntry)).rejects.toThrow()
+  })
+
+  it('preserves source EXDEV fallback copy when removing original fails', async () => {
+    // Arrange
+    const skillName = 'source-exdev-staged'
+    const sourcePath = join(tempHome, '.agents', 'skills', skillName)
+    const cursorSkillsDir = join(tempHome, '.cursor', 'skills')
+    const linkPath = join(cursorSkillsDir, skillName)
+    await mkdir(sourcePath, { recursive: true })
+    await writeFile(join(sourcePath, 'SKILL.md'), `# ${skillName}\n`, 'utf-8')
+    await mkdir(cursorSkillsDir, { recursive: true })
+    await symlink(sourcePath, linkPath)
+    vi.doMock('node:fs/promises', async () => {
+      const actual =
+        await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
+      return {
+        ...actual,
+        rename: async (oldPath: string, newPath: string): Promise<void> => {
+          if (oldPath === sourcePath && newPath.includes('/.agents/.trash/')) {
+            const error = new Error(
+              'forced cross-device source move',
+            ) as NodeJS.ErrnoException
+            error.code = 'EXDEV'
+            throw error
+          }
+          return actual.rename(oldPath, newPath)
+        },
+        rm: async (
+          path: string,
+          options?: Parameters<typeof actual.rm>[1],
+        ): Promise<void> => {
+          if (path === sourcePath) {
+            const error = new Error(
+              'forced source remove failure',
+            ) as NodeJS.ErrnoException
+            error.code = 'EACCES'
+            throw error
+          }
+          return actual.rm(path, options)
+        },
+      }
+    })
+    const { __getTrashDirForTests, moveToTrash } =
+      await import('./trashService')
+
+    // Act / Assert
+    await expect(moveToTrash(skillName)).rejects.toThrow(
+      /source copy preserved/i,
+    )
+    expect((await lstat(sourcePath)).isDirectory()).toBe(true)
+    expect((await lstat(linkPath)).isSymbolicLink()).toBe(true)
+    const trashEntries = await readdir(__getTrashDirForTests())
+    expect(trashEntries).toHaveLength(1)
+    const entryDir = join(__getTrashDirForTests(), trashEntries[0]!)
+    expect((await lstat(join(entryDir, 'source'))).isDirectory()).toBe(true)
+    await expect(
+      lstat(join(entryDir, '.manual-recovery')),
+    ).resolves.toBeDefined()
+  })
+
+  it('preserves local-only EXDEV fallback copy when removing original fails', async () => {
+    // Arrange
+    const skillName = 'local-exdev-staged'
+    const claudeSkillsDir = join(tempHome, '.claude', 'skills')
+    const localPath = join(claudeSkillsDir, skillName)
+    await mkdir(localPath, { recursive: true })
+    await writeFile(join(localPath, 'SKILL.md'), `# ${skillName}\n`, 'utf-8')
+    vi.doMock('node:fs/promises', async () => {
+      const actual =
+        await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
+      return {
+        ...actual,
+        rename: async (oldPath: string, newPath: string): Promise<void> => {
+          if (oldPath === localPath && newPath.includes('/.agents/.trash/')) {
+            const error = new Error(
+              'forced cross-device local move',
+            ) as NodeJS.ErrnoException
+            error.code = 'EXDEV'
+            throw error
+          }
+          return actual.rename(oldPath, newPath)
+        },
+        rm: async (
+          path: string,
+          options?: Parameters<typeof actual.rm>[1],
+        ): Promise<void> => {
+          if (path === localPath) {
+            const error = new Error(
+              'forced local remove failure',
+            ) as NodeJS.ErrnoException
+            error.code = 'EACCES'
+            throw error
+          }
+          return actual.rm(path, options)
+        },
+      }
+    })
+    const { __getTrashDirForTests, moveToTrash } =
+      await import('./trashService')
+
+    // Act / Assert
+    await expect(moveToTrash(skillName)).rejects.toThrow(
+      /staged copy preserved/i,
+    )
+    expect((await lstat(localPath)).isDirectory()).toBe(true)
+    const trashEntries = await readdir(__getTrashDirForTests())
+    expect(trashEntries).toHaveLength(1)
+    const entryDir = join(__getTrashDirForTests(), trashEntries[0]!)
+    expect(
+      (
+        await lstat(join(entryDir, 'local-copies', 'claude-code'))
+      ).isDirectory(),
+    ).toBe(true)
+    await expect(
+      lstat(join(entryDir, '.manual-recovery')),
+    ).resolves.toBeDefined()
+  })
 })

--- a/src/main/services/trashService.orphanRace.test.ts
+++ b/src/main/services/trashService.orphanRace.test.ts
@@ -44,69 +44,6 @@ describe('trashService orphan cleanup guarded commit', () => {
     await rm(tempHome, { recursive: true, force: true })
   })
 
-  it('refuses name-rescan orphan cleanup when the target is restored during commit', async () => {
-    // Arrange
-    const skillName = 'orphan-target-restored'
-    const cursorSkillsDir = join(tempHome, '.cursor', 'skills')
-    const targetPath = join(tempHome, '.agents', 'skills', skillName)
-    const linkPath = join(cursorSkillsDir, skillName)
-    await mkdir(cursorSkillsDir, { recursive: true })
-    await symlink(targetPath, linkPath)
-    vi.doMock('node:fs/promises', async () => {
-      const actual =
-        await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
-      return {
-        ...actual,
-        rename: async (oldPath: string, newPath: string): Promise<void> => {
-          if (oldPath === linkPath) {
-            await actual.mkdir(targetPath, { recursive: true })
-          }
-          return actual.rename(oldPath, newPath)
-        },
-      }
-    })
-    const { moveToTrash } = await import('./trashService')
-
-    // Act / Assert
-    await expect(moveToTrash(skillName)).rejects.toThrow(
-      `Failed to remove 1 of 1 orphan symlink for "${skillName}"`,
-    )
-    expect((await lstat(linkPath)).isSymbolicLink()).toBe(true)
-    expect(await readlink(linkPath)).toBe(targetPath)
-    expect((await lstat(targetPath)).isDirectory()).toBe(true)
-  })
-
-  it('restores an unreviewed local replacement moved during orphan cleanup commit', async () => {
-    // Arrange
-    const skillName = 'orphan-slot-replaced'
-    const cursorSkillsDir = join(tempHome, '.cursor', 'skills')
-    const targetPath = join(tempHome, '.agents', 'skills', skillName)
-    const linkPath = join(cursorSkillsDir, skillName)
-    await mkdir(cursorSkillsDir, { recursive: true })
-    await symlink(targetPath, linkPath)
-    vi.doMock('node:fs/promises', async () => {
-      const actual =
-        await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
-      return {
-        ...actual,
-        rename: async (oldPath: string, newPath: string): Promise<void> => {
-          if (oldPath === linkPath) {
-            await actual.rm(linkPath, { force: true })
-            await actual.mkdir(linkPath, { recursive: true })
-          }
-          return actual.rename(oldPath, newPath)
-        },
-      }
-    })
-    const { moveToTrash } = await import('./trashService')
-
-    // Act / Assert
-    await expect(moveToTrash(skillName)).rejects.toThrow(
-      `Failed to remove 1 of 1 orphan symlink for "${skillName}"`,
-    )
-    expect((await lstat(linkPath)).isDirectory()).toBe(true)
-  })
-
   it('aborts source-backed delete when quarantined symlink restore fails', async () => {
     // Arrange
     const skillName = 'source-restore-failure'
@@ -145,7 +82,7 @@ describe('trashService orphan cleanup guarded commit', () => {
       await import('./trashService')
 
     // Act / Assert
-    await expect(moveToTrash(skillName)).rejects.toThrow(
+    await expect(moveToTrash(skillName, sourcePath)).rejects.toThrow(
       /Moved entry left|could not be restored|Failed to remove symlinks/i,
     )
     expect((await lstat(sourcePath)).isDirectory()).toBe(true)
@@ -204,7 +141,7 @@ describe('trashService orphan cleanup guarded commit', () => {
       await import('./trashService')
 
     // Act / Assert
-    await expect(moveToTrash(skillName)).rejects.toThrow(
+    await expect(moveToTrash(skillName, sourcePath)).rejects.toThrow(
       /Failed to remove symlinks|could not be restored/i,
     )
     expect((await lstat(sourcePath)).isDirectory()).toBe(true)
@@ -275,7 +212,9 @@ describe('trashService orphan cleanup guarded commit', () => {
       await import('./trashService')
 
     // Act / Assert
-    await expect(moveToTrash(skillName)).rejects.toThrow(/source is stranded/i)
+    await expect(moveToTrash(skillName, sourcePath)).rejects.toThrow(
+      /source is stranded/i,
+    )
     await expect(lstat(sourcePath)).rejects.toThrow()
     expect((await lstat(linkPath)).isSymbolicLink()).toBe(true)
     expect(await readlink(linkPath)).toBe(sourcePath)
@@ -359,7 +298,7 @@ describe('trashService orphan cleanup guarded commit', () => {
       await import('./trashService')
 
     // Act / Assert
-    await expect(moveToTrash(skillName)).rejects.toThrow(
+    await expect(moveToTrash(skillName, sourcePath)).rejects.toThrow(
       /source copy preserved/i,
     )
     expect((await lstat(sourcePath)).isDirectory()).toBe(true)
@@ -414,7 +353,7 @@ describe('trashService orphan cleanup guarded commit', () => {
       await import('./trashService')
 
     // Act / Assert
-    await expect(moveToTrash(skillName)).rejects.toThrow(
+    await expect(moveToTrash(skillName, localPath)).rejects.toThrow(
       /staged copy preserved/i,
     )
     expect((await lstat(localPath)).isDirectory()).toBe(true)

--- a/src/main/services/trashService.orphanRace.test.ts
+++ b/src/main/services/trashService.orphanRace.test.ts
@@ -434,11 +434,15 @@ describe('trashService orphan cleanup guarded commit', () => {
         await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
       return {
         ...actual,
-        rename: async (oldPath: string, newPath: string): Promise<void> => {
+        cp: async (
+          source: string,
+          destination: string,
+          options?: Parameters<typeof actual.cp>[2],
+        ): Promise<void> => {
           if (
-            oldPath.includes('/.agents/.trash/') &&
-            oldPath.endsWith('/source') &&
-            newPath === sourcePath
+            source.includes('/.agents/.trash/') &&
+            source.endsWith('/source') &&
+            destination === sourcePath
           ) {
             const error = new Error(
               'forced source rollback failure',
@@ -446,7 +450,7 @@ describe('trashService orphan cleanup guarded commit', () => {
             error.code = 'EACCES'
             throw error
           }
-          return actual.rename(oldPath, newPath)
+          return actual.cp(source, destination, options)
         },
         writeFile: async (
           path: string,
@@ -591,7 +595,7 @@ describe('trashService orphan cleanup guarded commit', () => {
     ).resolves.toBeDefined()
   })
 
-  it('does not overwrite a replacement during manifest rollback EXDEV restore', async () => {
+  it('does not overwrite a replacement during manifest rollback restore', async () => {
     // Arrange
     const skillName = 'source-manifest-exdev-collision'
     const sourcePath = join(tempHome, '.agents', 'skills', skillName)
@@ -610,11 +614,15 @@ describe('trashService orphan cleanup guarded commit', () => {
         await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
       return {
         ...actual,
-        rename: async (oldPath: string, newPath: string): Promise<void> => {
+        cp: async (
+          source: string,
+          destination: string,
+          options?: Parameters<typeof actual.cp>[2],
+        ): Promise<void> => {
           if (
-            oldPath.includes('/.agents/.trash/') &&
-            oldPath.endsWith('/source') &&
-            newPath === sourcePath
+            source.includes('/.agents/.trash/') &&
+            source.endsWith('/source') &&
+            destination === sourcePath
           ) {
             await actual.mkdir(sourcePath, { recursive: true })
             await actual.writeFile(
@@ -622,13 +630,9 @@ describe('trashService orphan cleanup guarded commit', () => {
               `# replacement ${skillName}\n`,
               'utf-8',
             )
-            const error = new Error(
-              'forced cross-device source rollback collision',
-            ) as NodeJS.ErrnoException
-            error.code = 'EXDEV'
-            throw error
+            return actual.cp(source, destination, options)
           }
-          return actual.rename(oldPath, newPath)
+          return actual.cp(source, destination, options)
         },
         writeFile: async (
           path: string,

--- a/src/main/services/trashService.orphanRace.test.ts
+++ b/src/main/services/trashService.orphanRace.test.ts
@@ -15,6 +15,20 @@ import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { filesystemIdentityFromStats } from './filesystemIdentity'
+
+/**
+ * Capture the reviewed identity for the exact directory about to be deleted.
+ * @param path - Source or agent-local skill folder path.
+ * @returns Serializable identity payload passed through destructive IPC.
+ * @example await reviewedIdentityForPath('/tmp/home/.agents/skills/task')
+ */
+async function reviewedIdentityForPath(
+  path: string,
+): Promise<ReturnType<typeof filesystemIdentityFromStats>> {
+  return filesystemIdentityFromStats(await lstat(path))
+}
+
 describe('trashService orphan cleanup guarded commit', () => {
   let tempHome = ''
 
@@ -82,7 +96,13 @@ describe('trashService orphan cleanup guarded commit', () => {
       await import('./trashService')
 
     // Act / Assert
-    await expect(moveToTrash(skillName, sourcePath)).rejects.toThrow(
+    await expect(
+      moveToTrash(
+        skillName,
+        sourcePath,
+        await reviewedIdentityForPath(sourcePath),
+      ),
+    ).rejects.toThrow(
       /Moved entry left|could not be restored|Failed to remove symlinks/i,
     )
     expect((await lstat(sourcePath)).isDirectory()).toBe(true)
@@ -141,9 +161,13 @@ describe('trashService orphan cleanup guarded commit', () => {
       await import('./trashService')
 
     // Act / Assert
-    await expect(moveToTrash(skillName, sourcePath)).rejects.toThrow(
-      /Failed to remove symlinks|could not be restored/i,
-    )
+    await expect(
+      moveToTrash(
+        skillName,
+        sourcePath,
+        await reviewedIdentityForPath(sourcePath),
+      ),
+    ).rejects.toThrow(/Failed to remove symlinks|could not be restored/i)
     expect((await lstat(sourcePath)).isDirectory()).toBe(true)
     expect((await lstat(claudeLinkPath)).isSymbolicLink()).toBe(true)
     expect(await readlink(claudeLinkPath)).toBe(sourcePath)
@@ -212,9 +236,13 @@ describe('trashService orphan cleanup guarded commit', () => {
       await import('./trashService')
 
     // Act / Assert
-    await expect(moveToTrash(skillName, sourcePath)).rejects.toThrow(
-      /source is stranded/i,
-    )
+    await expect(
+      moveToTrash(
+        skillName,
+        sourcePath,
+        await reviewedIdentityForPath(sourcePath),
+      ),
+    ).rejects.toThrow(/source is stranded/i)
     await expect(lstat(sourcePath)).rejects.toThrow()
     expect((await lstat(linkPath)).isSymbolicLink()).toBe(true)
     expect(await readlink(linkPath)).toBe(sourcePath)
@@ -298,9 +326,13 @@ describe('trashService orphan cleanup guarded commit', () => {
       await import('./trashService')
 
     // Act / Assert
-    await expect(moveToTrash(skillName, sourcePath)).rejects.toThrow(
-      /source copy preserved/i,
-    )
+    await expect(
+      moveToTrash(
+        skillName,
+        sourcePath,
+        await reviewedIdentityForPath(sourcePath),
+      ),
+    ).rejects.toThrow(/source copy preserved/i)
     expect((await lstat(sourcePath)).isDirectory()).toBe(true)
     expect((await lstat(linkPath)).isSymbolicLink()).toBe(true)
     const trashEntries = await readdir(__getTrashDirForTests())
@@ -353,9 +385,13 @@ describe('trashService orphan cleanup guarded commit', () => {
       await import('./trashService')
 
     // Act / Assert
-    await expect(moveToTrash(skillName, localPath)).rejects.toThrow(
-      /staged copy preserved/i,
-    )
+    await expect(
+      moveToTrash(
+        skillName,
+        localPath,
+        await reviewedIdentityForPath(localPath),
+      ),
+    ).rejects.toThrow(/staged copy preserved/i)
     expect((await lstat(localPath)).isDirectory()).toBe(true)
     const trashEntries = await readdir(__getTrashDirForTests())
     expect(trashEntries).toHaveLength(1)

--- a/src/main/services/trashService.orphanRace.test.ts
+++ b/src/main/services/trashService.orphanRace.test.ts
@@ -152,9 +152,13 @@ describe('trashService orphan cleanup guarded commit', () => {
     expect((await lstat(linkPath)).isSymbolicLink()).toBe(true)
     expect(await readlink(linkPath)).toBe(replacementTargetPath)
     const leftovers = await readdir(cursorSkillsDir)
-    expect(
-      leftovers.some((entry) => entry.startsWith(`${skillName}.cleanup-`)),
-    ).toBe(true)
+    const cleanupEntries = leftovers.filter((entry) =>
+      entry.startsWith(`${skillName}.cleanup-`),
+    )
+    expect(cleanupEntries).toHaveLength(1)
+    const cleanupPath = join(cursorSkillsDir, cleanupEntries[0]!)
+    expect((await lstat(cleanupPath)).isSymbolicLink()).toBe(true)
+    expect(await readlink(cleanupPath)).toBe(sourcePath)
     expect(await readdir(__getTrashDirForTests())).toEqual([])
   })
 
@@ -209,9 +213,13 @@ describe('trashService orphan cleanup guarded commit', () => {
     expect((await lstat(cursorLinkPath)).isSymbolicLink()).toBe(true)
     expect(await readlink(cursorLinkPath)).toBe(replacementTargetPath)
     const leftovers = await readdir(cursorSkillsDir)
-    expect(
-      leftovers.some((entry) => entry.startsWith(`${skillName}.cleanup-`)),
-    ).toBe(true)
+    const cleanupEntries = leftovers.filter((entry) =>
+      entry.startsWith(`${skillName}.cleanup-`),
+    )
+    expect(cleanupEntries).toHaveLength(1)
+    const cleanupPath = join(cursorSkillsDir, cleanupEntries[0]!)
+    expect((await lstat(cleanupPath)).isSymbolicLink()).toBe(true)
+    expect(await readlink(cleanupPath)).toBe(sourcePath)
     expect(await readdir(__getTrashDirForTests())).toEqual([])
   })
 })

--- a/src/main/services/trashService.orphanRace.test.ts
+++ b/src/main/services/trashService.orphanRace.test.ts
@@ -1,0 +1,100 @@
+import { mkdir, mkdtemp, lstat, readlink, rm, symlink } from 'node:fs/promises'
+import type * as NodeFsPromises from 'node:fs/promises'
+import type * as NodeOs from 'node:os'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('trashService orphan cleanup guarded commit', () => {
+  let tempHome = ''
+
+  beforeEach(async () => {
+    vi.resetModules()
+    tempHome = await mkdtemp(join(tmpdir(), 'skills-trash-orphan-race-'))
+    vi.doMock('os', async () => {
+      const actual = await vi.importActual<typeof NodeOs>('os')
+      return {
+        ...actual,
+        homedir: () => tempHome,
+      }
+    })
+    vi.doMock('node:os', async () => {
+      const actual = await vi.importActual<typeof NodeOs>('node:os')
+      return {
+        ...actual,
+        homedir: () => tempHome,
+      }
+    })
+  })
+
+  afterEach(async () => {
+    vi.doUnmock('os')
+    vi.doUnmock('node:os')
+    vi.doUnmock('node:fs/promises')
+    await rm(tempHome, { recursive: true, force: true })
+  })
+
+  it('refuses name-rescan orphan cleanup when the target is restored during commit', async () => {
+    // Arrange
+    const skillName = 'orphan-target-restored'
+    const cursorSkillsDir = join(tempHome, '.cursor', 'skills')
+    const targetPath = join(tempHome, '.agents', 'skills', skillName)
+    const linkPath = join(cursorSkillsDir, skillName)
+    await mkdir(cursorSkillsDir, { recursive: true })
+    await symlink(targetPath, linkPath)
+    vi.doMock('node:fs/promises', async () => {
+      const actual =
+        await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
+      return {
+        ...actual,
+        rename: async (oldPath: string, newPath: string): Promise<void> => {
+          if (oldPath === linkPath) {
+            await actual.mkdir(targetPath, { recursive: true })
+          }
+          return actual.rename(oldPath, newPath)
+        },
+      }
+    })
+    const { moveToTrash } = await import('./trashService')
+
+    // Act / Assert
+    await expect(moveToTrash(skillName)).rejects.toThrow(
+      `Failed to remove 1 of 1 orphan symlink for "${skillName}"`,
+    )
+    expect((await lstat(linkPath)).isSymbolicLink()).toBe(true)
+    expect(await readlink(linkPath)).toBe(targetPath)
+    expect((await lstat(targetPath)).isDirectory()).toBe(true)
+  })
+
+  it('restores an unreviewed local replacement moved during orphan cleanup commit', async () => {
+    // Arrange
+    const skillName = 'orphan-slot-replaced'
+    const cursorSkillsDir = join(tempHome, '.cursor', 'skills')
+    const targetPath = join(tempHome, '.agents', 'skills', skillName)
+    const linkPath = join(cursorSkillsDir, skillName)
+    await mkdir(cursorSkillsDir, { recursive: true })
+    await symlink(targetPath, linkPath)
+    vi.doMock('node:fs/promises', async () => {
+      const actual =
+        await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
+      return {
+        ...actual,
+        rename: async (oldPath: string, newPath: string): Promise<void> => {
+          if (oldPath === linkPath) {
+            await actual.rm(linkPath, { force: true })
+            await actual.mkdir(linkPath, { recursive: true })
+          }
+          return actual.rename(oldPath, newPath)
+        },
+      }
+    })
+    const { moveToTrash } = await import('./trashService')
+
+    // Act / Assert
+    await expect(moveToTrash(skillName)).rejects.toThrow(
+      `Failed to remove 1 of 1 orphan symlink for "${skillName}"`,
+    )
+    expect((await lstat(linkPath)).isDirectory()).toBe(true)
+  })
+})

--- a/src/main/services/trashService.orphanRace.test.ts
+++ b/src/main/services/trashService.orphanRace.test.ts
@@ -120,6 +120,79 @@ describe('trashService orphan cleanup guarded commit', () => {
     expect(await readdir(__getTrashDirForTests())).toEqual([])
   })
 
+  it('preserves moved cleanup symlink when restore destination appears after empty check', async () => {
+    // Arrange
+    const skillName = 'source-restore-race-after-check'
+    const sourcePath = join(tempHome, '.agents', 'skills', skillName)
+    const cursorSkillsDir = join(tempHome, '.cursor', 'skills')
+    const linkPath = join(cursorSkillsDir, skillName)
+    const replacementTargetPath = join(
+      tempHome,
+      '.agents',
+      'skills',
+      'replacement-after-check',
+    )
+    await mkdir(sourcePath, { recursive: true })
+    await writeFile(join(sourcePath, 'SKILL.md'), `# ${skillName}\n`, 'utf-8')
+    await mkdir(cursorSkillsDir, { recursive: true })
+    await symlink(sourcePath, linkPath)
+    vi.doMock('node:fs/promises', async () => {
+      const actual =
+        await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
+      return {
+        ...actual,
+        unlink: async (path: string): Promise<void> => {
+          if (String(path).startsWith(`${linkPath}.cleanup-`)) {
+            const error = new Error(
+              'forced cleanup unlink failure before restore race',
+            ) as NodeJS.ErrnoException
+            error.code = 'EACCES'
+            throw error
+          }
+          return actual.unlink(path)
+        },
+        symlink: async (
+          target: string,
+          path: string,
+          type?: Parameters<typeof actual.symlink>[2],
+        ): Promise<void> => {
+          if (target === sourcePath && path === linkPath) {
+            await actual.symlink(replacementTargetPath, linkPath)
+            const error = new Error(
+              'forced restore destination collision',
+            ) as NodeJS.ErrnoException
+            error.code = 'EEXIST'
+            throw error
+          }
+          return actual.symlink(target, path, type)
+        },
+      }
+    })
+    const { __getTrashDirForTests, moveToTrash } =
+      await import('./trashService')
+
+    // Act / Assert
+    await expect(
+      moveToTrash(
+        skillName,
+        sourcePath,
+        await reviewedIdentityForPath(sourcePath),
+      ),
+    ).rejects.toThrow(/could not be restored/i)
+    expect((await lstat(sourcePath)).isDirectory()).toBe(true)
+    expect((await lstat(linkPath)).isSymbolicLink()).toBe(true)
+    expect(await readlink(linkPath)).toBe(replacementTargetPath)
+    const leftovers = await readdir(cursorSkillsDir)
+    const cleanupEntries = leftovers.filter((entry) =>
+      entry.startsWith(`${skillName}.cleanup-`),
+    )
+    expect(cleanupEntries).toHaveLength(1)
+    const cleanupPath = join(cursorSkillsDir, cleanupEntries[0]!)
+    expect((await lstat(cleanupPath)).isSymbolicLink()).toBe(true)
+    expect(await readlink(cleanupPath)).toBe(sourcePath)
+    expect(await readdir(__getTrashDirForTests())).toEqual([])
+  })
+
   it('restores earlier source-backed symlinks when a later agent aborts cascade cleanup', async () => {
     // Arrange
     const skillName = 'source-partial-rollback'

--- a/src/main/services/trashService.orphanRace.test.ts
+++ b/src/main/services/trashService.orphanRace.test.ts
@@ -1,4 +1,13 @@
-import { mkdir, mkdtemp, lstat, readlink, rm, symlink } from 'node:fs/promises'
+import {
+  mkdir,
+  mkdtemp,
+  lstat,
+  readdir,
+  readlink,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises'
 import type * as NodeFsPromises from 'node:fs/promises'
 import type * as NodeOs from 'node:os'
 import { tmpdir } from 'node:os'
@@ -96,5 +105,56 @@ describe('trashService orphan cleanup guarded commit', () => {
       `Failed to remove 1 of 1 orphan symlink for "${skillName}"`,
     )
     expect((await lstat(linkPath)).isDirectory()).toBe(true)
+  })
+
+  it('aborts source-backed delete when quarantined symlink restore fails', async () => {
+    // Arrange
+    const skillName = 'source-restore-failure'
+    const sourcePath = join(tempHome, '.agents', 'skills', skillName)
+    const cursorSkillsDir = join(tempHome, '.cursor', 'skills')
+    const linkPath = join(cursorSkillsDir, skillName)
+    const replacementTargetPath = join(
+      tempHome,
+      '.agents',
+      'skills',
+      'replacement-target',
+    )
+    await mkdir(sourcePath, { recursive: true })
+    await writeFile(join(sourcePath, 'SKILL.md'), `# ${skillName}\n`, 'utf-8')
+    await mkdir(cursorSkillsDir, { recursive: true })
+    await symlink(sourcePath, linkPath)
+    vi.doMock('node:fs/promises', async () => {
+      const actual =
+        await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
+      return {
+        ...actual,
+        unlink: async (path: string): Promise<void> => {
+          if (String(path).startsWith(`${linkPath}.cleanup-`)) {
+            await actual.symlink(replacementTargetPath, linkPath)
+            const error = new Error(
+              'forced cleanup unlink failure',
+            ) as NodeJS.ErrnoException
+            error.code = 'EACCES'
+            throw error
+          }
+          return actual.unlink(path)
+        },
+      }
+    })
+    const { __getTrashDirForTests, moveToTrash } =
+      await import('./trashService')
+
+    // Act / Assert
+    await expect(moveToTrash(skillName)).rejects.toThrow(
+      /Moved entry left|could not be restored|Failed to remove symlinks/i,
+    )
+    expect((await lstat(sourcePath)).isDirectory()).toBe(true)
+    expect((await lstat(linkPath)).isSymbolicLink()).toBe(true)
+    expect(await readlink(linkPath)).toBe(replacementTargetPath)
+    const leftovers = await readdir(cursorSkillsDir)
+    expect(
+      leftovers.some((entry) => entry.startsWith(`${skillName}.cleanup-`)),
+    ).toBe(true)
+    expect(await readdir(__getTrashDirForTests())).toEqual([])
   })
 })

--- a/src/main/services/trashService.orphanRace.test.ts
+++ b/src/main/services/trashService.orphanRace.test.ts
@@ -157,4 +157,61 @@ describe('trashService orphan cleanup guarded commit', () => {
     ).toBe(true)
     expect(await readdir(__getTrashDirForTests())).toEqual([])
   })
+
+  it('restores earlier source-backed symlinks when a later agent aborts cascade cleanup', async () => {
+    // Arrange
+    const skillName = 'source-partial-rollback'
+    const sourcePath = join(tempHome, '.agents', 'skills', skillName)
+    const claudeSkillsDir = join(tempHome, '.claude', 'skills')
+    const cursorSkillsDir = join(tempHome, '.cursor', 'skills')
+    const claudeLinkPath = join(claudeSkillsDir, skillName)
+    const cursorLinkPath = join(cursorSkillsDir, skillName)
+    const replacementTargetPath = join(
+      tempHome,
+      '.agents',
+      'skills',
+      'replacement-target',
+    )
+    await mkdir(sourcePath, { recursive: true })
+    await writeFile(join(sourcePath, 'SKILL.md'), `# ${skillName}\n`, 'utf-8')
+    await mkdir(claudeSkillsDir, { recursive: true })
+    await mkdir(cursorSkillsDir, { recursive: true })
+    await symlink(sourcePath, claudeLinkPath)
+    await symlink(sourcePath, cursorLinkPath)
+    vi.doMock('node:fs/promises', async () => {
+      const actual =
+        await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
+      return {
+        ...actual,
+        unlink: async (path: string): Promise<void> => {
+          if (String(path).startsWith(`${cursorLinkPath}.cleanup-`)) {
+            await actual.symlink(replacementTargetPath, cursorLinkPath)
+            const error = new Error(
+              'forced cleanup unlink failure',
+            ) as NodeJS.ErrnoException
+            error.code = 'EACCES'
+            throw error
+          }
+          return actual.unlink(path)
+        },
+      }
+    })
+    const { __getTrashDirForTests, moveToTrash } =
+      await import('./trashService')
+
+    // Act / Assert
+    await expect(moveToTrash(skillName)).rejects.toThrow(
+      /Failed to remove symlinks|could not be restored/i,
+    )
+    expect((await lstat(sourcePath)).isDirectory()).toBe(true)
+    expect((await lstat(claudeLinkPath)).isSymbolicLink()).toBe(true)
+    expect(await readlink(claudeLinkPath)).toBe(sourcePath)
+    expect((await lstat(cursorLinkPath)).isSymbolicLink()).toBe(true)
+    expect(await readlink(cursorLinkPath)).toBe(replacementTargetPath)
+    const leftovers = await readdir(cursorSkillsDir)
+    expect(
+      leftovers.some((entry) => entry.startsWith(`${skillName}.cleanup-`)),
+    ).toBe(true)
+    expect(await readdir(__getTrashDirForTests())).toEqual([])
+  })
 })

--- a/src/main/services/trashService.orphanRace.test.ts
+++ b/src/main/services/trashService.orphanRace.test.ts
@@ -311,7 +311,7 @@ describe('trashService orphan cleanup guarded commit', () => {
           path: string,
           options?: Parameters<typeof actual.rm>[1],
         ): Promise<void> => {
-          if (path === sourcePath) {
+          if (path.includes(`.${skillName}.trash-source-`)) {
             const error = new Error(
               'forced source remove failure',
             ) as NodeJS.ErrnoException
@@ -370,7 +370,7 @@ describe('trashService orphan cleanup guarded commit', () => {
           path: string,
           options?: Parameters<typeof actual.rm>[1],
         ): Promise<void> => {
-          if (path === localPath) {
+          if (path.includes(`.${skillName}.trash-local-claude-code-`)) {
             const error = new Error(
               'forced local remove failure',
             ) as NodeJS.ErrnoException

--- a/src/main/services/trashService.orphanRace.test.ts
+++ b/src/main/services/trashService.orphanRace.test.ts
@@ -6,6 +6,7 @@ import {
   readFile,
   readlink,
   rm,
+  stat,
   symlink,
   writeFile,
 } from 'node:fs/promises'
@@ -191,6 +192,166 @@ describe('trashService orphan cleanup guarded commit', () => {
     expect((await lstat(cleanupPath)).isSymbolicLink()).toBe(true)
     expect(await readlink(cleanupPath)).toBe(sourcePath)
     expect(await readdir(__getTrashDirForTests())).toEqual([])
+  })
+
+  it('preserves source-backed tombstone when source path reappears as an empty directory during restore', async () => {
+    // Arrange
+    const skillName = 'source-restore-empty-dir-race'
+    const sourcePath = join(tempHome, '.agents', 'skills', skillName)
+    let seededReplacement = false
+    vi.doMock('node:fs/promises', async () => {
+      const actual =
+        await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
+      return {
+        ...actual,
+        lstat: async (
+          path: string,
+          options?: Parameters<typeof actual.lstat>[1],
+        ): Promise<Awaited<ReturnType<typeof actual.lstat>>> => {
+          if (path === sourcePath && !seededReplacement) {
+            seededReplacement = true
+            await actual.mkdir(sourcePath, { recursive: true })
+            const error = new Error(
+              'source path was absent at review time',
+            ) as NodeJS.ErrnoException
+            error.code = 'ENOENT'
+            throw error
+          }
+          return actual.lstat(path, options)
+        },
+      }
+    })
+    const { __getTrashDirForTests, restore } = await import('./trashService')
+    const tombstone = `${Date.now()}-${skillName}-1234abcd`
+    const entryDir = join(__getTrashDirForTests(), tombstone)
+    const entrySourceDir = join(entryDir, 'source')
+    await mkdir(entrySourceDir, { recursive: true })
+    await writeFile(join(entrySourceDir, 'SKILL.md'), '# restored\n', 'utf-8')
+    await writeFile(
+      join(entryDir, 'manifest.json'),
+      JSON.stringify({
+        schemaVersion: 2,
+        kind: 'source-backed',
+        deletedAt: Date.now(),
+        skillName,
+        sourcePath,
+        symlinks: [],
+      }),
+      'utf-8',
+    )
+
+    // Act
+    const result = await restore(tombstone as never)
+
+    // Assert
+    expect(result.outcome).toBe('error')
+    if (result.outcome === 'error') {
+      expect(result.error.code).toBe('ERR_FS_CP_EEXIST')
+    }
+    expect(await readdir(sourcePath)).toEqual([])
+    await expect(stat(join(entrySourceDir, 'SKILL.md'))).resolves.toBeTruthy()
+  })
+
+  it('keeps local-only staged copy when agent slot reappears as an empty directory during restore', async () => {
+    // Arrange
+    const skillName = 'local-restore-empty-dir-race'
+    const linkPath = join(tempHome, '.claude', 'skills', skillName)
+    let seededReplacement = false
+    vi.doMock('node:fs/promises', async () => {
+      const actual =
+        await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
+      return {
+        ...actual,
+        lstat: async (
+          path: string,
+          options?: Parameters<typeof actual.lstat>[1],
+        ): Promise<Awaited<ReturnType<typeof actual.lstat>>> => {
+          if (path === linkPath && !seededReplacement) {
+            seededReplacement = true
+            await actual.mkdir(linkPath, { recursive: true })
+            const error = new Error(
+              'agent slot was absent at review time',
+            ) as NodeJS.ErrnoException
+            error.code = 'ENOENT'
+            throw error
+          }
+          return actual.lstat(path, options)
+        },
+      }
+    })
+    const { __getTrashDirForTests, restore } = await import('./trashService')
+    const tombstone = `${Date.now()}-${skillName}-5678abcd`
+    const entryDir = join(__getTrashDirForTests(), tombstone)
+    const stagedPath = join(entryDir, 'local-copies', 'claude-code')
+    await mkdir(stagedPath, { recursive: true })
+    await writeFile(join(stagedPath, 'SKILL.md'), '# staged\n', 'utf-8')
+    await writeFile(
+      join(entryDir, 'manifest.json'),
+      JSON.stringify({
+        schemaVersion: 2,
+        kind: 'local-only',
+        deletedAt: Date.now(),
+        skillName,
+        localCopies: [{ agentId: 'claude-code', linkPath }],
+      }),
+      'utf-8',
+    )
+
+    // Act
+    const result = await restore(tombstone as never)
+
+    // Assert
+    expect(result.outcome).toBe('restored')
+    if (result.outcome === 'restored') {
+      expect(result.symlinksRestored).toBe(0)
+      expect(result.symlinksSkipped).toBe(1)
+    }
+    expect(await readdir(linkPath)).toEqual([])
+    await expect(stat(join(stagedPath, 'SKILL.md'))).resolves.toBeTruthy()
+    await expect(stat(join(entryDir, 'manifest.json'))).resolves.toBeTruthy()
+  })
+
+  it('preserves relative symlink targets inside local-only staged copies during restore', async () => {
+    // Arrange
+    const skillName = 'local-restore-relative-symlink'
+    const linkPath = join(tempHome, '.claude', 'skills', skillName)
+    const { __getTrashDirForTests, restore } = await import('./trashService')
+    const tombstone = `${Date.now()}-${skillName}-9abcdeff`
+    const entryDir = join(__getTrashDirForTests(), tombstone)
+    const stagedPath = join(entryDir, 'local-copies', 'claude-code')
+    const symlinkPath = join(stagedPath, 'links', 'target-link')
+    await mkdir(join(stagedPath, 'links'), { recursive: true })
+    await mkdir(join(stagedPath, 'target'), { recursive: true })
+    await writeFile(
+      join(stagedPath, 'target', 'SKILL.md'),
+      '# target\n',
+      'utf-8',
+    )
+    await symlink('../target', symlinkPath)
+    await writeFile(
+      join(entryDir, 'manifest.json'),
+      JSON.stringify({
+        schemaVersion: 2,
+        kind: 'local-only',
+        deletedAt: Date.now(),
+        skillName,
+        localCopies: [{ agentId: 'claude-code', linkPath }],
+      }),
+      'utf-8',
+    )
+
+    // Act
+    const result = await restore(tombstone as never)
+
+    // Assert
+    expect(result.outcome).toBe('restored')
+    if (result.outcome === 'restored') {
+      expect(result.symlinksRestored).toBe(1)
+      expect(result.symlinksSkipped).toBe(0)
+    }
+    await expect(
+      readlink(join(linkPath, 'links', 'target-link')),
+    ).resolves.toBe('../target')
   })
 
   it('restores earlier source-backed symlinks when a later agent aborts cascade cleanup', async () => {

--- a/src/main/services/trashService.restore.test.ts
+++ b/src/main/services/trashService.restore.test.ts
@@ -73,6 +73,11 @@ interface TestSymlinkRecord {
   target: string
 }
 
+interface TestLocalCopyRecord {
+  agentId: string
+  linkPath: string
+}
+
 /**
  * Materialize a fake trash entry on disk so `restore()` has something to
  * consume. Returns the tombstoneId the caller should pass to `restore()`.
@@ -101,6 +106,39 @@ async function buildFakeTrashEntry(params: {
     skillName,
     sourcePath: join(sharedSourceDir, skillName),
     symlinks,
+  }
+  await writeFile(manifestPath, JSON.stringify(manifest), 'utf-8')
+  return tombstoneId
+}
+
+/**
+ * Materialize a fake local-only trash entry with staged agent folders.
+ * @param params - Skill name and local copy records to stage.
+ * @returns The tombstone id that can be passed to restore().
+ * @example await buildFakeLocalOnlyTrashEntry({ skillName: 'task', localCopies: [] })
+ */
+async function buildFakeLocalOnlyTrashEntry(params: {
+  skillName: string
+  localCopies: TestLocalCopyRecord[]
+}): Promise<string> {
+  const { skillName, localCopies } = params
+  const tombstoneId = `${Date.now()}-${skillName}-feedface`
+  const entryDir = join(sharedTrashDir, tombstoneId)
+  const localCopiesRoot = join(entryDir, 'local-copies')
+  const manifestPath = join(entryDir, 'manifest.json')
+
+  for (const copy of localCopies) {
+    const stagedPath = join(localCopiesRoot, copy.agentId)
+    await mkdir(stagedPath, { recursive: true })
+    await writeFile(join(stagedPath, 'SKILL.md'), `# ${skillName}\n`, 'utf-8')
+  }
+
+  const manifest = {
+    schemaVersion: 2,
+    kind: 'local-only',
+    deletedAt: Date.now(),
+    skillName,
+    localCopies,
   }
   await writeFile(manifestPath, JSON.stringify(manifest), 'utf-8')
   return tombstoneId
@@ -315,5 +353,34 @@ describe('trashService.restore target-containment', () => {
     }
     await stat(linkPathA)
     await expect(stat(linkPathB)).rejects.toThrow()
+  })
+
+  it('keeps local-only staged folders when destination collision skips restore', async () => {
+    // Arrange
+    const { restore } = await trashServicePromise
+    const skillName = 'local-partial-restore'
+    const linkPath = join(sharedClaudeAgent, skillName)
+    const tombstone = await buildFakeLocalOnlyTrashEntry({
+      skillName,
+      localCopies: [{ agentId: 'claude-code', linkPath }],
+    })
+    await mkdir(linkPath, { recursive: true })
+    await writeFile(join(linkPath, 'SKILL.md'), '# occupied\n', 'utf-8')
+
+    // Act
+    const result = await restore(tombstone as never)
+
+    // Assert
+    expect(result.outcome).toBe('restored')
+    if (result.outcome === 'restored') {
+      expect(result.symlinksRestored).toBe(0)
+      expect(result.symlinksSkipped).toBe(1)
+    }
+    const entryDir = join(sharedTrashDir, tombstone)
+    await expect(stat(entryDir)).resolves.toBeTruthy()
+    await expect(
+      stat(join(entryDir, 'local-copies', 'claude-code', 'SKILL.md')),
+    ).resolves.toBeTruthy()
+    await expect(stat(join(entryDir, 'manifest.json'))).resolves.toBeTruthy()
   })
 })

--- a/src/main/services/trashService.restore.test.ts
+++ b/src/main/services/trashService.restore.test.ts
@@ -185,6 +185,31 @@ describe('trashService.restore target-containment', () => {
     await expect(stat(join(sharedSourceDir, skillName))).resolves.toBeTruthy()
   })
 
+  it('recreates a missing agent skills parent before restoring a recorded symlink', async () => {
+    // Arrange
+    const { restore } = await trashServicePromise
+    const skillName = 'missing-agent-parent'
+    const linkPath = join(sharedClaudeAgent, skillName)
+    const target = join(sharedSourceDir, skillName)
+    const tombstone = await buildFakeTrashEntry({
+      skillName,
+      symlinks: [{ agentId: 'claude-code', linkPath, target }],
+    })
+    await rm(sharedClaudeAgent, { recursive: true, force: true })
+
+    // Act
+    const result = await restore(tombstone as never)
+
+    // Assert
+    expect(result.outcome).toBe('restored')
+    if (result.outcome === 'restored') {
+      expect(result.symlinksRestored).toBe(1)
+      expect(result.symlinksSkipped).toBe(0)
+    }
+    expect((await lstat(linkPath)).isSymbolicLink()).toBe(true)
+    await expect(readlink(linkPath)).resolves.toBe(target)
+  })
+
   it('skips symlink when manifest target absolute-escapes SOURCE_DIR', async () => {
     const { restore } = await trashServicePromise
     const skillName = 'target-abs-escape'

--- a/src/main/services/trashService.restore.test.ts
+++ b/src/main/services/trashService.restore.test.ts
@@ -1,7 +1,15 @@
 import { mkdtempSync, realpathSync } from 'node:fs'
-import { mkdir, rm, stat, writeFile } from 'node:fs/promises'
+import {
+  lstat,
+  mkdir,
+  readlink,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, relative } from 'node:path'
 
 import {
   afterAll,
@@ -114,6 +122,8 @@ describe('trashService.restore target-containment', () => {
     await rm(sharedTrashDir, { recursive: true, force: true })
     await rm(sharedSourceDir, { recursive: true, force: true })
     await rm(sharedClaudeAgent, { recursive: true, force: true })
+    await rm(join(sharedHome, '.config'), { recursive: true, force: true })
+    await rm(join(sharedHome, 'dotfiles'), { recursive: true, force: true })
     await mkdir(sharedSourceDir, { recursive: true })
     await mkdir(sharedClaudeAgent, { recursive: true })
   })
@@ -140,6 +150,39 @@ describe('trashService.restore target-containment', () => {
     await stat(join(sharedSourceDir, skillName))
     // Symlink re-planted.
     await stat(linkPath)
+  })
+
+  it('restores a Devin symlink whose relative target depends on physical .config parent', async () => {
+    // Arrange
+    const { restore } = await trashServicePromise
+    const skillName = 'devin-relative-restore'
+    const physicalConfigDir = join(sharedHome, 'dotfiles', '.config')
+    const physicalDevinSkillsDir = join(physicalConfigDir, 'devin', 'skills')
+    const logicalConfigDir = join(sharedHome, '.config')
+    const logicalDevinSkillsDir = join(logicalConfigDir, 'devin', 'skills')
+    const linkPath = join(logicalDevinSkillsDir, skillName)
+    const target = relative(
+      physicalDevinSkillsDir,
+      join(sharedSourceDir, skillName),
+    )
+    await mkdir(physicalDevinSkillsDir, { recursive: true })
+    await symlink(physicalConfigDir, logicalConfigDir)
+    const tombstone = await buildFakeTrashEntry({
+      skillName,
+      symlinks: [{ agentId: 'devin', linkPath, target }],
+    })
+
+    // Act
+    const result = await restore(tombstone as never)
+
+    // Assert
+    expect(result.outcome).toBe('restored')
+    if (result.outcome === 'restored') {
+      expect(result.symlinksRestored).toBeGreaterThanOrEqual(1)
+    }
+    expect((await lstat(linkPath)).isSymbolicLink()).toBe(true)
+    await expect(readlink(linkPath)).resolves.toBe(target)
+    await expect(stat(join(sharedSourceDir, skillName))).resolves.toBeTruthy()
   })
 
   it('skips symlink when manifest target absolute-escapes SOURCE_DIR', async () => {

--- a/src/main/services/trashService.restore.test.ts
+++ b/src/main/services/trashService.restore.test.ts
@@ -190,6 +190,38 @@ describe('trashService.restore target-containment', () => {
     await stat(linkPath)
   })
 
+  it('refuses source-backed restore when a dangling symlink occupies the source path', async () => {
+    // Arrange
+    const { restore } = await trashServicePromise
+    const skillName = 'source-path-dangling-collision'
+    const linkPath = join(sharedClaudeAgent, skillName)
+    const sourcePath = join(sharedSourceDir, skillName)
+    const tombstone = await buildFakeTrashEntry({
+      skillName,
+      symlinks: [{ agentId: 'claude-code', linkPath, target: sourcePath }],
+    })
+    await symlink(join(sharedSourceDir, 'missing-target'), sourcePath)
+
+    // Act
+    const result = await restore(tombstone as never)
+
+    // Assert
+    expect(result).toEqual({
+      outcome: 'error',
+      error: {
+        message: 'A skill already exists at the original path',
+        code: 'EEXIST',
+      },
+    })
+    expect((await lstat(sourcePath)).isSymbolicLink()).toBe(true)
+    await expect(readlink(sourcePath)).resolves.toBe(
+      join(sharedSourceDir, 'missing-target'),
+    )
+    await expect(
+      stat(join(sharedTrashDir, tombstone, 'source', 'SKILL.md')),
+    ).resolves.toBeTruthy()
+  })
+
   it('restores a Devin symlink whose relative target depends on physical .config parent', async () => {
     // Arrange
     const { restore } = await trashServicePromise

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -967,6 +967,9 @@ async function moveSourceBackedToTrash(
           // after scan. Leave them for manual review instead of cascading.
           continue
         }
+        // Source has not moved yet. Restore earlier cascade removals so a later
+        // fatal slot failure cannot leave a live source with missing agent links.
+        await rollbackRemovedSymlinks(recordedSymlinks)
         throw new TrashError(
           `Failed to remove symlinks: ${extractErrorMessage(error)}`,
           code,

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -1092,10 +1092,13 @@ async function moveSourceBackedToTrash(
     // Step 2: re-create the symlinks we removed. Best-effort; already logs per link.
     await rollbackRemovedSymlinks(recordedSymlinks)
 
-    // Step 3: drop the empty (or partial) trash entry dir.
-    await fs.rm(entryDir, { recursive: true, force: true }).catch(() => {
-      // entry cleanup is best-effort — caller already has the real error.
-    })
+    // Step 3: drop only fully rolled-back entries. If source restore failed,
+    // entrySourceDir is the manual recovery path and must survive this error.
+    if (!restoreSourceFailed) {
+      await fs.rm(entryDir, { recursive: true, force: true }).catch(() => {
+        // entry cleanup is best-effort — caller already has the real error.
+      })
+    }
 
     // If we couldn't put the source back the user is in a broken state. Flag
     // it in the thrown error so the caller surfaces "manual recovery" to the UI.
@@ -1532,8 +1535,8 @@ async function restoreSourceBacked(
 /**
  * Restore a local-only tombstone: for each `localCopies[i]`, rename
  * `<entryDir>/local-copies/<agentId>/` back to its original `linkPath`.
- * Per-copy collisions or unknown agents skip cleanly — partial restores are
- * still reported as `outcome: 'restored'` with `symlinksSkipped > 0`.
+ * Per-copy collisions or unknown agents skip cleanly. Partial restores keep
+ * the tombstone directory so skipped staged folders stay recoverable by hand.
  *
  * Reuses `symlinksRestored`/`symlinksSkipped` for parity with source-backed
  * — both fields semantically count "agent-side restorations" regardless of
@@ -1585,6 +1588,16 @@ async function restoreLocalOnly(
     }
   }
 
+  if (symlinksSkipped > 0) {
+    // Keep local-copies/<agentId> entries that could not be restored.
+    cancelEvictTimer(id)
+    return {
+      outcome: 'restored',
+      symlinksRestored,
+      symlinksSkipped,
+    }
+  }
+
   await finalizeRestore(id, entryDir)
 
   return {
@@ -1595,19 +1608,32 @@ async function restoreLocalOnly(
 }
 
 /**
- * Shared restore postlude: cancel pending evict timer + remove the trash entry
- * directory. Best-effort; called after both source-backed and local-only
- * restorations succeed past their per-record loop.
+ * Cancel the pending trash eviction timer without deleting the trash entry.
+ * @param id - Tombstone id whose timer should stop.
+ * @returns void
+ * @example cancelEvictTimer(tombstoneId('1729-task-deadbeef'))
  */
-async function finalizeRestore(
-  id: TombstoneId,
-  entryDir: string,
-): Promise<void> {
+function cancelEvictTimer(id: TombstoneId): void {
   const pendingTimer = evictTimers.get(id)
   if (pendingTimer) {
     clearTimeout(pendingTimer)
     evictTimers.delete(id)
   }
+}
+
+/**
+ * Shared restore postlude: cancel pending evict timer + remove the trash entry directory.
+ * Best-effort; called after complete source-backed or local-only restorations.
+ * @param id - Tombstone id whose timer and entry should be removed.
+ * @param entryDir - On-disk trash entry directory to delete.
+ * @returns Promise that resolves after the entry directory is removed.
+ * @example await finalizeRestore(tombstoneId('1729-task-deadbeef'), '/Users/me/.agents/.trash/1729-task-deadbeef')
+ */
+async function finalizeRestore(
+  id: TombstoneId,
+  entryDir: string,
+): Promise<void> {
+  cancelEvictTimer(id)
   await fs.rm(entryDir, { recursive: true, force: true })
 }
 

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -457,6 +457,127 @@ export async function readReviewedDanglingSymlink(options: {
 }
 
 /**
+ * Compare paths by filesystem identity when possible, falling back to resolve().
+ * @param leftPath - First path to compare.
+ * @param rightPath - Second path to compare.
+ * @returns true when both paths identify the same filesystem target.
+ * @example await pathsReferenceSameTarget('/tmp/a-link-target', '/tmp/a')
+ */
+async function pathsReferenceSameTarget(
+  leftPath: AbsolutePath,
+  rightPath: AbsolutePath,
+): Promise<boolean> {
+  const normalizeForIdentity = async (path: AbsolutePath): Promise<string> => {
+    try {
+      return await fs.realpath(path)
+    } catch {
+      return resolve(path)
+    }
+  }
+
+  return (
+    (await normalizeForIdentity(leftPath)) ===
+    (await normalizeForIdentity(rightPath))
+  )
+}
+
+/**
+ * Read and verify a source-backed agent symlink still points to the source.
+ * @param linkPath - Candidate agent symlink path.
+ * @param sourcePath - Source skill directory being moved to trash.
+ * @returns Raw and resolved target for manifest recording.
+ * @example await readReviewedSourceSymlink(linkPath, sourcePath)
+ */
+async function readReviewedSourceSymlink(
+  linkPath: AbsolutePath,
+  sourcePath: AbsolutePath,
+): Promise<{ rawTarget: string; resolvedTarget: AbsolutePath }> {
+  let stats: Stats
+  try {
+    stats = await fs.lstat(linkPath)
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      throw new TrashError(
+        'Source-backed agent symlink is already missing',
+        'ENOENT',
+      )
+    }
+    throw new TrashError(extractErrorMessage(error), errorCode(error))
+  }
+
+  if (!stats.isSymbolicLink()) {
+    throw new TrashError(
+      'Source-backed agent slot is no longer a symlink',
+      'ESTALE',
+    )
+  }
+
+  let rawTarget: string
+  try {
+    rawTarget = await fs.readlink(linkPath)
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      throw new TrashError(
+        'Source-backed agent symlink is already missing',
+        'ENOENT',
+      )
+    }
+    throw new TrashError(
+      'Source-backed agent slot is no longer a symlink',
+      'ESTALE',
+    )
+  }
+
+  const resolvedTarget = await resolveRawSymlinkTarget(linkPath, rawTarget)
+  if (!(await pathsReferenceSameTarget(resolvedTarget, sourcePath))) {
+    throw new TrashError(
+      'Source-backed agent symlink no longer points to the source being deleted',
+      'ESTALE',
+    )
+  }
+
+  return { rawTarget, resolvedTarget }
+}
+
+/**
+ * Quarantine, revalidate, then unlink one source-owned agent symlink.
+ * @param linkPath - Candidate symlink path under an agent skills directory.
+ * @param sourcePath - Source directory whose matching symlinks may be removed.
+ * @returns Missing status or the raw target removed for manifest restore.
+ * @example await unlinkReviewedSourceSymlink(linkPath, sourcePath)
+ */
+async function unlinkReviewedSourceSymlink(
+  linkPath: AbsolutePath,
+  sourcePath: AbsolutePath,
+): Promise<'missing' | { outcome: 'unlinked'; target: string }> {
+  try {
+    await readReviewedSourceSymlink(linkPath, sourcePath)
+  } catch (error) {
+    if (isMissingPathError(error)) return 'missing'
+    throw error
+  }
+
+  const movedPath =
+    `${linkPath}.cleanup-${randomBytes(4).toString('hex')}` as AbsolutePath
+
+  try {
+    await fs.rename(linkPath, movedPath)
+  } catch (error) {
+    if (isMissingPathError(error)) return 'missing'
+    throw new TrashError(extractErrorMessage(error), errorCode(error))
+  }
+
+  try {
+    const movedReviewed = await readReviewedSourceSymlink(movedPath, sourcePath)
+    await fs.unlink(movedPath)
+    return { outcome: 'unlinked', target: movedReviewed.rawTarget }
+  } catch (error) {
+    await restoreMovedCleanupCandidate(linkPath, movedPath)
+    throw error
+  }
+}
+
+/**
  * Assert the reviewed symlink target is still absent and cleanup-safe.
  * @param resolvedTarget - Absolute target path resolved from the reviewed symlink.
  * @param targetExistsMessage - Stale message when the source target reappears.
@@ -823,25 +944,17 @@ async function moveSourceBackedToTrash(
     }
 
     if (stats.isSymbolicLink()) {
-      let target: string
+      let removal: 'missing' | { outcome: 'unlinked'; target: string }
       try {
-        target = await fs.readlink(linkPath)
-      } catch (error) {
-        const code = errorCode(error)
-        if (code === 'ENOENT') continue
-        throw new TrashError(
-          `Failed to read symlink target: ${extractErrorMessage(error)}`,
-          code,
+        removal = await unlinkReviewedSourceSymlink(
+          linkPath as AbsolutePath,
+          sourcePath,
         )
-      }
-      try {
-        await fs.unlink(linkPath)
       } catch (error) {
         const code = errorCode(error)
-        if (code === 'ENOENT') {
-          // Race: file disappeared between lstat and unlink. Record best-effort, continue.
-          recordedSymlinks.push({ agentId: agent.id, linkPath, target })
-          cascadeAgentIds.push(agent.id)
+        if (code === 'ENOENT' || code === 'ESTALE') {
+          // Stale/mismatched same-name links belong to another source or changed
+          // after scan. Leave them for manual review instead of cascading.
           continue
         }
         throw new TrashError(
@@ -849,7 +962,12 @@ async function moveSourceBackedToTrash(
           code,
         )
       }
-      recordedSymlinks.push({ agentId: agent.id, linkPath, target })
+      if (removal === 'missing') continue
+      recordedSymlinks.push({
+        agentId: agent.id,
+        linkPath,
+        target: removal.target,
+      })
       cascadeAgentIds.push(agent.id)
     }
     // Non-symlink directories inside agent dirs are "local skills" — leave them

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -34,6 +34,9 @@ const TRASH_DIR = join(homedir(), '.agents', '.trash')
  */
 const ERR_MANIFEST_CORRUPT = 'EMANIFEST_CORRUPT'
 
+/** Stable code for a quarantined cleanup candidate that could not be restored. */
+const ERR_CLEANUP_RESTORE_FAILED = 'ECLEANUP_RESTORE_FAILED'
+
 /** How long a tombstone lives before being evicted in-session (ms). Matches E1 undo window. */
 const TRASH_TTL_MS = UNDO_WINDOW_MS
 
@@ -572,7 +575,14 @@ async function unlinkReviewedSourceSymlink(
     await fs.unlink(movedPath)
     return { outcome: 'unlinked', target: movedReviewed.rawTarget }
   } catch (error) {
-    await restoreMovedCleanupCandidate(linkPath, movedPath)
+    try {
+      await restoreMovedCleanupCandidate(linkPath, movedPath)
+    } catch (restoreError) {
+      throw new TrashError(
+        extractErrorMessage(restoreError),
+        ERR_CLEANUP_RESTORE_FAILED,
+      )
+    }
     throw error
   }
 }

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -2,7 +2,7 @@ import { randomBytes } from 'node:crypto'
 import type { Stats } from 'node:fs'
 import * as fs from 'node:fs/promises'
 import { homedir } from 'node:os'
-import { dirname, isAbsolute, join, resolve } from 'node:path'
+import { dirname, join } from 'node:path'
 
 import { match } from 'ts-pattern'
 import type { z } from 'zod'
@@ -1105,9 +1105,10 @@ async function restoreSourceBacked(
     // `fs.readlink` returned at delete-time — it may be absolute or relative
     // to the symlink's own directory (kernel resolution contract). A tampered
     // manifest could otherwise steer restore into planting links at '/etc/...'.
-    const resolvedTarget = isAbsolute(link.target)
-      ? link.target
-      : resolve(dirname(link.linkPath), link.target)
+    const resolvedTarget = await resolveRawSymlinkTarget(
+      link.linkPath,
+      link.target,
+    )
     try {
       validatePath(resolvedTarget, [SOURCE_DIR])
     } catch {

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -23,7 +23,10 @@ import type {
   UnixTimestampMs,
 } from '@/shared/types'
 
-import { isSameFilesystemIdentity } from './filesystemIdentity'
+import {
+  isReviewedEntryUnchanged,
+  isSameFilesystemIdentity,
+} from './filesystemIdentity'
 import { getAllowedBases, validatePath } from './pathValidation'
 import { isValidSkillDir } from './skillValidation'
 import { resolveRawSymlinkTarget } from './symlinkChecker'
@@ -265,7 +268,9 @@ async function assertReviewedSkillDirectory(
       'ESTALE',
     )
   }
-  if (!isSameFilesystemIdentity(stats, reviewedIdentity)) {
+  // Pre-staging gate: reject a same-path rm+mkdir replacement even when the
+  // OS recycled the inode number (ext4/CI), which dev+ino alone would miss.
+  if (!isReviewedEntryUnchanged(stats, reviewedIdentity)) {
     throw new TrashError('Reviewed skill folder changed since review', 'ESTALE')
   }
   if (!(await isValidSkillDir(reviewedPath))) {

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -23,11 +23,7 @@ import type {
   UnixTimestampMs,
 } from '@/shared/types'
 
-import {
-  filesystemIdentityFromStats,
-  isSameFilesystemEntryIdentity,
-  isSameFilesystemIdentity,
-} from './filesystemIdentity'
+import { isSameFilesystemIdentity } from './filesystemIdentity'
 import { getAllowedBases, validatePath } from './pathValidation'
 import { isValidSkillDir } from './skillValidation'
 import { resolveRawSymlinkTarget } from './symlinkChecker'
@@ -226,6 +222,48 @@ async function assertReviewedSkillDirectory(
 }
 
 /**
+ * Build a hidden sibling stage path so reviewed entries can be atomically renamed before copy/delete work.
+ * @param reviewedPath - Original reviewed directory path.
+ * @param label - Short operation label for diagnostics.
+ * @returns Hidden path in the same parent directory as the reviewed entry.
+ * @example buildSiblingStagePath('/Users/me/.agents/skills/task', 'trash')
+ */
+function buildSiblingStagePath(
+  reviewedPath: AbsolutePath,
+  label: string,
+): string {
+  const suffix = randomBytes(RAND_SUFFIX_BYTES).toString('hex')
+  return join(
+    dirname(reviewedPath),
+    `.${basename(reviewedPath)}.${label}-${suffix}`,
+  )
+}
+
+/**
+ * Verify a staged directory is still the entry the user reviewed before committing a destructive move.
+ * @param stagedPath - Directory path after an atomic rename/quarantine step.
+ * @param reviewedIdentity - Filesystem identity captured at review time.
+ * @param staleMessage - Error shown when the staged entry is not the reviewed one.
+ * @returns void after identity and directory-kind checks pass.
+ * @example
+ * await assertStagedReviewedDirectory('/tmp/.task.stage', reviewedIdentity, 'Reviewed skill folder changed since review')
+ */
+async function assertStagedReviewedDirectory(
+  stagedPath: string,
+  reviewedIdentity: FilesystemEntryIdentity,
+  staleMessage: string,
+): Promise<void> {
+  const stagedStats = await fs.lstat(stagedPath)
+  if (
+    !stagedStats.isDirectory() ||
+    stagedStats.isSymbolicLink() ||
+    !isSameFilesystemIdentity(stagedStats, reviewedIdentity)
+  ) {
+    throw new TrashError(staleMessage, 'ESTALE')
+  }
+}
+
+/**
  * Mark a trash entry as non-evictable because it contains manual recovery data.
  * @param entryDir - Trash entry directory that must survive TTL/startup cleanup.
  * @param reason - Human-readable recovery reason for operators and tests.
@@ -320,21 +358,85 @@ interface SourceMoveFailure {
 async function moveSourceIntoTrashEntry(
   sourcePath: AbsolutePath,
   entrySourceDir: string,
+  reviewedIdentity: FilesystemEntryIdentity,
 ): Promise<SourceMoveFailure | null> {
   try {
     await fs.rename(sourcePath, entrySourceDir)
+    try {
+      await assertStagedReviewedDirectory(
+        entrySourceDir,
+        reviewedIdentity,
+        'Reviewed skill folder changed since review',
+      )
+    } catch (identityError) {
+      try {
+        await renameWithCrossDeviceFallback(entrySourceDir, sourcePath)
+      } catch {
+        return {
+          preserveEntryDirForManualRecovery: true,
+          error:
+            identityError instanceof TrashError
+              ? identityError
+              : new TrashError(
+                  `Failed to validate staged source: ${extractErrorMessage(identityError)}`,
+                  errorCode(identityError),
+                ),
+        }
+      }
+      return {
+        preserveEntryDirForManualRecovery: false,
+        error:
+          identityError instanceof TrashError
+            ? identityError
+            : new TrashError(
+                `Failed to validate staged source: ${extractErrorMessage(identityError)}`,
+                errorCode(identityError),
+              ),
+      }
+    }
     return null
   } catch (error) {
     const code = errorCode(error)
 
     if (code === 'EXDEV') {
       let preserveEntryDirForManualRecovery = false
+      const siblingStagePath = buildSiblingStagePath(sourcePath, 'trash-source')
       try {
-        await fs.cp(sourcePath, entrySourceDir, { recursive: true })
+        // Cross-device fallback still starts with a same-directory rename, so
+        // the original reviewed entry is isolated before any copy/remove work.
+        await fs.rename(sourcePath, siblingStagePath)
+        try {
+          await assertStagedReviewedDirectory(
+            siblingStagePath,
+            reviewedIdentity,
+            'Reviewed skill folder changed since review',
+          )
+        } catch (identityError) {
+          await renameWithCrossDeviceFallback(siblingStagePath, sourcePath)
+          return {
+            preserveEntryDirForManualRecovery: false,
+            error:
+              identityError instanceof TrashError
+                ? identityError
+                : new TrashError(
+                    `Failed to validate staged source: ${extractErrorMessage(identityError)}`,
+                    errorCode(identityError),
+                  ),
+          }
+        }
+        await fs.cp(siblingStagePath, entrySourceDir, { recursive: true })
         preserveEntryDirForManualRecovery = true
-        await fs.rm(sourcePath, { recursive: true, force: true })
+        await fs.rm(siblingStagePath, { recursive: true, force: true })
         return null
       } catch (fallbackError) {
+        try {
+          await fs.lstat(siblingStagePath)
+          await renameWithCrossDeviceFallback(siblingStagePath, sourcePath)
+        } catch (restoreError) {
+          if (errorCode(restoreError) !== 'ENOENT') {
+            preserveEntryDirForManualRecovery = true
+          }
+        }
         const recoveryHint = preserveEntryDirForManualRecovery
           ? `; source copy preserved in ${entrySourceDir}`
           : ''
@@ -440,58 +542,6 @@ export type MoveToTrashResult = {
   tombstoneId: TombstoneId
   cascadeAgents: AgentId[]
   symlinksRemoved: number
-}
-
-/**
- * Walk every configured agent directory and find real (non-symlink) folders
- * matching `skillName`. Used by `moveToTrash` when `~/.agents/skills/<name>`
- * has no source dir but the skill exists as a local copy in one or more agents.
- *
- * Symlinks are deliberately ignored here — for local-only delete we only move
- * real directories. A stray symlink pointing at one of those copies will become
- * broken after delete and is surfaced by the next scan as a "broken" entry.
- *
- * @param skillName - Validated skill name (no separators)
- * @returns Per-agent local copy records, ordered by AGENTS iteration
- */
-async function scanLocalCopies(
-  skillName: SkillName,
-): Promise<RecordedLocalCopy[]> {
-  const copies: RecordedLocalCopy[] = []
-  for (const agent of AGENTS) {
-    const linkPath = join(agent.path, skillName)
-    try {
-      // For real directories validation can use [agent.path] specifically —
-      // unlike symlinks, realpath stops at the directory itself, which lives
-      // inside the agent's allowed base.
-      validatePath(linkPath, [agent.path])
-    } catch {
-      continue
-    }
-    let stats: Stats
-    try {
-      stats = await fs.lstat(linkPath)
-    } catch (error) {
-      if (errorCode(error) === 'ENOENT') continue
-      // Permission error or other — log and skip this agent rather than abort
-      // the whole scan; the user can retry once they've fixed perms.
-      console.warn('trashService: scanLocalCopies lstat failed', {
-        agentId: agent.id,
-        linkPath,
-        code: errorCode(error),
-        message: extractErrorMessage(error),
-      })
-      continue
-    }
-    if (stats.isDirectory() && !stats.isSymbolicLink()) {
-      copies.push({
-        agentId: agent.id,
-        linkPath: linkPath as AbsolutePath,
-        filesystemIdentity: filesystemIdentityFromStats(stats),
-      })
-    }
-  }
-  return copies
 }
 
 /**
@@ -875,25 +925,14 @@ export async function moveToTrash(
       deleteIdentity.reviewedLocalCopy.linkPath,
       reviewedIdentity,
     )
-    const localCopies = await scanLocalCopies(
-      deleteIdentity.filesystemSkillName,
-    )
-    const reviewedCopyStillPresent = localCopies.some(
-      (copy) =>
-        copy.linkPath === deleteIdentity.reviewedLocalCopy.linkPath &&
-        copy.filesystemIdentity !== undefined &&
-        isSameFilesystemEntryIdentity(
-          copy.filesystemIdentity,
-          reviewedIdentity,
-        ),
-    )
-    if (!reviewedCopyStillPresent) {
-      throw new TrashError(
-        'Reviewed local skill folder not found (already changed?)',
-        'ESTALE',
-      )
-    }
-    return moveLocalOnlyToTrash(skillName, localCopies)
+    // Local rows are reviewed one folder at a time; never sweep sibling agent
+    // folders that merely share the same basename.
+    return moveLocalOnlyToTrash(skillName, [
+      {
+        ...deleteIdentity.reviewedLocalCopy,
+        filesystemIdentity: reviewedIdentity,
+      },
+    ])
   }
 
   const { sourcePath } = deleteIdentity
@@ -901,7 +940,7 @@ export async function moveToTrash(
   // A reviewed source row must still be the same valid directory the user saw.
   await assertReviewedSkillDirectory(sourcePath, reviewedIdentity)
 
-  return moveSourceBackedToTrash(skillName, sourcePath)
+  return moveSourceBackedToTrash(skillName, sourcePath, reviewedIdentity)
 }
 
 /**
@@ -1005,6 +1044,7 @@ async function removeSourceBackedAgentSymlinks(
 async function moveSourceBackedToTrash(
   skillName: SkillName,
   sourcePath: AbsolutePath,
+  reviewedIdentity: FilesystemEntryIdentity,
 ): Promise<Extract<MoveToTrashResult, { kind: 'tombstoned' }>> {
   // fallow-ignore-next-line code-duplication
   const startTime = Date.now()
@@ -1027,6 +1067,7 @@ async function moveSourceBackedToTrash(
   const sourceMoveFailure = await moveSourceIntoTrashEntry(
     sourcePath,
     entrySourceDir,
+    reviewedIdentity,
   )
   if (sourceMoveFailure !== null) {
     // Rollback symlinks, but never delete an entry that now holds the recovery
@@ -1185,22 +1226,87 @@ async function moveLocalOnlyToTrash(
   const moved: RecordedLocalCopy[] = []
   for (const copy of localCopies) {
     const stagedPath = join(localCopiesRoot, copy.agentId)
+    if (!copy.filesystemIdentity) {
+      const unrestoredCopies = await rollbackMovedLocalCopies(entryDir, moved)
+      if (unrestoredCopies.length === 0) {
+        await fs.rm(entryDir, { recursive: true, force: true }).catch(() => {
+          // best-effort cleanup
+        })
+      } else {
+        await markManualRecoveryEntry(
+          entryDir,
+          'local-only rollback left staged copies in trash',
+        )
+      }
+      throw new TrashError(
+        'Reviewed local skill folder is missing filesystem identity',
+        'ESTALE',
+      )
+    }
+    const reviewedFilesystemIdentity = copy.filesystemIdentity
     try {
       await fs.rename(copy.linkPath, stagedPath)
       moved.push(copy)
+      await assertStagedReviewedDirectory(
+        stagedPath,
+        reviewedFilesystemIdentity,
+        'Reviewed local skill folder changed since review',
+      )
     } catch (error) {
       const code = errorCode(error)
       // EXDEV across volumes — fall back to cp + rm. ENOENT means the copy
       // disappeared mid-flight (race); skip and continue rather than abort.
       const recoveryOutcome = await match(code)
         .with('EXDEV', async () => {
+          const siblingStagePath = buildSiblingStagePath(
+            copy.linkPath,
+            `trash-local-${copy.agentId}`,
+          )
           let stagedCopyCreated = false
           try {
-            await fs.cp(copy.linkPath, stagedPath, { recursive: true })
+            // Rename inside the original agent dir first; this binds the copy
+            // to the reviewed identity before non-atomic cross-device copy.
+            await fs.rename(copy.linkPath, siblingStagePath)
+            try {
+              await assertStagedReviewedDirectory(
+                siblingStagePath,
+                reviewedFilesystemIdentity,
+                'Reviewed local skill folder changed since review',
+              )
+            } catch (identityError) {
+              await renameWithCrossDeviceFallback(
+                siblingStagePath,
+                copy.linkPath,
+              )
+              return {
+                kind: 'fatal' as const,
+                preserveEntryDir: false,
+                strandedAgentId: copy.agentId,
+                error:
+                  identityError instanceof TrashError
+                    ? identityError
+                    : new TrashError(
+                        `Failed to validate staged local copy (agent=${copy.agentId}): ${extractErrorMessage(identityError)}`,
+                        errorCode(identityError),
+                      ),
+              }
+            }
+            await fs.cp(siblingStagePath, stagedPath, { recursive: true })
             stagedCopyCreated = true
-            await fs.rm(copy.linkPath, { recursive: true, force: true })
+            await fs.rm(siblingStagePath, { recursive: true, force: true })
             return { kind: 'moved' as const }
           } catch (fallbackError) {
+            try {
+              await fs.lstat(siblingStagePath)
+              await renameWithCrossDeviceFallback(
+                siblingStagePath,
+                copy.linkPath,
+              )
+            } catch (restoreError) {
+              if (errorCode(restoreError) !== 'ENOENT') {
+                stagedCopyCreated = true
+              }
+            }
             const recoveryHint = stagedCopyCreated
               ? `; staged copy preserved in ${stagedPath}`
               : ''

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -86,6 +86,22 @@ export interface RecordedLocalCopy {
 }
 
 /**
+ * Reviewed delete identity after path validation; keeps source-backed and
+ * agent-local destructive flows separate so one cannot masquerade as the other.
+ */
+type DeleteIdentity =
+  | {
+      kind: 'source'
+      filesystemSkillName: SkillName
+      sourcePath: AbsolutePath
+    }
+  | {
+      kind: 'agent-local'
+      filesystemSkillName: SkillName
+      reviewedLocalCopy: RecordedLocalCopy
+    }
+
+/**
  * Build a unique trash entry name from skillName + current clock + random suffix.
  * `rand8hex` prevents same-ms collisions on fast machines (reviewer iter-2 HIGH-4).
  * @param skillName - Validated skill name (no path separators)
@@ -119,42 +135,37 @@ function skillNameFromPathBasename(absolutePath: AbsolutePath): SkillName {
 
 /**
  * Resolve a reviewed renderer path into the filesystem identity used for deletion.
- * @param skillName - Display/metadata name selected by the user.
- * @param reviewedSkillPath - Optional source or local folder path from the reviewed row.
- * @returns Filesystem name plus optional source directory path.
- * @example resolveDeleteIdentity('metadata-title', '/Users/me/.agents/skills/folder-basename')
+ * @param reviewedSkillPath - Source or local folder path from the reviewed row.
+ * @returns Reviewed filesystem identity for the exact destructive flow.
+ * @example resolveDeleteIdentity('/Users/me/.agents/skills/folder-basename')
  */
 function resolveDeleteIdentity(
-  skillName: SkillName,
-  reviewedSkillPath?: AbsolutePath,
-): { filesystemSkillName: SkillName; sourcePath: AbsolutePath } {
-  if (!reviewedSkillPath) {
-    const sourcePath = join(SOURCE_DIR, skillName) as AbsolutePath
-    validatePath(sourcePath, [SOURCE_DIR])
-    return { filesystemSkillName: skillName, sourcePath }
-  }
-
+  reviewedSkillPath: AbsolutePath,
+): DeleteIdentity {
   const normalizedPath = resolve(reviewedSkillPath) as AbsolutePath
   const sourceDir = resolve(SOURCE_DIR)
   if (dirname(normalizedPath) === sourceDir) {
     validatePath(normalizedPath, [SOURCE_DIR])
     return {
+      kind: 'source',
       filesystemSkillName: skillNameFromPathBasename(normalizedPath),
       sourcePath: normalizedPath,
     }
   }
 
-  const isAgentSlotPath = AGENTS.some(
+  const agent = AGENTS.find(
     (agent) => dirname(normalizedPath) === resolve(agent.path),
   )
-  if (isAgentSlotPath) {
-    validatePath(normalizedPath, getAllowedBases())
+  if (agent) {
+    validatePath(normalizedPath, [agent.path])
     const filesystemSkillName = skillNameFromPathBasename(normalizedPath)
-    const sourcePath = join(SOURCE_DIR, filesystemSkillName) as AbsolutePath
-    validatePath(sourcePath, [SOURCE_DIR])
     return {
+      kind: 'agent-local',
       filesystemSkillName,
-      sourcePath,
+      reviewedLocalCopy: {
+        agentId: agent.id,
+        linkPath: normalizedPath,
+      },
     }
   }
 
@@ -368,32 +379,15 @@ async function rollbackMovedLocalCopies(
 }
 
 /**
- * Discriminated result from `moveToTrash`.
- *
- * - `tombstoned`: source-backed or local-only delete; produces a trash entry +
- *   manifest + TTL evict timer; renderer can surface an Undo toast that calls
- *   `restore(tombstoneId)`.
- * - `orphan-cleared`: every record was a broken symlink whose target source no
- *   longer exists; cleanup is just a series of `unlink()` calls. No manifest,
- *   no TTL, no undo — there is nothing meaningful to restore (the resurrected
- *   symlinks would still be broken).
- *
- * Callers must dispatch on `kind` before reading `tombstoneId`. The discriminated
- * union makes the "no undo" property a compile-time guarantee instead of a
- * runtime convention.
+ * Tombstoned result from source-backed or local-only delete.
+ * @example { kind: 'tombstoned', tombstoneId, cascadeAgents: ['cursor'], symlinksRemoved: 1 }
  */
-export type MoveToTrashResult =
-  | {
-      kind: 'tombstoned'
-      tombstoneId: TombstoneId
-      cascadeAgents: AgentId[]
-      symlinksRemoved: number
-    }
-  | {
-      kind: 'orphan-cleared'
-      cascadeAgents: AgentId[]
-      symlinksRemoved: number
-    }
+export type MoveToTrashResult = {
+  kind: 'tombstoned'
+  tombstoneId: TombstoneId
+  cascadeAgents: AgentId[]
+  symlinksRemoved: number
+}
 
 /**
  * Walk every configured agent directory and find real (non-symlink) folders
@@ -441,103 +435,6 @@ async function scanLocalCopies(
     }
   }
   return copies
-}
-
-/**
- * Walk every configured agent directory and find broken symlinks matching
- * `skillName` — i.e. a symlink whose target no longer resolves. Used by
- * `moveToTrash` when neither a source dir nor any local folder copies exist
- * (every remaining record is a stranded link).
- *
- * Valid (resolvable) symlinks are deliberately ignored: if they exist we are
- * not in the orphan branch — `moveSourceBackedToTrash` already covers the
- * case where any symlink, broken or otherwise, sits next to a live source.
- *
- * @param skillName - Validated skill name (no separators)
- * @returns Per-agent broken-symlink records, ordered by AGENTS iteration
- * @example
- * // After `rm -rf ~/.agents/skills/abandoned`, all 14 agents still have
- * // dangling symlinks. scanOrphanSymlinkPaths('abandoned') returns one
- * // RecordedSymlink per agent with the broken target preserved for logging.
- */
-async function scanOrphanSymlinkPaths(
-  skillName: SkillName,
-): Promise<RecordedSymlink[]> {
-  const orphans: RecordedSymlink[] = []
-  for (const agent of AGENTS) {
-    // fallow-ignore-next-line code-duplication
-    const linkPath = join(agent.path, skillName)
-    // Use getAllowedBases() — validatePath realpath-follows linkPath. A broken
-    // symlink's realpath chase fails, so we fall through to the catch and skip
-    // this agent rather than mis-classify the unverifiable path.
-    try {
-      validatePath(linkPath, getAllowedBases())
-    } catch {
-      continue
-    }
-
-    let stats: Stats
-    try {
-      stats = await fs.lstat(linkPath)
-    } catch (error) {
-      if (errorCode(error) === 'ENOENT') continue
-      console.warn('trashService: scanOrphanSymlinkPaths lstat failed', {
-        agentId: agent.id,
-        linkPath,
-        code: errorCode(error),
-        message: extractErrorMessage(error),
-      })
-      continue
-    }
-    if (!stats.isSymbolicLink()) continue
-
-    let target: string
-    try {
-      target = await fs.readlink(linkPath)
-    } catch (error) {
-      if (errorCode(error) === 'ENOENT') continue
-      console.warn('trashService: scanOrphanSymlinkPaths readlink failed', {
-        agentId: agent.id,
-        linkPath,
-        code: errorCode(error),
-        message: extractErrorMessage(error),
-      })
-      continue
-    }
-
-    // Probe target. `readlink` returns the verbatim string used at create
-    // time — relative targets must be resolved against the link's own dir.
-    const resolvedTarget = await resolveRawSymlinkTarget(linkPath, target)
-    try {
-      await fs.access(resolvedTarget)
-      // Target resolves — not orphan. Skip.
-      continue
-    } catch (error) {
-      // Only ENOENT / ENOTDIR confirm "the target is gone". Other codes
-      // (EACCES, EPERM, ELOOP, etc.) mean we couldn't probe the target — the
-      // link might still be live and pointing at real data. Classifying those
-      // as orphan would let the subsequent `unlink` delete a working symlink
-      // a privileged process needs, so we log + skip and leave the entry
-      // for the user to investigate.
-      if (isMissingPathError(error)) {
-        orphans.push({
-          agentId: agent.id,
-          linkPath: linkPath as AbsolutePath,
-          target,
-          targetPath: resolvedTarget,
-        })
-        continue
-      }
-      console.warn('trashService: scanOrphanSymlinkPaths access failed', {
-        agentId: agent.id,
-        linkPath,
-        resolvedTarget,
-        code: errorCode(error),
-        message: extractErrorMessage(error),
-      })
-    }
-  }
-  return orphans
 }
 
 /**
@@ -881,124 +778,7 @@ export async function unlinkReviewedDanglingSymlink(options: {
 }
 
 /**
- * Guard orphan cleanup by revalidating reviewed target identity before unlinking.
- * @param orphan - Orphan symlink record captured by the scan.
- * @returns `removed` when cleaned, `missing` when already gone.
- * @example
- * await commitReviewedOrphanSymlink({ agentId: 'codex', linkPath, target, targetPath })
- */
-async function commitReviewedOrphanSymlink(
-  orphan: RecordedSymlink,
-): Promise<'removed' | 'missing'> {
-  const targetPath =
-    orphan.targetPath ??
-    (await resolveRawSymlinkTarget(orphan.linkPath, orphan.target))
-  const outcome = await unlinkReviewedDanglingSymlink({
-    linkPath: orphan.linkPath,
-    targetPath,
-    targetChangedMessage:
-      'Reviewed orphan link target changed. Rescan before cleanup.',
-    targetExistsMessage:
-      'Reviewed orphan link target now exists. Rescan before cleanup.',
-    targetProbePrefix: 'Cannot verify reviewed orphan target',
-  })
-  return outcome === 'unlinked' ? 'removed' : 'missing'
-}
-
-/**
- * Orphan path of `moveToTrash`. Removes every broken symlink for `skillName`
- * across agents. No tombstone, no manifest, no undo — the source is gone, so
- * resurrecting the broken links would only restore them to "still broken".
- *
- * Per-link errors are logged and skipped: bulk cleanup soldiers on so a
- * single permission-denied agent doesn't strand the rest. The returned
- * `symlinksRemoved` count reflects only successful unlinks.
- *
- * @param skillName - Validated skill name (only used for the info log)
- * @param orphans - Records produced by `scanOrphanSymlinkPaths`
- * @returns `kind: 'orphan-cleared'` with cascade list and unlink count
- */
-async function clearOrphanSymlinks(
-  skillName: SkillName,
-  orphans: RecordedSymlink[],
-): Promise<Extract<MoveToTrashResult, { kind: 'orphan-cleared' }>> {
-  const startTime = Date.now()
-  const cascadeAgents: AgentId[] = []
-  let symlinksRemoved = 0
-  /**
-   * Per-orphan unlink errors that did NOT recover via the ENOENT race path.
-   * Collected so we can fail the whole call atomically instead of returning
-   * a `'orphan-cleared'` success while data is still on disk — see why-throw
-   * note below.
-   */
-  const unlinkFailures: Array<{
-    agentId: AgentId
-    linkPath: AbsolutePath
-    code: string | undefined
-    message: string
-  }> = []
-
-  for (const orphan of orphans) {
-    try {
-      await commitReviewedOrphanSymlink(orphan)
-      cascadeAgents.push(orphan.agentId)
-      symlinksRemoved++
-    } catch (error) {
-      const code = errorCode(error)
-      if (code === 'ENOENT') {
-        // Race: link disappeared between scan and unlink. The user-visible
-        // outcome ("orphan is gone") is the same, so count it as success.
-        cascadeAgents.push(orphan.agentId)
-        symlinksRemoved++
-        continue
-      }
-      const message = extractErrorMessage(error)
-      console.warn('trashService: clearOrphanSymlinks unlink failed', {
-        agentId: orphan.agentId,
-        linkPath: orphan.linkPath,
-        code,
-        message,
-      })
-      unlinkFailures.push({
-        agentId: orphan.agentId,
-        linkPath: orphan.linkPath,
-        code,
-        message,
-      })
-    }
-  }
-
-  console.info('trashService: moveToTrash (orphan-cleared)', {
-    skillName,
-    orphanCount: orphans.length,
-    symlinksRemoved,
-    failureCount: unlinkFailures.length,
-    durationMs: Date.now() - startTime,
-  })
-
-  // Why throw on partial failure: the renderer (`MainContent.tsx`) treats
-  // `outcome: 'orphan-cleared'` as an unconditional success toast. Returning
-  // success while broken symlinks are still on disk would tell the user "all
-  // gone" while they're still seeing the orphan rows on the next scan — a
-  // trust-eroding lie. Throwing surfaces the failure as `outcome: 'error'`
-  // so the toast and row state stay honest. Successfully unlinked entries
-  // remain unlinked (no rollback) — re-running the delete will skip them via
-  // the ENOENT race path above, so the operation is idempotent.
-  if (unlinkFailures.length > 0) {
-    const firstFailure = unlinkFailures[0]
-    const summary = `Failed to remove ${unlinkFailures.length} of ${orphans.length} orphan ${orphans.length === 1 ? 'symlink' : 'symlinks'} for "${skillName}"`
-    throw new TrashError(summary, firstFailure?.code)
-  }
-
-  return {
-    kind: 'orphan-cleared',
-    cascadeAgents,
-    symlinksRemoved,
-  }
-}
-
-/**
- * Move a skill into the on-disk trash. The skill may be in one of three states:
+ * Move a skill into the on-disk trash. The skill may be in one of two states:
  *
  * - **source-backed** (`kind: 'tombstoned'`): `~/.agents/skills/<name>` exists;
  *   agent entries are symlinks pointing at it. Move source + unlink every
@@ -1006,152 +786,153 @@ async function clearOrphanSymlinks(
  * - **local-only** (`kind: 'tombstoned'`): no source dir; one or more agents
  *   hold the skill as a real folder. Move every real folder into
  *   `<entryDir>/local-copies/<agentId>/`. Writes a v2 manifest, supports undo.
- * - **orphan** (`kind: 'orphan-cleared'`): no source, no local folders, only
- *   broken symlinks remain. Unlink each broken symlink; no manifest, no
- *   tombstone, no undo (resurrection would only restore the broken state).
- *
- * Dispatch order matters: source > local-only > orphan. A live source covers
- * its broken peers (they get unlinked in the source-backed walk anyway), so
- * the orphan branch only fires when nothing else applies.
+ * Orphan symlink cleanup is intentionally outside this function and uses exact
+ * reviewed link+target records, not a source/local delete path.
  *
  * @param skillName - Display skill name selected in the UI.
- * @param reviewedSkillPath - Optional reviewed source/local folder path used when metadata name differs from folder basename.
- * @returns Discriminated `MoveToTrashResult`. Callers MUST switch on `kind`
- *   before reading `tombstoneId` — orphan-cleared has no tombstone.
+ * @param reviewedSkillPath - Mandatory reviewed source/local folder path.
+ * @returns Tombstoned source-backed or local-only result.
  * @throws TrashError when the skill cannot be located in any form, or any
  *   filesystem op fails non-recoverably mid-move
  * @example
  * // source-backed
- * const result = await moveToTrash('theme-generator')
+ * const result = await moveToTrash('theme-generator', '/Users/me/.agents/skills/theme-generator')
  * // { kind: 'tombstoned', tombstoneId: '1729...-theme-generator-a1b2c3d4', cascadeAgents: ['cursor'], symlinksRemoved: 1 }
  * @example
  * // local-only (skill lives in ~/.claude/skills/architecture-decision-records)
- * const result = await moveToTrash('architecture-decision-records')
+ * const result = await moveToTrash('architecture-decision-records', '/Users/me/.claude/skills/architecture-decision-records')
  * // { kind: 'tombstoned', tombstoneId: '1729...-architecture-decision-records-...', cascadeAgents: ['claude'], symlinksRemoved: 1 }
- * @example
- * // orphan (source already rm -rf'd, only broken symlinks remain)
- * const result = await moveToTrash('abandoned-skill')
- * // { kind: 'orphan-cleared', cascadeAgents: ['cursor', 'codex'], symlinksRemoved: 2 }
  */
 export async function moveToTrash(
   skillName: SkillName,
-  reviewedSkillPath?: AbsolutePath,
+  reviewedSkillPath: AbsolutePath,
 ): Promise<MoveToTrashResult> {
   // Destructive actions use the reviewed filesystem path when the renderer has
   // one; display metadata can differ from the source/slot folder basename.
-  const { filesystemSkillName, sourcePath } = resolveDeleteIdentity(
-    skillName,
-    reviewedSkillPath,
-  )
+  const deleteIdentity = resolveDeleteIdentity(reviewedSkillPath)
 
-  // Probe the source dir. If it exists, source-backed flow. Otherwise scan
-  // agent dirs for local copies and dispatch to local-only flow if found.
-  let sourceExists = false
-  try {
-    await fs.stat(sourcePath)
-    sourceExists = true
-  } catch (error) {
-    const code = errorCode(error)
-    if (code !== 'ENOENT') {
+  if (deleteIdentity.kind === 'agent-local') {
+    const localCopies = await scanLocalCopies(
+      deleteIdentity.filesystemSkillName,
+    )
+    const reviewedCopyStillPresent = localCopies.some(
+      (copy) => copy.linkPath === deleteIdentity.reviewedLocalCopy.linkPath,
+    )
+    if (!reviewedCopyStillPresent) {
       throw new TrashError(
-        `Failed to inspect skill source: ${extractErrorMessage(error)}`,
-        code,
+        'Reviewed local skill folder not found (already changed?)',
+        'ESTALE',
       )
     }
-  }
-
-  if (sourceExists) {
-    return moveSourceBackedToTrash(skillName, sourcePath)
-  }
-
-  const localCopies = await scanLocalCopies(filesystemSkillName)
-  if (localCopies.length > 0) {
     return moveLocalOnlyToTrash(skillName, localCopies)
   }
 
-  // Last-resort branch: nothing real or live exists, but agents may still
-  // have broken symlinks. Sweep them with no manifest/undo (orphan-cleared).
-  const orphans = await scanOrphanSymlinkPaths(filesystemSkillName)
-  if (orphans.length > 0) {
-    return clearOrphanSymlinks(skillName, orphans)
+  const { sourcePath } = deleteIdentity
+
+  // A reviewed source row must still be the reviewed source row. Local-only
+  // and orphan cleanup flows now have exact reviewed paths of their own.
+  try {
+    await fs.stat(sourcePath)
+  } catch (error) {
+    const code = errorCode(error)
+    throw new TrashError(
+      code === 'ENOENT'
+        ? 'Reviewed skill source not found (already changed?)'
+        : `Failed to inspect skill source: ${extractErrorMessage(error)}`,
+      code,
+    )
   }
 
-  throw new TrashError('Skill not found (already deleted?)', 'ENOENT')
+  return moveSourceBackedToTrash(skillName, sourcePath)
 }
 
 /**
  * Remove agent symlinks that still point at the reviewed source folder.
  * @param sourcePath - Reviewed source directory being moved to trash.
  * @returns Recorded symlinks plus agent IDs for manifest and UI reporting.
- * @example await removeSourceBackedAgentSymlinks('/Users/me/.agents/skills/task')
+ * @param skillName - Display/metadata name reviewed by the user.
+ * @param sourcePath - Reviewed source folder moved to the trash entry.
+ * @returns Removed symlink manifest records and affected agent ids.
+ * @example await removeSourceBackedAgentSymlinks('metadata-title', '/Users/me/.agents/skills/folder-basename')
  */
 async function removeSourceBackedAgentSymlinks(
+  skillName: SkillName,
   sourcePath: AbsolutePath,
 ): Promise<{
   recordedSymlinks: RecordedSymlink[]
   cascadeAgentIds: AgentId[]
 }> {
   const sourceFolderName = skillNameFromPathBasename(sourcePath)
+  const candidateSlotNames = Array.from(new Set([sourceFolderName, skillName]))
   const recordedSymlinks: RecordedSymlink[] = []
   const cascadeAgentIds: AgentId[] = []
+  const cascadeAgentIdSet = new Set<AgentId>()
+  const processedLinkPaths = new Set<string>()
 
   for (const agent of AGENTS) {
-    // fallow-ignore-next-line code-duplication
-    const linkPath = join(agent.path, sourceFolderName)
-    // Use getAllowedBases() — validatePath realpath-follows linkPath. A valid
-    // source-backed symlink resolves into SOURCE_DIR, which isn't under the
-    // individual agent.path. Restricting to [agent.path] alone would false-
-    // positive every legitimate symlink and silently skip cascade cleanup.
-    try {
-      validatePath(linkPath, getAllowedBases())
-    } catch {
-      continue
-    }
-
-    let stats: Stats
-    try {
-      stats = await fs.lstat(linkPath)
-    } catch (error) {
-      // Link doesn't exist — roll forward.
-      const code = errorCode(error)
-      if (code === 'ENOENT') continue
-      throw new TrashError(
-        `Failed to inspect symlink: ${extractErrorMessage(error)}`,
-        code,
-      )
-    }
-
-    if (!stats.isSymbolicLink()) {
-      // Local skills in agent dirs are unrelated to the source-backed delete.
-      continue
-    }
-
-    let removal: 'missing' | { outcome: 'unlinked'; target: string }
-    try {
-      removal = await unlinkReviewedSourceSymlink(
-        linkPath as AbsolutePath,
-        sourcePath,
-      )
-    } catch (error) {
-      const code = errorCode(error)
-      if (code === 'ENOENT' || code === 'ESTALE') {
-        // Stale/mismatched same-name links belong to another source or changed
-        // after scan. Leave them for manual review instead of cascading.
+    for (const slotName of candidateSlotNames) {
+      // fallow-ignore-next-line code-duplication
+      const linkPath = join(agent.path, slotName)
+      if (processedLinkPaths.has(linkPath)) continue
+      processedLinkPaths.add(linkPath)
+      // Use getAllowedBases() — validatePath realpath-follows linkPath. A valid
+      // source-backed symlink resolves into SOURCE_DIR, which isn't under the
+      // individual agent.path. Restricting to [agent.path] alone would false-
+      // positive every legitimate symlink and silently skip cascade cleanup.
+      try {
+        validatePath(linkPath, getAllowedBases())
+      } catch {
         continue
       }
-      await rollbackRemovedSymlinks(recordedSymlinks)
-      throw new TrashError(
-        `Failed to remove symlinks: ${extractErrorMessage(error)}`,
-        code,
-      )
+
+      let stats: Stats
+      try {
+        stats = await fs.lstat(linkPath)
+      } catch (error) {
+        // Link doesn't exist — roll forward.
+        const code = errorCode(error)
+        if (code === 'ENOENT') continue
+        throw new TrashError(
+          `Failed to inspect symlink: ${extractErrorMessage(error)}`,
+          code,
+        )
+      }
+
+      if (!stats.isSymbolicLink()) {
+        // Local skills in agent dirs are unrelated to the source-backed delete.
+        continue
+      }
+
+      let removal: 'missing' | { outcome: 'unlinked'; target: string }
+      try {
+        removal = await unlinkReviewedSourceSymlink(
+          linkPath as AbsolutePath,
+          sourcePath,
+        )
+      } catch (error) {
+        const code = errorCode(error)
+        if (code === 'ENOENT' || code === 'ESTALE') {
+          // Stale/mismatched same-name links belong to another source or changed
+          // after scan. Leave them for manual review instead of cascading.
+          continue
+        }
+        await rollbackRemovedSymlinks(recordedSymlinks)
+        throw new TrashError(
+          `Failed to remove symlinks: ${extractErrorMessage(error)}`,
+          code,
+        )
+      }
+      if (removal === 'missing') continue
+      recordedSymlinks.push({
+        agentId: agent.id,
+        linkPath,
+        target: removal.target,
+      })
+      if (!cascadeAgentIdSet.has(agent.id)) {
+        cascadeAgentIdSet.add(agent.id)
+        cascadeAgentIds.push(agent.id)
+      }
     }
-    if (removal === 'missing') continue
-    recordedSymlinks.push({
-      agentId: agent.id,
-      linkPath,
-      target: removal.target,
-    })
-    cascadeAgentIds.push(agent.id)
   }
 
   return { recordedSymlinks, cascadeAgentIds }
@@ -1178,7 +959,7 @@ async function moveSourceBackedToTrash(
 
   // Walk agents, collect + remove symlinks. Abort on non-ENOENT unlink failure.
   const { recordedSymlinks, cascadeAgentIds } =
-    await removeSourceBackedAgentSymlinks(sourcePath)
+    await removeSourceBackedAgentSymlinks(skillName, sourcePath)
 
   // Atomically move source → trash entry. On EXDEV, copy + remove.
   // If the move fails, the symlinks we already unlinked would otherwise be

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -64,6 +64,24 @@ const MANUAL_RECOVERY_MARKER = '.manual-recovery'
 const evictTimers = new Map<TombstoneId, NodeJS.Timeout>()
 
 /**
+ * Copy a recovery directory without overwriting anything already at destination.
+ * @param source - Staged source directory to copy from.
+ * @param destination - Destination that must be absent before the copy starts.
+ * @returns Promise that resolves only when no destination entry was overwritten.
+ * @example await copyDirectoryNoOverwrite('/trash/source', '/Users/me/.agents/skills/task')
+ */
+async function copyDirectoryNoOverwrite(
+  source: string,
+  destination: string,
+): Promise<void> {
+  await fs.cp(source, destination, {
+    recursive: true,
+    force: false,
+    errorOnExist: true,
+  })
+}
+
+/**
  * Record of a symlink that existed before delete, used to rebuild the agent's
  * skills directory on undo.
  */
@@ -335,7 +353,7 @@ async function renameWithCrossDeviceFallback(
     await fs.rename(source, destination)
   } catch (renameError) {
     if (errorCode(renameError) === 'EXDEV') {
-      await fs.cp(source, destination, { recursive: true })
+      await copyDirectoryNoOverwrite(source, destination)
       await fs.rm(source, { recursive: true, force: true })
     } else {
       throw renameError
@@ -424,7 +442,7 @@ async function moveSourceIntoTrashEntry(
                   ),
           }
         }
-        await fs.cp(siblingStagePath, entrySourceDir, { recursive: true })
+        await copyDirectoryNoOverwrite(siblingStagePath, entrySourceDir)
         preserveEntryDirForManualRecovery = true
         await fs.rm(siblingStagePath, { recursive: true, force: true })
         return null
@@ -1111,7 +1129,7 @@ async function moveSourceBackedToTrash(
     } catch (reverseMoveError) {
       if (errorCode(reverseMoveError) === 'EXDEV') {
         try {
-          await fs.cp(entrySourceDir, sourcePath, { recursive: true })
+          await copyDirectoryNoOverwrite(entrySourceDir, sourcePath)
           await fs.rm(entrySourceDir, { recursive: true, force: true })
         } catch (reverseCopyError) {
           restoreSourceFailed = true
@@ -1291,7 +1309,7 @@ async function moveLocalOnlyToTrash(
                       ),
               }
             }
-            await fs.cp(siblingStagePath, stagedPath, { recursive: true })
+            await copyDirectoryNoOverwrite(siblingStagePath, stagedPath)
             stagedCopyCreated = true
             await fs.rm(siblingStagePath, { recursive: true, force: true })
             return { kind: 'moved' as const }

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -78,6 +78,7 @@ async function copyDirectoryNoOverwrite(
     recursive: true,
     force: false,
     errorOnExist: true,
+    verbatimSymlinks: true,
   })
 }
 
@@ -366,37 +367,18 @@ async function hasManualRecoveryMarker(entryDir: string): Promise<boolean> {
 }
 
 /**
- * Move a path with cross-device fallback. `fs.rename` is atomic within a single
- * filesystem but throws `EXDEV` when source and destination live on different
- * mount points (e.g. `$HOME` on the user partition vs `/tmp` on a tmpfs). On
- * `EXDEV` we fall back to recursive copy + remove, which is non-atomic but the
- * only portable recovery.
- *
- * Used by all three restore-direction call sites:
- *   - `rollbackMovedLocalCopies` (per-copy revert during forward-move failure),
- *   - `restoreLocalOnly` (per-copy restore from a local-only tombstone),
- *   - `restoreSourceBacked` (move the source dir back from the trash).
- * Centralised so the EXDEV fallback policy stays consistent across them.
- *
- * @param source - Absolute source path (file or directory)
- * @param destination - Absolute destination path (must not exist)
- * @example
- * await renameWithCrossDeviceFallback('/var/tmp/staged', '/home/u/.claude/skills/x')
+ * Restore a staged directory without letting same-device rename replace a recreated empty destination.
+ * @param source - Staged directory that should be returned to the user-visible slot.
+ * @param destination - Destination path that must still be absent when copied.
+ * @returns Promise that resolves after source is removed only when the no-overwrite copy succeeds.
+ * @example await moveDirectoryNoOverwrite('/tmp/staged', '/Users/me/.claude/skills/task')
  */
-async function renameWithCrossDeviceFallback(
+async function moveDirectoryNoOverwrite(
   source: string,
   destination: string,
 ): Promise<void> {
-  try {
-    await fs.rename(source, destination)
-  } catch (renameError) {
-    if (errorCode(renameError) === 'EXDEV') {
-      await copyDirectoryNoOverwrite(source, destination)
-      await fs.rm(source, { recursive: true, force: true })
-    } else {
-      throw renameError
-    }
-  }
+  await copyDirectoryNoOverwrite(source, destination)
+  await fs.rm(source, { recursive: true, force: true })
 }
 
 interface SourceMoveFailure {
@@ -426,7 +408,7 @@ async function moveSourceIntoTrashEntry(
       )
     } catch (identityError) {
       try {
-        await renameWithCrossDeviceFallback(entrySourceDir, sourcePath)
+        await moveDirectoryNoOverwrite(entrySourceDir, sourcePath)
       } catch {
         return {
           preserveEntryDirForManualRecovery: true,
@@ -468,7 +450,7 @@ async function moveSourceIntoTrashEntry(
             'Reviewed skill folder changed since review',
           )
         } catch (identityError) {
-          await renameWithCrossDeviceFallback(siblingStagePath, sourcePath)
+          await moveDirectoryNoOverwrite(siblingStagePath, sourcePath)
           return {
             preserveEntryDirForManualRecovery: false,
             error:
@@ -487,7 +469,7 @@ async function moveSourceIntoTrashEntry(
       } catch (fallbackError) {
         try {
           await fs.lstat(siblingStagePath)
-          await renameWithCrossDeviceFallback(siblingStagePath, sourcePath)
+          await moveDirectoryNoOverwrite(siblingStagePath, sourcePath)
         } catch (restoreError) {
           if (errorCode(restoreError) !== 'ENOENT') {
             preserveEntryDirForManualRecovery = true
@@ -575,7 +557,7 @@ async function rollbackMovedLocalCopies(
     const stagedPath = join(entryDir, 'local-copies', copy.agentId)
     try {
       await fs.mkdir(dirname(copy.linkPath), { recursive: true })
-      await renameWithCrossDeviceFallback(stagedPath, copy.linkPath)
+      await moveDirectoryNoOverwrite(stagedPath, copy.linkPath)
     } catch (error) {
       console.warn('trashService: rollback local copy failed', {
         agentId: copy.agentId,
@@ -1330,10 +1312,7 @@ async function moveLocalOnlyToTrash(
                 'Reviewed local skill folder changed since review',
               )
             } catch (identityError) {
-              await renameWithCrossDeviceFallback(
-                siblingStagePath,
-                copy.linkPath,
-              )
+              await moveDirectoryNoOverwrite(siblingStagePath, copy.linkPath)
               return {
                 kind: 'fatal' as const,
                 preserveEntryDir: false,
@@ -1354,10 +1333,7 @@ async function moveLocalOnlyToTrash(
           } catch (fallbackError) {
             try {
               await fs.lstat(siblingStagePath)
-              await renameWithCrossDeviceFallback(
-                siblingStagePath,
-                copy.linkPath,
-              )
+              await moveDirectoryNoOverwrite(siblingStagePath, copy.linkPath)
             } catch (restoreError) {
               if (errorCode(restoreError) !== 'ENOENT') {
                 stagedCopyCreated = true
@@ -1617,7 +1593,7 @@ async function restoreSourceBacked(
   // Validate sourcePath is within SOURCE_DIR specifically — skill sources
   // always live there. A tampered manifest could otherwise claim sourcePath
   // is in an agent dir and restore would happily plant the files there.
-  // MUST run before the fs.stat probe below so a forged path like `/etc/...`
+  // MUST run before the lstat probe below so a forged path like `/etc/...`
   // can't even trigger a filesystem existence check — defense in depth.
   try {
     validatePath(manifest.sourcePath, [SOURCE_DIR])
@@ -1649,10 +1625,9 @@ async function restoreSourceBacked(
     // ENOENT = free, proceed.
   }
 
-  // Rename source back. Centralised EXDEV fallback so this matches the
-  // local-only restore path (`restoreLocalOnly`) — both go through the helper.
+  // Restore source back through the same no-overwrite helper as local-only.
   try {
-    await renameWithCrossDeviceFallback(entrySourceDir, manifest.sourcePath)
+    await moveDirectoryNoOverwrite(entrySourceDir, manifest.sourcePath)
   } catch (error) {
     return {
       outcome: 'error',
@@ -1782,7 +1757,7 @@ async function restoreLocalOnly(
     const stagedPath = join(localCopiesRoot, copy.agentId)
     try {
       await fs.mkdir(agent.path, { recursive: true })
-      await renameWithCrossDeviceFallback(stagedPath, copy.linkPath)
+      await moveDirectoryNoOverwrite(stagedPath, copy.linkPath)
       symlinksRestored++
     } catch {
       symlinksSkipped++

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -9,7 +9,7 @@ import type { z } from 'zod'
 
 import { AGENTS, SOURCE_DIR } from '@/main/constants'
 import { manifestSchema } from '@/main/ipc/ipc-schemas'
-import { errorCode } from '@/main/utils/errorCode'
+import { errorCode, isMissingPathError } from '@/main/utils/errorCode'
 import { extractErrorMessage } from '@/main/utils/errors'
 import { UNDO_WINDOW_MS } from '@/shared/constants'
 import { tombstoneId } from '@/shared/types'
@@ -23,6 +23,7 @@ import type {
 } from '@/shared/types'
 
 import { getAllowedBases, validatePath } from './pathValidation'
+import { resolveRawSymlinkTarget } from './symlinkChecker'
 
 /** Root of the on-disk trash. Created lazily on first delete. */
 const TRASH_DIR = join(homedir(), '.agents', '.trash')
@@ -329,9 +330,7 @@ async function scanOrphanSymlinkPaths(
 
     // Probe target. `readlink` returns the verbatim string used at create
     // time — relative targets must be resolved against the link's own dir.
-    const resolvedTarget = isAbsolute(target)
-      ? target
-      : resolve(dirname(linkPath), target)
+    const resolvedTarget = await resolveRawSymlinkTarget(linkPath, target)
     try {
       await fs.access(resolvedTarget)
       // Target resolves — not orphan. Skip.
@@ -343,8 +342,7 @@ async function scanOrphanSymlinkPaths(
       // as orphan would let the subsequent `unlink` delete a working symlink
       // a privileged process needs, so we log + skip and leave the entry
       // for the user to investigate.
-      const code = errorCode(error)
-      if (code === 'ENOENT' || code === 'ENOTDIR') {
+      if (isMissingPathError(error)) {
         orphans.push({
           agentId: agent.id,
           linkPath: linkPath as AbsolutePath,
@@ -356,7 +354,7 @@ async function scanOrphanSymlinkPaths(
         agentId: agent.id,
         linkPath,
         resolvedTarget,
-        code,
+        code: errorCode(error),
         message: extractErrorMessage(error),
       })
     }

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -2,7 +2,7 @@ import { randomBytes } from 'node:crypto'
 import type { Stats } from 'node:fs'
 import * as fs from 'node:fs/promises'
 import { homedir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 
 import { match } from 'ts-pattern'
 import type { z } from 'zod'
@@ -65,6 +65,8 @@ export interface RecordedSymlink {
   // created — it may be absolute OR relative. fs.readlink returns it verbatim,
   // so narrowing to AbsolutePath would state a contract readlink cannot guarantee.
   target: string
+  /** Resolved target captured for orphan cleanup revalidation; not required in persisted manifests. */
+  targetPath?: AbsolutePath
 }
 
 /**
@@ -347,6 +349,7 @@ async function scanOrphanSymlinkPaths(
           agentId: agent.id,
           linkPath: linkPath as AbsolutePath,
           target,
+          targetPath: resolvedTarget,
         })
         continue
       }
@@ -360,6 +363,243 @@ async function scanOrphanSymlinkPaths(
     }
   }
   return orphans
+}
+
+/**
+ * Restore a moved cleanup candidate when post-rename validation finds stale state.
+ * @param linkPath - Original agent slot reviewed before cleanup.
+ * @param movedPath - Same-directory temporary path created during guarded commit.
+ * @returns void after the moved entry is restored or a TrashError explains why it could not be.
+ * @example
+ * await restoreMovedCleanupCandidate('/agent/skill', '/agent/skill.cleanup-deadbeef')
+ */
+async function restoreMovedCleanupCandidate(
+  linkPath: AbsolutePath,
+  movedPath: AbsolutePath,
+): Promise<void> {
+  try {
+    await fs.lstat(linkPath)
+    throw new TrashError(
+      `Cleanup stopped after the reviewed slot changed. Moved entry left at ${movedPath} because ${linkPath} is occupied.`,
+      'ESTALE',
+    )
+  } catch (error) {
+    if (error instanceof TrashError) throw error
+    if (!isMissingPathError(error)) {
+      throw new TrashError(
+        `Cleanup stopped, but ${linkPath} could not be checked before restoring the moved entry: ${extractErrorMessage(error)}`,
+        errorCode(error),
+      )
+    }
+  }
+
+  try {
+    await fs.rename(movedPath, linkPath)
+  } catch (error) {
+    throw new TrashError(
+      `Cleanup stopped, but the moved entry could not be restored at ${linkPath}: ${extractErrorMessage(error)}`,
+      errorCode(error),
+    )
+  }
+}
+
+/**
+ * Read and verify the exact reviewed symlink target at the destructive slot.
+ * @param options - Reviewed link path, target path, and stale-target message.
+ * @returns Raw and resolved target for the still-reviewed symlink.
+ * @example
+ * await readReviewedDanglingSymlink({ linkPath, targetPath, targetChangedMessage })
+ */
+export async function readReviewedDanglingSymlink(options: {
+  linkPath: AbsolutePath
+  targetPath: AbsolutePath
+  targetChangedMessage: string
+}): Promise<{ rawTarget: string; resolvedTarget: AbsolutePath }> {
+  let stats: Stats
+  try {
+    stats = await fs.lstat(options.linkPath)
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      throw new TrashError('Reviewed cleanup slot is already missing', 'ENOENT')
+    }
+    throw new TrashError(extractErrorMessage(error), errorCode(error))
+  }
+
+  if (!stats.isSymbolicLink()) {
+    throw new TrashError(
+      'Reviewed cleanup slot is no longer a symlink',
+      'ESTALE',
+    )
+  }
+
+  let rawTarget: string
+  try {
+    rawTarget = await fs.readlink(options.linkPath)
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      throw new TrashError('Reviewed cleanup slot is already missing', 'ENOENT')
+    }
+    throw new TrashError(
+      'Reviewed cleanup slot is no longer a symlink',
+      'ESTALE',
+    )
+  }
+
+  const resolvedTarget = await resolveRawSymlinkTarget(
+    options.linkPath,
+    rawTarget,
+  )
+  if (resolve(resolvedTarget) !== resolve(options.targetPath)) {
+    throw new TrashError(options.targetChangedMessage, 'ESTALE')
+  }
+
+  return { rawTarget, resolvedTarget }
+}
+
+/**
+ * Assert the reviewed symlink target is still absent and cleanup-safe.
+ * @param resolvedTarget - Absolute target path resolved from the reviewed symlink.
+ * @param targetExistsMessage - Stale message when the source target reappears.
+ * @param targetProbePrefix - Prefix for non-missing probe failures.
+ * @returns void when the target remains missing.
+ * @example
+ * await assertReviewedTargetMissing('/Users/me/.agents/skills/task', 'Target exists', 'Cannot verify target')
+ */
+export async function assertReviewedTargetMissing(
+  resolvedTarget: AbsolutePath,
+  targetExistsMessage: string,
+  targetProbePrefix: string,
+): Promise<void> {
+  try {
+    await fs.access(resolvedTarget)
+    throw new TrashError(targetExistsMessage, 'ESTALE')
+  } catch (error) {
+    if (error instanceof TrashError) throw error
+    if (!isMissingPathError(error)) {
+      throw new TrashError(
+        `${targetProbePrefix}: ${extractErrorMessage(error)}`,
+        errorCode(error),
+      )
+    }
+  }
+}
+
+/**
+ * Commit cleanup by moving the candidate, validating the moved entry, then unlinking it.
+ * @param options - Reviewed path and target messages for final validation.
+ * @returns void after the moved, verified symlink is removed.
+ * @example
+ * await commitReviewedDanglingSymlink({ linkPath, targetPath, targetChangedMessage, targetExistsMessage, targetProbePrefix })
+ */
+export async function commitReviewedDanglingSymlink(options: {
+  linkPath: AbsolutePath
+  targetPath: AbsolutePath
+  targetChangedMessage: string
+  targetExistsMessage: string
+  targetProbePrefix: string
+}): Promise<void> {
+  const movedPath =
+    `${options.linkPath}.cleanup-${randomBytes(4).toString('hex')}` as AbsolutePath
+
+  try {
+    await fs.rename(options.linkPath, movedPath)
+  } catch (error) {
+    if (isMissingPathError(error)) return
+    throw new TrashError(extractErrorMessage(error), errorCode(error))
+  }
+
+  try {
+    const movedReviewed = await readReviewedDanglingSymlink({
+      linkPath: movedPath,
+      targetPath: options.targetPath,
+      targetChangedMessage: options.targetChangedMessage,
+    })
+    await assertReviewedTargetMissing(
+      movedReviewed.resolvedTarget,
+      options.targetExistsMessage,
+      options.targetProbePrefix,
+    )
+    await fs.unlink(movedPath)
+  } catch (error) {
+    await restoreMovedCleanupCandidate(options.linkPath, movedPath)
+    throw error
+  }
+}
+
+/**
+ * Revalidate and unlink one reviewed dangling symlink while protecting same-path replacements.
+ * @param options - Exact reviewed path/target plus messages for stale-target cases.
+ * @returns `missing` when the slot was already gone; otherwise `unlinked`.
+ * @example
+ * await unlinkReviewedDanglingSymlink({ linkPath, targetPath, targetChangedMessage, targetExistsMessage, targetProbePrefix })
+ */
+export async function unlinkReviewedDanglingSymlink(options: {
+  linkPath: AbsolutePath
+  targetPath: AbsolutePath
+  targetChangedMessage: string
+  targetExistsMessage: string
+  targetProbePrefix: string
+  beforeTargetProbe?: () => Promise<void>
+}): Promise<'missing' | 'unlinked'> {
+  try {
+    const reviewed = await readReviewedDanglingSymlink(options)
+
+    await options.beforeTargetProbe?.()
+
+    await assertReviewedTargetMissing(
+      reviewed.resolvedTarget,
+      options.targetExistsMessage,
+      options.targetProbePrefix,
+    )
+
+    const finalReviewed = await readReviewedDanglingSymlink(options)
+    await assertReviewedTargetMissing(
+      finalReviewed.resolvedTarget,
+      options.targetExistsMessage,
+      options.targetProbePrefix,
+    )
+
+    await commitReviewedDanglingSymlink(options)
+  } catch (error) {
+    if (isMissingPathError(error)) return 'missing'
+    if (error instanceof TrashError) throw error
+    const code = errorCode(error)
+    // A concurrent folder replacement should never be moved or removed.
+    if (code === 'EISDIR' || code === 'EPERM' || code === 'EINVAL') {
+      throw new TrashError(
+        'Reviewed cleanup slot is no longer a symlink',
+        'ESTALE',
+      )
+    }
+    throw new TrashError(extractErrorMessage(error), code)
+  }
+
+  return 'unlinked'
+}
+
+/**
+ * Guard orphan cleanup by revalidating reviewed target identity before unlinking.
+ * @param orphan - Orphan symlink record captured by the scan.
+ * @returns `removed` when cleaned, `missing` when already gone.
+ * @example
+ * await commitReviewedOrphanSymlink({ agentId: 'codex', linkPath, target, targetPath })
+ */
+async function commitReviewedOrphanSymlink(
+  orphan: RecordedSymlink,
+): Promise<'removed' | 'missing'> {
+  const targetPath =
+    orphan.targetPath ??
+    (await resolveRawSymlinkTarget(orphan.linkPath, orphan.target))
+  const outcome = await unlinkReviewedDanglingSymlink({
+    linkPath: orphan.linkPath,
+    targetPath,
+    targetChangedMessage:
+      'Reviewed orphan link target changed. Rescan before cleanup.',
+    targetExistsMessage:
+      'Reviewed orphan link target now exists. Rescan before cleanup.',
+    targetProbePrefix: 'Cannot verify reviewed orphan target',
+  })
+  return outcome === 'unlinked' ? 'removed' : 'missing'
 }
 
 /**
@@ -397,7 +637,7 @@ async function clearOrphanSymlinks(
 
   for (const orphan of orphans) {
     try {
-      await fs.unlink(orphan.linkPath)
+      await commitReviewedOrphanSymlink(orphan)
       cascadeAgents.push(orphan.agentId)
       symlinksRemoved++
     } catch (error) {
@@ -1101,15 +1341,20 @@ async function restoreSourceBacked(
       symlinksSkipped++
       continue
     }
-    // Re-validate target stays inside SOURCE_DIR. `target` is the raw string
-    // `fs.readlink` returned at delete-time — it may be absolute or relative
-    // to the symlink's own directory (kernel resolution contract). A tampered
-    // manifest could otherwise steer restore into planting links at '/etc/...'.
-    const resolvedTarget = await resolveRawSymlinkTarget(
-      link.linkPath,
-      link.target,
-    )
+    // Ensure the parent exists before resolving relative targets. Devin-style
+    // symlinked config parents need a real directory for realpath(dirname).
     try {
+      await fs.mkdir(agent.path, { recursive: true })
+    } catch {
+      symlinksSkipped++
+      continue
+    }
+
+    // Re-validate target stays inside SOURCE_DIR. Per-link resolver failures
+    // skip the link instead of aborting after the source has already restored.
+    let resolvedTarget: AbsolutePath
+    try {
+      resolvedTarget = await resolveRawSymlinkTarget(link.linkPath, link.target)
       validatePath(resolvedTarget, [SOURCE_DIR])
     } catch {
       symlinksSkipped++
@@ -1137,7 +1382,6 @@ async function restoreSourceBacked(
       }
     }
     try {
-      await fs.mkdir(agent.path, { recursive: true })
       await fs.symlink(link.target, link.linkPath)
       symlinksRestored++
     } catch {

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -2,7 +2,7 @@ import { randomBytes } from 'node:crypto'
 import type { Stats } from 'node:fs'
 import * as fs from 'node:fs/promises'
 import { homedir } from 'node:os'
-import { dirname, join, resolve } from 'node:path'
+import { basename, dirname, join, resolve } from 'node:path'
 
 import { match } from 'ts-pattern'
 import type { z } from 'zod'
@@ -48,6 +48,9 @@ const STARTUP_CLEANUP_CONCURRENCY = 4
 
 /** Number of random bytes in the `rand8hex` suffix (4 bytes = 8 hex chars). */
 const RAND_SUFFIX_BYTES = 4
+
+/** Marker file for trash entries that contain data the user must recover by hand. */
+const MANUAL_RECOVERY_MARKER = '.manual-recovery'
 
 /**
  * In-process map of scheduled evict timers. Keys are tombstone ids; values are
@@ -96,6 +99,115 @@ function buildEntryName(skillName: SkillName): string {
 }
 
 /**
+ * Narrow a path basename back to a SkillName after IPC path validation supplied the parent.
+ * @param absolutePath - Reviewed source or agent slot path.
+ * @returns Basename safe for name-derived filesystem scans.
+ * @example skillNameFromPathBasename('/Users/me/.agents/skills/folder-name')
+ */
+function skillNameFromPathBasename(absolutePath: AbsolutePath): SkillName {
+  const name = basename(absolutePath)
+  if (
+    name.length === 0 ||
+    name.includes('/') ||
+    name.includes('\\') ||
+    name.includes('\0')
+  ) {
+    throw new TrashError('Reviewed skill path has an invalid basename')
+  }
+  return name as SkillName
+}
+
+/**
+ * Resolve a reviewed renderer path into the filesystem identity used for deletion.
+ * @param skillName - Display/metadata name selected by the user.
+ * @param reviewedSkillPath - Optional source or local folder path from the reviewed row.
+ * @returns Filesystem name plus optional source directory path.
+ * @example resolveDeleteIdentity('metadata-title', '/Users/me/.agents/skills/folder-basename')
+ */
+function resolveDeleteIdentity(
+  skillName: SkillName,
+  reviewedSkillPath?: AbsolutePath,
+): { filesystemSkillName: SkillName; sourcePath: AbsolutePath } {
+  if (!reviewedSkillPath) {
+    const sourcePath = join(SOURCE_DIR, skillName) as AbsolutePath
+    validatePath(sourcePath, [SOURCE_DIR])
+    return { filesystemSkillName: skillName, sourcePath }
+  }
+
+  const normalizedPath = resolve(reviewedSkillPath) as AbsolutePath
+  const sourceDir = resolve(SOURCE_DIR)
+  if (dirname(normalizedPath) === sourceDir) {
+    validatePath(normalizedPath, [SOURCE_DIR])
+    return {
+      filesystemSkillName: skillNameFromPathBasename(normalizedPath),
+      sourcePath: normalizedPath,
+    }
+  }
+
+  const isAgentSlotPath = AGENTS.some(
+    (agent) => dirname(normalizedPath) === resolve(agent.path),
+  )
+  if (isAgentSlotPath) {
+    validatePath(normalizedPath, getAllowedBases())
+    const filesystemSkillName = skillNameFromPathBasename(normalizedPath)
+    const sourcePath = join(SOURCE_DIR, filesystemSkillName) as AbsolutePath
+    validatePath(sourcePath, [SOURCE_DIR])
+    return {
+      filesystemSkillName,
+      sourcePath,
+    }
+  }
+
+  throw new TrashError('Reviewed skill path is outside known skill directories')
+}
+
+/**
+ * Mark a trash entry as non-evictable because it contains manual recovery data.
+ * @param entryDir - Trash entry directory that must survive TTL/startup cleanup.
+ * @param reason - Human-readable recovery reason for operators and tests.
+ * @returns Promise that resolves after the marker is written or best-effort logged.
+ * @example await markManualRecoveryEntry(entryDir, 'source rollback failed')
+ */
+async function markManualRecoveryEntry(
+  entryDir: string,
+  reason: string,
+): Promise<void> {
+  const markerPath = join(entryDir, MANUAL_RECOVERY_MARKER)
+  const body = `manual recovery required\nreason: ${reason}\nmarkedAt: ${new Date().toISOString()}\n`
+  try {
+    await fs.writeFile(markerPath, body, 'utf-8')
+  } catch (error) {
+    console.warn('trashService: failed to mark manual recovery entry', {
+      entryDir,
+      code: errorCode(error),
+      message: extractErrorMessage(error),
+    })
+  }
+}
+
+/**
+ * Check whether startup cleanup must leave a trash entry for manual recovery.
+ * @param entryDir - Trash entry directory under TRASH_DIR.
+ * @returns true when the marker exists or cannot be checked safely.
+ * @example await hasManualRecoveryMarker('/Users/me/.agents/.trash/...')
+ */
+async function hasManualRecoveryMarker(entryDir: string): Promise<boolean> {
+  try {
+    await fs.access(join(entryDir, MANUAL_RECOVERY_MARKER))
+    return true
+  } catch (error) {
+    const code = errorCode(error)
+    if (code === 'ENOENT') return false
+    console.warn('trashService: manual recovery marker check failed', {
+      entryDir,
+      code,
+      message: extractErrorMessage(error),
+    })
+    return true
+  }
+}
+
+/**
  * Move a path with cross-device fallback. `fs.rename` is atomic within a single
  * filesystem but throws `EXDEV` when source and destination live on different
  * mount points (e.g. `$HOME` on the user partition vs `/tmp` on a tmpfs). On
@@ -125,6 +237,66 @@ async function renameWithCrossDeviceFallback(
       await fs.rm(source, { recursive: true, force: true })
     } else {
       throw renameError
+    }
+  }
+}
+
+interface SourceMoveFailure {
+  error: TrashError
+  preserveEntryDirForManualRecovery: boolean
+}
+
+/**
+ * Move a source folder into a trash entry while preserving staged EXDEV recovery copies.
+ * @param sourcePath - Reviewed skill source directory to move.
+ * @param entrySourceDir - Destination `<entryDir>/source` directory.
+ * @returns null on success, otherwise a failure object describing cleanup safety.
+ * @example await moveSourceIntoTrashEntry('/Users/me/.agents/skills/x', '/Users/me/.agents/.trash/id/source')
+ */
+async function moveSourceIntoTrashEntry(
+  sourcePath: AbsolutePath,
+  entrySourceDir: string,
+): Promise<SourceMoveFailure | null> {
+  try {
+    await fs.rename(sourcePath, entrySourceDir)
+    return null
+  } catch (error) {
+    const code = errorCode(error)
+
+    if (code === 'EXDEV') {
+      let preserveEntryDirForManualRecovery = false
+      try {
+        await fs.cp(sourcePath, entrySourceDir, { recursive: true })
+        preserveEntryDirForManualRecovery = true
+        await fs.rm(sourcePath, { recursive: true, force: true })
+        return null
+      } catch (fallbackError) {
+        const recoveryHint = preserveEntryDirForManualRecovery
+          ? `; source copy preserved in ${entrySourceDir}`
+          : ''
+        return {
+          preserveEntryDirForManualRecovery,
+          error: new TrashError(
+            `Failed to move source to trash (cross-device): ${extractErrorMessage(fallbackError)}${recoveryHint}`,
+            errorCode(fallbackError),
+          ),
+        }
+      }
+    }
+
+    if (code === 'ENOENT') {
+      return {
+        preserveEntryDirForManualRecovery: false,
+        error: new TrashError('Skill not found (already deleted?)', code),
+      }
+    }
+
+    return {
+      preserveEntryDirForManualRecovery: false,
+      error: new TrashError(
+        `Failed to move source to trash: ${extractErrorMessage(error)}`,
+        code,
+      ),
     }
   }
 }
@@ -842,7 +1014,8 @@ async function clearOrphanSymlinks(
  * its broken peers (they get unlinked in the source-backed walk anyway), so
  * the orphan branch only fires when nothing else applies.
  *
- * @param skillName - Validated skill name (no path separators, enforced by Zod)
+ * @param skillName - Display skill name selected in the UI.
+ * @param reviewedSkillPath - Optional reviewed source/local folder path used when metadata name differs from folder basename.
  * @returns Discriminated `MoveToTrashResult`. Callers MUST switch on `kind`
  *   before reading `tombstoneId` — orphan-cleared has no tombstone.
  * @throws TrashError when the skill cannot be located in any form, or any
@@ -862,13 +1035,14 @@ async function clearOrphanSymlinks(
  */
 export async function moveToTrash(
   skillName: SkillName,
+  reviewedSkillPath?: AbsolutePath,
 ): Promise<MoveToTrashResult> {
-  // Construct sourcePath from the (Zod-validated) skill name and re-check it
-  // against SOURCE_DIR for defense in depth — even though the renderer never
-  // passes a path, this keeps the file's invariants self-evident if a future
-  // caller forgets to validate.
-  const sourcePath = join(SOURCE_DIR, skillName) as AbsolutePath
-  validatePath(sourcePath, [SOURCE_DIR])
+  // Destructive actions use the reviewed filesystem path when the renderer has
+  // one; display metadata can differ from the source/slot folder basename.
+  const { filesystemSkillName, sourcePath } = resolveDeleteIdentity(
+    skillName,
+    reviewedSkillPath,
+  )
 
   // Probe the source dir. If it exists, source-backed flow. Otherwise scan
   // agent dirs for local copies and dispatch to local-only flow if found.
@@ -890,14 +1064,14 @@ export async function moveToTrash(
     return moveSourceBackedToTrash(skillName, sourcePath)
   }
 
-  const localCopies = await scanLocalCopies(skillName)
+  const localCopies = await scanLocalCopies(filesystemSkillName)
   if (localCopies.length > 0) {
     return moveLocalOnlyToTrash(skillName, localCopies)
   }
 
   // Last-resort branch: nothing real or live exists, but agents may still
   // have broken symlinks. Sweep them with no manifest/undo (orphan-cleared).
-  const orphans = await scanOrphanSymlinkPaths(skillName)
+  const orphans = await scanOrphanSymlinkPaths(filesystemSkillName)
   if (orphans.length > 0) {
     return clearOrphanSymlinks(skillName, orphans)
   }
@@ -906,30 +1080,24 @@ export async function moveToTrash(
 }
 
 /**
- * Source-backed path of `moveToTrash`. Walks agent dirs, removes symlinks,
- * renames the source dir into the entry, writes a v2 source-backed manifest.
- * Same lifecycle as the original v0.13.x implementation, just gated on the
- * source-existed branch in the wrapper.
+ * Remove agent symlinks that still point at the reviewed source folder.
+ * @param sourcePath - Reviewed source directory being moved to trash.
+ * @returns Recorded symlinks plus agent IDs for manifest and UI reporting.
+ * @example await removeSourceBackedAgentSymlinks('/Users/me/.agents/skills/task')
  */
-async function moveSourceBackedToTrash(
-  skillName: SkillName,
+async function removeSourceBackedAgentSymlinks(
   sourcePath: AbsolutePath,
-): Promise<Extract<MoveToTrashResult, { kind: 'tombstoned' }>> {
-  // fallow-ignore-next-line code-duplication
-  const startTime = Date.now()
-  await fs.mkdir(TRASH_DIR, { recursive: true, mode: 0o755 })
-
-  const entryName = buildEntryName(skillName)
-  const entryDir = join(TRASH_DIR, entryName)
-  const entrySourceDir = join(entryDir, 'source')
-  const manifestPath = join(entryDir, 'manifest.json')
-
-  // Walk agents, collect + remove symlinks. Abort on non-ENOENT unlink failure.
+): Promise<{
+  recordedSymlinks: RecordedSymlink[]
+  cascadeAgentIds: AgentId[]
+}> {
+  const sourceFolderName = skillNameFromPathBasename(sourcePath)
   const recordedSymlinks: RecordedSymlink[] = []
   const cascadeAgentIds: AgentId[] = []
+
   for (const agent of AGENTS) {
     // fallow-ignore-next-line code-duplication
-    const linkPath = join(agent.path, skillName)
+    const linkPath = join(agent.path, sourceFolderName)
     // Use getAllowedBases() — validatePath realpath-follows linkPath. A valid
     // source-backed symlink resolves into SOURCE_DIR, which isn't under the
     // individual agent.path. Restricting to [agent.path] alone would false-
@@ -953,87 +1121,89 @@ async function moveSourceBackedToTrash(
       )
     }
 
-    if (stats.isSymbolicLink()) {
-      let removal: 'missing' | { outcome: 'unlinked'; target: string }
-      try {
-        removal = await unlinkReviewedSourceSymlink(
-          linkPath as AbsolutePath,
-          sourcePath,
-        )
-      } catch (error) {
-        const code = errorCode(error)
-        if (code === 'ENOENT' || code === 'ESTALE') {
-          // Stale/mismatched same-name links belong to another source or changed
-          // after scan. Leave them for manual review instead of cascading.
-          continue
-        }
-        // Source has not moved yet. Restore earlier cascade removals so a later
-        // fatal slot failure cannot leave a live source with missing agent links.
-        await rollbackRemovedSymlinks(recordedSymlinks)
-        throw new TrashError(
-          `Failed to remove symlinks: ${extractErrorMessage(error)}`,
-          code,
-        )
-      }
-      if (removal === 'missing') continue
-      recordedSymlinks.push({
-        agentId: agent.id,
-        linkPath,
-        target: removal.target,
-      })
-      cascadeAgentIds.push(agent.id)
+    if (!stats.isSymbolicLink()) {
+      // Local skills in agent dirs are unrelated to the source-backed delete.
+      continue
     }
-    // Non-symlink directories inside agent dirs are "local skills" — leave them
-    // alone. The skill being deleted owns the SOURCE_DIR copy only.
+
+    let removal: 'missing' | { outcome: 'unlinked'; target: string }
+    try {
+      removal = await unlinkReviewedSourceSymlink(
+        linkPath as AbsolutePath,
+        sourcePath,
+      )
+    } catch (error) {
+      const code = errorCode(error)
+      if (code === 'ENOENT' || code === 'ESTALE') {
+        // Stale/mismatched same-name links belong to another source or changed
+        // after scan. Leave them for manual review instead of cascading.
+        continue
+      }
+      await rollbackRemovedSymlinks(recordedSymlinks)
+      throw new TrashError(
+        `Failed to remove symlinks: ${extractErrorMessage(error)}`,
+        code,
+      )
+    }
+    if (removal === 'missing') continue
+    recordedSymlinks.push({
+      agentId: agent.id,
+      linkPath,
+      target: removal.target,
+    })
+    cascadeAgentIds.push(agent.id)
   }
+
+  return { recordedSymlinks, cascadeAgentIds }
+}
+
+/**
+ * Source-backed path of `moveToTrash`. Walks agent dirs, removes symlinks,
+ * renames the source dir into the entry, writes a v2 source-backed manifest.
+ * Same lifecycle as the original v0.13.x implementation, just gated on the
+ * source-existed branch in the wrapper.
+ */
+async function moveSourceBackedToTrash(
+  skillName: SkillName,
+  sourcePath: AbsolutePath,
+): Promise<Extract<MoveToTrashResult, { kind: 'tombstoned' }>> {
+  // fallow-ignore-next-line code-duplication
+  const startTime = Date.now()
+  await fs.mkdir(TRASH_DIR, { recursive: true, mode: 0o755 })
+
+  const entryName = buildEntryName(skillName)
+  const entryDir = join(TRASH_DIR, entryName)
+  const entrySourceDir = join(entryDir, 'source')
+  const manifestPath = join(entryDir, 'manifest.json')
+
+  // Walk agents, collect + remove symlinks. Abort on non-ENOENT unlink failure.
+  const { recordedSymlinks, cascadeAgentIds } =
+    await removeSourceBackedAgentSymlinks(sourcePath)
 
   // Atomically move source → trash entry. On EXDEV, copy + remove.
   // If the move fails, the symlinks we already unlinked would otherwise be
   // lost. Best-effort re-create them before re-throwing so the user is not
   // left with a half-deleted skill (source still on disk but agents unlinked).
   await fs.mkdir(entryDir, { recursive: true })
-  try {
-    await fs.rename(sourcePath, entrySourceDir)
-  } catch (error) {
-    const code = errorCode(error)
-    // Discriminate on the errno code:
-    //   EXDEV  → cross-device rename; fall back to copy + remove (returns null on success)
-    //   ENOENT → source already gone
-    //   other  → generic failure surfacing the underlying message
-    const trashError = await match(code)
-      .with('EXDEV', async () => {
-        try {
-          await fs.cp(sourcePath, entrySourceDir, { recursive: true })
-          await fs.rm(sourcePath, { recursive: true, force: true })
-          return null
-        } catch (fallbackError) {
-          return new TrashError(
-            `Failed to move source to trash (cross-device): ${extractErrorMessage(fallbackError)}`,
-            errorCode(fallbackError),
-          )
-        }
-      })
-      .with(
-        'ENOENT',
-        async () => new TrashError('Skill not found (already deleted?)', code),
+  const sourceMoveFailure = await moveSourceIntoTrashEntry(
+    sourcePath,
+    entrySourceDir,
+  )
+  if (sourceMoveFailure !== null) {
+    // Rollback symlinks, but never delete an entry that now holds the recovery
+    // copy created by the EXDEV fallback.
+    await rollbackRemovedSymlinks(recordedSymlinks)
+    if (sourceMoveFailure.preserveEntryDirForManualRecovery) {
+      await markManualRecoveryEntry(
+        entryDir,
+        'source EXDEV fallback copied to trash but removing original failed',
       )
-      .otherwise(
-        async () =>
-          new TrashError(
-            `Failed to move source to trash: ${extractErrorMessage(error)}`,
-            code,
-          ),
-      )
-
-    if (trashError !== null) {
-      // Rollback: re-create symlinks we unlinked earlier, and drop the empty
-      // trash entry dir. Errors are logged, never masked over the real cause.
-      await rollbackRemovedSymlinks(recordedSymlinks)
+    } else {
       await fs.rm(entryDir, { recursive: true, force: true }).catch(() => {
         // entryDir cleanup is best-effort — caller already has the real error.
       })
-      throw trashError
     }
+    throw sourceMoveFailure.error
   }
 
   // Write manifest. If this fails after the source was already moved in, we
@@ -1098,6 +1268,11 @@ async function moveSourceBackedToTrash(
       await fs.rm(entryDir, { recursive: true, force: true }).catch(() => {
         // entry cleanup is best-effort — caller already has the real error.
       })
+    } else {
+      await markManualRecoveryEntry(
+        entryDir,
+        'source manifest rollback failed to restore original path',
+      )
     }
 
     // If we couldn't put the source back the user is in a broken state. Flag
@@ -1180,15 +1355,22 @@ async function moveLocalOnlyToTrash(
       // disappeared mid-flight (race); skip and continue rather than abort.
       const recoveryOutcome = await match(code)
         .with('EXDEV', async () => {
+          let stagedCopyCreated = false
           try {
             await fs.cp(copy.linkPath, stagedPath, { recursive: true })
+            stagedCopyCreated = true
             await fs.rm(copy.linkPath, { recursive: true, force: true })
             return { kind: 'moved' as const }
           } catch (fallbackError) {
+            const recoveryHint = stagedCopyCreated
+              ? `; staged copy preserved in ${stagedPath}`
+              : ''
             return {
               kind: 'fatal' as const,
+              preserveEntryDir: stagedCopyCreated,
+              strandedAgentId: copy.agentId,
               error: new TrashError(
-                `Failed to move local copy (cross-device, agent=${copy.agentId}): ${extractErrorMessage(fallbackError)}`,
+                `Failed to move local copy (cross-device, agent=${copy.agentId}): ${extractErrorMessage(fallbackError)}${recoveryHint}`,
                 errorCode(fallbackError),
               ),
             }
@@ -1197,6 +1379,8 @@ async function moveLocalOnlyToTrash(
         .with('ENOENT', async () => ({ kind: 'race-skip' as const }))
         .otherwise(async () => ({
           kind: 'fatal' as const,
+          preserveEntryDir: false,
+          strandedAgentId: copy.agentId,
           error: new TrashError(
             `Failed to move local copy (agent=${copy.agentId}): ${extractErrorMessage(error)}`,
             code,
@@ -1205,7 +1389,10 @@ async function moveLocalOnlyToTrash(
 
       if (recoveryOutcome.kind === 'fatal') {
         const unrestoredCopies = await rollbackMovedLocalCopies(entryDir, moved)
-        if (unrestoredCopies.length === 0) {
+        if (
+          unrestoredCopies.length === 0 &&
+          !recoveryOutcome.preserveEntryDir
+        ) {
           // All copies restored — safe to drop the staged entry dir.
           await fs.rm(entryDir, { recursive: true, force: true }).catch(() => {
             // best-effort cleanup
@@ -1216,11 +1403,20 @@ async function moveLocalOnlyToTrash(
         // <entryDir>/local-copies/<agentId>/ is the ONLY remaining copy of
         // the user's data. Preserve entryDir and surface a recovery hint so
         // the caller (and ultimately the UI) can guide the user to it.
-        const strandedAgents = unrestoredCopies
-          .map((copy) => copy.agentId)
-          .join(', ')
+        await markManualRecoveryEntry(
+          entryDir,
+          'local-only EXDEV fallback or rollback left staged copies in trash',
+        )
+        const strandedAgents = Array.from(
+          new Set([
+            ...unrestoredCopies.map((copy) => copy.agentId),
+            ...(recoveryOutcome.preserveEntryDir
+              ? [recoveryOutcome.strandedAgentId]
+              : []),
+          ]),
+        ).join(', ')
         throw new TrashError(
-          `${recoveryOutcome.error.message}; ${unrestoredCopies.length} local copy/copies stranded in ${entryDir}/local-copies (agents: ${strandedAgents})`,
+          `${recoveryOutcome.error.message}; local copy/copies stranded in ${entryDir}/local-copies (agents: ${strandedAgents})`,
           recoveryOutcome.error.code,
         )
       }
@@ -1266,6 +1462,10 @@ async function moveLocalOnlyToTrash(
     // Manifest write failed AND rollback could not restore every copy. The
     // staged folder is the ONLY remaining copy of the user's data — keep
     // entryDir intact so they can recover manually from local-copies/.
+    await markManualRecoveryEntry(
+      entryDir,
+      'local-only manifest rollback left staged copies in trash',
+    )
     const strandedAgents = unrestoredCopies
       .map((copy) => copy.agentId)
       .join(', ')
@@ -1591,6 +1791,10 @@ async function restoreLocalOnly(
   if (symlinksSkipped > 0) {
     // Keep local-copies/<agentId> entries that could not be restored.
     cancelEvictTimer(id)
+    await markManualRecoveryEntry(
+      entryDir,
+      'local-only restore skipped one or more staged copies',
+    )
     return {
       outcome: 'restored',
       symlinksRestored,
@@ -1665,13 +1869,21 @@ export async function startupCleanup(): Promise<void> {
   const cutoff = Date.now() - STARTUP_CLEANUP_MAX_AGE_MS
   // Parse entry name → unix_ms prefix; only sweep old ones.
   const toSweep: string[] = []
+  let manualRecoverySkippedCount = 0
   for (const entryName of entries) {
     const ms = parseDeletedAtFromEntryName(entryName)
     if (ms === null) {
       // Unparseable name = foreign file; do not touch.
       continue
     }
-    if (ms < cutoff) toSweep.push(entryName)
+    if (ms < cutoff) {
+      const entryDir = join(TRASH_DIR, entryName)
+      if (await hasManualRecoveryMarker(entryDir)) {
+        manualRecoverySkippedCount++
+        continue
+      }
+      toSweep.push(entryName)
+    }
   }
 
   // Manual semaphore at concurrency 4.
@@ -1703,6 +1915,7 @@ export async function startupCleanup(): Promise<void> {
 
   console.info('trashService: startupCleanup', {
     sweptCount: toSweep.length,
+    manualRecoverySkippedCount,
     totalEntries: entries.length,
     durationMs: Date.now() - startTime,
   })

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -16,13 +16,20 @@ import { tombstoneId } from '@/shared/types'
 import type {
   AbsolutePath,
   AgentId,
+  FilesystemEntryIdentity,
   RestoreDeletedSkillResult,
   SkillName,
   TombstoneId,
   UnixTimestampMs,
 } from '@/shared/types'
 
+import {
+  filesystemIdentityFromStats,
+  isSameFilesystemEntryIdentity,
+  isSameFilesystemIdentity,
+} from './filesystemIdentity'
 import { getAllowedBases, validatePath } from './pathValidation'
+import { isValidSkillDir } from './skillValidation'
 import { resolveRawSymlinkTarget } from './symlinkChecker'
 
 /** Root of the on-disk trash. Created lazily on first delete. */
@@ -83,6 +90,8 @@ export interface RecordedSymlink {
 export interface RecordedLocalCopy {
   agentId: AgentId
   linkPath: AbsolutePath
+  /** Scan-time directory identity, used to reject same-path replacements. */
+  filesystemIdentity?: FilesystemEntryIdentity
 }
 
 /**
@@ -170,6 +179,50 @@ function resolveDeleteIdentity(
   }
 
   throw new TrashError('Reviewed skill path is outside known skill directories')
+}
+
+/**
+ * Revalidate a reviewed source/local skill folder before moving it to trash.
+ * @param reviewedPath - Exact path displayed in the confirmation dialog.
+ * @param reviewedIdentity - lstat identity captured when the row was scanned.
+ * @returns Current stats when the same valid skill directory is still present.
+ * @throws TrashError when the path changed, became invalid, or is not a directory.
+ * @example await assertReviewedSkillDirectory('/Users/me/.agents/skills/task', identity)
+ */
+async function assertReviewedSkillDirectory(
+  reviewedPath: AbsolutePath,
+  reviewedIdentity: FilesystemEntryIdentity,
+): Promise<Stats> {
+  let stats: Stats
+  try {
+    stats = await fs.lstat(reviewedPath)
+  } catch (error) {
+    const code = errorCode(error)
+    throw new TrashError(
+      code === 'ENOENT'
+        ? 'Reviewed skill folder not found (already changed?)'
+        : `Failed to inspect reviewed skill folder: ${extractErrorMessage(error)}`,
+      code,
+    )
+  }
+
+  if (!stats.isDirectory() || stats.isSymbolicLink()) {
+    throw new TrashError(
+      'Reviewed skill path is no longer a real skill directory',
+      'ESTALE',
+    )
+  }
+  if (!isSameFilesystemIdentity(stats, reviewedIdentity)) {
+    throw new TrashError('Reviewed skill folder changed since review', 'ESTALE')
+  }
+  if (!(await isValidSkillDir(reviewedPath))) {
+    throw new TrashError(
+      'Reviewed skill directory is no longer a valid skill',
+      'ESTALE',
+    )
+  }
+
+  return stats
 }
 
 /**
@@ -431,7 +484,11 @@ async function scanLocalCopies(
       continue
     }
     if (stats.isDirectory() && !stats.isSymbolicLink()) {
-      copies.push({ agentId: agent.id, linkPath: linkPath as AbsolutePath })
+      copies.push({
+        agentId: agent.id,
+        linkPath: linkPath as AbsolutePath,
+        filesystemIdentity: filesystemIdentityFromStats(stats),
+      })
     }
   }
   return copies
@@ -791,32 +848,44 @@ export async function unlinkReviewedDanglingSymlink(options: {
  *
  * @param skillName - Display skill name selected in the UI.
  * @param reviewedSkillPath - Mandatory reviewed source/local folder path.
+ * @param reviewedIdentity - Directory identity captured when the row was reviewed.
  * @returns Tombstoned source-backed or local-only result.
  * @throws TrashError when the skill cannot be located in any form, or any
  *   filesystem op fails non-recoverably mid-move
  * @example
  * // source-backed
- * const result = await moveToTrash('theme-generator', '/Users/me/.agents/skills/theme-generator')
+ * const result = await moveToTrash('theme-generator', reviewedPath, reviewedIdentity)
  * // { kind: 'tombstoned', tombstoneId: '1729...-theme-generator-a1b2c3d4', cascadeAgents: ['cursor'], symlinksRemoved: 1 }
  * @example
  * // local-only (skill lives in ~/.claude/skills/architecture-decision-records)
- * const result = await moveToTrash('architecture-decision-records', '/Users/me/.claude/skills/architecture-decision-records')
+ * const result = await moveToTrash('architecture-decision-records', localPath, reviewedIdentity)
  * // { kind: 'tombstoned', tombstoneId: '1729...-architecture-decision-records-...', cascadeAgents: ['claude'], symlinksRemoved: 1 }
  */
 export async function moveToTrash(
   skillName: SkillName,
   reviewedSkillPath: AbsolutePath,
+  reviewedIdentity: FilesystemEntryIdentity,
 ): Promise<MoveToTrashResult> {
   // Destructive actions use the reviewed filesystem path when the renderer has
   // one; display metadata can differ from the source/slot folder basename.
   const deleteIdentity = resolveDeleteIdentity(reviewedSkillPath)
 
   if (deleteIdentity.kind === 'agent-local') {
+    await assertReviewedSkillDirectory(
+      deleteIdentity.reviewedLocalCopy.linkPath,
+      reviewedIdentity,
+    )
     const localCopies = await scanLocalCopies(
       deleteIdentity.filesystemSkillName,
     )
     const reviewedCopyStillPresent = localCopies.some(
-      (copy) => copy.linkPath === deleteIdentity.reviewedLocalCopy.linkPath,
+      (copy) =>
+        copy.linkPath === deleteIdentity.reviewedLocalCopy.linkPath &&
+        copy.filesystemIdentity !== undefined &&
+        isSameFilesystemEntryIdentity(
+          copy.filesystemIdentity,
+          reviewedIdentity,
+        ),
     )
     if (!reviewedCopyStillPresent) {
       throw new TrashError(
@@ -829,19 +898,8 @@ export async function moveToTrash(
 
   const { sourcePath } = deleteIdentity
 
-  // A reviewed source row must still be the reviewed source row. Local-only
-  // and orphan cleanup flows now have exact reviewed paths of their own.
-  try {
-    await fs.stat(sourcePath)
-  } catch (error) {
-    const code = errorCode(error)
-    throw new TrashError(
-      code === 'ENOENT'
-        ? 'Reviewed skill source not found (already changed?)'
-        : `Failed to inspect skill source: ${extractErrorMessage(error)}`,
-      code,
-    )
-  }
+  // A reviewed source row must still be the same valid directory the user saw.
+  await assertReviewedSkillDirectory(sourcePath, reviewedIdentity)
 
   return moveSourceBackedToTrash(skillName, sourcePath)
 }
@@ -1221,7 +1279,7 @@ async function moveLocalOnlyToTrash(
     kind: 'local-only' as const,
     deletedAt: Date.now(),
     skillName,
-    localCopies: moved,
+    localCopies: moved.map(({ agentId, linkPath }) => ({ agentId, linkPath })),
   }
   try {
     await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf-8')

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -1142,39 +1142,21 @@ async function moveSourceBackedToTrash(
     const manifestWriteCode = errorCode(manifestWriteError)
     const manifestWriteMessage = extractErrorMessage(manifestWriteError)
 
-    // Step 1: move the source back. Mirror the forward EXDEV fallback.
+    // Step 1: restore the source back without clobbering a recreated slot.
     let restoreSourceFailed = false
     try {
-      await fs.rename(entrySourceDir, sourcePath)
-    } catch (reverseMoveError) {
-      if (errorCode(reverseMoveError) === 'EXDEV') {
-        try {
-          await copyDirectoryNoOverwrite(entrySourceDir, sourcePath)
-          await fs.rm(entrySourceDir, { recursive: true, force: true })
-        } catch (reverseCopyError) {
-          restoreSourceFailed = true
-          console.error(
-            'trashService: manifest write rollback — failed to restore source (cross-device)',
-            {
-              skillName,
-              entryName,
-              code: errorCode(reverseCopyError),
-              message: extractErrorMessage(reverseCopyError),
-            },
-          )
-        }
-      } else {
-        restoreSourceFailed = true
-        console.error(
-          'trashService: manifest write rollback — failed to restore source',
-          {
-            skillName,
-            entryName,
-            code: errorCode(reverseMoveError),
-            message: extractErrorMessage(reverseMoveError),
-          },
-        )
-      }
+      await moveDirectoryNoOverwrite(entrySourceDir, sourcePath)
+    } catch (restoreError) {
+      restoreSourceFailed = true
+      console.error(
+        'trashService: manifest write rollback — failed to restore source',
+        {
+          skillName,
+          entryName,
+          code: errorCode(restoreError),
+          message: extractErrorMessage(restoreError),
+        },
+      )
     }
 
     // Step 2: re-create the symlinks we removed. Best-effort; already logs per link.

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from 'node:crypto'
-import type { Stats } from 'node:fs'
+import { constants, type Stats } from 'node:fs'
 import * as fs from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { basename, dirname, join, resolve } from 'node:path'
@@ -79,6 +79,44 @@ async function copyDirectoryNoOverwrite(
     force: false,
     errorOnExist: true,
   })
+}
+
+/**
+ * Restore a moved cleanup candidate without overwriting a recreated destination.
+ * @param movedPath - Temporary same-directory path currently holding the entry.
+ * @param destination - Original reviewed slot that must still be absent.
+ * @returns Promise that resolves after the moved entry is restored and removed.
+ * @example await restorePathNoOverwrite('/agent/task.cleanup-id', '/agent/task')
+ */
+async function restorePathNoOverwrite(
+  movedPath: string,
+  destination: string,
+): Promise<void> {
+  const stats = await fs.lstat(movedPath)
+
+  if (stats.isSymbolicLink()) {
+    const target = await fs.readlink(movedPath)
+    await fs.symlink(target, destination)
+    await fs.unlink(movedPath)
+    return
+  }
+
+  if (stats.isDirectory()) {
+    await copyDirectoryNoOverwrite(movedPath, destination)
+    await fs.rm(movedPath, { recursive: true, force: true })
+    return
+  }
+
+  if (stats.isFile()) {
+    await fs.copyFile(movedPath, destination, constants.COPYFILE_EXCL)
+    await fs.unlink(movedPath)
+    return
+  }
+
+  throw new TrashError(
+    `Cleanup stopped, but the moved entry type cannot be restored safely from ${movedPath}.`,
+    'EINVAL',
+  )
 }
 
 /**
@@ -591,7 +629,7 @@ async function restoreMovedCleanupCandidate(
   }
 
   try {
-    await fs.rename(movedPath, linkPath)
+    await restorePathNoOverwrite(movedPath, linkPath)
   } catch (error) {
     throw new TrashError(
       `Cleanup stopped, but the moved entry could not be restored at ${linkPath}: ${extractErrorMessage(error)}`,
@@ -1590,9 +1628,9 @@ async function restoreSourceBacked(
     }
   }
 
-  // Source path free?
+  // Source path free? Use lstat so a dangling symlink still blocks restore.
   try {
-    await fs.stat(manifest.sourcePath)
+    await fs.lstat(manifest.sourcePath)
     return {
       outcome: 'error',
       error: {

--- a/src/main/utils/errorCode.test.ts
+++ b/src/main/utils/errorCode.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import { isMissingPathError } from './errorCode'
+
+/**
+ * Build a Node-style filesystem error for cleanup safety tests.
+ * @param code - Errno code attached to the error object.
+ * @param message - Human-readable fs error text, including the path.
+ * @returns Error with a Node `code` field.
+ * @example makeFsError('ENOENT', 'missing').code // => 'ENOENT'
+ */
+function makeFsError(code: string, message: string): Error & { code: string } {
+  return Object.assign(new Error(message), { code })
+}
+
+describe('isMissingPathError', () => {
+  it('treats only missing-path errno codes as cleanup-safe missing targets', () => {
+    // Arrange
+    const missingFile = makeFsError('ENOENT', 'missing')
+    const missingParent = makeFsError('ENOTDIR', 'parent is not a directory')
+
+    // Act + Assert
+    expect(isMissingPathError(missingFile)).toBe(true)
+    expect(isMissingPathError(missingParent)).toBe(true)
+  })
+
+  it('does not parse ENOENT text from an inaccessible path message', () => {
+    // Arrange
+    const inaccessible = makeFsError(
+      'EACCES',
+      "EACCES: permission denied, access '/tmp/ENOENT-locked-skill'",
+    )
+
+    // Act
+    const result = isMissingPathError(inaccessible)
+
+    // Assert
+    expect(result).toBe(false)
+  })
+})

--- a/src/main/utils/errorCode.ts
+++ b/src/main/utils/errorCode.ts
@@ -18,3 +18,15 @@ export function errorCode(error: unknown): string | undefined {
   }
   return undefined
 }
+
+/**
+ * Checks whether an fs probe proves a path component is gone; cleanup callers use it to avoid treating permission failures as dangling symlinks.
+ * @param error - The caught filesystem error.
+ * @returns True only for Node codes that mean the target path cannot exist.
+ * @example
+ * isMissingPathError(Object.assign(new Error('missing'), { code: 'ENOENT' })) // => true
+ */
+export function isMissingPathError(error: unknown): boolean {
+  const code = errorCode(error)
+  return code === 'ENOENT' || code === 'ENOTDIR'
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4,6 +4,8 @@ import { IPC_CHANNELS } from '@/shared/ipc-channels'
 import type { Settings } from '@/shared/settings'
 import type {
   AbsolutePath,
+  ClearOrphanSymlinksOptions,
+  ClearBrokenSymlinkSlotsOptions,
   CopyToAgentsOptions,
   CreateSymlinksOptions,
   DeleteProgressPayload,
@@ -55,6 +57,10 @@ contextBridge.exposeInMainWorld('electron', {
     // deleteSkills runs serially in main; batches of >=10 emit progress events.
     deleteSkills: async (options: DeleteSkillsOptions) =>
       typedInvoke('skills:deleteSkills', options),
+    clearOrphanSymlinks: async (options: ClearOrphanSymlinksOptions) =>
+      typedInvoke('skills:clearOrphanSymlinks', options),
+    clearBrokenSymlinkSlots: async (options: ClearBrokenSymlinkSlotsOptions) =>
+      typedInvoke('skills:clearBrokenSymlinkSlots', options),
     unlinkManyFromAgent: async (options: UnlinkManyFromAgentOptions) =>
       typedInvoke('skills:unlinkManyFromAgent', options),
     restoreDeletedSkill: async (options: RestoreDeletedSkillOptions) =>

--- a/src/renderer/src/components/dashboard/DashboardEditToolbar.tsx
+++ b/src/renderer/src/components/dashboard/DashboardEditToolbar.tsx
@@ -9,6 +9,7 @@ import {
   selectIsEditMode,
   toggleEditMode,
 } from '@/renderer/src/redux/slices/dashboardSlice'
+import { closeSymlinkCleanupDialog } from '@/renderer/src/redux/slices/uiSlice'
 
 import { WidgetPicker } from './WidgetPicker'
 
@@ -52,11 +53,13 @@ export const DashboardEditToolbar = React.memo(
         'Reset dashboard to default layout? Your current arrangement will be lost.',
       )
       if (userConfirmed) {
+        dispatch(closeSymlinkCleanupDialog())
         dispatch(resetToDefaults())
       }
     }, [dispatch])
 
     const handleToggleEditMode = useCallback((): void => {
+      dispatch(closeSymlinkCleanupDialog())
       dispatch(toggleEditMode())
     }, [dispatch])
 

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
@@ -222,7 +222,14 @@ describe('SymlinkCleanupDialog', () => {
     mockGetSkills
       .mockResolvedValueOnce([makeSkillWithBrokenSlot('stale-task', 'cursor')])
       .mockResolvedValueOnce([])
-    const screen = await renderOpenedDialog()
+    const selectedSkillName = 'stale-list-row' as SkillName
+    const { screen, store } = await renderOpenedDialogWithStore()
+    const { toggleSelection } =
+      await import('@/renderer/src/redux/slices/skillsSlice')
+    store.dispatch(toggleSelection(selectedSkillName))
+    expect(store.getState().skills.selectedSkillNames).toEqual([
+      selectedSkillName,
+    ])
 
     // Act
     await expect
@@ -236,6 +243,7 @@ describe('SymlinkCleanupDialog', () => {
       .toBeVisible()
     expect(mockClearOrphanSymlinks).not.toHaveBeenCalled()
     expect(mockClearBrokenSymlinkSlots).not.toHaveBeenCalled()
+    expect(store.getState().skills.selectedSkillNames).toEqual([])
   })
 
   it('stops cleanup when a same-id broken slot points at a new target', async () => {

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
@@ -358,6 +358,12 @@ describe('SymlinkCleanupDialog', () => {
     await expect
       .element(screen.getByText('No safe cleanup items'))
       .toBeVisible()
+    await expect
+      .element(screen.getByText(/Dashboard refresh still offline/))
+      .toBeVisible()
+    await expect
+      .element(screen.getByRole('button', { name: 'Rescan' }))
+      .toBeVisible()
     expect(screen.getByText(/Cleanup failed/).query()).toBeNull()
   })
 

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
@@ -184,6 +184,28 @@ describe('SymlinkCleanupDialog', () => {
     })
   })
 
+  it('shows a rescan affordance after an initial scan failure', async () => {
+    // Arrange
+    mockGetSkills
+      .mockRejectedValueOnce(new Error('Transient scanner failure'))
+      .mockResolvedValueOnce([makeSkillWithBrokenSlot('retry-task', 'cursor')])
+    const screen = await renderOpenedDialog()
+
+    // Act
+    await expect
+      .element(screen.getByRole('button', { name: 'Rescan' }))
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Rescan' }).click()
+
+    // Assert
+    await expect
+      .element(screen.getByRole('button', { name: 'Clean 1 selected' }))
+      .toBeVisible()
+    await expect
+      .element(screen.getByText('retry-task', { exact: true }))
+      .toBeVisible()
+  })
+
   it('stops cleanup when the fresh scan no longer matches the reviewed plan', async () => {
     // Arrange
     mockGetSkills
@@ -242,15 +264,22 @@ describe('SymlinkCleanupDialog', () => {
       .mockResolvedValueOnce([makeSkillWithBrokenSlot('failed-task', 'codex')])
     mockClearBrokenSymlinkSlots.mockImplementation(
       async (options: {
-        items: Array<{ agentId: string; skillName: string; linkPath: string }>
+        items: Array<{ agentId: string; linkName: string; linkPath: string }>
       }) => {
         return {
           items: options.items.map((item) => {
             if (item.agentId === 'cursor') {
-              return { ...item, outcome: 'unlinked' }
+              return {
+                agentId: item.agentId,
+                skillName: item.linkName,
+                linkPath: item.linkPath,
+                outcome: 'unlinked',
+              }
             }
             return {
-              ...item,
+              agentId: item.agentId,
+              skillName: item.linkName,
+              linkPath: item.linkPath,
               outcome: 'error',
               error: { message: 'Permission denied', code: 'EACCES' },
             }
@@ -275,6 +304,49 @@ describe('SymlinkCleanupDialog', () => {
     await expect
       .element(screen.getByText('failed-task', { exact: true }))
       .toBeVisible()
+  })
+
+  it('keeps cleanup success when post-cleanup refresh fails', async () => {
+    // Arrange
+    const firstPlan = [makeSkillWithBrokenSlot('refresh-failed-task', 'cursor')]
+    mockGetSkills
+      .mockResolvedValueOnce(firstPlan)
+      .mockResolvedValueOnce(firstPlan)
+      .mockResolvedValueOnce([])
+    mockGetAgents.mockRejectedValueOnce(new Error('Dashboard refresh offline'))
+    mockClearBrokenSymlinkSlots.mockResolvedValue({
+      items: [
+        {
+          agentId: 'cursor',
+          skillName: 'refresh-failed-task',
+          linkPath: '/Users/test/.cursor/skills/refresh-failed-task',
+          outcome: 'unlinked',
+        },
+      ],
+    })
+    const screen = await renderOpenedDialog()
+
+    // Act
+    await expect
+      .element(screen.getByRole('button', { name: 'Clean 1 selected' }))
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Clean 1 selected' }).click()
+
+    // Assert
+    await expect
+      .element(screen.getByText(/Cleaned up 1 symlink issue/))
+      .toBeVisible()
+    await expect
+      .element(screen.getByText(/Refresh failed after cleanup/))
+      .toBeVisible()
+    await expect
+      .element(
+        screen.getByText(
+          'Cleanup succeeded. Rescan to refresh the dashboard state.',
+        ),
+      )
+      .toBeVisible()
+    expect(screen.getByText(/Cleanup failed/).query()).toBeNull()
   })
 
   it('requires rescan when a failed row keeps its id but changes target after cleanup', async () => {
@@ -328,13 +400,20 @@ describe('SymlinkCleanupDialog', () => {
       .mockResolvedValueOnce([makeSkillWithBrokenSlot('shared-task', 'codex')])
     mockClearBrokenSymlinkSlots.mockImplementation(
       async (options: {
-        items: Array<{ agentId: string; skillName: string; linkPath: string }>
+        items: Array<{ agentId: string; linkName: string; linkPath: string }>
       }) => ({
         items: options.items.map((item) =>
           item.agentId === 'cursor'
-            ? { ...item, outcome: 'unlinked' }
+            ? {
+                agentId: item.agentId,
+                skillName: item.linkName,
+                linkPath: item.linkPath,
+                outcome: 'unlinked',
+              }
             : {
-                ...item,
+                agentId: item.agentId,
+                skillName: item.linkName,
+                linkPath: item.linkPath,
                 outcome: 'error',
                 error: { message: 'Codex permission denied', code: 'EACCES' },
               },
@@ -458,6 +537,13 @@ describe('SymlinkCleanupDialog', () => {
     await expect
       .element(screen.getByText('Source skill exists. Rescan before cleanup.'))
       .toBeVisible()
+    await expect
+      .element(
+        screen.getByText(
+          'Codex: /Users/test/.codex/skills/abandoned-task -> /Users/test/.agents/skills/abandoned-task',
+        ),
+      )
+      .toBeVisible()
     expect(mockClearOrphanSymlinks).toHaveBeenCalledWith({
       items: [
         {
@@ -506,6 +592,13 @@ describe('SymlinkCleanupDialog', () => {
       .toBeVisible()
     await expect
       .element(
+        screen.getByText(
+          '/Users/test/.cursor/skills/link-folder-name -> /Users/test/.agents/skills/missing-target',
+        ),
+      )
+      .toBeVisible()
+    await expect
+      .element(
         screen.getByRole('checkbox', {
           name: 'Clean broken link for link-folder-name (metadata-title) from Cursor',
         }),
@@ -522,7 +615,7 @@ describe('SymlinkCleanupDialog', () => {
       items: [
         {
           agentId: 'cursor',
-          skillName: 'link-folder-name',
+          linkName: 'link-folder-name',
           linkPath: '/Users/test/.cursor/skills/link-folder-name',
           targetPath: '/Users/test/.agents/skills/missing-target',
         },

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
@@ -56,6 +56,7 @@ const TEST_AGENTS: Agent[] = [
 function makeBrokenSlot(
   skillName: SkillName,
   agentId: 'cursor' | 'codex',
+  overrides: Partial<SymlinkInfo> = {},
 ): SymlinkInfo {
   const agent = TEST_AGENTS.find((item) => item.id === agentId)
   if (!agent) throw new Error(`Unknown test agent: ${agentId}`)
@@ -63,9 +64,12 @@ function makeBrokenSlot(
     agentId,
     agentName: agent.name,
     status: 'broken',
-    linkPath: `/Users/test/.${agentId}/skills/${skillName}`,
-    targetPath: `/Users/test/.agents/skills/${skillName}`,
+    linkPath:
+      overrides.linkPath ?? `/Users/test/.${agentId}/skills/${skillName}`,
+    targetPath:
+      overrides.targetPath ?? `/Users/test/.agents/skills/${skillName}`,
     isLocal: false,
+    ...overrides,
   }
 }
 
@@ -80,13 +84,14 @@ function makeBrokenSlot(
 function makeSkillWithBrokenSlot(
   skillName: SkillName,
   agentId: 'cursor' | 'codex',
+  symlinkOverrides: Partial<SymlinkInfo> = {},
 ): Skill {
   return {
     name: skillName,
     description: `${skillName} description`,
     path: `/Users/test/.agents/skills/${skillName}`,
     symlinkCount: 0,
-    symlinks: [makeBrokenSlot(skillName, agentId)],
+    symlinks: [makeBrokenSlot(skillName, agentId, symlinkOverrides)],
     isSource: true,
     isOrphan: false,
   }
@@ -200,6 +205,31 @@ describe('SymlinkCleanupDialog', () => {
     expect(mockClearBrokenSymlinkSlots).not.toHaveBeenCalled()
   })
 
+  it('stops cleanup when a same-id broken slot points at a new target', async () => {
+    // Arrange
+    mockGetSkills
+      .mockResolvedValueOnce([makeSkillWithBrokenSlot('stale-task', 'cursor')])
+      .mockResolvedValueOnce([
+        makeSkillWithBrokenSlot('stale-task', 'cursor', {
+          targetPath: '/Users/test/.agents/skills/other-target',
+        }),
+      ])
+    const screen = await renderOpenedDialog()
+
+    // Act
+    await expect
+      .element(screen.getByRole('button', { name: 'Clean 1 selected' }))
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Clean 1 selected' }).click()
+
+    // Assert
+    await expect
+      .element(screen.getByText('Plan changed', { exact: true }))
+      .toBeVisible()
+    expect(mockClearOrphanSymlinks).not.toHaveBeenCalled()
+    expect(mockClearBrokenSymlinkSlots).not.toHaveBeenCalled()
+  })
+
   it('keeps only failed rows selected after partial unlink failure refreshes the plan', async () => {
     // Arrange
     const firstPlan = [
@@ -245,6 +275,46 @@ describe('SymlinkCleanupDialog', () => {
     await expect
       .element(screen.getByText('failed-task', { exact: true }))
       .toBeVisible()
+  })
+
+  it('requires rescan when a failed row keeps its id but changes target after cleanup', async () => {
+    // Arrange
+    const firstPlan = [makeSkillWithBrokenSlot('failed-task', 'codex')]
+    mockGetSkills
+      .mockResolvedValueOnce(firstPlan)
+      .mockResolvedValueOnce(firstPlan)
+      .mockResolvedValueOnce([
+        makeSkillWithBrokenSlot('failed-task', 'codex', {
+          targetPath: '/Users/test/.agents/skills/other-failed-target',
+        }),
+      ])
+    mockClearBrokenSymlinkSlots.mockResolvedValue({
+      items: [
+        {
+          agentId: 'codex',
+          skillName: 'failed-task',
+          linkPath: '/Users/test/.codex/skills/failed-task',
+          outcome: 'error',
+          error: { message: 'Permission denied', code: 'EACCES' },
+        },
+      ],
+    })
+    const screen = await renderOpenedDialog()
+
+    // Act
+    await expect
+      .element(screen.getByRole('button', { name: 'Clean 1 selected' }))
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Clean 1 selected' }).click()
+
+    // Assert
+    await expect
+      .element(screen.getByText('Cleanup result changed. Rescan required.'))
+      .toBeVisible()
+    expect(
+      screen.getByText('Cleanup finished with failures.').query(),
+    ).toBeNull()
+    expect(screen.getByText('Permission denied').query()).toBeNull()
   })
 
   it('keeps same-name broken slot failures attached to the failed agent row', async () => {
@@ -330,6 +400,14 @@ describe('SymlinkCleanupDialog', () => {
     await expect
       .element(screen.getByRole('button', { name: 'Cancel' }))
       .toBeDisabled()
+    expect(screen.getByRole('button', { name: /^Close$/i }).query()).toBeNull()
+
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+    )
+    await expect
+      .element(screen.getByText('Cleaning selected issues'))
+      .toBeVisible()
 
     finishCleanup({
       items: [
@@ -388,10 +466,36 @@ describe('SymlinkCleanupDialog', () => {
             {
               agentId: 'codex',
               linkPath: '/Users/test/.codex/skills/abandoned-task',
+              targetPath: '/Users/test/.agents/skills/abandoned-task',
             },
           ],
         },
       ],
     })
+  })
+
+  it('shows link-folder identity before metadata name for broken cleanup rows', async () => {
+    // Arrange
+    mockGetSkills.mockResolvedValueOnce([
+      makeSkillWithBrokenSlot('metadata-title', 'cursor', {
+        linkPath: '/Users/test/.cursor/skills/link-folder-name',
+        targetPath: '/Users/test/.agents/skills/missing-target',
+      }),
+    ])
+
+    // Act
+    const screen = await renderOpenedDialog()
+
+    // Assert
+    await expect
+      .element(screen.getByText('link-folder-name (metadata-title)'))
+      .toBeVisible()
+    await expect
+      .element(
+        screen.getByRole('checkbox', {
+          name: 'Clean broken link for link-folder-name (metadata-title) from Cursor',
+        }),
+      )
+      .toBeInTheDocument()
   })
 })

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
@@ -313,6 +313,7 @@ describe('SymlinkCleanupDialog', () => {
       .mockResolvedValueOnce(firstPlan)
       .mockResolvedValueOnce(firstPlan)
       .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
     mockGetAgents.mockRejectedValueOnce(new Error('Dashboard refresh offline'))
     mockClearBrokenSymlinkSlots.mockResolvedValue({
       items: [
@@ -348,6 +349,12 @@ describe('SymlinkCleanupDialog', () => {
       .toBeVisible()
     await expect
       .element(screen.getByRole('button', { name: 'Rescan' }))
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Rescan' }).click()
+    await expect.poll(() => mockGetAgents.mock.calls.length).toBe(2)
+    await expect.poll(() => mockGetSourceStats.mock.calls.length).toBe(2)
+    await expect
+      .element(screen.getByText('No safe cleanup items'))
       .toBeVisible()
     expect(screen.getByText(/Cleanup failed/).query()).toBeNull()
   })

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
@@ -138,11 +138,11 @@ function makeOrphanSkill(
 
 /**
  * Renders an opened SymlinkCleanupDialog with real reducers and mocked preload IPC.
- * @returns Browser screen for interaction assertions.
+ * @returns Browser screen and Redux store for interaction assertions.
  * @example
- * const screen = await renderOpenedDialog()
+ * const { screen, store } = await renderOpenedDialogWithStore()
  */
-async function renderOpenedDialog() {
+async function renderOpenedDialogWithStore() {
   const [
     { default: skillsReducer },
     { default: agentsReducer },
@@ -169,6 +169,17 @@ async function renderOpenedDialog() {
       </main>
     </Provider>,
   )
+  return { screen, store }
+}
+
+/**
+ * Renders an opened cleanup dialog and returns only the browser screen.
+ * @returns Browser screen for tests that do not inspect Redux state.
+ * @example
+ * const screen = await renderOpenedDialog()
+ */
+async function renderOpenedDialog() {
+  const { screen } = await renderOpenedDialogWithStore()
   return screen
 }
 
@@ -568,6 +579,47 @@ describe('SymlinkCleanupDialog', () => {
     await expect
       .element(screen.getByText(/Cleaned up 1 symlink issue/))
       .toBeVisible()
+  })
+
+  it('clears stale Installed-list selection when dashboard cleanup starts', async () => {
+    // Arrange
+    const selectedSkillName = 'stale-list-row' as SkillName
+    const cleanupPlan = [
+      makeSkillWithBrokenSlot('dialog-cleanup-task', 'cursor'),
+    ]
+    mockGetSkills
+      .mockResolvedValueOnce(cleanupPlan)
+      .mockResolvedValueOnce(cleanupPlan)
+      .mockResolvedValueOnce(cleanupPlan)
+    mockClearBrokenSymlinkSlots.mockResolvedValue({
+      items: [
+        {
+          agentId: 'cursor',
+          skillName: 'dialog-cleanup-task',
+          linkPath: '/Users/test/.cursor/skills/dialog-cleanup-task',
+          outcome: 'unlinked',
+        },
+      ],
+    })
+    const { screen, store } = await renderOpenedDialogWithStore()
+    const { toggleSelection } =
+      await import('@/renderer/src/redux/slices/skillsSlice')
+    store.dispatch(toggleSelection(selectedSkillName))
+    expect(store.getState().skills.selectedSkillNames).toEqual([
+      selectedSkillName,
+    ])
+
+    // Act
+    await expect
+      .element(screen.getByRole('button', { name: 'Clean 1 selected' }))
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Clean 1 selected' }).click()
+
+    // Assert
+    await expect
+      .poll(() => mockClearBrokenSymlinkSlots.mock.calls.length)
+      .toBe(1)
+    expect(store.getState().skills.selectedSkillNames).toEqual([])
   })
 
   it('surfaces orphan-only IPC failures without calling source delete', async () => {

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
@@ -476,12 +476,26 @@ describe('SymlinkCleanupDialog', () => {
 
   it('shows link-folder identity before metadata name for broken cleanup rows', async () => {
     // Arrange
-    mockGetSkills.mockResolvedValueOnce([
+    const mismatchPlan = [
       makeSkillWithBrokenSlot('metadata-title', 'cursor', {
         linkPath: '/Users/test/.cursor/skills/link-folder-name',
         targetPath: '/Users/test/.agents/skills/missing-target',
       }),
-    ])
+    ]
+    mockGetSkills
+      .mockResolvedValueOnce(mismatchPlan)
+      .mockResolvedValueOnce(mismatchPlan)
+      .mockResolvedValueOnce([])
+    mockClearBrokenSymlinkSlots.mockResolvedValue({
+      items: [
+        {
+          agentId: 'cursor',
+          skillName: 'link-folder-name',
+          linkPath: '/Users/test/.cursor/skills/link-folder-name',
+          outcome: 'unlinked',
+        },
+      ],
+    })
 
     // Act
     const screen = await renderOpenedDialog()
@@ -497,5 +511,25 @@ describe('SymlinkCleanupDialog', () => {
         }),
       )
       .toBeInTheDocument()
+    await screen.getByRole('button', { name: 'Clean 1 selected' }).click()
+
+    // Assert: the destructive IPC uses the reviewed folder name and paths, not
+    // the metadata display name that happens to own the row in scanner output.
+    await expect
+      .poll(() => mockClearBrokenSymlinkSlots.mock.calls.length)
+      .toBe(1)
+    expect(mockClearBrokenSymlinkSlots).toHaveBeenCalledWith({
+      items: [
+        {
+          agentId: 'cursor',
+          skillName: 'link-folder-name',
+          linkPath: '/Users/test/.cursor/skills/link-folder-name',
+          targetPath: '/Users/test/.agents/skills/missing-target',
+        },
+      ],
+    })
+    await expect
+      .element(screen.getByText(/Cleaned up 1 symlink issue/))
+      .toBeVisible()
   })
 })

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
@@ -540,6 +540,55 @@ describe('SymlinkCleanupDialog', () => {
     expect(screen.getByText('Permission denied').query()).toBeNull()
   })
 
+  it('refreshes every dashboard source when rescanning after a post-mutation stale prompt', async () => {
+    // Arrange — the cleanup row fails AND the post-cleanup fetchSkills rejects,
+    // so the dialog lands in the post-mutation 'stale' prompt. The rescan's
+    // fetchSkills then resolves a fresh plan, but the agent registry is offline
+    // only on that rescan: its warning surfaces solely if the rescan refreshes
+    // every dashboard source, which a pre-mutation stale rescan never does.
+    const firstPlan = [makeSkillWithBrokenSlot('stale-refresh-task', 'codex')]
+    mockGetSkills
+      .mockResolvedValueOnce(firstPlan)
+      .mockResolvedValueOnce(firstPlan)
+      .mockRejectedValueOnce(new Error('Scanner offline after cleanup'))
+      .mockResolvedValueOnce(firstPlan)
+    mockGetAgents
+      .mockResolvedValueOnce(TEST_AGENTS)
+      .mockRejectedValueOnce(new Error('Agent registry offline on rescan'))
+    mockClearBrokenSymlinkSlots.mockResolvedValue({
+      items: [
+        {
+          agentId: 'codex',
+          skillName: 'stale-refresh-task',
+          linkPath: '/Users/test/.codex/skills/stale-refresh-task',
+          outcome: 'error',
+          error: { message: 'Permission denied', code: 'EACCES' },
+        },
+      ],
+    })
+    const screen = await renderOpenedDialog()
+
+    // Act — clean (lands in the post-mutation stale prompt), then rescan.
+    await expect
+      .element(screen.getByRole('button', { name: 'Clean 1 selected' }))
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Clean 1 selected' }).click()
+    await expect
+      .element(
+        screen.getByText(
+          'Cleanup finished with failures, but the refresh failed. Rescan required.',
+        ),
+      )
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Rescan' }).click()
+
+    // Assert — the rescan re-fetched the agent registry (a dashboard source),
+    // so its offline warning appears; a skills-only rescan would never show it.
+    await expect
+      .element(screen.getByText(/Agent registry offline on rescan/))
+      .toBeVisible()
+  })
+
   it('keeps cleanup success when only the post-cleanup skills refresh rejects', async () => {
     // Arrange — same fetchSkills rejection, but the cleanup row succeeds, so
     // the happy path must still report completion (not a stale rescan prompt).

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
@@ -1,0 +1,397 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import '@/renderer/src/styles/globals.css'
+import type { Agent, Skill, SkillName, SymlinkInfo } from '@/shared/types'
+
+const mockGetSkills = vi.fn()
+const mockGetAgents = vi.fn()
+const mockGetSourceStats = vi.fn()
+const mockClearOrphanSymlinks = vi.fn()
+const mockClearBrokenSymlinkSlots = vi.fn()
+
+vi.stubGlobal('electron', {
+  skills: {
+    getAll: mockGetSkills,
+    clearOrphanSymlinks: mockClearOrphanSymlinks,
+    clearBrokenSymlinkSlots: mockClearBrokenSymlinkSlots,
+  },
+  agents: {
+    getAll: mockGetAgents,
+  },
+  source: {
+    getStats: mockGetSourceStats,
+  },
+})
+
+const TEST_AGENTS: Agent[] = [
+  {
+    id: 'cursor',
+    name: 'Cursor',
+    path: '/Users/test/.cursor/skills',
+    exists: true,
+    skillCount: 0,
+    localSkillCount: 0,
+  },
+  {
+    id: 'codex',
+    name: 'Codex',
+    path: '/Users/test/.codex/skills',
+    exists: true,
+    skillCount: 0,
+    localSkillCount: 0,
+  },
+]
+
+/**
+ * Builds one broken symlink slot for SymlinkCleanupDialog browser specs.
+ * @param skillName - Skill name and agent-side link name.
+ * @param agentId - Agent that owns the broken slot.
+ * @returns SymlinkInfo fixture eligible for cleanup.
+ * @example
+ * makeBrokenSlot('task', 'cursor').status // => 'broken'
+ */
+function makeBrokenSlot(
+  skillName: SkillName,
+  agentId: 'cursor' | 'codex',
+): SymlinkInfo {
+  const agent = TEST_AGENTS.find((item) => item.id === agentId)
+  if (!agent) throw new Error(`Unknown test agent: ${agentId}`)
+  return {
+    agentId,
+    agentName: agent.name,
+    status: 'broken',
+    linkPath: `/Users/test/.${agentId}/skills/${skillName}`,
+    targetPath: `/Users/test/.agents/skills/${skillName}`,
+    isLocal: false,
+  }
+}
+
+/**
+ * Builds a source skill with one cleanup-eligible broken slot.
+ * @param skillName - Skill and link name.
+ * @param agentId - Agent that owns the broken slot.
+ * @returns Skill fixture for the scanner thunk mock.
+ * @example
+ * makeSkillWithBrokenSlot('task', 'cursor').symlinks.length // => 1
+ */
+function makeSkillWithBrokenSlot(
+  skillName: SkillName,
+  agentId: 'cursor' | 'codex',
+): Skill {
+  return {
+    name: skillName,
+    description: `${skillName} description`,
+    path: `/Users/test/.agents/skills/${skillName}`,
+    symlinkCount: 0,
+    symlinks: [makeBrokenSlot(skillName, agentId)],
+    isSource: true,
+    isOrphan: false,
+  }
+}
+
+/**
+ * Builds one source skill with multiple cleanup-eligible broken agent slots.
+ * @param skillName - Shared basename used by every broken slot.
+ * @param agentIds - Agents that own broken links for the same skill.
+ * @returns Skill fixture whose rows differ by agent identity, not skill name.
+ * @example
+ * makeSkillWithBrokenSlots('task', ['cursor', 'codex']).symlinks.length // => 2
+ */
+function makeSkillWithBrokenSlots(
+  skillName: SkillName,
+  agentIds: Array<'cursor' | 'codex'>,
+): Skill {
+  return {
+    ...makeSkillWithBrokenSlot(skillName, agentIds[0] ?? 'cursor'),
+    symlinks: agentIds.map((agentId) => makeBrokenSlot(skillName, agentId)),
+    symlinkCount: agentIds.length,
+  }
+}
+
+/**
+ * Builds an orphan skill record with one broken agent symlink.
+ * @param skillName - Orphan skill name selected for cleanup.
+ * @param agentId - Agent that still owns the dangling symlink.
+ * @returns Skill fixture whose cleanup uses orphan-only IPC.
+ * @example
+ * makeOrphanSkill('abandoned', 'codex').isOrphan // => true
+ */
+function makeOrphanSkill(
+  skillName: SkillName,
+  agentId: 'cursor' | 'codex',
+): Skill {
+  return {
+    ...makeSkillWithBrokenSlot(skillName, agentId),
+    path: `/Users/test/.${agentId}/skills/${skillName}`,
+    isSource: false,
+    isOrphan: true,
+  }
+}
+
+/**
+ * Renders an opened SymlinkCleanupDialog with real reducers and mocked preload IPC.
+ * @returns Browser screen for interaction assertions.
+ * @example
+ * const screen = await renderOpenedDialog()
+ */
+async function renderOpenedDialog() {
+  const [
+    { default: skillsReducer },
+    { default: agentsReducer },
+    { default: uiReducer, openSymlinkCleanupDialog },
+    { SymlinkCleanupDialog },
+  ] = await Promise.all([
+    import('@/renderer/src/redux/slices/skillsSlice'),
+    import('@/renderer/src/redux/slices/agentsSlice'),
+    import('@/renderer/src/redux/slices/uiSlice'),
+    import('./SymlinkCleanupDialog'),
+  ])
+  const store = configureStore({
+    reducer: { skills: skillsReducer, agents: agentsReducer, ui: uiReducer },
+  })
+  store.dispatch(openSymlinkCleanupDialog())
+
+  const screen = await render(
+    <Provider store={store}>
+      <main id="main-content" tabIndex={-1}>
+        <button type="button" data-symlink-cleanup-trigger="true">
+          Scan issues
+        </button>
+        <SymlinkCleanupDialog />
+      </main>
+    </Provider>,
+  )
+  return screen
+}
+
+describe('SymlinkCleanupDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetAgents.mockResolvedValue(TEST_AGENTS)
+    mockGetSourceStats.mockResolvedValue({
+      skillCount: 0,
+      totalSize: '0 B',
+      path: '/Users/test/.agents/skills',
+      lastModified: '2026-05-28T00:00:00.000Z',
+    })
+  })
+
+  it('stops cleanup when the fresh scan no longer matches the reviewed plan', async () => {
+    // Arrange
+    mockGetSkills
+      .mockResolvedValueOnce([makeSkillWithBrokenSlot('stale-task', 'cursor')])
+      .mockResolvedValueOnce([])
+    const screen = await renderOpenedDialog()
+
+    // Act
+    await expect
+      .element(screen.getByRole('button', { name: 'Clean 1 selected' }))
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Clean 1 selected' }).click()
+
+    // Assert
+    await expect
+      .element(screen.getByText('Plan changed', { exact: true }))
+      .toBeVisible()
+    expect(mockClearOrphanSymlinks).not.toHaveBeenCalled()
+    expect(mockClearBrokenSymlinkSlots).not.toHaveBeenCalled()
+  })
+
+  it('keeps only failed rows selected after partial unlink failure refreshes the plan', async () => {
+    // Arrange
+    const firstPlan = [
+      makeSkillWithBrokenSlot('fixed-task', 'cursor'),
+      makeSkillWithBrokenSlot('failed-task', 'codex'),
+    ]
+    mockGetSkills
+      .mockResolvedValueOnce(firstPlan)
+      .mockResolvedValueOnce(firstPlan)
+      .mockResolvedValueOnce([makeSkillWithBrokenSlot('failed-task', 'codex')])
+    mockClearBrokenSymlinkSlots.mockImplementation(
+      async (options: {
+        items: Array<{ agentId: string; skillName: string; linkPath: string }>
+      }) => {
+        return {
+          items: options.items.map((item) => {
+            if (item.agentId === 'cursor') {
+              return { ...item, outcome: 'unlinked' }
+            }
+            return {
+              ...item,
+              outcome: 'error',
+              error: { message: 'Permission denied', code: 'EACCES' },
+            }
+          }),
+        }
+      },
+    )
+    const screen = await renderOpenedDialog()
+
+    // Act
+    await expect
+      .element(screen.getByRole('button', { name: 'Clean 2 selected' }))
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Clean 2 selected' }).click()
+
+    // Assert
+    await expect
+      .element(screen.getByText('Cleanup finished with failures.'))
+      .toBeVisible()
+    await expect.element(screen.getByText('Permission denied')).toBeVisible()
+    expect(screen.getByText('fixed-task', { exact: true }).query()).toBeNull()
+    await expect
+      .element(screen.getByText('failed-task', { exact: true }))
+      .toBeVisible()
+  })
+
+  it('keeps same-name broken slot failures attached to the failed agent row', async () => {
+    // Arrange
+    const firstPlan = [
+      makeSkillWithBrokenSlots('shared-task', ['cursor', 'codex']),
+    ]
+    mockGetSkills
+      .mockResolvedValueOnce(firstPlan)
+      .mockResolvedValueOnce(firstPlan)
+      .mockResolvedValueOnce([makeSkillWithBrokenSlot('shared-task', 'codex')])
+    mockClearBrokenSymlinkSlots.mockImplementation(
+      async (options: {
+        items: Array<{ agentId: string; skillName: string; linkPath: string }>
+      }) => ({
+        items: options.items.map((item) =>
+          item.agentId === 'cursor'
+            ? { ...item, outcome: 'unlinked' }
+            : {
+                ...item,
+                outcome: 'error',
+                error: { message: 'Codex permission denied', code: 'EACCES' },
+              },
+        ),
+      }),
+    )
+    const screen = await renderOpenedDialog()
+
+    // Act
+    await expect
+      .element(screen.getByRole('button', { name: 'Clean 2 selected' }))
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Clean 2 selected' }).click()
+
+    // Assert
+    await expect
+      .element(screen.getByText('Cleanup finished with failures.'))
+      .toBeVisible()
+    await expect
+      .element(screen.getByText('Codex permission denied'))
+      .toBeVisible()
+    await expect
+      .element(screen.getByText('Codex', { exact: true }))
+      .toBeVisible()
+    expect(screen.getByText('Cursor', { exact: true }).query()).toBeNull()
+  })
+
+  it('renders the cleaning phase while destructive IPC is pending', async () => {
+    // Arrange
+    let finishCleanup: (value: {
+      items: Array<{
+        agentId: string
+        skillName: string
+        linkPath: string
+        outcome: 'unlinked'
+      }>
+    }) => void = () => undefined
+    const firstPlan = [makeSkillWithBrokenSlot('pending-task', 'cursor')]
+    mockGetSkills
+      .mockResolvedValueOnce(firstPlan)
+      .mockResolvedValueOnce(firstPlan)
+      .mockResolvedValueOnce([])
+    mockClearBrokenSymlinkSlots.mockImplementation(async () => {
+      return new Promise((resolve) => {
+        finishCleanup = resolve
+      })
+    })
+    const screen = await renderOpenedDialog()
+
+    // Act
+    await expect
+      .element(screen.getByRole('button', { name: 'Clean 1 selected' }))
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Clean 1 selected' }).click()
+
+    // Assert
+    await expect
+      .element(screen.getByText('Cleaning selected issues'))
+      .toBeVisible()
+    await expect
+      .element(screen.getByRole('button', { name: 'Cleaning...' }))
+      .toBeDisabled()
+    await expect
+      .element(screen.getByRole('button', { name: 'Cancel' }))
+      .toBeDisabled()
+
+    finishCleanup({
+      items: [
+        {
+          agentId: 'cursor',
+          skillName: 'pending-task',
+          linkPath: '/Users/test/.cursor/skills/pending-task',
+          outcome: 'unlinked',
+        },
+      ],
+    })
+    await expect
+      .element(screen.getByText(/Cleaned up 1 symlink issue/))
+      .toBeVisible()
+  })
+
+  it('surfaces orphan-only IPC failures without calling source delete', async () => {
+    // Arrange
+    const orphanPlan = [makeOrphanSkill('abandoned-task', 'codex')]
+    mockGetSkills
+      .mockResolvedValueOnce(orphanPlan)
+      .mockResolvedValueOnce(orphanPlan)
+      .mockResolvedValueOnce(orphanPlan)
+    mockClearOrphanSymlinks.mockResolvedValue({
+      items: [
+        {
+          skillName: 'abandoned-task',
+          outcome: 'error',
+          error: {
+            message: 'Source skill exists. Rescan before cleanup.',
+            code: 'ESTALE',
+          },
+        },
+      ],
+    })
+    const screen = await renderOpenedDialog()
+
+    // Act
+    await expect
+      .element(screen.getByRole('button', { name: 'Clean 1 selected' }))
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Clean 1 selected' }).click()
+
+    // Assert
+    await expect
+      .element(screen.getByText('Cleanup finished with failures.'))
+      .toBeVisible()
+    await expect
+      .element(screen.getByText('Source skill exists. Rescan before cleanup.'))
+      .toBeVisible()
+    expect(mockClearOrphanSymlinks).toHaveBeenCalledWith({
+      items: [
+        {
+          skillName: 'abandoned-task',
+          agents: [
+            {
+              agentId: 'codex',
+              linkPath: '/Users/test/.codex/skills/abandoned-task',
+            },
+          ],
+        },
+      ],
+    })
+  })
+})

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
@@ -314,7 +314,9 @@ describe('SymlinkCleanupDialog', () => {
       .mockResolvedValueOnce(firstPlan)
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
-    mockGetAgents.mockRejectedValueOnce(new Error('Dashboard refresh offline'))
+    mockGetAgents
+      .mockRejectedValueOnce(new Error('Dashboard refresh offline'))
+      .mockRejectedValueOnce(new Error('Dashboard refresh still offline'))
     mockClearBrokenSymlinkSlots.mockResolvedValue({
       items: [
         {

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
@@ -498,6 +498,97 @@ describe('SymlinkCleanupDialog', () => {
     expect(screen.getByText('Permission denied').query()).toBeNull()
   })
 
+  it('requires rescan when a row fails and the post-cleanup skills refresh rejects', async () => {
+    // Arrange — open scan + pre-clean fetch succeed; the post-cleanup
+    // fetchSkills (the plan source) rejects so no post-cleanup plan exists.
+    const firstPlan = [makeSkillWithBrokenSlot('refresh-reject-task', 'codex')]
+    mockGetSkills
+      .mockResolvedValueOnce(firstPlan)
+      .mockResolvedValueOnce(firstPlan)
+      .mockRejectedValueOnce(new Error('Scanner offline after cleanup'))
+    mockClearBrokenSymlinkSlots.mockResolvedValue({
+      items: [
+        {
+          agentId: 'codex',
+          skillName: 'refresh-reject-task',
+          linkPath: '/Users/test/.codex/skills/refresh-reject-task',
+          outcome: 'error',
+          error: { message: 'Permission denied', code: 'EACCES' },
+        },
+      ],
+    })
+    const screen = await renderOpenedDialog()
+
+    // Act
+    await expect
+      .element(screen.getByRole('button', { name: 'Clean 1 selected' }))
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Clean 1 selected' }).click()
+
+    // Assert — the failed branch cannot recompute visibility without a fresh
+    // plan, so it asks for an explicit rescan instead of rendering row errors.
+    await expect
+      .element(
+        screen.getByText(
+          'Cleanup finished with failures, but the refresh failed. Rescan required.',
+        ),
+      )
+      .toBeVisible()
+    expect(
+      screen.getByText('Cleanup finished with failures.').query(),
+    ).toBeNull()
+    expect(screen.getByText('Permission denied').query()).toBeNull()
+  })
+
+  it('keeps cleanup success when only the post-cleanup skills refresh rejects', async () => {
+    // Arrange — same fetchSkills rejection, but the cleanup row succeeds, so
+    // the happy path must still report completion (not a stale rescan prompt).
+    const firstPlan = [makeSkillWithBrokenSlot('refresh-reject-ok', 'codex')]
+    mockGetSkills
+      .mockResolvedValueOnce(firstPlan)
+      .mockResolvedValueOnce(firstPlan)
+      .mockRejectedValueOnce(new Error('Scanner offline after cleanup'))
+    mockClearBrokenSymlinkSlots.mockResolvedValue({
+      items: [
+        {
+          agentId: 'codex',
+          skillName: 'refresh-reject-ok',
+          linkPath: '/Users/test/.codex/skills/refresh-reject-ok',
+          outcome: 'unlinked',
+        },
+      ],
+    })
+    const screen = await renderOpenedDialog()
+
+    // Act
+    await expect
+      .element(screen.getByRole('button', { name: 'Clean 1 selected' }))
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Clean 1 selected' }).click()
+
+    // Assert — completion summary with a refresh warning, never the stale guard.
+    await expect
+      .element(screen.getByText(/Cleaned up 1 symlink issue/))
+      .toBeVisible()
+    await expect
+      .element(screen.getByText(/Refresh failed after cleanup/))
+      .toBeVisible()
+    await expect
+      .element(
+        screen.getByText(
+          'Cleanup succeeded. Rescan to refresh the dashboard state.',
+        ),
+      )
+      .toBeVisible()
+    expect(
+      screen
+        .getByText(
+          'Cleanup finished with failures, but the refresh failed. Rescan required.',
+        )
+        .query(),
+    ).toBeNull()
+  })
+
   it('keeps same-name broken slot failures attached to the failed agent row', async () => {
     // Arrange
     const firstPlan = [

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
@@ -367,6 +367,55 @@ describe('SymlinkCleanupDialog', () => {
     expect(screen.getByText(/Cleanup failed/).query()).toBeNull()
   })
 
+  it('keeps dashboard refresh warnings when rescan finds more cleanup items', async () => {
+    // Arrange
+    const firstPlan = [makeSkillWithBrokenSlot('refresh-ready-task', 'cursor')]
+    const nextPlan = [makeSkillWithBrokenSlot('next-refresh-task', 'codex')]
+    mockGetSkills
+      .mockResolvedValueOnce(firstPlan)
+      .mockResolvedValueOnce(firstPlan)
+      .mockResolvedValueOnce(nextPlan)
+      .mockResolvedValueOnce(nextPlan)
+    mockGetAgents
+      .mockRejectedValueOnce(new Error('Dashboard refresh offline'))
+      .mockRejectedValueOnce(new Error('Dashboard refresh still offline'))
+    mockClearBrokenSymlinkSlots.mockResolvedValue({
+      items: [
+        {
+          agentId: 'cursor',
+          skillName: 'refresh-ready-task',
+          linkPath: '/Users/test/.cursor/skills/refresh-ready-task',
+          outcome: 'unlinked',
+        },
+      ],
+    })
+    const screen = await renderOpenedDialog()
+
+    // Act
+    await expect
+      .element(screen.getByRole('button', { name: 'Clean 1 selected' }))
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Clean 1 selected' }).click()
+    await expect
+      .element(screen.getByRole('button', { name: 'Rescan' }))
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Rescan' }).click()
+
+    // Assert
+    await expect
+      .element(screen.getByText('next-refresh-task', { exact: true }))
+      .toBeVisible()
+    await expect
+      .element(screen.getByRole('button', { name: 'Clean 1 selected' }))
+      .toBeVisible()
+    await expect
+      .element(screen.getByText(/Dashboard refresh still offline/))
+      .toBeVisible()
+    await expect
+      .element(screen.getByRole('button', { name: 'Rescan' }))
+      .toBeVisible()
+  })
+
   it('requires rescan when a failed row keeps its id but changes target after cleanup', async () => {
     // Arrange
     const firstPlan = [makeSkillWithBrokenSlot('failed-task', 'codex')]

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
@@ -346,6 +346,9 @@ describe('SymlinkCleanupDialog', () => {
         ),
       )
       .toBeVisible()
+    await expect
+      .element(screen.getByRole('button', { name: 'Rescan' }))
+      .toBeVisible()
     expect(screen.getByText(/Cleanup failed/).query()).toBeNull()
   })
 

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
@@ -582,8 +582,62 @@ describe('SymlinkCleanupDialog', () => {
       .toBeVisible()
     await screen.getByRole('button', { name: 'Rescan' }).click()
 
-    // Assert — the rescan re-fetched the agent registry (a dashboard source),
-    // so its offline warning appears; a skills-only rescan would never show it.
+    // Assert — the rescan re-fetched every dashboard source: the source stats
+    // aggregate (fetched once on cleanup, once on rescan) and the agent registry
+    // (whose offline warning then appears; a skills-only rescan would show
+    // neither).
+    await expect.poll(() => mockGetSourceStats.mock.calls.length).toBe(2)
+    await expect
+      .element(screen.getByText(/Agent registry offline on rescan/))
+      .toBeVisible()
+  })
+
+  it('refreshes every dashboard source when rescanning after a post-mutation cleanup error', async () => {
+    // Arrange — the cleanup row fails AND a post-cleanup dashboard refresh (the
+    // agent registry) rejects, but the post-cleanup fetchSkills resolves with
+    // the failed row still present, so the dialog lands in the post-mutation
+    // 'error' phase carrying a refresh-failure summary (not a stale prompt). The
+    // rescan's agent registry is offline only on that rescan: its warning
+    // surfaces solely if the rescan refreshes every dashboard source, which the
+    // error phase does only because its summary records the post-cleanup
+    // refresh failure.
+    const firstPlan = [makeSkillWithBrokenSlot('error-refresh-task', 'codex')]
+    mockGetSkills
+      .mockResolvedValueOnce(firstPlan)
+      .mockResolvedValueOnce(firstPlan)
+      .mockResolvedValueOnce(firstPlan)
+      .mockResolvedValueOnce(firstPlan)
+    mockGetAgents
+      .mockRejectedValueOnce(new Error('Dashboard offline after cleanup'))
+      .mockRejectedValueOnce(new Error('Agent registry offline on rescan'))
+    mockClearBrokenSymlinkSlots.mockResolvedValue({
+      items: [
+        {
+          agentId: 'codex',
+          skillName: 'error-refresh-task',
+          linkPath: '/Users/test/.codex/skills/error-refresh-task',
+          outcome: 'error',
+          error: { message: 'Permission denied', code: 'EACCES' },
+        },
+      ],
+    })
+    const screen = await renderOpenedDialog()
+
+    // Act — clean (lands in the post-mutation error phase), then rescan.
+    await expect
+      .element(screen.getByRole('button', { name: 'Clean 1 selected' }))
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Clean 1 selected' }).click()
+    await expect
+      .element(screen.getByText('Cleanup finished with failures.'))
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Rescan' }).click()
+
+    // Assert — the rescan re-fetched every dashboard source: the source stats
+    // aggregate (fetched once on cleanup, once on rescan) and the agent registry
+    // (whose offline warning then appears; before the error-phase fix the rescan
+    // re-fetched skills only and showed neither).
+    await expect.poll(() => mockGetSourceStats.mock.calls.length).toBe(2)
     await expect
       .element(screen.getByText(/Agent registry offline on rescan/))
       .toBeVisible()

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
@@ -195,6 +195,29 @@ describe('SymlinkCleanupDialog', () => {
     })
   })
 
+  it('shows destructive path evidence as a readable inspection block', async () => {
+    // Arrange
+    const destructivePath =
+      '/Users/test/.cursor/skills/readable-task -> /Users/test/.agents/skills/readable-task'
+    mockGetSkills.mockResolvedValueOnce([
+      makeSkillWithBrokenSlot('readable-task', 'cursor'),
+    ])
+
+    // Act
+    const screen = await renderOpenedDialog()
+
+    // Assert
+    const pathText = screen.getByText(destructivePath)
+    await expect.element(pathText).toBeVisible()
+    const evidence = pathText
+      .element()
+      .closest('[data-testid="cleanup-path-evidence"]')
+    expect(evidence).toBeInstanceOf(HTMLElement)
+    const evidenceElement = evidence as HTMLElement
+    expect(evidenceElement.className).toContain('text-xs')
+    expect(evidenceElement.className).toContain('bg-muted/30')
+  })
+
   it('shows a rescan affordance after an initial scan failure', async () => {
     // Arrange
     mockGetSkills

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
@@ -372,6 +372,23 @@ function collectFailedRows(params: {
 }
 
 /**
+ * Turns post-cleanup refresh failures into secondary copy so a successful mutation is not reported as failed.
+ * @param results - Settled refresh thunk results after cleanup mutation finishes.
+ * @returns Extra summary phrase, or null when every refresh thunk fulfilled.
+ * @example
+ * getRefreshFailureMessage([{ status: 'rejected', reason: new Error('offline') }]) // => 'Refresh failed after cleanup: offline. Rescan to update dashboard.'
+ */
+function getRefreshFailureMessage(
+  results: readonly PromiseSettledResult<unknown>[],
+): string | null {
+  const failedRefresh = results.find(
+    (result): result is PromiseRejectedResult => result.status === 'rejected',
+  )
+  if (!failedRefresh) return null
+  return `Refresh failed after cleanup: ${getErrorMessage(failedRefresh.reason)}. Rescan to update dashboard.`
+}
+
+/**
  * Aggregates bulk cleanup results into the compact final summary shown in the dialog.
  * @param params - Attempted item count and mutation results.
  * @returns Count and phrase summary for complete or partial-failure states.
@@ -382,6 +399,7 @@ function buildCleanupSummary(params: {
   attemptedCount: number
   deleteResult: BulkDeleteResult | null
   unlinkResults: Array<{ agentName: string; result: BulkUnlinkResult }>
+  refreshMessage?: string | null
 }): CleanupSummary {
   const deletePhrases = params.deleteResult
     ? [formatCascadeSummary(params.deleteResult)].filter(Boolean)
@@ -418,7 +436,11 @@ function buildCleanupSummary(params: {
   const failedCount = deleteFailureCount + unlinkFailureCount
 
   return {
-    phrases: [...deletePhrases, ...unlinkPhrases],
+    phrases: [
+      ...deletePhrases,
+      ...unlinkPhrases,
+      ...(params.refreshMessage ? [params.refreshMessage] : []),
+    ],
     cleanedIssues: params.attemptedCount - failedCount,
     orphanSymlinksRemoved,
     brokenLinksUnlinked,
@@ -600,7 +622,7 @@ export const SymlinkCleanupDialog = React.memo(
             clearSelectedBrokenSymlinkSlots({
               items: brokenItems.map((item) => ({
                 agentId: item.agentId,
-                skillName: item.linkName,
+                linkName: item.linkName,
                 linkPath: item.linkPath,
                 targetPath: item.targetPath,
               })),
@@ -626,19 +648,28 @@ export const SymlinkCleanupDialog = React.memo(
           }
         }
 
-        // Always refetch after cleanup: success updates the dashboard and
-        // failure rebuilds row state from the scanner the user now sees.
-        const [postCleanupSkills] = await Promise.all([
-          dispatch(fetchSkills()).unwrap(),
-          dispatch(fetchAgents()).unwrap(),
-          dispatch(fetchSourceStats()).unwrap(),
+        // Refresh failures after mutation are secondary: the cleanup already
+        // happened, so keep the mutation result and ask for an explicit rescan.
+        const [postCleanupSkillsResult, ...refreshResults] =
+          await Promise.allSettled([
+            dispatch(fetchSkills()).unwrap(),
+            dispatch(fetchAgents()).unwrap(),
+            dispatch(fetchSourceStats()).unwrap(),
+          ])
+        const refreshMessage = getRefreshFailureMessage([
+          postCleanupSkillsResult,
+          ...refreshResults,
         ])
-        const postCleanupPlan = buildSymlinkCleanupPlan(postCleanupSkills)
+        const postCleanupPlan =
+          postCleanupSkillsResult.status === 'fulfilled'
+            ? buildSymlinkCleanupPlan(postCleanupSkillsResult.value)
+            : freshPlan
 
         const summary = buildCleanupSummary({
           attemptedCount: freshItemsToClean.length,
           deleteResult,
           unlinkResults,
+          refreshMessage,
         })
         const { failedItemIds, rowErrors } = collectFailedRows({
           deleteResult,
@@ -791,7 +822,7 @@ export const SymlinkCleanupDialog = React.memo(
           <div className="min-h-0">{body}</div>
 
           <DialogFooter className="gap-2">
-            {state.phase === 'stale' ? (
+            {state.phase === 'stale' || state.phase === 'error' ? (
               <Button
                 type="button"
                 variant="outline"
@@ -909,6 +940,10 @@ interface CompleteSummaryProps {
 const CompleteSummary = React.memo(function CompleteSummary({
   summary,
 }: CompleteSummaryProps): React.ReactElement {
+  const didRefreshFail =
+    summary?.phrases.some((phrase) =>
+      phrase.startsWith('Refresh failed after cleanup:'),
+    ) ?? false
   return (
     <div className="py-5 space-y-3 text-sm" role="status" aria-atomic="true">
       <div className="flex items-start gap-3">
@@ -919,7 +954,9 @@ const CompleteSummary = React.memo(function CompleteSummary({
             {pluralize(summary?.cleanedIssues ?? 0, 'symlink issue')}
           </p>
           <p className="text-muted-foreground">
-            The dashboard will reflect the refreshed scanner state.
+            {didRefreshFail
+              ? 'Cleanup succeeded. Rescan to refresh the dashboard state.'
+              : 'The dashboard will reflect the refreshed scanner state.'}
           </p>
         </div>
       </div>
@@ -1100,9 +1137,13 @@ const CleanupRow = React.memo(function CleanupRow({
     : item.agentName
   const issueCount = isOrphan ? item.symlinkCount : 1
   const Icon = isOrphan ? Trash2 : Link2Off
-  const pathLine = isOrphan
-    ? item.agents.map((agent) => agent.linkPath).join(', ')
-    : `${item.linkPath}${item.targetPath ? ` -> ${item.targetPath}` : ''}`
+  const pathDetailsId = `${item.id}-path-details`
+  const pathDetails = isOrphan
+    ? item.agents.map(
+        (agent) =>
+          `${agent.agentName}: ${agent.linkPath} -> ${agent.targetPath}`,
+      )
+    : [`${item.linkPath} -> ${item.targetPath}`]
   const handleCheckedChange = useCallback((): void => {
     onToggleItem(item.id)
   }, [item.id, onToggleItem])
@@ -1118,6 +1159,7 @@ const CleanupRow = React.memo(function CleanupRow({
               ? `Clean orphan symlinks for ${label}`
               : `Clean broken link for ${label} from ${agentLabel}`
           }
+          aria-describedby={pathDetailsId}
         />
         <Icon
           className={cn(
@@ -1134,9 +1176,16 @@ const CleanupRow = React.memo(function CleanupRow({
           {issueCount}
         </span>
       </div>
-      <p className="ml-14 mt-1 truncate font-mono text-[11px] text-muted-foreground">
-        {pathLine}
-      </p>
+      <div
+        id={pathDetailsId}
+        className="ml-14 mt-1 space-y-1 font-mono text-[11px] text-muted-foreground"
+      >
+        {pathDetails.map((pathDetail) => (
+          <p key={pathDetail} className="break-all" title={pathDetail}>
+            {pathDetail}
+          </p>
+        ))}
+      </div>
       {error ? (
         <p className="ml-14 mt-1 text-xs text-destructive" role="alert">
           {error}

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
@@ -90,7 +90,11 @@ type SymlinkCleanupDialogAction =
   | { type: 'reset' }
   | { type: 'scanning' }
   | { type: 'ready'; plan: SymlinkCleanupPlan }
-  | { type: 'no-safe-cleanup'; plan: SymlinkCleanupPlan }
+  | {
+      type: 'no-safe-cleanup'
+      plan: SymlinkCleanupPlan
+      message?: string | null
+    }
   | { type: 'stale'; message: string }
   | { type: 'cleaning' }
   | {
@@ -160,7 +164,7 @@ function symlinkCleanupDialogReducer(
         selectedItemIds: [],
         rowErrors: {},
         summary: null,
-        message: null,
+        message: action.message ?? null,
       }
     case 'stale':
       return {
@@ -233,6 +237,14 @@ function symlinkCleanupDialogReducer(
 function getErrorMessage(error: unknown): string {
   if (error instanceof Error) return error.message
   if (typeof error === 'string') return error
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'message' in error &&
+    typeof error.message === 'string'
+  ) {
+    return error.message
+  }
   return 'Unknown error'
 }
 
@@ -510,16 +522,20 @@ export const SymlinkCleanupDialog = React.memo(
         scanRequestIdRef.current = requestId
         dispatchLocal({ type: 'scanning' })
         try {
+          let auxiliaryRefreshMessage: string | null = null
           const skills = refreshDashboard
             ? await (async () => {
-                const [skillsResult] = await Promise.allSettled([
-                  dispatch(fetchSkills()).unwrap(),
-                  dispatch(fetchAgents()).unwrap(),
-                  dispatch(fetchSourceStats()).unwrap(),
-                ] as const)
+                const [skillsResult, ...refreshResults] =
+                  await Promise.allSettled([
+                    dispatch(fetchSkills()).unwrap(),
+                    dispatch(fetchAgents()).unwrap(),
+                    dispatch(fetchSourceStats()).unwrap(),
+                  ] as const)
                 if (skillsResult.status === 'rejected') {
                   throw skillsResult.reason
                 }
+                auxiliaryRefreshMessage =
+                  getRefreshFailureMessage(refreshResults)
                 // Dashboard side panels can stay stale; the dialog only needs
                 // fresh skills to decide whether cleanup remains available.
                 return skillsResult.value
@@ -528,7 +544,11 @@ export const SymlinkCleanupDialog = React.memo(
           if (scanRequestIdRef.current !== requestId) return
           const plan = buildSymlinkCleanupPlan(skills)
           if (getSymlinkCleanupPlanItems(plan).length === 0) {
-            dispatchLocal({ type: 'no-safe-cleanup', plan })
+            dispatchLocal({
+              type: 'no-safe-cleanup',
+              plan,
+              message: auxiliaryRefreshMessage,
+            })
             return
           }
           dispatchLocal({ type: 'ready', plan })
@@ -582,9 +602,11 @@ export const SymlinkCleanupDialog = React.memo(
       // dialog's skill scan.
       void runScan({
         refreshDashboard:
-          state.phase === 'complete' && didCleanupRefreshFail(state.summary),
+          (state.phase === 'complete' &&
+            didCleanupRefreshFail(state.summary)) ||
+          (state.phase === 'no-safe-cleanup' && state.message !== null),
       })
-    }, [runScan, state.phase, state.summary])
+    }, [runScan, state.message, state.phase, state.summary])
 
     const handlePreventDismissDuringCleaning = useCallback(
       (event: Event): void => {
@@ -813,7 +835,10 @@ export const SymlinkCleanupDialog = React.memo(
         <StatusBlock
           icon={ShieldCheck}
           title="No safe cleanup items"
-          description="Missing coverage and local folders are not changed here."
+          description={
+            state.message ??
+            'Missing coverage and local folders are not changed here.'
+          }
         />
       ))
       .with('stale', () => (
@@ -840,6 +865,8 @@ export const SymlinkCleanupDialog = React.memo(
       .exhaustive()
     const completeNeedsRescan =
       state.phase === 'complete' && didCleanupRefreshFail(state.summary)
+    const noSafeNeedsRescan =
+      state.phase === 'no-safe-cleanup' && state.message !== null
 
     return (
       <Dialog open={isOpen} onOpenChange={handleClose}>
@@ -865,7 +892,8 @@ export const SymlinkCleanupDialog = React.memo(
           <DialogFooter className="gap-2">
             {state.phase === 'stale' ||
             state.phase === 'error' ||
-            completeNeedsRescan ? (
+            completeNeedsRescan ||
+            noSafeNeedsRescan ? (
               <Button
                 type="button"
                 variant="outline"

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
@@ -24,6 +24,7 @@ import type {
   SymlinkCleanupPlanItem,
 } from '@/renderer/src/components/dashboard/utils/buildSymlinkCleanupPlan'
 import {
+  countOrphanSymlinksRemoved,
   formatCascadeSummary,
   formatUnlinkSummary,
 } from '@/renderer/src/components/skills/bulkDeleteHelpers'
@@ -437,18 +438,11 @@ function buildCleanupSummary(params: {
     .filter(Boolean)
 
   const deleteItems = params.deleteResult?.items ?? []
-  const orphanSymlinksRemoved = deleteItems.reduce((total, item) => {
-    // Fully-cleared records plus partial cleanups that threw mid-loop: an error
-    // item carrying cascadeAgents already committed those unlinks to disk, so
-    // count them here instead of telling the user 0 were removed.
-    if (item.outcome === 'orphan-cleared') {
-      return total + item.symlinksRemoved
-    }
-    if (item.outcome === 'error' && item.cascadeAgents) {
-      return total + (item.symlinksRemoved ?? 0)
-    }
-    return total
-  }, 0)
+  // Shared with the result toast (formatCascadeSummary) via one pure helper so
+  // the dialog and toast can never report divergent orphan counts.
+  const orphanSymlinksRemoved = params.deleteResult
+    ? countOrphanSymlinksRemoved(params.deleteResult)
+    : 0
   const brokenLinksUnlinked = params.unlinkResults.reduce((total, group) => {
     return (
       total +
@@ -700,6 +694,7 @@ export const SymlinkCleanupDialog = React.memo(
               items: brokenItems.map((item) => ({
                 agentId: item.agentId,
                 linkName: item.linkName,
+                displaySkillName: item.displaySkillName,
                 linkPath: item.linkPath,
                 targetPath: item.targetPath,
               })),
@@ -740,7 +735,7 @@ export const SymlinkCleanupDialog = React.memo(
         const postCleanupPlan =
           postCleanupSkillsResult.status === 'fulfilled'
             ? buildSymlinkCleanupPlan(postCleanupSkillsResult.value)
-            : freshPlan
+            : null
 
         const summary = buildCleanupSummary({
           attemptedCount: freshItemsToClean.length,
@@ -754,6 +749,19 @@ export const SymlinkCleanupDialog = React.memo(
         })
 
         if (failedItemIds.length > 0) {
+          // The failed-row visibility check and the error dispatch below both
+          // need a post-cleanup plan. When the refresh rejected we cannot
+          // recompute it — falling back to the pre-cleanup plan would compare
+          // failed rows against stale state and mis-report them — so require an
+          // explicit rescan instead.
+          if (!postCleanupPlan) {
+            dispatchLocal({
+              type: 'stale',
+              message:
+                'Cleanup finished with failures, but the refresh failed. Rescan required.',
+            })
+            return
+          }
           const postCleanupItemsById = new Map(
             getSymlinkCleanupPlanItems(postCleanupPlan).map((item) => [
               item.id,

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
@@ -877,7 +877,7 @@ export const SymlinkCleanupDialog = React.memo(
     return (
       <Dialog open={isOpen} onOpenChange={handleClose}>
         <DialogContent
-          className="max-w-xl max-h-[85vh] overflow-hidden"
+          className="max-w-2xl max-h-[85vh] overflow-hidden"
           onOpenAutoFocus={handleOpenAutoFocus}
           onCloseAutoFocus={handleCloseAutoFocus}
           onEscapeKeyDown={handlePreventDismissDuringCleaning}
@@ -1244,10 +1244,10 @@ const CleanupRow = React.memo(function CleanupRow({
           aria-hidden="true"
         />
         <span className="min-w-0 truncate font-medium">{label}</span>
-        <span className="rounded border border-border px-1.5 py-0.5 text-[11px] text-muted-foreground">
+        <span className="shrink-0 rounded border border-border px-1.5 py-0.5 text-[11px] text-muted-foreground">
           {agentLabel}
         </span>
-        <span className="tabular-nums text-xs text-muted-foreground">
+        <span className="w-4 text-right tabular-nums text-xs text-muted-foreground">
           {issueCount}
         </span>
       </div>
@@ -1256,7 +1256,11 @@ const CleanupRow = React.memo(function CleanupRow({
         className="ml-14 mt-1 space-y-1 font-mono text-[11px] text-muted-foreground"
       >
         {pathDetails.map((pathDetail) => (
-          <p key={pathDetail} className="break-all" title={pathDetail}>
+          <p
+            key={pathDetail}
+            className="break-words leading-4"
+            title={pathDetail}
+          >
             {pathDetail}
           </p>
         ))}

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
@@ -616,14 +616,16 @@ export const SymlinkCleanupDialog = React.memo(
     const handleRescanClick = useCallback((): void => {
       // A rescan refreshes every dashboard source (not just the dialog's skill
       // scan) whenever the cleanup mutation already ran and may have left the
-      // dashboard side data stale: a 'complete' phase whose post-cleanup refresh
-      // failed, a 'ready'/'no-safe-cleanup' scan that carried a refresh-failure
-      // message, or a post-mutation 'stale' guard. The pre-mutation 'stale'
-      // ('plan changed' before any cleanup) is excluded — nothing mutated, so a
-      // skills-only rescan is enough.
+      // dashboard side data stale: a 'complete' or 'error' phase whose
+      // post-cleanup refresh failed (both carry that failure in the summary),
+      // a 'ready'/'no-safe-cleanup' scan that carried a refresh-failure message,
+      // or a post-mutation 'stale' guard. Pre-mutation phases are excluded —
+      // a 'stale' 'plan changed' (nothing mutated) and an 'error' scan failure
+      // (no summary, so didCleanupRefreshFail is false) only need a skills-only
+      // rescan.
       void runScan({
         refreshDashboard:
-          (state.phase === 'complete' &&
+          ((state.phase === 'complete' || state.phase === 'error') &&
             didCleanupRefreshFail(state.summary)) ||
           ((state.phase === 'no-safe-cleanup' || state.phase === 'ready') &&
             state.message !== null) ||

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
@@ -89,7 +89,7 @@ interface SymlinkCleanupDialogState {
 type SymlinkCleanupDialogAction =
   | { type: 'reset' }
   | { type: 'scanning' }
-  | { type: 'ready'; plan: SymlinkCleanupPlan }
+  | { type: 'ready'; plan: SymlinkCleanupPlan; message?: string | null }
   | {
       type: 'no-safe-cleanup'
       plan: SymlinkCleanupPlan
@@ -154,7 +154,7 @@ function symlinkCleanupDialogReducer(
         selectedItemIds,
         rowErrors: {},
         summary: null,
-        message: null,
+        message: action.message ?? null,
       }
     }
     case 'no-safe-cleanup':
@@ -551,7 +551,11 @@ export const SymlinkCleanupDialog = React.memo(
             })
             return
           }
-          dispatchLocal({ type: 'ready', plan })
+          dispatchLocal({
+            type: 'ready',
+            plan,
+            message: auxiliaryRefreshMessage,
+          })
         } catch (error) {
           if (scanRequestIdRef.current !== requestId) return
           dispatchLocal({
@@ -604,7 +608,8 @@ export const SymlinkCleanupDialog = React.memo(
         refreshDashboard:
           (state.phase === 'complete' &&
             didCleanupRefreshFail(state.summary)) ||
-          (state.phase === 'no-safe-cleanup' && state.message !== null),
+          ((state.phase === 'no-safe-cleanup' || state.phase === 'ready') &&
+            state.message !== null),
       })
     }, [runScan, state.message, state.phase, state.summary])
 
@@ -867,6 +872,7 @@ export const SymlinkCleanupDialog = React.memo(
       state.phase === 'complete' && didCleanupRefreshFail(state.summary)
     const noSafeNeedsRescan =
       state.phase === 'no-safe-cleanup' && state.message !== null
+    const readyNeedsRescan = state.phase === 'ready' && state.message !== null
 
     return (
       <Dialog open={isOpen} onOpenChange={handleClose}>
@@ -893,7 +899,8 @@ export const SymlinkCleanupDialog = React.memo(
             {state.phase === 'stale' ||
             state.phase === 'error' ||
             completeNeedsRescan ||
-            noSafeNeedsRescan ? (
+            noSafeNeedsRescan ||
+            readyNeedsRescan ? (
               <Button
                 type="button"
                 variant="outline"

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
@@ -438,9 +438,16 @@ function buildCleanupSummary(params: {
 
   const deleteItems = params.deleteResult?.items ?? []
   const orphanSymlinksRemoved = deleteItems.reduce((total, item) => {
-    return item.outcome === 'orphan-cleared'
-      ? total + item.symlinksRemoved
-      : total
+    // Fully-cleared records plus partial cleanups that threw mid-loop: an error
+    // item carrying cascadeAgents already committed those unlinks to disk, so
+    // count them here instead of telling the user 0 were removed.
+    if (item.outcome === 'orphan-cleared') {
+      return total + item.symlinksRemoved
+    }
+    if (item.outcome === 'error' && item.cascadeAgents) {
+      return total + (item.symlinksRemoved ?? 0)
+    }
+    return total
   }, 0)
   const brokenLinksUnlinked = params.unlinkResults.reduce((total, group) => {
     return (

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
@@ -295,10 +295,10 @@ function doesFreshItemMatchReviewedItem(
 
   if (freshItem.kind !== 'orphan-record') return false
   const reviewedAgents = reviewedItem.agents.map(
-    (agent) => `${agent.agentId}:${agent.linkPath}`,
+    (agent) => `${agent.agentId}:${agent.linkPath}:${agent.targetPath}`,
   )
   const freshAgents = freshItem.agents.map(
-    (agent) => `${agent.agentId}:${agent.linkPath}`,
+    (agent) => `${agent.agentId}:${agent.linkPath}:${agent.targetPath}`,
   )
   return (
     reviewedItem.skillName === freshItem.skillName &&
@@ -579,6 +579,7 @@ export const SymlinkCleanupDialog = React.memo(
             agents: item.agents.map((agent) => ({
               agentId: agent.agentId,
               linkPath: agent.linkPath,
+              targetPath: agent.targetPath,
             })),
           }))
         const deleteResult =
@@ -1089,7 +1090,11 @@ const CleanupRow = React.memo(function CleanupRow({
   onToggleItem,
 }: CleanupRowProps): React.ReactElement {
   const isOrphan = item.kind === 'orphan-record'
-  const label = isOrphan ? item.skillName : item.displaySkillName
+  const label = isOrphan
+    ? item.skillName
+    : item.displaySkillName === item.linkName
+      ? item.linkName
+      : `${item.linkName} (${item.displaySkillName})`
   const agentLabel = isOrphan
     ? `${item.agents.length} ${pluralize(item.agents.length, 'agent')}`
     : item.agentName

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
@@ -86,6 +86,13 @@ interface SymlinkCleanupDialogState {
   rowErrors: Record<SymlinkCleanupItemId, string>
   summary: CleanupSummary | null
   message: string | null
+  /**
+   * True only when a 'stale' phase was reached *after* the cleanup mutation
+   * ran (so the dashboard side data may be stale and a rescan must refresh
+   * every source). False for the pre-mutation 'plan changed' stale and for
+   * every non-stale phase.
+   */
+  staleAfterMutation: boolean
 }
 
 type SymlinkCleanupDialogAction =
@@ -97,7 +104,7 @@ type SymlinkCleanupDialogAction =
       plan: SymlinkCleanupPlan
       message?: string | null
     }
-  | { type: 'stale'; message: string }
+  | { type: 'stale'; message: string; staleAfterMutation?: boolean }
   | { type: 'cleaning' }
   | {
       type: 'error'
@@ -122,6 +129,7 @@ const INITIAL_DIALOG_STATE: SymlinkCleanupDialogState = {
   rowErrors: {},
   summary: null,
   message: null,
+  staleAfterMutation: false,
 }
 
 const SYMLINK_CLEANUP_TRIGGER_SELECTOR = '[data-symlink-cleanup-trigger="true"]'
@@ -157,6 +165,7 @@ function symlinkCleanupDialogReducer(
         rowErrors: {},
         summary: null,
         message: action.message ?? null,
+        staleAfterMutation: false,
       }
     }
     case 'no-safe-cleanup':
@@ -167,12 +176,14 @@ function symlinkCleanupDialogReducer(
         rowErrors: {},
         summary: null,
         message: action.message ?? null,
+        staleAfterMutation: false,
       }
     case 'stale':
       return {
         ...state,
         phase: 'stale',
         message: action.message,
+        staleAfterMutation: action.staleAfterMutation ?? false,
       }
     case 'cleaning':
       return {
@@ -603,17 +614,28 @@ export const SymlinkCleanupDialog = React.memo(
     }, [handleClose])
 
     const handleRescanClick = useCallback((): void => {
-      // Complete+refresh-failed means the mutation succeeded but dashboard
-      // side data may be stale, so retry every dashboard source, not just the
-      // dialog's skill scan.
+      // A rescan refreshes every dashboard source (not just the dialog's skill
+      // scan) whenever the cleanup mutation already ran and may have left the
+      // dashboard side data stale: a 'complete' phase whose post-cleanup refresh
+      // failed, a 'ready'/'no-safe-cleanup' scan that carried a refresh-failure
+      // message, or a post-mutation 'stale' guard. The pre-mutation 'stale'
+      // ('plan changed' before any cleanup) is excluded — nothing mutated, so a
+      // skills-only rescan is enough.
       void runScan({
         refreshDashboard:
           (state.phase === 'complete' &&
             didCleanupRefreshFail(state.summary)) ||
           ((state.phase === 'no-safe-cleanup' || state.phase === 'ready') &&
-            state.message !== null),
+            state.message !== null) ||
+          (state.phase === 'stale' && state.staleAfterMutation),
       })
-    }, [runScan, state.message, state.phase, state.summary])
+    }, [
+      runScan,
+      state.message,
+      state.phase,
+      state.staleAfterMutation,
+      state.summary,
+    ])
 
     const handlePreventDismissDuringCleaning = useCallback(
       (event: Event): void => {
@@ -759,6 +781,7 @@ export const SymlinkCleanupDialog = React.memo(
               type: 'stale',
               message:
                 'Cleanup finished with failures, but the refresh failed. Rescan required.',
+              staleAfterMutation: true,
             })
             return
           }
@@ -783,6 +806,7 @@ export const SymlinkCleanupDialog = React.memo(
             dispatchLocal({
               type: 'stale',
               message: 'Cleanup result changed. Rescan required.',
+              staleAfterMutation: true,
             })
             return
           }
@@ -797,6 +821,7 @@ export const SymlinkCleanupDialog = React.memo(
             dispatchLocal({
               type: 'stale',
               message: 'Cleanup result changed. Rescan required.',
+              staleAfterMutation: true,
             })
             return
           }

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
@@ -503,27 +503,39 @@ export const SymlinkCleanupDialog = React.memo(
       [],
     )
 
-    const runScan = useCallback(async (): Promise<void> => {
-      const requestId = scanRequestIdRef.current + 1
-      scanRequestIdRef.current = requestId
-      dispatchLocal({ type: 'scanning' })
-      try {
-        const skills = await dispatch(fetchSkills()).unwrap()
-        if (scanRequestIdRef.current !== requestId) return
-        const plan = buildSymlinkCleanupPlan(skills)
-        if (getSymlinkCleanupPlanItems(plan).length === 0) {
-          dispatchLocal({ type: 'no-safe-cleanup', plan })
-          return
+    const runScan = useCallback(
+      async (options: { refreshDashboard?: boolean } = {}): Promise<void> => {
+        const { refreshDashboard = false } = options
+        const requestId = scanRequestIdRef.current + 1
+        scanRequestIdRef.current = requestId
+        dispatchLocal({ type: 'scanning' })
+        try {
+          const skills = refreshDashboard
+            ? (
+                await Promise.all([
+                  dispatch(fetchSkills()).unwrap(),
+                  dispatch(fetchAgents()).unwrap(),
+                  dispatch(fetchSourceStats()).unwrap(),
+                ])
+              )[0]
+            : await dispatch(fetchSkills()).unwrap()
+          if (scanRequestIdRef.current !== requestId) return
+          const plan = buildSymlinkCleanupPlan(skills)
+          if (getSymlinkCleanupPlanItems(plan).length === 0) {
+            dispatchLocal({ type: 'no-safe-cleanup', plan })
+            return
+          }
+          dispatchLocal({ type: 'ready', plan })
+        } catch (error) {
+          if (scanRequestIdRef.current !== requestId) return
+          dispatchLocal({
+            type: 'error',
+            message: `Scan failed: ${getErrorMessage(error)}`,
+          })
         }
-        dispatchLocal({ type: 'ready', plan })
-      } catch (error) {
-        if (scanRequestIdRef.current !== requestId) return
-        dispatchLocal({
-          type: 'error',
-          message: `Scan failed: ${getErrorMessage(error)}`,
-        })
-      }
-    }, [dispatch])
+      },
+      [dispatch],
+    )
 
     const handleOpenAutoFocus = useCallback(
       (event: Event): void => {
@@ -559,8 +571,14 @@ export const SymlinkCleanupDialog = React.memo(
     }, [handleClose])
 
     const handleRescanClick = useCallback((): void => {
-      void runScan()
-    }, [runScan])
+      // Complete+refresh-failed means the mutation succeeded but dashboard
+      // side data may be stale, so retry every dashboard source, not just the
+      // dialog's skill scan.
+      void runScan({
+        refreshDashboard:
+          state.phase === 'complete' && didCleanupRefreshFail(state.summary),
+      })
+    }, [runScan, state.phase, state.summary])
 
     const handlePreventDismissDuringCleaning = useCallback(
       (event: Event): void => {

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
@@ -41,6 +41,7 @@ import { cn } from '@/renderer/src/lib/utils'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import { fetchAgents } from '@/renderer/src/redux/slices/agentsSlice'
 import {
+  clearSelection,
   clearSelectedBrokenSymlinkSlots,
   clearSelectedOrphanSymlinks,
   fetchSkills,
@@ -656,6 +657,9 @@ export const SymlinkCleanupDialog = React.memo(
           })
           return
         }
+        // Dashboard cleanup is independent from the Installed list selection.
+        // Clear stale row ticks here without changing MainContent retry behavior.
+        dispatch(clearSelection())
 
         const orphanRecords = freshItemsToClean
           .filter(

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
@@ -1,0 +1,1179 @@
+import {
+  AlertCircle,
+  CheckCircle,
+  Link2Off,
+  Loader2,
+  RefreshCcw,
+  ShieldCheck,
+  Trash2,
+} from 'lucide-react'
+import React, { useCallback, useMemo, useRef, useState } from 'react'
+import { match } from 'ts-pattern'
+
+import {
+  buildSymlinkCleanupPlan,
+  createBrokenSlotCleanupItemId,
+  createOrphanCleanupItemId,
+  getSymlinkCleanupPlanItems,
+} from '@/renderer/src/components/dashboard/utils/buildSymlinkCleanupPlan'
+import type {
+  BrokenSlotCleanupPlanItem,
+  OrphanCleanupPlanItem,
+  SymlinkCleanupItemId,
+  SymlinkCleanupPlan,
+  SymlinkCleanupPlanItem,
+} from '@/renderer/src/components/dashboard/utils/buildSymlinkCleanupPlan'
+import {
+  formatCascadeSummary,
+  formatUnlinkSummary,
+} from '@/renderer/src/components/skills/bulkDeleteHelpers'
+import { Button } from '@/renderer/src/components/ui/button'
+import { Checkbox } from '@/renderer/src/components/ui/checkbox'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/renderer/src/components/ui/dialog'
+import { cn } from '@/renderer/src/lib/utils'
+import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
+import { fetchAgents } from '@/renderer/src/redux/slices/agentsSlice'
+import {
+  clearSelectedBrokenSymlinkSlots,
+  clearSelectedOrphanSymlinks,
+  fetchSkills,
+} from '@/renderer/src/redux/slices/skillsSlice'
+import {
+  closeSymlinkCleanupDialog,
+  fetchSourceStats,
+  selectSymlinkCleanupDialogOpen,
+} from '@/renderer/src/redux/slices/uiSlice'
+import { pluralize } from '@/renderer/src/utils/pluralize'
+import type {
+  AgentId,
+  BulkDeleteItemResult,
+  BulkDeleteResult,
+  BulkUnlinkItemResult,
+  BulkUnlinkResult,
+} from '@/shared/types'
+
+type CleanupPhase =
+  | 'idle'
+  | 'scanning'
+  | 'ready'
+  | 'no-safe-cleanup'
+  | 'stale'
+  | 'cleaning'
+  | 'error'
+  | 'complete'
+
+interface CleanupSummary {
+  phrases: string[]
+  cleanedIssues: number
+  orphanSymlinksRemoved: number
+  brokenLinksUnlinked: number
+  failedCount: number
+}
+
+interface SymlinkCleanupDialogState {
+  phase: CleanupPhase
+  plan: SymlinkCleanupPlan | null
+  selectedItemIds: SymlinkCleanupItemId[]
+  rowErrors: Record<SymlinkCleanupItemId, string>
+  summary: CleanupSummary | null
+  message: string | null
+}
+
+type SymlinkCleanupDialogAction =
+  | { type: 'reset' }
+  | { type: 'scanning' }
+  | { type: 'ready'; plan: SymlinkCleanupPlan }
+  | { type: 'no-safe-cleanup'; plan: SymlinkCleanupPlan }
+  | { type: 'stale'; message: string }
+  | { type: 'cleaning' }
+  | {
+      type: 'error'
+      message: string
+      rowErrors?: Record<SymlinkCleanupItemId, string>
+      selectedItemIds?: SymlinkCleanupItemId[]
+      summary?: CleanupSummary
+      plan?: SymlinkCleanupPlan
+    }
+  | { type: 'complete'; summary: CleanupSummary }
+  | { type: 'toggle-item'; itemId: SymlinkCleanupItemId }
+  | {
+      type: 'set-section'
+      itemIds: SymlinkCleanupItemId[]
+      checked: boolean
+    }
+
+const INITIAL_DIALOG_STATE: SymlinkCleanupDialogState = {
+  phase: 'idle',
+  plan: null,
+  selectedItemIds: [],
+  rowErrors: {},
+  summary: null,
+  message: null,
+}
+
+const SYMLINK_CLEANUP_TRIGGER_SELECTOR = '[data-symlink-cleanup-trigger="true"]'
+
+/**
+ * Reduces SymlinkCleanupDialog state transitions while the dialog owns local scan and selection data.
+ * @param state - Current dialog state.
+ * @param action - State transition emitted by scan, review, or clean handlers.
+ * @returns Next dialog state.
+ * @example
+ * symlinkCleanupDialogReducer(INITIAL_DIALOG_STATE, { type: 'scanning' }).phase // => 'scanning'
+ */
+function symlinkCleanupDialogReducer(
+  state: SymlinkCleanupDialogState,
+  action: SymlinkCleanupDialogAction,
+): SymlinkCleanupDialogState {
+  switch (action.type) {
+    case 'reset':
+      return INITIAL_DIALOG_STATE
+    case 'scanning':
+      return {
+        ...INITIAL_DIALOG_STATE,
+        phase: 'scanning',
+      }
+    case 'ready': {
+      const selectedItemIds = getSymlinkCleanupPlanItems(action.plan).map(
+        (item) => item.id,
+      )
+      return {
+        phase: 'ready',
+        plan: action.plan,
+        selectedItemIds,
+        rowErrors: {},
+        summary: null,
+        message: null,
+      }
+    }
+    case 'no-safe-cleanup':
+      return {
+        phase: 'no-safe-cleanup',
+        plan: action.plan,
+        selectedItemIds: [],
+        rowErrors: {},
+        summary: null,
+        message: null,
+      }
+    case 'stale':
+      return {
+        ...state,
+        phase: 'stale',
+        message: action.message,
+      }
+    case 'cleaning':
+      return {
+        ...state,
+        phase: 'cleaning',
+        rowErrors: {},
+        message: null,
+      }
+    case 'error':
+      return {
+        ...state,
+        phase: 'error',
+        message: action.message,
+        rowErrors: action.rowErrors ?? state.rowErrors,
+        selectedItemIds: action.selectedItemIds ?? state.selectedItemIds,
+        summary: action.summary ?? state.summary,
+        plan: action.plan ?? state.plan,
+      }
+    case 'complete':
+      return {
+        ...state,
+        phase: 'complete',
+        selectedItemIds: [],
+        rowErrors: {},
+        summary: action.summary,
+        message: null,
+      }
+    case 'toggle-item': {
+      const selected = new Set(state.selectedItemIds)
+      if (selected.has(action.itemId)) {
+        selected.delete(action.itemId)
+      } else {
+        selected.add(action.itemId)
+      }
+      return {
+        ...state,
+        selectedItemIds: Array.from(selected),
+      }
+    }
+    case 'set-section': {
+      const selected = new Set(state.selectedItemIds)
+      for (const itemId of action.itemIds) {
+        if (action.checked) {
+          selected.add(itemId)
+        } else {
+          selected.delete(itemId)
+        }
+      }
+      return {
+        ...state,
+        selectedItemIds: Array.from(selected),
+      }
+    }
+  }
+}
+
+/**
+ * Converts an unknown thunk or IPC error into compact dialog copy.
+ * @param error - Error thrown by `.unwrap()` or local execution code.
+ * @returns Human-readable message.
+ * @example
+ * getErrorMessage(new Error('Denied')) // => 'Denied'
+ */
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  if (typeof error === 'string') return error
+  return 'Unknown error'
+}
+
+/**
+ * Narrows a cleanup row to a broken-slot row for grouped unlink execution.
+ * @param item - Cleanup plan row.
+ * @returns True when the row unlinks one agent-side broken symlink.
+ * @example
+ * isBrokenSlotItem({ kind: 'broken-slot', ...item }) // => true
+ */
+function isBrokenSlotItem(
+  item: SymlinkCleanupPlanItem,
+): item is BrokenSlotCleanupPlanItem {
+  return item.kind === 'broken-slot'
+}
+
+/**
+ * Returns selected cleanup rows from the current plan in stable display order.
+ * @param plan - Cleanup plan currently under review.
+ * @param selectedItemIds - Row ids checked by the user.
+ * @returns Selected cleanup rows, or an empty array when no plan exists.
+ * @example
+ * getSelectedPlanItems(plan, ['orphan:task']).length // => 1
+ */
+function getSelectedPlanItems(
+  plan: SymlinkCleanupPlan | null,
+  selectedItemIds: readonly SymlinkCleanupItemId[],
+): SymlinkCleanupPlanItem[] {
+  if (!plan) return []
+  const selected = new Set(selectedItemIds)
+  return getSymlinkCleanupPlanItems(plan).filter((item) =>
+    selected.has(item.id),
+  )
+}
+
+/**
+ * Checks whether a selected row still describes the exact cleanup target the user reviewed.
+ * @param reviewedItem - Row from the visible review plan.
+ * @param freshItem - Row rebuilt from a just-fetched scanner snapshot.
+ * @returns True when destructive identity fields still match.
+ * @example
+ * doesFreshItemMatchReviewedItem(reviewedBroken, freshBroken) // => true
+ */
+function doesFreshItemMatchReviewedItem(
+  reviewedItem: SymlinkCleanupPlanItem,
+  freshItem: SymlinkCleanupPlanItem | undefined,
+): boolean {
+  if (!freshItem || reviewedItem.kind !== freshItem.kind) return false
+
+  if (reviewedItem.kind === 'broken-slot') {
+    return (
+      freshItem.kind === 'broken-slot' &&
+      reviewedItem.agentId === freshItem.agentId &&
+      reviewedItem.linkName === freshItem.linkName &&
+      reviewedItem.linkPath === freshItem.linkPath &&
+      reviewedItem.targetPath === freshItem.targetPath &&
+      reviewedItem.preservedSkillPath === freshItem.preservedSkillPath
+    )
+  }
+
+  if (freshItem.kind !== 'orphan-record') return false
+  const reviewedAgents = reviewedItem.agents.map(
+    (agent) => `${agent.agentId}:${agent.linkPath}`,
+  )
+  const freshAgents = freshItem.agents.map(
+    (agent) => `${agent.agentId}:${agent.linkPath}`,
+  )
+  return (
+    reviewedItem.skillName === freshItem.skillName &&
+    reviewedItem.symlinkCount === freshItem.symlinkCount &&
+    reviewedAgents.length === freshAgents.length &&
+    reviewedAgents.every((agentKey, index) => agentKey === freshAgents[index])
+  )
+}
+
+/**
+ * Returns fresh selected rows only if every reviewed row still matches before cleanup mutates disk state.
+ * @param freshPlan - Plan rebuilt from a fresh `fetchSkills().unwrap()` snapshot.
+ * @param reviewedItems - Selected rows from the previous review plan.
+ * @returns Fresh rows to execute, or null when a stale-plan mismatch is detected.
+ * @example
+ * getFreshMatchingSelectedItems(plan, selectedRows)?.length // => selectedRows.length
+ */
+function getFreshMatchingSelectedItems(
+  freshPlan: SymlinkCleanupPlan,
+  reviewedItems: readonly SymlinkCleanupPlanItem[],
+): SymlinkCleanupPlanItem[] | null {
+  const freshItemsById = new Map(
+    getSymlinkCleanupPlanItems(freshPlan).map((item) => [item.id, item]),
+  )
+  const freshItems: SymlinkCleanupPlanItem[] = []
+
+  for (const reviewedItem of reviewedItems) {
+    const freshItem = freshItemsById.get(reviewedItem.id)
+    if (!freshItem) return null
+    if (!doesFreshItemMatchReviewedItem(reviewedItem, freshItem)) return null
+    freshItems.push(freshItem)
+  }
+
+  return freshItems
+}
+
+/**
+ * Builds row-error state and selected failed ids from delete and unlink results.
+ * @param params - Bulk delete result plus per-agent unlink results.
+ * @returns Failed row ids and row messages for retry rendering.
+ * @example
+ * collectFailedRows({ deleteResult, unlinkResults: [] }).failedItemIds
+ */
+function collectFailedRows(params: {
+  deleteResult: BulkDeleteResult | null
+  unlinkResults: Array<{ agentId: AgentId; result: BulkUnlinkResult }>
+}): {
+  failedItemIds: SymlinkCleanupItemId[]
+  rowErrors: Record<SymlinkCleanupItemId, string>
+} {
+  const failedItemIds: SymlinkCleanupItemId[] = []
+  const rowErrors: Record<SymlinkCleanupItemId, string> = {}
+
+  for (const item of params.deleteResult?.items ?? []) {
+    if (item.outcome !== 'error') continue
+    const itemId = createOrphanCleanupItemId(item.skillName)
+    failedItemIds.push(itemId)
+    rowErrors[itemId] = item.error.message
+  }
+
+  for (const { agentId, result } of params.unlinkResults) {
+    for (const item of result.items) {
+      if (item.outcome !== 'error') continue
+      const itemId = createBrokenSlotCleanupItemId(agentId, item.skillName)
+      failedItemIds.push(itemId)
+      rowErrors[itemId] = item.error.message
+    }
+  }
+
+  return { failedItemIds, rowErrors }
+}
+
+/**
+ * Aggregates bulk cleanup results into the compact final summary shown in the dialog.
+ * @param params - Attempted item count and mutation results.
+ * @returns Count and phrase summary for complete or partial-failure states.
+ * @example
+ * buildCleanupSummary({ attemptedCount: 1, deleteResult: null, unlinkResults: [] }).cleanedIssues
+ */
+function buildCleanupSummary(params: {
+  attemptedCount: number
+  deleteResult: BulkDeleteResult | null
+  unlinkResults: Array<{ agentName: string; result: BulkUnlinkResult }>
+}): CleanupSummary {
+  const deletePhrases = params.deleteResult
+    ? [formatCascadeSummary(params.deleteResult)].filter(Boolean)
+    : []
+  const unlinkPhrases = params.unlinkResults
+    .map(({ agentName, result }) => formatUnlinkSummary(result, agentName))
+    .filter(Boolean)
+
+  const deleteItems = params.deleteResult?.items ?? []
+  const orphanSymlinksRemoved = deleteItems.reduce((total, item) => {
+    return item.outcome === 'orphan-cleared'
+      ? total + item.symlinksRemoved
+      : total
+  }, 0)
+  const brokenLinksUnlinked = params.unlinkResults.reduce((total, group) => {
+    return (
+      total +
+      group.result.items.filter((item) => item.outcome === 'unlinked').length
+    )
+  }, 0)
+  const deleteFailureCount = deleteItems.filter(
+    (item): item is Extract<BulkDeleteItemResult, { outcome: 'error' }> =>
+      item.outcome === 'error',
+  ).length
+  const unlinkFailureCount = params.unlinkResults.reduce((total, group) => {
+    return (
+      total +
+      group.result.items.filter(
+        (item): item is Extract<BulkUnlinkItemResult, { outcome: 'error' }> =>
+          item.outcome === 'error',
+      ).length
+    )
+  }, 0)
+  const failedCount = deleteFailureCount + unlinkFailureCount
+
+  return {
+    phrases: [...deletePhrases, ...unlinkPhrases],
+    cleanedIssues: params.attemptedCount - failedCount,
+    orphanSymlinksRemoved,
+    brokenLinksUnlinked,
+    failedCount,
+  }
+}
+
+/**
+ * Dashboard dialog for Scan -> Review -> Clean of safe broken symlink issues.
+ * @returns Radix Dialog when open, otherwise null.
+ * @example
+ * <SymlinkCleanupDialog />
+ */
+export const SymlinkCleanupDialog = React.memo(
+  function SymlinkCleanupDialog(): React.ReactElement | null {
+    const dispatch = useAppDispatch()
+    const isOpen = useAppSelector(selectSymlinkCleanupDialogOpen)
+    const [state, setState] = useState(INITIAL_DIALOG_STATE)
+    const titleRef = useRef<HTMLHeadingElement>(null)
+    const scanRequestIdRef = useRef(0)
+
+    const selectedItemIdSet = useMemo(
+      () => new Set(state.selectedItemIds),
+      [state.selectedItemIds],
+    )
+    const planItems = useMemo(
+      () => (state.plan ? getSymlinkCleanupPlanItems(state.plan) : []),
+      [state.plan],
+    )
+    const selectedItems = useMemo(
+      () => getSelectedPlanItems(state.plan, state.selectedItemIds),
+      [state.plan, state.selectedItemIds],
+    )
+    const selectedCount = state.selectedItemIds.length
+    const hasSelectedOrphan = selectedItems.some(
+      (item) => item.kind === 'orphan-record',
+    )
+
+    const dispatchLocal = useCallback(
+      (action: SymlinkCleanupDialogAction): void => {
+        setState((currentState) =>
+          symlinkCleanupDialogReducer(currentState, action),
+        )
+      },
+      [],
+    )
+
+    const runScan = useCallback(async (): Promise<void> => {
+      const requestId = scanRequestIdRef.current + 1
+      scanRequestIdRef.current = requestId
+      dispatchLocal({ type: 'scanning' })
+      try {
+        const skills = await dispatch(fetchSkills()).unwrap()
+        if (scanRequestIdRef.current !== requestId) return
+        const plan = buildSymlinkCleanupPlan(skills)
+        if (getSymlinkCleanupPlanItems(plan).length === 0) {
+          dispatchLocal({ type: 'no-safe-cleanup', plan })
+          return
+        }
+        dispatchLocal({ type: 'ready', plan })
+      } catch (error) {
+        if (scanRequestIdRef.current !== requestId) return
+        dispatchLocal({
+          type: 'error',
+          message: `Scan failed: ${getErrorMessage(error)}`,
+        })
+      }
+    }, [dispatch])
+
+    const handleOpenAutoFocus = useCallback(
+      (event: Event): void => {
+        event.preventDefault()
+        titleRef.current?.focus()
+        void runScan()
+      },
+      [runScan],
+    )
+
+    const handleCloseAutoFocus = useCallback((event: Event): void => {
+      event.preventDefault()
+      const trigger = document.querySelector<HTMLButtonElement>(
+        SYMLINK_CLEANUP_TRIGGER_SELECTOR,
+      )
+      const fallback = document.querySelector<HTMLElement>('#main-content')
+      const focusTarget = trigger ?? fallback
+      focusTarget?.focus()
+    }, [])
+
+    const handleClose = useCallback(
+      (nextOpen: boolean): void => {
+        if (nextOpen || state.phase === 'cleaning') return
+        scanRequestIdRef.current += 1
+        dispatch(closeSymlinkCleanupDialog())
+        dispatchLocal({ type: 'reset' })
+      },
+      [dispatch, state.phase],
+    )
+
+    const handleDismissClick = useCallback((): void => {
+      handleClose(false)
+    }, [handleClose])
+
+    const handleRescanClick = useCallback((): void => {
+      void runScan()
+    }, [runScan])
+
+    const handlePreventDismissDuringCleaning = useCallback(
+      (event: Event): void => {
+        if (state.phase === 'cleaning') event.preventDefault()
+      },
+      [state.phase],
+    )
+
+    const handleToggleItem = useCallback(
+      (itemId: SymlinkCleanupItemId): void => {
+        dispatchLocal({ type: 'toggle-item', itemId })
+      },
+      [],
+    )
+
+    const handleSetSection = useCallback(
+      (itemIds: SymlinkCleanupItemId[], checked: boolean): void => {
+        dispatchLocal({ type: 'set-section', itemIds, checked })
+      },
+      [],
+    )
+
+    const handleCleanSelected = useCallback(async (): Promise<void> => {
+      if (!state.plan || state.selectedItemIds.length === 0) return
+      const itemsToClean = getSelectedPlanItems(
+        state.plan,
+        state.selectedItemIds,
+      )
+      dispatchLocal({ type: 'cleaning' })
+
+      try {
+        const freshSkills = await dispatch(fetchSkills()).unwrap()
+        const freshPlan = buildSymlinkCleanupPlan(freshSkills)
+        const freshItemsToClean = getFreshMatchingSelectedItems(
+          freshPlan,
+          itemsToClean,
+        )
+        if (!freshItemsToClean) {
+          dispatchLocal({
+            type: 'stale',
+            message: 'Plan changed. Rescan required.',
+          })
+          return
+        }
+
+        const orphanRecords = freshItemsToClean
+          .filter(
+            (item): item is OrphanCleanupPlanItem =>
+              item.kind === 'orphan-record',
+          )
+          .map((item) => ({
+            skillName: item.skillName,
+            agents: item.agents.map((agent) => ({
+              agentId: agent.agentId,
+              linkPath: agent.linkPath,
+            })),
+          }))
+        const deleteResult =
+          orphanRecords.length > 0
+            ? await dispatch(
+                clearSelectedOrphanSymlinks(orphanRecords),
+              ).unwrap()
+            : null
+
+        const unlinkResults: Array<{
+          agentId: AgentId
+          agentName: string
+          result: BulkUnlinkResult
+        }> = []
+        const brokenItems = freshItemsToClean.filter(isBrokenSlotItem)
+        if (brokenItems.length > 0) {
+          const result = await dispatch(
+            clearSelectedBrokenSymlinkSlots({
+              items: brokenItems.map((item) => ({
+                agentId: item.agentId,
+                skillName: item.linkName,
+                linkPath: item.linkPath,
+                targetPath: item.targetPath,
+              })),
+            }),
+          ).unwrap()
+          const agentNamesById = new Map(
+            brokenItems.map((item) => [item.agentId, item.agentName]),
+          )
+          for (const item of result.items) {
+            const agentId = item.agentId
+            const existingResult = unlinkResults.find(
+              (entry) => entry.agentId === agentId,
+            )
+            if (existingResult) {
+              existingResult.result.items.push(item)
+              continue
+            }
+            unlinkResults.push({
+              agentId,
+              agentName: agentNamesById.get(agentId) ?? 'agent',
+              result: { items: [item] },
+            })
+          }
+        }
+
+        // Always refetch after cleanup: success updates the dashboard and
+        // failure rebuilds row state from the scanner the user now sees.
+        const [postCleanupSkills] = await Promise.all([
+          dispatch(fetchSkills()).unwrap(),
+          dispatch(fetchAgents()).unwrap(),
+          dispatch(fetchSourceStats()).unwrap(),
+        ])
+        const postCleanupPlan = buildSymlinkCleanupPlan(postCleanupSkills)
+
+        const summary = buildCleanupSummary({
+          attemptedCount: freshItemsToClean.length,
+          deleteResult,
+          unlinkResults,
+        })
+        const { failedItemIds, rowErrors } = collectFailedRows({
+          deleteResult,
+          unlinkResults,
+        })
+
+        if (failedItemIds.length > 0) {
+          const postCleanupItemsById = new Map(
+            getSymlinkCleanupPlanItems(postCleanupPlan).map((item) => [
+              item.id,
+              item,
+            ]),
+          )
+          const failedAttemptedItems = freshItemsToClean.filter((item) =>
+            failedItemIds.includes(item.id),
+          )
+          const visibleFailedItemIds = failedAttemptedItems
+            .filter((item) =>
+              doesFreshItemMatchReviewedItem(
+                item,
+                postCleanupItemsById.get(item.id),
+              ),
+            )
+            .map((item) => item.id)
+          if (visibleFailedItemIds.length !== failedAttemptedItems.length) {
+            dispatchLocal({
+              type: 'stale',
+              message: 'Cleanup result changed. Rescan required.',
+            })
+            return
+          }
+          const visibleRowErrors = Object.fromEntries(
+            Object.entries(rowErrors).filter(([itemId]) =>
+              visibleFailedItemIds.includes(itemId as SymlinkCleanupItemId),
+            ),
+          )
+          if (
+            Object.keys(visibleRowErrors).length !== visibleFailedItemIds.length
+          ) {
+            dispatchLocal({
+              type: 'stale',
+              message: 'Cleanup result changed. Rescan required.',
+            })
+            return
+          }
+          dispatchLocal({
+            type: 'error',
+            message: 'Cleanup finished with failures.',
+            rowErrors: visibleRowErrors,
+            selectedItemIds: visibleFailedItemIds,
+            summary,
+            plan: postCleanupPlan,
+          })
+          return
+        }
+
+        dispatchLocal({ type: 'complete', summary })
+      } catch (error) {
+        // Always attempt the same refresh on unexpected thunk/IPC errors so a
+        // sticky skills error does not strand the list behind the dialog.
+        await Promise.allSettled([
+          dispatch(fetchSkills()).unwrap(),
+          dispatch(fetchAgents()).unwrap(),
+          dispatch(fetchSourceStats()).unwrap(),
+        ])
+        dispatchLocal({
+          type: 'error',
+          message: `Cleanup failed: ${getErrorMessage(error)}`,
+        })
+      }
+    }, [dispatch, state.plan, state.selectedItemIds])
+
+    const handleCleanSelectedClick = useCallback((): void => {
+      void handleCleanSelected()
+    }, [handleCleanSelected])
+
+    if (!isOpen) return null
+
+    const orphanItemIds = state.plan?.orphanRecords.map((item) => item.id) ?? []
+    const brokenItemIds = Object.values(
+      state.plan?.brokenSlotsByAgent ?? {},
+    ).flatMap((items) => items?.map((item) => item.id) ?? [])
+
+    const body = match(state.phase)
+      .with('idle', 'scanning', 'cleaning', () => (
+        <StatusBlock
+          icon={state.phase === 'cleaning' ? ShieldCheck : Loader2}
+          isSpinning={state.phase !== 'cleaning'}
+          title={
+            state.phase === 'cleaning'
+              ? 'Cleaning selected issues'
+              : 'Scanning agent symlinks'
+          }
+          description={
+            state.phase === 'cleaning'
+              ? 'Removing selected dangling links while preserving skill files.'
+              : 'Checking broken links across agents and preparing a safe plan.'
+          }
+        />
+      ))
+      .with('no-safe-cleanup', () => (
+        <StatusBlock
+          icon={ShieldCheck}
+          title="No safe cleanup items"
+          description="Missing coverage and local folders are not changed here."
+        />
+      ))
+      .with('stale', () => (
+        <StatusBlock
+          icon={RefreshCcw}
+          title="Plan changed"
+          description={state.message ?? 'Rescan required before cleanup.'}
+        />
+      ))
+      .with('complete', () => <CompleteSummary summary={state.summary} />)
+      .with('ready', 'error', () => (
+        <ReviewContent
+          plan={state.plan}
+          selectedItemIdSet={selectedItemIdSet}
+          rowErrors={state.rowErrors}
+          message={state.message}
+          summary={state.summary}
+          onToggleItem={handleToggleItem}
+          onSetSection={handleSetSection}
+          orphanItemIds={orphanItemIds}
+          brokenItemIds={brokenItemIds}
+        />
+      ))
+      .exhaustive()
+
+    return (
+      <Dialog open={isOpen} onOpenChange={handleClose}>
+        <DialogContent
+          className="max-w-xl max-h-[85vh] overflow-hidden"
+          onOpenAutoFocus={handleOpenAutoFocus}
+          onCloseAutoFocus={handleCloseAutoFocus}
+          onEscapeKeyDown={handlePreventDismissDuringCleaning}
+          onPointerDownOutside={handlePreventDismissDuringCleaning}
+          hideCloseButton={state.phase === 'cleaning'}
+        >
+          <DialogHeader>
+            <DialogTitle ref={titleRef} tabIndex={-1}>
+              Symlink cleanup
+            </DialogTitle>
+            <DialogDescription>
+              Review dangling skill links before removing them.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="min-h-0">{body}</div>
+
+          <DialogFooter className="gap-2">
+            {state.phase === 'stale' ? (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleRescanClick}
+              >
+                <RefreshCcw className="h-4 w-4" aria-hidden="true" />
+                Rescan
+              </Button>
+            ) : null}
+            {state.phase === 'complete' || state.phase === 'no-safe-cleanup' ? (
+              <Button
+                type="button"
+                onClick={handleDismissClick}
+                variant="default"
+              >
+                Done
+              </Button>
+            ) : (
+              <>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={handleDismissClick}
+                  disabled={state.phase === 'cleaning'}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="button"
+                  variant={hasSelectedOrphan ? 'destructive' : 'default'}
+                  disabled={
+                    selectedCount === 0 ||
+                    state.phase === 'scanning' ||
+                    state.phase === 'cleaning' ||
+                    state.phase === 'stale'
+                  }
+                  onClick={handleCleanSelectedClick}
+                >
+                  {state.phase === 'cleaning' ? (
+                    <>
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      Cleaning...
+                    </>
+                  ) : (
+                    `Clean ${selectedCount} selected`
+                  )}
+                </Button>
+              </>
+            )}
+          </DialogFooter>
+
+          {state.phase === 'ready' && (
+            <p className="sr-only" role="status" aria-atomic="true">
+              Scan complete. {planItems.length} cleanup items available.
+            </p>
+          )}
+        </DialogContent>
+      </Dialog>
+    )
+  },
+)
+
+interface StatusBlockProps {
+  icon: typeof Loader2
+  title: string
+  description: string
+  isSpinning?: boolean
+}
+
+/**
+ * Compact state block for scan, stale, empty, and cleaning states.
+ * @param props - Icon, title, description, and optional spinner flag.
+ * @returns Dialog body block for a non-review phase.
+ * @example
+ * <StatusBlock icon={Loader2} title="Scanning" description="Checking links" />
+ */
+const StatusBlock = React.memo(function StatusBlock({
+  icon: Icon,
+  title,
+  description,
+  isSpinning = false,
+}: StatusBlockProps): React.ReactElement {
+  return (
+    <div
+      className="py-8 flex items-start gap-3 text-sm"
+      role="status"
+      aria-atomic="true"
+    >
+      <Icon
+        className={cn(
+          'mt-0.5 h-4 w-4 shrink-0 text-primary',
+          isSpinning ? 'animate-spin' : '',
+        )}
+        aria-hidden="true"
+      />
+      <div className="space-y-1">
+        <p className="font-medium text-foreground">{title}</p>
+        <p className="text-muted-foreground">{description}</p>
+      </div>
+    </div>
+  )
+})
+
+interface CompleteSummaryProps {
+  summary: CleanupSummary | null
+}
+
+/**
+ * Renders final cleanup counts after all selected rows succeeded.
+ * @param props - Completion summary returned by the executor.
+ * @returns Compact success summary.
+ * @example
+ * <CompleteSummary summary={summary} />
+ */
+const CompleteSummary = React.memo(function CompleteSummary({
+  summary,
+}: CompleteSummaryProps): React.ReactElement {
+  return (
+    <div className="py-5 space-y-3 text-sm" role="status" aria-atomic="true">
+      <div className="flex items-start gap-3">
+        <CheckCircle className="mt-0.5 h-4 w-4 text-success" aria-hidden />
+        <div>
+          <p className="font-medium">
+            Cleaned up {summary?.cleanedIssues ?? 0}{' '}
+            {pluralize(summary?.cleanedIssues ?? 0, 'symlink issue')}
+          </p>
+          <p className="text-muted-foreground">
+            The dashboard will reflect the refreshed scanner state.
+          </p>
+        </div>
+      </div>
+      <SummaryLines summary={summary} />
+    </div>
+  )
+})
+
+interface ReviewContentProps {
+  plan: SymlinkCleanupPlan | null
+  selectedItemIdSet: ReadonlySet<SymlinkCleanupItemId>
+  rowErrors: Record<SymlinkCleanupItemId, string>
+  message: string | null
+  summary: CleanupSummary | null
+  orphanItemIds: SymlinkCleanupItemId[]
+  brokenItemIds: SymlinkCleanupItemId[]
+  onToggleItem: (itemId: SymlinkCleanupItemId) => void
+  onSetSection: (itemIds: SymlinkCleanupItemId[], checked: boolean) => void
+}
+
+/**
+ * Renders grouped orphan and broken-slot rows for the review and partial-failure phases.
+ * @param props - Plan, selection, row errors, and row/section callbacks.
+ * @returns Scrollable review content.
+ * @example
+ * <ReviewContent plan={plan} selectedItemIdSet={ids} rowErrors={{}} ... />
+ */
+const ReviewContent = React.memo(function ReviewContent({
+  plan,
+  selectedItemIdSet,
+  rowErrors,
+  message,
+  summary,
+  orphanItemIds,
+  brokenItemIds,
+  onToggleItem,
+  onSetSection,
+}: ReviewContentProps): React.ReactElement {
+  return (
+    <div className="max-h-[60vh] overflow-auto pr-1 space-y-4 text-sm">
+      {message ? (
+        <div
+          className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-destructive"
+          role="alert"
+        >
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden />
+          <span>{message}</span>
+        </div>
+      ) : null}
+      {summary ? <SummaryLines summary={summary} /> : null}
+      <CleanupSection
+        title="Orphan records"
+        description="Source is gone. Cleanup removes dangling symlinks only."
+        itemIds={orphanItemIds}
+        selectedItemIdSet={selectedItemIdSet}
+        onSetSection={onSetSection}
+      >
+        {plan?.orphanRecords.map((item) => (
+          <CleanupRow
+            key={item.id}
+            item={item}
+            checked={selectedItemIdSet.has(item.id)}
+            error={rowErrors[item.id]}
+            onToggleItem={onToggleItem}
+          />
+        ))}
+      </CleanupSection>
+      <CleanupSection
+        title="Broken agent links"
+        description="Skill files are preserved. Cleanup unlinks this agent slot."
+        itemIds={brokenItemIds}
+        selectedItemIdSet={selectedItemIdSet}
+        onSetSection={onSetSection}
+      >
+        {Object.values(plan?.brokenSlotsByAgent ?? {}).flatMap((items) =>
+          (items ?? []).map((item) => (
+            <CleanupRow
+              key={item.id}
+              item={item}
+              checked={selectedItemIdSet.has(item.id)}
+              error={rowErrors[item.id]}
+              onToggleItem={onToggleItem}
+            />
+          )),
+        )}
+      </CleanupSection>
+    </div>
+  )
+})
+
+interface CleanupSectionProps {
+  title: string
+  description: string
+  itemIds: SymlinkCleanupItemId[]
+  selectedItemIdSet: ReadonlySet<SymlinkCleanupItemId>
+  onSetSection: (itemIds: SymlinkCleanupItemId[], checked: boolean) => void
+  children: React.ReactNode
+}
+
+/**
+ * Renders one cleanup review section with a section-level checkbox.
+ * @param props - Section label, item ids, selected ids, callback, and rows.
+ * @returns Section wrapper with heading and rows.
+ * @example
+ * <CleanupSection title="Orphans" itemIds={ids}>...</CleanupSection>
+ */
+const CleanupSection = React.memo(function CleanupSection({
+  title,
+  description,
+  itemIds,
+  selectedItemIdSet,
+  onSetSection,
+  children,
+}: CleanupSectionProps): React.ReactElement | null {
+  const checkedCount = itemIds.filter((itemId) =>
+    selectedItemIdSet.has(itemId),
+  ).length
+  const checked = checkedCount === itemIds.length
+  const isIndeterminate = checkedCount > 0 && checkedCount < itemIds.length
+  const handleCheckedChange = useCallback(
+    (value: boolean | 'indeterminate'): void => {
+      onSetSection(itemIds, value === true)
+    },
+    [itemIds, onSetSection],
+  )
+
+  if (itemIds.length === 0) return null
+
+  return (
+    <section className="space-y-2">
+      <div className="flex items-start justify-between gap-3 border-b border-border pb-2">
+        <div>
+          <h3 className="text-sm font-medium">{title}</h3>
+          <p className="text-xs text-muted-foreground">{description}</p>
+        </div>
+        <label className="flex min-h-6 items-center gap-2 text-xs text-muted-foreground">
+          <Checkbox
+            checked={isIndeterminate ? 'indeterminate' : checked}
+            onCheckedChange={handleCheckedChange}
+            aria-label={`Select all ${title}`}
+          />
+          {checkedCount}/{itemIds.length}
+        </label>
+      </div>
+      <div className="divide-y divide-border">{children}</div>
+    </section>
+  )
+})
+
+interface CleanupRowProps {
+  item: SymlinkCleanupPlanItem
+  checked: boolean
+  error?: string
+  onToggleItem: (itemId: SymlinkCleanupItemId) => void
+}
+
+/**
+ * Renders one cleanup row with checkbox, status icon, target identity, path details, and errors.
+ * @param props - Cleanup item, checked state, optional row error, and toggle callback.
+ * @returns Review row for one cleanup item.
+ * @example
+ * <CleanupRow item={item} checked={true} onToggleItem={toggle} />
+ */
+const CleanupRow = React.memo(function CleanupRow({
+  item,
+  checked,
+  error,
+  onToggleItem,
+}: CleanupRowProps): React.ReactElement {
+  const isOrphan = item.kind === 'orphan-record'
+  const label = isOrphan ? item.skillName : item.displaySkillName
+  const agentLabel = isOrphan
+    ? `${item.agents.length} ${pluralize(item.agents.length, 'agent')}`
+    : item.agentName
+  const issueCount = isOrphan ? item.symlinkCount : 1
+  const Icon = isOrphan ? Trash2 : Link2Off
+  const pathLine = isOrphan
+    ? item.agents.map((agent) => agent.linkPath).join(', ')
+    : `${item.linkPath}${item.targetPath ? ` -> ${item.targetPath}` : ''}`
+  const handleCheckedChange = useCallback((): void => {
+    onToggleItem(item.id)
+  }, [item.id, onToggleItem])
+
+  return (
+    <div className="py-2">
+      <div className="grid grid-cols-[auto_auto_minmax(0,1fr)_auto_auto] items-center gap-2">
+        <Checkbox
+          checked={checked}
+          onCheckedChange={handleCheckedChange}
+          aria-label={
+            isOrphan
+              ? `Clean orphan symlinks for ${label}`
+              : `Clean broken link for ${label} from ${agentLabel}`
+          }
+        />
+        <Icon
+          className={cn(
+            'h-4 w-4',
+            isOrphan ? 'text-destructive' : 'text-amber-400',
+          )}
+          aria-hidden="true"
+        />
+        <span className="min-w-0 truncate font-medium">{label}</span>
+        <span className="rounded border border-border px-1.5 py-0.5 text-[11px] text-muted-foreground">
+          {agentLabel}
+        </span>
+        <span className="tabular-nums text-xs text-muted-foreground">
+          {issueCount}
+        </span>
+      </div>
+      <p className="ml-14 mt-1 truncate font-mono text-[11px] text-muted-foreground">
+        {pathLine}
+      </p>
+      {error ? (
+        <p className="ml-14 mt-1 text-xs text-destructive" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  )
+})
+
+interface SummaryLinesProps {
+  summary: CleanupSummary | null
+}
+
+/**
+ * Renders compact count and phrase lines for complete or partial cleanup results.
+ * @param props - Summary data from cleanup execution.
+ * @returns Summary lines or null when no summary exists.
+ * @example
+ * <SummaryLines summary={summary} />
+ */
+const SummaryLines = React.memo(function SummaryLines({
+  summary,
+}: SummaryLinesProps): React.ReactElement | null {
+  if (!summary) return null
+  return (
+    <div className="space-y-1 rounded-md border border-border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+      <p>
+        {summary.orphanSymlinksRemoved}{' '}
+        {pluralize(summary.orphanSymlinksRemoved, 'orphan symlink')} removed
+      </p>
+      <p>
+        {summary.brokenLinksUnlinked}{' '}
+        {pluralize(summary.brokenLinksUnlinked, 'broken agent link')} unlinked
+      </p>
+      {summary.failedCount > 0 ? (
+        <p className="text-destructive">
+          {summary.failedCount} {pluralize(summary.failedCount, 'issue')} failed
+        </p>
+      ) : null}
+      {summary.phrases.length > 0 ? (
+        <p className="pt-1">{summary.phrases.join(' ')}</p>
+      ) : null}
+    </div>
+  )
+})

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
@@ -511,13 +511,19 @@ export const SymlinkCleanupDialog = React.memo(
         dispatchLocal({ type: 'scanning' })
         try {
           const skills = refreshDashboard
-            ? (
-                await Promise.all([
+            ? await (async () => {
+                const [skillsResult] = await Promise.allSettled([
                   dispatch(fetchSkills()).unwrap(),
                   dispatch(fetchAgents()).unwrap(),
                   dispatch(fetchSourceStats()).unwrap(),
-                ])
-              )[0]
+                ] as const)
+                if (skillsResult.status === 'rejected') {
+                  throw skillsResult.reason
+                }
+                // Dashboard side panels can stay stale; the dialog only needs
+                // fresh skills to decide whether cleanup remains available.
+                return skillsResult.value
+              })()
             : await dispatch(fetchSkills()).unwrap()
           if (scanRequestIdRef.current !== requestId) return
           const plan = buildSymlinkCleanupPlan(skills)

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
@@ -1257,12 +1257,13 @@ const CleanupRow = React.memo(function CleanupRow({
       </div>
       <div
         id={pathDetailsId}
-        className="ml-14 mt-1 space-y-1 font-mono text-[11px] text-muted-foreground"
+        data-testid="cleanup-path-evidence"
+        className="ml-14 mt-2 space-y-1 rounded-md border border-border/70 bg-muted/30 px-2 py-1.5 font-mono text-xs text-foreground/75"
       >
         {pathDetails.map((pathDetail) => (
           <p
             key={pathDetail}
-            className="break-words leading-4"
+            className="break-all leading-5"
             title={pathDetail}
           >
             {pathDetail}

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
@@ -389,6 +389,21 @@ function getRefreshFailureMessage(
 }
 
 /**
+ * Detects complete cleanup states whose dashboard refresh failed afterward.
+ * @param summary - Cleanup summary stored in dialog state.
+ * @returns True when the complete state should expose a direct rescan action.
+ * @example
+ * didCleanupRefreshFail({ phrases: ['Refresh failed after cleanup: offline.'], cleanedIssues: 1, orphanSymlinksRemoved: 0, brokenLinksUnlinked: 1, failedCount: 0 }) // => true
+ */
+function didCleanupRefreshFail(summary: CleanupSummary | null): boolean {
+  return (
+    summary?.phrases.some((phrase) =>
+      phrase.startsWith('Refresh failed after cleanup:'),
+    ) ?? false
+  )
+}
+
+/**
  * Aggregates bulk cleanup results into the compact final summary shown in the dialog.
  * @param params - Attempted item count and mutation results.
  * @returns Count and phrase summary for complete or partial-failure states.
@@ -799,6 +814,8 @@ export const SymlinkCleanupDialog = React.memo(
         />
       ))
       .exhaustive()
+    const completeNeedsRescan =
+      state.phase === 'complete' && didCleanupRefreshFail(state.summary)
 
     return (
       <Dialog open={isOpen} onOpenChange={handleClose}>
@@ -822,7 +839,9 @@ export const SymlinkCleanupDialog = React.memo(
           <div className="min-h-0">{body}</div>
 
           <DialogFooter className="gap-2">
-            {state.phase === 'stale' || state.phase === 'error' ? (
+            {state.phase === 'stale' ||
+            state.phase === 'error' ||
+            completeNeedsRescan ? (
               <Button
                 type="button"
                 variant="outline"
@@ -940,10 +959,7 @@ interface CompleteSummaryProps {
 const CompleteSummary = React.memo(function CompleteSummary({
   summary,
 }: CompleteSummaryProps): React.ReactElement {
-  const didRefreshFail =
-    summary?.phrases.some((phrase) =>
-      phrase.startsWith('Refresh failed after cleanup:'),
-    ) ?? false
+  const didRefreshFail = didCleanupRefreshFail(summary)
   return (
     <div className="py-5 space-y-3 text-sm" role="status" aria-atomic="true">
       <div className="flex items-start gap-3">

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
@@ -642,6 +642,9 @@ export const SymlinkCleanupDialog = React.memo(
         state.selectedItemIds,
       )
       dispatchLocal({ type: 'cleaning' })
+      // Dashboard cleanup is independent from the Installed list selection.
+      // Clear stale row ticks before any fresh-scan early return can preserve them.
+      dispatch(clearSelection())
 
       try {
         const freshSkills = await dispatch(fetchSkills()).unwrap()
@@ -657,9 +660,6 @@ export const SymlinkCleanupDialog = React.memo(
           })
           return
         }
-        // Dashboard cleanup is independent from the Installed list selection.
-        // Clear stale row ticks here without changing MainContent retry behavior.
-        dispatch(clearSelection())
 
         const orphanRecords = freshItemsToClean
           .filter(

--- a/src/renderer/src/components/dashboard/utils/buildSymlinkCleanupPlan.test.ts
+++ b/src/renderer/src/components/dashboard/utils/buildSymlinkCleanupPlan.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, it } from 'vitest'
+
+import type {
+  AgentId,
+  AgentName,
+  Skill,
+  SkillName,
+  SymlinkInfo,
+  SymlinkStatus,
+} from '@/shared/types'
+
+import {
+  buildSymlinkCleanupPlan,
+  createBrokenSlotCleanupItemId,
+  getLinkNameFromPath,
+  getSymlinkCleanupPlanItems,
+} from './buildSymlinkCleanupPlan'
+
+/**
+ * Builds a SymlinkInfo fixture for plan-builder specs that need concrete per-agent slots.
+ * @param overrides - Slot properties overridden by the current spec.
+ * @returns SymlinkInfo suitable for a Skill fixture.
+ * @example
+ * makeSymlink({ status: 'broken' }).status // => 'broken'
+ */
+function makeSymlink(overrides: Partial<SymlinkInfo> = {}): SymlinkInfo {
+  const agentId: AgentId = overrides.agentId ?? 'cursor'
+  const agentName: AgentName = overrides.agentName ?? 'Cursor'
+  const status: SymlinkStatus = overrides.status ?? 'valid'
+  const linkName = overrides.linkPath?.split('/').pop() ?? 'task'
+
+  return {
+    agentId,
+    agentName,
+    status,
+    targetPath:
+      overrides.targetPath ?? `/Users/test/.agents/skills/${linkName}`,
+    linkPath: overrides.linkPath ?? `/Users/test/.cursor/skills/${linkName}`,
+    isLocal: overrides.isLocal ?? false,
+  }
+}
+
+/**
+ * Builds a Skill fixture whose symlinkCount matches its valid slots.
+ * @param overrides - Skill fields overridden by the current spec.
+ * @returns Skill fixture for cleanup-plan unit tests.
+ * @example
+ * makeSkill({ name: 'browser' }).name // => 'browser'
+ */
+function makeSkill(overrides: Partial<Skill> = {}): Skill {
+  const name: SkillName = overrides.name ?? 'task'
+  const symlinks = overrides.symlinks ?? [makeSymlink()]
+
+  return {
+    name,
+    description: `${name} description`,
+    path: overrides.path ?? `/Users/test/.agents/skills/${name}`,
+    symlinkCount: symlinks.filter((symlink) => symlink.status === 'valid')
+      .length,
+    symlinks,
+    isSource: overrides.isSource ?? true,
+    isOrphan: overrides.isOrphan ?? false,
+    source: overrides.source,
+    sourceUrl: overrides.sourceUrl,
+  }
+}
+
+describe('buildSymlinkCleanupPlan', () => {
+  it('shows no cleanup items when every symlink slot is valid', () => {
+    // Arrange
+    const skills = [
+      makeSkill({
+        name: 'healthy',
+        symlinks: [makeSymlink({ status: 'valid' })],
+      }),
+    ]
+
+    // Act
+    const plan = buildSymlinkCleanupPlan(skills)
+
+    // Assert
+    expect(getSymlinkCleanupPlanItems(plan)).toEqual([])
+    expect(plan.totals).toEqual({
+      orphanRecords: 0,
+      orphanSymlinks: 0,
+      brokenSlots: 0,
+      affectedAgents: 0,
+    })
+  })
+
+  it('classifies an orphan skill with broken symlinks as one orphan record', () => {
+    // Arrange
+    const skills = [
+      makeSkill({
+        name: 'abandoned',
+        path: '/Users/test/.cursor/skills/abandoned',
+        isSource: false,
+        isOrphan: true,
+        symlinks: [
+          makeSymlink({
+            agentId: 'cursor',
+            agentName: 'Cursor',
+            status: 'broken',
+            linkPath: '/Users/test/.cursor/skills/abandoned',
+          }),
+          makeSymlink({
+            agentId: 'codex',
+            agentName: 'Codex',
+            status: 'broken',
+            linkPath: '/Users/test/.codex/skills/abandoned',
+          }),
+        ],
+      }),
+    ]
+
+    // Act
+    const plan = buildSymlinkCleanupPlan(skills)
+
+    // Assert
+    expect(plan.orphanRecords).toEqual([
+      {
+        id: 'orphan:abandoned',
+        kind: 'orphan-record',
+        skillName: 'abandoned',
+        agents: [
+          {
+            agentId: 'cursor',
+            agentName: 'Cursor',
+            linkPath: '/Users/test/.cursor/skills/abandoned',
+          },
+          {
+            agentId: 'codex',
+            agentName: 'Codex',
+            linkPath: '/Users/test/.codex/skills/abandoned',
+          },
+        ],
+        symlinkCount: 2,
+      },
+    ])
+    expect(plan.totals).toEqual({
+      orphanRecords: 1,
+      orphanSymlinks: 2,
+      brokenSlots: 0,
+      affectedAgents: 2,
+    })
+  })
+
+  it('classifies a non-orphan broken symlink as a broken agent link', () => {
+    // Arrange
+    const skills = [
+      makeSkill({
+        name: 'metadata-title',
+        path: '/Users/test/.agents/skills/metadata-title',
+        isOrphan: false,
+        symlinks: [
+          makeSymlink({
+            status: 'broken',
+            linkPath: '/Users/test/.cursor/skills/link-folder-name',
+            targetPath: '/Users/test/.agents/skills/missing-target',
+          }),
+        ],
+      }),
+    ]
+
+    // Act
+    const plan = buildSymlinkCleanupPlan(skills)
+
+    // Assert
+    expect(plan.brokenSlotsByAgent.cursor).toEqual([
+      {
+        id: 'broken:cursor:link-folder-name',
+        kind: 'broken-slot',
+        displaySkillName: 'metadata-title',
+        linkName: 'link-folder-name',
+        preservedSkillPath: '/Users/test/.agents/skills/metadata-title',
+        agentId: 'cursor',
+        agentName: 'Cursor',
+        linkPath: '/Users/test/.cursor/skills/link-folder-name',
+        targetPath: '/Users/test/.agents/skills/missing-target',
+      },
+    ])
+    expect(plan.totals).toEqual({
+      orphanRecords: 0,
+      orphanSymlinks: 0,
+      brokenSlots: 1,
+      affectedAgents: 1,
+    })
+  })
+
+  it('ignores missing and local slots so coverage gaps are not cleaned', () => {
+    // Arrange
+    const skills = [
+      makeSkill({
+        name: 'mixed',
+        symlinks: [
+          makeSymlink({
+            agentId: 'cursor',
+            agentName: 'Cursor',
+            status: 'missing',
+            linkPath: '/Users/test/.cursor/skills/mixed',
+          }),
+          makeSymlink({
+            agentId: 'codex',
+            agentName: 'Codex',
+            status: 'broken',
+            isLocal: true,
+            linkPath: '/Users/test/.codex/skills/mixed',
+          }),
+          makeSymlink({
+            agentId: 'devin',
+            agentName: 'Devin for Terminal',
+            status: 'inaccessible',
+            linkPath: '/Users/test/.config/devin/skills/mixed',
+          }),
+        ],
+      }),
+    ]
+
+    // Act
+    const plan = buildSymlinkCleanupPlan(skills)
+
+    // Assert
+    expect(getSymlinkCleanupPlanItems(plan)).toEqual([])
+  })
+
+  it('keeps same skill broken in two agents as independently selectable rows', () => {
+    // Arrange
+    const skills = [
+      makeSkill({
+        name: 'task',
+        symlinks: [
+          makeSymlink({
+            agentId: 'cursor',
+            agentName: 'Cursor',
+            status: 'broken',
+            linkPath: '/Users/test/.cursor/skills/task',
+          }),
+          makeSymlink({
+            agentId: 'codex',
+            agentName: 'Codex',
+            status: 'broken',
+            linkPath: '/Users/test/.codex/skills/task',
+          }),
+        ],
+      }),
+    ]
+
+    // Act
+    const plan = buildSymlinkCleanupPlan(skills)
+
+    // Assert
+    expect(getSymlinkCleanupPlanItems(plan).map((item) => item.id)).toEqual([
+      'broken:cursor:task',
+      'broken:codex:task',
+    ])
+  })
+
+  it('escapes cleanup id segments so separators cannot collide', () => {
+    // Arrange
+    const agentId = 'cursor' as AgentId
+    const linkName = 'name:with/slash' as SkillName
+
+    // Act
+    const itemId = createBrokenSlotCleanupItemId(agentId, linkName)
+
+    // Assert
+    expect(itemId).toBe('broken:cursor:name%3Awith%2Fslash')
+  })
+})
+
+describe('getLinkNameFromPath', () => {
+  it('uses the final agent-side path segment as the unlink name', () => {
+    // Arrange
+    const linkPath = '/Users/test/.cursor/skills/link-folder-name'
+
+    // Act
+    const linkName = getLinkNameFromPath(linkPath)
+
+    // Assert
+    expect(linkName).toBe('link-folder-name')
+  })
+})

--- a/src/renderer/src/components/dashboard/utils/buildSymlinkCleanupPlan.test.ts
+++ b/src/renderer/src/components/dashboard/utils/buildSymlinkCleanupPlan.test.ts
@@ -127,11 +127,13 @@ describe('buildSymlinkCleanupPlan', () => {
             agentId: 'cursor',
             agentName: 'Cursor',
             linkPath: '/Users/test/.cursor/skills/abandoned',
+            targetPath: '/Users/test/.agents/skills/abandoned',
           },
           {
             agentId: 'codex',
             agentName: 'Codex',
             linkPath: '/Users/test/.codex/skills/abandoned',
+            targetPath: '/Users/test/.agents/skills/abandoned',
           },
         ],
         symlinkCount: 2,

--- a/src/renderer/src/components/dashboard/utils/buildSymlinkCleanupPlan.ts
+++ b/src/renderer/src/components/dashboard/utils/buildSymlinkCleanupPlan.ts
@@ -1,0 +1,222 @@
+import type {
+  AbsolutePath,
+  AgentId,
+  AgentName,
+  IsoTimestamp,
+  Skill,
+  SkillName,
+  SymlinkInfo,
+} from '@/shared/types'
+
+export type SymlinkCleanupItemId = string
+
+export interface OrphanCleanupPlanItem {
+  id: SymlinkCleanupItemId
+  kind: 'orphan-record'
+  skillName: SkillName
+  agents: Array<{
+    agentId: AgentId
+    agentName: AgentName
+    linkPath: AbsolutePath
+  }>
+  symlinkCount: number
+}
+
+export interface BrokenSlotCleanupPlanItem {
+  id: SymlinkCleanupItemId
+  kind: 'broken-slot'
+  displaySkillName: SkillName
+  linkName: SkillName
+  preservedSkillPath: AbsolutePath
+  agentId: AgentId
+  agentName: AgentName
+  linkPath: AbsolutePath
+  targetPath: AbsolutePath
+}
+
+export type SymlinkCleanupPlanItem =
+  | OrphanCleanupPlanItem
+  | BrokenSlotCleanupPlanItem
+
+export interface SymlinkCleanupPlan {
+  generatedAt: IsoTimestamp
+  orphanRecords: OrphanCleanupPlanItem[]
+  brokenSlotsByAgent: Partial<Record<AgentId, BrokenSlotCleanupPlanItem[]>>
+  totals: {
+    orphanRecords: number
+    orphanSymlinks: number
+    brokenSlots: number
+    affectedAgents: number
+  }
+}
+
+/**
+ * Builds a stable id segment for cleanup row selection when scan results drive dialog checkboxes.
+ * @param value - Raw skill, agent, or link name segment.
+ * @returns URI-escaped segment safe to join with `:`.
+ * @example
+ * encodeCleanupIdSegment('agent:skill') // => 'agent%3Askill'
+ */
+function encodeCleanupIdSegment(value: string): string {
+  return encodeURIComponent(value)
+}
+
+/**
+ * Builds an orphan cleanup row id from the skill name when the review list renders.
+ * @param skillName - Skill whose only remaining records are orphan symlinks.
+ * @returns Stable orphan row id.
+ * @example
+ * createOrphanCleanupItemId('abandoned') // => 'orphan:abandoned'
+ */
+export function createOrphanCleanupItemId(
+  skillName: SkillName,
+): SymlinkCleanupItemId {
+  return `orphan:${encodeCleanupIdSegment(skillName)}`
+}
+
+/**
+ * Builds a broken-slot cleanup row id from the agent and link name when rows need independent selection.
+ * @param agentId - Agent that owns the dangling symlink slot.
+ * @param linkName - Agent-side symlink basename used by unlink IPC.
+ * @returns Stable broken-slot row id.
+ * @example
+ * createBrokenSlotCleanupItemId('cursor', 'agent:skill') // => 'broken:cursor:agent%3Askill'
+ */
+export function createBrokenSlotCleanupItemId(
+  agentId: AgentId,
+  linkName: SkillName,
+): SymlinkCleanupItemId {
+  return `broken:${encodeCleanupIdSegment(agentId)}:${encodeCleanupIdSegment(linkName)}`
+}
+
+/**
+ * Extracts the final path segment from a symlink link path so unlink targets the agent-side name.
+ * @param linkPath - Absolute path to the symlink inside an agent skills directory.
+ * @returns Last path segment, or the full path when no separator is present.
+ * @example
+ * getLinkNameFromPath('/Users/me/.cursor/skills/task') // => 'task'
+ */
+export function getLinkNameFromPath(linkPath: AbsolutePath): SkillName {
+  const normalizedPath = linkPath.replaceAll('\\', '/')
+  const pathSegments = normalizedPath.split('/').filter(Boolean)
+  return pathSegments[pathSegments.length - 1] ?? normalizedPath
+}
+
+/**
+ * Returns true when the slot is a broken non-local symlink the cleanup flow may remove.
+ * @param symlink - Per-agent slot from a scanned Skill record.
+ * @returns Whether the slot is eligible for symlink cleanup.
+ * @example
+ * isCleanupEligibleBrokenSlot({ status: 'broken', isLocal: false, ...slot }) // => true
+ */
+function isCleanupEligibleBrokenSlot(
+  symlink: SymlinkInfo,
+): symlink is SymlinkInfo & {
+  status: 'broken'
+  isLocal: false
+  targetPath: AbsolutePath
+} {
+  return (
+    symlink.status === 'broken' &&
+    !symlink.isLocal &&
+    typeof symlink.targetPath === 'string'
+  )
+}
+
+/**
+ * Flattens a cleanup plan into review rows for selection, validation, and execution.
+ * @param plan - Cleanup plan returned by `buildSymlinkCleanupPlan`.
+ * @returns Orphan rows followed by broken-slot rows grouped by agent.
+ * @example
+ * getSymlinkCleanupPlanItems(plan).map((item) => item.id)
+ */
+export function getSymlinkCleanupPlanItems(
+  plan: SymlinkCleanupPlan,
+): SymlinkCleanupPlanItem[] {
+  return [
+    ...plan.orphanRecords,
+    ...Object.values(plan.brokenSlotsByAgent).flatMap((items) => items ?? []),
+  ]
+}
+
+/**
+ * Builds the Symlink Health cleanup plan from a fresh scanner snapshot before review or stale checks.
+ * @param skills - Fresh Skill[] returned by `fetchSkills().unwrap()`.
+ * @returns Renderer-only cleanup plan separating orphan records from broken agent slots.
+ * @example
+ * buildSymlinkCleanupPlan([{ name: 'task', isOrphan: true, symlinks: [brokenSlot], ...rest }])
+ */
+export function buildSymlinkCleanupPlan(
+  skills: readonly Skill[],
+): SymlinkCleanupPlan {
+  const orphanRecords: OrphanCleanupPlanItem[] = []
+  const brokenSlotsByAgent: Partial<
+    Record<AgentId, BrokenSlotCleanupPlanItem[]>
+  > = {}
+  const affectedAgentIds = new Set<AgentId>()
+
+  for (const skill of skills) {
+    const cleanupEligibleBrokenSlots = skill.symlinks.filter(
+      isCleanupEligibleBrokenSlot,
+    )
+    if (cleanupEligibleBrokenSlots.length === 0) continue
+
+    if (skill.isOrphan) {
+      orphanRecords.push({
+        id: createOrphanCleanupItemId(skill.name),
+        kind: 'orphan-record',
+        skillName: skill.name,
+        agents: cleanupEligibleBrokenSlots.map((symlink) => ({
+          agentId: symlink.agentId,
+          agentName: symlink.agentName,
+          linkPath: symlink.linkPath,
+        })),
+        symlinkCount: cleanupEligibleBrokenSlots.length,
+      })
+      for (const symlink of cleanupEligibleBrokenSlots) {
+        affectedAgentIds.add(symlink.agentId)
+      }
+      continue
+    }
+
+    for (const symlink of cleanupEligibleBrokenSlots) {
+      const linkName = getLinkNameFromPath(symlink.linkPath)
+      const planItem: BrokenSlotCleanupPlanItem = {
+        id: createBrokenSlotCleanupItemId(symlink.agentId, linkName),
+        kind: 'broken-slot',
+        displaySkillName: skill.name,
+        linkName,
+        preservedSkillPath: skill.path,
+        agentId: symlink.agentId,
+        agentName: symlink.agentName,
+        linkPath: symlink.linkPath,
+        targetPath: symlink.targetPath,
+      }
+      brokenSlotsByAgent[symlink.agentId] = [
+        ...(brokenSlotsByAgent[symlink.agentId] ?? []),
+        planItem,
+      ]
+      affectedAgentIds.add(symlink.agentId)
+    }
+  }
+
+  const brokenSlots = Object.values(brokenSlotsByAgent).reduce(
+    (total, items) => total + (items?.length ?? 0),
+    0,
+  )
+
+  return {
+    generatedAt: new Date().toISOString(),
+    orphanRecords,
+    brokenSlotsByAgent,
+    totals: {
+      orphanRecords: orphanRecords.length,
+      orphanSymlinks: orphanRecords.reduce(
+        (total, item) => total + item.symlinkCount,
+        0,
+      ),
+      brokenSlots,
+      affectedAgents: affectedAgentIds.size,
+    },
+  }
+}

--- a/src/renderer/src/components/dashboard/utils/buildSymlinkCleanupPlan.ts
+++ b/src/renderer/src/components/dashboard/utils/buildSymlinkCleanupPlan.ts
@@ -18,6 +18,7 @@ export interface OrphanCleanupPlanItem {
     agentId: AgentId
     agentName: AgentName
     linkPath: AbsolutePath
+    targetPath: AbsolutePath
   }>
   symlinkCount: number
 }
@@ -170,6 +171,7 @@ export function buildSymlinkCleanupPlan(
           agentId: symlink.agentId,
           agentName: symlink.agentName,
           linkPath: symlink.linkPath,
+          targetPath: symlink.targetPath,
         })),
         symlinkCount: cleanupEligibleBrokenSlots.length,
       })

--- a/src/renderer/src/components/dashboard/utils/gridConstants.ts
+++ b/src/renderer/src/components/dashboard/utils/gridConstants.ts
@@ -8,10 +8,12 @@
  * Row height is 64px. `WidgetShell` burns a fixed 36px header on every widget
  * (see WidgetShell.tsx — `h-9` Tailwind class; keep both sites in sync if the
  * header height ever changes). A 48px row left h=2 widgets with only ~68px of
- * body — not enough for stat tiles (icon+number+label ≈ 72px) or the health
- * widget's label/bar/legend stack (≈90px). Bumping to 64 gives h=2 ≈ 100px
- * body (fits the tightest content + breathing room) and keeps h=3/h=4 generous
- * for lists and cards.
+ * body — not enough for stat tiles (icon+number+label ≈ 72px). Bumping to 64
+ * gives h=2 ≈ 100px body, fitting the stat tiles with breathing room, and keeps
+ * h=3/h=4 generous for lists and cards. The Symlink Health widget is the
+ * exception that needs h=3, not h=2: PR #185 added a "Scan issues" action row
+ * below its label/bar/legend stack, so its `minSize.h` is 3 (see
+ * widgets/sizes.ts) and a v3 → v4 migration clamps persisted layouts up.
  */
 export const GRID_COLS = 6
 export const GRID_ROW_HEIGHT_PX = 64

--- a/src/renderer/src/components/dashboard/utils/widgetPresets.ts
+++ b/src/renderer/src/components/dashboard/utils/widgetPresets.ts
@@ -35,8 +35,12 @@ const PAGE_SPECS: readonly PageSpec[] = [
     widgets: [
       { type: 'welcome', x: 0, y: 0, w: 6, h: 3 },
       { type: 'stats', x: 0, y: 3 },
+      // health inherits its h=3 default (sizes.ts), occupying rows 3-5 at
+      // x3-5, so coverage starts at row 6 to clear it. (At y=5 the vertical
+      // compactor would push coverage to 6 on mount anyway; hand-author the
+      // honest value rather than rely on runtime collision-resolution.)
       { type: 'health', x: 3, y: 3 },
-      { type: 'coverage', x: 0, y: 5, w: 6, h: 3 },
+      { type: 'coverage', x: 0, y: 6, w: 6, h: 3 },
     ],
   },
   {

--- a/src/renderer/src/components/dashboard/widgets/AgentHeatmapWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/AgentHeatmapWidget.tsx
@@ -23,6 +23,7 @@ const MAX_SKILL_ROWS = 20
 const STATUS_FILL: Record<SymlinkStatus, string> = {
   valid: 'bg-success',
   broken: 'bg-amber-400',
+  inaccessible: 'bg-amber-400',
   missing: 'bg-muted',
 }
 

--- a/src/renderer/src/components/dashboard/widgets/HealthWidget.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/widgets/HealthWidget.browser.test.tsx
@@ -156,4 +156,23 @@ describe('HealthWidget', () => {
       .element(screen.getByRole('button', { name: 'Scan issues' }))
       .toBeVisible()
   })
+
+  it('does not present a remaining cleanup issue as 100 percent healthy', async () => {
+    // Arrange
+    const symlinks = [
+      ...Array.from({ length: 1035 }, () => makeSymlink('valid')),
+      makeSymlink('broken'),
+    ]
+    const skills = [makeSkill(symlinks)]
+
+    // Act
+    const { screen } = await renderHealthWidget(skills)
+
+    // Assert
+    await expect.element(screen.getByText('99.9%')).toBeVisible()
+    expect(screen.getByText('100%').query()).toBeNull()
+    await expect
+      .element(screen.getByRole('button', { name: 'Scan issues' }))
+      .toBeVisible()
+  })
 })

--- a/src/renderer/src/components/dashboard/widgets/HealthWidget.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/widgets/HealthWidget.browser.test.tsx
@@ -112,14 +112,48 @@ describe('HealthWidget', () => {
 
     // Assert
     await expect.element(screen.getByText('Manual review')).toBeVisible()
-    await expect.element(screen.getByText('needs review')).toBeVisible()
     await expect
-      .element(screen.getByRole('img', { name: '0 valid, 1 need review' }))
+      .element(screen.getByText('manual', { exact: true }))
+      .toBeVisible()
+    await expect
+      .element(
+        screen.getByRole('img', {
+          name: '0 valid, 0 cleanup issues, 1 manual review',
+        }),
+      )
       .toBeInTheDocument()
     expect(screen.getByText('Healthy').query()).toBeNull()
     expect(screen.getByText('broken').query()).toBeNull()
     expect(
       screen.getByRole('button', { name: 'Scan issues' }).query(),
     ).toBeNull()
+  })
+
+  it('splits cleanup-ready and manual-review counts when both need attention', async () => {
+    // Arrange
+    const skills = [
+      makeSkill([
+        makeSymlink('valid'),
+        makeSymlink('broken'),
+        makeSymlink('inaccessible'),
+      ]),
+    ]
+
+    // Act
+    const { screen } = await renderHealthWidget(skills)
+
+    // Assert
+    await expect.element(screen.getByText('cleanup')).toBeVisible()
+    await expect.element(screen.getByText('manual')).toBeVisible()
+    await expect
+      .element(
+        screen.getByRole('img', {
+          name: '1 valid, 1 cleanup issue, 1 manual review',
+        }),
+      )
+      .toBeInTheDocument()
+    await expect
+      .element(screen.getByRole('button', { name: 'Scan issues' }))
+      .toBeVisible()
   })
 })

--- a/src/renderer/src/components/dashboard/widgets/HealthWidget.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/widgets/HealthWidget.browser.test.tsx
@@ -1,0 +1,125 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import { describe, expect, it } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import '@/renderer/src/styles/globals.css'
+import type { Skill, SymlinkInfo } from '@/shared/types'
+
+/**
+ * Builds a SymlinkInfo fixture for HealthWidget display-state tests.
+ * @param status - Symlink status counted by the widget.
+ * @returns Minimal symlink slot.
+ * @example
+ * makeSymlink('broken').status // => 'broken'
+ */
+function makeSymlink(status: SymlinkInfo['status']): SymlinkInfo {
+  return {
+    agentId: 'cursor',
+    agentName: 'Cursor',
+    status,
+    linkPath: '/Users/test/.cursor/skills/task',
+    targetPath: '/Users/test/.agents/skills/task',
+    isLocal: false,
+  }
+}
+
+/**
+ * Builds a Skill fixture whose symlink slots drive the widget totals.
+ * @param symlinks - Slots counted by the HealthWidget.
+ * @returns Skill fixture for the Redux store.
+ * @example
+ * makeSkill([makeSymlink('valid')]).symlinkCount // => 1
+ */
+function makeSkill(symlinks: SymlinkInfo[]): Skill {
+  return {
+    name: 'task',
+    description: 'Task skill',
+    path: '/Users/test/.agents/skills/task',
+    symlinkCount: symlinks.filter((symlink) => symlink.status === 'valid')
+      .length,
+    symlinks,
+    isSource: true,
+    isOrphan: false,
+  }
+}
+
+/**
+ * Renders HealthWidget with real skills/ui reducers so button clicks update Redux normally.
+ * @param skills - Skill inventory to seed through the fetchSkills.fulfilled reducer.
+ * @returns Browser screen and store.
+ * @example
+ * const { screen } = await renderHealthWidget([makeSkill([makeSymlink('broken')])])
+ */
+async function renderHealthWidget(skills: Skill[]) {
+  const [
+    { default: skillsReducer, fetchSkills },
+    { default: uiReducer },
+    { HealthWidget },
+  ] = await Promise.all([
+    import('@/renderer/src/redux/slices/skillsSlice'),
+    import('@/renderer/src/redux/slices/uiSlice'),
+    import('./HealthWidget'),
+  ])
+  const store = configureStore({
+    reducer: { skills: skillsReducer, ui: uiReducer },
+  })
+  store.dispatch(fetchSkills.fulfilled(skills, 'req-skills'))
+
+  const screen = await render(
+    <Provider store={store}>
+      <div style={{ width: 240, height: 160 }}>
+        <HealthWidget />
+      </div>
+    </Provider>,
+  )
+  return { screen, store }
+}
+
+describe('HealthWidget', () => {
+  it('opens the Symlink Health cleanup dialog when broken links exist', async () => {
+    // Arrange
+    const skills = [makeSkill([makeSymlink('valid'), makeSymlink('broken')])]
+    const { screen, store } = await renderHealthWidget(skills)
+
+    // Act
+    await screen.getByRole('button', { name: 'Scan issues' }).click()
+
+    // Assert
+    expect(store.getState().ui.symlinkCleanupDialogOpen).toBe(true)
+  })
+
+  it('shows Healthy instead of Scan issues when no broken links exist', async () => {
+    // Arrange
+    const skills = [makeSkill([makeSymlink('valid')])]
+
+    // Act
+    const { screen } = await renderHealthWidget(skills)
+
+    // Assert
+    await expect.element(screen.getByText('Healthy')).toBeVisible()
+    expect(
+      screen.getByRole('button', { name: 'Scan issues' }).query(),
+    ).toBeNull()
+  })
+
+  it('shows Manual review instead of Healthy when only inaccessible links need attention', async () => {
+    // Arrange
+    const skills = [makeSkill([makeSymlink('inaccessible')])]
+
+    // Act
+    const { screen } = await renderHealthWidget(skills)
+
+    // Assert
+    await expect.element(screen.getByText('Manual review')).toBeVisible()
+    await expect.element(screen.getByText('needs review')).toBeVisible()
+    await expect
+      .element(screen.getByRole('img', { name: '0 valid, 1 need review' }))
+      .toBeInTheDocument()
+    expect(screen.getByText('Healthy').query()).toBeNull()
+    expect(screen.getByText('broken').query()).toBeNull()
+    expect(
+      screen.getByRole('button', { name: 'Scan issues' }).query(),
+    ).toBeNull()
+  })
+})

--- a/src/renderer/src/components/dashboard/widgets/HealthWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/HealthWidget.tsx
@@ -1,8 +1,10 @@
-import { AlertCircle, CheckCircle } from 'lucide-react'
-import React, { useMemo } from 'react'
+import { AlertCircle, CheckCircle, Search } from 'lucide-react'
+import React, { useCallback, useMemo } from 'react'
 
-import { useAppSelector } from '@/renderer/src/redux/hooks'
+import { Button } from '@/renderer/src/components/ui/button'
+import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import { selectSkillsItems } from '@/renderer/src/redux/slices/skillsSlice'
+import { openSymlinkCleanupDialog } from '@/renderer/src/redux/slices/uiSlice'
 import type { Skill } from '@/shared/types'
 
 // ----------------------------------------------------------------------------
@@ -12,6 +14,7 @@ import type { Skill } from '@/shared/types'
 interface HealthTotals {
   valid: number
   broken: number
+  inaccessible: number
   missing: number
 }
 
@@ -22,10 +25,15 @@ interface HealthTotals {
  * @returns totals across every symlink entry
  * @example
  * tallySymlinks([{symlinks:[{status:'valid'},{status:'broken'}]}])
- * // => { valid: 1, broken: 1, missing: 0 }
+ * // => { valid: 1, broken: 1, inaccessible: 0, missing: 0 }
  */
 function tallySymlinks(skills: readonly Skill[]): HealthTotals {
-  const totals: HealthTotals = { valid: 0, broken: 0, missing: 0 }
+  const totals: HealthTotals = {
+    valid: 0,
+    broken: 0,
+    inaccessible: 0,
+    missing: 0,
+  }
   for (const skill of skills) {
     for (const link of skill.symlinks) {
       totals[link.status] += 1
@@ -43,34 +51,34 @@ function tallySymlinks(skills: readonly Skill[]): HealthTotals {
  * @example healthPercent({valid:0, broken:0}) // => null
  */
 function healthPercent(totals: HealthTotals): number | null {
-  const attempted = totals.valid + totals.broken
+  const attempted = totals.valid + totals.broken + totals.inaccessible
   if (attempted === 0) return null
   return Math.round((totals.valid / attempted) * 100)
 }
 
 // ----------------------------------------------------------------------------
-// HealthBar — a 2-segment horizontal bar showing valid|broken ratio.
+// HealthBar — a 2-segment horizontal bar showing valid|needs-review ratio.
 // Pure presentational; accepts already-computed numbers to stay testable.
 // ----------------------------------------------------------------------------
 
 interface HealthBarProps {
   valid: number
-  broken: number
+  needsReview: number
 }
 
 const HealthBar = React.memo(function HealthBar({
   valid,
-  broken,
+  needsReview,
 }: HealthBarProps): React.ReactElement {
-  const total = valid + broken
+  const total = valid + needsReview
   const validPct = total > 0 ? (valid / total) * 100 : 0
-  const brokenPct = total > 0 ? (broken / total) * 100 : 0
+  const needsReviewPct = total > 0 ? (needsReview / total) * 100 : 0
 
   return (
     <div
       className="h-1.5 w-full rounded-full bg-muted overflow-hidden flex"
       role="img"
-      aria-label={`${valid} valid, ${broken} broken`}
+      aria-label={`${valid} valid, ${needsReview} need review`}
     >
       <div
         className="bg-success transition-[width] duration-300"
@@ -78,7 +86,7 @@ const HealthBar = React.memo(function HealthBar({
       />
       <div
         className="bg-amber-400 transition-[width] duration-300"
-        style={{ width: `${brokenPct}%` }}
+        style={{ width: `${needsReviewPct}%` }}
       />
     </div>
   )
@@ -93,12 +101,20 @@ const HealthBar = React.memo(function HealthBar({
  */
 export const HealthWidget = React.memo(
   function HealthWidget(): React.ReactElement {
+    const dispatch = useAppDispatch()
     const skills = useAppSelector(selectSkillsItems)
     const totals = useMemo(() => tallySymlinks(skills), [skills])
     const percent = healthPercent(totals)
+    const hasBrokenLinks = totals.broken > 0
+    const attentionCount = totals.broken + totals.inaccessible
+    const hasManualReviewOnly = !hasBrokenLinks && totals.inaccessible > 0
+
+    const handleScanIssues = useCallback((): void => {
+      dispatch(openSymlinkCleanupDialog())
+    }, [dispatch])
 
     return (
-      <div className="h-full w-full flex flex-col justify-center gap-3 px-4 py-3">
+      <div className="h-full w-full flex flex-col justify-center gap-2.5 px-4 py-3">
         <div className="flex items-baseline justify-between">
           <span className="text-[11px] text-muted-foreground uppercase tracking-wide">
             Health
@@ -107,7 +123,7 @@ export const HealthWidget = React.memo(
             {percent === null ? '—' : `${percent}%`}
           </span>
         </div>
-        <HealthBar valid={totals.valid} broken={totals.broken} />
+        <HealthBar valid={totals.valid} needsReview={attentionCount} />
         <div className="flex items-center justify-between text-xs">
           <span className="inline-flex items-center gap-1 text-success">
             <CheckCircle className="h-3 w-3" aria-hidden="true" />
@@ -116,9 +132,28 @@ export const HealthWidget = React.memo(
           </span>
           <span className="inline-flex items-center gap-1 text-amber-400">
             <AlertCircle className="h-3 w-3" aria-hidden="true" />
-            <span className="tabular-nums">{totals.broken}</span>
-            <span className="text-muted-foreground">broken</span>
+            <span className="tabular-nums">{attentionCount}</span>
+            <span className="text-muted-foreground">needs review</span>
           </span>
+        </div>
+        <div className="min-h-8 flex items-center justify-end">
+          {hasBrokenLinks ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="secondary"
+              onClick={handleScanIssues}
+              className="h-8 min-h-8 px-2.5 text-[11px]"
+              data-symlink-cleanup-trigger="true"
+            >
+              <Search className="h-3.5 w-3.5" aria-hidden="true" />
+              Scan issues
+            </Button>
+          ) : hasManualReviewOnly ? (
+            <span className="text-[11px] text-amber-400">Manual review</span>
+          ) : (
+            <span className="text-[11px] text-muted-foreground">Healthy</span>
+          )}
         </div>
       </div>
     )

--- a/src/renderer/src/components/dashboard/widgets/HealthWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/HealthWidget.tsx
@@ -44,17 +44,20 @@ function tallySymlinks(skills: readonly Skill[]): HealthTotals {
 }
 
 /**
- * Compute the valid-link percentage (ignoring `missing`).
- * "Health" is about the quality of links that *should* exist, not coverage,
- * so missing links don't drag the number down — that belongs in the Coverage
- * widget. Returns `null` when there are no links to judge yet.
- * @example healthPercent({valid:8, broken:2}) // => 80
- * @example healthPercent({valid:0, broken:0}) // => null
+ * Formats valid-link health so a remaining issue never presents as perfect.
+ * @param totals - Link totals counted from the current skill inventory.
+ * @returns Display label, or null when there are no attempted links.
+ * @example healthPercentLabel({valid:999, broken:1, inaccessible:0, missing:0}) // => '99.9%'
  */
-function healthPercent(totals: HealthTotals): number | null {
+function healthPercentLabel(totals: HealthTotals): string | null {
   const attempted = totals.valid + totals.broken + totals.inaccessible
   if (attempted === 0) return null
-  return Math.round((totals.valid / attempted) * 100)
+
+  const percent = (totals.valid / attempted) * 100
+  if (totals.valid === attempted) return '100%'
+
+  // Tiny issue counts are still issues; avoid visually rounding them to 100%.
+  return percent >= 99.5 ? `${percent.toFixed(1)}%` : `${Math.round(percent)}%`
 }
 
 // ----------------------------------------------------------------------------
@@ -112,7 +115,7 @@ export const HealthWidget = React.memo(
     const dispatch = useAppDispatch()
     const skills = useAppSelector(selectSkillsItems)
     const totals = useMemo(() => tallySymlinks(skills), [skills])
-    const percent = healthPercent(totals)
+    const percentLabel = healthPercentLabel(totals)
     const hasBrokenLinks = totals.broken > 0
     const hasManualReviewOnly = !hasBrokenLinks && totals.inaccessible > 0
 
@@ -127,7 +130,7 @@ export const HealthWidget = React.memo(
             Health
           </span>
           <span className="text-2xl font-semibold tabular-nums text-foreground">
-            {percent === null ? '—' : `${percent}%`}
+            {percentLabel === null ? '—' : percentLabel}
           </span>
         </div>
         <HealthBar

--- a/src/renderer/src/components/dashboard/widgets/HealthWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/HealthWidget.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/renderer/src/components/ui/button'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import { selectSkillsItems } from '@/renderer/src/redux/slices/skillsSlice'
 import { openSymlinkCleanupDialog } from '@/renderer/src/redux/slices/uiSlice'
+import { pluralize } from '@/renderer/src/utils/pluralize'
 import type { Skill } from '@/shared/types'
 
 // ----------------------------------------------------------------------------
@@ -63,22 +64,25 @@ function healthPercent(totals: HealthTotals): number | null {
 
 interface HealthBarProps {
   valid: number
-  needsReview: number
+  cleanupIssues: number
+  manualReview: number
 }
 
 const HealthBar = React.memo(function HealthBar({
   valid,
-  needsReview,
+  cleanupIssues,
+  manualReview,
 }: HealthBarProps): React.ReactElement {
-  const total = valid + needsReview
+  const total = valid + cleanupIssues + manualReview
   const validPct = total > 0 ? (valid / total) * 100 : 0
-  const needsReviewPct = total > 0 ? (needsReview / total) * 100 : 0
+  const cleanupPct = total > 0 ? (cleanupIssues / total) * 100 : 0
+  const manualPct = total > 0 ? (manualReview / total) * 100 : 0
 
   return (
     <div
       className="h-1.5 w-full rounded-full bg-muted overflow-hidden flex"
       role="img"
-      aria-label={`${valid} valid, ${needsReview} need review`}
+      aria-label={`${valid} valid, ${cleanupIssues} ${pluralize(cleanupIssues, 'cleanup issue')}, ${manualReview} manual review`}
     >
       <div
         className="bg-success transition-[width] duration-300"
@@ -86,7 +90,11 @@ const HealthBar = React.memo(function HealthBar({
       />
       <div
         className="bg-amber-400 transition-[width] duration-300"
-        style={{ width: `${needsReviewPct}%` }}
+        style={{ width: `${cleanupPct}%` }}
+      />
+      <div
+        className="bg-amber-300 transition-[width] duration-300"
+        style={{ width: `${manualPct}%` }}
       />
     </div>
   )
@@ -106,7 +114,6 @@ export const HealthWidget = React.memo(
     const totals = useMemo(() => tallySymlinks(skills), [skills])
     const percent = healthPercent(totals)
     const hasBrokenLinks = totals.broken > 0
-    const attentionCount = totals.broken + totals.inaccessible
     const hasManualReviewOnly = !hasBrokenLinks && totals.inaccessible > 0
 
     const handleScanIssues = useCallback((): void => {
@@ -123,18 +130,40 @@ export const HealthWidget = React.memo(
             {percent === null ? '—' : `${percent}%`}
           </span>
         </div>
-        <HealthBar valid={totals.valid} needsReview={attentionCount} />
+        <HealthBar
+          valid={totals.valid}
+          cleanupIssues={totals.broken}
+          manualReview={totals.inaccessible}
+        />
         <div className="flex items-center justify-between text-xs">
           <span className="inline-flex items-center gap-1 text-success">
             <CheckCircle className="h-3 w-3" aria-hidden="true" />
             <span className="tabular-nums">{totals.valid}</span>
             <span className="text-muted-foreground">valid</span>
           </span>
-          <span className="inline-flex items-center gap-1 text-amber-400">
-            <AlertCircle className="h-3 w-3" aria-hidden="true" />
-            <span className="tabular-nums">{attentionCount}</span>
-            <span className="text-muted-foreground">needs review</span>
-          </span>
+          <div className="flex items-center gap-2">
+            {totals.broken > 0 ? (
+              <span className="inline-flex items-center gap-1 text-amber-400">
+                <AlertCircle className="h-3 w-3" aria-hidden="true" />
+                <span className="tabular-nums">{totals.broken}</span>
+                <span className="text-muted-foreground">cleanup</span>
+              </span>
+            ) : null}
+            {totals.inaccessible > 0 ? (
+              <span className="inline-flex items-center gap-1 text-amber-300">
+                <AlertCircle className="h-3 w-3" aria-hidden="true" />
+                <span className="tabular-nums">{totals.inaccessible}</span>
+                <span className="text-muted-foreground">manual</span>
+              </span>
+            ) : null}
+            {totals.broken === 0 && totals.inaccessible === 0 ? (
+              <span className="inline-flex items-center gap-1 text-muted-foreground">
+                <AlertCircle className="h-3 w-3" aria-hidden="true" />
+                <span className="tabular-nums">0</span>
+                <span>needs review</span>
+              </span>
+            ) : null}
+          </div>
         </div>
         <div className="min-h-8 flex items-center justify-end">
           {hasBrokenLinks ? (

--- a/src/renderer/src/components/dashboard/widgets/HealthWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/HealthWidget.tsx
@@ -61,7 +61,7 @@ function healthPercentLabel(totals: HealthTotals): string | null {
 }
 
 // ----------------------------------------------------------------------------
-// HealthBar — a 2-segment horizontal bar showing valid|needs-review ratio.
+// HealthBar — a 3-segment horizontal bar showing valid|cleanup|manual ratio.
 // Pure presentational; accepts already-computed numbers to stay testable.
 // ----------------------------------------------------------------------------
 
@@ -83,7 +83,7 @@ const HealthBar = React.memo(function HealthBar({
 
   return (
     <div
-      className="h-1.5 w-full rounded-full bg-muted overflow-hidden flex"
+      className="h-1 w-full shrink-0 rounded-full bg-muted overflow-hidden flex"
       role="img"
       aria-label={`${valid} valid, ${cleanupIssues} ${pluralize(cleanupIssues, 'cleanup issue')}, ${manualReview} manual review`}
     >
@@ -95,8 +95,9 @@ const HealthBar = React.memo(function HealthBar({
         className="bg-amber-400 transition-[width] duration-300"
         style={{ width: `${cleanupPct}%` }}
       />
+      {/* Manual-review shares cleanup's amber-400 (broken + inaccessible = one needs-review hue app-wide; see SymlinkStatus). */}
       <div
-        className="bg-amber-300 transition-[width] duration-300"
+        className="bg-amber-400 transition-[width] duration-300"
         style={{ width: `${manualPct}%` }}
       />
     </div>
@@ -124,15 +125,12 @@ export const HealthWidget = React.memo(
     }, [dispatch])
 
     return (
-      <div className="h-full w-full flex flex-col justify-center gap-2.5 px-4 py-3">
-        <div className="flex items-baseline justify-between">
-          <span className="text-[11px] text-muted-foreground uppercase tracking-wide">
-            Health
-          </span>
-          <span className="text-2xl font-semibold tabular-nums text-foreground">
-            {percentLabel === null ? '—' : percentLabel}
-          </span>
-        </div>
+      <div className="h-full w-full flex flex-col gap-2 px-4 py-3">
+        {/* Percentage is the hero metric; the card title ("Symlink Health") already
+            names the widget, so the inline "HEALTH" label was redundant and removed. */}
+        <span className="text-2xl font-semibold tabular-nums text-foreground">
+          {percentLabel === null ? '—' : percentLabel}
+        </span>
         <HealthBar
           valid={totals.valid}
           cleanupIssues={totals.broken}
@@ -153,7 +151,7 @@ export const HealthWidget = React.memo(
               </span>
             ) : null}
             {totals.inaccessible > 0 ? (
-              <span className="inline-flex items-center gap-1 text-amber-300">
+              <span className="inline-flex items-center gap-1 text-amber-400">
                 <AlertCircle className="h-3 w-3" aria-hidden="true" />
                 <span className="tabular-nums">{totals.inaccessible}</span>
                 <span className="text-muted-foreground">manual</span>
@@ -168,14 +166,14 @@ export const HealthWidget = React.memo(
             ) : null}
           </div>
         </div>
-        <div className="min-h-8 flex items-center justify-end">
+        <div className="min-h-8 mt-auto flex items-center justify-end">
           {hasBrokenLinks ? (
             <Button
               type="button"
               size="sm"
               variant="secondary"
               onClick={handleScanIssues}
-              className="h-8 min-h-8 px-2.5 text-[11px]"
+              className="h-8 min-h-8 px-2 text-[11px]"
               data-symlink-cleanup-trigger="true"
             >
               <Search className="h-3.5 w-3.5" aria-hidden="true" />

--- a/src/renderer/src/components/dashboard/widgets/sizes.ts
+++ b/src/renderer/src/components/dashboard/widgets/sizes.ts
@@ -40,8 +40,8 @@ export const WIDGET_SIZES: Readonly<
     minSize: { w: 2, h: 2 },
   },
   health: {
-    defaultSize: { w: 3, h: 2 },
-    minSize: { w: 2, h: 2 },
+    defaultSize: { w: 3, h: 3 },
+    minSize: { w: 2, h: 3 },
   },
   coverage: {
     defaultSize: { w: 6, h: 3 },

--- a/src/renderer/src/components/layout/MainContent.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.browser.test.tsx
@@ -604,6 +604,7 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
       ],
     })
     expect(mockSkillsDeleteSkills).not.toHaveBeenCalled()
+    expect(store.getState().ui.undoToast).toBeNull()
   })
 
   it('keeps failed source rows selected after mixed source and orphan delete', async () => {

--- a/src/renderer/src/components/layout/MainContent.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.browser.test.tsx
@@ -3,6 +3,7 @@ import { Provider } from 'react-redux'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
+import { partitionGlobalDeleteTargets } from '@/renderer/src/components/skills/reviewedDestructiveTargets'
 import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
 import type {
   AgentId,
@@ -520,15 +521,11 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
     }
     mockSkillsDeleteSkills.mockResolvedValue(result)
 
-    store.dispatch(
-      fetchSkills.fulfilled(
-        [
-          makeSkill('brainstorming' as SkillName, true),
-          makeSkill('local-skill' as SkillName, false),
-        ],
-        'req-id',
-      ),
-    )
+    const selectedSkills = [
+      makeSkill('brainstorming' as SkillName, true),
+      makeSkill('local-skill' as SkillName, false),
+    ]
+    store.dispatch(fetchSkills.fulfilled(selectedSkills, 'req-id'))
     store.dispatch(enterBulkSelectMode())
     store.dispatch(
       setBulkConfirm({
@@ -537,6 +534,10 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
         agentId: null,
         agentName: null,
         sourceSummary: null,
+        ...partitionGlobalDeleteTargets(selectedSkills, [
+          'brainstorming' as SkillName,
+          'local-skill' as SkillName,
+        ]),
       }),
     )
 
@@ -587,12 +588,8 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
     })
 
     // Arrange
-    store.dispatch(
-      fetchSkills.fulfilled(
-        [makeSkill(metadataName, false, folderName)],
-        'req',
-      ),
-    )
+    const selectedSkills = [makeSkill(metadataName, false, folderName)]
+    store.dispatch(fetchSkills.fulfilled(selectedSkills, 'req'))
     store.dispatch(
       setBulkConfirm({
         kind: 'delete',
@@ -600,6 +597,7 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
         agentId: null,
         agentName: null,
         sourceSummary: null,
+        ...partitionGlobalDeleteTargets(selectedSkills, [metadataName]),
       }),
     )
 
@@ -805,6 +803,7 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
         agentId: null,
         agentName: null,
         sourceSummary: null,
+        ...partitionGlobalDeleteTargets([orphanSkill], [orphanSkillName]),
       }),
     )
 
@@ -907,6 +906,10 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
         agentId: null,
         agentName: null,
         sourceSummary: null,
+        ...partitionGlobalDeleteTargets(
+          [sourceSkill, orphanSkill],
+          [sourceSkillName, orphanSkillName],
+        ),
       }),
     )
 
@@ -993,6 +996,10 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
         agentId: null,
         agentName: null,
         sourceSummary: null,
+        ...partitionGlobalDeleteTargets(
+          [sourceSkill, orphanSkill],
+          [sourceSkillName, orphanSkillName],
+        ),
       }),
     )
 
@@ -1068,6 +1075,10 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
         agentId: null,
         agentName: null,
         sourceSummary: null,
+        ...partitionGlobalDeleteTargets(
+          [sourceSkill, staleOrphanSkill],
+          [sourceSkillName, orphanSkillName],
+        ),
       }),
     )
 
@@ -1135,6 +1146,10 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
         agentId: null,
         agentName: null,
         sourceSummary: null,
+        ...partitionGlobalDeleteTargets(
+          [sourceSkill, orphanSkill],
+          [sourceSkillName, orphanSkillName],
+        ),
       }),
     )
 
@@ -1190,6 +1205,7 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
         agentId: null,
         agentName: null,
         sourceSummary: null,
+        ...partitionGlobalDeleteTargets([orphanSkill], [orphanSkillName]),
       }),
     )
 
@@ -1239,6 +1255,7 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
         agentId: null,
         agentName: null,
         sourceSummary: null,
+        ...partitionGlobalDeleteTargets([staleOrphanSkill], [orphanSkillName]),
       }),
     )
 
@@ -1258,6 +1275,50 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
         .getByText(/removes reviewed dangling symlinks for 1 orphan skill/)
         .query(),
     ).toBeNull()
+  })
+
+  it('labels stale source rows as delete rescans, not orphan cleanup rescans', async () => {
+    const { screen, store } = await renderMainContent()
+    const { setBulkConfirm } =
+      await import('@/renderer/src/redux/slices/uiSlice')
+    const { fetchSkills } =
+      await import('@/renderer/src/redux/slices/skillsSlice')
+    const sourceSkillName = 'source-missing-identity' as SkillName
+    const staleSourceSkill: Skill = {
+      name: sourceSkillName,
+      description: '',
+      path: '/Users/me/.agents/skills/source-missing-identity' as never,
+      symlinkCount: 0,
+      symlinks: [],
+      isSource: true,
+      isOrphan: false,
+    }
+
+    // Arrange
+    store.dispatch(fetchSkills.fulfilled([staleSourceSkill], 'req-id'))
+    store.dispatch(
+      setBulkConfirm({
+        kind: 'delete',
+        skillNames: [sourceSkillName],
+        agentId: null,
+        agentName: null,
+        sourceSummary: null,
+        ...partitionGlobalDeleteTargets([staleSourceSkill], [sourceSkillName]),
+      }),
+    )
+
+    // Assert
+    await expect
+      .element(
+        screen.getByText(
+          'No selected skills are ready to delete. 1 selected skill needs a rescan before delete because the reviewed filesystem identity is missing.',
+        ),
+      )
+      .toBeVisible()
+    await expect
+      .element(screen.getByRole('button', { name: /^Delete$/ }))
+      .toBeDisabled()
+    expect(screen.getByText(/orphan skill needs a rescan/).query()).toBeNull()
   })
 })
 

--- a/src/renderer/src/components/layout/MainContent.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.browser.test.tsx
@@ -450,11 +450,15 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
    * Build a Skill fixture with either a `source` (CLI-tracked in the lock
    * file) or no source (plain). The pipeline now treats both identically.
    */
-  function makeSkill(name: SkillName, cliTracked: boolean): Skill {
+  function makeSkill(
+    name: SkillName,
+    cliTracked: boolean,
+    folderName: SkillName = name,
+  ): Skill {
     return {
       name,
       description: '',
-      path: `/home/user/.agents/skills/${name}` as Skill['path'],
+      path: `/home/user/.agents/skills/${folderName}` as Skill['path'],
       symlinkCount: 0,
       symlinks: [],
       isSource: true,
@@ -514,18 +518,78 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
 
     await screen.getByRole('button', { name: /^Delete$/ }).click()
 
-    // Single IPC call carrying BOTH names — partition is gone, no second
-    // pipeline. The payload shape is `{ items: [{ skillName }] }`; assert it
-    // verbatim so a future thunk tweak surfaces here.
+    // Single IPC call carrying BOTH reviewed row identities — partition is gone,
+    // no second pipeline. Assert the payload verbatim so thunk tweaks surface.
     await expect.poll(() => mockSkillsDeleteSkills.mock.calls.length).toBe(1)
     expect(mockSkillsDeleteSkills.mock.calls[0][0]).toEqual({
-      items: [{ skillName: 'brainstorming' }, { skillName: 'local-skill' }],
+      items: [
+        {
+          skillName: 'brainstorming',
+          skillPath: '/home/user/.agents/skills/brainstorming',
+        },
+        {
+          skillName: 'local-skill',
+          skillPath: '/home/user/.agents/skills/local-skill',
+        },
+      ],
     })
     // Flush the microtask queue and re-assert: `expect.poll` is satisfied at the
     // first hit, so a regression that triggers a *second* IPC call on a later
     // microtask would otherwise slip through.
     await new Promise((resolve) => setTimeout(resolve, 0))
     expect(mockSkillsDeleteSkills).toHaveBeenCalledTimes(1)
+  })
+
+  it('passes reviewed source path when metadata name differs from folder basename', async () => {
+    const { screen, store } = await renderMainContent()
+    const { setBulkConfirm } =
+      await import('@/renderer/src/redux/slices/uiSlice')
+    const { fetchSkills } =
+      await import('@/renderer/src/redux/slices/skillsSlice')
+    const metadataName = 'metadata-title' as SkillName
+    const folderName = 'folder-basename' as SkillName
+    mockSkillsDeleteSkills.mockResolvedValue({
+      items: [
+        {
+          skillName: metadataName,
+          outcome: 'deleted',
+          tombstoneId: tombstoneId('1729180800000-metadata-title-a1b2c3d4'),
+          symlinksRemoved: 1,
+          cascadeAgents: ['cursor'],
+        },
+      ],
+    })
+
+    // Arrange
+    store.dispatch(
+      fetchSkills.fulfilled(
+        [makeSkill(metadataName, false, folderName)],
+        'req',
+      ),
+    )
+    store.dispatch(
+      setBulkConfirm({
+        kind: 'delete',
+        skillNames: [metadataName],
+        agentId: null,
+        agentName: null,
+        sourceSummary: null,
+      }),
+    )
+
+    // Act
+    await screen.getByRole('button', { name: /^Delete$/ }).click()
+
+    // Assert
+    await expect.poll(() => mockSkillsDeleteSkills.mock.calls.length).toBe(1)
+    expect(mockSkillsDeleteSkills.mock.calls[0][0]).toEqual({
+      items: [
+        {
+          skillName: 'metadata-title',
+          skillPath: '/home/user/.agents/skills/folder-basename',
+        },
+      ],
+    })
   })
 
   it('routes global orphan deletes through reviewed orphan cleanup identity', async () => {

--- a/src/renderer/src/components/layout/MainContent.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.browser.test.tsx
@@ -686,6 +686,148 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
     expect(store.getState().ui.bulkSelectMode).toBe(true)
   })
 
+  it('excludes stale orphan preflight errors from retry selection and names rescan in the summary', async () => {
+    const { screen, store } = await renderMainContent()
+    const { enterBulkSelectMode, setBulkConfirm } =
+      await import('@/renderer/src/redux/slices/uiSlice')
+    const { fetchSkills, toggleSelection } =
+      await import('@/renderer/src/redux/slices/skillsSlice')
+    const sourceSkillName = 'source-task' as SkillName
+    const orphanSkillName = 'stale-abandoned' as SkillName
+    const sourceSkill: Skill = {
+      name: sourceSkillName,
+      description: '',
+      path: '/Users/me/.agents/skills/source-task' as never,
+      symlinkCount: 0,
+      symlinks: [],
+      isSource: true,
+      isOrphan: false,
+    }
+    const staleOrphanSkill: Skill = {
+      name: orphanSkillName,
+      description: '',
+      path: '/Users/me/.agents/skills/stale-abandoned' as never,
+      symlinkCount: 0,
+      symlinks: [
+        {
+          agentId: 'devin' as AgentId,
+          agentName: 'Devin' as never,
+          linkPath: '/Users/me/.config/devin/skills/stale-abandoned' as never,
+          status: 'broken',
+          isLocal: false,
+        },
+      ],
+      isSource: false,
+      isOrphan: true,
+    }
+    mockSkillsDeleteSkills.mockResolvedValue({
+      items: [
+        {
+          skillName: sourceSkillName,
+          outcome: 'deleted',
+          tombstoneId: tombstoneId('source-task-delete'),
+          symlinksRemoved: 0,
+          cascadeAgents: [],
+        },
+      ],
+    } satisfies BulkDeleteResult)
+
+    // Arrange: the source row succeeds, but the orphan row is stale before IPC.
+    store.dispatch(
+      fetchSkills.fulfilled([sourceSkill, staleOrphanSkill], 'req-id'),
+    )
+    store.dispatch(enterBulkSelectMode())
+    store.dispatch(toggleSelection(sourceSkillName))
+    store.dispatch(toggleSelection(orphanSkillName))
+    store.dispatch(
+      setBulkConfirm({
+        kind: 'delete',
+        skillNames: [sourceSkillName, orphanSkillName],
+        agentId: null,
+        agentName: null,
+        sourceSummary: null,
+      }),
+    )
+
+    // Act
+    await screen.getByRole('button', { name: /^Delete$/ }).click()
+
+    // Assert
+    await expect.poll(() => mockSkillsDeleteSkills.mock.calls.length).toBe(1)
+    expect(mockClearOrphanSymlinks).not.toHaveBeenCalled()
+    expect(store.getState().skills.selectedSkillNames).toEqual([])
+    expect(store.getState().ui.bulkSelectMode).toBe(false)
+    expect(store.getState().ui.undoToast?.summary).toBe(
+      'Deleted 1 of 2 skills. 1 orphan skill needs a rescan before cleanup.',
+    )
+  })
+
+  it('restores unresolved mixed delete selection when source delete rejects', async () => {
+    const { screen, store } = await renderMainContent()
+    const { enterBulkSelectMode, setBulkConfirm } =
+      await import('@/renderer/src/redux/slices/uiSlice')
+    const { fetchSkills, toggleSelection } =
+      await import('@/renderer/src/redux/slices/skillsSlice')
+    const sourceSkillName = 'source-task' as SkillName
+    const orphanSkillName = 'abandoned' as SkillName
+    const sourceSkill: Skill = {
+      name: sourceSkillName,
+      description: '',
+      path: '/Users/me/.agents/skills/source-task' as never,
+      symlinkCount: 0,
+      symlinks: [],
+      isSource: true,
+      isOrphan: false,
+    }
+    const orphanSkill: Skill = {
+      name: orphanSkillName,
+      description: '',
+      path: '/Users/me/.agents/skills/abandoned' as never,
+      symlinkCount: 0,
+      symlinks: [
+        {
+          agentId: 'devin' as AgentId,
+          agentName: 'Devin' as never,
+          linkPath: '/Users/me/.config/devin/skills/abandoned' as never,
+          targetPath: '/Users/me/.agents/skills/abandoned' as never,
+          status: 'broken',
+          isLocal: false,
+        },
+      ],
+      isSource: false,
+      isOrphan: true,
+    }
+    mockSkillsDeleteSkills.mockRejectedValueOnce(new Error('Disk offline'))
+
+    // Arrange: source delete rejects before orphan cleanup can run, so both
+    // unresolved rows must remain selected for a later retry.
+    store.dispatch(fetchSkills.fulfilled([sourceSkill, orphanSkill], 'req-id'))
+    store.dispatch(enterBulkSelectMode())
+    store.dispatch(toggleSelection(sourceSkillName))
+    store.dispatch(toggleSelection(orphanSkillName))
+    store.dispatch(
+      setBulkConfirm({
+        kind: 'delete',
+        skillNames: [sourceSkillName, orphanSkillName],
+        agentId: null,
+        agentName: null,
+        sourceSummary: null,
+      }),
+    )
+
+    // Act
+    await screen.getByRole('button', { name: /^Delete$/ }).click()
+
+    // Assert
+    await expect.poll(() => mockSkillsDeleteSkills.mock.calls.length).toBe(1)
+    expect(mockClearOrphanSymlinks).not.toHaveBeenCalled()
+    expect(store.getState().skills.selectedSkillNames).toEqual([
+      sourceSkillName,
+      orphanSkillName,
+    ])
+    expect(store.getState().ui.bulkSelectMode).toBe(true)
+  })
+
   it('does not count stale orphan rows as cleanup-ready in delete confirmation', async () => {
     const { screen, store } = await renderMainContent()
     const { setBulkConfirm } =

--- a/src/renderer/src/components/layout/MainContent.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.browser.test.tsx
@@ -7,6 +7,7 @@ import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
 import type {
   AgentId,
   BulkDeleteResult,
+  FilesystemEntryIdentity,
   Skill,
   SkillName,
   SymlinkInfo,
@@ -19,6 +20,15 @@ const mockOnDeleteProgress = vi.fn(() => () => {})
 const mockSkillsDeleteSkills = vi.fn()
 const mockClearOrphanSymlinks = vi.fn()
 const mockRefreshAllData = vi.hoisted(() => vi.fn())
+
+const directoryIdentity: FilesystemEntryIdentity = {
+  kind: 'directory',
+  dev: 1,
+  ino: 2,
+  size: 96,
+  ctimeMs: 3,
+  mtimeMs: 4,
+}
 
 /**
  * Short-circuit every heavy child MainContent renders so tests focus on the
@@ -186,6 +196,7 @@ function makeSourceSkill(name: string, source: string): Skill {
     name: name as SkillName,
     description: '',
     path: `/skills/${name}` as never,
+    filesystemIdentity: directoryIdentity,
     symlinkCount: 0,
     symlinks: [],
     isSource: true,
@@ -305,6 +316,7 @@ describe('MainContent keyboard shortcuts (Cmd+A)', () => {
         name: 'task' as SkillName,
         description: '',
         path: '/skills/task' as never,
+        filesystemIdentity: directoryIdentity,
         symlinkCount: 0,
         symlinks: [],
         isSource: true,
@@ -314,6 +326,7 @@ describe('MainContent keyboard shortcuts (Cmd+A)', () => {
         name: 'tdd' as SkillName,
         description: '',
         path: '/skills/tdd' as never,
+        filesystemIdentity: directoryIdentity,
         symlinkCount: 0,
         symlinks: [],
         isSource: true,
@@ -459,6 +472,7 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
       name,
       description: '',
       path: `/home/user/.agents/skills/${folderName}` as Skill['path'],
+      filesystemIdentity: directoryIdentity,
       symlinkCount: 0,
       symlinks: [],
       isSource: true,
@@ -526,10 +540,12 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
         {
           skillName: 'brainstorming',
           skillPath: '/home/user/.agents/skills/brainstorming',
+          filesystemIdentity: directoryIdentity,
         },
         {
           skillName: 'local-skill',
           skillPath: '/home/user/.agents/skills/local-skill',
+          filesystemIdentity: directoryIdentity,
         },
       ],
     })
@@ -587,6 +603,7 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
         {
           skillName: 'metadata-title',
           skillPath: '/home/user/.agents/skills/folder-basename',
+          filesystemIdentity: directoryIdentity,
         },
       ],
     })
@@ -683,6 +700,7 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
       name: sourceSkillName,
       description: '',
       path: '/Users/me/.agents/skills/source-task' as never,
+      filesystemIdentity: directoryIdentity,
       symlinkCount: 0,
       symlinks: [],
       isSource: true,
@@ -765,6 +783,7 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
       name: sourceSkillName,
       description: '',
       path: '/Users/me/.agents/skills/source-task' as never,
+      filesystemIdentity: directoryIdentity,
       symlinkCount: 0,
       symlinks: [],
       isSource: true,
@@ -841,6 +860,7 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
       name: sourceSkillName,
       description: '',
       path: '/Users/me/.agents/skills/source-task' as never,
+      filesystemIdentity: directoryIdentity,
       symlinkCount: 0,
       symlinks: [],
       isSource: true,
@@ -1118,6 +1138,7 @@ describe('MainContent SkillTypeFilter dropdown options', () => {
       name: 'linked-one' as SkillName,
       description: '',
       path: '/skills/linked-one' as never,
+      filesystemIdentity: directoryIdentity,
       symlinkCount: 1,
       symlinks: [
         {

--- a/src/renderer/src/components/layout/MainContent.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.browser.test.tsx
@@ -831,6 +831,59 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
     expect(mockRefreshAllData).toHaveBeenCalledTimes(1)
   })
 
+  it('restores orphan-only selection and refreshes when reviewed orphan cleanup rejects', async () => {
+    const { screen, store } = await renderMainContent()
+    const { enterBulkSelectMode, setBulkConfirm } =
+      await import('@/renderer/src/redux/slices/uiSlice')
+    const { fetchSkills, toggleSelection } =
+      await import('@/renderer/src/redux/slices/skillsSlice')
+    const orphanSkillName = 'abandoned' as SkillName
+    const orphanSkill: Skill = {
+      name: orphanSkillName,
+      description: '',
+      path: '/Users/me/.agents/skills/abandoned' as never,
+      symlinkCount: 0,
+      symlinks: [
+        {
+          agentId: 'devin' as AgentId,
+          agentName: 'Devin' as never,
+          linkPath: '/Users/me/.config/devin/skills/abandoned' as never,
+          targetPath: '/Users/me/.agents/skills/abandoned' as never,
+          status: 'broken',
+          isLocal: false,
+        },
+      ],
+      isSource: false,
+      isOrphan: true,
+    }
+    mockClearOrphanSymlinks.mockRejectedValueOnce(new Error('Disk offline'))
+
+    // Arrange
+    store.dispatch(fetchSkills.fulfilled([orphanSkill], 'req-id'))
+    store.dispatch(enterBulkSelectMode())
+    store.dispatch(toggleSelection(orphanSkillName))
+    store.dispatch(
+      setBulkConfirm({
+        kind: 'delete',
+        skillNames: [orphanSkillName],
+        agentId: null,
+        agentName: null,
+        sourceSummary: null,
+      }),
+    )
+
+    // Act
+    await screen.getByRole('button', { name: /^Delete$/ }).click()
+
+    // Assert
+    await expect.poll(() => mockClearOrphanSymlinks.mock.calls.length).toBe(1)
+    expect(store.getState().skills.selectedSkillNames).toEqual([
+      orphanSkillName,
+    ])
+    expect(store.getState().ui.bulkSelectMode).toBe(true)
+    expect(mockRefreshAllData).toHaveBeenCalledTimes(1)
+  })
+
   it('does not count stale orphan rows as cleanup-ready in delete confirmation', async () => {
     const { screen, store } = await renderMainContent()
     const { setBulkConfirm } =
@@ -876,6 +929,9 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
         ),
       )
       .toBeVisible()
+    await expect
+      .element(screen.getByRole('button', { name: /^Delete$/ }))
+      .toBeDisabled()
     expect(
       screen
         .getByText(/removes reviewed dangling symlinks for 1 orphan skill/)

--- a/src/renderer/src/components/layout/MainContent.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.browser.test.tsx
@@ -17,6 +17,7 @@ const mockGetAll = vi.fn()
 const mockShellOpenExternal = vi.fn()
 const mockOnDeleteProgress = vi.fn(() => () => {})
 const mockSkillsDeleteSkills = vi.fn()
+const mockClearOrphanSymlinks = vi.fn()
 
 /**
  * Short-circuit every heavy child MainContent renders so tests focus on the
@@ -76,6 +77,7 @@ beforeEach(() => {
   mockOnDeleteProgress.mockReset()
   mockOnDeleteProgress.mockImplementation(() => () => {})
   mockSkillsDeleteSkills.mockReset()
+  mockClearOrphanSymlinks.mockReset()
   // Install the `electron` IPC bridge — browser mode replaces the preload
   // context, so tests that exercise `window.electron.*` must plant a fake
   // before MainContent's mount effect fires.
@@ -84,6 +86,7 @@ beforeEach(() => {
       getAll: mockGetAll,
       onDeleteProgress: mockOnDeleteProgress,
       deleteSkills: mockSkillsDeleteSkills,
+      clearOrphanSymlinks: mockClearOrphanSymlinks,
     },
     shell: {
       openExternal: mockShellOpenExternal,
@@ -521,6 +524,77 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
     // microtask would otherwise slip through.
     await new Promise((resolve) => setTimeout(resolve, 0))
     expect(mockSkillsDeleteSkills).toHaveBeenCalledTimes(1)
+  })
+
+  it('routes global orphan deletes through reviewed orphan cleanup identity', async () => {
+    const { screen, store } = await renderMainContent()
+    const { setBulkConfirm } =
+      await import('@/renderer/src/redux/slices/uiSlice')
+    const { fetchSkills } =
+      await import('@/renderer/src/redux/slices/skillsSlice')
+    const orphanSkillName = 'abandoned' as SkillName
+    const orphanSkill: Skill = {
+      name: orphanSkillName,
+      description: '',
+      path: '/Users/me/.agents/skills/abandoned' as never,
+      symlinkCount: 0,
+      symlinks: [
+        {
+          agentId: 'devin' as AgentId,
+          agentName: 'Devin' as never,
+          linkPath: '/Users/me/.config/devin/skills/abandoned' as never,
+          targetPath: '/Users/me/.agents/skills/abandoned' as never,
+          status: 'broken',
+          isLocal: false,
+        },
+      ],
+      isSource: false,
+      isOrphan: true,
+    }
+    mockClearOrphanSymlinks.mockResolvedValue({
+      items: [
+        {
+          skillName: orphanSkillName,
+          outcome: 'orphan-cleared',
+          symlinksRemoved: 1,
+          cascadeAgents: ['devin'],
+        },
+      ],
+    })
+
+    // Arrange: the global confirmation references an orphan row; this must not
+    // fall back to deleteSkills because that path rescans by name in main.
+    store.dispatch(fetchSkills.fulfilled([orphanSkill], 'req-id'))
+    store.dispatch(
+      setBulkConfirm({
+        kind: 'delete',
+        skillNames: [orphanSkillName],
+        agentId: null,
+        agentName: null,
+        sourceSummary: null,
+      }),
+    )
+
+    // Act
+    await screen.getByRole('button', { name: /^Delete$/ }).click()
+
+    // Assert
+    await expect.poll(() => mockClearOrphanSymlinks.mock.calls.length).toBe(1)
+    expect(mockClearOrphanSymlinks.mock.calls[0][0]).toEqual({
+      items: [
+        {
+          skillName: 'abandoned',
+          agents: [
+            {
+              agentId: 'devin',
+              linkPath: '/Users/me/.config/devin/skills/abandoned',
+              targetPath: '/Users/me/.agents/skills/abandoned',
+            },
+          ],
+        },
+      ],
+    })
+    expect(mockSkillsDeleteSkills).not.toHaveBeenCalled()
   })
 })
 

--- a/src/renderer/src/components/layout/MainContent.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.browser.test.tsx
@@ -603,6 +603,140 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
     })
     expect(mockSkillsDeleteSkills).not.toHaveBeenCalled()
   })
+
+  it('keeps failed source rows selected after mixed source and orphan delete', async () => {
+    const { screen, store } = await renderMainContent()
+    const { enterBulkSelectMode, setBulkConfirm } =
+      await import('@/renderer/src/redux/slices/uiSlice')
+    const { fetchSkills, toggleSelection } =
+      await import('@/renderer/src/redux/slices/skillsSlice')
+    const sourceSkillName = 'source-task' as SkillName
+    const orphanSkillName = 'abandoned' as SkillName
+    const sourceSkill: Skill = {
+      name: sourceSkillName,
+      description: '',
+      path: '/Users/me/.agents/skills/source-task' as never,
+      symlinkCount: 0,
+      symlinks: [],
+      isSource: true,
+      isOrphan: false,
+    }
+    const orphanSkill: Skill = {
+      name: orphanSkillName,
+      description: '',
+      path: '/Users/me/.agents/skills/abandoned' as never,
+      symlinkCount: 0,
+      symlinks: [
+        {
+          agentId: 'devin' as AgentId,
+          agentName: 'Devin' as never,
+          linkPath: '/Users/me/.config/devin/skills/abandoned' as never,
+          targetPath: '/Users/me/.agents/skills/abandoned' as never,
+          status: 'broken',
+          isLocal: false,
+        },
+      ],
+      isSource: false,
+      isOrphan: true,
+    }
+    mockSkillsDeleteSkills.mockResolvedValue({
+      items: [
+        {
+          skillName: sourceSkillName,
+          outcome: 'error',
+          error: { message: 'Disk denied' },
+        },
+      ],
+    } satisfies BulkDeleteResult)
+    mockClearOrphanSymlinks.mockResolvedValue({
+      items: [
+        {
+          skillName: orphanSkillName,
+          outcome: 'orphan-cleared',
+          symlinksRemoved: 1,
+          cascadeAgents: ['devin'],
+        },
+      ],
+    })
+
+    // Arrange: mixed batch has one retryable source failure and one orphan
+    // cleanup success; the source failure must stay selected for retry.
+    store.dispatch(fetchSkills.fulfilled([sourceSkill, orphanSkill], 'req-id'))
+    store.dispatch(enterBulkSelectMode())
+    store.dispatch(toggleSelection(sourceSkillName))
+    store.dispatch(toggleSelection(orphanSkillName))
+    store.dispatch(
+      setBulkConfirm({
+        kind: 'delete',
+        skillNames: [sourceSkillName, orphanSkillName],
+        agentId: null,
+        agentName: null,
+        sourceSummary: null,
+      }),
+    )
+
+    // Act
+    await screen.getByRole('button', { name: /^Delete$/ }).click()
+
+    // Assert
+    await expect.poll(() => mockClearOrphanSymlinks.mock.calls.length).toBe(1)
+    expect(store.getState().skills.selectedSkillNames).toEqual([
+      sourceSkillName,
+    ])
+    expect(store.getState().ui.bulkSelectMode).toBe(true)
+  })
+
+  it('does not count stale orphan rows as cleanup-ready in delete confirmation', async () => {
+    const { screen, store } = await renderMainContent()
+    const { setBulkConfirm } =
+      await import('@/renderer/src/redux/slices/uiSlice')
+    const { fetchSkills } =
+      await import('@/renderer/src/redux/slices/skillsSlice')
+    const orphanSkillName = 'stale-abandoned' as SkillName
+    const staleOrphanSkill: Skill = {
+      name: orphanSkillName,
+      description: '',
+      path: '/Users/me/.agents/skills/stale-abandoned' as never,
+      symlinkCount: 0,
+      symlinks: [
+        {
+          agentId: 'devin' as AgentId,
+          agentName: 'Devin' as never,
+          linkPath: '/Users/me/.config/devin/skills/stale-abandoned' as never,
+          status: 'broken',
+          isLocal: false,
+        },
+      ],
+      isSource: false,
+      isOrphan: true,
+    }
+
+    // Arrange
+    store.dispatch(fetchSkills.fulfilled([staleOrphanSkill], 'req-id'))
+    store.dispatch(
+      setBulkConfirm({
+        kind: 'delete',
+        skillNames: [orphanSkillName],
+        agentId: null,
+        agentName: null,
+        sourceSummary: null,
+      }),
+    )
+
+    // Assert
+    await expect
+      .element(
+        screen.getByText(
+          'No selected orphan skills are cleanup-ready. 1 orphan skill needs a rescan before cleanup because the reviewed target identity is missing.',
+        ),
+      )
+      .toBeVisible()
+    expect(
+      screen
+        .getByText(/removes reviewed dangling symlinks for 1 orphan skill/)
+        .query(),
+    ).toBeNull()
+  })
 })
 
 describe('MainContent SkillTypeFilter dropdown options', () => {

--- a/src/renderer/src/components/layout/MainContent.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.browser.test.tsx
@@ -576,6 +576,13 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
     )
 
     // Act
+    await expect
+      .element(
+        screen.getByText(
+          'This removes reviewed dangling symlinks for 1 orphan skill. Source skill files are already missing, and this cleanup cannot be undone from the notification.',
+        ),
+      )
+      .toBeVisible()
     await screen.getByRole('button', { name: /^Delete$/ }).click()
 
     // Assert

--- a/src/renderer/src/components/layout/MainContent.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.browser.test.tsx
@@ -19,7 +19,9 @@ const mockShellOpenExternal = vi.fn()
 const mockOnDeleteProgress = vi.fn(() => () => {})
 const mockSkillsDeleteSkills = vi.fn()
 const mockClearOrphanSymlinks = vi.fn()
+const mockUnlinkManyFromAgent = vi.fn()
 const mockRefreshAllData = vi.hoisted(() => vi.fn())
+const mockSelectionToolbarState = vi.hoisted(() => ({ enabled: false }))
 
 const directoryIdentity: FilesystemEntryIdentity = {
   kind: 'directory',
@@ -46,7 +48,12 @@ vi.mock('../skills/SearchBox', () => ({
   SearchBox: () => null,
 }))
 vi.mock('../skills/SelectionToolbar', () => ({
-  SelectionToolbar: () => null,
+  SelectionToolbar: ({ onPrimaryAction }: { onPrimaryAction: () => void }) =>
+    mockSelectionToolbarState.enabled ? (
+      <button type="button" onClick={onPrimaryAction}>
+        Open bulk confirm
+      </button>
+    ) : null,
 }))
 vi.mock('../skills/UnlinkDialog', () => ({
   UnlinkDialog: () => null,
@@ -89,7 +96,9 @@ beforeEach(() => {
   mockOnDeleteProgress.mockImplementation(() => () => {})
   mockSkillsDeleteSkills.mockReset()
   mockClearOrphanSymlinks.mockReset()
+  mockUnlinkManyFromAgent.mockReset()
   mockRefreshAllData.mockReset()
+  mockSelectionToolbarState.enabled = false
   // Install the `electron` IPC bridge — browser mode replaces the preload
   // context, so tests that exercise `window.electron.*` must plant a fake
   // before MainContent's mount effect fires.
@@ -99,6 +108,7 @@ beforeEach(() => {
       onDeleteProgress: mockOnDeleteProgress,
       deleteSkills: mockSkillsDeleteSkills,
       clearOrphanSymlinks: mockClearOrphanSymlinks,
+      unlinkManyFromAgent: mockUnlinkManyFromAgent,
     },
     shell: {
       openExternal: mockShellOpenExternal,
@@ -609,6 +619,146 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
     })
   })
 
+  it('uses toolbar-captured delete targets when live rows drift before confirm', async () => {
+    mockSelectionToolbarState.enabled = true
+    const { screen, store } = await renderMainContent()
+    const { enterBulkSelectMode } =
+      await import('@/renderer/src/redux/slices/uiSlice')
+    const { fetchSkills, toggleSelection } =
+      await import('@/renderer/src/redux/slices/skillsSlice')
+    const skillName = 'snapshot-delete' as SkillName
+    const originalSkill = makeSkill(
+      skillName,
+      false,
+      'reviewed-folder' as SkillName,
+    )
+    const replacementSkill: Skill = {
+      ...originalSkill,
+      path: '/home/user/.agents/skills/replacement-folder' as never,
+      filesystemIdentity: {
+        ...directoryIdentity,
+        ino: 999,
+      },
+    }
+    mockSkillsDeleteSkills.mockResolvedValue({
+      items: [
+        {
+          skillName,
+          outcome: 'deleted',
+          tombstoneId: tombstoneId('1729180800000-snapshot-delete-a1b2c3d4'),
+          symlinksRemoved: 0,
+          cascadeAgents: [],
+        },
+      ],
+    } satisfies BulkDeleteResult)
+
+    // Arrange: open the real bulk-confirm path, then replace the live row with
+    // the same display name but a different reviewed filesystem identity.
+    store.dispatch(fetchSkills.fulfilled([originalSkill], 'req-original'))
+    store.dispatch(enterBulkSelectMode())
+    store.dispatch(toggleSelection(skillName))
+    await screen.getByRole('button', { name: 'Open bulk confirm' }).click()
+    store.dispatch(fetchSkills.fulfilled([replacementSkill], 'req-replace'))
+
+    // Act
+    await screen.getByRole('button', { name: /^Delete$/ }).click()
+
+    // Assert
+    await expect.poll(() => mockSkillsDeleteSkills.mock.calls.length).toBe(1)
+    expect(mockSkillsDeleteSkills.mock.calls[0][0]).toEqual({
+      items: [
+        {
+          skillName: 'snapshot-delete',
+          skillPath: '/home/user/.agents/skills/reviewed-folder',
+          filesystemIdentity: directoryIdentity,
+        },
+      ],
+    })
+  })
+
+  it('uses toolbar-captured unlink targets when live rows drift before confirm', async () => {
+    mockSelectionToolbarState.enabled = true
+    const { screen, store } = await renderMainContent()
+    const { fetchAgents } =
+      await import('@/renderer/src/redux/slices/agentsSlice')
+    const { enterBulkSelectMode, selectAgent } =
+      await import('@/renderer/src/redux/slices/uiSlice')
+    const { fetchSkills, toggleSelection } =
+      await import('@/renderer/src/redux/slices/skillsSlice')
+    const skillName = 'snapshot-unlink' as SkillName
+    const originalSkill: Skill = {
+      name: skillName,
+      description: '',
+      path: '/home/user/.agents/skills/snapshot-unlink' as never,
+      filesystemIdentity: directoryIdentity,
+      symlinkCount: 1,
+      symlinks: [
+        {
+          agentId: 'cursor' as AgentId,
+          agentName: 'Cursor' as never,
+          linkPath: '/home/user/.cursor/skills/reviewed-link' as never,
+          targetPath: '/home/user/.agents/skills/reviewed-target' as never,
+          status: 'valid',
+          isLocal: false,
+        },
+      ],
+      isSource: true,
+      isOrphan: false,
+    }
+    const replacementSkill: Skill = {
+      ...originalSkill,
+      symlinks: [
+        {
+          ...originalSkill.symlinks[0],
+          linkPath: '/home/user/.cursor/skills/replacement-link' as never,
+          targetPath: '/home/user/.agents/skills/replacement-target' as never,
+        } as SymlinkInfo,
+      ],
+    }
+    mockUnlinkManyFromAgent.mockResolvedValue({
+      items: [{ skillName, outcome: 'unlinked' }],
+    })
+
+    // Arrange
+    store.dispatch(
+      fetchAgents.fulfilled(
+        [
+          {
+            id: 'cursor' as AgentId,
+            name: 'Cursor' as never,
+            path: '/home/user/.cursor/skills' as never,
+            exists: true,
+            skillCount: 1,
+            localSkillCount: 0,
+          },
+        ],
+        'req-agent',
+      ),
+    )
+    store.dispatch(selectAgent('cursor' as AgentId))
+    store.dispatch(fetchSkills.fulfilled([originalSkill], 'req-original'))
+    store.dispatch(enterBulkSelectMode())
+    store.dispatch(toggleSelection(skillName))
+    await screen.getByRole('button', { name: 'Open bulk confirm' }).click()
+    store.dispatch(fetchSkills.fulfilled([replacementSkill], 'req-replace'))
+
+    // Act
+    await screen.getByRole('button', { name: /^Unlink$/ }).click()
+
+    // Assert
+    await expect.poll(() => mockUnlinkManyFromAgent.mock.calls.length).toBe(1)
+    expect(mockUnlinkManyFromAgent.mock.calls[0][0]).toEqual({
+      agentId: 'cursor',
+      items: [
+        {
+          skillName: 'snapshot-unlink',
+          linkPath: '/home/user/.cursor/skills/reviewed-link',
+          targetPath: '/home/user/.agents/skills/reviewed-target',
+        },
+      ],
+    })
+  })
+
   it('routes global orphan deletes through reviewed orphan cleanup identity', async () => {
     const { screen, store } = await renderMainContent()
     const { setBulkConfirm } =
@@ -746,6 +896,92 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
 
     // Arrange: mixed batch has one retryable source failure and one orphan
     // cleanup success; the source failure must stay selected for retry.
+    store.dispatch(fetchSkills.fulfilled([sourceSkill, orphanSkill], 'req-id'))
+    store.dispatch(enterBulkSelectMode())
+    store.dispatch(toggleSelection(sourceSkillName))
+    store.dispatch(toggleSelection(orphanSkillName))
+    store.dispatch(
+      setBulkConfirm({
+        kind: 'delete',
+        skillNames: [sourceSkillName, orphanSkillName],
+        agentId: null,
+        agentName: null,
+        sourceSummary: null,
+      }),
+    )
+
+    // Act
+    await screen.getByRole('button', { name: /^Delete$/ }).click()
+
+    // Assert
+    await expect.poll(() => mockClearOrphanSymlinks.mock.calls.length).toBe(1)
+    expect(store.getState().skills.selectedSkillNames).toEqual([
+      sourceSkillName,
+    ])
+    expect(store.getState().ui.bulkSelectMode).toBe(true)
+  })
+
+  it('keeps source ESTALE selected instead of treating it as orphan rescan', async () => {
+    const { screen, store } = await renderMainContent()
+    const { enterBulkSelectMode, setBulkConfirm } =
+      await import('@/renderer/src/redux/slices/uiSlice')
+    const { fetchSkills, toggleSelection } =
+      await import('@/renderer/src/redux/slices/skillsSlice')
+    const sourceSkillName = 'source-stale-task' as SkillName
+    const orphanSkillName = 'abandoned' as SkillName
+    const sourceSkill: Skill = {
+      name: sourceSkillName,
+      description: '',
+      path: '/Users/me/.agents/skills/source-stale-task' as never,
+      filesystemIdentity: directoryIdentity,
+      symlinkCount: 0,
+      symlinks: [],
+      isSource: true,
+      isOrphan: false,
+    }
+    const orphanSkill: Skill = {
+      name: orphanSkillName,
+      description: '',
+      path: '/Users/me/.agents/skills/abandoned' as never,
+      symlinkCount: 0,
+      symlinks: [
+        {
+          agentId: 'devin' as AgentId,
+          agentName: 'Devin' as never,
+          linkPath: '/Users/me/.config/devin/skills/abandoned' as never,
+          targetPath: '/Users/me/.agents/skills/abandoned' as never,
+          status: 'broken',
+          isLocal: false,
+        },
+      ],
+      isSource: false,
+      isOrphan: true,
+    }
+    mockSkillsDeleteSkills.mockResolvedValue({
+      items: [
+        {
+          skillName: sourceSkillName,
+          outcome: 'error',
+          error: {
+            message: 'Reviewed skill folder changed since review',
+            code: 'ESTALE',
+          },
+        },
+      ],
+    } satisfies BulkDeleteResult)
+    mockClearOrphanSymlinks.mockResolvedValue({
+      items: [
+        {
+          skillName: orphanSkillName,
+          outcome: 'orphan-cleared',
+          symlinksRemoved: 1,
+          cascadeAgents: ['devin'],
+        },
+      ],
+    })
+
+    // Arrange: source ESTALE is retry-visible; only orphan ESTALE/preflight
+    // rows should become rescan-required and be removed from retry selection.
     store.dispatch(fetchSkills.fulfilled([sourceSkill, orphanSkill], 'req-id'))
     store.dispatch(enterBulkSelectMode())
     store.dispatch(toggleSelection(sourceSkillName))

--- a/src/renderer/src/components/layout/MainContent.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.browser.test.tsx
@@ -18,6 +18,7 @@ const mockShellOpenExternal = vi.fn()
 const mockOnDeleteProgress = vi.fn(() => () => {})
 const mockSkillsDeleteSkills = vi.fn()
 const mockClearOrphanSymlinks = vi.fn()
+const mockRefreshAllData = vi.hoisted(() => vi.fn())
 
 /**
  * Short-circuit every heavy child MainContent renders so tests focus on the
@@ -59,7 +60,7 @@ vi.mock('../skills/UndoToast', () => ({
   UndoToast: () => null,
 }))
 vi.mock('../../redux/thunks', () => ({
-  refreshAllData: vi.fn(),
+  refreshAllData: mockRefreshAllData,
 }))
 vi.mock('sonner', () => ({
   toast: Object.assign(vi.fn(), {
@@ -78,6 +79,7 @@ beforeEach(() => {
   mockOnDeleteProgress.mockImplementation(() => () => {})
   mockSkillsDeleteSkills.mockReset()
   mockClearOrphanSymlinks.mockReset()
+  mockRefreshAllData.mockReset()
   // Install the `electron` IPC bridge — browser mode replaces the preload
   // context, so tests that exercise `window.electron.*` must plant a fake
   // before MainContent's mount effect fires.
@@ -826,6 +828,7 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
       orphanSkillName,
     ])
     expect(store.getState().ui.bulkSelectMode).toBe(true)
+    expect(mockRefreshAllData).toHaveBeenCalledTimes(1)
   })
 
   it('does not count stale orphan rows as cleanup-ready in delete confirmation', async () => {

--- a/src/renderer/src/components/layout/MainContent.selectionToolbar.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.selectionToolbar.browser.test.tsx
@@ -72,19 +72,20 @@ const CURSOR_AGENT: Agent = {
 function makeCursorSkill(
   name: SkillName,
   status: SymlinkInfo['status'],
+  slotName: SkillName = name,
 ): Skill {
   return {
     name,
     description: '',
-    path: `/Users/test/.agents/skills/${name}`,
+    path: `/Users/test/.agents/skills/${slotName}`,
     symlinkCount: status === 'missing' ? 0 : 1,
     symlinks: [
       {
         agentId: 'cursor',
         agentName: 'Cursor',
         status,
-        linkPath: `/Users/test/.cursor/skills/${name}`,
-        targetPath: `/Users/test/.agents/skills/${name}`,
+        linkPath: `/Users/test/.cursor/skills/${slotName}`,
+        targetPath: `/Users/test/.agents/skills/${slotName}`,
         isLocal: false,
       },
     ],
@@ -165,13 +166,15 @@ describe('MainContent SelectionToolbar integration', () => {
       await import('@/renderer/src/redux/slices/uiSlice')
     const { fetchSkills, toggleSelection } =
       await import('@/renderer/src/redux/slices/skillsSlice')
+    const metadataName = 'valid-toolbar-task' as SkillName
+    const slotName = 'valid-toolbar-folder' as SkillName
 
     // Arrange
     store.dispatch(fetchAgents.fulfilled([CURSOR_AGENT], 'agents-req'))
     store.dispatch(
       fetchSkills.fulfilled(
         [
-          makeCursorSkill('valid-toolbar-task' as SkillName, 'valid'),
+          makeCursorSkill(metadataName, 'valid', slotName),
           makeCursorSkill('broken-toolbar-task' as SkillName, 'broken'),
           makeCursorSkill(
             'inaccessible-toolbar-task' as SkillName,
@@ -183,7 +186,7 @@ describe('MainContent SelectionToolbar integration', () => {
     )
     store.dispatch(selectAgent('cursor'))
     store.dispatch(enterBulkSelectMode())
-    store.dispatch(toggleSelection('valid-toolbar-task' as SkillName))
+    store.dispatch(toggleSelection(metadataName))
     store.dispatch(toggleSelection('broken-toolbar-task' as SkillName))
 
     // Act
@@ -195,9 +198,7 @@ describe('MainContent SelectionToolbar integration', () => {
     await screen.getByRole('button', { name: 'Select all visible' }).click()
 
     // Assert
-    expect(store.getState().skills.selectedSkillNames).toEqual([
-      'valid-toolbar-task',
-    ])
+    expect(store.getState().skills.selectedSkillNames).toEqual([metadataName])
 
     await screen
       .getByRole('button', { name: 'Unlink selected skill from Cursor' })
@@ -207,7 +208,12 @@ describe('MainContent SelectionToolbar integration', () => {
     await expect.poll(() => mockUnlinkManyFromAgent.mock.calls.length).toBe(1)
     expect(mockUnlinkManyFromAgent).toHaveBeenCalledWith({
       agentId: 'cursor',
-      items: [{ skillName: 'valid-toolbar-task' }],
+      items: [
+        {
+          skillName: 'valid-toolbar-task',
+          linkPath: '/Users/test/.cursor/skills/valid-toolbar-folder',
+        },
+      ],
     })
   })
 })

--- a/src/renderer/src/components/layout/MainContent.selectionToolbar.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.selectionToolbar.browser.test.tsx
@@ -184,11 +184,14 @@ describe('MainContent SelectionToolbar integration', () => {
     store.dispatch(selectAgent('cursor'))
     store.dispatch(enterBulkSelectMode())
     store.dispatch(toggleSelection('valid-toolbar-task' as SkillName))
+    store.dispatch(toggleSelection('broken-toolbar-task' as SkillName))
 
     // Act
     await expect
       .element(screen.getByRole('group', { name: 'Bulk selection actions' }))
       .toBeVisible()
+    await expect.element(screen.getByText('+1 not eligible')).toBeVisible()
+    expect(screen.getByText(/hidden by filter/).query()).toBeNull()
     await screen.getByRole('button', { name: 'Select all visible' }).click()
 
     // Assert

--- a/src/renderer/src/components/layout/MainContent.selectionToolbar.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.selectionToolbar.browser.test.tsx
@@ -212,6 +212,7 @@ describe('MainContent SelectionToolbar integration', () => {
         {
           skillName: 'valid-toolbar-task',
           linkPath: '/Users/test/.cursor/skills/valid-toolbar-folder',
+          targetPath: '/Users/test/.agents/skills/valid-toolbar-folder',
         },
       ],
     })

--- a/src/renderer/src/components/layout/MainContent.selectionToolbar.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.selectionToolbar.browser.test.tsx
@@ -1,0 +1,210 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
+import type { Agent, Skill, SkillName, SymlinkInfo } from '@/shared/types'
+
+const mockUnlinkManyFromAgent = vi.fn()
+const mockOnDeleteProgress = vi.fn(() => () => {})
+const mockRefreshAllData = vi.hoisted(() => vi.fn())
+
+vi.mock('../skills/SkillsList', () => ({
+  SkillsList: () => null,
+}))
+vi.mock('../marketplace', () => ({
+  SkillsMarketplace: () => null,
+}))
+vi.mock('../skills/SearchBox', () => ({
+  SearchBox: () => null,
+}))
+vi.mock('../skills/UnlinkDialog', () => ({
+  UnlinkDialog: () => null,
+}))
+vi.mock('../skills/AddSymlinkModal', () => ({
+  AddSymlinkModal: () => null,
+}))
+vi.mock('../skills/CopyToAgentsModal', () => ({
+  CopyToAgentsModal: () => null,
+}))
+vi.mock('../sidebar/SyncConfirmDialog', () => ({
+  SyncConfirmDialog: () => null,
+}))
+vi.mock('../sidebar/SyncConflictDialog', () => ({
+  SyncConflictDialog: () => null,
+}))
+vi.mock('../sidebar/SyncResultDialog', () => ({
+  SyncResultDialog: () => null,
+}))
+vi.mock('../skills/UndoToast', () => ({
+  UndoToast: () => null,
+}))
+vi.mock('../../redux/thunks', () => ({
+  refreshAllData: mockRefreshAllData,
+}))
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    custom: vi.fn(() => 'toast-id'),
+    dismiss: vi.fn(),
+  }),
+}))
+
+const CURSOR_AGENT: Agent = {
+  id: 'cursor',
+  name: 'Cursor',
+  path: '/Users/test/.cursor/skills',
+  exists: true,
+  skillCount: 3,
+  localSkillCount: 0,
+}
+
+/**
+ * Build a source skill with one Cursor slot for toolbar integration tests.
+ * @param name - Skill name shown in Redux and bulk payloads.
+ * @param status - Cursor symlink status for this row.
+ * @returns Skill fixture loaded through the real skills reducer.
+ * @example makeCursorSkill('task', 'valid').symlinks[0]?.status // => 'valid'
+ */
+function makeCursorSkill(
+  name: SkillName,
+  status: SymlinkInfo['status'],
+): Skill {
+  return {
+    name,
+    description: '',
+    path: `/Users/test/.agents/skills/${name}`,
+    symlinkCount: status === 'missing' ? 0 : 1,
+    symlinks: [
+      {
+        agentId: 'cursor',
+        agentName: 'Cursor',
+        status,
+        linkPath: `/Users/test/.cursor/skills/${name}`,
+        targetPath: `/Users/test/.agents/skills/${name}`,
+        isLocal: false,
+      },
+    ],
+    isSource: true,
+    isOrphan: false,
+  }
+}
+
+/**
+ * Render MainContent with the real SelectionToolbar and lightweight child mocks.
+ * @returns Browser screen and Redux store used by the mounted MainContent.
+ * @example const { screen, store } = await renderMainContentWithToolbar()
+ */
+async function renderMainContentWithToolbar() {
+  const [
+    { default: uiReducer },
+    { default: skillsReducer },
+    { default: agentsReducer },
+    { default: bookmarksReducer },
+    { default: marketplaceReducer },
+    { MainContent },
+  ] = await Promise.all([
+    import('@/renderer/src/redux/slices/uiSlice'),
+    import('@/renderer/src/redux/slices/skillsSlice'),
+    import('@/renderer/src/redux/slices/agentsSlice'),
+    import('@/renderer/src/redux/slices/bookmarkSlice'),
+    import('@/renderer/src/redux/slices/marketplaceSlice'),
+    import('./MainContent'),
+  ])
+  const store = configureStore({
+    reducer: {
+      ui: uiReducer,
+      skills: skillsReducer,
+      agents: agentsReducer,
+      bookmarks: bookmarksReducer,
+      marketplace: marketplaceReducer,
+    },
+  })
+  const screen = await render(
+    <Provider store={store}>
+      <TooltipProvider>
+        <MainContent />
+      </TooltipProvider>
+    </Provider>,
+  )
+  return { screen, store }
+}
+
+describe('MainContent SelectionToolbar integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockOnDeleteProgress.mockImplementation(() => () => {})
+    mockUnlinkManyFromAgent.mockResolvedValue({
+      items: [
+        {
+          skillName: 'valid-toolbar-task',
+          outcome: 'unlinked',
+        },
+      ],
+    })
+    vi.stubGlobal('electron', {
+      skills: {
+        onDeleteProgress: mockOnDeleteProgress,
+        unlinkManyFromAgent: mockUnlinkManyFromAgent,
+      },
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('Select all visible excludes broken and inaccessible agent rows from bulk unlink payload', async () => {
+    const { screen, store } = await renderMainContentWithToolbar()
+    const { fetchAgents } =
+      await import('@/renderer/src/redux/slices/agentsSlice')
+    const { enterBulkSelectMode, selectAgent } =
+      await import('@/renderer/src/redux/slices/uiSlice')
+    const { fetchSkills, toggleSelection } =
+      await import('@/renderer/src/redux/slices/skillsSlice')
+
+    // Arrange
+    store.dispatch(fetchAgents.fulfilled([CURSOR_AGENT], 'agents-req'))
+    store.dispatch(
+      fetchSkills.fulfilled(
+        [
+          makeCursorSkill('valid-toolbar-task' as SkillName, 'valid'),
+          makeCursorSkill('broken-toolbar-task' as SkillName, 'broken'),
+          makeCursorSkill(
+            'inaccessible-toolbar-task' as SkillName,
+            'inaccessible',
+          ),
+        ],
+        'skills-req',
+      ),
+    )
+    store.dispatch(selectAgent('cursor'))
+    store.dispatch(enterBulkSelectMode())
+    store.dispatch(toggleSelection('valid-toolbar-task' as SkillName))
+
+    // Act
+    await expect
+      .element(screen.getByRole('group', { name: 'Bulk selection actions' }))
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Select all visible' }).click()
+
+    // Assert
+    expect(store.getState().skills.selectedSkillNames).toEqual([
+      'valid-toolbar-task',
+    ])
+
+    await screen
+      .getByRole('button', { name: 'Unlink selected skill from Cursor' })
+      .click()
+    await screen.getByRole('button', { name: 'Unlink' }).click()
+
+    await expect.poll(() => mockUnlinkManyFromAgent.mock.calls.length).toBe(1)
+    expect(mockUnlinkManyFromAgent).toHaveBeenCalledWith({
+      agentId: 'cursor',
+      items: [{ skillName: 'valid-toolbar-task' }],
+    })
+  })
+})

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -70,9 +70,11 @@ import type { SourceFilterRow } from '@/renderer/src/redux/selectors'
 import { setPreviewSkill } from '@/renderer/src/redux/slices/marketplaceSlice'
 import {
   clearSelection,
+  clearSelectedOrphanSymlinks,
   deleteSelectedSkills,
   selectAll,
   selectSelectedSkillNames,
+  selectSkillsItems,
   setBulkProgress,
   undoLastBulkDelete,
   unlinkSelectedFromAgent,
@@ -114,11 +116,15 @@ import {
 } from '@/shared/constants'
 import { FEATURE_FLAGS } from '@/shared/featureFlags'
 import type {
+  AbsolutePath,
   BulkDeleteItemResult,
+  ClearOrphanSymlinksOptions,
   IsoTimestamp,
   RepositoryId,
+  Skill,
   ToastId,
   TombstoneId,
+  SymlinkInfo,
 } from '@/shared/types'
 
 const SKILL_TYPE_FILTER_OPTIONS: {
@@ -164,6 +170,88 @@ function getUnavailableExcludeReason(
 
 const SKILLS_SH_URL = 'https://skills.sh'
 
+type ReviewedOrphanCleanupRecord = ClearOrphanSymlinksOptions['items'][number]
+
+interface PartitionedGlobalDeleteTargets {
+  deleteNames: Skill['name'][]
+  orphanRecords: ReviewedOrphanCleanupRecord[]
+  orphanErrors: BulkDeleteItemResult[]
+}
+
+/**
+ * Narrow to dangling, reviewed symlink slots that the orphan cleanup IPC can safely revalidate.
+ * @param symlink - Agent slot from the current renderer scan.
+ * @returns true when the slot has the exact path and target cleanup requires.
+ * @example
+ * isReviewedOrphanCleanupSlot(skill.symlinks[0]) // => true for broken non-local symlink with targetPath
+ */
+function isReviewedOrphanCleanupSlot(
+  symlink: SymlinkInfo,
+): symlink is SymlinkInfo & {
+  status: 'broken'
+  isLocal: false
+  targetPath: AbsolutePath
+} {
+  return (
+    symlink.status === 'broken' &&
+    symlink.isLocal === false &&
+    symlink.targetPath !== undefined
+  )
+}
+
+/**
+ * Split global delete selections so orphan rows use exact reviewed link cleanup instead of name rescans.
+ * @param skills - Current Redux skill inventory.
+ * @param skillNames - Names selected in the bulk confirm dialog.
+ * @returns Normal delete names, reviewed orphan cleanup records, and per-row preflight errors.
+ * @example
+ * partitionGlobalDeleteTargets(skills, ['abandoned'])
+ */
+function partitionGlobalDeleteTargets(
+  skills: readonly Skill[],
+  skillNames: readonly Skill['name'][],
+): PartitionedGlobalDeleteTargets {
+  const skillsByName = new Map(skills.map((skill) => [skill.name, skill]))
+  const deleteNames: Skill['name'][] = []
+  const orphanRecords: ReviewedOrphanCleanupRecord[] = []
+  const orphanErrors: BulkDeleteItemResult[] = []
+
+  for (const skillName of skillNames) {
+    const skill = skillsByName.get(skillName)
+    if (!skill?.isOrphan) {
+      deleteNames.push(skillName)
+      continue
+    }
+
+    const agents = skill.symlinks
+      .filter(isReviewedOrphanCleanupSlot)
+      .map((symlink) => ({
+        agentId: symlink.agentId,
+        linkPath: symlink.linkPath,
+        targetPath: symlink.targetPath,
+      }))
+
+    if (agents.length > 0) {
+      orphanRecords.push({ skillName, agents })
+      continue
+    }
+
+    // Do not fall back to name-only deletion for an orphan row whose reviewed
+    // slot identities are incomplete; ask for a rescan instead.
+    orphanErrors.push({
+      skillName,
+      outcome: 'error',
+      error: {
+        message:
+          'No reviewed orphan symlink targets available. Rescan before cleanup.',
+        code: 'ESTALE',
+      },
+    })
+  }
+
+  return { deleteNames, orphanRecords, orphanErrors }
+}
+
 /**
  * Main content area (flexible width).
  * Owns the Installed / Marketplace tabs, the bulk selection toolbar, and the
@@ -180,6 +268,7 @@ export const MainContent = React.memo(
     const visibleNames = useAppSelector(selectVisibleSkillNames)
     const selectedVisibleNames = useAppSelector(selectSelectedVisibleNames)
     const selectedAllNames = useAppSelector(selectSelectedSkillNames)
+    const skills = useAppSelector(selectSkillsItems)
     const bulkConfirm = useAppSelector(selectBulkConfirm)
     const bulkSelectMode = useAppSelector(selectBulkSelectMode)
     const sourceFilter = useAppSelector(selectSourceFilterViewModel)
@@ -497,14 +586,57 @@ export const MainContent = React.memo(
         return
       }
 
-      // Global view — bulk delete. Every skill (including ones tracked in
-      // `~/.agents/.skill-lock.json`) flows through the trash + UndoToast
-      // pipeline. The CLI removal path was retired because `npx skills remove`
-      // spawns were unreliable; stale lock-file entries are an acceptable
-      // trade-off for a deterministic delete that supports undo.
-      const action = await dispatch(deleteSelectedSkills(skillNames))
-      if (deleteSelectedSkills.fulfilled.match(action)) {
-        const tombstoneIds = action.payload.items
+      const { deleteNames, orphanRecords, orphanErrors } =
+        partitionGlobalDeleteTargets(skills, skillNames)
+      const deleteItems: BulkDeleteItemResult[] = [...orphanErrors]
+      if (orphanRecords.length > 0 || orphanErrors.length > 0) {
+        // Orphan-only cleanup has no tombstone, so manually leave bulk mode in
+        // the same way the delete thunk's pending reducer would for source rows.
+        dispatch(clearSelection())
+        dispatch(exitBulkSelectMode())
+      }
+
+      // Global view — normal skills still flow through the trash + UndoToast
+      // pipeline. Orphan rows are not source skills, so they use exact reviewed
+      // link cleanup below instead of the name-rescanning delete IPC.
+      if (deleteNames.length > 0) {
+        const action = await dispatch(deleteSelectedSkills(deleteNames))
+        if (deleteSelectedSkills.fulfilled.match(action)) {
+          deleteItems.push(...action.payload.items)
+        } else {
+          toast.error('Bulk delete failed', {
+            description: errorToastDescription(action),
+          })
+          return
+        }
+      }
+
+      if (orphanRecords.length > 0) {
+        const action = await dispatch(
+          clearSelectedOrphanSymlinks(orphanRecords),
+        )
+        if (clearSelectedOrphanSymlinks.fulfilled.match(action)) {
+          deleteItems.push(...action.payload.items)
+        } else {
+          const message = errorToastDescription(action)
+          if (deleteItems.length === 0) {
+            toast.error('Bulk delete failed', { description: message })
+            return
+          }
+          deleteItems.push(
+            ...orphanRecords.map(
+              (record): BulkDeleteItemResult => ({
+                skillName: record.skillName,
+                outcome: 'error',
+                error: { message },
+              }),
+            ),
+          )
+        }
+      }
+
+      if (deleteItems.length > 0) {
+        const tombstoneIds = deleteItems
           .filter(
             (
               item,
@@ -512,10 +644,10 @@ export const MainContent = React.memo(
               item.outcome === 'deleted',
           )
           .map((item) => item.tombstoneId)
-        const deletedNames = action.payload.items
+        const deletedNames = deleteItems
           .filter((item) => item.outcome === 'deleted')
           .map((item) => item.skillName)
-        const failedNames = action.payload.items
+        const failedNames = deleteItems
           .filter((item) => item.outcome === 'error')
           .map((item) => item.skillName)
 
@@ -527,15 +659,15 @@ export const MainContent = React.memo(
           // `orphan-cleared` (broken-symlink sweeps that have no undo path).
           // Distinguish all-errored from any-cleared so we don't slap an
           // "error" title on a row that the user actually wanted swept.
-          const anySuccess = action.payload.items.some(
+          const anySuccess = deleteItems.some(
             (item) =>
               item.outcome === 'deleted' || item.outcome === 'orphan-cleared',
           )
           if (anySuccess) {
-            toast.success(formatCascadeSummary(action.payload))
+            toast.success(formatCascadeSummary({ items: deleteItems }))
           } else {
             toast.error('Bulk delete failed', {
-              description: formatCascadeSummary(action.payload),
+              description: formatCascadeSummary({ items: deleteItems }),
             })
           }
           return
@@ -551,7 +683,7 @@ export const MainContent = React.memo(
         const expiresAt: IsoTimestamp = new Date(
           Date.now() + UNDO_WINDOW_MS,
         ).toISOString()
-        const summary = formatCascadeSummary(action.payload)
+        const summary = formatCascadeSummary({ items: deleteItems })
         const handleToastDismissed = (): void => {
           dispatch(clearUndoToast())
         }
@@ -583,12 +715,8 @@ export const MainContent = React.memo(
             summary,
           }),
         )
-      } else {
-        toast.error('Bulk delete failed', {
-          description: errorToastDescription(action),
-        })
       }
-    }, [bulkConfirm, dispatch, handleUndoDelete])
+    }, [bulkConfirm, dispatch, handleUndoDelete, skills])
 
     const handleCancelBulkConfirm = useCallback((): void => {
       dispatch(clearBulkConfirm())

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -23,6 +23,11 @@ import {
   formatUnlinkSummary,
 } from '@/renderer/src/components/skills/bulkDeleteHelpers'
 import { CopyToAgentsModal } from '@/renderer/src/components/skills/CopyToAgentsModal'
+import {
+  buildAgentUnlinkTargets,
+  type PartitionedGlobalDeleteTargets,
+  partitionGlobalDeleteTargets,
+} from '@/renderer/src/components/skills/reviewedDestructiveTargets'
 import { SearchBox } from '@/renderer/src/components/skills/SearchBox'
 import { SelectionToolbar } from '@/renderer/src/components/skills/SelectionToolbar'
 import { SkillsList } from '@/renderer/src/components/skills/SkillsList'
@@ -79,10 +84,6 @@ import {
   undoLastBulkDelete,
   unlinkSelectedFromAgent,
 } from '@/renderer/src/redux/slices/skillsSlice'
-import type {
-  DeleteSelectedSkillTarget,
-  UnlinkSelectedSkillTarget,
-} from '@/renderer/src/redux/slices/skillsSlice'
 import {
   clearBulkConfirm,
   clearExcludedSkillTypeFilters,
@@ -121,16 +122,12 @@ import {
 } from '@/shared/constants'
 import { FEATURE_FLAGS } from '@/shared/featureFlags'
 import type {
-  AbsolutePath,
-  AgentId,
   BulkDeleteItemResult,
-  ClearOrphanSymlinksOptions,
   IsoTimestamp,
   RepositoryId,
   Skill,
   ToastId,
   TombstoneId,
-  SymlinkInfo,
 } from '@/shared/types'
 
 const SKILL_TYPE_FILTER_OPTIONS: {
@@ -176,136 +173,6 @@ function getUnavailableExcludeReason(
 
 const SKILLS_SH_URL = 'https://skills.sh'
 
-type ReviewedOrphanCleanupRecord = ClearOrphanSymlinksOptions['items'][number]
-
-interface PartitionedGlobalDeleteTargets {
-  deleteTargets: DeleteSelectedSkillTarget[]
-  orphanRecords: ReviewedOrphanCleanupRecord[]
-  orphanErrors: BulkDeleteItemResult[]
-}
-
-interface AgentUnlinkTargets {
-  targets: UnlinkSelectedSkillTarget[]
-  staleNames: Skill['name'][]
-}
-
-/**
- * Narrow to dangling, reviewed symlink slots that the orphan cleanup IPC can safely revalidate.
- * @param symlink - Agent slot from the current renderer scan.
- * @returns true when the slot has the exact path and target cleanup requires.
- * @example
- * isReviewedOrphanCleanupSlot(skill.symlinks[0]) // => true for broken non-local symlink with targetPath
- */
-function isReviewedOrphanCleanupSlot(
-  symlink: SymlinkInfo,
-): symlink is SymlinkInfo & {
-  status: 'broken'
-  isLocal: false
-  targetPath: AbsolutePath
-} {
-  return (
-    symlink.status === 'broken' &&
-    symlink.isLocal === false &&
-    symlink.targetPath !== undefined
-  )
-}
-
-/**
- * Split global delete selections so orphan rows use exact reviewed link cleanup instead of name rescans.
- * @param skills - Current Redux skill inventory.
- * @param skillNames - Names selected in the bulk confirm dialog.
- * @returns Reviewed source/local targets, reviewed orphan cleanup records, and per-row preflight errors.
- * @example
- * partitionGlobalDeleteTargets(skills, ['abandoned'])
- */
-function partitionGlobalDeleteTargets(
-  skills: readonly Skill[],
-  skillNames: readonly Skill['name'][],
-): PartitionedGlobalDeleteTargets {
-  const skillsByName = new Map(skills.map((skill) => [skill.name, skill]))
-  const deleteTargets: DeleteSelectedSkillTarget[] = []
-  const orphanRecords: ReviewedOrphanCleanupRecord[] = []
-  const orphanErrors: BulkDeleteItemResult[] = []
-
-  for (const skillName of skillNames) {
-    const skill = skillsByName.get(skillName)
-    if (!skill?.isOrphan) {
-      if (skill) {
-        deleteTargets.push({
-          skillName,
-          skillPath: skill.path,
-        })
-        continue
-      }
-      orphanErrors.push({
-        skillName,
-        outcome: 'error',
-        error: {
-          message: 'Selected skill row is stale. Rescan before delete.',
-          code: 'ESTALE',
-        },
-      })
-      continue
-    }
-
-    const agents = skill.symlinks
-      .filter(isReviewedOrphanCleanupSlot)
-      .map((symlink) => ({
-        agentId: symlink.agentId,
-        linkPath: symlink.linkPath,
-        targetPath: symlink.targetPath,
-      }))
-
-    if (agents.length > 0) {
-      orphanRecords.push({ skillName, agents })
-      continue
-    }
-
-    // Do not fall back to name-only deletion for an orphan row whose reviewed
-    // slot identities are incomplete; ask for a rescan instead.
-    orphanErrors.push({
-      skillName,
-      outcome: 'error',
-      error: {
-        message:
-          'No reviewed orphan symlink targets available. Rescan before cleanup.',
-        code: 'ESTALE',
-      },
-    })
-  }
-
-  return { deleteTargets, orphanRecords, orphanErrors }
-}
-
-/**
- * Build bulk-unlink targets with the reviewed agent slot path.
- * @param skills - Current skill rows in Redux.
- * @param skillNames - Display names selected in the confirmation dialog.
- * @param agentId - Selected agent whose slots are being unlinked.
- * @returns Reviewed unlink targets plus stale rows that need a rescan.
- * @example buildAgentUnlinkTargets(skills, ['metadata-title'], 'cursor')
- */
-function buildAgentUnlinkTargets(
-  skills: readonly Skill[],
-  skillNames: readonly Skill['name'][],
-  agentId: AgentId,
-): AgentUnlinkTargets {
-  const skillsByName = new Map(skills.map((skill) => [skill.name, skill]))
-  const targets: UnlinkSelectedSkillTarget[] = []
-  const staleNames: Skill['name'][] = []
-  for (const skillName of skillNames) {
-    const symlink = skillsByName
-      .get(skillName)
-      ?.symlinks.find((slot) => slot.agentId === agentId)
-    if (symlink?.linkPath) {
-      targets.push({ skillName, linkPath: symlink.linkPath })
-      continue
-    }
-    staleNames.push(skillName)
-  }
-  return { targets, staleNames }
-}
-
 /**
  * Build bulk-delete targets only for delete confirms so MainContent stays branch-light.
  * @param bulkConfirm - Pending bulk confirm dialog state.
@@ -319,6 +186,17 @@ function getBulkDeleteTargetSummary(
   skills: readonly Skill[],
 ): PartitionedGlobalDeleteTargets | null {
   if (!bulkConfirm || bulkConfirm.kind !== 'delete') return null
+  if (
+    bulkConfirm.deleteTargets ||
+    bulkConfirm.orphanRecords ||
+    bulkConfirm.orphanErrors
+  ) {
+    return {
+      deleteTargets: bulkConfirm.deleteTargets ?? [],
+      orphanRecords: bulkConfirm.orphanRecords ?? [],
+      orphanErrors: bulkConfirm.orphanErrors ?? [],
+    }
+  }
   return partitionGlobalDeleteTargets(skills, bulkConfirm.skillNames)
 }
 
@@ -644,13 +522,44 @@ export const MainContent = React.memo(
               localHiddenCount: sourceFilter.localHiddenCount,
             }
           : null
+      if (selectedAgentId) {
+        const { targets, staleNames } = buildAgentUnlinkTargets(
+          skills,
+          selectedVisibleNames,
+          selectedAgentId,
+        )
+        if (staleNames.length > 0) {
+          flashFailedRows(staleNames)
+          toast.error('Bulk unlink failed', {
+            description: 'Selection changed. Rescan before unlinking.',
+          })
+          refreshAllData(dispatch)
+          return
+        }
+        dispatch(
+          setBulkConfirm({
+            kind: 'unlink',
+            skillNames: targets.map((target) => target.skillName),
+            agentId: selectedAgentId,
+            agentName: selectedAgent?.name ?? null,
+            sourceSummary,
+            unlinkTargets: targets,
+          }),
+        )
+        return
+      }
+      const { deleteTargets, orphanRecords, orphanErrors } =
+        partitionGlobalDeleteTargets(skills, selectedVisibleNames)
       dispatch(
         setBulkConfirm({
-          kind: selectedAgentId ? 'unlink' : 'delete',
+          kind: 'delete',
           skillNames: selectedVisibleNames,
-          agentId: selectedAgentId,
-          agentName: selectedAgent?.name ?? null,
+          agentId: null,
+          agentName: null,
           sourceSummary,
+          deleteTargets,
+          orphanRecords,
+          orphanErrors,
         }),
       )
     }, [
@@ -658,6 +567,7 @@ export const MainContent = React.memo(
       selectedAgentId,
       selectedAgent?.name,
       selectedVisibleNames,
+      skills,
       sourceFilter.validRepoIds,
       sourceFilter.localHiddenCount,
     ])
@@ -732,25 +642,18 @@ export const MainContent = React.memo(
     )
 
     /**
-     * Invoked by the BulkConfirmDialog's primary button. Reads the pending
-     * payload from Redux, clears the dialog, then runs the existing thunk +
-     * post-action logic (toast, refresh, undo toast for deletes).
+     * Execute reviewed agent-view unlink confirmation after the dialog closes.
+     * @param confirm - Snapshot captured when the confirmation dialog opened.
+     * @returns void after thunk, toast, and refresh side effects finish.
+     * @example await confirmBulkUnlink(bulkConfirm)
      */
-    const handleConfirmBulk = useCallback(async (): Promise<void> => {
-      if (!bulkConfirm) return
-      const { kind, skillNames, agentId, agentName } = bulkConfirm
-      // Clear FIRST so the dialog unmounts before the thunk suspends; the
-      // thunk's `.pending` reducer also clears, but the explicit clear removes
-      // the "frozen dialog while request is in flight" race on slow disks.
-      dispatch(clearBulkConfirm())
-
-      if (kind === 'unlink' && agentId) {
-        // Agent view — bulk unlink (not tombstoned, no undo toast).
-        const { targets: unlinkTargets, staleNames } = buildAgentUnlinkTargets(
-          skills,
-          skillNames,
-          agentId,
-        )
+    const confirmBulkUnlink = useCallback(
+      async (confirm: BulkConfirmState): Promise<void> => {
+        const { skillNames, agentId, agentName } = confirm
+        if (!agentId) return
+        const { targets: unlinkTargets, staleNames } = confirm.unlinkTargets
+          ? { targets: confirm.unlinkTargets, staleNames: [] }
+          : buildAgentUnlinkTargets(skills, skillNames, agentId)
         if (staleNames.length > 0) {
           flashFailedRows(staleNames)
           toast.error('Bulk unlink failed', {
@@ -759,11 +662,9 @@ export const MainContent = React.memo(
           refreshAllData(dispatch)
           return
         }
+
         const action = await dispatch(
-          unlinkSelectedFromAgent({
-            agentId,
-            selectedNames: unlinkTargets,
-          }),
+          unlinkSelectedFromAgent({ agentId, selectedNames: unlinkTargets }),
         )
         if (unlinkSelectedFromAgent.fulfilled.match(action)) {
           const failedNames = action.payload.items
@@ -772,9 +673,6 @@ export const MainContent = React.memo(
           const unlinkedCount = action.payload.items.length - failedNames.length
           flashFailedRows(failedNames)
           if (unlinkedCount === 0) {
-            // Every item failed — a success toast would lie to the user.
-            // Match the delete-all-errored path: surface a failure toast with
-            // the same per-item summary we'd show on partial success.
             toast.error('Bulk unlink failed', {
               description: formatUnlinkSummary(
                 action.payload,
@@ -792,67 +690,80 @@ export const MainContent = React.memo(
           })
         }
         refreshAllData(dispatch)
-        return
-      }
+      },
+      [dispatch, skills],
+    )
 
-      const { deleteTargets, orphanRecords, orphanErrors } =
-        partitionGlobalDeleteTargets(skills, skillNames)
-      const deleteItems: BulkDeleteItemResult[] = [...orphanErrors]
-      const hasOrphanCleanupRows =
-        orphanRecords.length > 0 || orphanErrors.length > 0
-      const cleanupReadyOrphanNames = orphanRecords.map(
-        (record) => record.skillName,
-      )
-
-      // Global view — normal skills still flow through the trash + UndoToast
-      // pipeline. Orphan rows are not source skills, so they use exact reviewed
-      // link cleanup below instead of the name-rescanning delete IPC.
-      if (deleteTargets.length > 0) {
-        const action = await dispatch(deleteSelectedSkills(deleteTargets))
-        if (deleteSelectedSkills.fulfilled.match(action)) {
-          deleteItems.push(...action.payload.items)
-        } else {
-          if (hasOrphanCleanupRows) {
-            restoreUnresolvedMixedDeleteSelection(
-              deleteTargets.map((target) => target.skillName),
-              cleanupReadyOrphanNames,
-            )
-          }
-          toast.error('Bulk delete failed', {
-            description: errorToastDescription(action),
-          })
-          refreshAllData(dispatch)
-          return
-        }
-      }
-
-      if (orphanRecords.length > 0) {
-        const action = await dispatch(
-          clearSelectedOrphanSymlinks(orphanRecords),
+    /**
+     * Execute reviewed global delete confirmation, including orphan cleanup rows.
+     * @param confirm - Snapshot captured when the confirmation dialog opened.
+     * @returns void after delete/cleanup thunks, toast, undo, and refresh.
+     * @example await confirmBulkDelete(bulkConfirm)
+     */
+    const confirmBulkDelete = useCallback(
+      async (confirm: BulkConfirmState): Promise<void> => {
+        const { skillNames } = confirm
+        const { deleteTargets, orphanRecords, orphanErrors } =
+          confirm.deleteTargets || confirm.orphanRecords || confirm.orphanErrors
+            ? {
+                deleteTargets: confirm.deleteTargets ?? [],
+                orphanRecords: confirm.orphanRecords ?? [],
+                orphanErrors: confirm.orphanErrors ?? [],
+              }
+            : partitionGlobalDeleteTargets(skills, skillNames)
+        const deleteItems: BulkDeleteItemResult[] = [...orphanErrors]
+        const hasOrphanCleanupRows =
+          orphanRecords.length > 0 || orphanErrors.length > 0
+        const cleanupReadyOrphanNames = orphanRecords.map(
+          (record) => record.skillName,
         )
-        if (clearSelectedOrphanSymlinks.fulfilled.match(action)) {
-          deleteItems.push(...action.payload.items)
-        } else {
-          const message = errorToastDescription(action)
-          if (deleteItems.length === 0) {
-            restoreUnresolvedMixedDeleteSelection([], cleanupReadyOrphanNames)
-            toast.error('Bulk delete failed', { description: message })
+
+        if (deleteTargets.length > 0) {
+          const action = await dispatch(deleteSelectedSkills(deleteTargets))
+          if (deleteSelectedSkills.fulfilled.match(action)) {
+            deleteItems.push(...action.payload.items)
+          } else {
+            if (hasOrphanCleanupRows) {
+              restoreUnresolvedMixedDeleteSelection(
+                deleteTargets.map((target) => target.skillName),
+                cleanupReadyOrphanNames,
+              )
+            }
+            toast.error('Bulk delete failed', {
+              description: errorToastDescription(action),
+            })
             refreshAllData(dispatch)
             return
           }
-          deleteItems.push(
-            ...orphanRecords.map(
-              (record): BulkDeleteItemResult => ({
-                skillName: record.skillName,
-                outcome: 'error',
-                error: { message },
-              }),
-            ),
-          )
         }
-      }
 
-      if (deleteItems.length > 0) {
+        if (orphanRecords.length > 0) {
+          const action = await dispatch(
+            clearSelectedOrphanSymlinks(orphanRecords),
+          )
+          if (clearSelectedOrphanSymlinks.fulfilled.match(action)) {
+            deleteItems.push(...action.payload.items)
+          } else {
+            const message = errorToastDescription(action)
+            if (deleteItems.length === 0) {
+              restoreUnresolvedMixedDeleteSelection([], cleanupReadyOrphanNames)
+              toast.error('Bulk delete failed', { description: message })
+              refreshAllData(dispatch)
+              return
+            }
+            deleteItems.push(
+              ...orphanRecords.map(
+                (record): BulkDeleteItemResult => ({
+                  skillName: record.skillName,
+                  outcome: 'error',
+                  error: { message },
+                }),
+              ),
+            )
+          }
+        }
+
+        if (deleteItems.length === 0) return
         const tombstoneIds = deleteItems
           .filter(
             (
@@ -861,52 +772,32 @@ export const MainContent = React.memo(
               item.outcome === 'deleted',
           )
           .map((item) => item.tombstoneId)
-        const deletedNames = deleteItems
-          .filter((item) => item.outcome === 'deleted')
-          .map((item) => item.skillName)
         const { rescanRequiredNames } = reconcileMixedDeleteSelection(
           deleteItems,
           hasOrphanCleanupRows,
         )
         refreshAllData(dispatch)
-
-        if (tombstoneIds.length === 0) {
-          // No tombstones, but the rows still might have succeeded as
-          // `orphan-cleared` (broken-symlink sweeps that have no undo path).
-          // Distinguish all-errored from any-cleared so we don't slap an
-          // "error" title on a row that the user actually wanted swept.
-          const anySuccess = deleteItems.some(
-            (item) =>
-              item.outcome === 'deleted' || item.outcome === 'orphan-cleared',
-          )
-          const summary = appendRescanRequiredSummary(
-            formatCascadeSummary({ items: deleteItems }),
-            rescanRequiredNames.length,
-          )
-          if (anySuccess) {
-            toast.success(summary)
-          } else {
-            toast.error('Bulk delete failed', {
-              description: summary,
-            })
-          }
-          return
-        }
-
-        // Render via sonner's default-styled wrapper (NOT `toast.custom`) so
-        // the per-toast `closeButton: true` opt-in injects sonner's built-in ×
-        // — sonner only renders the close affordance on styled toasts, and
-        // `toast.custom` opts out of that styling.
-        //
-        // `onUndoComplete` reads `toastId` through the closure at click time,
-        // so it resolves after the surrounding const has been assigned.
-        const expiresAt: IsoTimestamp = new Date(
-          Date.now() + UNDO_WINDOW_MS,
-        ).toISOString()
         const summary = appendRescanRequiredSummary(
           formatCascadeSummary({ items: deleteItems }),
           rescanRequiredNames.length,
         )
+
+        if (tombstoneIds.length === 0) {
+          const anySuccess = deleteItems.some(
+            (item) =>
+              item.outcome === 'deleted' || item.outcome === 'orphan-cleared',
+          )
+          if (anySuccess) toast.success(summary)
+          else toast.error('Bulk delete failed', { description: summary })
+          return
+        }
+
+        const deletedNames = deleteItems
+          .filter((item) => item.outcome === 'deleted')
+          .map((item) => item.skillName)
+        const expiresAt: IsoTimestamp = new Date(
+          Date.now() + UNDO_WINDOW_MS,
+        ).toISOString()
         const handleToastDismissed = (): void => {
           dispatch(clearUndoToast())
         }
@@ -938,15 +829,31 @@ export const MainContent = React.memo(
             summary,
           }),
         )
+      },
+      [
+        dispatch,
+        handleUndoDelete,
+        reconcileMixedDeleteSelection,
+        restoreUnresolvedMixedDeleteSelection,
+        skills,
+      ],
+    )
+
+    /**
+     * Route the active bulk confirmation to the reviewed unlink or delete executor.
+     * @returns void after the selected executor completes.
+     * @example await handleConfirmBulk()
+     */
+    const handleConfirmBulk = useCallback(async (): Promise<void> => {
+      if (!bulkConfirm) return
+      const confirm = bulkConfirm
+      dispatch(clearBulkConfirm())
+      if (confirm.kind === 'unlink' && confirm.agentId) {
+        await confirmBulkUnlink(confirm)
+        return
       }
-    }, [
-      bulkConfirm,
-      dispatch,
-      handleUndoDelete,
-      reconcileMixedDeleteSelection,
-      restoreUnresolvedMixedDeleteSelection,
-      skills,
-    ])
+      await confirmBulkDelete(confirm)
+    }, [bulkConfirm, confirmBulkDelete, confirmBulkUnlink, dispatch])
 
     const handleCancelBulkConfirm = useCallback((): void => {
       dispatch(clearBulkConfirm())

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -10,6 +10,7 @@ import {
 import React, { useCallback, useMemo, useRef } from 'react'
 import { toast } from 'sonner'
 
+import { SymlinkCleanupDialog } from '@/renderer/src/components/dashboard/SymlinkCleanupDialog'
 import { SkillsMarketplace } from '@/renderer/src/components/marketplace'
 import { CleanupAgentDialog } from '@/renderer/src/components/sidebar/CleanupAgentDialog'
 import { SyncConfirmDialog } from '@/renderer/src/components/sidebar/SyncConfirmDialog'
@@ -929,6 +930,7 @@ export const MainContent = React.memo(
         <SyncConflictDialog />
         <SyncResultDialog />
         <CleanupAgentDialog />
+        <SymlinkCleanupDialog />
 
         {/*
           Bulk delete / unlink confirmation. Copy is driven by

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -593,12 +593,8 @@ export const MainContent = React.memo(
       const { deleteNames, orphanRecords, orphanErrors } =
         partitionGlobalDeleteTargets(skills, skillNames)
       const deleteItems: BulkDeleteItemResult[] = [...orphanErrors]
-      if (orphanRecords.length > 0 || orphanErrors.length > 0) {
-        // Orphan-only cleanup has no tombstone, so manually leave bulk mode in
-        // the same way the delete thunk's pending reducer would for source rows.
-        dispatch(clearSelection())
-        dispatch(exitBulkSelectMode())
-      }
+      const hasOrphanCleanupRows =
+        orphanRecords.length > 0 || orphanErrors.length > 0
 
       // Global view — normal skills still flow through the trash + UndoToast
       // pipeline. Orphan rows are not source skills, so they use exact reviewed
@@ -654,8 +650,21 @@ export const MainContent = React.memo(
         const failedNames = deleteItems
           .filter((item) => item.outcome === 'error')
           .map((item) => item.skillName)
+        const uniqueFailedNames = Array.from(new Set(failedNames))
 
-        flashFailedRows(failedNames)
+        flashFailedRows(uniqueFailedNames)
+        if (hasOrphanCleanupRows) {
+          // Orphan cleanup has no slice reducer, so reconcile its side effects
+          // after all paths settle: retryable rows stay selected, all-success
+          // batches leave bulk mode like source-delete success.
+          if (uniqueFailedNames.length > 0) {
+            dispatch(enterBulkSelectMode())
+            dispatch(selectAll(uniqueFailedNames))
+          } else {
+            dispatch(clearSelection())
+            dispatch(exitBulkSelectMode())
+          }
+        }
         refreshAllData(dispatch)
 
         if (tombstoneIds.length === 0) {
@@ -1087,8 +1096,9 @@ export const MainContent = React.memo(
                         bulkDeleteTargetSummary?.deleteNames.length ??
                         bulkConfirm.skillNames.length,
                       orphanCleanupCount:
-                        (bulkDeleteTargetSummary?.orphanRecords.length ?? 0) +
-                        (bulkDeleteTargetSummary?.orphanErrors.length ?? 0),
+                        bulkDeleteTargetSummary?.orphanRecords.length ?? 0,
+                      orphanRescanCount:
+                        bulkDeleteTargetSummary?.orphanErrors.length ?? 0,
                       sourceSummary: bulkConfirm.sourceSummary,
                     })
                   : `This removes the symlinks in ${bulkConfirm?.agentName ?? 'this agent'}. The underlying skill files stay in your source directory.`}

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -625,9 +625,9 @@ export const MainContent = React.memo(
 
         flashFailedRows(uniqueFailedNames)
         if (!hasOrphanCleanupRows) return { rescanRequiredNames }
-        // Orphan cleanup has no slice reducer, so reconcile its side effects
-        // after all paths settle: retryable rows stay selected, all-success
-        // batches leave bulk mode like source-delete success.
+        // Mixed source+orphan cleanup needs combined reconciliation after all
+        // paths settle: retryable rows stay selected, all-success batches
+        // leave bulk mode like source-delete success.
         if (retryableFailedNames.length > 0) {
           dispatch(enterBulkSelectMode())
           dispatch(selectAll(retryableFailedNames))
@@ -717,6 +717,7 @@ export const MainContent = React.memo(
           toast.error('Bulk delete failed', {
             description: errorToastDescription(action),
           })
+          refreshAllData(dispatch)
           return
         }
       }

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -278,6 +278,10 @@ export const MainContent = React.memo(
     )
 
     const selectedAgent = agents.find((a) => a.id === selectedAgentId)
+    const bulkDeleteTargetSummary = useMemo(() => {
+      if (!bulkConfirm || bulkConfirm.kind !== 'delete') return null
+      return partitionGlobalDeleteTargets(skills, bulkConfirm.skillNames)
+    }, [bulkConfirm, skills])
     const selectedSkillTypeLabel =
       SKILL_TYPE_FILTER_OPTIONS.find(
         (option) => option.value === skillTypeFilter,
@@ -1079,6 +1083,12 @@ export const MainContent = React.memo(
                 {bulkConfirm?.kind === 'delete'
                   ? renderBulkDeleteDescription({
                       totalCount: bulkConfirm.skillNames.length,
+                      trashCount:
+                        bulkDeleteTargetSummary?.deleteNames.length ??
+                        bulkConfirm.skillNames.length,
+                      orphanCleanupCount:
+                        (bulkDeleteTargetSummary?.orphanRecords.length ?? 0) +
+                        (bulkDeleteTargetSummary?.orphanErrors.length ?? 0),
                       sourceSummary: bulkConfirm.sourceSummary,
                     })
                   : `This removes the symlinks in ${bulkConfirm?.agentName ?? 'this agent'}. The underlying skill files stay in your source directory.`}

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -184,6 +184,11 @@ interface PartitionedGlobalDeleteTargets {
   orphanErrors: BulkDeleteItemResult[]
 }
 
+interface AgentUnlinkTargets {
+  targets: UnlinkSelectedSkillTarget[]
+  staleNames: Skill['name'][]
+}
+
 /**
  * Narrow to dangling, reviewed symlink slots that the orphan cleanup IPC can safely revalidate.
  * @param symlink - Agent slot from the current renderer scan.
@@ -209,7 +214,7 @@ function isReviewedOrphanCleanupSlot(
  * Split global delete selections so orphan rows use exact reviewed link cleanup instead of name rescans.
  * @param skills - Current Redux skill inventory.
  * @param skillNames - Names selected in the bulk confirm dialog.
- * @returns Normal delete names, reviewed orphan cleanup records, and per-row preflight errors.
+ * @returns Reviewed source/local targets, reviewed orphan cleanup records, and per-row preflight errors.
  * @example
  * partitionGlobalDeleteTargets(skills, ['abandoned'])
  */
@@ -225,14 +230,21 @@ function partitionGlobalDeleteTargets(
   for (const skillName of skillNames) {
     const skill = skillsByName.get(skillName)
     if (!skill?.isOrphan) {
-      deleteTargets.push(
-        skill
-          ? {
-              skillName,
-              skillPath: skill.path,
-            }
-          : skillName,
-      )
+      if (skill) {
+        deleteTargets.push({
+          skillName,
+          skillPath: skill.path,
+        })
+        continue
+      }
+      orphanErrors.push({
+        skillName,
+        outcome: 'error',
+        error: {
+          message: 'Selected skill row is stale. Rescan before delete.',
+          code: 'ESTALE',
+        },
+      })
       continue
     }
 
@@ -266,27 +278,32 @@ function partitionGlobalDeleteTargets(
 }
 
 /**
- * Build bulk-unlink targets with the reviewed agent slot path when available.
+ * Build bulk-unlink targets with the reviewed agent slot path.
  * @param skills - Current skill rows in Redux.
  * @param skillNames - Display names selected in the confirmation dialog.
  * @param agentId - Selected agent whose slots are being unlinked.
- * @returns Name-compatible targets with optional reviewed linkPath.
+ * @returns Reviewed unlink targets plus stale rows that need a rescan.
  * @example buildAgentUnlinkTargets(skills, ['metadata-title'], 'cursor')
  */
 function buildAgentUnlinkTargets(
   skills: readonly Skill[],
   skillNames: readonly Skill['name'][],
   agentId: AgentId,
-): UnlinkSelectedSkillTarget[] {
+): AgentUnlinkTargets {
   const skillsByName = new Map(skills.map((skill) => [skill.name, skill]))
-  return skillNames.map((skillName) => {
+  const targets: UnlinkSelectedSkillTarget[] = []
+  const staleNames: Skill['name'][] = []
+  for (const skillName of skillNames) {
     const symlink = skillsByName
       .get(skillName)
       ?.symlinks.find((slot) => slot.agentId === agentId)
-    return symlink?.linkPath
-      ? { skillName, linkPath: symlink.linkPath }
-      : skillName
-  })
+    if (symlink?.linkPath) {
+      targets.push({ skillName, linkPath: symlink.linkPath })
+      continue
+    }
+    staleNames.push(skillName)
+  }
+  return { targets, staleNames }
 }
 
 /**
@@ -729,11 +746,19 @@ export const MainContent = React.memo(
 
       if (kind === 'unlink' && agentId) {
         // Agent view — bulk unlink (not tombstoned, no undo toast).
-        const unlinkTargets = buildAgentUnlinkTargets(
+        const { targets: unlinkTargets, staleNames } = buildAgentUnlinkTargets(
           skills,
           skillNames,
           agentId,
         )
+        if (staleNames.length > 0) {
+          flashFailedRows(staleNames)
+          toast.error('Bulk unlink failed', {
+            description: 'Selection changed. Rescan before unlinking.',
+          })
+          refreshAllData(dispatch)
+          return
+        }
         const action = await dispatch(
           unlinkSelectedFromAgent({
             agentId,
@@ -789,9 +814,7 @@ export const MainContent = React.memo(
         } else {
           if (hasOrphanCleanupRows) {
             restoreUnresolvedMixedDeleteSelection(
-              deleteTargets.map((target) =>
-                typeof target === 'string' ? target : target.skillName,
-              ),
+              deleteTargets.map((target) => target.skillName),
               cleanupReadyOrphanNames,
             )
           }

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -221,13 +221,18 @@ function isBulkDeleteConfirmPrimaryDisabled(
 /**
  * Detects orphan cleanup errors that need a fresh scan, not a direct retry.
  * @param item - Bulk delete item result from source delete or orphan cleanup.
+ * @param orphanCleanupNames - Names known to come from orphan cleanup/preflight.
  * @returns True when selecting the row again would repeat the same stale failure.
  * @example
- * isRescanRequiredDeleteError({ skillName: 'task', outcome: 'error', error: { message: 'Rescan before cleanup.' } })
+ * isRescanRequiredDeleteError(item, new Set(['abandoned']))
  */
-function isRescanRequiredDeleteError(item: BulkDeleteItemResult): boolean {
+function isRescanRequiredDeleteError(
+  item: BulkDeleteItemResult,
+  orphanCleanupNames: ReadonlySet<Skill['name']>,
+): boolean {
   return (
     item.outcome === 'error' &&
+    orphanCleanupNames.has(item.skillName) &&
     (item.error.code === 'ESTALE' ||
       item.error.message.includes('Rescan before cleanup'))
   )
@@ -600,14 +605,16 @@ export const MainContent = React.memo(
      * Keeps retryable failures selected while dropping rescan-required orphan failures.
      * @param deleteItems - Combined source-delete and orphan-cleanup results.
      * @param hasOrphanCleanupRows - Whether this batch needed manual orphan reconciliation.
+     * @param orphanCleanupNames - Names that belong to reviewed orphan cleanup rows.
      * @returns Rescan-required orphan names for toast summary copy.
      * @example
-     * reconcileMixedDeleteSelection([{ skillName: 'orphan', outcome: 'error', error: { message: 'Rescan before cleanup.' } }], true)
+     * reconcileMixedDeleteSelection([orphanError], true, new Set(['orphan']))
      */
     const reconcileMixedDeleteSelection = useCallback(
       (
         deleteItems: readonly BulkDeleteItemResult[],
         hasOrphanCleanupRows: boolean,
+        orphanCleanupNames: ReadonlySet<Skill['name']>,
       ): { rescanRequiredNames: Skill['name'][] } => {
         const failedNames = deleteItems
           .filter((item) => item.outcome === 'error')
@@ -616,7 +623,9 @@ export const MainContent = React.memo(
         const rescanRequiredNames = Array.from(
           new Set(
             deleteItems
-              .filter(isRescanRequiredDeleteError)
+              .filter((item) =>
+                isRescanRequiredDeleteError(item, orphanCleanupNames),
+              )
               .map((item) => item.skillName),
           ),
         )
@@ -717,6 +726,10 @@ export const MainContent = React.memo(
         const cleanupReadyOrphanNames = orphanRecords.map(
           (record) => record.skillName,
         )
+        const orphanCleanupNames = new Set([
+          ...cleanupReadyOrphanNames,
+          ...orphanErrors.map((item) => item.skillName),
+        ])
 
         if (deleteTargets.length > 0) {
           const action = await dispatch(deleteSelectedSkills(deleteTargets))
@@ -775,6 +788,7 @@ export const MainContent = React.memo(
         const { rescanRequiredNames } = reconcileMixedDeleteSelection(
           deleteItems,
           hasOrphanCleanupRows,
+          orphanCleanupNames,
         )
         refreshAllData(dispatch)
         const summary = appendRescanRequiredSummary(

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -79,6 +79,10 @@ import {
   undoLastBulkDelete,
   unlinkSelectedFromAgent,
 } from '@/renderer/src/redux/slices/skillsSlice'
+import type {
+  DeleteSelectedSkillTarget,
+  UnlinkSelectedSkillTarget,
+} from '@/renderer/src/redux/slices/skillsSlice'
 import {
   clearBulkConfirm,
   clearExcludedSkillTypeFilters,
@@ -118,6 +122,7 @@ import {
 import { FEATURE_FLAGS } from '@/shared/featureFlags'
 import type {
   AbsolutePath,
+  AgentId,
   BulkDeleteItemResult,
   ClearOrphanSymlinksOptions,
   IsoTimestamp,
@@ -174,7 +179,7 @@ const SKILLS_SH_URL = 'https://skills.sh'
 type ReviewedOrphanCleanupRecord = ClearOrphanSymlinksOptions['items'][number]
 
 interface PartitionedGlobalDeleteTargets {
-  deleteNames: Skill['name'][]
+  deleteTargets: DeleteSelectedSkillTarget[]
   orphanRecords: ReviewedOrphanCleanupRecord[]
   orphanErrors: BulkDeleteItemResult[]
 }
@@ -213,14 +218,21 @@ function partitionGlobalDeleteTargets(
   skillNames: readonly Skill['name'][],
 ): PartitionedGlobalDeleteTargets {
   const skillsByName = new Map(skills.map((skill) => [skill.name, skill]))
-  const deleteNames: Skill['name'][] = []
+  const deleteTargets: DeleteSelectedSkillTarget[] = []
   const orphanRecords: ReviewedOrphanCleanupRecord[] = []
   const orphanErrors: BulkDeleteItemResult[] = []
 
   for (const skillName of skillNames) {
     const skill = skillsByName.get(skillName)
     if (!skill?.isOrphan) {
-      deleteNames.push(skillName)
+      deleteTargets.push(
+        skill
+          ? {
+              skillName,
+              skillPath: skill.path,
+            }
+          : skillName,
+      )
       continue
     }
 
@@ -250,7 +262,31 @@ function partitionGlobalDeleteTargets(
     })
   }
 
-  return { deleteNames, orphanRecords, orphanErrors }
+  return { deleteTargets, orphanRecords, orphanErrors }
+}
+
+/**
+ * Build bulk-unlink targets with the reviewed agent slot path when available.
+ * @param skills - Current skill rows in Redux.
+ * @param skillNames - Display names selected in the confirmation dialog.
+ * @param agentId - Selected agent whose slots are being unlinked.
+ * @returns Name-compatible targets with optional reviewed linkPath.
+ * @example buildAgentUnlinkTargets(skills, ['metadata-title'], 'cursor')
+ */
+function buildAgentUnlinkTargets(
+  skills: readonly Skill[],
+  skillNames: readonly Skill['name'][],
+  agentId: AgentId,
+): UnlinkSelectedSkillTarget[] {
+  const skillsByName = new Map(skills.map((skill) => [skill.name, skill]))
+  return skillNames.map((skillName) => {
+    const symlink = skillsByName
+      .get(skillName)
+      ?.symlinks.find((slot) => slot.agentId === agentId)
+    return symlink?.linkPath
+      ? { skillName, linkPath: symlink.linkPath }
+      : skillName
+  })
 }
 
 /**
@@ -282,7 +318,9 @@ function isBulkDeleteConfirmPrimaryDisabled(
   summary: PartitionedGlobalDeleteTargets | null,
 ): boolean {
   if (bulkConfirm?.kind !== 'delete' || summary === null) return false
-  return summary.deleteNames.length === 0 && summary.orphanRecords.length === 0
+  return (
+    summary.deleteTargets.length === 0 && summary.orphanRecords.length === 0
+  )
 }
 
 /**
@@ -691,10 +729,15 @@ export const MainContent = React.memo(
 
       if (kind === 'unlink' && agentId) {
         // Agent view — bulk unlink (not tombstoned, no undo toast).
+        const unlinkTargets = buildAgentUnlinkTargets(
+          skills,
+          skillNames,
+          agentId,
+        )
         const action = await dispatch(
           unlinkSelectedFromAgent({
             agentId,
-            selectedNames: skillNames,
+            selectedNames: unlinkTargets,
           }),
         )
         if (unlinkSelectedFromAgent.fulfilled.match(action)) {
@@ -727,7 +770,7 @@ export const MainContent = React.memo(
         return
       }
 
-      const { deleteNames, orphanRecords, orphanErrors } =
+      const { deleteTargets, orphanRecords, orphanErrors } =
         partitionGlobalDeleteTargets(skills, skillNames)
       const deleteItems: BulkDeleteItemResult[] = [...orphanErrors]
       const hasOrphanCleanupRows =
@@ -739,14 +782,16 @@ export const MainContent = React.memo(
       // Global view — normal skills still flow through the trash + UndoToast
       // pipeline. Orphan rows are not source skills, so they use exact reviewed
       // link cleanup below instead of the name-rescanning delete IPC.
-      if (deleteNames.length > 0) {
-        const action = await dispatch(deleteSelectedSkills(deleteNames))
+      if (deleteTargets.length > 0) {
+        const action = await dispatch(deleteSelectedSkills(deleteTargets))
         if (deleteSelectedSkills.fulfilled.match(action)) {
           deleteItems.push(...action.payload.items)
         } else {
           if (hasOrphanCleanupRows) {
             restoreUnresolvedMixedDeleteSelection(
-              deleteNames,
+              deleteTargets.map((target) =>
+                typeof target === 'string' ? target : target.skillName,
+              ),
               cleanupReadyOrphanNames,
             )
           }
@@ -1242,7 +1287,7 @@ export const MainContent = React.memo(
                   ? renderBulkDeleteDescription({
                       totalCount: bulkConfirm.skillNames.length,
                       trashCount:
-                        bulkDeleteTargetSummary?.deleteNames.length ??
+                        bulkDeleteTargetSummary?.deleteTargets.length ??
                         bulkConfirm.skillNames.length,
                       orphanCleanupCount:
                         bulkDeleteTargetSummary?.orphanRecords.length ?? 0,

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -61,10 +61,10 @@ import { useRenderEffect } from '@/renderer/src/hooks/useRenderEffect'
 import { cn } from '@/renderer/src/lib/utils'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import {
+  selectBulkSelectableVisibleSkillNames,
   selectRepoFacetOptions,
   selectSelectedVisibleNames,
   selectSourceFilterViewModel,
-  selectVisibleSkillNames,
 } from '@/renderer/src/redux/selectors'
 import type { SourceFilterRow } from '@/renderer/src/redux/selectors'
 import { setPreviewSkill } from '@/renderer/src/redux/slices/marketplaceSlice'
@@ -102,6 +102,7 @@ import {
 } from '@/renderer/src/redux/slices/uiSlice'
 import type {
   ActiveTab,
+  BulkConfirmState,
   ExcludableSkillTypeFilter,
   SkillTypeFilter,
 } from '@/renderer/src/redux/slices/uiSlice'
@@ -253,6 +254,38 @@ function partitionGlobalDeleteTargets(
 }
 
 /**
+ * Build bulk-delete targets only for delete confirms so MainContent stays branch-light.
+ * @param bulkConfirm - Pending bulk confirm dialog state.
+ * @param skills - Current skill inventory used to resolve orphan rows.
+ * @returns Partitioned delete targets, or null for unlink/no dialog.
+ * @example
+ * getBulkDeleteTargetSummary(confirmState, skills)
+ */
+function getBulkDeleteTargetSummary(
+  bulkConfirm: BulkConfirmState | null,
+  skills: readonly Skill[],
+): PartitionedGlobalDeleteTargets | null {
+  if (!bulkConfirm || bulkConfirm.kind !== 'delete') return null
+  return partitionGlobalDeleteTargets(skills, bulkConfirm.skillNames)
+}
+
+/**
+ * Disable destructive confirm when selected orphan rows require rescan and no cleanup can run.
+ * @param bulkConfirm - Pending bulk confirm dialog state.
+ * @param summary - Partitioned delete targets for the dialog.
+ * @returns True when the primary button would be a no-op.
+ * @example
+ * isBulkDeleteConfirmPrimaryDisabled(confirmState, summary)
+ */
+function isBulkDeleteConfirmPrimaryDisabled(
+  bulkConfirm: BulkConfirmState | null,
+  summary: PartitionedGlobalDeleteTargets | null,
+): boolean {
+  if (bulkConfirm?.kind !== 'delete' || summary === null) return false
+  return summary.deleteNames.length === 0 && summary.orphanRecords.length === 0
+}
+
+/**
  * Detects orphan cleanup errors that need a fresh scan, not a direct retry.
  * @param item - Bulk delete item result from source delete or orphan cleanup.
  * @returns True when selecting the row again would repeat the same stale failure.
@@ -297,7 +330,7 @@ export const MainContent = React.memo(
     const skillTypeFilter = useAppSelector((state) => state.ui.skillTypeFilter)
     const { items: agents } = useAppSelector((state) => state.agents)
     const activeTab = useAppSelector((state) => state.ui.activeTab)
-    const visibleNames = useAppSelector(selectVisibleSkillNames)
+    const visibleNames = useAppSelector(selectBulkSelectableVisibleSkillNames)
     const selectedVisibleNames = useAppSelector(selectSelectedVisibleNames)
     const selectedAllNames = useAppSelector(selectSelectedSkillNames)
     const skills = useAppSelector(selectSkillsItems)
@@ -311,9 +344,12 @@ export const MainContent = React.memo(
 
     const selectedAgent = agents.find((a) => a.id === selectedAgentId)
     const bulkDeleteTargetSummary = useMemo(() => {
-      if (!bulkConfirm || bulkConfirm.kind !== 'delete') return null
-      return partitionGlobalDeleteTargets(skills, bulkConfirm.skillNames)
+      return getBulkDeleteTargetSummary(bulkConfirm, skills)
     }, [bulkConfirm, skills])
+    const isBulkConfirmPrimaryDisabled = isBulkDeleteConfirmPrimaryDisabled(
+      bulkConfirm,
+      bulkDeleteTargetSummary,
+    )
     const selectedSkillTypeLabel =
       SKILL_TYPE_FILTER_OPTIONS.find(
         (option) => option.value === skillTypeFilter,
@@ -731,7 +767,9 @@ export const MainContent = React.memo(
         } else {
           const message = errorToastDescription(action)
           if (deleteItems.length === 0) {
+            restoreUnresolvedMixedDeleteSelection([], cleanupReadyOrphanNames)
             toast.error('Bulk delete failed', { description: message })
+            refreshAllData(dispatch)
             return
           }
           deleteItems.push(
@@ -1223,6 +1261,7 @@ export const MainContent = React.memo(
                 variant={
                   bulkConfirm?.kind === 'delete' ? 'destructive' : 'default'
                 }
+                disabled={isBulkConfirmPrimaryDisabled}
                 onClick={handleConfirmBulk}
               >
                 {bulkConfirm?.kind === 'delete' ? 'Delete' : 'Unlink'}

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -176,32 +176,24 @@ const SKILLS_SH_URL = 'https://skills.sh'
 /**
  * Build bulk-delete targets only for delete confirms so MainContent stays branch-light.
  * @param bulkConfirm - Pending bulk confirm dialog state.
- * @param skills - Current skill inventory used to resolve orphan rows.
  * @returns Partitioned delete targets, or null for unlink/no dialog.
  * @example
- * getBulkDeleteTargetSummary(confirmState, skills)
+ * getBulkDeleteTargetSummary(confirmState)
  */
 function getBulkDeleteTargetSummary(
   bulkConfirm: BulkConfirmState | null,
-  skills: readonly Skill[],
 ): PartitionedGlobalDeleteTargets | null {
   if (!bulkConfirm || bulkConfirm.kind !== 'delete') return null
-  if (
-    bulkConfirm.deleteTargets ||
-    bulkConfirm.orphanRecords ||
-    bulkConfirm.orphanErrors
-  ) {
-    return {
-      deleteTargets: bulkConfirm.deleteTargets ?? [],
-      orphanRecords: bulkConfirm.orphanRecords ?? [],
-      orphanErrors: bulkConfirm.orphanErrors ?? [],
-    }
+  return {
+    deleteTargets: bulkConfirm.deleteTargets,
+    orphanRecords: bulkConfirm.orphanRecords,
+    staleDeleteErrors: bulkConfirm.staleDeleteErrors,
+    orphanErrors: bulkConfirm.orphanErrors,
   }
-  return partitionGlobalDeleteTargets(skills, bulkConfirm.skillNames)
 }
 
 /**
- * Disable destructive confirm when selected orphan rows require rescan and no cleanup can run.
+ * Disable destructive confirm when every reviewed row is stale and no cleanup can run.
  * @param bulkConfirm - Pending bulk confirm dialog state.
  * @param summary - Partitioned delete targets for the dialog.
  * @returns True when the primary button would be a no-op.
@@ -239,20 +231,33 @@ function isRescanRequiredDeleteError(
 }
 
 /**
- * Appends stale-orphan guidance to bulk delete summaries when cleanup cannot run yet.
+ * Appends stale-row guidance to bulk delete summaries when cleanup cannot run yet.
  * @param summary - Existing formatted delete/orphan summary.
- * @param rescanRequiredCount - Number of stale orphan rows excluded from retry.
+ * @param staleDeleteCount - Number of source/local rows needing a fresh scan.
+ * @param orphanRescanCount - Number of stale orphan rows excluded from retry.
  * @returns Summary with explicit rescan guidance when needed.
  * @example
- * appendRescanRequiredSummary('Deleted 1 of 2 skills.', 1)
+ * appendDeleteRescanSummary('Deleted 1 of 3 skills.', 1, 1)
  */
-function appendRescanRequiredSummary(
+function appendDeleteRescanSummary(
   summary: string,
-  rescanRequiredCount: number,
+  staleDeleteCount: number,
+  orphanRescanCount: number,
 ): string {
-  if (rescanRequiredCount === 0) return summary
-  const guidance = `${rescanRequiredCount} orphan ${pluralize(rescanRequiredCount, 'skill')} ${pluralize(rescanRequiredCount, 'needs', 'need')} a rescan before cleanup.`
-  return summary.length > 0 ? `${summary} ${guidance}` : guidance
+  const guidance: string[] = []
+  if (staleDeleteCount > 0) {
+    guidance.push(
+      `${staleDeleteCount} selected ${pluralize(staleDeleteCount, 'skill')} ${pluralize(staleDeleteCount, 'needs', 'need')} a rescan before delete.`,
+    )
+  }
+  if (orphanRescanCount > 0) {
+    guidance.push(
+      `${orphanRescanCount} orphan ${pluralize(orphanRescanCount, 'skill')} ${pluralize(orphanRescanCount, 'needs', 'need')} a rescan before cleanup.`,
+    )
+  }
+  if (guidance.length === 0) return summary
+  const suffix = guidance.join(' ')
+  return summary.length > 0 ? `${summary} ${suffix}` : suffix
 }
 
 /**
@@ -282,8 +287,8 @@ export const MainContent = React.memo(
 
     const selectedAgent = agents.find((a) => a.id === selectedAgentId)
     const bulkDeleteTargetSummary = useMemo(() => {
-      return getBulkDeleteTargetSummary(bulkConfirm, skills)
-    }, [bulkConfirm, skills])
+      return getBulkDeleteTargetSummary(bulkConfirm)
+    }, [bulkConfirm])
     const isBulkConfirmPrimaryDisabled = isBulkDeleteConfirmPrimaryDisabled(
       bulkConfirm,
       bulkDeleteTargetSummary,
@@ -553,7 +558,7 @@ export const MainContent = React.memo(
         )
         return
       }
-      const { deleteTargets, orphanRecords, orphanErrors } =
+      const { deleteTargets, orphanRecords, staleDeleteErrors, orphanErrors } =
         partitionGlobalDeleteTargets(skills, selectedVisibleNames)
       dispatch(
         setBulkConfirm({
@@ -564,6 +569,7 @@ export const MainContent = React.memo(
           sourceSummary,
           deleteTargets,
           orphanRecords,
+          staleDeleteErrors,
           orphanErrors,
         }),
       )
@@ -658,19 +664,9 @@ export const MainContent = React.memo(
      */
     const confirmBulkUnlink = useCallback(
       async (confirm: BulkConfirmState): Promise<void> => {
-        const { skillNames, agentId, agentName } = confirm
-        if (!agentId) return
-        const { targets: unlinkTargets, staleNames } = confirm.unlinkTargets
-          ? { targets: confirm.unlinkTargets, staleNames: [] }
-          : buildAgentUnlinkTargets(skills, skillNames, agentId)
-        if (staleNames.length > 0) {
-          flashFailedRows(staleNames)
-          toast.error('Bulk unlink failed', {
-            description: 'Selection changed. Rescan before unlinking.',
-          })
-          refreshAllData(dispatch)
-          return
-        }
+        if (confirm.kind !== 'unlink') return
+        const { agentId, agentName } = confirm
+        const unlinkTargets = confirm.unlinkTargets
 
         const action = await dispatch(
           unlinkSelectedFromAgent({ agentId, selectedNames: unlinkTargets }),
@@ -700,7 +696,7 @@ export const MainContent = React.memo(
         }
         refreshAllData(dispatch)
       },
-      [dispatch, skills],
+      [dispatch],
     )
 
     /**
@@ -711,16 +707,17 @@ export const MainContent = React.memo(
      */
     const confirmBulkDelete = useCallback(
       async (confirm: BulkConfirmState): Promise<void> => {
-        const { skillNames } = confirm
-        const { deleteTargets, orphanRecords, orphanErrors } =
-          confirm.deleteTargets || confirm.orphanRecords || confirm.orphanErrors
-            ? {
-                deleteTargets: confirm.deleteTargets ?? [],
-                orphanRecords: confirm.orphanRecords ?? [],
-                orphanErrors: confirm.orphanErrors ?? [],
-              }
-            : partitionGlobalDeleteTargets(skills, skillNames)
-        const deleteItems: BulkDeleteItemResult[] = [...orphanErrors]
+        if (confirm.kind !== 'delete') return
+        const {
+          deleteTargets,
+          orphanRecords,
+          staleDeleteErrors,
+          orphanErrors,
+        } = confirm
+        const deleteItems: BulkDeleteItemResult[] = [
+          ...staleDeleteErrors,
+          ...orphanErrors,
+        ]
         const hasOrphanCleanupRows =
           orphanRecords.length > 0 || orphanErrors.length > 0
         const cleanupReadyOrphanNames = orphanRecords.map(
@@ -791,8 +788,9 @@ export const MainContent = React.memo(
           orphanCleanupNames,
         )
         refreshAllData(dispatch)
-        const summary = appendRescanRequiredSummary(
+        const summary = appendDeleteRescanSummary(
           formatCascadeSummary({ items: deleteItems }),
+          staleDeleteErrors.length,
           rescanRequiredNames.length,
         )
 
@@ -849,7 +847,6 @@ export const MainContent = React.memo(
         handleUndoDelete,
         reconcileMixedDeleteSelection,
         restoreUnresolvedMixedDeleteSelection,
-        skills,
       ],
     )
 
@@ -862,7 +859,7 @@ export const MainContent = React.memo(
       if (!bulkConfirm) return
       const confirm = bulkConfirm
       dispatch(clearBulkConfirm())
-      if (confirm.kind === 'unlink' && confirm.agentId) {
+      if (confirm.kind === 'unlink') {
         await confirmBulkUnlink(confirm)
         return
       }
@@ -1235,6 +1232,8 @@ export const MainContent = React.memo(
                         bulkConfirm.skillNames.length,
                       orphanCleanupCount:
                         bulkDeleteTargetSummary?.orphanRecords.length ?? 0,
+                      staleDeleteCount:
+                        bulkDeleteTargetSummary?.staleDeleteErrors.length ?? 0,
                       orphanRescanCount:
                         bulkDeleteTargetSummary?.orphanErrors.length ?? 0,
                       sourceSummary: bulkConfirm.sourceSummary,

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -253,6 +253,38 @@ function partitionGlobalDeleteTargets(
 }
 
 /**
+ * Detects orphan cleanup errors that need a fresh scan, not a direct retry.
+ * @param item - Bulk delete item result from source delete or orphan cleanup.
+ * @returns True when selecting the row again would repeat the same stale failure.
+ * @example
+ * isRescanRequiredDeleteError({ skillName: 'task', outcome: 'error', error: { message: 'Rescan before cleanup.' } })
+ */
+function isRescanRequiredDeleteError(item: BulkDeleteItemResult): boolean {
+  return (
+    item.outcome === 'error' &&
+    (item.error.code === 'ESTALE' ||
+      item.error.message.includes('Rescan before cleanup'))
+  )
+}
+
+/**
+ * Appends stale-orphan guidance to bulk delete summaries when cleanup cannot run yet.
+ * @param summary - Existing formatted delete/orphan summary.
+ * @param rescanRequiredCount - Number of stale orphan rows excluded from retry.
+ * @returns Summary with explicit rescan guidance when needed.
+ * @example
+ * appendRescanRequiredSummary('Deleted 1 of 2 skills.', 1)
+ */
+function appendRescanRequiredSummary(
+  summary: string,
+  rescanRequiredCount: number,
+): string {
+  if (rescanRequiredCount === 0) return summary
+  const guidance = `${rescanRequiredCount} orphan ${pluralize(rescanRequiredCount, 'skill')} ${pluralize(rescanRequiredCount, 'needs', 'need')} a rescan before cleanup.`
+  return summary.length > 0 ? `${summary} ${guidance}` : guidance
+}
+
+/**
  * Main content area (flexible width).
  * Owns the Installed / Marketplace tabs, the bulk selection toolbar, and the
  * global keyboard shortcuts that back the bulk-delete flow (Cmd/Ctrl+A, Esc).
@@ -540,6 +572,75 @@ export const MainContent = React.memo(
     ])
 
     /**
+     * Reselect unresolved rows when source deletion rejects before orphan cleanup can run.
+     * @param deleteNames - Source-backed names whose delete thunk rejected.
+     * @param cleanupReadyOrphanNames - Orphan rows whose cleanup IPC never ran.
+     * @returns void after bulk selection is restored for retry.
+     * @example
+     * restoreUnresolvedMixedDeleteSelection(['task'], ['orphan'])
+     */
+    const restoreUnresolvedMixedDeleteSelection = useCallback(
+      (
+        deleteNames: readonly Skill['name'][],
+        cleanupReadyOrphanNames: readonly Skill['name'][],
+      ): void => {
+        const unresolvedNames = Array.from(
+          new Set([...deleteNames, ...cleanupReadyOrphanNames]),
+        )
+        flashFailedRows(unresolvedNames)
+        if (unresolvedNames.length === 0) return
+        dispatch(enterBulkSelectMode())
+        dispatch(selectAll(unresolvedNames))
+      },
+      [dispatch],
+    )
+
+    /**
+     * Keeps retryable failures selected while dropping rescan-required orphan failures.
+     * @param deleteItems - Combined source-delete and orphan-cleanup results.
+     * @param hasOrphanCleanupRows - Whether this batch needed manual orphan reconciliation.
+     * @returns Rescan-required orphan names for toast summary copy.
+     * @example
+     * reconcileMixedDeleteSelection([{ skillName: 'orphan', outcome: 'error', error: { message: 'Rescan before cleanup.' } }], true)
+     */
+    const reconcileMixedDeleteSelection = useCallback(
+      (
+        deleteItems: readonly BulkDeleteItemResult[],
+        hasOrphanCleanupRows: boolean,
+      ): { rescanRequiredNames: Skill['name'][] } => {
+        const failedNames = deleteItems
+          .filter((item) => item.outcome === 'error')
+          .map((item) => item.skillName)
+        const uniqueFailedNames = Array.from(new Set(failedNames))
+        const rescanRequiredNames = Array.from(
+          new Set(
+            deleteItems
+              .filter(isRescanRequiredDeleteError)
+              .map((item) => item.skillName),
+          ),
+        )
+        const retryableFailedNames = uniqueFailedNames.filter(
+          (name) => !rescanRequiredNames.includes(name),
+        )
+
+        flashFailedRows(uniqueFailedNames)
+        if (!hasOrphanCleanupRows) return { rescanRequiredNames }
+        // Orphan cleanup has no slice reducer, so reconcile its side effects
+        // after all paths settle: retryable rows stay selected, all-success
+        // batches leave bulk mode like source-delete success.
+        if (retryableFailedNames.length > 0) {
+          dispatch(enterBulkSelectMode())
+          dispatch(selectAll(retryableFailedNames))
+        } else {
+          dispatch(clearSelection())
+          dispatch(exitBulkSelectMode())
+        }
+        return { rescanRequiredNames }
+      },
+      [dispatch],
+    )
+
+    /**
      * Invoked by the BulkConfirmDialog's primary button. Reads the pending
      * payload from Redux, clears the dialog, then runs the existing thunk +
      * post-action logic (toast, refresh, undo toast for deletes).
@@ -595,6 +696,9 @@ export const MainContent = React.memo(
       const deleteItems: BulkDeleteItemResult[] = [...orphanErrors]
       const hasOrphanCleanupRows =
         orphanRecords.length > 0 || orphanErrors.length > 0
+      const cleanupReadyOrphanNames = orphanRecords.map(
+        (record) => record.skillName,
+      )
 
       // Global view — normal skills still flow through the trash + UndoToast
       // pipeline. Orphan rows are not source skills, so they use exact reviewed
@@ -604,6 +708,12 @@ export const MainContent = React.memo(
         if (deleteSelectedSkills.fulfilled.match(action)) {
           deleteItems.push(...action.payload.items)
         } else {
+          if (hasOrphanCleanupRows) {
+            restoreUnresolvedMixedDeleteSelection(
+              deleteNames,
+              cleanupReadyOrphanNames,
+            )
+          }
           toast.error('Bulk delete failed', {
             description: errorToastDescription(action),
           })
@@ -647,24 +757,10 @@ export const MainContent = React.memo(
         const deletedNames = deleteItems
           .filter((item) => item.outcome === 'deleted')
           .map((item) => item.skillName)
-        const failedNames = deleteItems
-          .filter((item) => item.outcome === 'error')
-          .map((item) => item.skillName)
-        const uniqueFailedNames = Array.from(new Set(failedNames))
-
-        flashFailedRows(uniqueFailedNames)
-        if (hasOrphanCleanupRows) {
-          // Orphan cleanup has no slice reducer, so reconcile its side effects
-          // after all paths settle: retryable rows stay selected, all-success
-          // batches leave bulk mode like source-delete success.
-          if (uniqueFailedNames.length > 0) {
-            dispatch(enterBulkSelectMode())
-            dispatch(selectAll(uniqueFailedNames))
-          } else {
-            dispatch(clearSelection())
-            dispatch(exitBulkSelectMode())
-          }
-        }
+        const { rescanRequiredNames } = reconcileMixedDeleteSelection(
+          deleteItems,
+          hasOrphanCleanupRows,
+        )
         refreshAllData(dispatch)
 
         if (tombstoneIds.length === 0) {
@@ -676,11 +772,15 @@ export const MainContent = React.memo(
             (item) =>
               item.outcome === 'deleted' || item.outcome === 'orphan-cleared',
           )
+          const summary = appendRescanRequiredSummary(
+            formatCascadeSummary({ items: deleteItems }),
+            rescanRequiredNames.length,
+          )
           if (anySuccess) {
-            toast.success(formatCascadeSummary({ items: deleteItems }))
+            toast.success(summary)
           } else {
             toast.error('Bulk delete failed', {
-              description: formatCascadeSummary({ items: deleteItems }),
+              description: summary,
             })
           }
           return
@@ -696,7 +796,10 @@ export const MainContent = React.memo(
         const expiresAt: IsoTimestamp = new Date(
           Date.now() + UNDO_WINDOW_MS,
         ).toISOString()
-        const summary = formatCascadeSummary({ items: deleteItems })
+        const summary = appendRescanRequiredSummary(
+          formatCascadeSummary({ items: deleteItems }),
+          rescanRequiredNames.length,
+        )
         const handleToastDismissed = (): void => {
           dispatch(clearUndoToast())
         }
@@ -729,7 +832,14 @@ export const MainContent = React.memo(
           }),
         )
       }
-    }, [bulkConfirm, dispatch, handleUndoDelete, skills])
+    }, [
+      bulkConfirm,
+      dispatch,
+      handleUndoDelete,
+      reconcileMixedDeleteSelection,
+      restoreUnresolvedMixedDeleteSelection,
+      skills,
+    ])
 
     const handleCancelBulkConfirm = useCallback((): void => {
       dispatch(clearBulkConfirm())

--- a/src/renderer/src/components/skills/SelectionToolbar.tsx
+++ b/src/renderer/src/components/skills/SelectionToolbar.tsx
@@ -9,6 +9,7 @@ import {
   selectHiddenSelectedCount,
   selectSelectedCount,
   selectSelectedVisibleCount,
+  selectVisibleIneligibleSelectedCount,
 } from '@/renderer/src/redux/selectors'
 import {
   clearSelection,
@@ -44,6 +45,7 @@ interface SelectionToolbarProps {
  * skill is ticked. Shows:
  *   - `N selected` (aria-live="polite")
  *   - `+K hidden by filter` badge when some ticked names are outside the filter
+ *   - `+K not eligible` badge when visible rows cannot use the bulk action
  *   - Primary action button (Delete / Unlink) whose label varies by view
  *   - Secondary "Select all visible" + "Clear selection" buttons
  *   - Progress counter ("3 of 12") during active bulk op when total >= 10
@@ -64,6 +66,9 @@ export const SelectionToolbar = React.memo(function SelectionToolbar({
   const selectedCount = useAppSelector(selectSelectedCount)
   const visibleSelectedCount = useAppSelector(selectSelectedVisibleCount)
   const hiddenSelectedCount = useAppSelector(selectHiddenSelectedCount)
+  const visibleIneligibleSelectedCount = useAppSelector(
+    selectVisibleIneligibleSelectedCount,
+  )
   const visibleNames = useAppSelector(selectBulkSelectableVisibleSkillNames)
   const selectedAgentId = useAppSelector(selectSelectedAgentId)
   const bulkSelectMode = useAppSelector(selectBulkSelectMode)
@@ -126,6 +131,17 @@ export const SelectionToolbar = React.memo(function SelectionToolbar({
           title={`${hiddenSelectedCount} selected ${hiddenSelectedCount === 1 ? 'row is' : 'rows are'} hidden by the current filter and will not be affected`}
         >
           +{hiddenSelectedCount} hidden by filter
+        </span>
+      )}
+
+      {/* Visible-but-ineligible indicator — separates on-screen manual-review
+          rows from genuinely hidden filtered selections. */}
+      {visibleIneligibleSelectedCount > 0 && (
+        <span
+          className="text-xs text-muted-foreground shrink-0"
+          title={`${visibleIneligibleSelectedCount} selected ${visibleIneligibleSelectedCount === 1 ? 'row is' : 'rows are'} visible but cannot use this bulk action`}
+        >
+          +{visibleIneligibleSelectedCount} not eligible
         </span>
       )}
 

--- a/src/renderer/src/components/skills/SelectionToolbar.tsx
+++ b/src/renderer/src/components/skills/SelectionToolbar.tsx
@@ -5,10 +5,10 @@ import { Button } from '@/renderer/src/components/ui/button'
 import { cn } from '@/renderer/src/lib/utils'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import {
+  selectBulkSelectableVisibleSkillNames,
   selectHiddenSelectedCount,
   selectSelectedCount,
   selectSelectedVisibleCount,
-  selectVisibleSkillNames,
 } from '@/renderer/src/redux/selectors'
 import {
   clearSelection,
@@ -64,7 +64,7 @@ export const SelectionToolbar = React.memo(function SelectionToolbar({
   const selectedCount = useAppSelector(selectSelectedCount)
   const visibleSelectedCount = useAppSelector(selectSelectedVisibleCount)
   const hiddenSelectedCount = useAppSelector(selectHiddenSelectedCount)
-  const visibleNames = useAppSelector(selectVisibleSkillNames)
+  const visibleNames = useAppSelector(selectBulkSelectableVisibleSkillNames)
   const selectedAgentId = useAppSelector(selectSelectedAgentId)
   const bulkSelectMode = useAppSelector(selectBulkSelectMode)
   const bulkDeleting = useAppSelector(selectBulkDeleting)

--- a/src/renderer/src/components/skills/SkillDetail.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillDetail.browser.test.tsx
@@ -98,7 +98,10 @@ afterEach(() => {
  * @param selectedAgentId - Optional selected agent; when present, Location shows both source and symlink paths.
  * @returns Render handle and Redux store.
  */
-async function renderSkillDetail(selectedAgentId: AgentId | null = null) {
+async function renderSkillDetail(
+  selectedAgentId: AgentId | null = null,
+  skill: Skill = makeSkill(),
+) {
   const { default: settingsReducer } =
     await import('@/renderer/src/redux/slices/settingsSlice')
   const { setSettings } =
@@ -131,7 +134,7 @@ async function renderSkillDetail(selectedAgentId: AgentId | null = null) {
 
   const screen = await render(
     <Provider store={store}>
-      <SkillDetail skill={makeSkill()} />
+      <SkillDetail skill={skill} />
     </Provider>,
   )
 
@@ -173,5 +176,29 @@ describe('SkillDetail Info path copy', () => {
     await expect
       .poll(() => toastErrorMock.mock.calls[0]?.[0])
       .toBe('Failed to copy path')
+  })
+
+  it('counts inaccessible symlinks separately in the info summary', async () => {
+    // Arrange
+    const skill = makeSkill()
+    skill.symlinks = [
+      {
+        agentId: 'cursor' as AgentId,
+        agentName: 'Cursor',
+        status: 'inaccessible',
+        targetPath: SOURCE_PATH,
+        linkPath: CURSOR_PATH,
+        isLocal: false,
+      },
+    ]
+
+    // Act
+    const { screen } = await renderSkillDetail(null, skill)
+
+    // Assert
+    await expect.element(screen.getByText('Valid:')).toBeInTheDocument()
+    await expect.element(screen.getByText('Broken:')).toBeInTheDocument()
+    await expect.element(screen.getByText('Inaccessible:')).toBeInTheDocument()
+    await expect.element(screen.getByText('1')).toBeInTheDocument()
   })
 })

--- a/src/renderer/src/components/skills/SkillDetail.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillDetail.browser.test.tsx
@@ -199,6 +199,15 @@ describe('SkillDetail Info path copy', () => {
     await expect.element(screen.getByText('Valid:')).toBeInTheDocument()
     await expect.element(screen.getByText('Broken:')).toBeInTheDocument()
     await expect.element(screen.getByText('Inaccessible:')).toBeInTheDocument()
-    await expect.element(screen.getByText('1')).toBeInTheDocument()
+    // Scope the count assertion to the Inaccessible row so it cannot pass on a
+    // stray "1" rendered elsewhere (e.g. if the count landed in Valid instead).
+    const inaccessibleRow = screen
+      .getByText('Inaccessible:')
+      .element()
+      .closest('div')
+    expect(inaccessibleRow).toBeInstanceOf(HTMLElement)
+    await expect
+      .element(inaccessibleRow as HTMLElement)
+      .toHaveTextContent(/Inaccessible:\s*1/)
   })
 })

--- a/src/renderer/src/components/skills/SkillDetail.tsx
+++ b/src/renderer/src/components/skills/SkillDetail.tsx
@@ -61,6 +61,9 @@ export const SkillDetail = React.memo(function SkillDetail({
   const brokenCount = filteredSymlinks.filter(
     (s) => s.status === 'broken',
   ).length
+  const inaccessibleCount = filteredSymlinks.filter(
+    (s) => s.status === 'inaccessible',
+  ).length
 
   return (
     <div className="flex flex-col h-full">
@@ -127,6 +130,7 @@ export const SkillDetail = React.memo(function SkillDetail({
             filteredSymlinks={filteredSymlinks}
             validCount={validCount}
             brokenCount={brokenCount}
+            inaccessibleCount={inaccessibleCount}
             location={locationView}
           />
         </Activity>
@@ -161,6 +165,7 @@ interface InfoViewProps {
   filteredSymlinks: SymlinkInfo[]
   validCount: number
   brokenCount: number
+  inaccessibleCount: number
   location: LocationViewModel
 }
 
@@ -221,6 +226,7 @@ const InfoView = React.memo(function InfoView({
   filteredSymlinks,
   validCount,
   brokenCount,
+  inaccessibleCount,
   location,
 }: InfoViewProps): React.ReactElement {
   const { copiedPath, copyPath } = useLocationPathClipboard()
@@ -237,6 +243,10 @@ const InfoView = React.memo(function InfoView({
         <div>
           <span className="text-muted-foreground">Broken:</span>
           <span className="ml-1 text-amber-400">{brokenCount}</span>
+        </div>
+        <div>
+          <span className="text-muted-foreground">Inaccessible:</span>
+          <span className="ml-1 text-amber-400">{inaccessibleCount}</span>
         </div>
       </div>
 

--- a/src/renderer/src/components/skills/SkillItem.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillItem.browser.test.tsx
@@ -289,6 +289,34 @@ describe('SkillItem symlink status badges', () => {
       .poll(() => screen.getByRole('button', { name: /^Add$/i }).query())
       .toBeNull()
   })
+
+  it('does not render bulk checkbox for broken agent rows that cannot use generic unlink', async () => {
+    // Arrange
+    const brokenSkill = makeSkill({
+      symlinks: [
+        {
+          agentId: 'cursor',
+          agentName: 'Cursor',
+          status: 'broken',
+          linkPath: '/home/user/.cursor/skills/task' as SymlinkInfo['linkPath'],
+          targetPath:
+            '/home/user/.agents/skills/task' as SymlinkInfo['targetPath'],
+          isLocal: false,
+        },
+      ],
+      isOrphan: true,
+    })
+    const { screen, store } = await renderSkillItem(brokenSkill)
+    const { enterBulkSelectMode, selectAgent } =
+      await import('@/renderer/src/redux/slices/uiSlice')
+
+    // Act
+    store.dispatch(selectAgent('cursor'))
+    store.dispatch(enterBulkSelectMode())
+
+    // Assert
+    await expect.poll(() => screen.getByRole('checkbox').query()).toBeNull()
+  })
 })
 
 describe('SkillItem delete button', () => {

--- a/src/renderer/src/components/skills/SkillItem.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillItem.browser.test.tsx
@@ -256,6 +256,9 @@ describe('SkillItem symlink status badges', () => {
         screen.getByRole('button', { name: /^Unlink task from/i }).query(),
       )
       .toBeNull()
+    await expect
+      .poll(() => screen.getByRole('button', { name: 'Add' }).query())
+      .toBeNull()
   })
 
   it('hides Add for inaccessible slots so copy routing cannot fan out', async () => {

--- a/src/renderer/src/components/skills/SkillItem.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillItem.browser.test.tsx
@@ -156,6 +156,34 @@ describe('SkillItem bulk-select checkbox visibility', () => {
   })
 })
 
+describe('SkillItem symlink status badges', () => {
+  it('shows inaccessible slots instead of treating them as unlinked', async () => {
+    // Arrange
+    const inaccessibleSkill = makeSkill({
+      symlinks: [
+        {
+          agentId: 'cursor',
+          agentName: 'Cursor',
+          status: 'inaccessible',
+          linkPath: '/home/user/.cursor/skills/task' as SymlinkInfo['linkPath'],
+          targetPath:
+            '/home/user/.agents/skills/task' as SymlinkInfo['targetPath'],
+          isLocal: false,
+        },
+      ],
+    })
+
+    // Act
+    const { screen } = await renderSkillItem(inaccessibleSkill)
+
+    // Assert
+    await expect
+      .element(screen.getByLabelText('Inaccessible: 1'))
+      .toBeInTheDocument()
+    expect(screen.getByText('Not linked to any agent').query()).toBeNull()
+  })
+})
+
 describe('SkillItem delete button', () => {
   // Every skill — including ones tracked in `~/.agents/.skill-lock.json` via a
   // `source` field — opens the same trash + UndoToast dialog. The CLI removal

--- a/src/renderer/src/components/skills/SkillItem.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillItem.browser.test.tsx
@@ -182,6 +182,38 @@ describe('SkillItem symlink status badges', () => {
       .toBeInTheDocument()
     expect(screen.getByText('Not linked to any agent').query()).toBeNull()
   })
+
+  it('hides the normal unlink button for inaccessible slots in agent view', async () => {
+    // Arrange
+    const inaccessibleSkill = makeSkill({
+      symlinks: [
+        {
+          agentId: 'cursor',
+          agentName: 'Cursor',
+          status: 'inaccessible',
+          linkPath: '/home/user/.cursor/skills/task' as SymlinkInfo['linkPath'],
+          targetPath:
+            '/home/user/.agents/skills/task' as SymlinkInfo['targetPath'],
+          isLocal: false,
+        },
+      ],
+    })
+    const { screen, store } = await renderSkillItem(inaccessibleSkill)
+    const { selectAgent } = await import('@/renderer/src/redux/slices/uiSlice')
+
+    // Act
+    store.dispatch(selectAgent('cursor'))
+
+    // Assert
+    await expect
+      .element(
+        screen.getByLabelText('Inaccessible link - manual review required'),
+      )
+      .toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /^Unlink task from/i }).query(),
+    ).toBeNull()
+  })
 })
 
 describe('SkillItem delete button', () => {

--- a/src/renderer/src/components/skills/SkillItem.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillItem.browser.test.tsx
@@ -308,7 +308,7 @@ describe('SkillItem symlink status badges', () => {
       .toBeNull()
   })
 
-  it('does not render bulk checkbox for broken agent rows that cannot use generic unlink', async () => {
+  it('renders a disabled checkbox for broken agent rows that cannot use generic unlink', async () => {
     // Arrange
     const brokenSkill = makeSkill({
       symlinks: [
@@ -332,8 +332,15 @@ describe('SkillItem symlink status badges', () => {
     store.dispatch(selectAgent('cursor'))
     store.dispatch(enterBulkSelectMode())
 
-    // Assert
-    await expect.poll(() => screen.getByRole('checkbox').query()).toBeNull()
+    // Assert — the slot stays rendered (so titles stay aligned) but the row is
+    // marked out-of-scope via a disabled checkbox and an "is not eligible"
+    // label, instead of vanishing. Keeping the checkbox lets a row that was
+    // selected and then became ineligible still be deselected individually.
+    const ineligibleCheckbox = screen.getByRole('checkbox', {
+      name: 'task is not eligible for bulk selection',
+    })
+    await expect.element(ineligibleCheckbox).toBeInTheDocument()
+    await expect.element(ineligibleCheckbox).toBeDisabled()
   })
 })
 

--- a/src/renderer/src/components/skills/SkillItem.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillItem.browser.test.tsx
@@ -214,6 +214,81 @@ describe('SkillItem symlink status badges', () => {
       screen.getByRole('button', { name: /^Unlink task from/i }).query(),
     ).toBeNull()
   })
+
+  it('hides the normal unlink button for broken slots in agent view', async () => {
+    // Arrange
+    const brokenSkill = makeSkill({
+      symlinks: [
+        {
+          agentId: 'cursor',
+          agentName: 'Cursor',
+          status: 'broken',
+          linkPath: '/home/user/.cursor/skills/task' as SymlinkInfo['linkPath'],
+          targetPath:
+            '/home/user/.agents/skills/task' as SymlinkInfo['targetPath'],
+          isLocal: false,
+        },
+        {
+          agentId: 'codex',
+          agentName: 'Codex',
+          status: 'valid',
+          linkPath: '/home/user/.codex/skills/task' as SymlinkInfo['linkPath'],
+          targetPath:
+            '/home/user/.agents/skills/task' as SymlinkInfo['targetPath'],
+          isLocal: false,
+        },
+      ],
+      isOrphan: false,
+    })
+    const { screen, store } = await renderSkillItem(brokenSkill)
+    const { selectAgent } = await import('@/renderer/src/redux/slices/uiSlice')
+    await expect.element(screen.getByLabelText('Broken: 1')).toBeInTheDocument()
+
+    // Act
+    store.dispatch(selectAgent('cursor'))
+
+    // Assert
+    await expect
+      .poll(() => screen.getByLabelText('Broken: 1').query())
+      .toBeNull()
+    await expect
+      .poll(() =>
+        screen.getByRole('button', { name: /^Unlink task from/i }).query(),
+      )
+      .toBeNull()
+  })
+
+  it('hides Add for inaccessible slots so copy routing cannot fan out', async () => {
+    // Arrange
+    const inaccessibleSkill = makeSkill({
+      symlinks: [
+        {
+          agentId: 'cursor',
+          agentName: 'Cursor',
+          status: 'inaccessible',
+          linkPath: '/home/user/.cursor/skills/task' as SymlinkInfo['linkPath'],
+          targetPath:
+            '/home/user/.agents/skills/task' as SymlinkInfo['targetPath'],
+          isLocal: false,
+        },
+      ],
+    })
+    const { screen, store } = await renderSkillItem(inaccessibleSkill)
+    const { selectAgent } = await import('@/renderer/src/redux/slices/uiSlice')
+
+    // Act
+    store.dispatch(selectAgent('cursor'))
+
+    // Assert
+    await expect
+      .element(
+        screen.getByLabelText('Inaccessible link - manual review required'),
+      )
+      .toBeInTheDocument()
+    await expect
+      .poll(() => screen.getByRole('button', { name: /^Add$/i }).query())
+      .toBeNull()
+  })
 })
 
 describe('SkillItem delete button', () => {

--- a/src/renderer/src/components/skills/SkillItem.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillItem.browser.test.tsx
@@ -446,6 +446,25 @@ describe('SkillItem delete button', () => {
 })
 
 describe('SkillItem Add button routing', () => {
+  it('keeps Add out of the row heading so screen readers announce only the skill name', async () => {
+    // Arrange
+    const { screen } = await renderSkillItem(makeSkill())
+
+    // Act
+    const headingWithAction = screen.getByRole('heading', {
+      name: /task Add/i,
+    })
+
+    // Assert
+    await expect
+      .element(screen.getByRole('heading', { name: /^task$/i }))
+      .toBeInTheDocument()
+    expect(headingWithAction.query()).toBeNull()
+    await expect
+      .element(screen.getByRole('button', { name: /^Add$/i }))
+      .toBeInTheDocument()
+  })
+
   it('shows Add button in agent view when the skill exists in selected agent', async () => {
     const { screen, store } = await renderSkillItem(
       makeSkill({

--- a/src/renderer/src/components/skills/SkillItem.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillItem.browser.test.tsx
@@ -396,6 +396,7 @@ describe('SkillItem delete button', () => {
         },
       ],
       orphanRecords: [],
+      staleDeleteErrors: [],
       orphanErrors: [],
     })
   })
@@ -422,6 +423,7 @@ describe('SkillItem delete button', () => {
         },
       ],
       orphanRecords: [],
+      staleDeleteErrors: [],
       orphanErrors: [],
     })
   })

--- a/src/renderer/src/components/skills/SkillItem.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillItem.browser.test.tsx
@@ -5,7 +5,12 @@ import { render } from 'vitest-browser-react'
 
 import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
 import { GSTACK_REPOSITORY_URL } from '@/shared/constants'
-import type { Skill, SkillName, SymlinkInfo } from '@/shared/types'
+import type {
+  FilesystemEntryIdentity,
+  Skill,
+  SkillName,
+  SymlinkInfo,
+} from '@/shared/types'
 import { repositoryId } from '@/shared/types'
 
 const mockGetAll = vi.fn()
@@ -26,6 +31,15 @@ afterEach(() => {
   vi.unstubAllGlobals()
 })
 
+const directoryIdentity: FilesystemEntryIdentity = {
+  kind: 'directory',
+  dev: 1,
+  ino: 2,
+  size: 96,
+  ctimeMs: 3,
+  mtimeMs: 4,
+}
+
 /**
  * Build a minimal Skill fixture.
  * @param overrides - Partial Skill overrides
@@ -37,6 +51,7 @@ function makeSkill(overrides: Partial<Skill> = {}): Skill {
     name: 'task' as SkillName,
     description: 'Task management skill',
     path: '/home/user/.agents/skills/task' as Skill['path'],
+    filesystemIdentity: directoryIdentity,
     symlinkCount: 0,
     symlinks: [],
     isSource: true,
@@ -373,6 +388,15 @@ describe('SkillItem delete button', () => {
       agentName: null,
       // Single-row delete carries no repo-filter scope, so the summary is null.
       sourceSummary: null,
+      deleteTargets: [
+        {
+          skillName: 'brainstorming',
+          skillPath: '/home/user/.agents/skills/task',
+          filesystemIdentity: directoryIdentity,
+        },
+      ],
+      orphanRecords: [],
+      orphanErrors: [],
     })
   })
 
@@ -390,6 +414,15 @@ describe('SkillItem delete button', () => {
       agentName: null,
       // Single-row delete carries no repo-filter scope, so the summary is null.
       sourceSummary: null,
+      deleteTargets: [
+        {
+          skillName: 'local-skill',
+          skillPath: '/home/user/.agents/skills/task',
+          filesystemIdentity: directoryIdentity,
+        },
+      ],
+      orphanRecords: [],
+      orphanErrors: [],
     })
   })
 

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -30,9 +30,9 @@ import { useUnmountEffect } from '@/renderer/src/hooks/useUnmountEffect'
 import { cn } from '@/renderer/src/lib/utils'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import {
+  selectBulkSelectableVisibleSkillNames,
   selectAnyInFlightRemovalSet,
   selectSelectedSkillNamesSet,
-  selectVisibleSkillNames,
 } from '@/renderer/src/redux/selectors'
 import {
   addBookmark,
@@ -121,6 +121,24 @@ function getSymlinkStatusBuckets(
   return buckets
 }
 
+/**
+ * Decide whether this rendered row can participate in bulk selection.
+ * @param selectedAgentId - Current agent filter, or null in global view.
+ * @param visibleNames - Selector-approved names for agent-view bulk actions.
+ * @param skillName - Skill row currently rendered by SkillItem.
+ * @returns True when a checkbox should render for this row.
+ * @example
+ * canBulkSelectRenderedSkill(null, [], 'task') // => true
+ */
+function canBulkSelectRenderedSkill(
+  selectedAgentId: string | null,
+  visibleNames: readonly SkillName[],
+  skillName: SkillName,
+): boolean {
+  if (selectedAgentId === null) return true
+  return visibleNames.includes(skillName)
+}
+
 interface GlobalStatusBadgesProps {
   buckets: SymlinkStatusBuckets
 }
@@ -197,7 +215,7 @@ export const SkillItem = React.memo(function SkillItem({
   const selectedNamesSet = useAppSelector(selectSelectedSkillNamesSet)
   const inFlightRemovalSet = useAppSelector(selectAnyInFlightRemovalSet)
   const selectionAnchor = useAppSelector(selectSelectionAnchor)
-  const visibleNames = useAppSelector(selectVisibleSkillNames)
+  const visibleNames = useAppSelector(selectBulkSelectableVisibleSkillNames)
   const bulkSelectMode = useAppSelector(selectBulkSelectMode)
   const isTicked = selectedNamesSet.has(skill.name)
   const isInFlight = inFlightRemovalSet.has(skill.name)
@@ -219,6 +237,11 @@ export const SkillItem = React.memo(function SkillItem({
     selectedLocalSkillInfo,
     showGStackBadge,
   } = getSkillItemVisibility(selectedAgentId, skill)
+  const isBulkSelectable = canBulkSelectRenderedSkill(
+    selectedAgentId,
+    visibleNames,
+    skill.name,
+  )
 
   // Get selected agent name for tooltip
   const selectedAgentName =
@@ -524,7 +547,7 @@ export const SkillItem = React.memo(function SkillItem({
                   caused some screen readers to announce the skill twice.
                   Rendered only when the user has entered bulk-select mode via
                   the filter-row toggle; the default view stays clean. */}
-              {bulkSelectMode && (
+              {bulkSelectMode && isBulkSelectable && (
                 <label
                   className="shrink-0 min-h-11 min-w-11 flex items-center justify-center -mt-1 -ml-1 cursor-pointer"
                   onClick={(e) => e.stopPropagation()}

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -214,6 +214,7 @@ export const SkillItem = React.memo(function SkillItem({
     showDeleteButton,
     isLinked,
     isLocalSkill,
+    isInaccessibleSkill,
     selectedAgentSymlink,
     selectedLocalSkillInfo,
     showGStackBadge,
@@ -401,6 +402,9 @@ export const SkillItem = React.memo(function SkillItem({
             !didPartialFail &&
               isLocalSkill &&
               'border-l-2 border-l-emerald-400/40',
+            !didPartialFail &&
+              isInaccessibleSkill &&
+              'border-l-2 border-l-amber-400/60',
             // Orphan accent — surfaces dangling rows that the loosened
             // selectFilteredSkills now lets through. Mutually exclusive with
             // isLinked/isLocalSkill by definition (no source dir → no valid
@@ -552,6 +556,16 @@ export const SkillItem = React.memo(function SkillItem({
                     />
                   )}
                   <span className="truncate">{skill.name}</span>
+                  {isInaccessibleSkill && (
+                    <span
+                      role="img"
+                      className="inline-flex items-center rounded-md border border-amber-400/50 bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-amber-300 shrink-0"
+                      aria-label="Inaccessible link - manual review required"
+                      title="Target cannot be verified - review this link before removing it"
+                    >
+                      inaccessible
+                    </span>
+                  )}
                   {/* Orphan badge — paired with the amber left-border so the
                       row's state is legible even when the user hasn't
                       noticed the border accent. The plain word "orphan"

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -277,7 +277,7 @@ export const SkillItem = React.memo(function SkillItem({
    */
   const handleDeleteClick = (e: React.MouseEvent): void => {
     e.stopPropagation()
-    const { deleteTargets, orphanRecords, orphanErrors } =
+    const { deleteTargets, orphanRecords, staleDeleteErrors, orphanErrors } =
       partitionGlobalDeleteTargets([skill], [skill.name])
     dispatch(
       setBulkConfirm({
@@ -289,6 +289,7 @@ export const SkillItem = React.memo(function SkillItem({
         sourceSummary: null,
         deleteTargets,
         orphanRecords,
+        staleDeleteErrors,
         orphanErrors,
       }),
     )

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -191,6 +191,102 @@ const GlobalStatusBadges = React.memo(function GlobalStatusBadges({
   )
 })
 
+interface SkillTitleRowProps {
+  skill: Skill
+  isLinked: boolean
+  isLocalSkill: boolean
+  isInaccessibleSkill: boolean
+  showAddButton: boolean
+  showGStackBadge: boolean
+  onAddClick: React.MouseEventHandler<HTMLButtonElement>
+}
+
+/**
+ * Renders skill identity and compact row actions without merging controls into the heading.
+ * @param props - Skill state flags and Add click handler for one list row.
+ * @returns Header row with a clean skill heading plus adjacent actions.
+ * @example
+ * <SkillTitleRow skill={skill} isLinked={false} isLocalSkill={false} isInaccessibleSkill={false} showAddButton showGStackBadge={false} onAddClick={handleAddClick} />
+ */
+const SkillTitleRow = React.memo(function SkillTitleRow({
+  skill,
+  isLinked,
+  isLocalSkill,
+  isInaccessibleSkill,
+  showAddButton,
+  showGStackBadge,
+  onAddClick,
+}: SkillTitleRowProps): React.ReactElement {
+  return (
+    <div className="flex items-start gap-2">
+      <h3 className="font-medium truncate flex min-w-0 flex-1 items-center gap-1.5">
+        {isLinked && (
+          <Link2
+            className="h-3.5 w-3.5 shrink-0 text-success/70"
+            aria-label="Linked skill"
+          />
+        )}
+        {isLocalSkill && (
+          <FolderDot
+            className="h-3.5 w-3.5 shrink-0 text-emerald-400/70"
+            aria-label="Local skill"
+          />
+        )}
+        <span className="truncate">{skill.name}</span>
+        {isInaccessibleSkill && (
+          <span
+            role="img"
+            className="inline-flex items-center rounded-md border border-amber-400/50 bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-amber-300 shrink-0"
+            aria-label="Inaccessible link - manual review required"
+            title="Target cannot be verified - review this link before removing it"
+          >
+            inaccessible
+          </span>
+        )}
+        {skill.isOrphan && (
+          <span
+            role="img"
+            data-testid={`skill-orphan-badge-${skill.name}`}
+            className="inline-flex items-center rounded-md border border-amber-400/50 bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-amber-300 shrink-0"
+            aria-label="Orphan skill — source directory is missing"
+            title="Source directory is missing — use Cleanup to remove the dangling symlinks"
+          >
+            orphan
+          </span>
+        )}
+      </h3>
+      {(showAddButton || showGStackBadge) && (
+        <div className="flex shrink-0 items-center gap-1">
+          {showAddButton && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onAddClick}
+              className="h-6 px-2 text-xs"
+            >
+              <Plus className="mr-0.5 h-3 w-3" />
+              Add
+            </Button>
+          )}
+          {showGStackBadge && (
+            <a
+              href={GSTACK_REPOSITORY_URL}
+              target="_blank"
+              rel="noreferrer"
+              onClick={(e) => e.stopPropagation()}
+              className="inline-flex h-6 items-center gap-1 rounded-md border border-sky-400/40 bg-sky-500/15 px-1.5 text-[10px] font-semibold text-sky-300 transition-colors hover:bg-sky-500/25"
+              aria-label="Open G-Stack GitHub repository"
+            >
+              G-Stack
+              <ExternalLink className="h-2.5 w-2.5" />
+            </a>
+          )}
+        </div>
+      )}
+    </div>
+  )
+})
+
 /**
  * Single skill card in the skills list.
  *
@@ -572,73 +668,15 @@ export const SkillItem = React.memo(function SkillItem({
                 </label>
               )}
               <div className="flex-1 min-w-0">
-                <h3 className="font-medium truncate flex items-center gap-1.5">
-                  {isLinked && (
-                    <Link2
-                      className="h-3.5 w-3.5 shrink-0 text-success/70"
-                      aria-label="Linked skill"
-                    />
-                  )}
-                  {isLocalSkill && (
-                    <FolderDot
-                      className="h-3.5 w-3.5 shrink-0 text-emerald-400/70"
-                      aria-label="Local skill"
-                    />
-                  )}
-                  <span className="truncate">{skill.name}</span>
-                  {isInaccessibleSkill && (
-                    <span
-                      role="img"
-                      className="inline-flex items-center rounded-md border border-amber-400/50 bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-amber-300 shrink-0"
-                      aria-label="Inaccessible link - manual review required"
-                      title="Target cannot be verified - review this link before removing it"
-                    >
-                      inaccessible
-                    </span>
-                  )}
-                  {/* Orphan badge — paired with the amber left-border so the
-                      row's state is legible even when the user hasn't
-                      noticed the border accent. The plain word "orphan"
-                      keeps it scannable; tooltip explains the action. */}
-                  {skill.isOrphan && (
-                    <span
-                      role="img"
-                      data-testid={`skill-orphan-badge-${skill.name}`}
-                      className="inline-flex items-center rounded-md border border-amber-400/50 bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-amber-300 shrink-0"
-                      aria-label="Orphan skill — source directory is missing"
-                      title="Source directory is missing — use Cleanup to remove the dangling symlinks"
-                    >
-                      orphan
-                    </span>
-                  )}
-                  {/* Add button:
-                      - global view => AddSymlinkModal
-                      - agent view => CopyToAgentsModal */}
-                  {showAddButton && (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={handleAddClick}
-                      className="h-5 px-1.5 text-xs shrink-0 ml-1"
-                    >
-                      <Plus className="h-3 w-3 mr-0.5" />
-                      Add
-                    </Button>
-                  )}
-                  {showGStackBadge && (
-                    <a
-                      href={GSTACK_REPOSITORY_URL}
-                      target="_blank"
-                      rel="noreferrer"
-                      onClick={(e) => e.stopPropagation()}
-                      className="inline-flex items-center gap-1 rounded-md border border-sky-400/40 bg-sky-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-sky-300 transition-colors hover:bg-sky-500/25 shrink-0"
-                      aria-label="Open G-Stack GitHub repository"
-                    >
-                      G-Stack
-                      <ExternalLink className="h-2.5 w-2.5" />
-                    </a>
-                  )}
-                </h3>
+                <SkillTitleRow
+                  skill={skill}
+                  isLinked={isLinked}
+                  isLocalSkill={isLocalSkill}
+                  isInaccessibleSkill={isInaccessibleSkill}
+                  showAddButton={showAddButton}
+                  showGStackBadge={showGStackBadge}
+                  onAddClick={handleAddClick}
+                />
                 {skill.description && (
                   <p className="text-sm text-muted-foreground line-clamp-2 mt-1 min-h-10">
                     {skill.description}

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -650,7 +650,7 @@ export const SkillItem = React.memo(function SkillItem({
                   caused some screen readers to announce the skill twice.
                   Rendered only when the user has entered bulk-select mode via
                   the filter-row toggle; the default view stays clean. */}
-              {bulkSelectMode && isBulkSelectable && (
+              {bulkSelectMode && (
                 <label
                   className="shrink-0 min-h-11 min-w-11 flex items-center justify-center -mt-1 -ml-1 cursor-pointer"
                   onClick={(e) => e.stopPropagation()}
@@ -659,10 +659,16 @@ export const SkillItem = React.memo(function SkillItem({
                     checked={isTicked}
                     onCheckedChange={handleCheckedChange}
                     onPointerDown={handleCheckboxPointerDown}
+                    // Keep the slot rendered for every row in bulk mode so titles
+                    // stay aligned, but block selecting an ineligible row (still
+                    // allow deselecting one that is already ticked).
+                    disabled={!isBulkSelectable && !isTicked}
                     aria-label={
                       isTicked
                         ? `Deselect ${skill.name}`
-                        : `Select ${skill.name}`
+                        : isBulkSelectable
+                          ? `Select ${skill.name}`
+                          : `${skill.name} is not eligible for bulk selection`
                     }
                   />
                 </label>

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -564,7 +564,7 @@ export const SkillItem = React.memo(function SkillItem({
                       ? `Delete ${skill.name} from ${selectedAgentName}`
                       : `Unlink ${skill.name} from ${selectedAgentName}`
                   }
-                  className="absolute top-0 right-0 min-h-11 min-w-11 flex items-center justify-center rounded-md hover:bg-destructive/10 text-muted-foreground hover:text-destructive z-10 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
+                  className="absolute top-1.5 right-0 min-h-11 min-w-11 flex items-center justify-center rounded-md hover:bg-destructive/10 text-muted-foreground hover:text-destructive z-10 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
                 >
                   <X className="h-3.5 w-3.5" />
                 </button>
@@ -589,7 +589,7 @@ export const SkillItem = React.memo(function SkillItem({
                   onClick={handleDeleteClick}
                   aria-label={`Delete ${skill.name}`}
                   data-testid={`skill-delete-${skill.name}`}
-                  className="absolute top-0 right-0 min-h-11 min-w-11 flex items-center justify-center rounded-md hover:bg-destructive/10 text-muted-foreground hover:text-destructive z-10 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
+                  className="absolute top-1.5 right-0 min-h-11 min-w-11 flex items-center justify-center rounded-md hover:bg-destructive/10 text-muted-foreground hover:text-destructive z-10 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
                 >
                   <X className="h-3.5 w-3.5" />
                 </button>
@@ -612,7 +612,7 @@ export const SkillItem = React.memo(function SkillItem({
                       : `Bookmark ${skill.name}`
                   }
                   className={cn(
-                    'absolute top-0 min-h-11 min-w-11 flex items-center justify-center rounded-md z-10 transition-opacity',
+                    'absolute top-1.5 min-h-11 min-w-11 flex items-center justify-center rounded-md z-10 transition-opacity',
                     // Right-align: slide the bookmark left of the X when an
                     // X button (unlink in agent view, delete in global view)
                     // shares the top-right corner.

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -59,7 +59,10 @@ import type { Skill, SkillName, SymlinkInfo } from '@/shared/types'
 import { canBookmarkSkill, skillToBookmarkData } from './bookmarkHelpers'
 import { computeRangeSelection } from './bulkDeleteHelpers'
 import { partitionGlobalDeleteTargets } from './reviewedDestructiveTargets'
-import { getSkillItemVisibility } from './skillItemHelpers'
+import {
+  getCardContentPaddingClass,
+  getSkillItemVisibility,
+} from './skillItemHelpers'
 import { SourceLink } from './SourceLink'
 
 // Strongly-type the `skills:bulkItemFailed` CustomEvent so the cast inside
@@ -637,10 +640,15 @@ export const SkillItem = React.memo(function SkillItem({
           <CardContent
             className={cn(
               'p-4',
-              // Reserve right space for the X/bookmark buttons when shown.
-              showUnlinkButton || showDeleteButton || showBookmark
-                ? 'pr-14'
-                : 'pr-4',
+              // Reserve right space for the absolute-positioned X/bookmark
+              // overlays so the always-visible "+ Add" control never slides
+              // under them on hover. Bookmark + X stack to 88px, so that case
+              // needs pr-24 (96px), not the single-button pr-14 (56px).
+              getCardContentPaddingClass({
+                showBookmark,
+                showUnlinkButton,
+                showDeleteButton,
+              }),
             )}
           >
             <div className="flex items-start gap-3">

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -621,7 +621,7 @@ export const SkillItem = React.memo(function SkillItem({
                       : 'right-0',
                     isBookmarked
                       ? 'text-primary'
-                      : 'text-muted-foreground hover:text-foreground opacity-0 group-hover:opacity-100 focus-visible:opacity-100',
+                      : 'text-muted-foreground hover:text-foreground opacity-40 group-hover:opacity-100 focus-visible:opacity-100',
                   )}
                 >
                   {isBookmarked ? (

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -58,6 +58,7 @@ import type { Skill, SkillName, SymlinkInfo } from '@/shared/types'
 
 import { canBookmarkSkill, skillToBookmarkData } from './bookmarkHelpers'
 import { computeRangeSelection } from './bulkDeleteHelpers'
+import { partitionGlobalDeleteTargets } from './reviewedDestructiveTargets'
 import { getSkillItemVisibility } from './skillItemHelpers'
 import { SourceLink } from './SourceLink'
 
@@ -276,6 +277,8 @@ export const SkillItem = React.memo(function SkillItem({
    */
   const handleDeleteClick = (e: React.MouseEvent): void => {
     e.stopPropagation()
+    const { deleteTargets, orphanRecords, orphanErrors } =
+      partitionGlobalDeleteTargets([skill], [skill.name])
     dispatch(
       setBulkConfirm({
         kind: 'delete',
@@ -284,6 +287,9 @@ export const SkillItem = React.memo(function SkillItem({
         agentName: null,
         // A single-row delete carries no repo-filter scope to report.
         sourceSummary: null,
+        deleteTargets,
+        orphanRecords,
+        orphanErrors,
       }),
     )
   }

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -54,7 +54,7 @@ import {
 } from '@/renderer/src/redux/slices/uiSlice'
 import { BULK_ITEM_FAILED_EVENT } from '@/renderer/src/utils/bulkOpVisuals'
 import { GSTACK_REPOSITORY_URL } from '@/shared/constants'
-import type { Skill, SkillName } from '@/shared/types'
+import type { Skill, SkillName, SymlinkInfo } from '@/shared/types'
 
 import { canBookmarkSkill, skillToBookmarkData } from './bookmarkHelpers'
 import { computeRangeSelection } from './bulkDeleteHelpers'
@@ -74,8 +74,103 @@ interface SkillItemProps {
   skill: Skill
 }
 
+interface SymlinkStatusBuckets {
+  validCount: number
+  brokenCount: number
+  inaccessibleCount: number
+  validAgentNames: string[]
+  brokenAgentNames: string[]
+  inaccessibleAgentNames: string[]
+}
+
 /** How long the partial-failure red edge persists (ms). */
 const PARTIAL_FAIL_FLASH_MS = 3_000
+
+/**
+ * Groups symlink status counts outside the large card render path to keep the component under fallow complexity limits.
+ * @param symlinks - Symlink rows attached to the skill being rendered.
+ * @returns Counts plus tooltip agent names for the global-view badges.
+ * @example
+ * getSymlinkStatusBuckets([{ status: 'valid', agentName: 'Codex', ... }]).validCount // => 1
+ */
+function getSymlinkStatusBuckets(
+  symlinks: readonly SymlinkInfo[],
+): SymlinkStatusBuckets {
+  const buckets: SymlinkStatusBuckets = {
+    validCount: 0,
+    brokenCount: 0,
+    inaccessibleCount: 0,
+    validAgentNames: [],
+    brokenAgentNames: [],
+    inaccessibleAgentNames: [],
+  }
+
+  for (const symlink of symlinks) {
+    if (symlink.status === 'valid') {
+      buckets.validCount += 1
+      buckets.validAgentNames.push(symlink.agentName)
+    } else if (symlink.status === 'broken') {
+      buckets.brokenCount += 1
+      buckets.brokenAgentNames.push(symlink.agentName)
+    } else if (symlink.status === 'inaccessible') {
+      buckets.inaccessibleCount += 1
+      buckets.inaccessibleAgentNames.push(symlink.agentName)
+    }
+  }
+
+  return buckets
+}
+
+interface GlobalStatusBadgesProps {
+  buckets: SymlinkStatusBuckets
+}
+
+/**
+ * Renders global-view symlink badges while keeping the already-large card component simple.
+ * @param props - Precomputed symlink status buckets for one skill.
+ * @returns Badge row showing valid, broken, inaccessible, or unlinked state.
+ * @example
+ * <GlobalStatusBadges buckets={buckets} />
+ */
+const GlobalStatusBadges = React.memo(function GlobalStatusBadges({
+  buckets,
+}: GlobalStatusBadgesProps): React.ReactElement {
+  const hasNoLinks =
+    buckets.validCount === 0 &&
+    buckets.brokenCount === 0 &&
+    buckets.inaccessibleCount === 0
+
+  return (
+    <div className="flex items-center gap-2 mt-3">
+      {buckets.validCount > 0 && (
+        <StatusBadge
+          status="valid"
+          count={buckets.validCount}
+          agentNames={buckets.validAgentNames}
+        />
+      )}
+      {buckets.brokenCount > 0 && (
+        <StatusBadge
+          status="broken"
+          count={buckets.brokenCount}
+          agentNames={buckets.brokenAgentNames}
+        />
+      )}
+      {buckets.inaccessibleCount > 0 && (
+        <StatusBadge
+          status="inaccessible"
+          count={buckets.inaccessibleCount}
+          agentNames={buckets.inaccessibleAgentNames}
+        />
+      )}
+      {hasNoLinks && (
+        <span className="text-xs text-muted-foreground">
+          Not linked to any agent
+        </span>
+      )}
+    </div>
+  )
+})
 
 /**
  * Single skill card in the skills list.
@@ -107,23 +202,9 @@ export const SkillItem = React.memo(function SkillItem({
   const isTicked = selectedNamesSet.has(skill.name)
   const isInFlight = inFlightRemovalSet.has(skill.name)
 
-  const validSymlinks = useMemo(
-    () => skill.symlinks.filter((s) => s.status === 'valid'),
+  const symlinkStatusBuckets = useMemo(
+    () => getSymlinkStatusBuckets(skill.symlinks),
     [skill.symlinks],
-  )
-  const brokenSymlinks = useMemo(
-    () => skill.symlinks.filter((s) => s.status === 'broken'),
-    [skill.symlinks],
-  )
-  const validCount = validSymlinks.length
-  const brokenCount = brokenSymlinks.length
-  const validAgentNames = useMemo(
-    () => validSymlinks.map((s) => s.agentName),
-    [validSymlinks],
-  )
-  const brokenAgentNames = useMemo(
-    () => brokenSymlinks.map((s) => s.agentName),
-    [brokenSymlinks],
   )
 
   const {
@@ -525,27 +606,7 @@ export const SkillItem = React.memo(function SkillItem({
 
             {/* Status badges — only shown in global view (no agent selected) */}
             {!selectedAgentId && (
-              <div className="flex items-center gap-2 mt-3">
-                {validCount > 0 && (
-                  <StatusBadge
-                    status="valid"
-                    count={validCount}
-                    agentNames={validAgentNames}
-                  />
-                )}
-                {brokenCount > 0 && (
-                  <StatusBadge
-                    status="broken"
-                    count={brokenCount}
-                    agentNames={brokenAgentNames}
-                  />
-                )}
-                {validCount === 0 && brokenCount === 0 && (
-                  <span className="text-xs text-muted-foreground">
-                    Not linked to any agent
-                  </span>
-                )}
-              </div>
+              <GlobalStatusBadges buckets={symlinkStatusBuckets} />
             )}
           </CardContent>
         </Card>

--- a/src/renderer/src/components/skills/UnlinkDialog.tsx
+++ b/src/renderer/src/components/skills/UnlinkDialog.tsx
@@ -16,13 +16,14 @@ import type { SymlinkInfo } from '@/shared/types'
  * - `local`  : real skill folder lives in the agent dir; removal is permanent.
  * - `broken` : the agent has a dangling symlink to a source that no longer
  *              exists (orphan); removal is permanent (nothing to restore to).
+ * - `inaccessible`: symlink target could not be verified; require manual review.
  * - `valid`  : a working symlink that can be safely removed (the source dir
  *              and any other agents' links survive).
  *
  * `'missing'` symlinks never reach this dialog — the unlink button is gated
  * out for them upstream (see SkillItemHelpers).
  */
-type UnlinkVariant = 'local' | 'broken' | 'valid'
+type UnlinkVariant = 'local' | 'broken' | 'inaccessible' | 'valid'
 
 interface UnlinkCopy {
   title: string
@@ -61,6 +62,16 @@ function getUnlinkCopy(
       successDescription: `Broken symlink to ${skillName} removed from ${agentName}`,
       errorTitle: 'Failed to remove broken link',
     }))
+    .with('inaccessible', () => ({
+      title: 'Manual Review Required',
+      detailText:
+        'The target could not be verified. Review the link in the filesystem before removing it.',
+      confirmLabel: 'Close',
+      loadingLabel: 'Closing...',
+      successTitle: `Manual review needed for ${agentName}`,
+      successDescription: `${skillName} was not removed because its target could not be verified.`,
+      errorTitle: 'Manual review required',
+    }))
     .with('valid', () => ({
       title: 'Remove from Agent',
       detailText:
@@ -85,6 +96,7 @@ function getUnlinkCopy(
  */
 function pickVariant(symlink: SymlinkInfo): UnlinkVariant {
   if (symlink.isLocal) return 'local'
+  if (symlink.status === 'inaccessible') return 'inaccessible'
   if (symlink.status === 'broken' || symlink.status === 'missing')
     return 'broken'
   return 'valid'
@@ -92,8 +104,8 @@ function pickVariant(symlink: SymlinkInfo): UnlinkVariant {
 
 /**
  * Confirmation dialog for removing a skill from the selected agent.
- * Handles three states (local folder delete / broken-symlink cleanup / live
- * symlink unlink) via an exhaustive ts-pattern match — adding a future
+ * Handles local, broken, inaccessible, and live symlink states via an
+ * exhaustive ts-pattern match — adding a future
  * variant forces the copy table to be updated at compile time.
  */
 export const UnlinkDialog = React.memo(
@@ -118,6 +130,13 @@ export const UnlinkDialog = React.memo(
 
     const handleUnlink = useCallback(async (): Promise<void> => {
       if (!skillToUnlink) return
+      if (variant === 'inaccessible') {
+        toast.warning(copy.errorTitle, {
+          description: copy.successDescription,
+        })
+        dispatch(setSkillToUnlink(null))
+        return
+      }
 
       const { skill, symlink } = skillToUnlink
       const result = await dispatch(unlinkSkillFromAgent({ skill, symlink }))
@@ -136,7 +155,7 @@ export const UnlinkDialog = React.memo(
       // so the SkillsList does not stay stuck on the error view.
       refreshAllData(dispatch)
       dispatch(setSkillToUnlink(null))
-    }, [copy, dispatch, skillToUnlink])
+    }, [copy, dispatch, skillToUnlink, variant])
 
     return (
       <DestructiveConfirmDialog

--- a/src/renderer/src/components/skills/agentSelectionHelpers.test.ts
+++ b/src/renderer/src/components/skills/agentSelectionHelpers.test.ts
@@ -95,6 +95,23 @@ describe('buildCopyAgentOptionViewModel', () => {
     })
   })
 
+  it('labels inaccessible occupancy as manual review instead of broken cleanup', () => {
+    const agent = makeAgent({ id: 'cursor', exists: true, name: 'Cursor' })
+
+    const result = buildCopyAgentOptionViewModel(agent, {
+      occupiedAgentReasonById: new Map([['cursor' as AgentId, 'inaccessible']]),
+      selectedAgentIds: [],
+      copying: false,
+      isSourceUnavailable: false,
+    })
+
+    expect(result).toMatchObject({
+      checked: true,
+      disabled: true,
+      secondaryLabel: 'manual review required',
+    })
+  })
+
   it('disables otherwise-free rows while copying or source is unavailable', () => {
     const agent = makeAgent({ id: 'amp', exists: false, name: 'Amp' })
 
@@ -121,6 +138,15 @@ describe('getAddAgentSecondaryLabel', () => {
         exists: false,
       }),
     ).toBe('broken link')
+  })
+
+  it('returns manual review copy for inaccessible destinations', () => {
+    expect(
+      getAddAgentSecondaryLabel({
+        occupiedReason: 'inaccessible',
+        exists: true,
+      }),
+    ).toBe('manual review required')
   })
 
   it('returns not installed for free missing agents', () => {

--- a/src/renderer/src/components/skills/agentSelectionHelpers.ts
+++ b/src/renderer/src/components/skills/agentSelectionHelpers.ts
@@ -4,7 +4,7 @@ import type { Agent, AgentId, SymlinkInfo } from '@/shared/types'
  * Why an agent row is unavailable as a destination in Add/Copy flows.
  * - `linked`: a valid symlink already exists
  * - `local`: a real directory already exists in the agent's skills dir
- * - `broken`: a broken symlink occupies the destination path
+ * - `broken`: a broken or inaccessible symlink occupies the destination path
  */
 export type OccupiedAgentReason = 'linked' | 'local' | 'broken'
 
@@ -193,6 +193,10 @@ function getOccupiedAgentReason(
   }
 
   if (symlink.status === 'broken') {
+    return 'broken'
+  }
+
+  if (symlink.status === 'inaccessible') {
     return 'broken'
   }
 

--- a/src/renderer/src/components/skills/agentSelectionHelpers.ts
+++ b/src/renderer/src/components/skills/agentSelectionHelpers.ts
@@ -4,9 +4,10 @@ import type { Agent, AgentId, SymlinkInfo } from '@/shared/types'
  * Why an agent row is unavailable as a destination in Add/Copy flows.
  * - `linked`: a valid symlink already exists
  * - `local`: a real directory already exists in the agent's skills dir
- * - `broken`: a broken or inaccessible symlink occupies the destination path
+ * - `broken`: a broken symlink occupies the destination path
+ * - `inaccessible`: a symlink exists but needs manual filesystem review
  */
-export type OccupiedAgentReason = 'linked' | 'local' | 'broken'
+export type OccupiedAgentReason = 'linked' | 'local' | 'broken' | 'inaccessible'
 
 export interface CopyAgentOptionViewModel {
   agentId: AgentId
@@ -20,6 +21,7 @@ const OCCUPIED_AGENT_REASON_LABELS: Record<OccupiedAgentReason, string> = {
   linked: 'linked',
   local: 'local',
   broken: 'broken link',
+  inaccessible: 'manual review required',
 }
 
 /**
@@ -176,6 +178,7 @@ export function buildCopyAgentOptionViewModel(
  * - `linked`: valid symlink already present
  * - `local`: local skill directory already present
  * - `broken`: broken symlink still occupies the destination path
+ * - `inaccessible`: target cannot be verified; manual review required
  * - `null`: destination is free (`missing`)
  * @example
  * getOccupiedAgentReason({ status: 'broken', isLocal: false } as SymlinkInfo)
@@ -197,7 +200,7 @@ function getOccupiedAgentReason(
   }
 
   if (symlink.status === 'inaccessible') {
-    return 'broken'
+    return 'inaccessible'
   }
 
   return null

--- a/src/renderer/src/components/skills/bulkDeleteCopy.test.ts
+++ b/src/renderer/src/components/skills/bulkDeleteCopy.test.ts
@@ -33,6 +33,36 @@ describe('renderBulkDeleteDescription', () => {
     )
   })
 
+  it('describes orphan-only cleanup without promising trash undo', () => {
+    // Arrange / Act
+    const description = renderBulkDeleteDescription({
+      totalCount: 2,
+      trashCount: 0,
+      orphanCleanupCount: 2,
+      sourceSummary: null,
+    })
+
+    // Assert — orphan cleanup has no tombstone or UndoToast restore path
+    expect(description).toBe(
+      'This removes reviewed dangling symlinks for 2 orphan skills. Source skill files are already missing, and this cleanup cannot be undone from the notification.',
+    )
+  })
+
+  it('separates trash undo from orphan cleanup in a mixed delete batch', () => {
+    // Arrange / Act
+    const description = renderBulkDeleteDescription({
+      totalCount: 3,
+      trashCount: 1,
+      orphanCleanupCount: 2,
+      sourceSummary: null,
+    })
+
+    // Assert — only tombstoned source skills advertise the undo window
+    expect(description).toBe(
+      'This moves 1 skill to the app trash with a 15-second restore window and removes reviewed dangling symlinks for 2 orphan skills. Orphan cleanup cannot be undone from the notification.',
+    )
+  })
+
   it('names the single in-scope repository', () => {
     // Arrange / Act
     const description = renderBulkDeleteDescription({

--- a/src/renderer/src/components/skills/bulkDeleteCopy.test.ts
+++ b/src/renderer/src/components/skills/bulkDeleteCopy.test.ts
@@ -79,6 +79,21 @@ describe('renderBulkDeleteDescription', () => {
     )
   })
 
+  it('warns stale source rows with delete rescan copy, not orphan cleanup copy', () => {
+    // Arrange / Act
+    const description = renderBulkDeleteDescription({
+      totalCount: 1,
+      trashCount: 0,
+      staleDeleteCount: 1,
+      sourceSummary: null,
+    })
+
+    // Assert — missing source/local identity is a delete rescan, not orphan cleanup.
+    expect(description).toBe(
+      'No selected skills are ready to delete. 1 selected skill needs a rescan before delete because the reviewed filesystem identity is missing.',
+    )
+  })
+
   it('keeps stale orphan copy separate from source-trash copy', () => {
     // Arrange / Act
     const description = renderBulkDeleteDescription({
@@ -92,6 +107,23 @@ describe('renderBulkDeleteDescription', () => {
     // Assert — only the source row promises trash/undo
     expect(description).toBe(
       'This moves 1 skill to the app trash with a 15-second restore window. 1 orphan skill needs a rescan before cleanup because the reviewed target identity is missing.',
+    )
+  })
+
+  it('keeps stale source copy separate from orphan rescan copy in a mixed preflight batch', () => {
+    // Arrange / Act
+    const description = renderBulkDeleteDescription({
+      totalCount: 3,
+      trashCount: 1,
+      orphanCleanupCount: 0,
+      staleDeleteCount: 1,
+      orphanRescanCount: 1,
+      sourceSummary: null,
+    })
+
+    // Assert — both stale categories are named without collapsing source into orphan.
+    expect(description).toBe(
+      'This moves 1 skill to the app trash with a 15-second restore window. 1 selected skill needs a rescan before delete because the reviewed filesystem identity is missing. 1 orphan skill needs a rescan before cleanup because the reviewed target identity is missing.',
     )
   })
 

--- a/src/renderer/src/components/skills/bulkDeleteCopy.test.ts
+++ b/src/renderer/src/components/skills/bulkDeleteCopy.test.ts
@@ -63,6 +63,38 @@ describe('renderBulkDeleteDescription', () => {
     )
   })
 
+  it('warns when selected orphan rows require rescan before cleanup', () => {
+    // Arrange / Act
+    const description = renderBulkDeleteDescription({
+      totalCount: 1,
+      trashCount: 0,
+      orphanCleanupCount: 0,
+      orphanRescanCount: 1,
+      sourceSummary: null,
+    })
+
+    // Assert — stale orphan rows are not counted as cleanup-ready
+    expect(description).toBe(
+      'No selected orphan skills are cleanup-ready. 1 orphan skill needs a rescan before cleanup because the reviewed target identity is missing.',
+    )
+  })
+
+  it('keeps stale orphan copy separate from source-trash copy', () => {
+    // Arrange / Act
+    const description = renderBulkDeleteDescription({
+      totalCount: 2,
+      trashCount: 1,
+      orphanCleanupCount: 0,
+      orphanRescanCount: 1,
+      sourceSummary: null,
+    })
+
+    // Assert — only the source row promises trash/undo
+    expect(description).toBe(
+      'This moves 1 skill to the app trash with a 15-second restore window. 1 orphan skill needs a rescan before cleanup because the reviewed target identity is missing.',
+    )
+  })
+
   it('names the single in-scope repository', () => {
     // Arrange / Act
     const description = renderBulkDeleteDescription({

--- a/src/renderer/src/components/skills/bulkDeleteCopy.tsx
+++ b/src/renderer/src/components/skills/bulkDeleteCopy.tsx
@@ -19,6 +19,7 @@ import { pluralize } from '@/renderer/src/utils/pluralize'
  * @param totalCount - Total skills in the pending batch.
  * @param trashCount - Source-backed rows that produce tombstones and undo.
  * @param orphanCleanupCount - Orphan rows cleaned as dangling symlinks only.
+ * @param orphanRescanCount - Stale orphan rows that need a fresh scan first.
  * @param sourceSummary - Active repo-filter scope snapshot, or null when no
  *   repo filter is active and no local skills are hidden.
  * @returns
@@ -44,40 +45,50 @@ export const renderBulkDeleteDescription = ({
   totalCount,
   trashCount = totalCount,
   orphanCleanupCount = 0,
+  orphanRescanCount = 0,
   sourceSummary,
 }: {
   totalCount: number
   trashCount?: number
   orphanCleanupCount?: number
+  orphanRescanCount?: number
   sourceSummary: SourceFilterSummary | null
 }): React.ReactNode => {
   const base =
-    orphanCleanupCount === 0
+    orphanCleanupCount === 0 && orphanRescanCount === 0
       ? `This moves the ${pluralize(totalCount, 'skill')} to the app trash and removes every symlink pointing to ${pluralize(totalCount, 'it', 'them')}. You can restore within 15 seconds from the notification.`
-      : trashCount === 0
-        ? `This removes reviewed dangling symlinks for ${orphanCleanupCount} orphan ${pluralize(orphanCleanupCount, 'skill')}. Source skill files are already missing, and this cleanup cannot be undone from the notification.`
-        : `This moves ${trashCount} ${pluralize(trashCount, 'skill')} to the app trash with a 15-second restore window and removes reviewed dangling symlinks for ${orphanCleanupCount} orphan ${pluralize(orphanCleanupCount, 'skill')}. Orphan cleanup cannot be undone from the notification.`
-
-  // No active repo filter (and nothing hidden) → the base copy is complete.
-  if (sourceSummary === null) return base
+      : trashCount > 0 && orphanCleanupCount === 0
+        ? `This moves ${trashCount} ${pluralize(trashCount, 'skill')} to the app trash with a 15-second restore window.`
+        : trashCount === 0 && orphanCleanupCount > 0
+          ? `This removes reviewed dangling symlinks for ${orphanCleanupCount} orphan ${pluralize(orphanCleanupCount, 'skill')}. Source skill files are already missing, and this cleanup cannot be undone from the notification.`
+          : trashCount > 0 && orphanCleanupCount > 0
+            ? `This moves ${trashCount} ${pluralize(trashCount, 'skill')} to the app trash with a 15-second restore window and removes reviewed dangling symlinks for ${orphanCleanupCount} orphan ${pluralize(orphanCleanupCount, 'skill')}. Orphan cleanup cannot be undone from the notification.`
+            : 'No selected orphan skills are cleanup-ready.'
 
   const scopeSentences: string[] = []
-  // Name the repositories the batch is drawn from. A single repo is spelled in
-  // full (NOT the truncated trigger label) — this is a destructive confirm, so
-  // the user must see the exact source; many repos collapse to a count.
-  if (sourceSummary.repositoryIds.length > 0) {
-    const repoScope =
-      sourceSummary.repositoryIds.length === 1
-        ? sourceSummary.repositoryIds[0]
-        : `the ${sourceSummary.repositoryIds.length} selected repositories`
-    scopeSentences.push(`Only skills from ${repoScope} are in scope.`)
-  }
-  // Reassure that source-less local skills the filter hides stay untouched.
-  if (sourceSummary.localHiddenCount > 0) {
-    const { localHiddenCount } = sourceSummary
+  if (orphanRescanCount > 0) {
     scopeSentences.push(
-      `${localHiddenCount} local ${pluralize(localHiddenCount, 'skill')} hidden by the source filter ${pluralize(localHiddenCount, 'is', 'are')} not affected.`,
+      `${orphanRescanCount} orphan ${pluralize(orphanRescanCount, 'skill')} ${pluralize(orphanRescanCount, 'needs', 'need')} a rescan before cleanup because the reviewed target identity is missing.`,
     )
+  }
+  if (sourceSummary !== null) {
+    // Name the repositories the batch is drawn from. A single repo is spelled in
+    // full (NOT the truncated trigger label) — this is a destructive confirm, so
+    // the user must see the exact source; many repos collapse to a count.
+    if (sourceSummary.repositoryIds.length > 0) {
+      const repoScope =
+        sourceSummary.repositoryIds.length === 1
+          ? sourceSummary.repositoryIds[0]
+          : `the ${sourceSummary.repositoryIds.length} selected repositories`
+      scopeSentences.push(`Only skills from ${repoScope} are in scope.`)
+    }
+    // Reassure that source-less local skills the filter hides stay untouched.
+    if (sourceSummary.localHiddenCount > 0) {
+      const { localHiddenCount } = sourceSummary
+      scopeSentences.push(
+        `${localHiddenCount} local ${pluralize(localHiddenCount, 'skill')} hidden by the source filter ${pluralize(localHiddenCount, 'is', 'are')} not affected.`,
+      )
+    }
   }
 
   if (scopeSentences.length === 0) return base

--- a/src/renderer/src/components/skills/bulkDeleteCopy.tsx
+++ b/src/renderer/src/components/skills/bulkDeleteCopy.tsx
@@ -6,9 +6,8 @@ import { pluralize } from '@/renderer/src/utils/pluralize'
 /**
  * Render the DialogDescription body for the bulk-delete confirm dialog.
  *
- * Every skill — including ones tracked in `~/.agents/.skill-lock.json` — is
- * trashed via `moveToTrash` with a 15s undo window. The CLI removal branch
- * was removed; lock-file entries are not rewritten by the desktop app.
+ * Source-backed skills are trashed with a 15s undo window; orphan rows remove
+ * reviewed dangling symlinks directly and therefore have no undo toast.
  *
  * When a source-repo include filter is active, `sourceSummary` appends a scope
  * clause: which repositories the batch is drawn from, and how many source-less
@@ -18,10 +17,12 @@ import { pluralize } from '@/renderer/src/utils/pluralize'
  * copy stays testable without mounting the full MainContent tree.
  *
  * @param totalCount - Total skills in the pending batch.
+ * @param trashCount - Source-backed rows that produce tombstones and undo.
+ * @param orphanCleanupCount - Orphan rows cleaned as dangling symlinks only.
  * @param sourceSummary - Active repo-filter scope snapshot, or null when no
  *   repo filter is active and no local skills are hidden.
  * @returns
- * - Base trash + undo sentence (always present).
+ * - Trash + undo sentence for source rows, or no-undo cleanup copy for orphan rows.
  * - `+ " Only skills from <repo> are in scope."` when ≥1 repo is in scope.
  * - `+ " N local skills hidden by the source filter are not affected."` when
  *   the filter suppresses source-less local skills.
@@ -41,12 +42,21 @@ import { pluralize } from '@/renderer/src/utils/pluralize'
  */
 export const renderBulkDeleteDescription = ({
   totalCount,
+  trashCount = totalCount,
+  orphanCleanupCount = 0,
   sourceSummary,
 }: {
   totalCount: number
+  trashCount?: number
+  orphanCleanupCount?: number
   sourceSummary: SourceFilterSummary | null
 }): React.ReactNode => {
-  const base = `This moves the ${pluralize(totalCount, 'skill')} to the app trash and removes every symlink pointing to ${pluralize(totalCount, 'it', 'them')}. You can restore within 15 seconds from the notification.`
+  const base =
+    orphanCleanupCount === 0
+      ? `This moves the ${pluralize(totalCount, 'skill')} to the app trash and removes every symlink pointing to ${pluralize(totalCount, 'it', 'them')}. You can restore within 15 seconds from the notification.`
+      : trashCount === 0
+        ? `This removes reviewed dangling symlinks for ${orphanCleanupCount} orphan ${pluralize(orphanCleanupCount, 'skill')}. Source skill files are already missing, and this cleanup cannot be undone from the notification.`
+        : `This moves ${trashCount} ${pluralize(trashCount, 'skill')} to the app trash with a 15-second restore window and removes reviewed dangling symlinks for ${orphanCleanupCount} orphan ${pluralize(orphanCleanupCount, 'skill')}. Orphan cleanup cannot be undone from the notification.`
 
   // No active repo filter (and nothing hidden) → the base copy is complete.
   if (sourceSummary === null) return base

--- a/src/renderer/src/components/skills/bulkDeleteCopy.tsx
+++ b/src/renderer/src/components/skills/bulkDeleteCopy.tsx
@@ -19,6 +19,7 @@ import { pluralize } from '@/renderer/src/utils/pluralize'
  * @param totalCount - Total skills in the pending batch.
  * @param trashCount - Source-backed rows that produce tombstones and undo.
  * @param orphanCleanupCount - Orphan rows cleaned as dangling symlinks only.
+ * @param staleDeleteCount - Source/local rows that need a fresh scan before delete.
  * @param orphanRescanCount - Stale orphan rows that need a fresh scan first.
  * @param sourceSummary - Active repo-filter scope snapshot, or null when no
  *   repo filter is active and no local skills are hidden.
@@ -45,17 +46,21 @@ export const renderBulkDeleteDescription = ({
   totalCount,
   trashCount = totalCount,
   orphanCleanupCount = 0,
+  staleDeleteCount = 0,
   orphanRescanCount = 0,
   sourceSummary,
 }: {
   totalCount: number
   trashCount?: number
   orphanCleanupCount?: number
+  staleDeleteCount?: number
   orphanRescanCount?: number
   sourceSummary: SourceFilterSummary | null
 }): React.ReactNode => {
   const base =
-    orphanCleanupCount === 0 && orphanRescanCount === 0
+    orphanCleanupCount === 0 &&
+    orphanRescanCount === 0 &&
+    staleDeleteCount === 0
       ? `This moves the ${pluralize(totalCount, 'skill')} to the app trash and removes every symlink pointing to ${pluralize(totalCount, 'it', 'them')}. You can restore within 15 seconds from the notification.`
       : trashCount > 0 && orphanCleanupCount === 0
         ? `This moves ${trashCount} ${pluralize(trashCount, 'skill')} to the app trash with a 15-second restore window.`
@@ -63,9 +68,16 @@ export const renderBulkDeleteDescription = ({
           ? `This removes reviewed dangling symlinks for ${orphanCleanupCount} orphan ${pluralize(orphanCleanupCount, 'skill')}. Source skill files are already missing, and this cleanup cannot be undone from the notification.`
           : trashCount > 0 && orphanCleanupCount > 0
             ? `This moves ${trashCount} ${pluralize(trashCount, 'skill')} to the app trash with a 15-second restore window and removes reviewed dangling symlinks for ${orphanCleanupCount} orphan ${pluralize(orphanCleanupCount, 'skill')}. Orphan cleanup cannot be undone from the notification.`
-            : 'No selected orphan skills are cleanup-ready.'
+            : orphanRescanCount > 0 && staleDeleteCount === 0
+              ? 'No selected orphan skills are cleanup-ready.'
+              : 'No selected skills are ready to delete.'
 
   const scopeSentences: string[] = []
+  if (staleDeleteCount > 0) {
+    scopeSentences.push(
+      `${staleDeleteCount} selected ${pluralize(staleDeleteCount, 'skill')} ${pluralize(staleDeleteCount, 'needs', 'need')} a rescan before delete because the reviewed filesystem identity is missing.`,
+    )
+  }
   if (orphanRescanCount > 0) {
     scopeSentences.push(
       `${orphanRescanCount} orphan ${pluralize(orphanRescanCount, 'skill')} ${pluralize(orphanRescanCount, 'needs', 'need')} a rescan before cleanup because the reviewed target identity is missing.`,

--- a/src/renderer/src/components/skills/bulkDeleteHelpers.test.ts
+++ b/src/renderer/src/components/skills/bulkDeleteHelpers.test.ts
@@ -97,7 +97,26 @@ describe('getToolbarState', () => {
       count: 5, // user has 5 selected globally
       visibleCount: 0, // but search filter leaves none visible
     })
+    expect(result.variantKey).toBe('global-zero')
     expect(result.isPrimaryDisabled).toBe(true)
+    expect(result.primaryLabel).toBe('No visible skills')
+    expect(result.primaryAriaLabel).toBe('No visible selected skills to delete')
+  })
+
+  it('uses unlink-specific zero-visible copy in agent view', () => {
+    const result = getToolbarState({
+      view: 'agent',
+      agentId: 'cursor' as AgentId,
+      count: 3,
+      visibleCount: 0,
+      agentDisplayName: 'Cursor',
+    })
+    expect(result.variantKey).toBe('agent-zero')
+    expect(result.isPrimaryDisabled).toBe(true)
+    expect(result.primaryLabel).toBe('No visible skills')
+    expect(result.primaryAriaLabel).toBe(
+      'No visible selected skills to unlink from Cursor',
+    )
   })
 
   it('labels the primary button with visible action targets when filters hide selected rows', () => {

--- a/src/renderer/src/components/skills/bulkDeleteHelpers.test.ts
+++ b/src/renderer/src/components/skills/bulkDeleteHelpers.test.ts
@@ -10,6 +10,7 @@ import { tombstoneId } from '@/shared/types'
 
 import {
   computeRangeSelection,
+  countOrphanSymlinksRemoved,
   formatCascadeSummary,
   formatUnlinkSummary,
   getToolbarState,
@@ -131,6 +132,63 @@ describe('getToolbarState', () => {
     expect(result.primaryAriaLabel).toBe(
       'Move 2 visible selected skills to app trash',
     )
+  })
+})
+
+describe('countOrphanSymlinksRemoved', () => {
+  it('adds mid-loop partial-error commits to the orphan-cleared total', () => {
+    // Arrange — one fully orphan-cleared row plus one cleanup that threw
+    // mid-loop after committing unlinks (error row still carrying cascadeAgents).
+    const result: BulkDeleteResult = {
+      items: [
+        {
+          skillName: 'abandoned',
+          outcome: 'orphan-cleared',
+          symlinksRemoved: 2,
+          cascadeAgents: ['cursor' as AgentId],
+        },
+        {
+          skillName: 'half-cleared',
+          outcome: 'error',
+          symlinksRemoved: 1,
+          cascadeAgents: ['claude-code' as AgentId],
+          error: { message: 'EACCES', code: 'EACCES' },
+        },
+      ],
+    }
+
+    // Act
+    const total = countOrphanSymlinksRemoved(result)
+
+    // Assert — 2 cleared + 1 committed-before-throw = 3.
+    expect(total).toBe(3)
+  })
+
+  it('ignores deleted rows and clean errors that committed nothing', () => {
+    // Arrange — a tombstoned delete (its symlinks belong to the Undo cascade,
+    // not orphan cleanup) and an error row with no cascadeAgents (committed 0).
+    const result: BulkDeleteResult = {
+      items: [
+        {
+          skillName: 'task',
+          outcome: 'deleted',
+          tombstoneId: tombstoneId('1-task-aaaa'),
+          symlinksRemoved: 5,
+          cascadeAgents: ['cursor' as AgentId],
+        },
+        {
+          skillName: 'locked',
+          outcome: 'error',
+          error: { message: 'EACCES', code: 'EACCES' },
+        },
+      ],
+    }
+
+    // Act
+    const total = countOrphanSymlinksRemoved(result)
+
+    // Assert — neither row contributes to the orphan tally.
+    expect(total).toBe(0)
   })
 })
 

--- a/src/renderer/src/components/skills/bulkDeleteHelpers.test.ts
+++ b/src/renderer/src/components/skills/bulkDeleteHelpers.test.ts
@@ -38,7 +38,7 @@ describe('getToolbarState', () => {
     })
     expect(result.variantKey).toBe('global-multi')
     expect(result.primaryLabel).toBe('Delete 7 skills')
-    expect(result.primaryAriaLabel).toBe('Delete 7 selected skills permanently')
+    expect(result.primaryAriaLabel).toBe('Move 7 selected skills to app trash')
     expect(result.isDestructive).toBe(true)
   })
 
@@ -129,7 +129,7 @@ describe('getToolbarState', () => {
     expect(result.isPrimaryDisabled).toBe(false)
     expect(result.primaryLabel).toBe('Delete 2 skills')
     expect(result.primaryAriaLabel).toBe(
-      'Delete 2 visible selected skills permanently',
+      'Move 2 visible selected skills to app trash',
     )
   })
 })

--- a/src/renderer/src/components/skills/bulkDeleteHelpers.test.ts
+++ b/src/renderer/src/components/skills/bulkDeleteHelpers.test.ts
@@ -100,7 +100,7 @@ describe('getToolbarState', () => {
     expect(result.isPrimaryDisabled).toBe(true)
   })
 
-  it('keeps the primary enabled when visibleCount > 0 even if it is lower than count', () => {
+  it('labels the primary button with visible action targets when filters hide selected rows', () => {
     const result = getToolbarState({
       view: 'global',
       agentId: null,
@@ -108,8 +108,10 @@ describe('getToolbarState', () => {
       visibleCount: 2,
     })
     expect(result.isPrimaryDisabled).toBe(false)
-    // Label reflects full selection count per v2.4 spec
-    expect(result.primaryLabel).toBe('Delete 5 skills')
+    expect(result.primaryLabel).toBe('Delete 2 skills')
+    expect(result.primaryAriaLabel).toBe(
+      'Delete 2 visible selected skills permanently',
+    )
   })
 })
 

--- a/src/renderer/src/components/skills/bulkDeleteHelpers.test.ts
+++ b/src/renderer/src/components/skills/bulkDeleteHelpers.test.ts
@@ -297,6 +297,29 @@ describe('formatCascadeSummary', () => {
       'Cleaned up 2 orphan symlinks. 1 deletion failed.',
     )
   })
+
+  it('counts symlinks already unlinked when a multi-agent cleanup fails partway', () => {
+    // Arrange — a 3-agent orphan record where the source reappeared between
+    // the 2nd and 3rd unlink: codex + cursor committed to disk, then ESTALE.
+    // The error variant carries the partial cascade so the count is honest.
+    const result: BulkDeleteResult = {
+      items: [
+        {
+          skillName: 'abandoned',
+          outcome: 'error',
+          error: { message: 'Source skill exists', code: 'ESTALE' },
+          symlinksRemoved: 2,
+          cascadeAgents: ['codex' as AgentId, 'cursor' as AgentId],
+        },
+      ],
+    }
+
+    // Act
+    const summary = formatCascadeSummary(result)
+
+    // Assert — the 2 committed unlinks surface instead of an undercount of 0.
+    expect(summary).toBe('Cleaned up 2 orphan symlinks. 1 deletion failed.')
+  })
 })
 
 describe('formatUnlinkSummary', () => {

--- a/src/renderer/src/components/skills/bulkDeleteHelpers.ts
+++ b/src/renderer/src/components/skills/bulkDeleteHelpers.ts
@@ -200,10 +200,18 @@ export const formatCascadeSummary = (result: BulkDeleteResult): string => {
     (sum, item) => sum + item.symlinksRemoved,
     0,
   )
-  const orphanSymlinks = orphanItems.reduce(
-    (sum, item) => sum + item.symlinksRemoved,
+  // Partial cleanups that threw mid-loop report their committed unlinks on the
+  // error variant — fold them into the orphan tally so the summary mirrors disk.
+  const partialErrorSymlinks = result.items.reduce(
+    (sum, item) =>
+      item.outcome === 'error' && item.cascadeAgents
+        ? sum + (item.symlinksRemoved ?? 0)
+        : sum,
     0,
   )
+  const orphanSymlinks =
+    orphanItems.reduce((sum, item) => sum + item.symlinksRemoved, 0) +
+    partialErrorSymlinks
 
   const phrases: string[] = []
 

--- a/src/renderer/src/components/skills/bulkDeleteHelpers.ts
+++ b/src/renderer/src/components/skills/bulkDeleteHelpers.ts
@@ -139,6 +139,30 @@ export const getToolbarState = ({
 }
 
 /**
+ * Sum every orphan symlink unlink that actually reached disk: fully
+ * orphan-cleared rows PLUS partial cleanups that threw mid-loop after
+ * committing unlinks (error rows that still carry `cascadeAgents`). Exists so
+ * the result toast (`formatCascadeSummary`) and the cleanup dialog
+ * (`buildCleanupSummary`) report one identical count instead of drifting when
+ * only one site is edited; called by both.
+ * @param result - Bulk delete outcome set from the main-process thunk.
+ * @returns Total orphan symlinks removed across cleared + partial-error rows.
+ * @example
+ * countOrphanSymlinksRemoved({ items: [
+ *   { skillName: 'a', outcome: 'orphan-cleared', symlinksRemoved: 2, cascadeAgents: ['cursor'] },
+ *   { skillName: 'b', outcome: 'error', symlinksRemoved: 1, cascadeAgents: ['claude-code'], error: { message: 'EACCES', code: 'EACCES' } },
+ * ] }) // => 3
+ */
+export const countOrphanSymlinksRemoved = (result: BulkDeleteResult): number =>
+  result.items.reduce((total, item) => {
+    if (item.outcome === 'orphan-cleared') return total + item.symlinksRemoved
+    if (item.outcome === 'error' && item.cascadeAgents) {
+      return total + (item.symlinksRemoved ?? 0)
+    }
+    return total
+  }, 0)
+
+/**
  * Build the summary string shown in the toast body after a bulk DELETE.
  *
  * The phrases are deliberately independent so the Undo-facing text only
@@ -184,12 +208,6 @@ export const formatCascadeSummary = (result: BulkDeleteResult): string => {
     (item): item is Extract<BulkDeleteItemResult, { outcome: 'deleted' }> =>
       item.outcome === 'deleted',
   )
-  const orphanItems = result.items.filter(
-    (
-      item,
-    ): item is Extract<BulkDeleteItemResult, { outcome: 'orphan-cleared' }> =>
-      item.outcome === 'orphan-cleared',
-  )
   const errorCount = result.items.filter(
     (item) => item.outcome === 'error',
   ).length
@@ -200,18 +218,9 @@ export const formatCascadeSummary = (result: BulkDeleteResult): string => {
     (sum, item) => sum + item.symlinksRemoved,
     0,
   )
-  // Partial cleanups that threw mid-loop report their committed unlinks on the
-  // error variant — fold them into the orphan tally so the summary mirrors disk.
-  const partialErrorSymlinks = result.items.reduce(
-    (sum, item) =>
-      item.outcome === 'error' && item.cascadeAgents
-        ? sum + (item.symlinksRemoved ?? 0)
-        : sum,
-    0,
-  )
-  const orphanSymlinks =
-    orphanItems.reduce((sum, item) => sum + item.symlinksRemoved, 0) +
-    partialErrorSymlinks
+  // Orphan tally (cleared rows + mid-loop partial-error commits) is computed by
+  // the shared helper so this toast and the cleanup dialog never drift.
+  const orphanSymlinks = countOrphanSymlinksRemoved(result)
 
   const phrases: string[] = []
 

--- a/src/renderer/src/components/skills/bulkDeleteHelpers.ts
+++ b/src/renderer/src/components/skills/bulkDeleteHelpers.ts
@@ -22,7 +22,7 @@ import type {
  * count>=2 surfaces the batch treatment (progress counter when >=10, etc.).
  */
 export type ToolbarView = 'global' | 'agent'
-type ToolbarCountKind = 'single' | 'multi'
+type ToolbarCountKind = 'zero' | 'single' | 'multi'
 
 export interface ToolbarStateInput {
   view: ToolbarView
@@ -48,8 +48,14 @@ export interface ToolbarStateOutput {
   isPrimaryDisabled: boolean
   /** Destructive styling flag — renders red accent; always true for global, always false for agent. */
   isDestructive: boolean
-  /** Key used to identify the four visual states during testing/debug. */
-  variantKey: 'global-single' | 'global-multi' | 'agent-single' | 'agent-multi'
+  /** Key used to identify the six visual states during testing/debug. */
+  variantKey:
+    | 'global-zero'
+    | 'global-single'
+    | 'global-multi'
+    | 'agent-zero'
+    | 'agent-single'
+    | 'agent-multi'
 }
 
 /**
@@ -77,7 +83,8 @@ export const getToolbarState = ({
   // The primary button acts only on selected rows that survived the current
   // filter, while the adjacent selection summary owns the total hidden count.
   const actionCount = visibleCount
-  const countKind: ToolbarCountKind = actionCount <= 1 ? 'single' : 'multi'
+  const countKind: ToolbarCountKind =
+    actionCount === 0 ? 'zero' : actionCount === 1 ? 'single' : 'multi'
   const isPrimaryDisabled = visibleCount === 0
   const ariaSelectionScope =
     count === visibleCount ? 'selected' : 'visible selected'
@@ -86,6 +93,13 @@ export const getToolbarState = ({
   const agentLabel = agentDisplayName ?? 'agent'
 
   return match({ view, countKind })
+    .with({ view: 'global', countKind: 'zero' }, () => ({
+      primaryLabel: 'No visible skills',
+      primaryAriaLabel: 'No visible selected skills to delete',
+      isPrimaryDisabled,
+      isDestructive: true,
+      variantKey: 'global-zero' as const,
+    }))
     .with({ view: 'global', countKind: 'single' }, () => ({
       primaryLabel: 'Delete skill',
       primaryAriaLabel: `Delete ${ariaSelectionScope} skill permanently`,
@@ -99,6 +113,13 @@ export const getToolbarState = ({
       isPrimaryDisabled,
       isDestructive: true,
       variantKey: 'global-multi' as const,
+    }))
+    .with({ view: 'agent', countKind: 'zero' }, () => ({
+      primaryLabel: 'No visible skills',
+      primaryAriaLabel: `No visible selected skills to unlink from ${agentLabel}`,
+      isPrimaryDisabled,
+      isDestructive: false,
+      variantKey: 'agent-zero' as const,
     }))
     .with({ view: 'agent', countKind: 'single' }, () => ({
       primaryLabel: `Unlink from ${agentLabel}`,

--- a/src/renderer/src/components/skills/bulkDeleteHelpers.ts
+++ b/src/renderer/src/components/skills/bulkDeleteHelpers.ts
@@ -74,8 +74,13 @@ export const getToolbarState = ({
   visibleCount,
   agentDisplayName,
 }: ToolbarStateInput): ToolbarStateOutput => {
-  const countKind: ToolbarCountKind = count <= 1 ? 'single' : 'multi'
+  // The primary button acts only on selected rows that survived the current
+  // filter, while the adjacent selection summary owns the total hidden count.
+  const actionCount = visibleCount
+  const countKind: ToolbarCountKind = actionCount <= 1 ? 'single' : 'multi'
   const isPrimaryDisabled = visibleCount === 0
+  const ariaSelectionScope =
+    count === visibleCount ? 'selected' : 'visible selected'
   // Fall back to "agent" when the caller doesn't know the display name yet
   // (e.g. render-before-data). Agent view is guaranteed by the match arm.
   const agentLabel = agentDisplayName ?? 'agent'
@@ -83,28 +88,28 @@ export const getToolbarState = ({
   return match({ view, countKind })
     .with({ view: 'global', countKind: 'single' }, () => ({
       primaryLabel: 'Delete skill',
-      primaryAriaLabel: 'Delete selected skill permanently',
+      primaryAriaLabel: `Delete ${ariaSelectionScope} skill permanently`,
       isPrimaryDisabled,
       isDestructive: true,
       variantKey: 'global-single' as const,
     }))
     .with({ view: 'global', countKind: 'multi' }, () => ({
-      primaryLabel: `Delete ${count} skills`,
-      primaryAriaLabel: `Delete ${count} selected skills permanently`,
+      primaryLabel: `Delete ${actionCount} skills`,
+      primaryAriaLabel: `Delete ${actionCount} ${ariaSelectionScope} skills permanently`,
       isPrimaryDisabled,
       isDestructive: true,
       variantKey: 'global-multi' as const,
     }))
     .with({ view: 'agent', countKind: 'single' }, () => ({
       primaryLabel: `Unlink from ${agentLabel}`,
-      primaryAriaLabel: `Unlink selected skill from ${agentLabel}`,
+      primaryAriaLabel: `Unlink ${ariaSelectionScope} skill from ${agentLabel}`,
       isPrimaryDisabled,
       isDestructive: false,
       variantKey: 'agent-single' as const,
     }))
     .with({ view: 'agent', countKind: 'multi' }, () => ({
-      primaryLabel: `Unlink ${count} from ${agentLabel}`,
-      primaryAriaLabel: `Unlink ${count} selected skills from ${agentLabel}`,
+      primaryLabel: `Unlink ${actionCount} from ${agentLabel}`,
+      primaryAriaLabel: `Unlink ${actionCount} ${ariaSelectionScope} skills from ${agentLabel}`,
       isPrimaryDisabled,
       isDestructive: false,
       variantKey: 'agent-multi' as const,

--- a/src/renderer/src/components/skills/bulkDeleteHelpers.ts
+++ b/src/renderer/src/components/skills/bulkDeleteHelpers.ts
@@ -102,14 +102,14 @@ export const getToolbarState = ({
     }))
     .with({ view: 'global', countKind: 'single' }, () => ({
       primaryLabel: 'Delete skill',
-      primaryAriaLabel: `Delete ${ariaSelectionScope} skill permanently`,
+      primaryAriaLabel: `Move ${ariaSelectionScope} skill to app trash`,
       isPrimaryDisabled,
       isDestructive: true,
       variantKey: 'global-single' as const,
     }))
     .with({ view: 'global', countKind: 'multi' }, () => ({
       primaryLabel: `Delete ${actionCount} skills`,
-      primaryAriaLabel: `Delete ${actionCount} ${ariaSelectionScope} skills permanently`,
+      primaryAriaLabel: `Move ${actionCount} ${ariaSelectionScope} skills to app trash`,
       isPrimaryDisabled,
       isDestructive: true,
       variantKey: 'global-multi' as const,

--- a/src/renderer/src/components/skills/reviewedDestructiveTargets.ts
+++ b/src/renderer/src/components/skills/reviewedDestructiveTargets.ts
@@ -1,0 +1,141 @@
+import type {
+  AbsolutePath,
+  AgentId,
+  BulkDeleteItemResult,
+  ClearOrphanSymlinksOptions,
+  Skill,
+  SymlinkInfo,
+} from '@/shared/types'
+
+import type {
+  DeleteSelectedSkillTarget,
+  UnlinkSelectedSkillTarget,
+} from '../../redux/slices/skillsSlice'
+
+export type ReviewedOrphanCleanupRecord =
+  ClearOrphanSymlinksOptions['items'][number]
+
+export interface PartitionedGlobalDeleteTargets {
+  deleteTargets: DeleteSelectedSkillTarget[]
+  orphanRecords: ReviewedOrphanCleanupRecord[]
+  orphanErrors: BulkDeleteItemResult[]
+}
+
+export interface AgentUnlinkTargets {
+  targets: UnlinkSelectedSkillTarget[]
+  staleNames: Skill['name'][]
+}
+
+/**
+ * Narrow to dangling, reviewed symlink slots that the orphan cleanup IPC can safely revalidate.
+ * @param symlink - Agent slot from the reviewed renderer scan.
+ * @returns true when the slot has the exact path and target cleanup requires.
+ * @example isReviewedOrphanCleanupSlot(skill.symlinks[0])
+ */
+function isReviewedOrphanCleanupSlot(
+  symlink: SymlinkInfo,
+): symlink is SymlinkInfo & {
+  status: 'broken'
+  isLocal: false
+  targetPath: AbsolutePath
+} {
+  return (
+    symlink.status === 'broken' &&
+    symlink.isLocal === false &&
+    symlink.targetPath !== undefined
+  )
+}
+
+/**
+ * Split reviewed global delete rows into source/local deletes and orphan cleanup.
+ * @param skills - Skill rows exactly visible when the confirmation opened.
+ * @param skillNames - Display names selected for deletion.
+ * @returns Reviewed targets plus stale/preflight errors.
+ * @example partitionGlobalDeleteTargets(skills, ['task'])
+ */
+export function partitionGlobalDeleteTargets(
+  skills: readonly Skill[],
+  skillNames: readonly Skill['name'][],
+): PartitionedGlobalDeleteTargets {
+  const skillsByName = new Map(skills.map((skill) => [skill.name, skill]))
+  const deleteTargets: DeleteSelectedSkillTarget[] = []
+  const orphanRecords: ReviewedOrphanCleanupRecord[] = []
+  const orphanErrors: BulkDeleteItemResult[] = []
+
+  for (const skillName of skillNames) {
+    const skill = skillsByName.get(skillName)
+    if (!skill?.isOrphan) {
+      if (skill?.filesystemIdentity) {
+        deleteTargets.push({
+          skillName,
+          skillPath: skill.path,
+          filesystemIdentity: skill.filesystemIdentity,
+        })
+        continue
+      }
+      orphanErrors.push({
+        skillName,
+        outcome: 'error',
+        error: {
+          message: 'Selected skill row is stale. Rescan before delete.',
+          code: 'ESTALE',
+        },
+      })
+      continue
+    }
+
+    const agents = skill.symlinks
+      .filter(isReviewedOrphanCleanupSlot)
+      .map((symlink) => ({
+        agentId: symlink.agentId,
+        linkPath: symlink.linkPath,
+        targetPath: symlink.targetPath,
+      }))
+
+    if (agents.length > 0) {
+      orphanRecords.push({ skillName, agents })
+      continue
+    }
+
+    orphanErrors.push({
+      skillName,
+      outcome: 'error',
+      error: {
+        message:
+          'No reviewed orphan symlink targets available. Rescan before cleanup.',
+        code: 'ESTALE',
+      },
+    })
+  }
+
+  return { deleteTargets, orphanRecords, orphanErrors }
+}
+
+/**
+ * Build bulk-unlink targets with the reviewed agent slot path.
+ * @param skills - Current skill rows in Redux.
+ * @param skillNames - Display names selected in the confirmation dialog.
+ * @param agentId - Selected agent whose slots are being unlinked.
+ * @returns Reviewed unlink targets plus stale rows that need a rescan.
+ * @example buildAgentUnlinkTargets(skills, ['metadata-title'], 'cursor')
+ */
+export function buildAgentUnlinkTargets(
+  skills: readonly Skill[],
+  skillNames: readonly Skill['name'][],
+  agentId: AgentId,
+): AgentUnlinkTargets {
+  const skillsByName = new Map(skills.map((skill) => [skill.name, skill]))
+  const targets: UnlinkSelectedSkillTarget[] = []
+  const staleNames: Skill['name'][] = []
+  for (const skillName of skillNames) {
+    const symlink = skillsByName
+      .get(skillName)
+      ?.symlinks.find((slot) => slot.agentId === agentId)
+    if (symlink?.linkPath) {
+      targets.push({ skillName, linkPath: symlink.linkPath })
+      continue
+    }
+    staleNames.push(skillName)
+  }
+  return { targets, staleNames }
+}

--- a/src/renderer/src/components/skills/reviewedDestructiveTargets.ts
+++ b/src/renderer/src/components/skills/reviewedDestructiveTargets.ts
@@ -18,6 +18,7 @@ export type ReviewedOrphanCleanupRecord =
 export interface PartitionedGlobalDeleteTargets {
   deleteTargets: DeleteSelectedSkillTarget[]
   orphanRecords: ReviewedOrphanCleanupRecord[]
+  staleDeleteErrors: BulkDeleteItemResult[]
   orphanErrors: BulkDeleteItemResult[]
 }
 
@@ -60,6 +61,7 @@ export function partitionGlobalDeleteTargets(
   const skillsByName = new Map(skills.map((skill) => [skill.name, skill]))
   const deleteTargets: DeleteSelectedSkillTarget[] = []
   const orphanRecords: ReviewedOrphanCleanupRecord[] = []
+  const staleDeleteErrors: BulkDeleteItemResult[] = []
   const orphanErrors: BulkDeleteItemResult[] = []
 
   for (const skillName of skillNames) {
@@ -73,7 +75,7 @@ export function partitionGlobalDeleteTargets(
         })
         continue
       }
-      orphanErrors.push({
+      staleDeleteErrors.push({
         skillName,
         outcome: 'error',
         error: {
@@ -108,7 +110,7 @@ export function partitionGlobalDeleteTargets(
     })
   }
 
-  return { deleteTargets, orphanRecords, orphanErrors }
+  return { deleteTargets, orphanRecords, staleDeleteErrors, orphanErrors }
 }
 
 /**

--- a/src/renderer/src/components/skills/reviewedDestructiveTargets.ts
+++ b/src/renderer/src/components/skills/reviewedDestructiveTargets.ts
@@ -131,8 +131,12 @@ export function buildAgentUnlinkTargets(
     const symlink = skillsByName
       .get(skillName)
       ?.symlinks.find((slot) => slot.agentId === agentId)
-    if (symlink?.linkPath) {
-      targets.push({ skillName, linkPath: symlink.linkPath })
+    if (symlink?.linkPath && symlink.targetPath) {
+      targets.push({
+        skillName,
+        linkPath: symlink.linkPath,
+        targetPath: symlink.targetPath,
+      })
       continue
     }
     staleNames.push(skillName)

--- a/src/renderer/src/components/skills/skillItemHelpers.test.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.test.ts
@@ -106,34 +106,32 @@ describe('getSkillItemVisibility', () => {
       expect(result.selectedAgentSymlink).toBe(symlinks[0])
     })
 
-    it('shows unlink button for orphan-only broken symlink so user can clean it up', () => {
-      // PR #131 (issue #71 PR-2) intentionally surfaces unlink for orphan
-      // rows: removing a dangling symlink at `linkPath` is a safe `rm` op
-      // regardless of whether the target resolves, and it's how the user
-      // sweeps orphans one row at a time without the bulk Cleanup dialog.
-      // Add stays gated separately because re-adding requires a live source.
+    it('hides normal unlink for orphan-only broken symlink so reviewed cleanup owns it', () => {
+      // Broken rows can become live after scan. The normal per-row unlink
+      // lacks reviewed target revalidation, so cleanup must route through the
+      // exact broken-slot IPC instead of this generic affordance.
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'broken', isLocal: false }),
       ]
       const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
 
-      expect(result.showUnlinkButton).toBe(true)
+      expect(result.showUnlinkButton).toBe(false)
       // isLinked still requires status==='valid'; broken does NOT count as
-      // linked even though it now satisfies showUnlinkButton.
+      // linked.
       expect(result.isLinked).toBe(false)
     })
 
-    it('still shows unlink for broken symlink when another agent has a valid copy', () => {
+    it('hides normal unlink for broken symlink even when another agent has a valid copy', () => {
       // Live source skill with one healthy and one broken agent link — the
-      // orphan guard must NOT trigger here. Removing the broken link is safe
-      // and meaningful because the source still exists.
+      // source exists, but the reviewed link path can still be stale by the
+      // time the user clicks. The cleanup IPC owns the safe path.
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'broken', isLocal: false }),
         makeSymlink({ agentId: 'codex', status: 'valid', isLocal: false }),
       ]
       const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
 
-      expect(result.showUnlinkButton).toBe(true)
+      expect(result.showUnlinkButton).toBe(false)
       expect(result.isLinked).toBe(false)
     })
 
@@ -212,6 +210,21 @@ describe('getSkillItemVisibility', () => {
       expect(result.showUnlinkButton).toBe(false)
       expect(result.isInaccessibleSkill).toBe(true)
       expect(result.selectedAgentSymlink).toBe(symlinks[0])
+    })
+
+    it('hides Add and Copy for inaccessible symlinks so unverifiable targets cannot fan out', () => {
+      const symlinks = [
+        makeSymlink({
+          agentId: 'cursor',
+          status: 'inaccessible',
+          isLocal: false,
+        }),
+      ]
+      const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
+
+      expect(result.showAddButton).toBe(false)
+      expect(result.showCopyButton).toBe(false)
+      expect(result.isInaccessibleSkill).toBe(true)
     })
   })
 
@@ -450,7 +463,7 @@ describe('getSkillItemVisibility', () => {
       expect(result.showAddButton).toBe(false)
     })
 
-    it('hides Add but shows Unlink for orphan skill in agent view', () => {
+    it('hides Add and normal Unlink for orphan skill in agent view', () => {
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'broken', isLocal: false }),
         makeSymlink({ agentId: 'codex', status: 'broken', isLocal: false }),
@@ -460,8 +473,8 @@ describe('getSkillItemVisibility', () => {
       // Add stays gated: even though the broken cursor entry passes the
       // `valid|broken` filter, there is no live source to symlink TO.
       expect(result.showAddButton).toBe(false)
-      // Unlink is the per-agent cleanup affordance for orphan rows.
-      expect(result.showUnlinkButton).toBe(true)
+      // Reviewed cleanup owns broken symlink removal.
+      expect(result.showUnlinkButton).toBe(false)
       // Copy fans out from the live source skill — same reason Add is
       // hidden, this must be hidden too. Without this assertion the
       // context-menu Copy entry leaks through and lands the user in

--- a/src/renderer/src/components/skills/skillItemHelpers.test.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import type { AbsolutePath, AgentId, Skill, SymlinkInfo } from '@/shared/types'
 
 import {
+  getCardContentPaddingClass,
   getSkillItemVisibility,
   type SkillVisibilityInput,
 } from './skillItemHelpers'
@@ -547,5 +548,86 @@ describe('getSkillItemVisibility', () => {
         false,
       )
     })
+  })
+})
+
+describe('getCardContentPaddingClass', () => {
+  it('reserves the wide gutter so the Add control never overlaps a stacked bookmark + delete pair', () => {
+    // Arrange — global-view repo skill: bookmark slides to right-11 (44px) and
+    // the delete X sits at right-0 (44px), forming an 88px stack. This is the
+    // exact state from the reported hover bug where "+ Add" slid under the
+    // bookmark.
+    const flags = {
+      showBookmark: true,
+      showUnlinkButton: false,
+      showDeleteButton: true,
+    }
+
+    // Act
+    const paddingClass = getCardContentPaddingClass(flags)
+
+    // Assert — pr-24 (96px) clears the 88px stack with an 8px gap.
+    expect(paddingClass).toBe('pr-24')
+  })
+
+  it('reserves the wide gutter when a bookmark stacks with the unlink button in agent view', () => {
+    // Arrange — agent view, valid symlink: bookmark + unlink X also stack to 88px.
+    const flags = {
+      showBookmark: true,
+      showUnlinkButton: true,
+      showDeleteButton: false,
+    }
+
+    // Act
+    const paddingClass = getCardContentPaddingClass(flags)
+
+    // Assert
+    expect(paddingClass).toBe('pr-24')
+  })
+
+  it('reserves a single-button gutter when only the bookmark shows', () => {
+    // Arrange — bookmarkable skill whose agent row is broken: no X button, so
+    // the bookmark sits alone at right-0 (one 44px overlay).
+    const flags = {
+      showBookmark: true,
+      showUnlinkButton: false,
+      showDeleteButton: false,
+    }
+
+    // Act
+    const paddingClass = getCardContentPaddingClass(flags)
+
+    // Assert — pr-14 (56px) clears one 44px button.
+    expect(paddingClass).toBe('pr-14')
+  })
+
+  it('reserves a single-button gutter when only an X button shows (non-bookmarkable skill)', () => {
+    // Arrange — local skill (no repo source → not bookmarkable) with an unlink X.
+    const flags = {
+      showBookmark: false,
+      showUnlinkButton: true,
+      showDeleteButton: false,
+    }
+
+    // Act
+    const paddingClass = getCardContentPaddingClass(flags)
+
+    // Assert
+    expect(paddingClass).toBe('pr-14')
+  })
+
+  it('uses normal padding when no overlay buttons render', () => {
+    // Arrange — no bookmark, no X (e.g. orphan row in agent view).
+    const flags = {
+      showBookmark: false,
+      showUnlinkButton: false,
+      showDeleteButton: false,
+    }
+
+    // Act
+    const paddingClass = getCardContentPaddingClass(flags)
+
+    // Assert — falls back to the default p-4 right padding.
+    expect(paddingClass).toBe('pr-4')
   })
 })

--- a/src/renderer/src/components/skills/skillItemHelpers.test.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.test.ts
@@ -198,6 +198,21 @@ describe('getSkillItemVisibility', () => {
 
       expect(result.showUnlinkButton).toBe(false)
     })
+
+    it('hides normal unlink for inaccessible symlinks while keeping manual-review state visible', () => {
+      const symlinks = [
+        makeSymlink({
+          agentId: 'cursor',
+          status: 'inaccessible',
+          isLocal: false,
+        }),
+      ]
+      const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
+
+      expect(result.showUnlinkButton).toBe(false)
+      expect(result.isInaccessibleSkill).toBe(true)
+      expect(result.selectedAgentSymlink).toBe(symlinks[0])
+    })
   })
 
   describe('showCopyButton', () => {

--- a/src/renderer/src/components/skills/skillItemHelpers.test.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.test.ts
@@ -135,6 +135,20 @@ describe('getSkillItemVisibility', () => {
       expect(result.isLinked).toBe(false)
     })
 
+    it('hides Add and Copy when the selected agent row is broken', () => {
+      // The source exists through another agent, but Cursor's visible row is a
+      // broken slot. Add/Copy would route through a generic source-copy flow
+      // instead of the reviewed cleanup path for this exact broken link.
+      const symlinks = [
+        makeSymlink({ agentId: 'cursor', status: 'broken', isLocal: false }),
+        makeSymlink({ agentId: 'codex', status: 'valid', isLocal: false }),
+      ]
+      const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
+
+      expect(result.showAddButton).toBe(false)
+      expect(result.showCopyButton).toBe(false)
+    })
+
     it('hides unlink button when no symlink for selected agent', () => {
       const symlinks = [
         makeSymlink({ agentId: 'codex', status: 'valid', isLocal: false }),

--- a/src/renderer/src/components/skills/skillItemHelpers.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.ts
@@ -104,7 +104,8 @@ export function getSkillItemVisibility(
     : null
 
   const isLocalSkill = Boolean(selectedLocalSkillInfo)
-  const hasSkillInSelectedAgent = selectedAgentSymlink !== null || isLocalSkill
+  const hasUsableSkillInSelectedAgent =
+    isLocalSkill || selectedAgentSymlink?.status === 'valid'
   const isInaccessibleSkill =
     selectedAgentSymlink !== null &&
     selectedAgentSymlink.status === 'inaccessible'
@@ -123,7 +124,7 @@ export function getSkillItemVisibility(
     // that can only fail. Stays gated on `!isOrphan` even after the Delete
     // and Unlink loosens.
     showAddButton:
-      (!selectedAgentId || hasSkillInSelectedAgent) &&
+      (!selectedAgentId || hasUsableSkillInSelectedAgent) &&
       !isOrphan &&
       !isInaccessibleSkill,
     // Broken and inaccessible non-local symlinks need reviewed cleanup paths
@@ -143,7 +144,7 @@ export function getSkillItemVisibility(
     // for the same reason `showAddButton` is gated on `!isOrphan`.
     showCopyButton:
       selectedAgentId !== null &&
-      hasSkillInSelectedAgent &&
+      hasUsableSkillInSelectedAgent &&
       !isOrphan &&
       !isInaccessibleSkill,
     showGStackBadge,

--- a/src/renderer/src/components/skills/skillItemHelpers.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.ts
@@ -75,13 +75,13 @@ export type SkillVisibilityInput = Pick<Skill, 'symlinks' | 'isOrphan'>
  * // => { showDeleteButton: true, showAddButton: false, showUnlinkButton: false, ... }
  *
  * @example
- * // Orphan in agent view — Unlink is shown so the user can clear the
- * // dangling agent-side symlink one row at a time. Add stays hidden.
+ * // Orphan in agent view — normal Unlink stays hidden so reviewed cleanup
+ * // paths handle stale broken links. Add stays hidden.
  * getSkillItemVisibility('cursor', {
  *   symlinks: [{ agentId: 'cursor', status: 'broken', isLocal: false, ... }],
  *   isOrphan: true,
  * })
- * // => { showDeleteButton: false, showAddButton: false, showUnlinkButton: true, ... }
+ * // => { showDeleteButton: false, showAddButton: false, showUnlinkButton: false, ... }
  */
 export function getSkillItemVisibility(
   selectedAgentId: AgentId | null,
@@ -103,10 +103,11 @@ export function getSkillItemVisibility(
     ? (symlinks.find((s) => s.agentId === selectedAgentId && s.isLocal) ?? null)
     : null
 
-  const isLocalSkill = !!selectedLocalSkillInfo
-  const hasSkillInSelectedAgent = !!selectedAgentSymlink || isLocalSkill
+  const isLocalSkill = Boolean(selectedLocalSkillInfo)
+  const hasSkillInSelectedAgent = selectedAgentSymlink !== null || isLocalSkill
   const isInaccessibleSkill =
-    !!selectedAgentSymlink && selectedAgentSymlink.status === 'inaccessible'
+    selectedAgentSymlink !== null &&
+    selectedAgentSymlink.status === 'inaccessible'
   // Orphan handling — see Skill.isOrphan for why the Add button is gated.
   // Source: scanOrphanSymlinks() in src/main/services/skillScanner.ts.
   const showGStackBadge = isGStackManagedForAgent(skill, selectedAgentId)
@@ -121,12 +122,18 @@ export function getSkillItemVisibility(
     // (which opens AddSymlinkModal / CopyToAgentsModal) would surface a flow
     // that can only fail. Stays gated on `!isOrphan` even after the Delete
     // and Unlink loosens.
-    showAddButton: (!selectedAgentId || hasSkillInSelectedAgent) && !isOrphan,
-    // Inaccessible symlinks need manual filesystem review before deletion; do
-    // not route them through the normal "safe unlink" affordance.
+    showAddButton:
+      (!selectedAgentId || hasSkillInSelectedAgent) &&
+      !isOrphan &&
+      !isInaccessibleSkill,
+    // Broken and inaccessible non-local symlinks need reviewed cleanup paths
+    // that recheck the target; generic unlink only stays for valid symlinks.
     showUnlinkButton:
-      isLocalSkill || (!!selectedAgentSymlink && !isInaccessibleSkill),
-    isLinked: !!selectedAgentSymlink && selectedAgentSymlink.status === 'valid',
+      isLocalSkill ||
+      (selectedAgentSymlink !== null &&
+        selectedAgentSymlink.status === 'valid'),
+    isLinked:
+      selectedAgentSymlink !== null && selectedAgentSymlink.status === 'valid',
     isLocalSkill,
     isInaccessibleSkill,
     selectedAgentSymlink,
@@ -134,7 +141,11 @@ export function getSkillItemVisibility(
     // "Copy to..." opens CopyToAgentsModal which fans out from the live
     // source skill — for an orphan, that source is gone. Hide the action
     // for the same reason `showAddButton` is gated on `!isOrphan`.
-    showCopyButton: !!selectedAgentId && hasSkillInSelectedAgent && !isOrphan,
+    showCopyButton:
+      selectedAgentId !== null &&
+      hasSkillInSelectedAgent &&
+      !isOrphan &&
+      !isInaccessibleSkill,
     showGStackBadge,
   }
 }

--- a/src/renderer/src/components/skills/skillItemHelpers.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.ts
@@ -90,7 +90,9 @@ export function getSkillItemVisibility(
     ? (symlinks.find(
         (s) =>
           s.agentId === selectedAgentId &&
-          (s.status === 'valid' || s.status === 'broken') &&
+          (s.status === 'valid' ||
+            s.status === 'broken' ||
+            s.status === 'inaccessible') &&
           !s.isLocal,
       ) ?? null)
     : null

--- a/src/renderer/src/components/skills/skillItemHelpers.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.ts
@@ -150,3 +150,37 @@ export function getSkillItemVisibility(
     showGStackBadge,
   }
 }
+
+/**
+ * Tailwind right-padding class for a SkillItem card body.
+ *
+ * Exists because the action buttons (bookmark + X) are `absolute`-positioned
+ * overlays out of the content flow, so the body needs a manual right gutter to
+ * keep its always-visible title-row controls (the "+ Add" button) from sliding
+ * under those overlays on hover. The bookmark + X form an 88px stack
+ * (bookmark at `right-11` = 44px wide, X at `right-0` = 44px wide), so a single
+ * `pr-14` (56px) reserve only clears one button — two need `pr-24` (96px).
+ *
+ * @param flags - Which overlay buttons render (from `getSkillItemVisibility` + `canBookmarkSkill`)
+ * @returns
+ * - `'pr-24'` (96px): bookmark AND an X button both show → clear the 88px stack
+ * - `'pr-14'` (56px): exactly one of bookmark / X shows → clear one 44px button
+ * - `'pr-4'` (16px): no overlay buttons → normal card padding
+ * @example
+ * getCardContentPaddingClass({ showBookmark: true, showUnlinkButton: false, showDeleteButton: true }) // => 'pr-24'
+ * getCardContentPaddingClass({ showBookmark: true, showUnlinkButton: false, showDeleteButton: false }) // => 'pr-14'
+ * getCardContentPaddingClass({ showBookmark: false, showUnlinkButton: false, showDeleteButton: false }) // => 'pr-4'
+ */
+export function getCardContentPaddingClass(flags: {
+  showBookmark: boolean
+  showUnlinkButton: boolean
+  showDeleteButton: boolean
+}): 'pr-24' | 'pr-14' | 'pr-4' {
+  const { showBookmark, showUnlinkButton, showDeleteButton } = flags
+  const hasXButton = showUnlinkButton || showDeleteButton
+  // Two stacked 44px buttons span 88px; only pr-24 (96px) leaves a gap.
+  if (showBookmark && hasXButton) return 'pr-24'
+  // Either button alone is a single 44px overlay; pr-14 (56px) clears it.
+  if (showBookmark || hasXButton) return 'pr-14'
+  return 'pr-4'
+}

--- a/src/renderer/src/components/skills/skillItemHelpers.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.ts
@@ -20,6 +20,8 @@ export interface SkillItemVisibility {
   isLinked: boolean
   /** Skill is a local (real folder) in selected agent's skills directory */
   isLocalSkill: boolean
+  /** Selected agent has a symlink whose target needs manual filesystem review */
+  isInaccessibleSkill: boolean
   /** The symlink for the selected agent, if any (needed for unlink handler) */
   selectedAgentSymlink: SymlinkInfo | null
   /** The local skill SymlinkInfo for the selected agent, if any (needed for delete handler) */
@@ -103,6 +105,8 @@ export function getSkillItemVisibility(
 
   const isLocalSkill = !!selectedLocalSkillInfo
   const hasSkillInSelectedAgent = !!selectedAgentSymlink || isLocalSkill
+  const isInaccessibleSkill =
+    !!selectedAgentSymlink && selectedAgentSymlink.status === 'inaccessible'
   // Orphan handling — see Skill.isOrphan for why the Add button is gated.
   // Source: scanOrphanSymlinks() in src/main/services/skillScanner.ts.
   const showGStackBadge = isGStackManagedForAgent(skill, selectedAgentId)
@@ -118,12 +122,13 @@ export function getSkillItemVisibility(
     // that can only fail. Stays gated on `!isOrphan` even after the Delete
     // and Unlink loosens.
     showAddButton: (!selectedAgentId || hasSkillInSelectedAgent) && !isOrphan,
-    // Unlink is the per-agent cleanup action — drives the right-click
-    // "Cleanup missing skills..." flow's row-level analogue. For orphans
-    // it removes the dangling symlink without touching siblings.
-    showUnlinkButton: hasSkillInSelectedAgent,
+    // Inaccessible symlinks need manual filesystem review before deletion; do
+    // not route them through the normal "safe unlink" affordance.
+    showUnlinkButton:
+      isLocalSkill || (!!selectedAgentSymlink && !isInaccessibleSkill),
     isLinked: !!selectedAgentSymlink && selectedAgentSymlink.status === 'valid',
     isLocalSkill,
+    isInaccessibleSkill,
     selectedAgentSymlink,
     selectedLocalSkillInfo,
     // "Copy to..." opens CopyToAgentsModal which fans out from the live

--- a/src/renderer/src/components/status/StatusBadge.tsx
+++ b/src/renderer/src/components/status/StatusBadge.tsx
@@ -29,6 +29,12 @@ const STATUS_CONFIG = {
     variant: 'broken' as const,
     tooltip: 'Broken symlink',
   },
+  inaccessible: {
+    icon: AlertCircle,
+    label: 'Inaccessible',
+    variant: 'broken' as const,
+    tooltip: 'Symlink target cannot be checked safely',
+  },
   missing: {
     icon: Circle,
     label: 'Missing',
@@ -40,7 +46,7 @@ const STATUS_CONFIG = {
 /**
  * Badge showing symlink status with optional count.
  * Displays tooltip on hover explaining the status meaning.
- * @param status - The symlink status: 'valid' | 'broken' | 'missing'
+ * @param status - The symlink status: 'valid' | 'broken' | 'inaccessible' | 'missing'
  * @param count - Optional count to display instead of label
  * @param agentNames - Agent names to list in tooltip
  * @returns Badge with icon and tooltip
@@ -55,11 +61,17 @@ export const StatusBadge = React.memo(function StatusBadge({
 }: StatusBadgeProps): React.ReactElement {
   const config = STATUS_CONFIG[status]
   const Icon = config.icon
+  const accessibleLabel =
+    count !== undefined ? `${config.label}: ${count}` : config.label
 
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <Badge variant={config.variant} className="gap-1 cursor-default">
+        <Badge
+          variant={config.variant}
+          className="gap-1 cursor-default"
+          aria-label={accessibleLabel}
+        >
           <Icon className="h-3 w-3" aria-hidden="true" />
           <span>{count !== undefined ? count : config.label}</span>
         </Badge>

--- a/src/renderer/src/components/status/SymlinkStatus.tsx
+++ b/src/renderer/src/components/status/SymlinkStatus.tsx
@@ -19,6 +19,11 @@ const STATUS_STYLES = {
     iconClass: 'text-amber-400',
     bgClass: 'bg-amber-500/10',
   },
+  inaccessible: {
+    icon: AlertCircle,
+    iconClass: 'text-amber-400',
+    bgClass: 'bg-amber-500/10',
+  },
   missing: {
     icon: Circle,
     iconClass: 'text-muted-foreground',

--- a/src/renderer/src/components/ui/checkbox.tsx
+++ b/src/renderer/src/components/ui/checkbox.tsx
@@ -1,16 +1,19 @@
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox'
-import { Check } from 'lucide-react'
+import { Check, Minus } from 'lucide-react'
 import * as React from 'react'
 
 import { cn } from '@/renderer/src/lib/utils'
 
 const Checkbox = React.memo(function Checkbox({
   className,
+  checked,
   ref,
   ...props
 }: React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root> & {
   ref?: React.Ref<React.ComponentRef<typeof CheckboxPrimitive.Root>>
 }) {
+  const isIndeterminate = checked === 'indeterminate'
+
   return (
     <CheckboxPrimitive.Root
       ref={ref}
@@ -18,12 +21,17 @@ const Checkbox = React.memo(function Checkbox({
         'peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
         className,
       )}
+      checked={checked}
       {...props}
     >
       <CheckboxPrimitive.Indicator
         className={cn('flex items-center justify-center text-current')}
       >
-        <Check className="h-4 w-4" />
+        {isIndeterminate ? (
+          <Minus className="h-4 w-4" />
+        ) : (
+          <Check className="h-4 w-4" />
+        )}
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
   )

--- a/src/renderer/src/components/ui/dialog.tsx
+++ b/src/renderer/src/components/ui/dialog.tsx
@@ -12,6 +12,13 @@ const DialogPortal = DialogPrimitive.Portal
 
 const DialogClose = DialogPrimitive.Close
 
+type DialogContentProps = React.ComponentPropsWithRef<
+  typeof DialogPrimitive.Content
+> & {
+  /** Hides the built-in corner close button when a controlled dialog must block dismissal during an in-flight mutation. */
+  hideCloseButton?: boolean
+}
+
 const DialogOverlay = React.memo(function DialogOverlay({
   className,
   ref,
@@ -32,9 +39,10 @@ const DialogOverlay = React.memo(function DialogOverlay({
 const DialogContent = React.memo(function DialogContent({
   className,
   children,
+  hideCloseButton = false,
   ref,
   ...props
-}: React.ComponentPropsWithRef<typeof DialogPrimitive.Content>) {
+}: DialogContentProps) {
   return (
     <DialogPortal>
       <DialogOverlay />
@@ -47,10 +55,12 @@ const DialogContent = React.memo(function DialogContent({
         {...props}
       >
         {children}
-        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground min-h-11 min-w-11 flex items-center justify-center">
-          <X className="h-4 w-4" />
-          <span className="sr-only">Close</span>
-        </DialogPrimitive.Close>
+        {hideCloseButton ? null : (
+          <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground min-h-11 min-w-11 flex items-center justify-center">
+            <X className="h-4 w-4" />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
       </DialogPrimitive.Content>
     </DialogPortal>
   )

--- a/src/renderer/src/redux/migrations.test.ts
+++ b/src/renderer/src/redux/migrations.test.ts
@@ -7,7 +7,11 @@ import {
   THEME_PRESETS,
 } from '@/shared/constants'
 
-import { migrateState, V2_WIDGET_MIN_SIZES } from './migrations'
+import {
+  migrateState,
+  V2_WIDGET_MIN_SIZES,
+  V4_WIDGET_MIN_SIZES,
+} from './migrations'
 import type { ThemeState } from './slices/themeSlice'
 
 /**
@@ -401,6 +405,108 @@ describe('migrateState — v2 → v3 theme modePreference seeding', () => {
   })
 })
 
+describe('migrateState — v3 → v4 dashboard health min-size clamp', () => {
+  /**
+   * Same envelope builder as the v1 → v2 block, scoped locally so this
+   * describe stays self-contained (DAMP) — each test declares only the
+   * widget it exercises instead of restating the dashboard boilerplate.
+   */
+  type WidgetFixture = {
+    id: string
+    type: string
+    x: number
+    y: number
+    w: number
+    h: number
+  }
+  function makeDashboardState(
+    pages: Array<{ id?: string; name?: string; widgets: WidgetFixture[] }>,
+  ) {
+    const normalized = pages.map((p, i) => ({
+      id: p.id ?? `page-${i + 1}`,
+      name: p.name ?? 'Home',
+      widgets: p.widgets,
+    }))
+    return {
+      dashboard: {
+        pages: normalized,
+        currentPageId: normalized[0].id,
+        isEditMode: false,
+        welcomeDismissed: false,
+        initialized: true,
+      },
+    }
+  }
+
+  /**
+   * PR #185 added a "Scan issues" action row to the Symlink Health widget,
+   * which clipped against the card's bottom edge at the old h: 2. The fix grew
+   * `WIDGET_REGISTRY['health'].minSize.h` to 3; this migration rewrites layouts
+   * persisted on the old floor so react-grid-layout doesn't re-clamp (and shove
+   * neighbors) on first render.
+   */
+  it('clamps health widget h: 2 up to 3', () => {
+    const state = makeDashboardState([
+      { widgets: [{ id: 'w1', type: 'health', x: 3, y: 3, w: 3, h: 2 }] },
+    ])
+    migrateState(state, 3)
+    expect(state.dashboard.pages[0].widgets[0].h).toBe(3)
+    expect(state.dashboard.pages[0].widgets[0].w).toBe(3)
+  })
+
+  it('leaves health widget h: 3 untouched (no over-clamp)', () => {
+    const state = makeDashboardState([
+      { widgets: [{ id: 'w1', type: 'health', x: 3, y: 3, w: 3, h: 3 }] },
+    ])
+    migrateState(state, 3)
+    expect(state.dashboard.pages[0].widgets[0].h).toBe(3)
+  })
+
+  it('leaves health widget h: 4 untouched (clamp is upward-only)', () => {
+    const state = makeDashboardState([
+      { widgets: [{ id: 'w1', type: 'health', x: 3, y: 3, w: 3, h: 4 }] },
+    ])
+    migrateState(state, 3)
+    expect(state.dashboard.pages[0].widgets[0].h).toBe(4)
+  })
+
+  it('does not touch widgets outside the v4 floor map (e.g., stats)', () => {
+    // stats shares health's old { w: 3, h: 2 } footprint but is absent from
+    // V4_WIDGET_MIN_SIZES, so the v3 → v4 clamp must leave it alone.
+    const state = makeDashboardState([
+      { widgets: [{ id: 'w1', type: 'stats', x: 0, y: 3, w: 3, h: 2 }] },
+    ])
+    migrateState(state, 3)
+    expect(state.dashboard.pages[0].widgets[0].h).toBe(2)
+    expect(state.dashboard.pages[0].widgets[0].w).toBe(3)
+  })
+
+  it('handles missing dashboard slice gracefully', () => {
+    const state = {
+      theme: {
+        hue: 0,
+        chroma: 0,
+        mode: 'dark' as const,
+        modePreference: 'dark' as const,
+        preset: 'neutral-dark' as const,
+      },
+    }
+    expect(() => migrateState(state, 3)).not.toThrow()
+  })
+
+  it('clamps health when migrating across the full v1 → v4 chain', () => {
+    // Guards that `case 3` is actually wired into the switch: a layout
+    // persisted way back at v1 must still pick up the v4 health floor in a
+    // single migrateState() call (v1 → v2 leaves health alone, v2 → v3 is
+    // theme-only, v3 → v4 clamps it).
+    const state = makeDashboardState([
+      { widgets: [{ id: 'w1', type: 'health', x: 3, y: 3, w: 3, h: 2 }] },
+    ])
+    migrateState(state, 1)
+    expect(state.dashboard.pages[0].widgets[0].h).toBe(3)
+  })
+})
+
 describe('V2_WIDGET_MIN_SIZES drift guard', () => {
   // The map in migrations.ts mirrors `WIDGET_REGISTRY[*].minSize`. If anyone
   // bumps a widget's runtime min in the registry without updating the
@@ -422,6 +528,30 @@ describe('V2_WIDGET_MIN_SIZES drift guard', () => {
       expect(
         registryEntry,
         `V2_WIDGET_MIN_SIZES has '${type}' but WIDGET_REGISTRY does not`,
+      ).toBeDefined()
+      expect(
+        registryEntry.minSize,
+        `WIDGET_REGISTRY['${type}'].minSize is missing — bump migrations or registry`,
+      ).toEqual(min)
+    }
+  })
+})
+
+describe('V4_WIDGET_MIN_SIZES drift guard', () => {
+  // Mirrors the V2 guard: `V4_WIDGET_MIN_SIZES` must stay in sync with
+  // `WIDGET_REGISTRY[*].minSize`. If someone changes the health widget's
+  // runtime min again without updating this map AND shipping a migration,
+  // persisted layouts on the prior floor silently violate the registry
+  // constraint after upgrade. One-way by design (see the V2 guard note): a
+  // future bump of a widget NOT in the v4 map is the trigger to add a V5 floor
+  // + migrateV4ToV5, not to retroactively widen v4's scope.
+  it('mirror entries match WIDGET_REGISTRY minSize', () => {
+    for (const [type, min] of Object.entries(V4_WIDGET_MIN_SIZES)) {
+      const registryEntry =
+        WIDGET_REGISTRY[type as keyof typeof WIDGET_REGISTRY]
+      expect(
+        registryEntry,
+        `V4_WIDGET_MIN_SIZES has '${type}' but WIDGET_REGISTRY does not`,
       ).toBeDefined()
       expect(
         registryEntry.minSize,

--- a/src/renderer/src/redux/migrations.ts
+++ b/src/renderer/src/redux/migrations.ts
@@ -39,6 +39,18 @@ export const V2_WIDGET_MIN_SIZES = {
 } as const satisfies Partial<Record<WidgetType, { w: number; h: number }>>
 
 /**
+ * v4 floor — the Symlink Health widget's `minSize.h` grew 2 → 3 (PR #185 added
+ * a "Scan issues" action row that clipped against the card's bottom edge at
+ * h=2). **Mirror** of `WIDGET_REGISTRY['health'].minSize`, kept here for the
+ * same reason as {@link V2_WIDGET_MIN_SIZES} — this module must stay free of
+ * the widget-component graph. Same contract: bump the registry, add the floor
+ * here, AND ship a migration.
+ */
+export const V4_WIDGET_MIN_SIZES = {
+  health: { w: 2, h: 3 },
+} as const satisfies Partial<Record<WidgetType, { w: number; h: number }>>
+
+/**
  * v0 → v1 migration for the theme slice. The old shape carried a
  * `presetType: 'color' | 'neutral'` discriminator; v1 replaces that with a
  * numeric `chroma` scalar so the same OKLCH formula drives both ramps. When
@@ -79,18 +91,27 @@ function migrateV0ToV1(state: MigratableState): void {
 }
 
 /**
- * v1 → v2 migration for the dashboard slice. The Quick Actions widget's
- * `minSize.h` was bumped from 2 to 3 alongside a `GRID_ROW_HEIGHT_PX`
- * increase (48 → 64). Persisted layouts saved before the bump carry the old
- * `h: 2` for Quick Actions; without a clamp, react-grid-layout would silently
- * re-clamp on first render, shoving neighboring widgets and producing a
- * surprise jolt for users who carefully arranged their dashboard.
+ * Walk every persisted dashboard widget and clamp `{w,h}` upward to a per-type
+ * floor — the shared engine behind the v1 → v2 and v3 → v4 dashboard
+ * migrations. Both raised a widget's registry `minSize`, so layouts persisted
+ * on the old floor must be rewritten in storage; otherwise react-grid-layout
+ * re-clamps them mid-render and shoves the user's arranged neighbors. Mutates
+ * `state.dashboard` in place and no-ops when the slice is missing or malformed
+ * (a thrown migration makes the storage middleware wipe every persisted slice).
  *
- * Strategy: walk every persisted widget, look up its floor in
- * `V2_WIDGET_MIN_SIZES`, and clamp `{w,h}` upward in place. Widgets whose
- * type isn't in the map (most of them) are untouched.
+ * @param state - migratable persisted state; `dashboard` may be any shape.
+ * @param floors - per-widget-type minimum `{w,h}`; types absent are untouched.
+ * @param migrationName - label used in the dev-only malformed-entry warnings.
+ * @returns nothing — `state.dashboard` is mutated in place.
+ * @example
+ * // health persisted at h:2 is raised to the v4 floor h:3
+ * clampPersistedWidgetSizes(state, V4_WIDGET_MIN_SIZES, 'migrateV3ToV4')
  */
-function migrateV1ToV2(state: MigratableState): void {
+function clampPersistedWidgetSizes(
+  state: MigratableState,
+  floors: Partial<Record<string, { w: number; h: number }>>,
+  migrationName: string,
+): void {
   if (!state.dashboard || typeof state.dashboard !== 'object') return
   const dashboard = state.dashboard as {
     pages?: Array<{
@@ -110,7 +131,7 @@ function migrateV1ToV2(state: MigratableState): void {
       // console clean for users.
       if (import.meta.env.DEV) {
         console.warn(
-          `migrateV1ToV2: skipping malformed page at index ${pageIndex}`,
+          `${migrationName}: skipping malformed page at index ${pageIndex}`,
         )
       }
       continue
@@ -122,24 +143,34 @@ function migrateV1ToV2(state: MigratableState): void {
       if (!widget || typeof widget !== 'object') {
         if (import.meta.env.DEV) {
           console.warn(
-            `migrateV1ToV2: skipping malformed widget on page ${pageIndex}`,
+            `${migrationName}: skipping malformed widget on page ${pageIndex}`,
           )
         }
         continue
       }
       if (!widget.type) continue
-      // `satisfies` keeps V2_WIDGET_MIN_SIZES literal-typed for the drift
-      // test, but the indexer here expects WidgetType (a wider union than
-      // the v2 map). Cast to a partial-record at the call site to recover
-      // "lookup may miss" semantics — most widget types aren't in v2's map.
-      const min = (
-        V2_WIDGET_MIN_SIZES as Partial<Record<string, { w: number; h: number }>>
-      )[widget.type]
+      // `floors` is already string-keyed, so indexing with `widget.type`
+      // (string) needs no cast — the lookup is `{ w, h } | undefined` and the
+      // guard below recovers "type not in this version's floor map" semantics.
+      const min = floors[widget.type]
       if (!min) continue
       if (typeof widget.w === 'number' && widget.w < min.w) widget.w = min.w
       if (typeof widget.h === 'number' && widget.h < min.h) widget.h = min.h
     }
   }
+}
+
+/**
+ * v1 → v2 migration for the dashboard slice. The Quick Actions widget's
+ * `minSize.h` was bumped from 2 to 3 alongside a `GRID_ROW_HEIGHT_PX`
+ * increase (48 → 64). Persisted layouts saved before the bump carry the old
+ * `h: 2` for Quick Actions; without a clamp, react-grid-layout would silently
+ * re-clamp on first render, shoving neighboring widgets and producing a
+ * surprise jolt for users who carefully arranged their dashboard. Delegates to
+ * {@link clampPersistedWidgetSizes} with the v2 floors.
+ */
+function migrateV1ToV2(state: MigratableState): void {
+  clampPersistedWidgetSizes(state, V2_WIDGET_MIN_SIZES, 'migrateV1ToV2')
 }
 
 /**
@@ -172,6 +203,19 @@ function migrateV2ToV3(state: MigratableState): void {
 }
 
 /**
+ * v3 → v4 migration for the dashboard slice. The Symlink Health widget's
+ * `minSize.h` grew 2 → 3 so its "Scan issues" action row (added in PR #185)
+ * stops clipping against the card's bottom edge. Layouts persisted at the old
+ * `h: 2` are clamped up to the v4 floor; react-grid-layout's default vertical
+ * compactor then reflows any widget the taller card now overlaps on first
+ * render (and re-persists the result via `onLayoutChange`), so only the size
+ * needs rewriting here. Delegates to {@link clampPersistedWidgetSizes}.
+ */
+function migrateV3ToV4(state: MigratableState): void {
+  clampPersistedWidgetSizes(state, V4_WIDGET_MIN_SIZES, 'migrateV3ToV4')
+}
+
+/**
  * Chain migrations up to `PERSIST_STATE_VERSION`. Each `case` must advance
  * `current` to the next schema version; unknown sources throw so bumping
  * `PERSIST_STATE_VERSION` without adding a migration fails loudly in tests
@@ -199,6 +243,10 @@ export function migrateState<T extends MigratableState>(
       case 2:
         migrateV2ToV3(state)
         current = 3
+        break
+      case 3:
+        migrateV3ToV4(state)
+        current = 4
         break
       default:
         throw new Error(

--- a/src/renderer/src/redux/selectors.test.ts
+++ b/src/renderer/src/redux/selectors.test.ts
@@ -17,6 +17,7 @@ import type {
 
 import {
   selectBookmarksWithInstallStatus,
+  selectBulkSelectableVisibleSkillNames,
   selectFilteredSkills,
   selectHiddenSelectedCount,
   selectInFlightDeleteNamesSet,
@@ -837,6 +838,62 @@ describe('selectVisibleSkillNames', () => {
     const skills = [makeSkill('task', 'claude-code')]
     const state = buildState({ skills, searchQuery: 'unmatched' })
     expect(selectVisibleSkillNames(state as never)).toEqual([])
+  })
+})
+
+describe('selectBulkSelectableVisibleSkillNames', () => {
+  it('keeps broken agent rows visible but excludes them from bulk unlink names', () => {
+    const brokenSkill: Skill = {
+      ...makeSkill('broken-skill', 'cursor'),
+      isSource: false,
+      isOrphan: true,
+      symlinks: [
+        {
+          agentId: 'cursor' as AgentId,
+          agentName: 'Cursor' as SymlinkInfo['agentName'],
+          linkPath: '/home/user/.cursor/skills/broken-skill',
+          targetPath: '/home/user/.agents/skills/broken-skill',
+          status: 'broken',
+          isLocal: false,
+        },
+      ],
+    }
+    const validSkill = makeSkill('valid-skill', 'cursor')
+    const state = buildState({
+      skills: [brokenSkill, validSkill],
+      selectedAgentId: 'cursor',
+    })
+
+    expect(selectVisibleSkillNames(state as never)).toEqual([
+      'broken-skill',
+      'valid-skill',
+    ])
+    expect(selectBulkSelectableVisibleSkillNames(state as never)).toEqual([
+      'valid-skill',
+    ])
+  })
+
+  it('excludes inaccessible agent rows from bulk unlink names', () => {
+    const inaccessibleSkill: Skill = {
+      ...makeSkill('manual-review', 'cursor'),
+      symlinks: [
+        {
+          agentId: 'cursor' as AgentId,
+          agentName: 'Cursor' as SymlinkInfo['agentName'],
+          linkPath: '/home/user/.cursor/skills/manual-review',
+          targetPath: '/home/user/.agents/skills/manual-review',
+          status: 'inaccessible',
+          isLocal: false,
+        },
+      ],
+    }
+    const state = buildState({
+      skills: [inaccessibleSkill],
+      selectedAgentId: 'cursor',
+    })
+
+    expect(selectFilteredSkills(state as never)).toHaveLength(1)
+    expect(selectBulkSelectableVisibleSkillNames(state as never)).toEqual([])
   })
 })
 

--- a/src/renderer/src/redux/selectors.test.ts
+++ b/src/renderer/src/redux/selectors.test.ts
@@ -898,6 +898,34 @@ describe('selectBulkSelectableVisibleSkillNames', () => {
     expect(selectFilteredSkills(state as never)).toHaveLength(1)
     expect(selectBulkSelectableVisibleSkillNames(state as never)).toEqual([])
   })
+
+  it('excludes local agent folders from bulk unlink names', () => {
+    const localSkill: Skill = {
+      ...makeSkill('local-only', 'cursor'),
+      symlinks: [
+        {
+          agentId: 'cursor' as AgentId,
+          agentName: 'Cursor' as SymlinkInfo['agentName'],
+          linkPath: '/home/user/.cursor/skills/local-only',
+          status: 'valid',
+          isLocal: true,
+        },
+      ],
+    }
+    const validSymlinkSkill = makeSkill('valid-symlink', 'cursor')
+    const state = buildState({
+      skills: [localSkill, validSymlinkSkill],
+      selectedAgentId: 'cursor',
+    })
+
+    expect(selectVisibleSkillNames(state as never)).toEqual([
+      'local-only',
+      'valid-symlink',
+    ])
+    expect(selectBulkSelectableVisibleSkillNames(state as never)).toEqual([
+      'valid-symlink',
+    ])
+  })
 })
 
 describe('selectSelectedCount', () => {

--- a/src/renderer/src/redux/selectors.test.ts
+++ b/src/renderer/src/redux/selectors.test.ts
@@ -27,6 +27,7 @@ import {
   selectSelectedVisibleCount,
   selectSelectedVisibleNames,
   selectSourceFilterViewModel,
+  selectVisibleIneligibleSelectedCount,
   selectVisibleSkillNames,
 } from './selectors'
 
@@ -130,19 +131,21 @@ function buildState(overrides: {
  *   both `source` and `sourceUrl` on the skill so repo-scope tests can assert
  *   on a real value. Omitted by default to mimic the most common state where
  *   skills lack source metadata.
+ * @param status - Agent symlink status for bulk-action eligibility tests.
  */
 const makeSkill = (
   name: string,
   agentId: AgentId,
   isLocal = false,
   source?: string,
+  status: SymlinkInfo['status'] = 'valid',
 ): Skill => ({
   name,
   description: `${name} skill`,
   path: isLocal
     ? `/home/user/.${agentId}/skills/${name}`
     : `/home/user/.agents/skills/${name}`,
-  symlinkCount: isLocal ? 0 : 1,
+  symlinkCount: isLocal || status === 'missing' ? 0 : 1,
   symlinks: [
     {
       agentId: agentId as SymlinkInfo['agentId'],
@@ -151,7 +154,7 @@ const makeSkill = (
       targetPath: isLocal
         ? `/home/user/.${agentId}/skills/${name}`
         : `/home/user/.agents/skills/${name}`,
-      status: 'valid',
+      status,
       isLocal,
     },
   ],
@@ -978,6 +981,36 @@ describe('selectHiddenSelectedCount', () => {
       selectedSkillNames: ['alpha', 'browser'],
     })
     expect(selectHiddenSelectedCount(state as never)).toBe(0)
+  })
+
+  it('does not count visible but ineligible agent rows as hidden by filter', () => {
+    const skills = [
+      makeSkill('valid-task', 'cursor'),
+      makeSkill('broken-task', 'cursor', false, undefined, 'broken'),
+    ]
+    const state = buildState({
+      skills,
+      selectedAgentId: 'cursor',
+      selectedSkillNames: ['valid-task', 'broken-task'],
+    })
+
+    expect(selectHiddenSelectedCount(state as never)).toBe(0)
+  })
+})
+
+describe('selectVisibleIneligibleSelectedCount', () => {
+  it('counts selected rows that are visible but excluded from bulk action', () => {
+    const skills = [
+      makeSkill('valid-task', 'cursor'),
+      makeSkill('broken-task', 'cursor', false, undefined, 'broken'),
+    ]
+    const state = buildState({
+      skills,
+      selectedAgentId: 'cursor',
+      selectedSkillNames: ['valid-task', 'broken-task', 'hidden-task'],
+    })
+
+    expect(selectVisibleIneligibleSelectedCount(state as never)).toBe(1)
   })
 })
 

--- a/src/renderer/src/redux/selectors.ts
+++ b/src/renderer/src/redux/selectors.ts
@@ -41,7 +41,7 @@ interface RepoFacetOption {
  * Detect whether one scanner slot belongs to the active agent list.
  * @param slot - Symlink slot emitted by the skill scanner.
  * @param selectedAgentId - Agent currently selected in the Installed view.
- * @returns True for valid or broken slots that should appear in that agent.
+ * @returns True for occupied slots that should appear in that agent.
  * @example
  * isSelectedAgentSlot(skill.symlinks[0], 'cursor')
  */
@@ -51,7 +51,9 @@ function isSelectedAgentSlot(
 ): boolean {
   return (
     slot.agentId === selectedAgentId &&
-    (slot.status === 'valid' || slot.status === 'broken')
+    (slot.status === 'valid' ||
+      slot.status === 'broken' ||
+      slot.status === 'inaccessible')
   )
 }
 

--- a/src/renderer/src/redux/selectors.ts
+++ b/src/renderer/src/redux/selectors.ts
@@ -465,7 +465,7 @@ export const selectVisibleSkillNames = createSelector(
 )
 
 /**
- * Detect whether a visible agent-view row can use the generic bulk Unlink path.
+ * Detect whether a visible agent-view row can use the reviewed bulk Unlink path.
  * @param skill - Visible skill row.
  * @param selectedAgentId - Active agent filter; null means global delete flow.
  * @returns True when bulk action can safely include this row.
@@ -481,14 +481,15 @@ function isBulkSelectableSkill(
   return skill.symlinks.some(
     (symlink) =>
       symlink.agentId === selectedAgentId &&
-      (symlink.isLocal || symlink.status === 'valid'),
+      symlink.status === 'valid' &&
+      !symlink.isLocal,
   )
 }
 
 /**
  * Ordered visible names that can safely flow through the current bulk action.
- * Agent-view broken/inaccessible rows stay visible but are excluded because
- * name-only bulk Unlink cannot revalidate their reviewed target identity.
+ * Agent-view local/broken/inaccessible rows stay visible but are excluded
+ * because reviewed bulk Unlink only removes symlink slots.
  * @returns Skill names eligible for Select all, Shift range, and primary action.
  * @example
  * const names = useAppSelector(selectBulkSelectableVisibleSkillNames)

--- a/src/renderer/src/redux/selectors.ts
+++ b/src/renderer/src/redux/selectors.ts
@@ -465,6 +465,43 @@ export const selectVisibleSkillNames = createSelector(
 )
 
 /**
+ * Detect whether a visible agent-view row can use the generic bulk Unlink path.
+ * @param skill - Visible skill row.
+ * @param selectedAgentId - Active agent filter; null means global delete flow.
+ * @returns True when bulk action can safely include this row.
+ * @example
+ * isBulkSelectableSkill(validSkill, 'cursor') // => true
+ */
+function isBulkSelectableSkill(
+  skill: Skill,
+  selectedAgentId: AgentId | null,
+): boolean {
+  if (selectedAgentId === null) return true
+
+  return skill.symlinks.some(
+    (symlink) =>
+      symlink.agentId === selectedAgentId &&
+      (symlink.isLocal || symlink.status === 'valid'),
+  )
+}
+
+/**
+ * Ordered visible names that can safely flow through the current bulk action.
+ * Agent-view broken/inaccessible rows stay visible but are excluded because
+ * name-only bulk Unlink cannot revalidate their reviewed target identity.
+ * @returns Skill names eligible for Select all, Shift range, and primary action.
+ * @example
+ * const names = useAppSelector(selectBulkSelectableVisibleSkillNames)
+ */
+export const selectBulkSelectableVisibleSkillNames = createSelector(
+  [selectFilteredSkills, selectSelectedAgentId],
+  (filteredSkills, selectedAgentId): SkillName[] =>
+    filteredSkills
+      .filter((skill) => isBulkSelectableSkill(skill, selectedAgentId))
+      .map((skill) => skill.name),
+)
+
+/**
  * Count of items currently ticked in `selectedSkillNames`. Separate from
  * `selectedSkillNames.length` at callsites so components can subscribe to the
  * scalar without re-rendering on any selection mutation (toolbar shows
@@ -490,7 +527,7 @@ export const selectSelectedCount = createSelector(
  * // => ['task', 'browser']
  */
 export const selectSelectedVisibleNames = createSelector(
-  [selectSelectedSkillNames, selectVisibleSkillNames],
+  [selectSelectedSkillNames, selectBulkSelectableVisibleSkillNames],
   (selectedNames, visibleNames): SkillName[] => {
     const selectedSet = new Set(selectedNames)
     return visibleNames.filter((name) => selectedSet.has(name))
@@ -515,7 +552,7 @@ export const selectSelectedVisibleCount = createSelector(
  * @returns number — selected names that are NOT in the visible list
  */
 export const selectHiddenSelectedCount = createSelector(
-  [selectSelectedSkillNames, selectVisibleSkillNames],
+  [selectSelectedSkillNames, selectBulkSelectableVisibleSkillNames],
   (selectedNames, visibleNames): number => {
     const visibleSet = new Set(visibleNames)
     let hidden = 0

--- a/src/renderer/src/redux/selectors.ts
+++ b/src/renderer/src/redux/selectors.ts
@@ -547,12 +547,12 @@ export const selectSelectedVisibleCount = createSelector(
 
 /**
  * The hidden-selected count shown in the toolbar as a badge ("+2 hidden by
- * filter") so the user realizes they have out-of-view selections that the
- * Delete button will NOT act on.
+ * filter") so the user realizes they have out-of-view selections. Visible
+ * but ineligible rows are counted separately by `selectVisibleIneligibleSelectedCount`.
  * @returns number — selected names that are NOT in the visible list
  */
 export const selectHiddenSelectedCount = createSelector(
-  [selectSelectedSkillNames, selectBulkSelectableVisibleSkillNames],
+  [selectSelectedSkillNames, selectVisibleSkillNames],
   (selectedNames, visibleNames): number => {
     const visibleSet = new Set(visibleNames)
     let hidden = 0
@@ -560,6 +560,31 @@ export const selectHiddenSelectedCount = createSelector(
       if (!visibleSet.has(name)) hidden += 1
     }
     return hidden
+  },
+)
+
+/**
+ * Count selected rows that are visible but excluded from the current bulk action.
+ * @returns number — visible selected rows that cannot use Delete/Unlink safely.
+ * @example
+ * // broken agent-view row selected on screen => 1 not eligible
+ */
+export const selectVisibleIneligibleSelectedCount = createSelector(
+  [
+    selectSelectedSkillNames,
+    selectVisibleSkillNames,
+    selectBulkSelectableVisibleSkillNames,
+  ],
+  (selectedNames, visibleNames, eligibleVisibleNames): number => {
+    const selectedSet = new Set(selectedNames)
+    const eligibleSet = new Set(eligibleVisibleNames)
+    let visibleIneligible = 0
+    for (const name of visibleNames) {
+      if (selectedSet.has(name) && !eligibleSet.has(name)) {
+        visibleIneligible += 1
+      }
+    }
+    return visibleIneligible
   },
 )
 

--- a/src/renderer/src/redux/slices/agentsSlice.test.ts
+++ b/src/renderer/src/redux/slices/agentsSlice.test.ts
@@ -6,6 +6,15 @@ import type { Agent } from '@/shared/types'
 const mockGetAll = vi.fn()
 const mockRemoveAllFromAgent = vi.fn()
 
+const directoryIdentity = {
+  kind: 'directory' as const,
+  dev: 1,
+  ino: 2,
+  size: 96,
+  ctimeMs: 3,
+  mtimeMs: 4,
+}
+
 vi.stubGlobal('window', {
   electron: {
     agents: { getAll: mockGetAll },
@@ -25,6 +34,7 @@ const sampleAgent: Agent = {
   exists: true,
   skillCount: 3,
   localSkillCount: 0,
+  filesystemIdentity: directoryIdentity,
 }
 
 describe('agentsSlice', () => {
@@ -112,6 +122,25 @@ describe('agentsSlice', () => {
 
     expect(store.getState().agents.agentToDelete).toBeNull()
     expect(store.getState().agents.deleting).toBe(false)
+    expect(mockRemoveAllFromAgent).toHaveBeenCalledWith({
+      agentId: 'claude-code',
+      agentPath: '/home/user/.claude/skills',
+      filesystemIdentity: directoryIdentity,
+    })
+  })
+
+  it('removeAllSymlinksFromAgent rejects when reviewed agent identity is missing', async () => {
+    const staleAgent: Agent = { ...sampleAgent, filesystemIdentity: undefined }
+
+    const store = await createTestStore()
+    const { removeAllSymlinksFromAgent } = await import('./agentsSlice')
+    await store.dispatch(removeAllSymlinksFromAgent(staleAgent))
+
+    expect(store.getState().agents.deleting).toBe(false)
+    expect(store.getState().agents.error).toBe(
+      'Agent skills folder changed since review. Rescan before deleting.',
+    )
+    expect(mockRemoveAllFromAgent).not.toHaveBeenCalled()
   })
 
   it('removeAllSymlinksFromAgent sets deleting during pending', async () => {

--- a/src/renderer/src/redux/slices/agentsSlice.ts
+++ b/src/renderer/src/redux/slices/agentsSlice.ts
@@ -45,9 +45,15 @@ export const fetchAgents = createAsyncThunk('agents/fetchAll', async () => {
 export const removeAllSymlinksFromAgent = createAsyncThunk(
   'agents/removeAllSymlinks',
   async (agent: Agent) => {
+    if (!agent.filesystemIdentity) {
+      throw new Error(
+        'Agent skills folder changed since review. Rescan before deleting.',
+      )
+    }
     const result = await window.electron.skills.removeAllFromAgent({
       agentId: agent.id,
       agentPath: agent.path,
+      filesystemIdentity: agent.filesystemIdentity,
     })
     if (!result.success) {
       throw new Error(result.error || 'Failed to delete skills folder')

--- a/src/renderer/src/redux/slices/skillsSlice.test.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.test.ts
@@ -127,7 +127,11 @@ function unlinkTarget(
   skillName: Skill['name'],
   linkPath = `/home/user/.cursor/skills/${skillName}`,
 ) {
-  return { skillName, linkPath: linkPath as AbsolutePath }
+  return {
+    skillName,
+    linkPath: linkPath as AbsolutePath,
+    targetPath: `/home/user/.agents/skills/${skillName}` as AbsolutePath,
+  }
 }
 
 /** Seed items into the store so mid-op reconciliation has something to intersect. */
@@ -317,6 +321,31 @@ describe('skillsSlice', () => {
 
     expect(store.getState().skills.unlinking).toBe(false)
     expect(store.getState().skills.error).toBe('Permission denied')
+  })
+
+  it('unlinkSkillFromAgent passes reviewed local directory identity for local slots', async () => {
+    mockUnlinkFromAgent.mockResolvedValue({ success: true })
+    const localSymlink: SymlinkInfo = {
+      ...sampleSymlink,
+      isLocal: true,
+      targetPath: undefined,
+      filesystemIdentity: directoryIdentity,
+    }
+
+    const store = await createTestStore()
+    const { unlinkSkillFromAgent } = await import('./skillsSlice')
+    await store.dispatch(
+      unlinkSkillFromAgent({ skill: sampleSkill, symlink: localSymlink }),
+    )
+
+    expect(mockUnlinkFromAgent).toHaveBeenCalledWith({
+      skillName: 'task',
+      agentId: 'claude-code',
+      linkPath: '/home/user/.claude/skills/task',
+      targetPath: undefined,
+      confirmedLocalDirectoryDelete: true,
+      reviewedDirectoryIdentity: directoryIdentity,
+    })
   })
 
   // --- createSymlinks thunk ---
@@ -1030,6 +1059,8 @@ describe('skillsSlice unlinkSelectedFromAgent thunk', () => {
             skillName: 'metadata-title',
             linkPath:
               '/home/user/.cursor/skills/folder-basename' as AbsolutePath,
+            targetPath:
+              '/home/user/.agents/skills/folder-basename' as AbsolutePath,
           },
         ],
       }),
@@ -1041,6 +1072,7 @@ describe('skillsSlice unlinkSelectedFromAgent thunk', () => {
         {
           skillName: 'metadata-title',
           linkPath: '/home/user/.cursor/skills/folder-basename',
+          targetPath: '/home/user/.agents/skills/folder-basename',
         },
       ],
     })

--- a/src/renderer/src/redux/slices/skillsSlice.test.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.test.ts
@@ -5,6 +5,7 @@ import type {
   AgentId,
   BulkDeleteResult,
   BulkUnlinkResult,
+  ClearOrphanSymlinksResult,
   RestoreDeletedSkillResult,
   Skill,
   SymlinkInfo,
@@ -605,6 +606,172 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
     expect(state.bulkDeleting).toBe(false)
     expect(state.inFlightDeleteNames).toEqual([])
     expect(state.error).toBe('EACCES')
+  })
+})
+
+describe('skillsSlice clearSelectedOrphanSymlinks thunk', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('sets bulkDeleting and reconciles orphan inFlightDeleteNames against live items on pending', async () => {
+    const store = await createTestStore()
+    await seedItems(store, [sampleSkill, secondSkill])
+    let resolve!: (value: ClearOrphanSymlinksResult) => void
+    mockClearOrphanSymlinks.mockReturnValue(
+      new Promise<ClearOrphanSymlinksResult>((r) => {
+        resolve = r
+      }),
+    )
+
+    const { clearSelectedOrphanSymlinks } = await import('./skillsSlice')
+    const promise = store.dispatch(
+      clearSelectedOrphanSymlinks([
+        {
+          skillName: 'task',
+          agents: [
+            {
+              agentId: 'codex' as AgentId,
+              linkPath: '/home/user/.codex/skills/task',
+              targetPath: '/home/user/.agents/skills/task',
+            },
+          ],
+        },
+        {
+          skillName: 'ghost',
+          agents: [
+            {
+              agentId: 'cursor' as AgentId,
+              linkPath: '/home/user/.cursor/skills/ghost',
+              targetPath: '/home/user/.agents/skills/ghost',
+            },
+          ],
+        },
+      ]),
+    )
+
+    expect(store.getState().skills.bulkDeleting).toBe(true)
+    expect(store.getState().skills.inFlightDeleteNames).toEqual(['task'])
+
+    resolve({
+      items: [
+        {
+          skillName: 'task',
+          outcome: 'orphan-cleared',
+          symlinksRemoved: 1,
+          cascadeAgents: ['codex' as AgentId],
+        },
+      ],
+    })
+    await promise
+  })
+
+  it('clears orphan selection, anchor, inFlight, and progress on fulfilled', async () => {
+    const store = await createTestStore()
+    await seedItems(store, [sampleSkill])
+    mockClearOrphanSymlinks.mockResolvedValue({
+      items: [
+        {
+          skillName: 'task',
+          outcome: 'orphan-cleared',
+          symlinksRemoved: 1,
+          cascadeAgents: ['codex' as AgentId],
+        },
+      ],
+    } satisfies ClearOrphanSymlinksResult)
+
+    const { clearSelectedOrphanSymlinks, setBulkProgress, toggleSelection } =
+      await import('./skillsSlice')
+    store.dispatch(toggleSelection('task'))
+    store.dispatch(setBulkProgress({ current: 1, total: 1 }))
+
+    await store.dispatch(
+      clearSelectedOrphanSymlinks([
+        {
+          skillName: 'task',
+          agents: [
+            {
+              agentId: 'codex' as AgentId,
+              linkPath: '/home/user/.codex/skills/task',
+              targetPath: '/home/user/.agents/skills/task',
+            },
+          ],
+        },
+      ]),
+    )
+
+    const state = store.getState().skills
+    expect(state.bulkDeleting).toBe(false)
+    expect(state.inFlightDeleteNames).toEqual([])
+    expect(state.selectedSkillNames).toEqual([])
+    expect(state.selectionAnchor).toBeNull()
+    expect(state.bulkProgress).toBeNull()
+  })
+
+  it('keeps failed orphan rows selected while clearing busy state on fulfilled', async () => {
+    const store = await createTestStore()
+    await seedItems(store, [sampleSkill])
+    mockClearOrphanSymlinks.mockResolvedValue({
+      items: [
+        {
+          skillName: 'task',
+          outcome: 'error',
+          error: { message: 'Rescan before cleanup.' },
+        },
+      ],
+    } satisfies ClearOrphanSymlinksResult)
+
+    const { clearSelectedOrphanSymlinks, toggleSelection } =
+      await import('./skillsSlice')
+    store.dispatch(toggleSelection('task'))
+
+    await store.dispatch(
+      clearSelectedOrphanSymlinks([
+        {
+          skillName: 'task',
+          agents: [
+            {
+              agentId: 'codex' as AgentId,
+              linkPath: '/home/user/.codex/skills/task',
+              targetPath: '/home/user/.agents/skills/task',
+            },
+          ],
+        },
+      ]),
+    )
+
+    const state = store.getState().skills
+    expect(state.bulkDeleting).toBe(false)
+    expect(state.inFlightDeleteNames).toEqual([])
+    expect(state.selectedSkillNames).toEqual(['task'])
+    expect(state.selectionAnchor).toBe('task')
+  })
+
+  it('clears orphan in-flight state and sets error on rejected', async () => {
+    const store = await createTestStore()
+    await seedItems(store, [sampleSkill])
+    mockClearOrphanSymlinks.mockRejectedValue(new Error('Permission denied'))
+
+    const { clearSelectedOrphanSymlinks } = await import('./skillsSlice')
+    await store.dispatch(
+      clearSelectedOrphanSymlinks([
+        {
+          skillName: 'task',
+          agents: [
+            {
+              agentId: 'codex' as AgentId,
+              linkPath: '/home/user/.codex/skills/task',
+              targetPath: '/home/user/.agents/skills/task',
+            },
+          ],
+        },
+      ]),
+    )
+
+    const state = store.getState().skills
+    expect(state.bulkDeleting).toBe(false)
+    expect(state.inFlightDeleteNames).toEqual([])
+    expect(state.error).toBe('Permission denied')
   })
 })
 

--- a/src/renderer/src/redux/slices/skillsSlice.test.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.test.ts
@@ -8,6 +8,7 @@ import type {
   BulkUnlinkResult,
   ClearBrokenSymlinkSlotsResult,
   ClearOrphanSymlinksResult,
+  FilesystemEntryIdentity,
   RestoreDeletedSkillResult,
   Skill,
   SymlinkInfo,
@@ -25,6 +26,15 @@ const mockClearBrokenSymlinkSlots = vi.fn()
 const mockUnlinkManyFromAgent = vi.fn()
 const mockRestoreDeletedSkill = vi.fn()
 const mockOnDeleteProgress = vi.fn()
+
+const directoryIdentity: FilesystemEntryIdentity = {
+  kind: 'directory',
+  dev: 1,
+  ino: 2,
+  size: 96,
+  ctimeMs: 3,
+  mtimeMs: 4,
+}
 
 vi.stubGlobal('window', {
   electron: {
@@ -57,6 +67,7 @@ const sampleSkill: Skill = {
   name: 'task',
   description: 'Task management skill',
   path: '/home/user/.agents/skills/task',
+  filesystemIdentity: directoryIdentity,
   symlinkCount: 1,
   symlinks: [
     {
@@ -98,7 +109,11 @@ function deleteTarget(
   skillName: Skill['name'],
   skillPath = `/home/user/.agents/skills/${skillName}`,
 ) {
-  return { skillName, skillPath: skillPath as AbsolutePath }
+  return {
+    skillName,
+    skillPath: skillPath as AbsolutePath,
+    filesystemIdentity: directoryIdentity,
+  }
 }
 
 /**
@@ -590,6 +605,7 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
           skillName: 'metadata-title',
           skillPath:
             '/home/user/.agents/skills/folder-basename' as AbsolutePath,
+          filesystemIdentity: directoryIdentity,
         },
       ]),
     )
@@ -599,6 +615,7 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
         {
           skillName: 'metadata-title',
           skillPath: '/home/user/.agents/skills/folder-basename',
+          filesystemIdentity: directoryIdentity,
         },
       ],
     })

--- a/src/renderer/src/redux/slices/skillsSlice.test.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.test.ts
@@ -87,6 +87,34 @@ const thirdSkill: Skill = {
 /** Sample symlink info */
 const sampleSymlink: SymlinkInfo = sampleSkill.symlinks[0]
 
+/**
+ * Build a reviewed delete target so tests exercise the mandatory path IPC contract.
+ * @param skillName - Display name selected by the user.
+ * @param skillPath - Reviewed source/local folder path.
+ * @returns Delete thunk target with exact filesystem identity.
+ * @example deleteTarget('task')
+ */
+function deleteTarget(
+  skillName: Skill['name'],
+  skillPath = `/home/user/.agents/skills/${skillName}`,
+) {
+  return { skillName, skillPath: skillPath as AbsolutePath }
+}
+
+/**
+ * Build a reviewed unlink target so tests exercise the mandatory slot IPC contract.
+ * @param skillName - Display name selected by the user.
+ * @param linkPath - Reviewed agent slot path.
+ * @returns Unlink thunk target with exact agent-slot identity.
+ * @example unlinkTarget('task')
+ */
+function unlinkTarget(
+  skillName: Skill['name'],
+  linkPath = `/home/user/.cursor/skills/${skillName}`,
+) {
+  return { skillName, linkPath: linkPath as AbsolutePath }
+}
+
 /** Seed items into the store so mid-op reconciliation has something to intersect. */
 async function seedItems(
   store: Awaited<ReturnType<typeof createTestStore>>,
@@ -501,7 +529,11 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
     const { deleteSelectedSkills } = await import('./skillsSlice')
     // Include a ghost name that is NOT in state.items — reconciliation should drop it
     const promise = store.dispatch(
-      deleteSelectedSkills(['task', 'theme-generator', 'already-gone']),
+      deleteSelectedSkills([
+        deleteTarget('task'),
+        deleteTarget('theme-generator'),
+        deleteTarget('already-gone'),
+      ]),
     )
 
     expect(store.getState().skills.bulkDeleting).toBe(true)
@@ -592,7 +624,7 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
     store.dispatch(toggleSelection('task'))
     store.dispatch(setBulkProgress({ current: 1, total: 1 }))
 
-    await store.dispatch(deleteSelectedSkills(['task']))
+    await store.dispatch(deleteSelectedSkills([deleteTarget('task')]))
 
     const state = store.getState().skills
     expect(state.bulkDeleting).toBe(false)
@@ -621,7 +653,7 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
     store.dispatch(toggleSelection('task'))
     store.dispatch(setBulkProgress({ current: 1, total: 1 }))
 
-    await store.dispatch(deleteSelectedSkills(['task']))
+    await store.dispatch(deleteSelectedSkills([deleteTarget('task')]))
 
     const state = store.getState().skills
     expect(state.bulkDeleting).toBe(false)
@@ -637,7 +669,7 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
     mockDeleteSkills.mockRejectedValue(new Error('EACCES'))
 
     const { deleteSelectedSkills } = await import('./skillsSlice')
-    await store.dispatch(deleteSelectedSkills(['task']))
+    await store.dispatch(deleteSelectedSkills([deleteTarget('task')]))
 
     const state = store.getState().skills
     expect(state.bulkDeleting).toBe(false)
@@ -943,7 +975,11 @@ describe('skillsSlice unlinkSelectedFromAgent thunk', () => {
     const promise = store.dispatch(
       unlinkSelectedFromAgent({
         agentId: 'cursor' as AgentId,
-        selectedNames: ['task', 'browser', 'ghost'],
+        selectedNames: [
+          unlinkTarget('task'),
+          unlinkTarget('browser'),
+          unlinkTarget('ghost'),
+        ],
       }),
     )
 
@@ -1007,7 +1043,7 @@ describe('skillsSlice unlinkSelectedFromAgent thunk', () => {
     await store.dispatch(
       unlinkSelectedFromAgent({
         agentId: 'cursor' as AgentId,
-        selectedNames: ['task'],
+        selectedNames: [unlinkTarget('task')],
       }),
     )
 
@@ -1027,7 +1063,7 @@ describe('skillsSlice unlinkSelectedFromAgent thunk', () => {
     await store.dispatch(
       unlinkSelectedFromAgent({
         agentId: 'cursor' as AgentId,
-        selectedNames: ['task'],
+        selectedNames: [unlinkTarget('task')],
       }),
     )
 

--- a/src/renderer/src/redux/slices/skillsSlice.test.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.test.ts
@@ -2,6 +2,7 @@ import { configureStore } from '@reduxjs/toolkit'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type {
+  AbsolutePath,
   AgentId,
   BulkDeleteResult,
   BulkUnlinkResult,
@@ -536,6 +537,41 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
     await promise
   })
 
+  it('passes reviewed skillPath through deleteSkills IPC', async () => {
+    const store = await createTestStore()
+    mockDeleteSkills.mockResolvedValue({
+      items: [
+        {
+          skillName: 'metadata-title',
+          outcome: 'deleted',
+          tombstoneId: tombstoneId('1-metadata-title-aaaaaaaa'),
+          symlinksRemoved: 1,
+          cascadeAgents: [],
+        },
+      ],
+    } satisfies BulkDeleteResult)
+
+    const { deleteSelectedSkills } = await import('./skillsSlice')
+    await store.dispatch(
+      deleteSelectedSkills([
+        {
+          skillName: 'metadata-title',
+          skillPath:
+            '/home/user/.agents/skills/folder-basename' as AbsolutePath,
+        },
+      ]),
+    )
+
+    expect(mockDeleteSkills).toHaveBeenCalledWith({
+      items: [
+        {
+          skillName: 'metadata-title',
+          skillPath: '/home/user/.agents/skills/folder-basename',
+        },
+      ],
+    })
+  })
+
   it('clears selection, anchor, inFlight, and progress on fulfilled', async () => {
     const store = await createTestStore()
     await seedItems(store, [sampleSkill])
@@ -924,6 +960,37 @@ describe('skillsSlice unlinkSelectedFromAgent thunk', () => {
       ],
     })
     await promise
+  })
+
+  it('passes reviewed linkPath through unlinkManyFromAgent IPC', async () => {
+    const store = await createTestStore()
+    mockUnlinkManyFromAgent.mockResolvedValue({
+      items: [{ skillName: 'metadata-title', outcome: 'unlinked' }],
+    } satisfies BulkUnlinkResult)
+
+    const { unlinkSelectedFromAgent } = await import('./skillsSlice')
+    await store.dispatch(
+      unlinkSelectedFromAgent({
+        agentId: 'cursor' as AgentId,
+        selectedNames: [
+          {
+            skillName: 'metadata-title',
+            linkPath:
+              '/home/user/.cursor/skills/folder-basename' as AbsolutePath,
+          },
+        ],
+      }),
+    )
+
+    expect(mockUnlinkManyFromAgent).toHaveBeenCalledWith({
+      agentId: 'cursor',
+      items: [
+        {
+          skillName: 'metadata-title',
+          linkPath: '/home/user/.cursor/skills/folder-basename',
+        },
+      ],
+    })
   })
 
   it('clears selection, anchor, and inFlight on fulfilled', async () => {

--- a/src/renderer/src/redux/slices/skillsSlice.test.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.test.ts
@@ -564,6 +564,35 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
     expect(state.bulkProgress).toBeNull()
   })
 
+  it('clears selection and anchor when delete returns orphan-cleared', async () => {
+    const store = await createTestStore()
+    await seedItems(store, [sampleSkill])
+    mockDeleteSkills.mockResolvedValue({
+      items: [
+        {
+          skillName: 'task',
+          outcome: 'orphan-cleared',
+          symlinksRemoved: 1,
+          cascadeAgents: ['claude-code' as AgentId],
+        },
+      ],
+    } satisfies BulkDeleteResult)
+
+    const { deleteSelectedSkills, toggleSelection, setBulkProgress } =
+      await import('./skillsSlice')
+    store.dispatch(toggleSelection('task'))
+    store.dispatch(setBulkProgress({ current: 1, total: 1 }))
+
+    await store.dispatch(deleteSelectedSkills(['task']))
+
+    const state = store.getState().skills
+    expect(state.bulkDeleting).toBe(false)
+    expect(state.inFlightDeleteNames).toEqual([])
+    expect(state.selectedSkillNames).toEqual([])
+    expect(state.selectionAnchor).toBeNull()
+    expect(state.bulkProgress).toBeNull()
+  })
+
   it('clears in-flight and sets error on rejected', async () => {
     const store = await createTestStore()
     await seedItems(store, [sampleSkill])

--- a/src/renderer/src/redux/slices/skillsSlice.test.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.test.ts
@@ -957,13 +957,18 @@ describe('skillsSlice clearSelectedBrokenSymlinkSlots thunk', () => {
         items: [
           {
             agentId: 'codex' as AgentId,
-            linkName: 'task',
-            linkPath: '/home/user/.codex/skills/task',
+            // linkName (on-disk basename) intentionally differs from
+            // displaySkillName to prove reconciliation matches the live
+            // skill.name ('task'), not the symlink basename.
+            linkName: 'task-symlink',
+            displaySkillName: 'task',
+            linkPath: '/home/user/.codex/skills/task-symlink',
             targetPath: '/home/user/.agents/skills/task',
           },
           {
             agentId: 'cursor' as AgentId,
             linkName: 'ghost',
+            displaySkillName: 'ghost',
             linkPath: '/home/user/.cursor/skills/ghost',
             targetPath: '/home/user/.agents/skills/ghost',
           },
@@ -1008,6 +1013,7 @@ describe('skillsSlice clearSelectedBrokenSymlinkSlots thunk', () => {
           {
             agentId: 'codex' as AgentId,
             linkName: 'task',
+            displaySkillName: 'task',
             linkPath: '/home/user/.codex/skills/task',
             targetPath: '/home/user/.agents/skills/task',
           },
@@ -1034,6 +1040,7 @@ describe('skillsSlice clearSelectedBrokenSymlinkSlots thunk', () => {
           {
             agentId: 'codex' as AgentId,
             linkName: 'task',
+            displaySkillName: 'task',
             linkPath: '/home/user/.codex/skills/task',
             targetPath: '/home/user/.agents/skills/task',
           },

--- a/src/renderer/src/redux/slices/skillsSlice.test.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.test.ts
@@ -17,6 +17,8 @@ const mockUnlinkFromAgent = vi.fn()
 const mockCreateSymlinks = vi.fn()
 const mockCopyToAgents = vi.fn()
 const mockDeleteSkills = vi.fn()
+const mockClearOrphanSymlinks = vi.fn()
+const mockClearBrokenSymlinkSlots = vi.fn()
 const mockUnlinkManyFromAgent = vi.fn()
 const mockRestoreDeletedSkill = vi.fn()
 const mockOnDeleteProgress = vi.fn()
@@ -29,6 +31,8 @@ vi.stubGlobal('window', {
       createSymlinks: mockCreateSymlinks,
       copyToAgents: mockCopyToAgents,
       deleteSkills: mockDeleteSkills,
+      clearOrphanSymlinks: mockClearOrphanSymlinks,
+      clearBrokenSymlinkSlots: mockClearBrokenSymlinkSlots,
       unlinkManyFromAgent: mockUnlinkManyFromAgent,
       restoreDeletedSkill: mockRestoreDeletedSkill,
       onDeleteProgress: mockOnDeleteProgress,

--- a/src/renderer/src/redux/slices/skillsSlice.test.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.test.ts
@@ -5,6 +5,7 @@ import type {
   AgentId,
   BulkDeleteResult,
   BulkUnlinkResult,
+  ClearBrokenSymlinkSlotsResult,
   ClearOrphanSymlinksResult,
   RestoreDeletedSkillResult,
   Skill,
@@ -771,6 +772,118 @@ describe('skillsSlice clearSelectedOrphanSymlinks thunk', () => {
     const state = store.getState().skills
     expect(state.bulkDeleting).toBe(false)
     expect(state.inFlightDeleteNames).toEqual([])
+    expect(state.error).toBe('Permission denied')
+  })
+})
+
+describe('skillsSlice clearSelectedBrokenSymlinkSlots thunk', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('sets bulkUnlinking and reconciles broken-slot inFlightUnlinkNames on pending', async () => {
+    const store = await createTestStore()
+    await seedItems(store, [sampleSkill])
+    let resolve!: (value: ClearBrokenSymlinkSlotsResult) => void
+    mockClearBrokenSymlinkSlots.mockReturnValue(
+      new Promise<ClearBrokenSymlinkSlotsResult>((r) => {
+        resolve = r
+      }),
+    )
+
+    const { clearSelectedBrokenSymlinkSlots } = await import('./skillsSlice')
+    const promise = store.dispatch(
+      clearSelectedBrokenSymlinkSlots({
+        items: [
+          {
+            agentId: 'codex' as AgentId,
+            linkName: 'task',
+            linkPath: '/home/user/.codex/skills/task',
+            targetPath: '/home/user/.agents/skills/task',
+          },
+          {
+            agentId: 'cursor' as AgentId,
+            linkName: 'ghost',
+            linkPath: '/home/user/.cursor/skills/ghost',
+            targetPath: '/home/user/.agents/skills/ghost',
+          },
+        ],
+      }),
+    )
+
+    expect(store.getState().skills.bulkUnlinking).toBe(true)
+    expect(store.getState().skills.inFlightUnlinkNames).toEqual(['task'])
+
+    resolve({
+      items: [
+        {
+          agentId: 'codex' as AgentId,
+          skillName: 'task',
+          linkPath: '/home/user/.codex/skills/task',
+          outcome: 'unlinked',
+        },
+      ],
+    })
+    await promise
+  })
+
+  it('clears broken-slot busy state on fulfilled', async () => {
+    const store = await createTestStore()
+    await seedItems(store, [sampleSkill])
+    mockClearBrokenSymlinkSlots.mockResolvedValue({
+      items: [
+        {
+          agentId: 'codex' as AgentId,
+          skillName: 'task',
+          linkPath: '/home/user/.codex/skills/task',
+          outcome: 'unlinked',
+        },
+      ],
+    } satisfies ClearBrokenSymlinkSlotsResult)
+
+    const { clearSelectedBrokenSymlinkSlots } = await import('./skillsSlice')
+    await store.dispatch(
+      clearSelectedBrokenSymlinkSlots({
+        items: [
+          {
+            agentId: 'codex' as AgentId,
+            linkName: 'task',
+            linkPath: '/home/user/.codex/skills/task',
+            targetPath: '/home/user/.agents/skills/task',
+          },
+        ],
+      }),
+    )
+
+    const state = store.getState().skills
+    expect(state.bulkUnlinking).toBe(false)
+    expect(state.inFlightUnlinkNames).toEqual([])
+  })
+
+  it('clears broken-slot busy state and sets error on rejected', async () => {
+    const store = await createTestStore()
+    await seedItems(store, [sampleSkill])
+    mockClearBrokenSymlinkSlots.mockRejectedValue(
+      new Error('Permission denied'),
+    )
+
+    const { clearSelectedBrokenSymlinkSlots } = await import('./skillsSlice')
+    await store.dispatch(
+      clearSelectedBrokenSymlinkSlots({
+        items: [
+          {
+            agentId: 'codex' as AgentId,
+            linkName: 'task',
+            linkPath: '/home/user/.codex/skills/task',
+            targetPath: '/home/user/.agents/skills/task',
+          },
+        ],
+      }),
+    )
+
+    const state = store.getState().skills
+    expect(state.bulkUnlinking).toBe(false)
+    expect(state.inFlightUnlinkNames).toEqual([])
     expect(state.error).toBe('Permission denied')
   })
 })

--- a/src/renderer/src/redux/slices/skillsSlice.test.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.test.ts
@@ -342,10 +342,56 @@ describe('skillsSlice', () => {
       skillName: 'task',
       agentId: 'claude-code',
       linkPath: '/home/user/.claude/skills/task',
-      targetPath: undefined,
       confirmedLocalDirectoryDelete: true,
       reviewedDirectoryIdentity: directoryIdentity,
     })
+  })
+
+  it('unlinkSkillFromAgent asks for rescan when local directory identity is missing', async () => {
+    // Arrange
+    const localSymlink: SymlinkInfo = {
+      ...sampleSymlink,
+      isLocal: true,
+      targetPath: undefined,
+      filesystemIdentity: undefined,
+    }
+
+    const store = await createTestStore()
+    const { unlinkSkillFromAgent } = await import('./skillsSlice')
+
+    // Act
+    await store.dispatch(
+      unlinkSkillFromAgent({ skill: sampleSkill, symlink: localSymlink }),
+    )
+
+    // Assert
+    expect(mockUnlinkFromAgent).not.toHaveBeenCalled()
+    expect(store.getState().skills.error).toBe(
+      'Rescan before delete. The reviewed local folder identity is missing.',
+    )
+  })
+
+  it('unlinkSkillFromAgent asks for rescan when symlink target identity is missing', async () => {
+    // Arrange
+    const staleSymlink: SymlinkInfo = {
+      ...sampleSymlink,
+      isLocal: false,
+      targetPath: undefined,
+    }
+
+    const store = await createTestStore()
+    const { unlinkSkillFromAgent } = await import('./skillsSlice')
+
+    // Act
+    await store.dispatch(
+      unlinkSkillFromAgent({ skill: sampleSkill, symlink: staleSymlink }),
+    )
+
+    // Assert
+    expect(mockUnlinkFromAgent).not.toHaveBeenCalled()
+    expect(store.getState().skills.error).toBe(
+      'Rescan before unlink. The reviewed symlink target is missing.',
+    )
   })
 
   // --- createSymlinks thunk ---

--- a/src/renderer/src/redux/slices/skillsSlice.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.ts
@@ -249,7 +249,7 @@ export const clearSelectedOrphanSymlinks = createAsyncThunk<
  * @param brokenSlots - Broken agent symlinks selected in Symlink Health cleanup.
  * @returns BulkUnlinkResult with per-slot outcome.
  * @example
- * await dispatch(clearSelectedBrokenSymlinkSlots({ items: [{ agentId: 'codex', skillName: 'task', linkPath: '/Users/me/.codex/skills/task', targetPath: '/Users/me/.agents/skills/task' }] }))
+ * await dispatch(clearSelectedBrokenSymlinkSlots({ items: [{ agentId: 'codex', linkName: 'task', linkPath: '/Users/me/.codex/skills/task', targetPath: '/Users/me/.agents/skills/task' }] }))
  */
 export const clearSelectedBrokenSymlinkSlots = createAsyncThunk<
   ClearBrokenSymlinkSlotsResult,

--- a/src/renderer/src/redux/slices/skillsSlice.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.ts
@@ -512,22 +512,26 @@ const skillsSlice = createSlice({
         state.inFlightDeleteNames = []
         state.bulkDeleting = false
         state.bulkProgress = null
-        // Narrow clearSelection to the items that actually deleted — keep
-        // failed ones selected so the user can retry without re-ticking them.
-        const deletedNames = new Set(
+        // Narrow clearSelection to the items that actually disappeared from
+        // the list — keep failed ones selected so the user can retry without
+        // re-ticking them.
+        const removedNames = new Set(
           action.payload.items
-            .filter((item) => item.outcome === 'deleted')
+            .filter(
+              (item) =>
+                item.outcome === 'deleted' || item.outcome === 'orphan-cleared',
+            )
             .map((item) => item.skillName),
         )
         state.selectedSkillNames = state.selectedSkillNames.filter(
-          (name) => !deletedNames.has(name),
+          (name) => !removedNames.has(name),
         )
         // Reconcile anchor: drop if selection emptied or if anchor itself was
         // deleted. Otherwise leave it so Shift+click continues from the same
         // origin.
         const anchorWasDeleted =
           state.selectionAnchor !== null &&
-          deletedNames.has(state.selectionAnchor)
+          removedNames.has(state.selectionAnchor)
         if (state.selectedSkillNames.length === 0 || anchorWasDeleted) {
           state.selectionAnchor = null
         }

--- a/src/renderer/src/redux/slices/skillsSlice.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.ts
@@ -223,16 +223,20 @@ export const deleteSelectedSkills = createAsyncThunk<
 
 /**
  * Clear reviewed orphan symlink records without invoking source deletion.
- * @param orphanRecords - Orphan skill name and exact agent link paths reviewed in the cleanup dialog.
+ * @param orphanRecords - Orphan skill name plus exact agent link and target paths reviewed in the cleanup dialog.
  * @returns Per-orphan cleanup result with no tombstones.
  * @example
- * await dispatch(clearSelectedOrphanSymlinks([{ skillName: 'abandoned', agents: [{ agentId: 'codex', linkPath: '/Users/me/.codex/skills/abandoned' }] }]))
+ * await dispatch(clearSelectedOrphanSymlinks([{ skillName: 'abandoned', agents: [{ agentId: 'codex', linkPath: '/Users/me/.codex/skills/abandoned', targetPath: '/Users/me/.agents/skills/abandoned' }] }]))
  */
 export const clearSelectedOrphanSymlinks = createAsyncThunk<
   ClearOrphanSymlinksResult,
   Array<{
     skillName: SkillName
-    agents: Array<{ agentId: AgentId; linkPath: AbsolutePath }>
+    agents: Array<{
+      agentId: AgentId
+      linkPath: AbsolutePath
+      targetPath: AbsolutePath
+    }>
   }>
 >('skills/clearSelectedOrphanSymlinks', async (orphanRecords) => {
   return window.electron.skills.clearOrphanSymlinks({

--- a/src/renderer/src/redux/slices/skillsSlice.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.ts
@@ -113,6 +113,60 @@ function reconcileByLiveNames(
   return names.filter((name) => liveNames.has(name))
 }
 
+export type DeleteSelectedSkillTarget =
+  | SkillName
+  | { skillName: SkillName; skillPath?: AbsolutePath }
+
+export type UnlinkSelectedSkillTarget =
+  | SkillName
+  | { skillName: SkillName; linkPath?: AbsolutePath }
+
+/**
+ * Read the display name from a bulk-delete target while keeping old name-only callers valid.
+ * @param target - Name string or reviewed delete target object.
+ * @returns Display skill name used for selection reconciliation.
+ * @example getDeleteTargetName({ skillName: 'metadata-title', skillPath: '/x/folder' })
+ */
+function getDeleteTargetName(target: DeleteSelectedSkillTarget): SkillName {
+  return typeof target === 'string' ? target : target.skillName
+}
+
+/**
+ * Convert renderer delete targets into the IPC item shape that preserves reviewed paths.
+ * @param target - Name string or reviewed delete target object.
+ * @returns IPC delete item with optional skillPath.
+ * @example toDeleteSkillItem({ skillName: 'metadata-title', skillPath: '/x/folder' })
+ */
+function toDeleteSkillItem(target: DeleteSelectedSkillTarget): {
+  skillName: SkillName
+  skillPath?: AbsolutePath
+} {
+  return typeof target === 'string' ? { skillName: target } : target
+}
+
+/**
+ * Read the display name from a bulk-unlink target while keeping old name-only callers valid.
+ * @param target - Name string or reviewed unlink target object.
+ * @returns Display skill name used for selection reconciliation.
+ * @example getUnlinkTargetName({ skillName: 'metadata-title', linkPath: '/x/slot' })
+ */
+function getUnlinkTargetName(target: UnlinkSelectedSkillTarget): SkillName {
+  return typeof target === 'string' ? target : target.skillName
+}
+
+/**
+ * Convert renderer unlink targets into the IPC item shape that preserves reviewed link paths.
+ * @param target - Name string or reviewed unlink target object.
+ * @returns IPC unlink item with optional linkPath.
+ * @example toUnlinkSkillItem({ skillName: 'metadata-title', linkPath: '/x/slot' })
+ */
+function toUnlinkSkillItem(target: UnlinkSelectedSkillTarget): {
+  skillName: SkillName
+  linkPath?: AbsolutePath
+} {
+  return typeof target === 'string' ? { skillName: target } : target
+}
+
 /**
  * Fetch all skills from the main process
  * @returns Promise<Skill[]> - Array of skill objects from ~/.agents/skills/
@@ -206,17 +260,17 @@ export const copyToAgents = createAsyncThunk(
  * `.pending` reducer intersects the passed list with `state.items` to
  * reconcile against any fresh `fetchSkills` that landed between the user
  * click and thunk dispatch.
- * @param selectedNames - Names to delete (already validated by caller).
+ * @param selectedTargets - Names or reviewed row identities to delete.
  * @returns BulkDeleteResult with per-item outcome
  * @example
  * await dispatch(deleteSelectedSkills(['task', 'browse']))
  */
 export const deleteSelectedSkills = createAsyncThunk<
   BulkDeleteResult,
-  SkillName[]
->('skills/deleteSelected', async (selectedNames) => {
+  DeleteSelectedSkillTarget[]
+>('skills/deleteSelected', async (selectedTargets) => {
   const result = await window.electron.skills.deleteSkills({
-    items: selectedNames.map((skillName) => ({ skillName })),
+    items: selectedTargets.map(toDeleteSkillItem),
   })
   return result
 })
@@ -261,18 +315,18 @@ export const clearSelectedBrokenSymlinkSlots = createAsyncThunk<
 /**
  * Unlink every selected skill from a single agent. No tombstone produced —
  * unlink is benign (removes one symlink/folder, keeps source intact).
- * @param params - agentId + names to unlink
+ * @param params - agentId + names or reviewed link paths to unlink.
  * @returns BulkUnlinkResult with per-item outcome
  * @example
  * await dispatch(unlinkSelectedFromAgent({ agentId: 'cursor', selectedNames: ['task'] }))
  */
 export const unlinkSelectedFromAgent = createAsyncThunk<
   BulkUnlinkResult,
-  { agentId: AgentId; selectedNames: SkillName[] }
+  { agentId: AgentId; selectedNames: UnlinkSelectedSkillTarget[] }
 >('skills/unlinkSelectedFromAgent', async ({ agentId, selectedNames }) => {
   const result = await window.electron.skills.unlinkManyFromAgent({
     agentId,
-    items: selectedNames.map((skillName) => ({ skillName })),
+    items: selectedNames.map(toUnlinkSkillItem),
   })
   return result
 })
@@ -501,7 +555,7 @@ const skillsSlice = createSlice({
       .addCase(deleteSelectedSkills.pending, (state, action) => {
         state.inFlightDeleteNames = reconcileByLiveNames(
           state.items,
-          action.meta.arg,
+          action.meta.arg.map(getDeleteTargetName),
         )
         state.bulkDeleting = true
         state.error = null
@@ -595,7 +649,7 @@ const skillsSlice = createSlice({
       .addCase(unlinkSelectedFromAgent.pending, (state, action) => {
         state.inFlightUnlinkNames = reconcileByLiveNames(
           state.items,
-          action.meta.arg.selectedNames,
+          action.meta.arg.selectedNames.map(getUnlinkTargetName),
         )
         state.bulkUnlinking = true
         state.error = null

--- a/src/renderer/src/redux/slices/skillsSlice.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.ts
@@ -191,16 +191,36 @@ export const unlinkSkillFromAgent = createAsyncThunk(
   'skills/unlinkFromAgent',
   async (params: { skill: Skill; symlink: SymlinkInfo }) => {
     const { skill, symlink } = params
-    const result = await window.electron.skills.unlinkFromAgent({
-      skillName: skill.name,
-      agentId: symlink.agentId,
-      linkPath: symlink.linkPath,
-      targetPath: symlink.isLocal ? undefined : symlink.targetPath,
-      confirmedLocalDirectoryDelete: symlink.isLocal,
-      reviewedDirectoryIdentity: symlink.isLocal
-        ? symlink.filesystemIdentity
-        : undefined,
-    })
+    const result = await window.electron.skills.unlinkFromAgent(
+      symlink.isLocal
+        ? (() => {
+            if (!symlink.filesystemIdentity) {
+              throw new Error(
+                'Rescan before delete. The reviewed local folder identity is missing.',
+              )
+            }
+            return {
+              skillName: skill.name,
+              agentId: symlink.agentId,
+              linkPath: symlink.linkPath,
+              confirmedLocalDirectoryDelete: true,
+              reviewedDirectoryIdentity: symlink.filesystemIdentity,
+            }
+          })()
+        : (() => {
+            if (!symlink.targetPath) {
+              throw new Error(
+                'Rescan before unlink. The reviewed symlink target is missing.',
+              )
+            }
+            return {
+              skillName: skill.name,
+              agentId: symlink.agentId,
+              linkPath: symlink.linkPath,
+              targetPath: symlink.targetPath,
+            }
+          })(),
+    )
     if (!result.success) {
       throw new Error(result.error || 'Failed to unlink skill')
     }

--- a/src/renderer/src/redux/slices/skillsSlice.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.ts
@@ -10,6 +10,7 @@ import type {
   ClearOrphanSymlinksResult,
   ClearBrokenSymlinkSlotsOptions,
   ClearBrokenSymlinkSlotsResult,
+  FilesystemEntryIdentity,
   RestoreDeletedSkillResult,
   Skill,
   SkillName,
@@ -116,6 +117,7 @@ function reconcileByLiveNames(
 export type DeleteSelectedSkillTarget = {
   skillName: SkillName
   skillPath: AbsolutePath
+  filesystemIdentity: FilesystemEntryIdentity
 }
 
 export type UnlinkSelectedSkillTarget = {
@@ -142,6 +144,7 @@ function getDeleteTargetName(target: DeleteSelectedSkillTarget): SkillName {
 function toDeleteSkillItem(target: DeleteSelectedSkillTarget): {
   skillName: SkillName
   skillPath: AbsolutePath
+  filesystemIdentity: FilesystemEntryIdentity
 } {
   return target
 }
@@ -191,6 +194,9 @@ export const unlinkSkillFromAgent = createAsyncThunk(
       agentId: symlink.agentId,
       linkPath: symlink.linkPath,
       confirmedLocalDirectoryDelete: symlink.isLocal,
+      reviewedDirectoryIdentity: symlink.isLocal
+        ? symlink.filesystemIdentity
+        : undefined,
     })
     if (!result.success) {
       throw new Error(result.error || 'Failed to unlink skill')

--- a/src/renderer/src/redux/slices/skillsSlice.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.ts
@@ -575,6 +575,23 @@ const skillsSlice = createSlice({
         state.bulkProgress = null
         state.error = action.error.message ?? 'Orphan cleanup failed'
       })
+      .addCase(clearSelectedBrokenSymlinkSlots.pending, (state, action) => {
+        state.inFlightUnlinkNames = reconcileByLiveNames(
+          state.items,
+          action.meta.arg.items.map((item) => item.linkName),
+        )
+        state.bulkUnlinking = true
+        state.error = null
+      })
+      .addCase(clearSelectedBrokenSymlinkSlots.fulfilled, (state) => {
+        state.inFlightUnlinkNames = []
+        state.bulkUnlinking = false
+      })
+      .addCase(clearSelectedBrokenSymlinkSlots.rejected, (state, action) => {
+        state.inFlightUnlinkNames = []
+        state.bulkUnlinking = false
+        state.error = action.error.message ?? 'Broken symlink cleanup failed'
+      })
       .addCase(unlinkSelectedFromAgent.pending, (state, action) => {
         state.inFlightUnlinkNames = reconcileByLiveNames(
           state.items,

--- a/src/renderer/src/redux/slices/skillsSlice.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.ts
@@ -542,6 +542,39 @@ const skillsSlice = createSlice({
         state.bulkProgress = null
         state.error = action.error.message ?? 'Bulk delete failed'
       })
+      .addCase(clearSelectedOrphanSymlinks.pending, (state, action) => {
+        state.inFlightDeleteNames = reconcileByLiveNames(
+          state.items,
+          action.meta.arg.map((record) => record.skillName),
+        )
+        state.bulkDeleting = true
+        state.error = null
+      })
+      .addCase(clearSelectedOrphanSymlinks.fulfilled, (state, action) => {
+        state.inFlightDeleteNames = []
+        state.bulkDeleting = false
+        state.bulkProgress = null
+        const removedNames = new Set(
+          action.payload.items
+            .filter((item) => item.outcome === 'orphan-cleared')
+            .map((item) => item.skillName),
+        )
+        state.selectedSkillNames = state.selectedSkillNames.filter(
+          (name) => !removedNames.has(name),
+        )
+        const anchorWasRemoved =
+          state.selectionAnchor !== null &&
+          removedNames.has(state.selectionAnchor)
+        if (state.selectedSkillNames.length === 0 || anchorWasRemoved) {
+          state.selectionAnchor = null
+        }
+      })
+      .addCase(clearSelectedOrphanSymlinks.rejected, (state, action) => {
+        state.inFlightDeleteNames = []
+        state.bulkDeleting = false
+        state.bulkProgress = null
+        state.error = action.error.message ?? 'Orphan cleanup failed'
+      })
       .addCase(unlinkSelectedFromAgent.pending, (state, action) => {
         state.inFlightUnlinkNames = reconcileByLiveNames(
           state.items,

--- a/src/renderer/src/redux/slices/skillsSlice.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.ts
@@ -113,58 +113,60 @@ function reconcileByLiveNames(
   return names.filter((name) => liveNames.has(name))
 }
 
-export type DeleteSelectedSkillTarget =
-  | SkillName
-  | { skillName: SkillName; skillPath?: AbsolutePath }
+export type DeleteSelectedSkillTarget = {
+  skillName: SkillName
+  skillPath: AbsolutePath
+}
 
-export type UnlinkSelectedSkillTarget =
-  | SkillName
-  | { skillName: SkillName; linkPath?: AbsolutePath }
+export type UnlinkSelectedSkillTarget = {
+  skillName: SkillName
+  linkPath: AbsolutePath
+}
 
 /**
- * Read the display name from a bulk-delete target while keeping old name-only callers valid.
- * @param target - Name string or reviewed delete target object.
+ * Read the display name from a bulk-delete target that carries reviewed path identity.
+ * @param target - Reviewed delete target object.
  * @returns Display skill name used for selection reconciliation.
  * @example getDeleteTargetName({ skillName: 'metadata-title', skillPath: '/x/folder' })
  */
 function getDeleteTargetName(target: DeleteSelectedSkillTarget): SkillName {
-  return typeof target === 'string' ? target : target.skillName
+  return target.skillName
 }
 
 /**
  * Convert renderer delete targets into the IPC item shape that preserves reviewed paths.
- * @param target - Name string or reviewed delete target object.
- * @returns IPC delete item with optional skillPath.
+ * @param target - Reviewed delete target object.
+ * @returns IPC delete item with mandatory skillPath.
  * @example toDeleteSkillItem({ skillName: 'metadata-title', skillPath: '/x/folder' })
  */
 function toDeleteSkillItem(target: DeleteSelectedSkillTarget): {
   skillName: SkillName
-  skillPath?: AbsolutePath
+  skillPath: AbsolutePath
 } {
-  return typeof target === 'string' ? { skillName: target } : target
+  return target
 }
 
 /**
- * Read the display name from a bulk-unlink target while keeping old name-only callers valid.
- * @param target - Name string or reviewed unlink target object.
+ * Read the display name from a bulk-unlink target that carries reviewed path identity.
+ * @param target - Reviewed unlink target object.
  * @returns Display skill name used for selection reconciliation.
  * @example getUnlinkTargetName({ skillName: 'metadata-title', linkPath: '/x/slot' })
  */
 function getUnlinkTargetName(target: UnlinkSelectedSkillTarget): SkillName {
-  return typeof target === 'string' ? target : target.skillName
+  return target.skillName
 }
 
 /**
  * Convert renderer unlink targets into the IPC item shape that preserves reviewed link paths.
- * @param target - Name string or reviewed unlink target object.
- * @returns IPC unlink item with optional linkPath.
+ * @param target - Reviewed unlink target object.
+ * @returns IPC unlink item with mandatory linkPath.
  * @example toUnlinkSkillItem({ skillName: 'metadata-title', linkPath: '/x/slot' })
  */
 function toUnlinkSkillItem(target: UnlinkSelectedSkillTarget): {
   skillName: SkillName
-  linkPath?: AbsolutePath
+  linkPath: AbsolutePath
 } {
-  return typeof target === 'string' ? { skillName: target } : target
+  return target
 }
 
 /**
@@ -260,10 +262,10 @@ export const copyToAgents = createAsyncThunk(
  * `.pending` reducer intersects the passed list with `state.items` to
  * reconcile against any fresh `fetchSkills` that landed between the user
  * click and thunk dispatch.
- * @param selectedTargets - Names or reviewed row identities to delete.
+ * @param selectedTargets - Reviewed row identities to delete.
  * @returns BulkDeleteResult with per-item outcome
  * @example
- * await dispatch(deleteSelectedSkills(['task', 'browse']))
+ * await dispatch(deleteSelectedSkills([{ skillName: 'task', skillPath: '/Users/me/.agents/skills/task' }]))
  */
 export const deleteSelectedSkills = createAsyncThunk<
   BulkDeleteResult,
@@ -315,10 +317,10 @@ export const clearSelectedBrokenSymlinkSlots = createAsyncThunk<
 /**
  * Unlink every selected skill from a single agent. No tombstone produced —
  * unlink is benign (removes one symlink/folder, keeps source intact).
- * @param params - agentId + names or reviewed link paths to unlink.
+ * @param params - agentId + reviewed link paths to unlink.
  * @returns BulkUnlinkResult with per-item outcome
  * @example
- * await dispatch(unlinkSelectedFromAgent({ agentId: 'cursor', selectedNames: ['task'] }))
+ * await dispatch(unlinkSelectedFromAgent({ agentId: 'cursor', selectedNames: [{ skillName: 'task', linkPath: '/Users/me/.cursor/skills/task' }] }))
  */
 export const unlinkSelectedFromAgent = createAsyncThunk<
   BulkUnlinkResult,

--- a/src/renderer/src/redux/slices/skillsSlice.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.ts
@@ -127,6 +127,17 @@ export type UnlinkSelectedSkillTarget = {
 }
 
 /**
+ * Reviewed broken-slot target carrying the on-disk `linkName` (basename, used by
+ * main for path identity) alongside the `displaySkillName` (the source skill's
+ * display name) so the pending reducer can reconcile selection by the live
+ * `skill.name`, which can differ from the symlink basename.
+ */
+type ClearBrokenSymlinkSlotTarget =
+  ClearBrokenSymlinkSlotsOptions['items'][number] & {
+    displaySkillName: SkillName
+  }
+
+/**
  * Read the display name from a bulk-delete target that carries reviewed path identity.
  * @param target - Reviewed delete target object.
  * @returns Display skill name used for selection reconciliation.
@@ -334,13 +345,22 @@ export const clearSelectedOrphanSymlinks = createAsyncThunk<
  * @param brokenSlots - Broken agent symlinks selected in Symlink Health cleanup.
  * @returns BulkUnlinkResult with per-slot outcome.
  * @example
- * await dispatch(clearSelectedBrokenSymlinkSlots({ items: [{ agentId: 'codex', linkName: 'task', linkPath: '/Users/me/.codex/skills/task', targetPath: '/Users/me/.agents/skills/task' }] }))
+ * await dispatch(clearSelectedBrokenSymlinkSlots({ items: [{ agentId: 'codex', linkName: 'task', displaySkillName: 'task', linkPath: '/Users/me/.codex/skills/task', targetPath: '/Users/me/.agents/skills/task' }] }))
  */
 export const clearSelectedBrokenSymlinkSlots = createAsyncThunk<
   ClearBrokenSymlinkSlotsResult,
-  ClearBrokenSymlinkSlotsOptions
->('skills/clearSelectedBrokenSymlinkSlots', async (options) => {
-  return window.electron.skills.clearBrokenSymlinkSlots(options)
+  { items: ClearBrokenSymlinkSlotTarget[] }
+>('skills/clearSelectedBrokenSymlinkSlots', async ({ items }) => {
+  // Strip the renderer-only `displaySkillName` before crossing IPC — main
+  // validates path identity from linkName/linkPath/targetPath only.
+  return window.electron.skills.clearBrokenSymlinkSlots({
+    items: items.map(({ agentId, linkName, linkPath, targetPath }) => ({
+      agentId,
+      linkName,
+      linkPath,
+      targetPath,
+    })),
+  })
 })
 
 /**
@@ -663,7 +683,9 @@ const skillsSlice = createSlice({
       .addCase(clearSelectedBrokenSymlinkSlots.pending, (state, action) => {
         state.inFlightUnlinkNames = reconcileByLiveNames(
           state.items,
-          action.meta.arg.items.map((item) => item.linkName),
+          // Reconcile by display name (`skill.name`), not the symlink basename —
+          // the two can differ, and reconcileByLiveNames matches `skill.name`.
+          action.meta.arg.items.map((item) => item.displaySkillName),
         )
         state.bulkUnlinking = true
         state.error = null

--- a/src/renderer/src/redux/slices/skillsSlice.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.ts
@@ -123,6 +123,7 @@ export type DeleteSelectedSkillTarget = {
 export type UnlinkSelectedSkillTarget = {
   skillName: SkillName
   linkPath: AbsolutePath
+  targetPath: AbsolutePath
 }
 
 /**
@@ -153,7 +154,7 @@ function toDeleteSkillItem(target: DeleteSelectedSkillTarget): {
  * Read the display name from a bulk-unlink target that carries reviewed path identity.
  * @param target - Reviewed unlink target object.
  * @returns Display skill name used for selection reconciliation.
- * @example getUnlinkTargetName({ skillName: 'metadata-title', linkPath: '/x/slot' })
+ * @example getUnlinkTargetName({ skillName: 'metadata-title', linkPath: '/x/slot', targetPath: '/x/source' })
  */
 function getUnlinkTargetName(target: UnlinkSelectedSkillTarget): SkillName {
   return target.skillName
@@ -163,11 +164,12 @@ function getUnlinkTargetName(target: UnlinkSelectedSkillTarget): SkillName {
  * Convert renderer unlink targets into the IPC item shape that preserves reviewed link paths.
  * @param target - Reviewed unlink target object.
  * @returns IPC unlink item with mandatory linkPath.
- * @example toUnlinkSkillItem({ skillName: 'metadata-title', linkPath: '/x/slot' })
+ * @example toUnlinkSkillItem({ skillName: 'metadata-title', linkPath: '/x/slot', targetPath: '/x/source' })
  */
 function toUnlinkSkillItem(target: UnlinkSelectedSkillTarget): {
   skillName: SkillName
   linkPath: AbsolutePath
+  targetPath: AbsolutePath
 } {
   return target
 }
@@ -193,6 +195,7 @@ export const unlinkSkillFromAgent = createAsyncThunk(
       skillName: skill.name,
       agentId: symlink.agentId,
       linkPath: symlink.linkPath,
+      targetPath: symlink.isLocal ? undefined : symlink.targetPath,
       confirmedLocalDirectoryDelete: symlink.isLocal,
       reviewedDirectoryIdentity: symlink.isLocal
         ? symlink.filesystemIdentity
@@ -326,7 +329,7 @@ export const clearSelectedBrokenSymlinkSlots = createAsyncThunk<
  * @param params - agentId + reviewed link paths to unlink.
  * @returns BulkUnlinkResult with per-item outcome
  * @example
- * await dispatch(unlinkSelectedFromAgent({ agentId: 'cursor', selectedNames: [{ skillName: 'task', linkPath: '/Users/me/.cursor/skills/task' }] }))
+ * await dispatch(unlinkSelectedFromAgent({ agentId: 'cursor', selectedNames: [{ skillName: 'task', linkPath: '/Users/me/.cursor/skills/task', targetPath: '/Users/me/.agents/skills/task' }] }))
  */
 export const unlinkSelectedFromAgent = createAsyncThunk<
   BulkUnlinkResult,

--- a/src/renderer/src/redux/slices/skillsSlice.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.ts
@@ -7,6 +7,9 @@ import type {
   AgentId,
   BulkDeleteResult,
   BulkUnlinkResult,
+  ClearOrphanSymlinksResult,
+  ClearBrokenSymlinkSlotsOptions,
+  ClearBrokenSymlinkSlotsResult,
   RestoreDeletedSkillResult,
   Skill,
   SkillName,
@@ -216,6 +219,39 @@ export const deleteSelectedSkills = createAsyncThunk<
     items: selectedNames.map((skillName) => ({ skillName })),
   })
   return result
+})
+
+/**
+ * Clear reviewed orphan symlink records without invoking source deletion.
+ * @param orphanRecords - Orphan skill name and exact agent link paths reviewed in the cleanup dialog.
+ * @returns Per-orphan cleanup result with no tombstones.
+ * @example
+ * await dispatch(clearSelectedOrphanSymlinks([{ skillName: 'abandoned', agents: [{ agentId: 'codex', linkPath: '/Users/me/.codex/skills/abandoned' }] }]))
+ */
+export const clearSelectedOrphanSymlinks = createAsyncThunk<
+  ClearOrphanSymlinksResult,
+  Array<{
+    skillName: SkillName
+    agents: Array<{ agentId: AgentId; linkPath: AbsolutePath }>
+  }>
+>('skills/clearSelectedOrphanSymlinks', async (orphanRecords) => {
+  return window.electron.skills.clearOrphanSymlinks({
+    items: orphanRecords,
+  })
+})
+
+/**
+ * Clear reviewed broken symlink slots after main revalidates exact path and target identity.
+ * @param brokenSlots - Broken agent symlinks selected in Symlink Health cleanup.
+ * @returns BulkUnlinkResult with per-slot outcome.
+ * @example
+ * await dispatch(clearSelectedBrokenSymlinkSlots({ items: [{ agentId: 'codex', skillName: 'task', linkPath: '/Users/me/.codex/skills/task', targetPath: '/Users/me/.agents/skills/task' }] }))
+ */
+export const clearSelectedBrokenSymlinkSlots = createAsyncThunk<
+  ClearBrokenSymlinkSlotsResult,
+  ClearBrokenSymlinkSlotsOptions
+>('skills/clearSelectedBrokenSymlinkSlots', async (options) => {
+  return window.electron.skills.clearBrokenSymlinkSlots(options)
 })
 
 /**

--- a/src/renderer/src/redux/slices/uiSlice.test.ts
+++ b/src/renderer/src/redux/slices/uiSlice.test.ts
@@ -654,6 +654,7 @@ describe('uiSlice undoToast (v2.4 bulk delete)', () => {
           {
             agentId: 'codex' as AgentId,
             linkName: 'task',
+            displaySkillName: 'task',
             linkPath: '/home/user/.codex/skills/task',
             targetPath: '/home/user/.agents/skills/task',
           },
@@ -837,6 +838,7 @@ describe('uiSlice bulkSelectMode', () => {
           {
             agentId: 'codex' as AgentId,
             linkName: 'task',
+            displaySkillName: 'task',
             linkPath: '/home/user/.codex/skills/task',
             targetPath: '/home/user/.agents/skills/task',
           },

--- a/src/renderer/src/redux/slices/uiSlice.test.ts
+++ b/src/renderer/src/redux/slices/uiSlice.test.ts
@@ -6,6 +6,7 @@ import type {
   AgentId,
   BulkDeleteResult,
   BulkUnlinkResult,
+  ClearOrphanSymlinksResult,
   Skill,
   SyncExecuteResult,
   SyncPreviewResult,
@@ -559,6 +560,41 @@ describe('uiSlice undoToast (v2.4 bulk delete)', () => {
     await promise
   })
 
+  it('clearSelectedOrphanSymlinks.pending clears undoToast (combined store)', async () => {
+    const store = await createCombinedStore()
+    const { setUndoToast } = await import('./uiSlice')
+    const { clearSelectedOrphanSymlinks } = await import('./skillsSlice')
+
+    store.dispatch(setUndoToast(makeToast()))
+    expect(store.getState().ui.undoToast).not.toBeNull()
+
+    let resolve!: (value: ClearOrphanSymlinksResult) => void
+    mockClearOrphanSymlinks.mockReturnValue(
+      new Promise<ClearOrphanSymlinksResult>((r) => {
+        resolve = r
+      }),
+    )
+    const promise = store.dispatch(
+      clearSelectedOrphanSymlinks([
+        {
+          skillName: 'task',
+          agents: [
+            {
+              agentId: 'codex' as AgentId,
+              linkPath: '/home/user/.codex/skills/task',
+              targetPath: '/home/user/.agents/skills/task',
+            },
+          ],
+        },
+      ]),
+    )
+
+    expect(store.getState().ui.undoToast).toBeNull()
+
+    resolve({ items: [] })
+    await promise
+  })
+
   it('unlinkSelectedFromAgent.pending clears undoToast (combined store)', async () => {
     const store = await createCombinedStore()
     const { setUndoToast } = await import('./uiSlice')
@@ -669,6 +705,40 @@ describe('uiSlice bulkSelectMode', () => {
       }),
     )
     const promise = store.dispatch(deleteSelectedSkills(['task']))
+
+    expect(store.getState().ui.bulkSelectMode).toBe(false)
+
+    resolve({ items: [] })
+    await promise
+  })
+
+  it('clearSelectedOrphanSymlinks.pending clears bulkSelectMode (combined store)', async () => {
+    const store = await createCombinedStore()
+    const { enterBulkSelectMode } = await import('./uiSlice')
+    const { clearSelectedOrphanSymlinks } = await import('./skillsSlice')
+
+    store.dispatch(enterBulkSelectMode())
+
+    let resolve!: (value: ClearOrphanSymlinksResult) => void
+    mockClearOrphanSymlinks.mockReturnValue(
+      new Promise<ClearOrphanSymlinksResult>((r) => {
+        resolve = r
+      }),
+    )
+    const promise = store.dispatch(
+      clearSelectedOrphanSymlinks([
+        {
+          skillName: 'task',
+          agents: [
+            {
+              agentId: 'codex' as AgentId,
+              linkPath: '/home/user/.codex/skills/task',
+              targetPath: '/home/user/.agents/skills/task',
+            },
+          ],
+        },
+      ]),
+    )
 
     expect(store.getState().ui.bulkSelectMode).toBe(false)
 

--- a/src/renderer/src/redux/slices/uiSlice.test.ts
+++ b/src/renderer/src/redux/slices/uiSlice.test.ts
@@ -45,6 +45,32 @@ vi.stubGlobal('window', {
 })
 
 /**
+ * Build a reviewed delete target so combined-store tests satisfy destructive IPC shape.
+ * @param skillName - Display name selected by the user.
+ * @returns Delete thunk target with exact reviewed source path.
+ * @example deleteTarget('task')
+ */
+function deleteTarget(skillName: Skill['name']) {
+  return {
+    skillName,
+    skillPath: `/home/user/.agents/skills/${skillName}`,
+  }
+}
+
+/**
+ * Build a reviewed unlink target so combined-store tests satisfy destructive IPC shape.
+ * @param skillName - Display name selected by the user.
+ * @returns Unlink thunk target with exact reviewed agent slot path.
+ * @example unlinkTarget('task')
+ */
+function unlinkTarget(skillName: Skill['name']) {
+  return {
+    skillName,
+    linkPath: `/home/user/.cursor/skills/${skillName}`,
+  }
+}
+
+/**
  * Create a minimal Redux store with only the ui reducer.
  * Avoids storage middleware and listener middleware used in production.
  * @returns Test store instance
@@ -553,7 +579,7 @@ describe('uiSlice undoToast (v2.4 bulk delete)', () => {
         resolve = r
       }),
     )
-    const promise = store.dispatch(deleteSelectedSkills(['task']))
+    const promise = store.dispatch(deleteSelectedSkills([deleteTarget('task')]))
 
     expect(store.getState().ui.undoToast).toBeNull()
 
@@ -646,7 +672,7 @@ describe('uiSlice undoToast (v2.4 bulk delete)', () => {
     const promise = store.dispatch(
       unlinkSelectedFromAgent({
         agentId: 'cursor' as AgentId,
-        selectedNames: ['task'],
+        selectedNames: [unlinkTarget('task')],
       }),
     )
 
@@ -738,7 +764,7 @@ describe('uiSlice bulkSelectMode', () => {
         resolve = r
       }),
     )
-    const promise = store.dispatch(deleteSelectedSkills(['task']))
+    const promise = store.dispatch(deleteSelectedSkills([deleteTarget('task')]))
 
     expect(store.getState().ui.bulkSelectMode).toBe(false)
 
@@ -828,7 +854,7 @@ describe('uiSlice bulkSelectMode', () => {
     const promise = store.dispatch(
       unlinkSelectedFromAgent({
         agentId: 'cursor' as AgentId,
-        selectedNames: ['task'],
+        selectedNames: [unlinkTarget('task')],
       }),
     )
 
@@ -968,7 +994,7 @@ describe('uiSlice atomic-clear contract on context switch', () => {
         resolve = r
       }),
     )
-    const promise = store.dispatch(deleteSelectedSkills(['a']))
+    const promise = store.dispatch(deleteSelectedSkills([deleteTarget('a')]))
 
     expect(store.getState().ui).toMatchObject({
       bulkSelectMode: false,
@@ -992,7 +1018,7 @@ describe('uiSlice atomic-clear contract on context switch', () => {
         resolve = r
       }),
     )
-    const promise = store.dispatch(deleteSelectedSkills(['a']))
+    const promise = store.dispatch(deleteSelectedSkills([deleteTarget('a')]))
 
     expect(store.getState().ui.symlinkCleanupDialogOpen).toBe(true)
 
@@ -1014,7 +1040,7 @@ describe('uiSlice atomic-clear contract on context switch', () => {
     const promise = store.dispatch(
       unlinkSelectedFromAgent({
         agentId: 'cursor' as AgentId,
-        selectedNames: ['a'],
+        selectedNames: [unlinkTarget('a')],
       }),
     )
 
@@ -1043,7 +1069,7 @@ describe('uiSlice atomic-clear contract on context switch', () => {
     const promise = store.dispatch(
       unlinkSelectedFromAgent({
         agentId: 'cursor' as AgentId,
-        selectedNames: ['a'],
+        selectedNames: [unlinkTarget('a')],
       }),
     )
 
@@ -1086,7 +1112,7 @@ describe('uiSlice bulkSelectMode on rejection', () => {
     store.dispatch(enterBulkSelectMode())
     mockDeleteSkills.mockRejectedValue(new Error('FS error'))
 
-    await store.dispatch(deleteSelectedSkills(['task']))
+    await store.dispatch(deleteSelectedSkills([deleteTarget('task')]))
 
     expect(store.getState().ui.bulkSelectMode).toBe(false)
   })
@@ -1102,7 +1128,7 @@ describe('uiSlice bulkSelectMode on rejection', () => {
     await store.dispatch(
       unlinkSelectedFromAgent({
         agentId: 'cursor' as AgentId,
-        selectedNames: ['task'],
+        selectedNames: [unlinkTarget('task')],
       }),
     )
 

--- a/src/renderer/src/redux/slices/uiSlice.test.ts
+++ b/src/renderer/src/redux/slices/uiSlice.test.ts
@@ -78,6 +78,7 @@ function unlinkTarget(skillName: Skill['name']) {
   return {
     skillName,
     linkPath: `/home/user/.cursor/skills/${skillName}`,
+    targetPath: `/home/user/.agents/skills/${skillName}`,
   }
 }
 

--- a/src/renderer/src/redux/slices/uiSlice.test.ts
+++ b/src/renderer/src/redux/slices/uiSlice.test.ts
@@ -6,6 +6,7 @@ import type {
   AgentId,
   BulkDeleteResult,
   BulkUnlinkResult,
+  ClearBrokenSymlinkSlotsResult,
   ClearOrphanSymlinksResult,
   Skill,
   SyncExecuteResult,
@@ -595,6 +596,39 @@ describe('uiSlice undoToast (v2.4 bulk delete)', () => {
     await promise
   })
 
+  it('clearSelectedBrokenSymlinkSlots.pending clears undoToast (combined store)', async () => {
+    const store = await createCombinedStore()
+    const { setUndoToast } = await import('./uiSlice')
+    const { clearSelectedBrokenSymlinkSlots } = await import('./skillsSlice')
+
+    store.dispatch(setUndoToast(makeToast()))
+    expect(store.getState().ui.undoToast).not.toBeNull()
+
+    let resolve!: (value: ClearBrokenSymlinkSlotsResult) => void
+    mockClearBrokenSymlinkSlots.mockReturnValue(
+      new Promise<ClearBrokenSymlinkSlotsResult>((r) => {
+        resolve = r
+      }),
+    )
+    const promise = store.dispatch(
+      clearSelectedBrokenSymlinkSlots({
+        items: [
+          {
+            agentId: 'codex' as AgentId,
+            linkName: 'task',
+            linkPath: '/home/user/.codex/skills/task',
+            targetPath: '/home/user/.agents/skills/task',
+          },
+        ],
+      }),
+    )
+
+    expect(store.getState().ui.undoToast).toBeNull()
+
+    resolve({ items: [] })
+    await promise
+  })
+
   it('unlinkSelectedFromAgent.pending clears undoToast (combined store)', async () => {
     const store = await createCombinedStore()
     const { setUndoToast } = await import('./uiSlice')
@@ -738,6 +772,38 @@ describe('uiSlice bulkSelectMode', () => {
           ],
         },
       ]),
+    )
+
+    expect(store.getState().ui.bulkSelectMode).toBe(false)
+
+    resolve({ items: [] })
+    await promise
+  })
+
+  it('clearSelectedBrokenSymlinkSlots.pending clears bulkSelectMode (combined store)', async () => {
+    const store = await createCombinedStore()
+    const { enterBulkSelectMode } = await import('./uiSlice')
+    const { clearSelectedBrokenSymlinkSlots } = await import('./skillsSlice')
+
+    store.dispatch(enterBulkSelectMode())
+
+    let resolve!: (value: ClearBrokenSymlinkSlotsResult) => void
+    mockClearBrokenSymlinkSlots.mockReturnValue(
+      new Promise<ClearBrokenSymlinkSlotsResult>((r) => {
+        resolve = r
+      }),
+    )
+    const promise = store.dispatch(
+      clearSelectedBrokenSymlinkSlots({
+        items: [
+          {
+            agentId: 'codex' as AgentId,
+            linkName: 'task',
+            linkPath: '/home/user/.codex/skills/task',
+            targetPath: '/home/user/.agents/skills/task',
+          },
+        ],
+      }),
     )
 
     expect(store.getState().ui.bulkSelectMode).toBe(false)

--- a/src/renderer/src/redux/slices/uiSlice.test.ts
+++ b/src/renderer/src/redux/slices/uiSlice.test.ts
@@ -19,6 +19,8 @@ const mockSyncExecute = vi.fn()
 const mockGetStats = vi.fn()
 const mockGetAll = vi.fn()
 const mockDeleteSkills = vi.fn()
+const mockClearOrphanSymlinks = vi.fn()
+const mockClearBrokenSymlinkSlots = vi.fn()
 const mockUnlinkManyFromAgent = vi.fn()
 
 vi.stubGlobal('window', {
@@ -33,6 +35,8 @@ vi.stubGlobal('window', {
     skills: {
       getAll: mockGetAll,
       deleteSkills: mockDeleteSkills,
+      clearOrphanSymlinks: mockClearOrphanSymlinks,
+      clearBrokenSymlinkSlots: mockClearBrokenSymlinkSlots,
       unlinkManyFromAgent: mockUnlinkManyFromAgent,
     },
   },
@@ -98,6 +102,76 @@ describe('uiSlice activeTab', () => {
     const { setActiveTab } = await import('./uiSlice')
     store.dispatch(setActiveTab('marketplace'))
     expect(store.getState().ui.activeTab).toBe('marketplace')
+  })
+})
+
+describe('uiSlice symlink cleanup dialog', () => {
+  it('starts with the Symlink Health cleanup dialog closed', async () => {
+    // Arrange
+    const store = await createTestStore()
+
+    // Act
+    const isOpen = store.getState().ui.symlinkCleanupDialogOpen
+
+    // Assert
+    expect(isOpen).toBe(false)
+  })
+
+  it('opens and closes the Symlink Health cleanup dialog', async () => {
+    // Arrange
+    const store = await createTestStore()
+    const { closeSymlinkCleanupDialog, openSymlinkCleanupDialog } =
+      await import('./uiSlice')
+
+    // Act
+    store.dispatch(openSymlinkCleanupDialog())
+    const openState = store.getState().ui.symlinkCleanupDialogOpen
+    store.dispatch(closeSymlinkCleanupDialog())
+    const closedState = store.getState().ui.symlinkCleanupDialogOpen
+
+    // Assert
+    expect(openState).toBe(true)
+    expect(closedState).toBe(false)
+  })
+
+  it('setActiveTab closes the Symlink Health cleanup dialog', async () => {
+    // Arrange
+    const store = await createTestStore()
+    const { openSymlinkCleanupDialog, setActiveTab } = await import('./uiSlice')
+    store.dispatch(openSymlinkCleanupDialog())
+
+    // Act
+    store.dispatch(setActiveTab('marketplace'))
+
+    // Assert
+    expect(store.getState().ui.symlinkCleanupDialogOpen).toBe(false)
+  })
+
+  it('selectAgent closes the Symlink Health cleanup dialog', async () => {
+    // Arrange
+    const store = await createTestStore()
+    const { openSymlinkCleanupDialog, selectAgent } = await import('./uiSlice')
+    store.dispatch(openSymlinkCleanupDialog())
+
+    // Act
+    store.dispatch(selectAgent('cursor'))
+
+    // Assert
+    expect(store.getState().ui.symlinkCleanupDialogOpen).toBe(false)
+  })
+
+  it('setCleanupAgentTarget closes the Symlink Health cleanup dialog', async () => {
+    // Arrange
+    const store = await createTestStore()
+    const { openSymlinkCleanupDialog, setCleanupAgentTarget } =
+      await import('./uiSlice')
+    store.dispatch(openSymlinkCleanupDialog())
+
+    // Act
+    store.dispatch(setCleanupAgentTarget('cursor'))
+
+    // Assert
+    expect(store.getState().ui.symlinkCleanupDialogOpen).toBe(false)
   })
 })
 
@@ -770,6 +844,26 @@ describe('uiSlice atomic-clear contract on context switch', () => {
     await promise
   })
 
+  it('deleteSelectedSkills.pending preserves the Symlink Health cleanup dialog it may be running inside', async () => {
+    const store = await createCombinedStore()
+    const { openSymlinkCleanupDialog } = await import('./uiSlice')
+    const { deleteSelectedSkills } = await import('./skillsSlice')
+    store.dispatch(openSymlinkCleanupDialog())
+
+    let resolve!: (value: BulkDeleteResult) => void
+    mockDeleteSkills.mockReturnValue(
+      new Promise<BulkDeleteResult>((r) => {
+        resolve = r
+      }),
+    )
+    const promise = store.dispatch(deleteSelectedSkills(['a']))
+
+    expect(store.getState().ui.symlinkCleanupDialogOpen).toBe(true)
+
+    resolve({ items: [] })
+    await promise
+  })
+
   it('unlinkSelectedFromAgent.pending atomically clears all ephemeral UI state', async () => {
     const store = await createCombinedStore()
     await seedAllEphemeralState(store)
@@ -793,6 +887,31 @@ describe('uiSlice atomic-clear contract on context switch', () => {
       undoToast: null,
       bulkConfirm: null,
     })
+
+    resolve({ items: [] })
+    await promise
+  })
+
+  it('unlinkSelectedFromAgent.pending preserves the Symlink Health cleanup dialog it may be running inside', async () => {
+    const store = await createCombinedStore()
+    const { openSymlinkCleanupDialog } = await import('./uiSlice')
+    const { unlinkSelectedFromAgent } = await import('./skillsSlice')
+    store.dispatch(openSymlinkCleanupDialog())
+
+    let resolve!: (value: BulkUnlinkResult) => void
+    mockUnlinkManyFromAgent.mockReturnValue(
+      new Promise<BulkUnlinkResult>((r) => {
+        resolve = r
+      }),
+    )
+    const promise = store.dispatch(
+      unlinkSelectedFromAgent({
+        agentId: 'cursor' as AgentId,
+        selectedNames: ['a'],
+      }),
+    )
+
+    expect(store.getState().ui.symlinkCleanupDialogOpen).toBe(true)
 
     resolve({ items: [] })
     await promise

--- a/src/renderer/src/redux/slices/uiSlice.test.ts
+++ b/src/renderer/src/redux/slices/uiSlice.test.ts
@@ -940,6 +940,10 @@ describe('uiSlice atomic-clear contract on context switch', () => {
         agentId: null,
         agentName: null,
         sourceSummary: null,
+        deleteTargets: [deleteTarget('a' as Skill['name'])],
+        orphanRecords: [],
+        staleDeleteErrors: [],
+        orphanErrors: [],
       }),
     )
   }

--- a/src/renderer/src/redux/slices/uiSlice.test.ts
+++ b/src/renderer/src/redux/slices/uiSlice.test.ts
@@ -8,12 +8,22 @@ import type {
   BulkUnlinkResult,
   ClearBrokenSymlinkSlotsResult,
   ClearOrphanSymlinksResult,
+  FilesystemEntryIdentity,
   Skill,
   SyncExecuteResult,
   SyncPreviewResult,
   TombstoneId,
 } from '@/shared/types'
 import { repositoryId, tombstoneId } from '@/shared/types'
+
+const directoryIdentity: FilesystemEntryIdentity = {
+  kind: 'directory',
+  dev: 1,
+  ino: 2,
+  size: 96,
+  ctimeMs: 3,
+  mtimeMs: 4,
+}
 
 // Stub window.electron before importing the slice (thunks reference it at call time)
 const mockSyncPreview = vi.fn()
@@ -54,6 +64,7 @@ function deleteTarget(skillName: Skill['name']) {
   return {
     skillName,
     skillPath: `/home/user/.agents/skills/${skillName}`,
+    filesystemIdentity: directoryIdentity,
   }
 }
 

--- a/src/renderer/src/redux/slices/uiSlice.ts
+++ b/src/renderer/src/redux/slices/uiSlice.ts
@@ -499,6 +499,9 @@ const uiSlice = createSlice({
      */
     openSymlinkCleanupDialog: (state) => {
       state.symlinkCleanupDialogOpen = true
+      // One cleanup surface at a time: opening the dashboard dialog clears any
+      // per-agent target so the two cleanup surfaces stay mutually exclusive.
+      state.cleanupAgentTarget = null
     },
     /**
      * Close the Dashboard Symlink Health cleanup dialog. Local plan and row

--- a/src/renderer/src/redux/slices/uiSlice.ts
+++ b/src/renderer/src/redux/slices/uiSlice.ts
@@ -170,6 +170,12 @@ interface UiState {
    * agent-scoped counts and conflicts.
    */
   cleanupAgentTarget: AgentId | null
+  /**
+   * Whether the Dashboard Symlink Health cleanup dialog is open. The dialog
+   * keeps scan plan and row selection locally; Redux owns only foreground
+   * surface coordination with tabs, sync, and bulk operations.
+   */
+  symlinkCleanupDialogOpen: boolean
 }
 
 const initialState: UiState = {
@@ -192,6 +198,7 @@ const initialState: UiState = {
   bulkConfirm: null,
   bulkSelectMode: false,
   cleanupAgentTarget: null,
+  symlinkCleanupDialogOpen: false,
 }
 
 /**
@@ -276,6 +283,8 @@ const uiSlice = createSlice({
       state.bulkConfirm = null
       // The bulk-select affordance is list-scoped; leaving the list exits mode.
       state.bulkSelectMode = false
+      // The Dashboard cleanup dialog belongs to the current dashboard context.
+      state.symlinkCleanupDialogOpen = false
     },
     setSearchQuery: (state, action: PayloadAction<SearchQuery>) => {
       state.searchQuery = action.payload
@@ -333,6 +342,8 @@ const uiSlice = createSlice({
       state.bulkConfirm = null
       // Selection is agent-scoped in skillsSlice; mode should follow.
       state.bulkSelectMode = false
+      // Agent switches replace the symlink graph under review; close the dialog.
+      state.symlinkCleanupDialogOpen = false
     },
     toggleSortOrder: (state) => {
       state.sortOrder = state.sortOrder === 'asc' ? 'desc' : 'asc'
@@ -443,6 +454,8 @@ const uiSlice = createSlice({
      */
     setCleanupAgentTarget: (state, action: PayloadAction<AgentId>) => {
       state.cleanupAgentTarget = action.payload
+      // One cleanup surface at a time: per-agent missing-skill cleanup wins.
+      state.symlinkCleanupDialogOpen = false
     },
     /**
      * Close the per-agent Cleanup dialog. Also clears any stale
@@ -452,6 +465,20 @@ const uiSlice = createSlice({
     clearCleanupAgentTarget: (state) => {
       state.cleanupAgentTarget = null
       state.syncPreview = null
+    },
+    /**
+     * Open the Dashboard Symlink Health cleanup dialog. The component performs
+     * the awaited scan on open so Redux does not store stale filesystem plans.
+     */
+    openSymlinkCleanupDialog: (state) => {
+      state.symlinkCleanupDialogOpen = true
+    },
+    /**
+     * Close the Dashboard Symlink Health cleanup dialog. Local plan and row
+     * selection reset inside the dialog component on this close edge.
+     */
+    closeSymlinkCleanupDialog: (state) => {
+      state.symlinkCleanupDialogOpen = false
     },
   },
   extraReducers: (builder) => {
@@ -480,6 +507,8 @@ const uiSlice = createSlice({
         state.bulkConfirm = null
         // Sync preview supersedes bulk affordance; user's attention shifts.
         state.bulkSelectMode = false
+        // Sync is another filesystem plan; do not overlap with symlink cleanup.
+        state.symlinkCleanupDialogOpen = false
       })
       .addCase(fetchSyncPreview.fulfilled, (state, action) => {
         state.syncPreview = action.payload
@@ -561,6 +590,8 @@ export const {
   exitBulkSelectMode,
   setCleanupAgentTarget,
   clearCleanupAgentTarget,
+  openSymlinkCleanupDialog,
+  closeSymlinkCleanupDialog,
 } = uiSlice.actions
 export default uiSlice.reducer
 
@@ -604,3 +635,12 @@ export const selectBulkSelectMode = (state: RootState): boolean =>
  */
 export const selectCleanupAgentTarget = (state: RootState): AgentId | null =>
   state.ui.cleanupAgentTarget
+/**
+ * Whether the Dashboard Symlink Health cleanup dialog should be mounted open.
+ * @param state - Root Redux state.
+ * @returns True while the cleanup dialog owns the foreground surface.
+ * @example
+ * const open = useAppSelector(selectSymlinkCleanupDialogOpen)
+ */
+export const selectSymlinkCleanupDialogOpen = (state: RootState): boolean =>
+  state.ui.symlinkCleanupDialogOpen

--- a/src/renderer/src/redux/slices/uiSlice.ts
+++ b/src/renderer/src/redux/slices/uiSlice.ts
@@ -101,21 +101,32 @@ export interface SourceFilterSummary {
  * - `sourceSummary`: repository-filter scope snapshot, or null when no repo
  *   filter is active and no local skills are hidden.
  */
-export interface BulkConfirmState {
-  kind: 'delete' | 'unlink'
+interface BulkConfirmBase {
   skillNames: SkillName[]
-  agentId: AgentId | null
-  agentName: AgentName | null
   sourceSummary: SourceFilterSummary | null
-  /** Reviewed source/local delete targets captured when the dialog opened. */
-  deleteTargets?: DeleteSelectedSkillTarget[]
-  /** Reviewed orphan cleanup records captured when the dialog opened. */
-  orphanRecords?: ClearOrphanSymlinksOptions['items']
-  /** Stale preflight errors captured when the dialog opened. */
-  orphanErrors?: BulkDeleteItemResult[]
-  /** Reviewed symlink unlink targets captured when the dialog opened. */
-  unlinkTargets?: UnlinkSelectedSkillTarget[]
 }
+
+export type BulkConfirmState =
+  | (BulkConfirmBase & {
+      kind: 'delete'
+      agentId: null
+      agentName: null
+      /** Reviewed source/local delete targets captured when the dialog opened. */
+      deleteTargets: DeleteSelectedSkillTarget[]
+      /** Reviewed orphan cleanup records captured when the dialog opened. */
+      orphanRecords: ClearOrphanSymlinksOptions['items']
+      /** Stale source/local preflight errors captured when the dialog opened. */
+      staleDeleteErrors: BulkDeleteItemResult[]
+      /** Stale orphan preflight errors captured when the dialog opened. */
+      orphanErrors: BulkDeleteItemResult[]
+    })
+  | (BulkConfirmBase & {
+      kind: 'unlink'
+      agentId: AgentId
+      agentName: AgentName | null
+      /** Reviewed symlink unlink targets captured when the dialog opened. */
+      unlinkTargets: UnlinkSelectedSkillTarget[]
+    })
 
 interface UiState {
   /** Active main content tab */

--- a/src/renderer/src/redux/slices/uiSlice.ts
+++ b/src/renderer/src/redux/slices/uiSlice.ts
@@ -20,6 +20,7 @@ import type {
 } from '@/shared/types'
 
 import {
+  clearSelectedBrokenSymlinkSlots,
   clearSelectedOrphanSymlinks,
   deleteSelectedSkills,
   fetchSkills,
@@ -543,6 +544,11 @@ const uiSlice = createSlice({
         state.bulkSelectMode = false
       })
       .addCase(clearSelectedOrphanSymlinks.pending, (state) => {
+        state.undoToast = null
+        state.bulkConfirm = null
+        state.bulkSelectMode = false
+      })
+      .addCase(clearSelectedBrokenSymlinkSlots.pending, (state) => {
         state.undoToast = null
         state.bulkConfirm = null
         state.bulkSelectMode = false

--- a/src/renderer/src/redux/slices/uiSlice.ts
+++ b/src/renderer/src/redux/slices/uiSlice.ts
@@ -6,6 +6,8 @@ import type {
   AgentId,
   AgentName,
   BookmarkedSkill,
+  BulkDeleteItemResult,
+  ClearOrphanSymlinksOptions,
   IsoTimestamp,
   RepositoryId,
   SearchQuery,
@@ -19,6 +21,10 @@ import type {
   TombstoneId,
 } from '@/shared/types'
 
+import type {
+  DeleteSelectedSkillTarget,
+  UnlinkSelectedSkillTarget,
+} from './skillsSlice'
 import {
   clearSelectedBrokenSymlinkSlots,
   clearSelectedOrphanSymlinks,
@@ -101,6 +107,14 @@ export interface BulkConfirmState {
   agentId: AgentId | null
   agentName: AgentName | null
   sourceSummary: SourceFilterSummary | null
+  /** Reviewed source/local delete targets captured when the dialog opened. */
+  deleteTargets?: DeleteSelectedSkillTarget[]
+  /** Reviewed orphan cleanup records captured when the dialog opened. */
+  orphanRecords?: ClearOrphanSymlinksOptions['items']
+  /** Stale preflight errors captured when the dialog opened. */
+  orphanErrors?: BulkDeleteItemResult[]
+  /** Reviewed symlink unlink targets captured when the dialog opened. */
+  unlinkTargets?: UnlinkSelectedSkillTarget[]
 }
 
 interface UiState {

--- a/src/renderer/src/redux/slices/uiSlice.ts
+++ b/src/renderer/src/redux/slices/uiSlice.ts
@@ -20,6 +20,7 @@ import type {
 } from '@/shared/types'
 
 import {
+  clearSelectedOrphanSymlinks,
   deleteSelectedSkills,
   fetchSkills,
   unlinkSelectedFromAgent,
@@ -539,6 +540,11 @@ const uiSlice = createSlice({
         state.bulkConfirm = null
         // Bulk op committed — leaving mode ON would strand a checkbox column
         // over a fresh post-delete list the user is now observing for result.
+        state.bulkSelectMode = false
+      })
+      .addCase(clearSelectedOrphanSymlinks.pending, (state) => {
+        state.undoToast = null
+        state.bulkConfirm = null
         state.bulkSelectMode = false
       })
       .addCase(unlinkSelectedFromAgent.pending, (state) => {

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -27,6 +27,10 @@ import type {
   DeleteSkillResult,
   DeleteSkillsOptions,
   BulkDeleteResult,
+  ClearOrphanSymlinksOptions,
+  ClearOrphanSymlinksResult,
+  ClearBrokenSymlinkSlotsOptions,
+  ClearBrokenSymlinkSlotsResult,
   UnlinkManyFromAgentOptions,
   BulkUnlinkResult,
   RestoreDeletedSkillOptions,
@@ -66,6 +70,12 @@ declare global {
         deleteSkills: (
           options: DeleteSkillsOptions,
         ) => Promise<BulkDeleteResult>
+        clearOrphanSymlinks: (
+          options: ClearOrphanSymlinksOptions,
+        ) => Promise<ClearOrphanSymlinksResult>
+        clearBrokenSymlinkSlots: (
+          options: ClearBrokenSymlinkSlotsOptions,
+        ) => Promise<ClearBrokenSymlinkSlotsResult>
         unlinkManyFromAgent: (
           options: UnlinkManyFromAgentOptions,
         ) => Promise<BulkUnlinkResult>

--- a/src/renderer/src/utils/gstackSkill.ts
+++ b/src/renderer/src/utils/gstackSkill.ts
@@ -41,7 +41,9 @@ function getGStackPathCandidatesForAgent(
     symlinks.find(
       (slot) =>
         slot.agentId === selectedAgentId &&
-        (slot.status === 'valid' || slot.status === 'broken') &&
+        (slot.status === 'valid' ||
+          slot.status === 'broken' ||
+          slot.status === 'inaccessible') &&
         !slot.isLocal,
     ) ?? null
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -598,7 +598,7 @@ export const AGENT_DEFINITIONS = [
 ] as const
 
 /**
- * Any valid theme preset name — 12 OKLCH color hues + 2 neutral variants.
+ * Any valid theme preset name — 17 OKLCH hues, 2 pure neutrals, and 8 tinted neutrals.
  * Derived from `THEME_PRESETS` so new presets only need to be added in one
  * place; Redux reducers, selectors, and the ThemeSelector all pick up the
  * widened union automatically.

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -27,8 +27,12 @@ export const PERSIST_STORAGE_KEY = 'skills-desktop-state'
  *    `modePreference` from it (e.g. mode='dark' → modePreference='dark').
  *    "system" is opt-in, never inherited from a pre-v3 user — they explicitly
  *    picked light or dark before, so we keep that pin.
+ *  - v3 → v4: dashboard widget `{w,h}` clamped upward again — the Symlink
+ *    Health widget's `minSize.h` grew 2 → 3 so its action row ("Scan issues")
+ *    no longer clips against the card's bottom edge. Same mechanism and
+ *    rationale as v1 → v2 (see `clampPersistedWidgetSizes`).
  */
-export const PERSIST_STATE_VERSION = 3
+export const PERSIST_STATE_VERSION = 4
 
 /**
  * Chroma value applied to OKLCH tokens for fully-saturated (color) presets.

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -33,6 +33,8 @@ export const IPC_CHANNELS = {
   SKILLS_COPY_TO_AGENTS: 'skills:copyToAgents',
   // Skills bulk delete + undo
   SKILLS_DELETE_BATCH: 'skills:deleteSkills',
+  SKILLS_CLEAR_ORPHAN_SYMLINKS: 'skills:clearOrphanSymlinks',
+  SKILLS_CLEAR_BROKEN_SYMLINK_SLOTS: 'skills:clearBrokenSymlinkSlots',
   SKILLS_UNLINK_MANY_FROM_AGENT: 'skills:unlinkManyFromAgent',
   SKILLS_RESTORE_DELETED: 'skills:restoreDeletedSkill',
   SKILLS_DELETE_PROGRESS: 'skills:deleteProgress',

--- a/src/shared/ipc-contract.test.ts
+++ b/src/shared/ipc-contract.test.ts
@@ -14,6 +14,8 @@ describe('IPC contract alignment', () => {
       [IPC_CHANNELS.SKILLS_CREATE_SYMLINKS]: true,
       [IPC_CHANNELS.SKILLS_COPY_TO_AGENTS]: true,
       [IPC_CHANNELS.SKILLS_DELETE_BATCH]: true,
+      [IPC_CHANNELS.SKILLS_CLEAR_ORPHAN_SYMLINKS]: true,
+      [IPC_CHANNELS.SKILLS_CLEAR_BROKEN_SYMLINK_SLOTS]: true,
       [IPC_CHANNELS.SKILLS_UNLINK_MANY_FROM_AGENT]: true,
       [IPC_CHANNELS.SKILLS_RESTORE_DELETED]: true,
       [IPC_CHANNELS.AGENTS_GET_ALL]: true,
@@ -44,7 +46,7 @@ describe('IPC contract alignment', () => {
     // IPC channel (input validation, authz scope, side-effect blast radius).
     // The `satisfies` clause above is a structural guard; this length check is
     // the trip-wire that forces a human PR diff when a channel is added.
-    expect(Object.keys(invokeMapping)).toHaveLength(30)
+    expect(Object.keys(invokeMapping)).toHaveLength(32)
   })
 
   it('all IPC_CHANNELS event values are valid event contract keys', () => {

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -4,6 +4,10 @@ import type {
   Agent,
   BulkDeleteResult,
   BulkUnlinkResult,
+  ClearOrphanSymlinksOptions,
+  ClearOrphanSymlinksResult,
+  ClearBrokenSymlinkSlotsOptions,
+  ClearBrokenSymlinkSlotsResult,
   CliCommandResult,
   CopyToAgentsOptions,
   CopyToAgentsResult,
@@ -78,6 +82,14 @@ export interface IpcInvokeContract {
   'skills:deleteSkills': {
     args: [DeleteSkillsOptions]
     result: BulkDeleteResult
+  }
+  'skills:clearOrphanSymlinks': {
+    args: [ClearOrphanSymlinksOptions]
+    result: ClearOrphanSymlinksResult
+  }
+  'skills:clearBrokenSymlinkSlots': {
+    args: [ClearBrokenSymlinkSlotsOptions]
+    result: ClearBrokenSymlinkSlotsResult
   }
   'skills:unlinkManyFromAgent': {
     args: [UnlinkManyFromAgentOptions]

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -730,27 +730,43 @@ export interface LeaderboardData {
 }
 
 /**
- * IPC argument for `skills:unlinkFromAgent` — removes one selected agent path.
- * Symlinks are unlinked without touching their target; local skill folders
- * require an explicit renderer confirmation flag before main moves them to OS
- * Trash.
+ * IPC argument for `skills:unlinkFromAgent` — removes one reviewed agent path.
+ * Symlink unlink requires the reviewed resolved target; local folder delete
+ * requires explicit confirmation plus reviewed directory identity.
  * @example
- * { skillName: 'tdd-workflow', agentId: 'cursor', linkPath: '/Users/me/.cursor/skills/tdd-workflow', confirmedLocalDirectoryDelete: false }
+ * { skillName: 'tdd-workflow', agentId: 'cursor', linkPath: '/Users/me/.cursor/skills/tdd-workflow', targetPath: '/Users/me/.agents/skills/tdd-workflow' }
+ * @example
+ * { skillName: 'local-task', agentId: 'cursor', linkPath: '/Users/me/.cursor/skills/local-task', confirmedLocalDirectoryDelete: true, reviewedDirectoryIdentity }
  */
-export interface UnlinkFromAgentOptions {
-  /** Skill whose symlink will be removed. @example "tdd-workflow" */
-  skillName: SkillName
-  /** Agent the symlink belongs to. */
-  agentId: AgentId
-  /** Absolute path to the symlink itself (inside the agent's skills directory). */
-  linkPath: AbsolutePath
-  /** Reviewed resolved target for symlink unlink; omitted only for local folder delete. */
-  targetPath?: AbsolutePath
-  /** True only after the local-folder destructive confirmation dialog submits. */
-  confirmedLocalDirectoryDelete?: boolean
-  /** Required when deleting a local folder; proves main still sees the reviewed directory. */
-  reviewedDirectoryIdentity?: FilesystemEntryIdentity
-}
+export type UnlinkFromAgentOptions =
+  | {
+      /** Skill whose symlink will be removed. @example "tdd-workflow" */
+      skillName: SkillName
+      /** Agent the symlink belongs to. */
+      agentId: AgentId
+      /** Absolute path to the symlink itself (inside the agent's skills directory). */
+      linkPath: AbsolutePath
+      /** Reviewed resolved target for symlink unlink. */
+      targetPath: AbsolutePath
+      /** Must be false/omitted for symlink unlink. */
+      confirmedLocalDirectoryDelete?: false
+      /** Local-folder identity is invalid for symlink unlink. */
+      reviewedDirectoryIdentity?: never
+    }
+  | {
+      /** Skill whose local folder will be moved to OS Trash. @example "local-task" */
+      skillName: SkillName
+      /** Agent the local folder belongs to. */
+      agentId: AgentId
+      /** Absolute path to the local folder inside the agent's skills directory. */
+      linkPath: AbsolutePath
+      /** True only after the local-folder destructive confirmation dialog submits. */
+      confirmedLocalDirectoryDelete: true
+      /** Required when deleting a local folder; proves main still sees the reviewed directory. */
+      reviewedDirectoryIdentity: FilesystemEntryIdentity
+      /** Symlink target is invalid for local folder delete. */
+      targetPath?: never
+    }
 
 /**
  * Result from unlinking a single symlink.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -41,6 +41,25 @@ export type SkillName = string
 export type AbsolutePath = string
 
 /**
+ * Filesystem object identity captured at scan/review time for destructive guards.
+ * @example { kind: 'directory', dev: 16777233, ino: 12345, size: 96, ctimeMs: 1710000000000, mtimeMs: 1710000000000 }
+ */
+export interface FilesystemEntryIdentity {
+  /** Filesystem entry kind observed by lstat. */
+  kind: 'directory' | 'symlink' | 'file' | 'other'
+  /** Device id from fs.Stats, paired with ino for stable same-object checks. */
+  dev: number
+  /** Inode/file id from fs.Stats, paired with dev for stable same-object checks. */
+  ino: number
+  /** Entry size from fs.Stats, used as fallback identity on filesystems without ino. */
+  size: number
+  /** Metadata change timestamp from fs.Stats, used as fallback identity. */
+  ctimeMs: number
+  /** Modification timestamp from fs.Stats, used as fallback identity. */
+  mtimeMs: number
+}
+
+/**
  * Filesystem path written with forward slashes, used for display and tree keys
  * regardless of the host OS. Always relative to some known root.
  * @example "lib/helper.py"
@@ -194,6 +213,8 @@ export interface Skill {
   description: string
   /** Absolute filesystem path to the skill directory. @example "/Users/me/.agents/skills/tdd-workflow" */
   path: AbsolutePath
+  /** Scan-time filesystem identity for `path`, required before source/local delete. */
+  filesystemIdentity?: FilesystemEntryIdentity
   /** Number of agents this skill is symlinked to (valid symlinks only). @example 3 */
   symlinkCount: SymlinkCount
   /** Per-agent symlink status entries */
@@ -277,6 +298,8 @@ export interface SymlinkInfo {
   linkPath: AbsolutePath
   /** true = real folder in agent dir (local skill), false = symlink */
   isLocal: boolean
+  /** Scan-time identity for real local folder slots, required before local-folder delete. */
+  filesystemIdentity?: FilesystemEntryIdentity
   /**
    * Resolved absolute path of THIS agent slot's `SKILL.md` symlink target,
    * when the slot is a real local folder whose `SKILL.md` is a symlink (e.g.
@@ -721,6 +744,8 @@ export interface UnlinkFromAgentOptions {
   linkPath: AbsolutePath
   /** True only after the local-folder destructive confirmation dialog submits. */
   confirmedLocalDirectoryDelete?: boolean
+  /** Required when deleting a local folder; proves main still sees the reviewed directory. */
+  reviewedDirectoryIdentity?: FilesystemEntryIdentity
 }
 
 /**
@@ -764,13 +789,15 @@ export interface RemoveAllFromAgentResult {
  * IPC argument for `skills:deleteSkill` — removes the reviewed source/local path
  * and every agent symlink pointing at it. `skillPath` preserves filesystem
  * identity when the SKILL.md metadata name differs from the folder basename.
- * @example { skillName: 'theme-generator', skillPath: '/Users/me/.agents/skills/theme-generator' }
+ * @example { skillName: 'theme-generator', skillPath: '/Users/me/.agents/skills/theme-generator', filesystemIdentity: { kind: 'directory', dev: 1, ino: 2, size: 96, ctimeMs: 1, mtimeMs: 1 } }
  */
 export interface DeleteSkillOptions {
   /** Skill to delete. @example "theme-generator" */
   skillName: SkillName
   /** Reviewed source/local folder path from the selected row. */
   skillPath: AbsolutePath
+  /** Scan-time identity for the reviewed source/local folder path. */
+  filesystemIdentity: FilesystemEntryIdentity
 }
 
 /**
@@ -806,11 +833,15 @@ export const tombstoneId = (value: string): TombstoneId => value as TombstoneId
 /**
  * IPC argument for `skills:deleteSkills` — batch delete N reviewed skills atomically with trash/undo.
  * `skillPath` is mandatory so main deletes the reviewed folder even when metadata name and basename differ.
- * @example { items: [{ skillName: 'task', skillPath: '/Users/me/.agents/skills/task' }] }
+ * @example { items: [{ skillName: 'task', skillPath: '/Users/me/.agents/skills/task', filesystemIdentity: { kind: 'directory', dev: 1, ino: 2, size: 96, ctimeMs: 1, mtimeMs: 1 } }] }
  */
 export interface DeleteSkillsOptions {
   /** Skills to delete, in the order the user selected them (batch runs serially per reviewer #21). */
-  items: Array<{ skillName: SkillName; skillPath: AbsolutePath }>
+  items: Array<{
+    skillName: SkillName
+    skillPath: AbsolutePath
+    filesystemIdentity: FilesystemEntryIdentity
+  }>
 }
 
 /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -264,6 +264,8 @@ export interface Agent {
   skillCount: number
   /** Number of local skills (real folders, not symlinks). @example 2 */
   localSkillCount: number
+  /** Directory identity for destructive "remove all" confirmation guards. */
+  filesystemIdentity?: FilesystemEntryIdentity
 }
 
 /**
@@ -742,6 +744,8 @@ export interface UnlinkFromAgentOptions {
   agentId: AgentId
   /** Absolute path to the symlink itself (inside the agent's skills directory). */
   linkPath: AbsolutePath
+  /** Reviewed resolved target for symlink unlink; omitted only for local folder delete. */
+  targetPath?: AbsolutePath
   /** True only after the local-folder destructive confirmation dialog submits. */
   confirmedLocalDirectoryDelete?: boolean
   /** Required when deleting a local folder; proves main still sees the reviewed directory. */
@@ -770,6 +774,8 @@ export interface RemoveAllFromAgentOptions {
   agentId: AgentId
   /** Absolute path to the agent's skills directory. @example "/Users/me/.claude/skills" */
   agentPath: AbsolutePath
+  /** Review-time directory identity for the agent skills folder. */
+  filesystemIdentity: FilesystemEntryIdentity
 }
 
 /**
@@ -978,14 +984,18 @@ export interface ClearBrokenSymlinkSlotsResult {
 
 /**
  * IPC argument for `skills:unlinkManyFromAgent` — batch unlink N reviewed slots from a single agent.
- * Main verifies each `linkPath` is a direct child of the selected agent path.
- * @example { agentId: 'cursor', items: [{ skillName: 'task', linkPath: '/Users/me/.cursor/skills/task' }] }
+ * Main verifies each `linkPath` is a direct child of the selected agent path and still points at `targetPath`.
+ * @example { agentId: 'cursor', items: [{ skillName: 'task', linkPath: '/Users/me/.cursor/skills/task', targetPath: '/Users/me/.agents/skills/task' }] }
  */
 export interface UnlinkManyFromAgentOptions {
   /** Agent the symlinks belong to. */
   agentId: AgentId
   /** Skills whose symlinks should be removed (serial processing, no tombstone — unlink is benign). */
-  items: Array<{ skillName: SkillName; linkPath: AbsolutePath }>
+  items: Array<{
+    skillName: SkillName
+    linkPath: AbsolutePath
+    targetPath: AbsolutePath
+  }>
 }
 
 /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -878,10 +878,14 @@ export interface DeleteSkillsOptions {
  *   exists. Cleanup is just `unlink()` calls — no tombstone, no undo, because
  *   resurrecting the broken links is meaningless.
  * - `error`: the operation failed mid-flight; the renderer flashes the row.
+ *   When a multi-agent cleanup fails partway, `cascadeAgents`/`symlinksRemoved`
+ *   carry the unlinks already committed to disk before the throw, so the
+ *   summary mirrors disk state instead of undercounting.
  *
  * @example { skillName: 'task', outcome: 'deleted', tombstoneId: '1729180800000-task-a1b2c3d4', symlinksRemoved: 3, cascadeAgents: ['cursor'] }
  * @example { skillName: 'abandoned', outcome: 'orphan-cleared', symlinksRemoved: 2, cascadeAgents: ['cursor', 'codex'] }
  * @example { skillName: 'task', outcome: 'error', error: { message: 'Permission denied', code: 'EACCES' } }
+ * @example { skillName: 'abandoned', outcome: 'error', error: { message: 'Source skill exists', code: 'ESTALE' }, symlinksRemoved: 2, cascadeAgents: ['codex', 'cursor'] }
  */
 export type BulkDeleteItemResult =
   | {
@@ -901,6 +905,10 @@ export type BulkDeleteItemResult =
       skillName: SkillName
       outcome: 'error'
       error: { message: string; code?: string }
+      /** Unlinks committed to disk before the failing iteration threw, if any. */
+      symlinksRemoved?: number
+      /** Agents whose links were removed before the throw, for partial-cleanup reporting. */
+      cascadeAgents?: AgentId[]
     }
 
 /**
@@ -933,6 +941,7 @@ export interface ClearOrphanSymlinksOptions {
  * Per-item result from orphan-only symlink cleanup.
  * @example { skillName: 'abandoned', outcome: 'orphan-cleared', symlinksRemoved: 1, cascadeAgents: ['codex'] }
  * @example { skillName: 'abandoned', outcome: 'error', error: { message: 'Plan changed' } }
+ * @example { skillName: 'abandoned', outcome: 'error', error: { message: 'Source skill exists', code: 'ESTALE' }, symlinksRemoved: 2, cascadeAgents: ['codex', 'cursor'] }
  */
 export type ClearOrphanSymlinkItemResult =
   | {
@@ -945,6 +954,10 @@ export type ClearOrphanSymlinkItemResult =
       skillName: SkillName
       outcome: 'error'
       error: { message: string; code?: string }
+      /** Unlinks committed to disk before the failing iteration threw, if any. */
+      symlinksRemoved?: number
+      /** Agents whose links were removed before the throw, for partial-cleanup reporting. */
+      cascadeAgents?: AgentId[]
     }
 
 /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -903,13 +903,13 @@ export interface ClearOrphanSymlinksResult {
 
 /**
  * IPC argument for `skills:clearBrokenSymlinkSlots` — remove reviewed broken agent links after exact target revalidation.
- * @example { items: [{ agentId: 'codex', skillName: 'task', linkPath: '/Users/me/.codex/skills/task', targetPath: '/Users/me/.agents/skills/task' }] }
+ * @example { items: [{ agentId: 'codex', linkName: 'task', linkPath: '/Users/me/.codex/skills/task', targetPath: '/Users/me/.agents/skills/task' }] }
  */
 export interface ClearBrokenSymlinkSlotsOptions {
   /** Broken slots selected in the Symlink Health cleanup dialog. */
   items: Array<{
     agentId: AgentId
-    skillName: SkillName
+    linkName: SkillName
     linkPath: AbsolutePath
     targetPath: AbsolutePath
   }>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -946,7 +946,7 @@ export interface ClearBrokenSymlinkSlotsResult {
 
 /**
  * IPC argument for `skills:unlinkManyFromAgent` — batch unlink N skills from a single agent.
- * Main derives `linkPath = join(agent.path, skillName)` server-side.
+ * Main verifies `linkPath` is a direct child of the selected agent path.
  * @example { agentId: 'cursor', items: [{ skillName: 'task' }, { skillName: 'theme-generator' }] }
  */
 export interface UnlinkManyFromAgentOptions {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -286,7 +286,7 @@ export interface SymlinkInfo {
   agentId: AgentId
   /** Agent display name. @example "Cursor" */
   agentName: AgentName
-  /** Current symlink state: valid (linked), broken (dangling), or missing (no link) */
+  /** Current symlink state: valid, broken, inaccessible, or missing. */
   status: SymlinkStatus
   /**
    * Where the symlink points to (skill source directory). Omitted when no
@@ -329,6 +329,7 @@ export interface SymlinkInfo {
  *
  * @example 'valid'
  * @example 'broken'
+ * @example 'inaccessible'
  * @example 'missing'
  */
 export type SymlinkStatus = 'valid' | 'broken' | 'inaccessible' | 'missing'

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -770,7 +770,7 @@ export interface DeleteSkillOptions {
   /** Skill to delete. @example "theme-generator" */
   skillName: SkillName
   /** Reviewed source/local folder path from the selected row. */
-  skillPath?: AbsolutePath
+  skillPath: AbsolutePath
 }
 
 /**
@@ -805,13 +805,12 @@ export const tombstoneId = (value: string): TombstoneId => value as TombstoneId
 
 /**
  * IPC argument for `skills:deleteSkills` — batch delete N reviewed skills atomically with trash/undo.
- * `skillPath` is optional for old callers, but new renderer flows include it
- * so main deletes the reviewed folder even when metadata name and basename differ.
+ * `skillPath` is mandatory so main deletes the reviewed folder even when metadata name and basename differ.
  * @example { items: [{ skillName: 'task', skillPath: '/Users/me/.agents/skills/task' }] }
  */
 export interface DeleteSkillsOptions {
   /** Skills to delete, in the order the user selected them (batch runs serially per reviewer #21). */
-  items: Array<{ skillName: SkillName; skillPath?: AbsolutePath }>
+  items: Array<{ skillName: SkillName; skillPath: AbsolutePath }>
 }
 
 /**
@@ -948,14 +947,14 @@ export interface ClearBrokenSymlinkSlotsResult {
 
 /**
  * IPC argument for `skills:unlinkManyFromAgent` — batch unlink N reviewed slots from a single agent.
- * Main verifies `linkPath` is a direct child of the selected agent path when supplied.
+ * Main verifies each `linkPath` is a direct child of the selected agent path.
  * @example { agentId: 'cursor', items: [{ skillName: 'task', linkPath: '/Users/me/.cursor/skills/task' }] }
  */
 export interface UnlinkManyFromAgentOptions {
   /** Agent the symlinks belong to. */
   agentId: AgentId
   /** Skills whose symlinks should be removed (serial processing, no tombstone — unlink is benign). */
-  items: Array<{ skillName: SkillName; linkPath?: AbsolutePath }>
+  items: Array<{ skillName: SkillName; linkPath: AbsolutePath }>
 }
 
 /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -761,14 +761,16 @@ export interface RemoveAllFromAgentResult {
 }
 
 /**
- * IPC argument for `skills:deleteSkill` — removes the skill source directory
- * AND every agent symlink pointing at it. Main derives `sourcePath` from
- * `SOURCE_DIR + skillName` server-side; renderer never passes a path.
- * @example { skillName: 'theme-generator' }
+ * IPC argument for `skills:deleteSkill` — removes the reviewed source/local path
+ * and every agent symlink pointing at it. `skillPath` preserves filesystem
+ * identity when the SKILL.md metadata name differs from the folder basename.
+ * @example { skillName: 'theme-generator', skillPath: '/Users/me/.agents/skills/theme-generator' }
  */
 export interface DeleteSkillOptions {
   /** Skill to delete. @example "theme-generator" */
   skillName: SkillName
+  /** Reviewed source/local folder path from the selected row. */
+  skillPath?: AbsolutePath
 }
 
 /**
@@ -802,14 +804,14 @@ export type TombstoneId = Brand<string, 'TombstoneId'>
 export const tombstoneId = (value: string): TombstoneId => value as TombstoneId
 
 /**
- * IPC argument for `skills:deleteSkills` — batch delete N skills atomically with trash/undo.
- * Main derives each `sourcePath = join(SOURCE_DIR, skillName)` server-side; the renderer
- * does not pass paths (security: removes a trust-boundary widening).
- * @example { items: [{ skillName: 'task' }, { skillName: 'theme-generator' }] }
+ * IPC argument for `skills:deleteSkills` — batch delete N reviewed skills atomically with trash/undo.
+ * `skillPath` is optional for old callers, but new renderer flows include it
+ * so main deletes the reviewed folder even when metadata name and basename differ.
+ * @example { items: [{ skillName: 'task', skillPath: '/Users/me/.agents/skills/task' }] }
  */
 export interface DeleteSkillsOptions {
   /** Skills to delete, in the order the user selected them (batch runs serially per reviewer #21). */
-  items: Array<{ skillName: SkillName }>
+  items: Array<{ skillName: SkillName; skillPath?: AbsolutePath }>
 }
 
 /**
@@ -945,15 +947,15 @@ export interface ClearBrokenSymlinkSlotsResult {
 }
 
 /**
- * IPC argument for `skills:unlinkManyFromAgent` — batch unlink N skills from a single agent.
- * Main verifies `linkPath` is a direct child of the selected agent path.
- * @example { agentId: 'cursor', items: [{ skillName: 'task' }, { skillName: 'theme-generator' }] }
+ * IPC argument for `skills:unlinkManyFromAgent` — batch unlink N reviewed slots from a single agent.
+ * Main verifies `linkPath` is a direct child of the selected agent path when supplied.
+ * @example { agentId: 'cursor', items: [{ skillName: 'task', linkPath: '/Users/me/.cursor/skills/task' }] }
  */
 export interface UnlinkManyFromAgentOptions {
   /** Agent the symlinks belong to. */
   agentId: AgentId
   /** Skills whose symlinks should be removed (serial processing, no tombstone — unlink is benign). */
-  items: Array<{ skillName: SkillName }>
+  items: Array<{ skillName: SkillName; linkPath?: AbsolutePath }>
 }
 
 /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -269,6 +269,7 @@ export interface SymlinkInfo {
    * Where the symlink points to (skill source directory). Omitted when no
    * symlink exists for this agent (`status === 'missing'`) or the entry is a
    * real local folder (`isLocal === true`) — both have no target to record.
+   * Inaccessible symlinks still record their target when `readlink` succeeds.
    * @example "/Users/me/.agents/skills/tdd-workflow"
    */
   targetPath?: AbsolutePath
@@ -292,18 +293,20 @@ export interface SymlinkInfo {
 /**
  * Symlink state between a skill source and an agent's skills directory.
  * Surfaced in `SymlinkInfo.status` and color-coded in the UI:
- * `--success` (green) for valid, amber for broken, `--muted-foreground`
- * for missing — the status drives every status-at-a-glance affordance.
+ * `--success` (green) for valid, amber for broken/inaccessible,
+ * `--muted-foreground` for missing — the status drives every
+ * status-at-a-glance affordance.
  *
  * - `valid`: symlink exists and points to a present source skill.
  * - `broken`: symlink exists but the target is missing (orphan).
+ * - `inaccessible`: symlink exists but the target cannot be probed safely.
  * - `missing`: no symlink for this agent (the skill is not linked here).
  *
  * @example 'valid'
  * @example 'broken'
  * @example 'missing'
  */
-export type SymlinkStatus = 'valid' | 'broken' | 'missing'
+export type SymlinkStatus = 'valid' | 'broken' | 'inaccessible' | 'missing'
 
 /**
  * Identifier for the macOS terminal application launched by
@@ -853,6 +856,88 @@ export type BulkDeleteItemResult =
 export interface BulkDeleteResult {
   /** Per-item outcome, index-aligned with the input `items` array (serial execution). */
   items: BulkDeleteItemResult[]
+}
+
+/**
+ * IPC argument for `skills:clearOrphanSymlinks` — remove reviewed dangling agent links without touching source skills.
+ * @example { items: [{ skillName: 'abandoned', agents: [{ agentId: 'codex', linkPath: '/Users/me/.codex/skills/abandoned' }] }] }
+ */
+export interface ClearOrphanSymlinksOptions {
+  /** Orphan records selected in the Symlink Health cleanup dialog. */
+  items: Array<{
+    skillName: SkillName
+    agents: Array<{ agentId: AgentId; linkPath: AbsolutePath }>
+  }>
+}
+
+/**
+ * Per-item result from orphan-only symlink cleanup.
+ * @example { skillName: 'abandoned', outcome: 'orphan-cleared', symlinksRemoved: 1, cascadeAgents: ['codex'] }
+ * @example { skillName: 'abandoned', outcome: 'error', error: { message: 'Plan changed' } }
+ */
+export type ClearOrphanSymlinkItemResult =
+  | {
+      skillName: SkillName
+      outcome: 'orphan-cleared'
+      symlinksRemoved: number
+      cascadeAgents: AgentId[]
+    }
+  | {
+      skillName: SkillName
+      outcome: 'error'
+      error: { message: string; code?: string }
+    }
+
+/**
+ * Orphan-only cleanup result. Same row shape as bulk delete for dialog summary reuse, but it never returns tombstones.
+ * @example { items: [{ skillName: 'abandoned', outcome: 'orphan-cleared', symlinksRemoved: 1, cascadeAgents: ['codex'] }] }
+ */
+export interface ClearOrphanSymlinksResult {
+  /** Per-orphan-record outcome, index-aligned with the selected orphan records. */
+  items: ClearOrphanSymlinkItemResult[]
+}
+
+/**
+ * IPC argument for `skills:clearBrokenSymlinkSlots` — remove reviewed broken agent links after exact target revalidation.
+ * @example { items: [{ agentId: 'codex', skillName: 'task', linkPath: '/Users/me/.codex/skills/task', targetPath: '/Users/me/.agents/skills/task' }] }
+ */
+export interface ClearBrokenSymlinkSlotsOptions {
+  /** Broken slots selected in the Symlink Health cleanup dialog. */
+  items: Array<{
+    agentId: AgentId
+    skillName: SkillName
+    linkPath: AbsolutePath
+    targetPath: AbsolutePath
+  }>
+}
+
+/**
+ * Per-slot result from broken-symlink cleanup, echoing the reviewed row identity.
+ * @example { agentId: 'codex', skillName: 'task', linkPath: '/Users/me/.codex/skills/task', outcome: 'unlinked' }
+ * @example { agentId: 'codex', skillName: 'task', linkPath: '/Users/me/.codex/skills/task', outcome: 'error', error: { message: 'Plan changed' } }
+ */
+export type ClearBrokenSymlinkSlotItemResult =
+  | {
+      agentId: AgentId
+      skillName: SkillName
+      linkPath: AbsolutePath
+      outcome: 'unlinked'
+    }
+  | {
+      agentId: AgentId
+      skillName: SkillName
+      linkPath: AbsolutePath
+      outcome: 'error'
+      error: { message: string; code?: string }
+    }
+
+/**
+ * Broken-slot cleanup result; item order matches the requested slot list.
+ * @example { items: [{ agentId: 'codex', skillName: 'task', linkPath: '/Users/me/.codex/skills/task', outcome: 'unlinked' }] }
+ */
+export interface ClearBrokenSymlinkSlotsResult {
+  /** Per-slot outcome, index-aligned with the input `items` array. */
+  items: ClearBrokenSymlinkSlotItemResult[]
 }
 
 /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -53,7 +53,7 @@ export interface FilesystemEntryIdentity {
   ino: number
   /** Entry size from fs.Stats, used as fallback identity on filesystems without ino. */
   size: number
-  /** Metadata change timestamp from fs.Stats, used as fallback identity. */
+  /** Metadata change timestamp from fs.Stats; strict gates also compare it to reject reused-inode same-path replacements. */
   ctimeMs: number
   /** Modification timestamp from fs.Stats, used as fallback identity. */
   mtimeMs: number

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -860,13 +860,17 @@ export interface BulkDeleteResult {
 
 /**
  * IPC argument for `skills:clearOrphanSymlinks` — remove reviewed dangling agent links without touching source skills.
- * @example { items: [{ skillName: 'abandoned', agents: [{ agentId: 'codex', linkPath: '/Users/me/.codex/skills/abandoned' }] }] }
+ * @example { items: [{ skillName: 'abandoned', agents: [{ agentId: 'codex', linkPath: '/Users/me/.codex/skills/abandoned', targetPath: '/Users/me/.agents/skills/abandoned' }] }] }
  */
 export interface ClearOrphanSymlinksOptions {
   /** Orphan records selected in the Symlink Health cleanup dialog. */
   items: Array<{
     skillName: SkillName
-    agents: Array<{ agentId: AgentId; linkPath: AbsolutePath }>
+    agents: Array<{
+      agentId: AgentId
+      linkPath: AbsolutePath
+      targetPath: AbsolutePath
+    }>
   }>
 }
 

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -2,7 +2,7 @@
 
 > Skills Desktop is a free, open-source macOS Electron app that visualizes AI agent skill symlinks. It helps developers manage and monitor skills installed via `npx skills add` across 21 AI agents including Claude Code, Cursor, Gemini CLI, and more.
 
-Skills Desktop scans your `~/.agents/skills/` directory and displays the symlink status (valid, broken, or missing) for each skill across all supported AI agents. Built with Electron, React 19, Redux Toolkit, and TypeScript.
+Skills Desktop scans your `~/.agents/skills/` directory and displays the symlink status (valid, broken, inaccessible, or missing) for each skill across all supported AI agents. Built with Electron, React 19, Redux Toolkit, and TypeScript.
 
 ## Download
 
@@ -12,7 +12,7 @@ Skills Desktop scans your `~/.agents/skills/` directory and displays the symlink
 
 ## Core Features
 
-- **Skill Visualization**: Real-time symlink status monitoring with valid/broken/missing indicators.
+- **Skill Visualization**: Real-time symlink status monitoring with valid/broken/inaccessible/missing indicators.
 - **21 AI Agents Support**: Claude Code, Cursor, Gemini CLI, OpenAI Codex, GitHub Copilot, Cline, Roo Code, Amp, Goose, Aider, Windsurf, Zed, Continue, PearAI, Void, Melty, Trae, Junie, Kilo Code, Blackbox AI, and OpenCode.
 - **Centralized Skills Hub**: All skills stored in `~/.agents/skills/` and symlinked to each agent directory.
 - **Native macOS Experience**: Electron-based desktop app with system integration.

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -1,6 +1,6 @@
 # Skills Desktop
 
-> Skills Desktop is a free, open-source macOS Electron app that visualizes AI agent skill symlinks. It helps developers manage and monitor skills installed via `npx skills add` across 21 AI agents including Claude Code, Cursor, Gemini CLI, and more.
+> Skills Desktop is a free, open-source macOS Electron app that visualizes AI agent skill symlinks. It helps developers manage and monitor skills installed via `npx skills add` across 54 AI agents including Claude Code, Cursor, Gemini CLI, and more.
 
 Skills Desktop scans your `~/.agents/skills/` directory and displays the symlink status (valid, broken, inaccessible, or missing) for each skill across all supported AI agents. Built with Electron, React 19, Redux Toolkit, and TypeScript.
 

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -13,10 +13,10 @@ Skills Desktop scans your `~/.agents/skills/` directory and displays the symlink
 ## Core Features
 
 - **Skill Visualization**: Real-time symlink status monitoring with valid/broken/inaccessible/missing indicators.
-- **21 AI Agents Support**: Claude Code, Cursor, Gemini CLI, OpenAI Codex, GitHub Copilot, Cline, Roo Code, Amp, Goose, Aider, Windsurf, Zed, Continue, PearAI, Void, Melty, Trae, Junie, Kilo Code, Blackbox AI, and OpenCode.
+- **54 AI Agents Support**: Claude Code, Cursor, Gemini CLI, OpenAI Codex, GitHub Copilot, Cline, Roo Code, Amp, Goose, Aider, Windsurf, Zed, Continue, PearAI, Void, Melty, Trae, Junie, Kilo Code, Blackbox AI, OpenCode, and more.
 - **Centralized Skills Hub**: All skills stored in `~/.agents/skills/` and symlinked to each agent directory.
 - **Native macOS Experience**: Electron-based desktop app with system integration.
-- **26 Theme Presets**: 12 OKLCH color themes with light/dark modes.
+- **27 Theme Presets**: 44 visual themes across OKLCH color hues, pure neutrals, and shadcn/ui tinted neutrals.
 
 ## Technical Details
 

--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -17,12 +17,12 @@ export const metadata: Metadata = {
   metadataBase: new URL('https://skills-desktop.vercel.app'),
   title: 'Skills Desktop - AI Agent Skills Manager',
   description:
-    'Visualize and manage installed Skills across 21 AI agents. See symlink status, discover skills, and keep your AI tools in sync.',
+    'Visualize and manage installed Skills across 54 AI agents. See symlink status, discover skills, and keep your AI tools in sync.',
   keywords: ['AI', 'Claude Code', 'Skills', 'Desktop App', 'macOS', 'Electron'],
   authors: [{ name: 'Laststance.io' }],
   openGraph: {
     title: 'Skills Desktop - AI Agent Skills Manager',
-    description: 'Visualize and manage installed Skills across 21 AI agents',
+    description: 'Visualize and manage installed Skills across 54 AI agents',
     url: 'https://skills-desktop.vercel.app',
     siteName: 'Skills Desktop',
     images: [
@@ -39,7 +39,7 @@ export const metadata: Metadata = {
   twitter: {
     card: 'summary_large_image',
     title: 'Skills Desktop - AI Agent Skills Manager',
-    description: 'Visualize and manage installed Skills across 21 AI agents',
+    description: 'Visualize and manage installed Skills across 54 AI agents',
     images: ['/og-image.png'],
   },
 }

--- a/website/src/components/Features.tsx
+++ b/website/src/components/Features.tsx
@@ -13,7 +13,7 @@ const features = [
     icon: Link2,
     title: 'Symlink Status at a Glance',
     description:
-      'See valid, broken, or missing symlinks for each skill across all your AI agents instantly.',
+      'See valid, broken, inaccessible, or missing symlinks for each skill across all your AI agents instantly.',
   },
   {
     icon: Palette,

--- a/website/src/components/Features.tsx
+++ b/website/src/components/Features.tsx
@@ -5,9 +5,9 @@ import { Monitor, Link2, Palette, Bot, FolderSync, Eye } from 'lucide-react'
 const features = [
   {
     icon: Bot,
-    title: '21 AI Agents Supported',
+    title: '54 AI Agents Supported',
     description:
-      'Claude Code, Cursor, Gemini CLI, OpenAI Codex, GitHub Copilot, and 16 more agents auto-detected.',
+      'Claude Code, Cursor, Gemini CLI, OpenAI Codex, GitHub Copilot, and dozens more agents auto-detected.',
   },
   {
     icon: Link2,
@@ -17,9 +17,9 @@ const features = [
   },
   {
     icon: Palette,
-    title: '26 Theme Presets',
+    title: '27 Theme Presets',
     description:
-      '12 OKLCH color themes with light/dark modes, plus shadcn/ui neutral themes for your preference.',
+      '44 visual themes across OKLCH color hues, pure neutrals, and shadcn/ui tinted neutrals.',
   },
   {
     icon: FolderSync,

--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -24,7 +24,7 @@ export function Hero() {
 
           {/* Subtitle */}
           <p className="mb-10 max-w-2xl text-lg text-muted-foreground lg:text-xl">
-            Visualize installed Skills, check symlink status across 21 AI
+            Visualize installed Skills, check symlink status across 54 AI
             agents, and keep your development tools perfectly synchronized.
           </p>
 


### PR DESCRIPTION
## Summary
- Fix symlink cleanup identity handling so valid symlinks that realpath into `~/.agents/skills/...` are not shown as broken `/Users/.agents/...` entries.
- Harden destructive delete/unlink flows with reviewed filesystem identities, rollback preservation, IPC schema checks, and recovery-path coverage.
- Add focused regression and Electron E2E coverage for symlinked config cleanup, delete, unlink, undo, and the design-review polish around cleanup path evidence.

## Validation
- `pnpm validate` ✅
- `pnpm test:e2e` ✅
- gstack-review subagent review: 3/3 clean ✅

## Notes
- Latest commit: `b5eb9b5 fix: polish design review findings`
- Review follow-ups are recorded in `TODOS.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * シンボリックリンク健全性ダッシュボードウィジェットに「クリーンアップ」機能を追加
  * 孤児スキルと破壊されたシンボリックリンクスロットの自動クリーンアップ対応
  * シンボリックリンク状態に「アクセス不可」ステータスを追加

* **Bug Fixes**
  * スキル削除・リンク解除時にファイルシステム同一性を検証し、操作の安全性を向上

* **Documentation**
  * Electron 42対応、pnpm最小バージョンを10以上に更新
  * シンボリックリンク仕様をアクセス不可状態に対応

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/skills-desktop/pull/185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->