### PR TITLE
docs: document the customizable dashboard in README and SPEC

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Skills Desktop provides a GUI to manage and monitor skills installed via [`npx s
 
 - **54 AI Agents Supported** - Auto-detects Claude Code, Cursor, Codex, Gemini CLI, and more
 - **Symlink Status Visualization** - Valid (✓), Broken (◐), Inaccessible (!), Missing (○) indicators
+- **Customizable Dashboard** - Widget-based home view with skill stats, symlink health, agent coverage, bookmarks, and quick actions — drag, resize, and arrange across multiple pages
 - **44 Themes** - 34 OKLCH color themes (17 hues × light/dark) + 2 pure neutral + 8 tinted neutral
 - **Auto Update** - Automatic updates via GitHub Releases
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -126,6 +126,36 @@ Agent definitions are synced with [vercel-labs/skills CLI](https://github.com/ve
 - [x] Validate symlink integrity (valid/broken/inaccessible/missing)
 - [x] Local skills support with visual distinction
 
+### Dashboard
+
+When the **Installed** tab is open and no skill is selected, the detail panel renders a customizable, widget-based dashboard (`DashboardCanvas`) as the home view. It is not a separate tab — the app has only `installed` and `marketplace` tabs, and the dashboard fills the Installed tab's no-selection state. Layout is a draggable, resizable grid persisted across launches via the Redux `dashboard` slice.
+
+- [x] Widget grid with drag-to-move and resize (edit mode via `DashboardEditToolbar`)
+- [x] Multiple dashboard pages with tab navigation (`DashboardPageTabs`)
+- [x] Widget picker with live preview before adding (`WidgetPicker`)
+- [x] Keyboard shortcuts for edit-mode actions (`useDashboardKeyboardShortcuts`)
+- [x] Layout and page state persisted between sessions
+
+**Built-in widgets:**
+
+| Widget         | Shows                                                                                  |
+| -------------- | -------------------------------------------------------------------------------------- |
+| Welcome        | Dismissible introduction card shown on first launch                                    |
+| Skill Stats    | Totals for skills, linked skills, and agents at a glance                               |
+| Symlink Health | Valid vs. broken symlinks across all agents; "Scan issues" opens orphan/broken cleanup |
+| Agent Coverage | Which agents have which skills — quick matrix view                                     |
+| Bookmarks      | Saved skills from the marketplace                                                      |
+| Trending       | Popular marketplace skills right now                                                   |
+| What's New     | Recently added or updated marketplace skills                                           |
+| Quick Actions  | Frequent actions: sync, refresh, open marketplace                                      |
+
+**Experimental widgets** — hidden from the picker unless `FEATURE_FLAGS.ENABLE_DASHBOARD_EXPERIMENTAL` is enabled:
+
+| Widget            | Shows                                                |
+| ----------------- | ---------------------------------------------------- |
+| Agent Heatmap     | Symlink density per agent visualized as a heatmap    |
+| Activity Timeline | Recent add/remove/sync events in chronological order |
+
 ### Skills Marketplace
 
 GUI wrapper for `npx skills` CLI commands:


### PR DESCRIPTION
## Why

v0.21.0 shipped the widget-based **Dashboard**, but it was missing from the user-facing docs. README's Features list and SPEC's `## Features` section had no entry for it (only incidental mentions via Symlink Health cleanup).

## What

- **README.md** — add a `Customizable Dashboard` bullet to the Features list (qualitative; representative widgets + drag/resize/multi-page).
- **SPEC.md** — add a dedicated `### Dashboard` subsection under `## Features`:
  - Clarifies it is the **Installed tab's no-selection home view**, not a separate tab (tabs are only `installed` / `marketplace`).
  - Documents **8 built-in widgets** + **2 experimental widgets** gated behind `FEATURE_FLAGS.ENABLE_DASHBOARD_EXPERIMENTAL`.
  - Notes multi-page edit mode, `WidgetPicker` live preview, keyboard shortcuts, and Redux-persisted layout.

## Verification

- Grounded in `WIDGET_REGISTRY` (registry.ts) and `DetailPanel.tsx` (renders `<DashboardCanvas />` unconditionally — no master flag gates the dashboard itself).
- Docs-only change; no code/behavior touched. `eslint` targets `.ts/.tsx` only, so the `validate` gate is not affected. prettier (pre-commit) reformatted the SPEC table.
- Verified all existing numeric claims stay accurate (54 agents, 44 themes, 13 universal, Electron 42, CLI 1.5.5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * カスタマイズ可能なダッシュボード機能の仕様を追加しました
  * 複数ページ対応、ドラッグ/リサイズ可能なウィジェットベース設計
  * スキル統計、ブックマーク等の複数ウィジェットと編集ツール、キーボードショートカット対応

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/skills-desktop/pull/186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->