### PR TITLE
refactor(test): apply AAA + behavior-named specs across test suite

### DIFF
--- a/e2e/spec/agent-linked-symlinks.e2e.ts
+++ b/e2e/spec/agent-linked-symlinks.e2e.ts
@@ -126,6 +126,8 @@ test('agent-only valid symlinks appear as linked skills in the selected agent vi
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange — stage an external skill dir whose frontmatter name differs from
+  // its folder name, then symlink it into the codex agent's skills dir.
   await waitForStoreReady(appWindow)
 
   const externalSkillPath = join(isolatedHome, 'external-skills', LINK_NAME)
@@ -146,14 +148,17 @@ test('agent-only valid symlinks appear as linked skills in the selected agent vi
   )
   symlinkSync(externalSkillPath, codexLinkPath)
 
+  // Arrange — setup sanity that the staged entry is a real symlink on disk.
   expect(lstatSync(codexLinkPath).isSymbolicLink()).toBe(true)
 
+  // Act — rescan from disk and select the codex agent so the linked skill surfaces.
   await refreshSkillsState(appWindow)
   await dispatchAction(appWindow, {
     type: 'ui/selectAgent',
     payload: AGENT_ID,
   })
 
+  // Assert — the scan surfaces the agent-only symlink as a valid linked skill.
   const scanFacts = await getStoreState(
     appWindow,
     selectAgentLinkedSkillFacts,
@@ -175,6 +180,8 @@ test('agent-only valid symlinks appear as linked skills in the selected agent vi
     },
   })
 
+  // Assert — the folder name labels the heading, and the frontmatter name
+  // never wins (no heading rendered under the frontmatter alias).
   await expect(
     appWindow.getByRole('heading', {
       name: new RegExp(`Linked skill ${LINK_NAME}`),

--- a/e2e/spec/bulk-delete.e2e.ts
+++ b/e2e/spec/bulk-delete.e2e.ts
@@ -130,10 +130,11 @@ function deleteItemsFor(isolatedHome: string, skillNames: string[]) {
  * linking behavior — bulk delete only requires the source dir to exist.
  */
 
-test('bulk deleteSkills below BULK_PROGRESS_THRESHOLD (N=9) skips progress events', async ({
+test('bulk delete of fewer than 10 skills shows no progress toast updates', async ({
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange — pre-stage 9 source-backed dummy skills (below the toast threshold).
   const skillNames = preStageDummySkills(isolatedHome, 9, 'bulk-below')
 
   // Wait for renderer to mount + finish initial scan. Pre-staged skills may
@@ -143,12 +144,14 @@ test('bulk deleteSkills below BULK_PROGRESS_THRESHOLD (N=9) skips progress event
 
   await clearIpcEvents(appWindow)
 
+  // Act — bulk-delete all 9 staged skills via the IPC handler.
   const result = await appWindow.evaluate(
     async (items: DeleteSkillItem[]) =>
       window.electron.skills.deleteSkills({ items }),
     deleteItemsFor(isolatedHome, skillNames),
   )
 
+  // Assert — every item deleted, no progress events, and trash entries written.
   expect(result.items).toHaveLength(9)
   for (const item of result.items) {
     expect(item.outcome).toBe('deleted')
@@ -187,22 +190,25 @@ test('bulk deleteSkills below BULK_PROGRESS_THRESHOLD (N=9) skips progress event
   expect(sampleManifest.kind).toBe('source-backed')
 })
 
-test('bulk deleteSkills at BULK_PROGRESS_THRESHOLD (N=10) emits sequential progress events', async ({
+test('bulk delete of exactly 10 skills reports progress 1-of-10 through 10-of-10 in order', async ({
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange — pre-stage exactly 10 source-backed dummy skills (at the threshold).
   const skillNames = preStageDummySkills(isolatedHome, 10, 'bulk-at')
 
   await waitForInitialScan(appWindow)
 
   await clearIpcEvents(appWindow)
 
+  // Act — bulk-delete all 10 staged skills via the IPC handler.
   const result = await appWindow.evaluate(
     async (items: DeleteSkillItem[]) =>
       window.electron.skills.deleteSkills({ items }),
     deleteItemsFor(isolatedHome, skillNames),
   )
 
+  // Assert — every item deleted in order, with 10 sequential progress ticks.
   expect(result.items).toHaveLength(10)
   for (const [index, item] of result.items.entries()) {
     expect(item.outcome).toBe('deleted')
@@ -254,10 +260,12 @@ test('bulk deleteSkills at BULK_PROGRESS_THRESHOLD (N=10) emits sequential progr
  *      drop the failing item's tick and the progress stream would only have
  *      9 events for a 10-item batch.
  */
-test('bulk deleteSkills with one missing source returns per-item error and continues the batch', async ({
+test('bulk delete keeps deleting the rest of the batch when one skill is already gone from disk', async ({
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange — stage 10 skills, then wipe a middle one out-of-band so its
+  // delete raises ENOENT mid-batch.
   const skillNames = preStageDummySkills(isolatedHome, 10, 'bulk-partial')
   // Pick a middle index so a regression that breaks AFTER the first error
   // still trips the assertion. Index 0 or N-1 would not catch a partial loop
@@ -274,12 +282,14 @@ test('bulk deleteSkills with one missing source returns per-item error and conti
 
   await clearIpcEvents(appWindow)
 
+  // Act — bulk-delete the 10 items, one of which now points at a missing source.
   const result = await appWindow.evaluate(
     async (items: DeleteSkillItem[]) =>
       window.electron.skills.deleteSkills({ items }),
     deleteItems,
   )
 
+  // Assert — 10 result rows: one error at the failing index, nine deleted.
   expect(result.items).toHaveLength(10)
 
   // Per-item assertions — exactly one error row at the expected index, every
@@ -329,7 +339,7 @@ test('bulk deleteSkills with one missing source returns per-item error and conti
   ).toBe(false)
 })
 
-test('bulk deleteSkills uses reviewed skillPath when metadata name differs from folder basename', async ({
+test('bulk delete removes the reviewed folder, not the decoy that shares the skill metadata name', async ({
   appWindow,
   isolatedHome,
 }) => {

--- a/e2e/spec/copy.e2e.ts
+++ b/e2e/spec/copy.e2e.ts
@@ -77,10 +77,12 @@ test.beforeEach(() => {
   )
 })
 
-test('copyToAgents replicates azure-ai to a missing target agent', async ({
+test('copying azure-ai to an unlinked agent makes that agent show it as installed', async ({
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange — wait for the renderer's initial fetch, then locate azure-ai and
+  // an agent that does not yet have it linked.
   // Wait for the renderer's initial fetch — both skills and agents must land
   // before the spec can pick a target. Generous timeout because the fetch
   // races with skillScanner walking the snapshot HOME.
@@ -126,6 +128,7 @@ test('copyToAgents replicates azure-ai to a missing target agent', async ({
 
   await clearIpcEvents(appWindow)
 
+  // Act — copy azure-ai into the unlinked target agent.
   const ipcResult = await appWindow.evaluate(
     async (args: {
       skillName: string
@@ -139,6 +142,8 @@ test('copyToAgents replicates azure-ai to a missing target agent', async ({
     },
   )
 
+  // Assert — IPC reports one successful copy, the target dir exists on disk,
+  // the refreshed store reads the link as valid, and no progress events fired.
   expect(ipcResult.success).toBe(true)
   expect(ipcResult.copied).toBe(1)
   expect(ipcResult.failures).toEqual([])
@@ -205,10 +210,12 @@ test('copyToAgents replicates azure-ai to a missing target agent', async ({
  * target instead of a symlink, and the test would catch it before the broken
  * "deleting the target deletes the source" UX shipped.
  */
-test('copyToAgents replicates a symlink source verbatim (local-copy variant)', async ({
+test('copying from an agent that has azure-ai linked re-links it without duplicating the files', async ({
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange — wait for the initial scan, then find a valid linked agent (the
+  // symlink source) and an unlinked agent (the target).
   await waitForInitialScan(appWindow)
 
   const expectedSourceDir = join(
@@ -270,6 +277,7 @@ test('copyToAgents replicates a symlink source verbatim (local-copy variant)', a
 
   await clearIpcEvents(appWindow)
 
+  // Act — copy using the source agent's symlink as the source path.
   const ipcResult = await appWindow.evaluate(
     async (args: {
       skillName: string
@@ -283,6 +291,8 @@ test('copyToAgents replicates a symlink source verbatim (local-copy variant)', a
     },
   )
 
+  // Assert — IPC reports one copy, the target is itself a symlink (not a copied
+  // directory) that resolves back to the universal source, and the store reads valid.
   expect(ipcResult.success).toBe(true)
   expect(ipcResult.copied).toBe(1)
   expect(ipcResult.failures).toEqual([])
@@ -329,10 +339,11 @@ test('copyToAgents replicates a symlink source verbatim (local-copy variant)', a
  * Source is a fresh dummy dir created procedurally so the snapshot's azure-*
  * link topology is irrelevant to the assertion.
  */
-test('copyToAgents reports per-target Already exists and continues with the rest (no rollback)', async ({
+test('copying to one occupied and one free agent skips the occupied one and still copies to the free one', async ({
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange — create a fresh source skill plus two distinct target agents.
   // Brand-new skill name so no agent in the snapshot has it linked. Avoids
   // dependency on global-setup's --global link set.
   const skillName = 'copy-partial'
@@ -395,6 +406,7 @@ test('copyToAgents reports per-target Already exists and continues with the rest
   const sentinelContent = `# pre-existing\nDO NOT OVERWRITE — collision sentinel.\n`
   writeFileSync(join(occupiedSkillDir, 'SKILL.md'), sentinelContent)
 
+  // Act — copy to both the occupied and the free agent in one call.
   const ipcResult = await appWindow.evaluate(
     async (args: {
       skillName: string
@@ -408,6 +420,8 @@ test('copyToAgents reports per-target Already exists and continues with the rest
     },
   )
 
+  // Assert — partial success: the occupied target is reported as Already
+  // exists with its sentinel intact, while the free target receives the source.
   expect(ipcResult.success).toBe(false)
   expect(ipcResult.copied).toBe(1)
   expect(ipcResult.failures).toEqual([
@@ -451,9 +465,11 @@ test('copyToAgents reports per-target Already exists and continues with the rest
  * and the primary button must fire the `copyToAgents` thunk. Filesystem
  * existence is the simplest proxy that the whole click chain reached `fs.cp`.
  */
-test('copyToAgents UI-driven modal copies via dispatch + checkbox click', async ({
+test('the Copy to Agents modal copies a skill to the agent whose checkbox is ticked', async ({
   appWindow,
 }) => {
+  // Arrange — wait for the scan, then locate a valid source agent plus an
+  // unlinked target agent (with its display name for the checkbox label).
   await waitForInitialScan(appWindow)
 
   // Locate a valid source agent (provides linkPath the modal needs) plus a
@@ -498,13 +514,14 @@ test('copyToAgents UI-driven modal copies via dispatch + checkbox click', async 
   }
   const targetLinkPath = modalSelection.targetLinkPath
 
-  // Pre-condition the FS state. If a snapshot reset ever leaves stale bytes
-  // at this path, the post-click existence check would be a false positive
-  // — a "test passed" outcome that doesn't prove the click chain reached
-  // `fs.cp` at all. Asserting non-existence up front converts that mode
+  // Arrange — pre-condition the FS state. If a snapshot reset ever leaves stale
+  // bytes at this path, the post-click existence check would be a false
+  // positive — a "test passed" outcome that doesn't prove the click chain
+  // reached `fs.cp` at all. Asserting non-existence up front converts that mode
   // into a loud failure right at the boundary.
   expect(existsSync(targetLinkPath)).toBe(false)
 
+  // Act — drive Redux to open the modal, tick the target checkbox, click Copy.
   // Drive Redux. `selectedAgentId` is set first because the modal's
   // `targetAgents` memo depends on it; toggling order would briefly render
   // an empty list. Action types are inlined string literals — these
@@ -548,6 +565,7 @@ test('copyToAgents UI-driven modal copies via dispatch + checkbox click', async 
     .getByRole('button', { name: /^Copy to \d+ agent\(s\)$/ })
     .click()
 
+  // Assert — the copied entry appears at the target link path.
   // Poll the FS directly. `state.skills.copying` flips false on both initial
   // mount AND fulfillment, so a Redux poll can pass before the click chain
   // ever reaches `fs.cp` — masking a regression where the dispatch never

--- a/e2e/spec/delete.e2e.ts
+++ b/e2e/spec/delete.e2e.ts
@@ -192,10 +192,11 @@ function skipWhenAzureSnapshotUnavailable(isolatedHome: string): void {
   )
 }
 
-test('deleteSkill moves source-backed skill into trash and unlinks every agent symlink', async ({
+test('deleting a source-backed skill removes its source and unlinks it from every agent', async ({
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange — wait for the scan and snapshot azure-ai's source path and links.
   skipWhenAzureSnapshotUnavailable(isolatedHome)
   await waitForInitialScan(appWindow)
 
@@ -217,12 +218,15 @@ test('deleteSkill moves source-backed skill into trash and unlinks every agent s
     'expected at least one valid agent symlink to exercise the cascade',
   ).toBeGreaterThan(0)
 
+  // Act — delete the source-backed azure-ai skill.
   const ipcResult = await appWindow.evaluate(
     async (payload: DeleteSkillPayload) =>
       window.electron.skills.deleteSkill(payload),
     deleteSkillPayload(isolatedHome, AZURE_AI_NAME),
   )
 
+  // Assert — IPC reports the cascade, source + every symlink gone, a single
+  // source-backed trash entry written, and the store drops azure-ai on refresh.
   expect(ipcResult.success).toBe(true)
   expect(ipcResult.symlinksRemoved).toBe(initial.validSymlinks.length)
   // cascadeAgents order follows the AGENTS iteration in main, not the
@@ -271,10 +275,11 @@ test('deleteSkill moves source-backed skill into trash and unlinks every agent s
   expect(afterDelete).toBe(false)
 })
 
-test('restoreDeletedSkill recovers a source-backed deletion within the undo window', async ({
+test('undoing a delete within the undo window brings the skill and its agent links back', async ({
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange — snapshot azure-ai, then delete it so there is something to undo.
   skipWhenAzureSnapshotUnavailable(isolatedHome)
   await waitForInitialScan(appWindow)
 
@@ -307,12 +312,15 @@ test('restoreDeletedSkill recovers a source-backed deletion within the undo wind
   expect(trashEntries).toHaveLength(1)
   const tombstoneIdValue = trashEntries[0]
 
+  // Act — restore the deleted skill from its tombstone.
   const restoreResult = await appWindow.evaluate(
     async (id: string) =>
       window.electron.skills.restoreDeletedSkill({ tombstoneId: id }),
     tombstoneIdValue,
   )
 
+  // Assert — IPC reports a full restore, the source + symlinks are recreated,
+  // the tombstone is cleaned up, and the store shows azure-ai with its links again.
   expect(restoreResult.outcome).toBe('restored')
   if (restoreResult.outcome === 'restored') {
     expect(restoreResult.symlinksRestored).toBe(initial.validSymlinks.length)
@@ -381,10 +389,12 @@ interface LocalOnlyManifest {
  * symlink rows, so a post-delete `state.skills.items` lookup is the canonical
  * way to confirm the entry vanished — same shape as the source-backed test.
  */
-test('deleteSkill moves a local-only skill into trash with kind="local-only" manifest', async ({
+test('deleting a skill that lives only inside an agent folder trashes it as a local-only entry', async ({
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange — stage a skill that exists ONLY under codex's agent dir, with no
+  // universal source dir backing it.
   const skillName = 'local-only-skill'
   const codexAgentDir = join(isolatedHome, '.codex', 'skills', skillName)
   mkdirSync(codexAgentDir, { recursive: true })
@@ -403,12 +413,15 @@ test('deleteSkill moves a local-only skill into trash with kind="local-only" man
 
   await waitForInitialScan(appWindow)
 
+  // Act — delete the local-only skill via the codex agent folder path.
   const ipcResult = await appWindow.evaluate(
     async (payload: DeleteSkillPayload) =>
       window.electron.skills.deleteSkill(payload),
     deleteSkillPayload(isolatedHome, skillName, codexAgentDir),
   )
 
+  // Assert — codex folder moved to trash under local-copies/ with a
+  // kind="local-only" manifest (no source/ subdir).
   expect(ipcResult.success).toBe(true)
   // The local-only return reuses `symlinksRemoved` to mean "agent folders
   // moved" — see trashService.ts:660-664. One agent staged, so 1.
@@ -458,10 +471,12 @@ test('deleteSkill moves a local-only skill into trash with kind="local-only" man
  *   3. NO trash entry, NO manifest, NO TTL timer — the source is gone, so
  *      "undo" would only restore broken links.
  */
-test('clearOrphanSymlinks removes reviewed broken symlinks with no trash entry', async ({
+test('cleaning up a broken orphan symlink removes the dangling link without creating an undo entry', async ({
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange — stage a dangling symlink under codex pointing at a source that
+  // never exists, so the orphan scanner picks it up.
   const skillName = 'orphan-only-fixture'
   // Stage a dangling symlink under codex (chosen for the same QA Safety
   // reason as the local-only test above — avoids touching .claude/.cursor).
@@ -479,6 +494,7 @@ test('clearOrphanSymlinks removes reviewed broken symlinks with no trash entry',
 
   await waitForInitialScan(appWindow)
 
+  // Act — clear the reviewed orphan symlink for codex.
   const ipcResult = await appWindow.evaluate(
     async (payload: {
       items: Array<{
@@ -502,6 +518,8 @@ test('clearOrphanSymlinks removes reviewed broken symlinks with no trash entry',
     },
   )
 
+  // Assert — IPC reports orphan-cleared, the dangling link is gone, NO trash
+  // entry was written, and the orphan row disappears from the store on rescan.
   expect(ipcResult.items).toEqual([
     {
       skillName,
@@ -567,10 +585,11 @@ test('clearOrphanSymlinks removes reviewed broken symlinks with no trash entry',
  * macOS CI variance. Happy path returns as soon as `existsSync(entryDir)`
  * flips false (typically within ~100ms of UNDO_WINDOW_MS firing).
  */
-test('source-backed delete entry is auto-evicted after UNDO_WINDOW_MS', async ({
+test('a deleted skill becomes permanently unrecoverable once the undo window elapses', async ({
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange — snapshot azure-ai and allow extra wall-time for the real timer.
   skipWhenAzureSnapshotUnavailable(isolatedHome)
   test.setTimeout(45_000)
 
@@ -586,6 +605,7 @@ test('source-backed delete entry is auto-evicted after UNDO_WINDOW_MS', async ({
   const initial = await getStoreState(appWindow, azureSnapshotSelector)
   expect(initial.hasAzure).toBe(true)
 
+  // Act — delete azure-ai, then wait for the undo window to elapse.
   const deleteResult = await appWindow.evaluate(
     async (payload: DeleteSkillPayload) =>
       window.electron.skills.deleteSkill(payload),
@@ -609,6 +629,8 @@ test('source-backed delete entry is auto-evicted after UNDO_WINDOW_MS', async ({
   expect(existsSync(entryDir)).toBe(true)
   expect(existsSync(expectedSourcePath)).toBe(false)
 
+  // Assert — after the undo window the trash entry is auto-evicted and the
+  // source stays gone (eviction deletes the staged copy, never resurrects it).
   // KEY assertion — the entire entry is gone. A bounded poll instead of a
   // fixed sleep: the happy path returns as soon as eviction lands (under
   // load CI macOS runners can take an extra few hundred ms after the timer

--- a/e2e/spec/folder-actions.e2e.ts
+++ b/e2e/spec/folder-actions.e2e.ts
@@ -36,16 +36,19 @@ test.beforeEach(() => {
   )
 })
 
-test('SourceCard kebab exposes Reveal in Finder + Open in Terminal', async ({
+test('the source folder menu offers Reveal in Finder and Open in Terminal', async ({
   appWindow,
 }) => {
+  // Arrange — wait for the initial scan so the source card renders.
   await waitForInitialScan(appWindow)
 
+  // Act — open the source folder actions menu via its kebab trigger.
   // Single kebab-only trigger; right-click on the card body opens the same
   // menu but is covered separately by the unit-level component story. Here
   // we exercise the explicit click path the user typically takes.
   await appWindow.getByLabel('Source folder actions').click()
 
+  // Assert — both folder action items are visible in the menu.
   await expect(
     appWindow.getByRole('menuitem', { name: 'Reveal in Finder' }),
   ).toBeVisible()
@@ -54,18 +57,19 @@ test('SourceCard kebab exposes Reveal in Finder + Open in Terminal', async ({
   ).toBeVisible()
 })
 
-test('AgentItem right-click menu exposes folder actions above destructive items', async ({
+test('right-clicking an agent shows the safe folder actions above the destructive Cleanup and Delete items', async ({
   appWindow,
   isolatedHome,
 }) => {
-  // Stage `.cursor/skills` so the Cursor agent reports `exists: true` —
-  // `handleContextMenu` short-circuits when the agent dir is absent, so the
-  // menu would never open without this. Single mkdir is enough; we never
+  // Arrange — stage `.cursor/skills` so the Cursor agent reports `exists: true`
+  // (`handleContextMenu` short-circuits when the agent dir is absent, so the
+  // menu would never open without this). Single mkdir is enough; we never
   // write any skill files because the test asserts DOM, not symlink state.
   mkdirSync(join(isolatedHome, '.cursor', 'skills'), { recursive: true })
 
   await waitForInitialScan(appWindow)
 
+  // Act — right-click the Cursor row to open its context menu.
   // The Cursor row's aria-label is "Filter skills by Cursor (N linked, M local)";
   // the prefix is stable across snapshot churn so we anchor on it. Right-click
   // is the documented gesture for opening the menu — left-click only filters.
@@ -74,6 +78,8 @@ test('AgentItem right-click menu exposes folder actions above destructive items'
     .first()
     .click({ button: 'right' })
 
+  // Assert — all four items are visible and the safe folder actions sit above
+  // Cleanup/Delete on the y-axis.
   // Folder actions render above Cleanup/Delete by design (see AgentItem.tsx
   // comment on line 158-159) — keyboard nav (Down then Enter) lands on a
   // safe action first. Asserting both the new and existing items pins the
@@ -114,6 +120,7 @@ test('Settings → Preferred terminal picker lists all 8 IDs and reveals custom 
   appWindow,
   electronApp,
 }) => {
+  // Arrange — open Settings in its own window and surface the terminal picker.
   await waitForInitialScan(appWindow)
 
   // Opening Settings spawns a second BrowserWindow. Capture the window event
@@ -127,6 +134,7 @@ test('Settings → Preferred terminal picker lists all 8 IDs and reveals custom 
   const picker = settingsWindow.getByLabel('Preferred terminal')
   await picker.waitFor({ state: 'visible' })
 
+  // Assert — the picker lists all 8 terminal IDs in order.
   // Pin the option list against `TERMINAL_APP_IDS` order. A regression that
   // appended/removed an ID without updating the picker would land here, not
   // in production where the user notices a missing terminal a week later.
@@ -144,6 +152,7 @@ test('Settings → Preferred terminal picker lists all 8 IDs and reveals custom 
     'custom',
   ])
 
+  // Act — choose the 'custom' option.
   // The custom-name <input> is rendered conditionally on
   // `settings.preferredTerminal === 'custom'` (General.tsx:163). The
   // load-bearing assertion is that selecting 'custom' makes the input
@@ -151,6 +160,8 @@ test('Settings → Preferred terminal picker lists all 8 IDs and reveals custom 
   // persisted into the snapshot HOME from a prior dev session, which
   // would make a "starts hidden" precondition flaky.
   await picker.selectOption('custom')
+
+  // Assert — the custom terminal name input becomes visible.
   await expect(
     settingsWindow.getByLabel('Custom terminal app name'),
   ).toBeVisible()

--- a/e2e/spec/hide-agents.e2e.ts
+++ b/e2e/spec/hide-agents.e2e.ts
@@ -65,11 +65,11 @@ test('toggling Cursor in Settings → Agents hides it from the sidebar and persi
   electronApp,
   isolatedHome,
 }) => {
-  // Pre-stage `~/.cursor/skills` so Cursor reports `exists: true` in the
-  // agent scan. Without this, all 21 agents land in the "21 not installed"
-  // disclosure and the "Show Cursor in sidebar" checkbox renders disabled.
-  // Same recipe as folder-actions.e2e.ts:65 for the AgentItem context-menu
-  // test.
+  // Arrange — pre-stage `~/.cursor/skills` so Cursor reports `exists: true`
+  // in the agent scan. Without this, all 21 agents land in the "21 not
+  // installed" disclosure and the "Show Cursor in sidebar" checkbox renders
+  // disabled. Same recipe as folder-actions.e2e.ts:65 for the AgentItem
+  // context-menu test.
   mkdirSync(join(isolatedHome, '.cursor', 'skills'), { recursive: true })
 
   await waitForInitialScan(appWindow)
@@ -92,8 +92,8 @@ test('toggling Cursor in Settings → Agents hides it from the sidebar and persi
     })
   })
 
-  // Sanity: Cursor is now installed in the main window's store. If this
-  // assertion fails, the rest of the test is meaningless because the
+  // Arrange sanity guard: Cursor is now installed in the main window's store.
+  // If this assertion fails, the rest of the test is meaningless because the
   // Settings checkbox would refer to a "not installed" agent.
   const cursorExistsBefore = await getStoreState(appWindow, (state) => {
     const root = state as {
@@ -103,14 +103,15 @@ test('toggling Cursor in Settings → Agents hides it from the sidebar and persi
   })
   expect(cursorExistsBefore).toBe(true)
 
-  // Initial state: nothing hidden yet — settings.json doesn't even exist
-  // on disk because `saveSettings` only writes after the first mutation.
+  // Arrange sanity guard: nothing hidden yet — settings.json doesn't even
+  // exist on disk because `saveSettings` only writes after the first mutation.
   const hiddenBefore = await getStoreState(appWindow, (state) => {
     const root = state as { settings: { hiddenAgentIds: string[] } }
     return root.settings.hiddenAgentIds
   })
   expect(hiddenBefore).toEqual([])
 
+  // Act — open Settings → Agents and uncheck "Show Cursor in sidebar".
   // Open Settings — spawns a second BrowserWindow. Capture the window
   // event BEFORE clicking; Electron fires it synchronously when the new
   // webContents is created and racing it surfaces as a flaky timeout.
@@ -133,6 +134,8 @@ test('toggling Cursor in Settings → Agents hides it from the sidebar and persi
 
   await cursorCheckbox.click()
 
+  // Assert — the hide propagated through IPC to the main window, the sidebar,
+  // and the on-disk settings.json.
   // Wait for the cross-window IPC roundtrip to land. The sequence is:
   //   1. Settings window: optimistic `setSettings` dispatch.
   //   2. Settings window: `settings:set` IPC fires.
@@ -172,13 +175,14 @@ test('IPC strict-enum boundary rejects unknown agent ids without persisting', as
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange — wait for the initial scan so the IPC surface is live.
   await waitForInitialScan(appWindow)
 
-  // Direct preload-bridge call, bypassing `useUpdateSettings` — that hook
-  // does an optimistic dispatch FIRST and then voids the IPC promise, so
-  // a rejection there would silently leave the renderer with the bad
-  // value. The boundary we're testing is the IPC schema, so we hit it
-  // directly and observe the rejection.
+  // Act — call the preload bridge directly with an unknown agent id,
+  // bypassing `useUpdateSettings` — that hook does an optimistic dispatch
+  // FIRST and then voids the IPC promise, so a rejection there would silently
+  // leave the renderer with the bad value. The boundary we're testing is the
+  // IPC schema, so we hit it directly and observe the rejection.
   const result = await appWindow.evaluate(async () => {
     try {
       // `window.electron.settings.set` is typed loosely in `e2e/types.d.ts`
@@ -195,6 +199,8 @@ test('IPC strict-enum boundary rejects unknown agent ids without persisting', as
     }
   })
 
+  // Assert — the boundary rejected, the error names the channel + validation
+  // marker, the renderer state stayed empty, and nothing was written to disk.
   expect(
     result.rejected,
     'settings.set should reject on unknown agent id',
@@ -224,8 +230,8 @@ test('IPC strict-enum boundary rejects unknown agent ids without persisting', as
 test('stale agent id is filtered from settings.json without dropping siblings', async ({
   isolatedHome,
 }) => {
-  // Pre-stage settings.json with a mix of valid + stale ids and several
-  // sibling fields. Writes must happen BEFORE Electron boots so
+  // Arrange — pre-stage settings.json with a mix of valid + stale ids and
+  // several sibling fields. Writes must happen BEFORE Electron boots so
   // `loadSettings` parses this file on startup. We don't request
   // `electronApp` or `appWindow` from the fixture so Playwright's lazy
   // fixture instantiation skips them — the default fixture would launch
@@ -257,10 +263,12 @@ test('stale agent id is filtered from settings.json without dropping siblings', 
     },
   })
   try {
+    // Act — boot the app so `loadSettings` parses the pre-staged file.
     const appWindow = await electronApp.firstWindow()
     await appWindow.waitForLoadState('domcontentloaded')
     await waitForInitialScan(appWindow)
 
+    // Assert — the stale id is dropped, the valid id survives, siblings intact.
     const settings = await getStoreState(appWindow, (state) => {
       const root = state as {
         settings: {

--- a/e2e/spec/marketplace-install-regression.e2e.ts
+++ b/e2e/spec/marketplace-install-regression.e2e.ts
@@ -9,8 +9,6 @@ import { dirname, join, resolve } from 'node:path'
 
 import { _electron, type Page } from '@playwright/test'
 
-import { SKILLS_CLI_VERSION } from '@/shared/constants'
-
 import { test, expect } from '../fixtures/electron-app'
 import { dispatchAction } from '../helpers/redux'
 
@@ -130,13 +128,14 @@ test('Marketplace Install works when Electron starts with sparse macOS GUI PATH'
   })
 
   try {
+    // Arrange — boot the window and wait until Claude Code is installable.
     const appWindow = await electronApp.firstWindow()
     await appWindow.waitForLoadState('domcontentloaded')
     await waitForClaudeCodeAgent(appWindow)
 
-    // Drive the real Marketplace UI without relying on skills.sh or the real
-    // skills CLI search endpoint. The Install button still goes through IPC,
-    // skillsCliService, and child_process.spawn.
+    // Seed the Marketplace search results without hitting skills.sh. The
+    // Install button below still goes through IPC, skillsCliService, and
+    // child_process.spawn.
     await dispatchAction(appWindow, {
       type: 'marketplace/setMarketplaceSearchQuery',
       payload: 'find-skills',
@@ -151,6 +150,7 @@ test('Marketplace Install works when Electron starts with sparse macOS GUI PATH'
       },
     })
 
+    // Act — open the Marketplace tab and confirm the install through the dialog.
     await appWindow.getByRole('tab', { name: 'Marketplace' }).click()
     await appWindow
       .getByRole('button', { name: 'Install', exact: true })
@@ -161,11 +161,15 @@ test('Marketplace Install works when Electron starts with sparse macOS GUI PATH'
     await expect(dialog.getByText('find-skills')).toBeVisible()
     await dialog.getByRole('button', { name: 'Install', exact: true }).click()
 
+    // Assert — the fake npx ran with the pinned CLI version (SKILLS_CLI_VERSION
+    // is '1.5.5' in src/shared/constants.ts; hardcoded here so this test pins
+    // the literal command rather than computing the expectation from the same
+    // constant the production command builds from) and the installed badge shows.
     await expect
       .poll(() => existsSync(markerPath), { timeout: 10_000 })
       .toBe(true)
     expect(readFileSync(markerPath, 'utf-8')).toContain(
-      `skills@${SKILLS_CLI_VERSION} add vercel-labs/skills`,
+      'skills@1.5.5 add vercel-labs/skills',
     )
     await expect(
       appWindow.getByRole('img', { name: /find-skills is installed/i }),

--- a/e2e/spec/orphan-filter.e2e.ts
+++ b/e2e/spec/orphan-filter.e2e.ts
@@ -70,6 +70,8 @@ test('Orphan filter narrows visible list to orphan skills only', async ({
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange — wait for the initial scan, then stage a dangling symlink under
+  // windsurf so `scanOrphanSymlinks` surfaces a synthetic orphan row.
   await waitForInitialScan(appWindow)
 
   const orphanSkillName = 'orphan-filter-fixture'
@@ -87,11 +89,13 @@ test('Orphan filter narrows visible list to orphan skills only', async ({
   const orphanLinkPath = join(windsurfSkillsDir, orphanSkillName)
   symlinkSync(phantomSourcePath, orphanLinkPath)
 
+  // FS-truth sanity guards (still Arrange): a real symlink with an absent target.
   expect(lstatSync(orphanLinkPath).isSymbolicLink()).toBe(true)
   expect(existsSync(phantomSourcePath)).toBe(false)
 
   await refreshSkillsState(appWindow)
 
+  // Act — select windsurf and switch the visible list to the Orphan filter.
   await dispatchAction(appWindow, {
     type: 'ui/selectAgent',
     payload: 'windsurf',
@@ -101,6 +105,7 @@ test('Orphan filter narrows visible list to orphan skills only', async ({
     payload: 'orphan',
   })
 
+  // Assert — the UI state reflects the chosen agent + filter.
   const uiState = await getStoreState(appWindow, (state) => {
     const root = state as {
       ui: { selectedAgentId: string | null; skillTypeFilter: string }
@@ -113,8 +118,9 @@ test('Orphan filter narrows visible list to orphan skills only', async ({
   expect(uiState.selectedAgentId).toBe('windsurf')
   expect(uiState.skillTypeFilter).toBe('orphan')
 
-  // Single-row equality (not `.toContain`) so a regression that lets
-  // non-orphan rows leak shows the offending names in the failure diff.
+  // Assert — only the staged orphan remains under windsurf. Single-row
+  // equality (not `.toContain`) so a regression that lets non-orphan rows
+  // leak shows the offending names in the failure diff.
   const filteredNames = await getStoreState(
     appWindow,
     filterOrphanNamesByAgent,
@@ -122,15 +128,17 @@ test('Orphan filter narrows visible list to orphan skills only', async ({
   )
   expect(filteredNames).toEqual([orphanSkillName])
 
-  // Negative control — the orphan's only `'broken'` slot is on windsurf,
-  // so the agent-slot gate must drop it under cursor. Without this leg,
-  // a regression that ran the orphan predicate against the unfiltered
-  // skills array would still pass the positive assertion above.
+  // Act — switch to cursor for the negative control.
+  // The orphan's only `'broken'` slot is on windsurf, so the agent-slot gate
+  // must drop it under cursor. Without this leg, a regression that ran the
+  // orphan predicate against the unfiltered skills array would still pass the
+  // positive assertion above.
   await dispatchAction(appWindow, {
     type: 'ui/selectAgent',
     payload: 'cursor',
   })
 
+  // Assert — the orphan does not surface under cursor.
   const filteredNamesUnderCursor = await getStoreState(
     appWindow,
     filterOrphanNamesByAgent,

--- a/e2e/spec/regression.e2e.ts
+++ b/e2e/spec/regression.e2e.ts
@@ -120,26 +120,30 @@ test('selection survives no further than a tab switch or agent switch (regressio
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange
   skipWhenAzureSnapshotUnavailable(isolatedHome)
   await waitForInitialScan(appWindow)
 
-  // Tab-switch leg — toggle one azure-* skill into the selection, flip the
-  // active tab, expect listener middleware to dispatch clearSelection.
+  // Tab-switch leg.
+  // Arrange — toggle one azure-* skill into the selection.
   await dispatchAction(appWindow, {
     type: 'skills/toggleSelection',
     payload: AZURE_AI_NAME,
   })
   await waitForSelectionCount(appWindow, 1)
 
+  // Act — flip the active tab.
   await dispatchAction(appWindow, {
     type: 'ui/setActiveTab',
     payload: 'marketplace',
   })
+  // Assert — listener middleware dispatched clearSelection.
   await waitForSelectionCount(appWindow, 0)
 
   // Agent-switch leg — same matcher set in listener.ts, different action.
   // Re-tick the selection to prove the listener fires on a second action and
   // not just once per session.
+  // Arrange
   await dispatchAction(appWindow, {
     type: 'ui/setActiveTab',
     payload: 'installed',
@@ -150,10 +154,12 @@ test('selection survives no further than a tab switch or agent switch (regressio
   })
   await waitForSelectionCount(appWindow, 1)
 
+  // Act — switch the selected agent.
   await dispatchAction(appWindow, {
     type: 'ui/selectAgent',
     payload: 'cursor',
   })
+  // Assert — selection cleared again.
   await waitForSelectionCount(appWindow, 0)
 })
 
@@ -190,27 +196,29 @@ test('selection survives no further than a tab switch or agent switch (regressio
  * also bring brittleness (button visibility / disabled state during the test's
  * isolated-HOME bootstrap) that this test doesn't need to absorb.
  */
-test('selection clears on fetchSyncPreview.pending — third listener-matcher leg (regression 2f05684 follow-up)', async ({
+test('starting a sync preview clears the selection, but other sync thunks leave it intact (regression 2f05684 follow-up)', async ({
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange
   skipWhenAzureSnapshotUnavailable(isolatedHome)
   await waitForInitialScan(appWindow)
 
-  // Tick one azure-* skill so the listener has something to clear. Leg-1/-2
-  // test re-ticks between dispatches; we don't need that here because there's
-  // exactly one matcher leg under test.
+  // Arrange — tick one azure-* skill so the listener has something to clear.
+  // Leg-1/-2 test re-ticks between dispatches; we don't need that here because
+  // there's exactly one matcher leg under test.
   await dispatchAction(appWindow, {
     type: 'skills/toggleSelection',
     payload: AZURE_AI_NAME,
   })
   await waitForSelectionCount(appWindow, 1)
 
-  // Dispatch the exact action shape RTK builds when a real thunk fires .pending.
-  // `meta.requestStatus: 'pending'` is what RTK's internal action creators add;
-  // we mirror it for fidelity even though `isAnyOf` only inspects `.type`. If a
-  // future RTK version ever switched `isAnyOf` to also match on
-  // `meta.requestStatus`, this test stays correct without modification.
+  // Act — dispatch the exact action shape RTK builds when a real sync-preview
+  // thunk fires .pending. `meta.requestStatus: 'pending'` is what RTK's
+  // internal action creators add; we mirror it for fidelity even though
+  // `isAnyOf` only inspects `.type`. If a future RTK version ever switched
+  // `isAnyOf` to also match on `meta.requestStatus`, this test stays correct
+  // without modification.
   await dispatchAction(appWindow, {
     type: 'ui/fetchSyncPreview/pending',
     meta: {
@@ -219,6 +227,7 @@ test('selection clears on fetchSyncPreview.pending — third listener-matcher le
       requestStatus: 'pending',
     },
   })
+  // Assert — selection cleared.
   await waitForSelectionCount(appWindow, 0)
 
   // Negative control — `executeSyncAction.pending` has the same shape family
@@ -228,12 +237,14 @@ test('selection clears on fetchSyncPreview.pending — third listener-matcher le
   // matcher to `isAnyOf(..., fetchSyncPreview.pending, executeSyncAction.pending)`
   // would silently pass — losing the "selection clears on PREVIEW only, not on
   // every sync-related thunk" contract that the listener encodes.
+  // Arrange
   await dispatchAction(appWindow, {
     type: 'skills/toggleSelection',
     payload: AZURE_AI_NAME,
   })
   await waitForSelectionCount(appWindow, 1)
 
+  // Act — dispatch the wrong sync thunk's pending action.
   await dispatchAction(appWindow, {
     type: 'ui/executeSyncAction/pending',
     meta: {
@@ -242,7 +253,7 @@ test('selection clears on fetchSyncPreview.pending — third listener-matcher le
       requestStatus: 'pending',
     },
   })
-  // Assert selection count remains 1 after the wrong-thunk dispatch. Direct
+  // Assert — selection count remains 1 after the wrong-thunk dispatch. Direct
   // synchronous read instead of `waitForSelectionCount` because we need to
   // assert STABILITY (the listener should NOT have cleared); a wait helper
   // would silently succeed if the count happened to be 1 at the moment of
@@ -254,12 +265,14 @@ test('cline/warp do NOT report universal source skills as their own local skills
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange
   skipWhenAzureSnapshotUnavailable(isolatedHome)
   await waitForInitialScan(appWindow)
 
-  // FS truth — universal source has azure-ai but neither cline nor warp's
-  // own scanDir does. If post-fix scanner reads the right place, cline/warp
-  // symlink entries should reflect this asymmetry rather than mirror SOURCE_DIR.
+  // Arrange FS-truth guards — universal source has azure-ai but neither cline
+  // nor warp's own scanDir does. If post-fix scanner reads the right place,
+  // cline/warp symlink entries should reflect this asymmetry rather than
+  // mirror SOURCE_DIR.
   expect(
     existsSync(join(isolatedHome, '.agents', 'skills', AZURE_AI_NAME)),
   ).toBe(true)
@@ -287,6 +300,7 @@ test('cline/warp do NOT report universal source skills as their own local skills
     ).toBe(false)
   }
 
+  // Act — read azure-ai's per-agent symlink rows from the scanned store state.
   const azureSymlinks = await getStoreState(
     appWindow,
     (state): SymlinkSnapshot[] => {
@@ -300,7 +314,7 @@ test('cline/warp do NOT report universal source skills as their own local skills
     },
   )
 
-  // The load-bearing assertion. Pre-fix would have set
+  // Assert — the load-bearing checks. Pre-fix would have set
   //   { status: 'valid', isLocal: true, linkPath: '<HOME>/.agents/skills/azure-ai' }
   // because cline.path === SOURCE_DIR caused `checkLinkOrLocal` to lstat the
   // real source dir as if it belonged to cline. Post-fix the linkPath must
@@ -323,8 +337,8 @@ test('cline/warp do NOT report universal source skills as their own local skills
     ).not.toContain(`${isolatedHome}/.agents/skills/`)
   }
 
-  // Sanity — the source-side row for azure-ai still exists, so the regression
-  // would fail closed (assertion above) rather than silently skip.
+  // Assert sanity — the source-side row for azure-ai still exists, so the
+  // regression would fail closed (assertion above) rather than silently skip.
   await refreshSkillsState(appWindow)
   const stillPresent = await getStoreState(appWindow, (state) => {
     const root = state as { skills: { items: Array<{ name: string }> } }
@@ -333,12 +347,12 @@ test('cline/warp do NOT report universal source skills as their own local skills
   expect(stillPresent).toBe(true)
 })
 
-test('removeAllFromAgent refuses on a multi-agent shared scanDir (.config/agents/skills)', async ({
+test('refuses to delete every skill from a directory shared by multiple agents (.config/agents/skills)', async ({
   appWindow,
   isolatedHome,
 }) => {
-  // Pre-stage the shared scanDir as a real directory with a sentinel entry —
-  // amp, kimi-cli, replit all resolve to this path, so SHARED_AGENT_PATHS
+  // Arrange — pre-stage the shared scanDir as a real directory with a sentinel
+  // entry. amp, kimi-cli, replit all resolve to this path, so SHARED_AGENT_PATHS
   // includes it via the multi-agent collision pass in main/constants.ts.
   // No symlinking required: stage 1 (`SHARED_AGENT_PATHS.has(resolved)`) of
   // `isSharedAgentPath` short-circuits before any realpath fallback runs.
@@ -351,6 +365,7 @@ test('removeAllFromAgent refuses on a multi-agent shared scanDir (.config/agents
     Boolean(window.electron?.skills?.removeAllFromAgent),
   )
 
+  // Act — ask the IPC handler to remove all skills from the shared dir.
   const result = await appWindow.evaluate(
     async (args: {
       agentId: string
@@ -364,6 +379,7 @@ test('removeAllFromAgent refuses on a multi-agent shared scanDir (.config/agents
     },
   )
 
+  // Assert — the IRON RULE refused and the directory + sentinel survived.
   expectIronRuleRefusal(result)
 
   // FS — the sentinel still exists. If the IRON RULE check ever migrates to
@@ -397,10 +413,11 @@ test('removeAllFromAgent refuses on a multi-agent shared scanDir (.config/agents
  * "non-aliased shared path with rich contents" axis — distinct from
  * `unlink-agent.e2e.ts` Test 3 (stage 2/3 via symlink-alias scanDir).
  */
-test('removeAllFromAgent refusal leaves both aliased symlinks and local skill bytes untouched', async ({
+test('refuses to delete a shared directory and leaves both aliased symlinks and local skill bytes untouched', async ({
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange — stage the shared scanDir.
   const sharedScanDir = join(isolatedHome, '.config', 'agents', 'skills')
   mkdirSync(sharedScanDir, { recursive: true })
 
@@ -409,7 +426,8 @@ test('removeAllFromAgent refusal leaves both aliased symlinks and local skill by
   const aliasSkillName = 'b1-source-alias-fixture'
   const aliasTargetPath = stageSourceSkill(isolatedHome, aliasSkillName)
 
-  // Pre-stage mixed contents inside the shared dir.
+  // Arrange — pre-stage mixed contents inside the shared dir (one alias symlink
+  // plus one real local-only skill dir).
   const aliasLinkPath = join(sharedScanDir, 'b1-azure-alias')
   symlinkSync(aliasTargetPath, aliasLinkPath)
 
@@ -420,6 +438,7 @@ test('removeAllFromAgent refusal leaves both aliased symlinks and local skill by
 
   await waitForInitialScan(appWindow)
 
+  // Act — ask the IPC handler to remove all skills from the shared dir.
   const result = await appWindow.evaluate(
     async (args: {
       agentId: string
@@ -433,6 +452,7 @@ test('removeAllFromAgent refusal leaves both aliased symlinks and local skill by
     },
   )
 
+  // Assert — the IRON RULE refused; nothing in the mixed directory was touched.
   expectIronRuleRefusal(result)
 
   // FS — the alias still resolves to the source target, the local skill is
@@ -476,10 +496,11 @@ test('removeAllFromAgent refusal leaves both aliased symlinks and local skill by
  * destroying every universal agent's source bytes. The existing
  * `unlink-agent.e2e.ts` Test 3 covers stage 2 only (single-hop alias).
  */
-test('removeAllFromAgent refusal still fires when SOURCE_DIR itself is a symlink (firmlink edge)', async ({
+test('refuses to delete an agent dir even when SOURCE_DIR itself is a symlink (firmlink edge)', async ({
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange
   stageSourceSkill(isolatedHome, 'firmlink-source-fixture')
   // Wait for the renderer's initial scan BEFORE renaming SOURCE_DIR.
   // The scanner reads SOURCE_DIR's contents; renaming mid-scan would race
@@ -530,6 +551,7 @@ test('removeAllFromAgent refusal still fires when SOURCE_DIR itself is a symlink
     'expected the relocated SOURCE_DIR to retain staged source contents',
   ).toBeGreaterThan(0)
 
+  // Act — ask the IPC handler to remove all skills via the two-hop symlinked dir.
   const result = await appWindow.evaluate(
     async (args: {
       agentId: string
@@ -543,6 +565,7 @@ test('removeAllFromAgent refusal still fires when SOURCE_DIR itself is a symlink
     },
   )
 
+  // Assert — the IRON RULE refused and the relocated source survived intact.
   expectIronRuleRefusal(result)
 
   // FS — every link still in place, every byte in realSourceDir untouched.
@@ -592,14 +615,15 @@ test('removeAllFromAgent refusal still fires when SOURCE_DIR itself is a symlink
  * confirms the orphan flag did NOT broaden across all rows — the previous
  * three assertions alone could pass while every row got `isOrphan: true`.
  */
-test('scanSkills surfaces broken symlinks as orphan skills (regression #127)', async ({
+test('broken symlinks show up as orphan skill rows in the list (regression #127)', async ({
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange
   stageSourceSkill(isolatedHome, 'source-control-fixture')
   await waitForInitialScan(appWindow)
 
-  // Stage the orphan condition: a non-universal agent dir containing a
+  // Arrange — stage the orphan condition: a non-universal agent dir containing a
   // dangling symlink whose target source has never existed (equivalent to
   // a user-driven `rm -rf ~/.agents/skills/<name>` after install). The
   // `phantom-` prefix isolates this fixture from any name the snapshot's
@@ -621,13 +645,14 @@ test('scanSkills surfaces broken symlinks as orphan skills (regression #127)', a
   const orphanLinkPath = join(windsurfSkillsDir, orphanSkillName)
   symlinkSync(phantomSourcePath, orphanLinkPath)
 
-  // FS sanity — the staged shape must be a real symlink with an absent
+  // Arrange FS-sanity — the staged shape must be a real symlink with an absent
   // target. `existsSync` follows symlinks so a broken link reads as `false`;
   // `lstatSync` does NOT follow, so it confirms the symlink itself is real.
   expect(lstatSync(orphanLinkPath).isSymbolicLink()).toBe(true)
   expect(existsSync(phantomSourcePath)).toBe(false)
   expect(existsSync(orphanLinkPath)).toBe(false)
 
+  // Act — rescan so the orphan scanner picks up the dangling link.
   await refreshSkillsState(appWindow)
 
   interface OrphanSkillSnapshot {
@@ -652,6 +677,7 @@ test('scanSkills surfaces broken symlinks as orphan skills (regression #127)', a
     },
   )
 
+  // Assert — the orphan row exists with the right flags and per-agent statuses.
   expect(
     orphanRecord,
     'orphan skill must surface in state.skills.items — pre-fix bug indicator (the entire row was being silently dropped)',
@@ -771,15 +797,18 @@ test('sidebar inner ScrollArea wrapper does not inflate beyond aside width (regr
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange — stage one source skill so the Sidebar mounts with the SourceCard.
   stageSourceSkill(isolatedHome, 'sidebar-sourcecard-fixture')
   await waitForInitialScan(appWindow)
 
+  // Act — locate the aside, the inner Radix wrapper, and the truncated path.
   const aside = appWindow.locator('aside[aria-label="Agent sidebar"]')
   const wrapper = aside
     .locator('[data-radix-scroll-area-viewport] > div')
     .first()
   const truncatedPath = aside.getByText('~/.agents/skills', { exact: true })
 
+  // Assert — all three are present, then the wrapper width / display invariant.
   await expect(aside).toBeVisible()
   await expect(wrapper).toBeAttached()
   await expect(truncatedPath).toBeVisible()
@@ -875,9 +904,11 @@ test('skills list scroll position survives a background refetch (regression 5619
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange
   skipWhenAzureSnapshotUnavailable(isolatedHome)
   await waitForInitialScan(appWindow)
 
+  // Arrange sanity guard — the snapshot must contain rows to scroll.
   const itemCount = await getStoreState(appWindow, (state) => {
     const root = state as { skills: { items: unknown[] } }
     return root.skills.items.length
@@ -933,7 +964,7 @@ test('skills list scroll position survives a background refetch (regression 5619
     'browser refused the scrollTop assignment — element is not scrollable',
   ).toBeGreaterThan(0)
 
-  // Dispatch the thunk's pending action directly. Pre-fix, SkillsList's
+  // Act — dispatch the thunk's pending action directly. Pre-fix, SkillsList's
   // top-level `if (loading)` would unmount the List on the next render
   // tick, dropping the scroll container.
   await dispatchAction(appWindow, {
@@ -954,6 +985,7 @@ test('skills list scroll position survives a background refetch (regression 5619
     await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
   })
 
+  // Assert — the scroll container is still mounted and retained its scrollTop.
   const scrollTopAfter = await appWindow.evaluate(() => {
     const scroller = document.querySelector<HTMLElement>(
       '[data-e2e-scroll-target="true"]',

--- a/e2e/spec/smoke.e2e.ts
+++ b/e2e/spec/smoke.e2e.ts
@@ -13,10 +13,12 @@ import { test, expect } from '../fixtures/electron-app'
  * Specs covering the actual copy/delete IPC channels arrive in Phase 2.
  */
 test('app launches with E2E build harness exposed', async ({ appWindow }) => {
+  // Act — read the harness globals the production bundle only exposes under E2E_BUILD=1.
   const exposedStore = await appWindow.evaluate(() => Boolean(window.__store__))
   const exposedEvents = await appWindow.evaluate(() =>
     Boolean(window.__ipcEvents__),
   )
+  // Assert
   expect(
     exposedStore,
     'window.__store__ should be exposed under E2E_BUILD=1',
@@ -26,9 +28,11 @@ test('app launches with E2E build harness exposed', async ({ appWindow }) => {
     'window.__ipcEvents__ should be exposed under E2E_BUILD=1',
   ).toBe(true)
 
+  // Act — the exposed store must yield real state, not an undefined stub.
   const initialState = await appWindow.evaluate(() =>
     window.__store__?.getState(),
   )
+  // Assert
   expect(
     initialState,
     'store.getState() should return a real object',
@@ -41,12 +45,14 @@ test('app launches with E2E build harness exposed', async ({ appWindow }) => {
   // `update:error` channel for the entire process lifetime. Reading the
   // recorder once at the end of launch is enough — these channels fire
   // synchronously off `app.whenReady` in the production code path.
+  // Act — collect every recorded update:* IPC event seen during launch.
   const updaterIpcEvents = await appWindow.evaluate(
     () =>
       window.__ipcEvents__
         ?.list()
         .filter((event) => event.channel.startsWith('update:')) ?? [],
   )
+  // Assert
   expect(
     updaterIpcEvents,
     'auto-updater should stay dormant under E2E_DISABLE_UPDATE=1',

--- a/e2e/spec/sync.e2e.ts
+++ b/e2e/spec/sync.e2e.ts
@@ -67,10 +67,11 @@ test.beforeEach(() => {
   )
 })
 
-test('fetchSyncPreview populates state.ui.syncPreview with non-zero toCreate (global)', async ({
+test('clicking Sync on the source card previews how many agent links a global sync would create', async ({
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange
   await waitForInitialScan(appWindow)
 
   // Stage two agent dirs that the snapshot did NOT pre-stage. Cursor and
@@ -84,6 +85,7 @@ test('fetchSyncPreview populates state.ui.syncPreview with non-zero toCreate (gl
   mkdirSync(join(isolatedHome, '.cursor'), { recursive: true })
   mkdirSync(join(isolatedHome, '.cline'), { recursive: true })
 
+  // Act
   // Click the SourceCard's Sync button. Scoped to `<aside>` so the
   // selector also-matches-by-text doesn't collide with the
   // SyncConfirmDialog's submit button (which is named "Sync" too) — the
@@ -113,6 +115,7 @@ test('fetchSyncPreview populates state.ui.syncPreview with non-zero toCreate (gl
     return root.ui.syncPreview
   })
 
+  // Assert
   expect(
     preview,
     'syncPreview should be populated after thunk fulfills',
@@ -139,10 +142,11 @@ test('fetchSyncPreview populates state.ui.syncPreview with non-zero toCreate (gl
   expect(preview!.forAgent).toBeUndefined()
 })
 
-test('per-agent preview narrows scope and echoes forAgent', async ({
+test('previewing sync for a single agent narrows the scope to just that agent', async ({
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange
   await waitForInitialScan(appWindow)
 
   // The snapshot already pre-stages ~30 agent dirs (see file-level doc),
@@ -152,6 +156,7 @@ test('per-agent preview narrows scope and echoes forAgent', async ({
   // even though the baseline has many agents on disk.
   mkdirSync(join(isolatedHome, '.cursor'), { recursive: true })
 
+  // Act
   // Direct preload-bridge call. The per-agent Cleanup flow uses this
   // option internally; there's no top-level UI button that emits
   // `{ agentId }` from the renderer, so wiring this through a click
@@ -169,6 +174,7 @@ test('per-agent preview narrows scope and echoes forAgent', async ({
     forAgent?: string
   }
 
+  // Assert
   expect(preview.forAgent).toBe('cursor')
   // Despite ~31 agents existing on disk (snapshot side-effects + our
   // staged cursor), totalAgents collapses to 1 because the filter ran.
@@ -179,10 +185,11 @@ test('per-agent preview narrows scope and echoes forAgent', async ({
   expect(preview.conflicts).toEqual([])
 })
 
-test('executing sync creates symlinks and opens SyncResultDialog', async ({
+test('confirming a sync creates the agent symlinks and opens the Sync Results dialog', async ({
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange
   await waitForInitialScan(appWindow)
 
   // One staged agent is enough for the execute proof — keeping it to
@@ -190,6 +197,7 @@ test('executing sync creates symlinks and opens SyncResultDialog', async ({
   // for filesystem evidence below.
   mkdirSync(join(isolatedHome, '.cursor'), { recursive: true })
 
+  // Act
   // Step 1: trigger preview via the SourceCard. The dialog auto-mounts
   // when `state.ui.syncPreview.toCreate > 0 && conflicts.length === 0`
   // (via `shouldShowSyncConfirm`), so this single click both fetches
@@ -231,6 +239,7 @@ test('executing sync creates symlinks and opens SyncResultDialog', async ({
     return root.ui.syncResult
   })
 
+  // Assert
   expect(
     result,
     'syncResult should be populated after execute fulfills',

--- a/e2e/spec/undo-toast.e2e.ts
+++ b/e2e/spec/undo-toast.e2e.ts
@@ -115,6 +115,7 @@ test('UI: clicking Undo on the bulk-delete toast restores staged source files an
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange
   const { sourcePath: expectedSourcePath } =
     stageUndoToastSkillFixture(isolatedHome)
   await waitForInitialScan(appWindow)
@@ -132,6 +133,7 @@ test('UI: clicking Undo on the bulk-delete toast restores staged source files an
     'expected at least one valid agent symlink so restore actually has work to do',
   ).toBeGreaterThan(0)
 
+  // Act
   // Drive Redux directly into the bulk-select + selected state. Action types
   // are inlined string literals because the dispatch re-evaluates inside the
   // renderer where the slice action creators are out of scope.
@@ -185,6 +187,7 @@ test('UI: clicking Undo on the bulk-delete toast restores staged source files an
   await undoButton.waitFor({ state: 'visible', timeout: 5_000 })
   await undoButton.click()
 
+  // Assert
   // PRIMARY ASSERTION — wait for the FULL restored state in a single poll so
   // we don't race the order of "dir restored → SKILL.md written → symlinks
   // recreated". Polling only the source-dir existence and then doing

--- a/e2e/spec/unlink-agent.e2e.ts
+++ b/e2e/spec/unlink-agent.e2e.ts
@@ -174,10 +174,11 @@ function expectPathMissing(path: string): void {
  * tests.
  */
 
-test('unlinkFromAgent removes one valid azure-ai symlink without touching the source or other agents', async ({
+test('unlinking one agent removes only that agent link and leaves the source skill and other agents intact', async ({
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange
   const expectedSourcePath = join(
     isolatedHome,
     '.agents',
@@ -226,6 +227,7 @@ test('unlinkFromAgent removes one valid azure-ai symlink without touching the so
       symlink.status === 'valid' && symlink.linkPath !== target.linkPath,
   )
 
+  // Act
   const ipcResult = await appWindow.evaluate(
     async (args: {
       skillName: string
@@ -241,6 +243,7 @@ test('unlinkFromAgent removes one valid azure-ai symlink without touching the so
     },
   )
 
+  // Assert
   expect(ipcResult.success).toBe(true)
   expect(ipcResult.error).toBeUndefined()
 
@@ -302,10 +305,11 @@ test('unlinkFromAgent removes one valid azure-ai symlink without touching the so
  * regular file the renderer happens to pass.
  */
 
-test('unlinkFromAgent treats a missing linkPath as an idempotent success', async ({
+test('unlinking an agent link that was already removed succeeds idempotently instead of erroring', async ({
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange
   // Pre-create the parent agent dir so validatePath's allowed-bases check
   // succeeds. Without this, validatePath could throw before lstat runs and
   // we'd be testing the wrong failure branch.
@@ -318,6 +322,7 @@ test('unlinkFromAgent treats a missing linkPath as an idempotent success', async
   // the idempotent missing-path branch.
   expectPathMissing(missingLinkPath)
 
+  // Act
   const ipcResult = await appWindow.evaluate(
     async (args: {
       skillName: string
@@ -333,13 +338,15 @@ test('unlinkFromAgent treats a missing linkPath as an idempotent success', async
     },
   )
 
+  // Assert
   expect(ipcResult).toEqual({ success: true })
 })
 
-test('unlinkFromAgent refuses a regular file with the structured kind-mismatch error', async ({
+test('unlinking refuses a stray regular file and leaves it on disk instead of deleting it', async ({
   isolatedHome,
   appWindow,
 }) => {
+  // Arrange
   const claudeAgentPath = join(isolatedHome, '.claude', 'skills')
   mkdirSync(claudeAgentPath, { recursive: true })
   const regularFilePath = join(claudeAgentPath, 'not-a-skill.txt')
@@ -354,6 +361,7 @@ test('unlinkFromAgent refuses a regular file with the structured kind-mismatch e
   expect(stagedStat.isSymbolicLink()).toBe(false)
   expect(stagedStat.isDirectory()).toBe(false)
 
+  // Act
   const ipcResult = await appWindow.evaluate(
     async (args: {
       skillName: string
@@ -369,6 +377,7 @@ test('unlinkFromAgent refuses a regular file with the structured kind-mismatch e
     },
   )
 
+  // Assert
   expect(ipcResult.success).toBe(false)
   // Pin the exact handler copy. If this string ever changes, the renderer
   // toast copy probably needs to update with it — surfacing the literal
@@ -384,10 +393,11 @@ test('unlinkFromAgent refuses a regular file with the structured kind-mismatch e
   expect(existsSync(regularFilePath)).toBe(true)
 })
 
-test('unlinkManyFromAgent removes every pre-staged symlink and leaves source dirs untouched', async ({
+test('batch-unlinking an agent removes every selected link while keeping all source skills', async ({
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange
   // Pre-stage BEFORE waiting for the renderer scan. The handler reads from
   // disk independently of the renderer's scan, so it doesn't matter whether
   // these landed before or after the initial fetchSkills.
@@ -408,6 +418,7 @@ test('unlinkManyFromAgent removes every pre-staged symlink and leaves source dir
     expect(lstatSync(linkPath).isSymbolicLink()).toBe(true)
   }
 
+  // Act
   const result = await appWindow.evaluate(
     async (args: {
       agentId: string
@@ -419,6 +430,7 @@ test('unlinkManyFromAgent removes every pre-staged symlink and leaves source dir
     },
   )
 
+  // Assert
   expect(result.items).toHaveLength(skillNames.length)
   for (const [index, item] of result.items.entries()) {
     expect(item.outcome).toBe('unlinked')
@@ -436,7 +448,7 @@ test('unlinkManyFromAgent removes every pre-staged symlink and leaves source dir
   }
 })
 
-test('unlinkManyFromAgent uses reviewed linkPath when metadata name differs from slot basename', async ({
+test('batch-unlinking removes the reviewed link slot, not a decoy whose name matches the skill metadata', async ({
   appWindow,
   isolatedHome,
 }) => {
@@ -508,10 +520,11 @@ test('unlinkManyFromAgent uses reviewed linkPath when metadata name differs from
  * "expected 'unlinked' got 'pending'" diff. Index 0 or N-1 wouldn't catch a
  * partial loop.
  */
-test('unlinkManyFromAgent aggregates per-item failures without short-circuiting the batch', async ({
+test('a single failing item in a batch unlink does not abort the rest and still refuses to delete the local skill', async ({
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange
   const claudeAgentPath = join(isolatedHome, '.claude', 'skills')
   const skillNames = preStageLinkedSkills(
     isolatedHome,
@@ -549,6 +562,7 @@ test('unlinkManyFromAgent aggregates per-item failures without short-circuiting 
   expect(lstatSync(poisonedLinkPath).isDirectory()).toBe(true)
   expect(lstatSync(poisonedLinkPath).isSymbolicLink()).toBe(false)
 
+  // Act
   const result = await appWindow.evaluate(
     async (args: {
       agentId: string
@@ -560,6 +574,7 @@ test('unlinkManyFromAgent aggregates per-item failures without short-circuiting 
     },
   )
 
+  // Assert
   expect(result.items).toHaveLength(skillNames.length)
 
   // Iterate by index instead of filtering so a regression that misroutes the
@@ -596,10 +611,11 @@ test('unlinkManyFromAgent aggregates per-item failures without short-circuiting 
   }
 })
 
-test('removeAllFromAgent refuses when the agent path is a symlink alias to the universal source', async ({
+test('removing all links from an agent is refused when its folder is a symlink alias to the universal source', async ({
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange
   // Pre-stage the IRON RULE trigger condition: an agent's scanDir is itself
   // a symlink alias to SOURCE_DIR. Without this layout the handler's
   // validatePath + isSharedAgentPath chain wouldn't fire — picking cursor
@@ -631,6 +647,7 @@ test('removeAllFromAgent refuses when the agent path is a symlink alias to the u
   const sourceContentsBefore = readdirSync(sourceDir).sort()
   expect(sourceContentsBefore).toContain(sentinelSourceName)
 
+  // Act
   const result = await appWindow.evaluate(
     async (args: {
       agentId: string
@@ -644,6 +661,7 @@ test('removeAllFromAgent refuses when the agent path is a symlink alias to the u
     },
   )
 
+  // Assert
   expectIronRuleRefusal(result)
 
   // FS — the symlink alias itself is still in place (handler short-circuits
@@ -683,10 +701,11 @@ test('removeAllFromAgent refuses when the agent path is a symlink alias to the u
  *      when targeted via `--agent`), giving us a clean tempdir corner to stage
  *      without colliding with snapshot fixture state.
  */
-test('removeAllFromAgent moves a non-shared agent dir to OS Trash and reports the right count', async ({
+test('removing all links from a non-shared agent moves its folder to the OS Trash and reports the removed count', async ({
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange
   // Cross-volume isolatedHome would route shell.trashItem into
   // <volume>/.Trashes/<uid> instead of ~/.Trash, breaking both the
   // diffUserTrash inspection and the cleanup. Skip loudly rather than
@@ -741,6 +760,7 @@ test('removeAllFromAgent moves a non-shared agent dir to OS Trash and reports th
   // cleanup.
   let createdTrashEntryPaths: string[] = []
   try {
+    // Act
     const result = await appWindow.evaluate(
       async (args: {
         agentId: string
@@ -754,6 +774,7 @@ test('removeAllFromAgent moves a non-shared agent dir to OS Trash and reports th
       },
     )
 
+    // Assert
     // Diff ~/.Trash IMMEDIATELY after the IPC call returns, then narrow
     // the cleanup target to OUR specific trashed dir — never the full
     // newPaths set. Match by exact-set of skill basenames (per-run unique
@@ -795,10 +816,11 @@ test('removeAllFromAgent moves a non-shared agent dir to OS Trash and reports th
   }
 })
 
-test('removeAllFromAgent surfaces structured failure when shell.trashItem rejects (parent dir is read-only)', async ({
+test('removing all links reports a structured failure and leaves the agent folder in place when the OS Trash move is rejected', async ({
   appWindow,
   isolatedHome,
 }) => {
+  // Arrange
   // Why this test exists
   // ====================
   // The handler at src/main/ipc/skills.ts wraps the entire body in a single
@@ -884,6 +906,7 @@ test('removeAllFromAgent surfaces structured failure when shell.trashItem reject
   // a false-fail and our entry never leaks on regression.
   let regressionTrashEntryPaths: string[] = []
   try {
+    // Act
     const result = await appWindow.evaluate(
       async (args: {
         agentId: string
@@ -897,6 +920,7 @@ test('removeAllFromAgent surfaces structured failure when shell.trashItem reject
       },
     )
 
+    // Assert
     const { newPaths } = diffUserTrash(trashEntriesBefore)
     const regressionTrashedAgentDir = findMatchingTrashedAgentDir(
       newPaths,

--- a/src/main/constants.test.ts
+++ b/src/main/constants.test.ts
@@ -18,102 +18,188 @@ describe('AGENTS path computation', () => {
   // those agents, and the per-skill Inspector marked all source skills
   // as Valid for Cline/Warp. The fix splits `installDir` (kept for CLI
   // sync) from `scanDir` (used by AGENTS.path).
-  it('Cline scans its own home dir, not the universal source', () => {
+  it('scans Cline from its own home dir so source skills are not mislabeled as Cline-local', () => {
+    // Arrange
     const cline = AGENTS.find((a) => a.id === 'cline')!
-    expect(cline.path).toBe(join(homedir(), '.cline', 'skills'))
-    expect(cline.path).not.toBe(SOURCE_DIR)
+
+    // Act
+    const clinePath = cline.path
+
+    // Assert
+    expect(clinePath).toBe(join(homedir(), '.cline', 'skills'))
+    expect(clinePath).not.toBe(SOURCE_DIR)
   })
 
-  it('Warp scans its own home dir, not the universal source', () => {
+  it('scans Warp from its own home dir so source skills are not mislabeled as Warp-local', () => {
+    // Arrange
     const warp = AGENTS.find((a) => a.id === 'warp')!
-    expect(warp.path).toBe(join(homedir(), '.warp', 'skills'))
-    expect(warp.path).not.toBe(SOURCE_DIR)
+
+    // Act
+    const warpPath = warp.path
+
+    // Assert
+    expect(warpPath).toBe(join(homedir(), '.warp', 'skills'))
+    expect(warpPath).not.toBe(SOURCE_DIR)
   })
 
-  it('no agent.path collides with SOURCE_DIR', () => {
+  it('keeps every agent path off the universal source so the scanner never surfaces source content as agent-local skills', () => {
     // If any agent path equals SOURCE_DIR, the scanner will surface
     // source content as that agent's local skills — the exact bug the
     // scanDir divergence was added to prevent. Future cli-upgrade syncs
     // that introduce new universal-style agents must diverge scanDir
     // from installDir.
-    for (const agent of AGENTS) {
-      expect(agent.path).not.toBe(SOURCE_DIR)
+    // Arrange
+    const agentPaths = AGENTS.map((agent) => agent.path)
+
+    // Act + Assert
+    for (const agentPath of agentPaths) {
+      expect(agentPath).not.toBe(SOURCE_DIR)
     }
   })
 })
 
 describe('SHARED_AGENT_PATHS', () => {
-  it('always includes SOURCE_DIR so "delete agent" cannot wipe the universal source', () => {
-    expect(SHARED_AGENT_PATHS.has(SOURCE_DIR)).toBe(true)
+  it('protects the universal source dir so deleting an agent cannot wipe everyone’s shared skills', () => {
+    // Arrange
+    const universalSourceDir = SOURCE_DIR
+
+    // Act
+    const isGuarded = SHARED_AGENT_PATHS.has(universalSourceDir)
+
+    // Assert
+    expect(isGuarded).toBe(true)
   })
 
-  it('includes ~/.agents/skills — the v0.13.0 regression path', () => {
+  it('guards ~/.agents/skills so the v0.13.0 delete-wipes-source regression cannot return', () => {
     // SOURCE_DIR resolves to this path and is unconditionally seeded into
     // SHARED_AGENT_PATHS. Post Cline/Warp scanDir divergence no other
     // agent aliases here, but SOURCE_DIR alone is enough to guard deletes.
-    expect(SHARED_AGENT_PATHS.has(join(homedir(), '.agents', 'skills'))).toBe(
-      true,
-    )
+    // Arrange
+    const v0130RegressionPath = join(homedir(), '.agents', 'skills')
+
+    // Act
+    const isGuarded = SHARED_AGENT_PATHS.has(v0130RegressionPath)
+
+    // Assert
+    expect(isGuarded).toBe(true)
   })
 
-  it('includes ~/.config/agents/skills — aliased across amp/kimi-cli/replit', () => {
-    expect(
-      SHARED_AGENT_PATHS.has(join(homedir(), '.config', 'agents', 'skills')),
-    ).toBe(true)
+  it('guards ~/.config/agents/skills so deleting amp or kimi-cli cannot wipe the dir they share', () => {
+    // Arrange
+    const sharedConfigPath = join(homedir(), '.config', 'agents', 'skills')
+
+    // Act
+    const isGuarded = SHARED_AGENT_PATHS.has(sharedConfigPath)
+
+    // Assert
+    expect(isGuarded).toBe(true)
   })
 
-  it('does not flag agents that own their own non-shared directory', () => {
+  it('lets an agent with its own dedicated dir be deleted without tripping the shared-path guard', () => {
+    // Arrange
     const claude = AGENTS.find((a) => a.id === 'claude-code')!
     const cursor = AGENTS.find((a) => a.id === 'cursor')!
     const codex = AGENTS.find((a) => a.id === 'codex')!
 
-    expect(SHARED_AGENT_PATHS.has(claude.path)).toBe(false)
-    expect(SHARED_AGENT_PATHS.has(cursor.path)).toBe(false)
-    expect(SHARED_AGENT_PATHS.has(codex.path)).toBe(false)
+    // Act
+    const claudeIsGuarded = SHARED_AGENT_PATHS.has(claude.path)
+    const cursorIsGuarded = SHARED_AGENT_PATHS.has(cursor.path)
+    const codexIsGuarded = SHARED_AGENT_PATHS.has(codex.path)
+
+    // Assert
+    expect(claudeIsGuarded).toBe(false)
+    expect(cursorIsGuarded).toBe(false)
+    expect(codexIsGuarded).toBe(false)
   })
 
-  it('includes every agent whose path aliases another agent', () => {
-    const pathCounts = new Map<string, number>()
-    for (const a of AGENTS)
-      pathCounts.set(a.path, (pathCounts.get(a.path) ?? 0) + 1)
+  it('guards the path that amp and kimi-cli both point at so neither delete destroys the other’s skills', () => {
+    // amp and kimi-cli are the two agents whose scanDir resolves to the
+    // same ~/.config/agents/skills directory; both must be guarded so a
+    // delete on either cannot wipe the directory shared with the other.
+    // Arrange
+    const amp = AGENTS.find((a) => a.id === 'amp')!
+    const kimiCli = AGENTS.find((a) => a.id === 'kimi-cli')!
 
-    for (const [path, count] of pathCounts) {
-      if (count > 1) expect(SHARED_AGENT_PATHS.has(path)).toBe(true)
-    }
+    // Act
+    const ampIsGuarded = SHARED_AGENT_PATHS.has(amp.path)
+    const kimiCliIsGuarded = SHARED_AGENT_PATHS.has(kimiCli.path)
+
+    // Assert
+    expect(ampIsGuarded).toBe(true)
+    expect(kimiCliIsGuarded).toBe(true)
   })
 })
 
 describe('isSharedAgentPath', () => {
-  it('returns true for SOURCE_DIR', () => {
-    expect(isSharedAgentPath(SOURCE_DIR)).toBe(true)
+  it('rejects a delete aimed straight at the universal source dir', () => {
+    // Arrange
+    const universalSourceDir = SOURCE_DIR
+
+    // Act
+    const isShared = isSharedAgentPath(universalSourceDir)
+
+    // Assert
+    expect(isShared).toBe(true)
   })
 
-  it('returns false for a non-shared agent path', () => {
+  it('allows a delete on an agent that owns its own private directory', () => {
+    // Arrange
     const claude = AGENTS.find((a) => a.id === 'claude-code')!
-    expect(isSharedAgentPath(claude.path)).toBe(false)
+
+    // Act
+    const isShared = isSharedAgentPath(claude.path)
+
+    // Assert
+    expect(isShared).toBe(false)
   })
 
-  it('returns false for an unknown path', () => {
-    expect(isSharedAgentPath('/tmp/not-a-real-agent/skills')).toBe(false)
+  it('allows a delete on a path that belongs to no known agent', () => {
+    // Arrange
+    const unknownPath = '/tmp/not-a-real-agent/skills'
+
+    // Act
+    const isShared = isSharedAgentPath(unknownPath)
+
+    // Assert
+    expect(isShared).toBe(false)
   })
 
   // Normalization guards — Set.has() does exact-string match, and
   // SHARED_AGENT_PATHS stores canonically-joined paths. Without a resolve()
   // normalization in isSharedAgentPath, these shapes would bypass the
   // check even though they point at the same on-disk target.
-  it('normalizes trailing slash to prevent Set.has bypass', () => {
-    expect(isSharedAgentPath(SOURCE_DIR + '/')).toBe(true)
+  it('still blocks a delete on the source dir when the path carries a trailing slash', () => {
+    // Arrange
+    const trailingSlashPath = SOURCE_DIR + '/'
+
+    // Act
+    const isShared = isSharedAgentPath(trailingSlashPath)
+
+    // Assert
+    expect(isShared).toBe(true)
   })
 
-  it('normalizes .. segments to prevent bypass', () => {
+  it('still blocks a delete on the source dir when the path contains .. segments', () => {
     // e.g. /Users/me/.agents/skills/../skills → /Users/me/.agents/skills
-    const bypass = join(SOURCE_DIR, '..', 'skills')
-    expect(isSharedAgentPath(bypass)).toBe(true)
+    // Arrange
+    const dotDotPath = join(SOURCE_DIR, '..', 'skills')
+
+    // Act
+    const isShared = isSharedAgentPath(dotDotPath)
+
+    // Assert
+    expect(isShared).toBe(true)
   })
 
-  it('normalizes double-slash to prevent bypass', () => {
+  it('still blocks a delete on the source dir when the path contains a double slash', () => {
     // e.g. /Users/me/.agents//skills → /Users/me/.agents/skills
-    const bypass = SOURCE_DIR.replace('/.agents/', '/.agents//')
-    expect(isSharedAgentPath(bypass)).toBe(true)
+    // Arrange
+    const doubleSlashPath = SOURCE_DIR.replace('/.agents/', '/.agents//')
+
+    // Act
+    const isShared = isSharedAgentPath(doubleSlashPath)
+
+    // Assert
+    expect(isShared).toBe(true)
   })
 })

--- a/src/main/ipc/folder.integration.test.ts
+++ b/src/main/ipc/folder.integration.test.ts
@@ -122,19 +122,29 @@ describe('folder IPC handlers (integration)', () => {
   })
 
   describe('folder:revealInFinder', () => {
-    it('returns ok:true on happy path', async () => {
+    it('reveals an existing folder in Finder', async () => {
+      // Arrange
       realpathMock.mockResolvedValue('/Users/me/.agents/skills')
       openPathMock.mockResolvedValue('')
       const handler = getRegisteredHandler('folder:revealInFinder')
+
+      // Act
       const result = await handler({}, '/Users/me/.agents/skills')
+
+      // Assert
       expect(result).toEqual({ ok: true })
     })
 
-    it('returns not-found when realpath rejects with ENOENT', async () => {
+    it('tells the user the folder is gone instead of revealing it when the path no longer exists', async () => {
+      // Arrange
       const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
       realpathMock.mockRejectedValue(err)
       const handler = getRegisteredHandler('folder:revealInFinder')
+
+      // Act
       const result = await handler({}, '/missing/path')
+
+      // Assert
       expect(result).toEqual({
         ok: false,
         reason: 'not-found',
@@ -143,36 +153,54 @@ describe('folder IPC handlers (integration)', () => {
       expect(openPathMock).not.toHaveBeenCalled()
     })
 
-    it('returns not-found for ELOOP (symlink cycle)', async () => {
+    it('treats a symlink cycle (ELOOP) as a missing folder rather than reveal it', async () => {
+      // Arrange
       const err = Object.assign(new Error('ELOOP'), { code: 'ELOOP' })
       realpathMock.mockRejectedValue(err)
       const handler = getRegisteredHandler('folder:revealInFinder')
+
+      // Act
       const result = await handler({}, '/cycle')
+
+      // Assert
       expect(result).toMatchObject({ ok: false, reason: 'not-found' })
     })
 
-    it('returns not-found for ENOTDIR (parent component is a file)', async () => {
+    it('treats a file-in-the-path (ENOTDIR) as a missing folder rather than reveal it', async () => {
+      // Arrange
       const err = Object.assign(new Error('ENOTDIR'), { code: 'ENOTDIR' })
       realpathMock.mockRejectedValue(err)
       const handler = getRegisteredHandler('folder:revealInFinder')
+
+      // Act
       const result = await handler({}, '/file/inside')
+
+      // Assert
       expect(result).toMatchObject({ ok: false, reason: 'not-found' })
       expect(openPathMock).not.toHaveBeenCalled()
     })
 
-    it('rethrows unexpected realpath errors (e.g. EPERM) to the IPC boundary', async () => {
+    it('surfaces an unexpected filesystem error (e.g. EPERM) to the IPC boundary instead of swallowing it', async () => {
+      // Arrange
       const err = Object.assign(new Error('EPERM'), { code: 'EPERM' })
       realpathMock.mockRejectedValue(err)
       const handler = getRegisteredHandler('folder:revealInFinder')
+
+      // Act / Assert
       await expect(handler({}, '/locked')).rejects.toThrow('EPERM')
       expect(openPathMock).not.toHaveBeenCalled()
     })
 
-    it('returns launch-failed when shell.openPath returns an error string', async () => {
+    it('reports a launch failure when Finder cannot open the folder', async () => {
+      // Arrange
       realpathMock.mockResolvedValue('/x')
       openPathMock.mockResolvedValue('Permission denied')
       const handler = getRegisteredHandler('folder:revealInFinder')
+
+      // Act
       const result = await handler({}, '/x')
+
+      // Assert
       expect(result).toMatchObject({
         ok: false,
         reason: 'launch-failed',
@@ -185,13 +213,16 @@ describe('folder IPC handlers (integration)', () => {
   })
 
   describe('folder:openInTerminal', () => {
-    it('returns ok:true when spawn fires exit(0)', async () => {
+    it('opens the folder in Terminal and detaches the launched process', async () => {
+      // Arrange
       realpathMock.mockResolvedValue('/x')
       const child = spawnFiringEvent('exit', 0)
       const handler = getRegisteredHandler('folder:openInTerminal')
 
+      // Act
       const result = await handler({}, '/x')
 
+      // Assert
       expect(result).toEqual({ ok: true })
       expect(child.unref).toHaveBeenCalled()
       expect(spawnMock).toHaveBeenCalledWith('open', ['-a', 'Terminal', '/x'], {
@@ -199,31 +230,38 @@ describe('folder IPC handlers (integration)', () => {
       })
     })
 
-    it('returns not-found BEFORE getSettings/spawn when path missing', async () => {
+    it('reports a missing folder without reading settings or spawning a terminal', async () => {
+      // Arrange
       const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
       realpathMock.mockRejectedValue(err)
       const handler = getRegisteredHandler('folder:openInTerminal')
 
+      // Act
       const result = await handler({}, '/gone')
 
+      // Assert
       expect(result).toMatchObject({ ok: false, reason: 'not-found' })
       expect(getSettingsMock).not.toHaveBeenCalled()
       expect(spawnMock).not.toHaveBeenCalled()
     })
 
-    it('returns not-found for ENOTDIR (parent component is a file)', async () => {
+    it('treats a file-in-the-path (ENOTDIR) as missing and never spawns a terminal', async () => {
+      // Arrange
       const err = Object.assign(new Error('ENOTDIR'), { code: 'ENOTDIR' })
       realpathMock.mockRejectedValue(err)
       const handler = getRegisteredHandler('folder:openInTerminal')
 
+      // Act
       const result = await handler({}, '/file/inside')
 
+      // Assert
       expect(result).toMatchObject({ ok: false, reason: 'not-found' })
       expect(getSettingsMock).not.toHaveBeenCalled()
       expect(spawnMock).not.toHaveBeenCalled()
     })
 
-    it('returns invalid-path when preferredTerminal=custom and customTerminalAppName missing', async () => {
+    it('refuses to launch when a custom terminal is selected but no app name is configured', async () => {
+      // Arrange
       realpathMock.mockResolvedValue('/x')
       getSettingsMock.mockReturnValue({
         defaultSkillTab: 'files',
@@ -231,8 +269,10 @@ describe('folder IPC handlers (integration)', () => {
       })
       const handler = getRegisteredHandler('folder:openInTerminal')
 
+      // Act
       const result = await handler({}, '/x')
 
+      // Assert
       expect(result).toMatchObject({
         ok: false,
         reason: 'invalid-path',
@@ -240,26 +280,32 @@ describe('folder IPC handlers (integration)', () => {
       expect(spawnMock).not.toHaveBeenCalled()
     })
 
-    it('returns launch-failed on spawn exit(1) (app not installed)', async () => {
+    it('reports a launch failure when the terminal app is not installed (spawn exits non-zero)', async () => {
+      // Arrange
       realpathMock.mockResolvedValue('/x')
       spawnFiringEvent('exit', 1)
       const handler = getRegisteredHandler('folder:openInTerminal')
 
+      // Act
       const result = await handler({}, '/x')
 
+      // Assert
       expect(result).toMatchObject({
         ok: false,
         reason: 'launch-failed',
       })
     })
 
-    it('returns launch-failed on spawn error event', async () => {
+    it('reports a launch failure with the underlying error message when spawn errors', async () => {
+      // Arrange
       realpathMock.mockResolvedValue('/x')
       spawnFiringEvent('error', new Error('spawn ENOENT'))
       const handler = getRegisteredHandler('folder:openInTerminal')
 
+      // Act
       const result = await handler({}, '/x')
 
+      // Assert
       expect(result).toMatchObject({
         ok: false,
         reason: 'launch-failed',
@@ -270,11 +316,12 @@ describe('folder IPC handlers (integration)', () => {
       )
     })
 
-    it('reads getSettings on EVERY call (no module-load caching)', async () => {
+    it('honors a terminal preference changed in Settings without an app restart', async () => {
+      // Arrange
       realpathMock.mockResolvedValue('/x')
       const handler = getRegisteredHandler('folder:openInTerminal')
 
-      // First click: Terminal
+      // Act / Assert — first click launches the default Terminal.
       spawnFiringEvent('exit', 0)
       await handler({}, '/x')
       expect(spawnMock).toHaveBeenLastCalledWith(
@@ -283,7 +330,7 @@ describe('folder IPC handlers (integration)', () => {
         { stdio: 'ignore' },
       )
 
-      // User changed Settings to iTerm — no app restart, just another click.
+      // Act / Assert — user switched Settings to iTerm; next click uses iTerm.
       getSettingsMock.mockReturnValue({
         defaultSkillTab: 'files',
         preferredTerminal: 'iterm',

--- a/src/main/ipc/folder.test.ts
+++ b/src/main/ipc/folder.test.ts
@@ -7,86 +7,138 @@ import { buildOpenArgs } from './folder'
  * curated × custom matrix without spawning processes or touching the filesystem.
  * Integration tests (mocked spawn / realpath) live in `folder.integration.test.ts`.
  */
-describe('buildOpenArgs', () => {
-  it('maps curated id "terminal" to Apple Terminal display name', () => {
-    expect(buildOpenArgs('terminal', undefined, '/x')).toEqual([
-      '-a',
-      'Terminal',
-      '/x',
-    ])
+describe('Open in Terminal: choosing which app launches', () => {
+  it('opens the Terminal app when the user picked the "terminal" preset', () => {
+    // Arrange
+    const preferredTerminal = 'terminal'
+
+    // Act
+    const openArgs = buildOpenArgs(preferredTerminal, undefined, '/x')
+
+    // Assert
+    expect(openArgs).toEqual(['-a', 'Terminal', '/x'])
   })
 
-  it('maps curated id "iterm" to iTerm display name', () => {
-    expect(buildOpenArgs('iterm', undefined, '/x')).toEqual([
-      '-a',
-      'iTerm',
-      '/x',
-    ])
+  it('opens iTerm when the user picked the "iterm" preset', () => {
+    // Arrange
+    const preferredTerminal = 'iterm'
+
+    // Act
+    const openArgs = buildOpenArgs(preferredTerminal, undefined, '/x')
+
+    // Assert
+    expect(openArgs).toEqual(['-a', 'iTerm', '/x'])
   })
 
-  it('maps curated id "warp" to Warp display name', () => {
-    expect(buildOpenArgs('warp', undefined, '/x')).toEqual(['-a', 'Warp', '/x'])
+  it('opens Warp when the user picked the "warp" preset', () => {
+    // Arrange
+    const preferredTerminal = 'warp'
+
+    // Act
+    const openArgs = buildOpenArgs(preferredTerminal, undefined, '/x')
+
+    // Assert
+    expect(openArgs).toEqual(['-a', 'Warp', '/x'])
   })
 
-  it('maps curated id "ghostty" to Ghostty display name', () => {
-    expect(buildOpenArgs('ghostty', undefined, '/x')).toEqual([
-      '-a',
-      'Ghostty',
-      '/x',
-    ])
+  it('opens Ghostty when the user picked the "ghostty" preset', () => {
+    // Arrange
+    const preferredTerminal = 'ghostty'
+
+    // Act
+    const openArgs = buildOpenArgs(preferredTerminal, undefined, '/x')
+
+    // Assert
+    expect(openArgs).toEqual(['-a', 'Ghostty', '/x'])
   })
 
-  it('maps curated id "alacritty" to Alacritty display name', () => {
-    expect(buildOpenArgs('alacritty', undefined, '/x')).toEqual([
-      '-a',
-      'Alacritty',
-      '/x',
-    ])
+  it('opens Alacritty when the user picked the "alacritty" preset', () => {
+    // Arrange
+    const preferredTerminal = 'alacritty'
+
+    // Act
+    const openArgs = buildOpenArgs(preferredTerminal, undefined, '/x')
+
+    // Assert
+    expect(openArgs).toEqual(['-a', 'Alacritty', '/x'])
   })
 
-  it('maps curated id "kitty" to lowercased "kitty" display name', () => {
-    expect(buildOpenArgs('kitty', undefined, '/x')).toEqual([
-      '-a',
-      'kitty',
-      '/x',
-    ])
+  it('opens kitty using its lowercased app name when the user picked the "kitty" preset', () => {
+    // Arrange
+    const preferredTerminal = 'kitty'
+
+    // Act
+    const openArgs = buildOpenArgs(preferredTerminal, undefined, '/x')
+
+    // Assert
+    expect(openArgs).toEqual(['-a', 'kitty', '/x'])
   })
 
-  it('maps curated id "wezterm" to WezTerm display name', () => {
-    expect(buildOpenArgs('wezterm', undefined, '/x')).toEqual([
-      '-a',
-      'WezTerm',
-      '/x',
-    ])
+  it('opens WezTerm when the user picked the "wezterm" preset', () => {
+    // Arrange
+    const preferredTerminal = 'wezterm'
+
+    // Act
+    const openArgs = buildOpenArgs(preferredTerminal, undefined, '/x')
+
+    // Assert
+    expect(openArgs).toEqual(['-a', 'WezTerm', '/x'])
   })
 
-  it('uses customTerminalAppName when preferredTerminal is "custom"', () => {
-    expect(buildOpenArgs('custom', 'Hyper', '/x')).toEqual([
-      '-a',
-      'Hyper',
-      '/x',
-    ])
+  it('opens the user-named custom app when the "custom" preset is selected', () => {
+    // Arrange
+    const customTerminalAppName = 'Hyper'
+
+    // Act
+    const openArgs = buildOpenArgs('custom', customTerminalAppName, '/x')
+
+    // Assert
+    expect(openArgs).toEqual(['-a', 'Hyper', '/x'])
   })
 
-  it('returns null for "custom" with undefined customTerminalAppName', () => {
-    expect(buildOpenArgs('custom', undefined, '/x')).toBeNull()
+  it('refuses to open anything when "custom" is selected but no app name is configured', () => {
+    // Arrange
+    const customTerminalAppName = undefined
+
+    // Act
+    const openArgs = buildOpenArgs('custom', customTerminalAppName, '/x')
+
+    // Assert
+    expect(openArgs).toBeNull()
   })
 
-  it('returns null for "custom" with empty string customTerminalAppName', () => {
-    expect(buildOpenArgs('custom', '', '/x')).toBeNull()
+  it('refuses to open anything when the custom app name is an empty string', () => {
+    // Arrange
+    const customTerminalAppName = ''
+
+    // Act
+    const openArgs = buildOpenArgs('custom', customTerminalAppName, '/x')
+
+    // Assert
+    expect(openArgs).toBeNull()
   })
 
-  it('returns null for "custom" with whitespace-only customTerminalAppName', () => {
+  it('refuses to open anything when the custom app name is only whitespace', () => {
+    // Arrange
     // Defense-in-depth: Zod already trims+min(1)s the input, but the function
     // also trims internally so a stale settings.json with '   ' is rejected.
-    expect(buildOpenArgs('custom', '   ', '/x')).toBeNull()
+    const customTerminalAppName = '   '
+
+    // Act
+    const openArgs = buildOpenArgs('custom', customTerminalAppName, '/x')
+
+    // Assert
+    expect(openArgs).toBeNull()
   })
 
-  it('trims surrounding whitespace from custom name', () => {
-    expect(buildOpenArgs('custom', '  Hyper  ', '/x')).toEqual([
-      '-a',
-      'Hyper',
-      '/x',
-    ])
+  it('strips surrounding whitespace from the custom app name before opening', () => {
+    // Arrange
+    const customTerminalAppName = '  Hyper  '
+
+    // Act
+    const openArgs = buildOpenArgs('custom', customTerminalAppName, '/x')
+
+    // Assert
+    expect(openArgs).toEqual(['-a', 'Hyper', '/x'])
   })
 })

--- a/src/main/ipc/ipc-schemas.test.ts
+++ b/src/main/ipc/ipc-schemas.test.ts
@@ -328,6 +328,16 @@ describe('destructive reviewed-path IPC schemas', () => {
         },
       ]).success,
     ).toBe(false)
+    // Act / Assert — single delete with an absolute skillPath is accepted.
+    expect(
+      singleDeleteSchema.safeParse([
+        {
+          skillName: 'task',
+          skillPath: '/tmp/task',
+          filesystemIdentity: directoryIdentity,
+        },
+      ]).success,
+    ).toBe(true)
     // Act / Assert — batch delete without a skillPath is rejected.
     expect(
       batchDeleteSchema.safeParse([{ items: [{ skillName: 'task' }] }]).success,

--- a/src/main/ipc/ipc-schemas.test.ts
+++ b/src/main/ipc/ipc-schemas.test.ts
@@ -25,38 +25,39 @@ const directoryIdentity = {
  * sandbox escape.
  */
 
-describe('skillNameString consistency across channels', () => {
+describe('path-traversal skill names blocked on every skill-name-accepting channel', () => {
   // The same refined string is used by every skill-name-accepting channel;
   // a regression in one place would undermine the overall boundary. This
   // test asserts the uniformity explicitly — if someone adds a new channel
   // and forgets to use skillNameString, this will not catch it directly
   // but the `../` rejections above will (all channels share the refinement).
-  it('rejects "../etc/passwd" across every skill-name-accepting channel', () => {
+  it('blocks a path-traversal skill name ("../etc/passwd") on every skill-name-accepting channel', () => {
+    // Arrange
     const malicious = '../etc/passwd'
-    const channelCases: Array<{
-      channel: keyof typeof IPC_ARG_SCHEMAS
-      payload: unknown
-    }> = [
-      {
-        channel: 'skills:unlinkFromAgent',
-        payload: {
+
+    // Act / Assert — each channel must reject the traversal name independently.
+    expect(
+      IPC_ARG_SCHEMAS['skills:unlinkFromAgent']!.safeParse([
+        {
           skillName: malicious,
           agentId: 'cursor',
           linkPath: '/tmp/x',
           targetPath: '/tmp/target',
         },
-      },
-      {
-        channel: 'skills:deleteSkill',
-        payload: {
+      ]).success,
+    ).toBe(false)
+    expect(
+      IPC_ARG_SCHEMAS['skills:deleteSkill']!.safeParse([
+        {
           skillName: malicious,
           skillPath: '/tmp/x',
           filesystemIdentity: directoryIdentity,
         },
-      },
-      {
-        channel: 'skills:deleteSkills',
-        payload: {
+      ]).success,
+    ).toBe(false)
+    expect(
+      IPC_ARG_SCHEMAS['skills:deleteSkills']!.safeParse([
+        {
           items: [
             {
               skillName: malicious,
@@ -65,26 +66,29 @@ describe('skillNameString consistency across channels', () => {
             },
           ],
         },
-      },
-      {
-        channel: 'skills:createSymlinks',
-        payload: {
+      ]).success,
+    ).toBe(false)
+    expect(
+      IPC_ARG_SCHEMAS['skills:createSymlinks']!.safeParse([
+        {
           skillName: malicious,
           skillPath: '/tmp/x',
           agentIds: ['cursor'],
         },
-      },
-      {
-        channel: 'skills:copyToAgents',
-        payload: {
+      ]).success,
+    ).toBe(false)
+    expect(
+      IPC_ARG_SCHEMAS['skills:copyToAgents']!.safeParse([
+        {
           skillName: malicious,
           sourcePath: '/tmp/x',
           targetAgentIds: ['cursor'],
         },
-      },
-      {
-        channel: 'skills:clearOrphanSymlinks',
-        payload: {
+      ]).success,
+    ).toBe(false)
+    expect(
+      IPC_ARG_SCHEMAS['skills:clearOrphanSymlinks']!.safeParse([
+        {
           items: [
             {
               skillName: malicious,
@@ -98,10 +102,11 @@ describe('skillNameString consistency across channels', () => {
             },
           ],
         },
-      },
-      {
-        channel: 'skills:clearBrokenSymlinkSlots',
-        payload: {
+      ]).success,
+    ).toBe(false)
+    expect(
+      IPC_ARG_SCHEMAS['skills:clearBrokenSymlinkSlots']!.safeParse([
+        {
           items: [
             {
               agentId: 'cursor',
@@ -111,10 +116,11 @@ describe('skillNameString consistency across channels', () => {
             },
           ],
         },
-      },
-      {
-        channel: 'skills:unlinkManyFromAgent',
-        payload: {
+      ]).success,
+    ).toBe(false)
+    expect(
+      IPC_ARG_SCHEMAS['skills:unlinkManyFromAgent']!.safeParse([
+        {
           agentId: 'cursor',
           items: [
             {
@@ -124,17 +130,8 @@ describe('skillNameString consistency across channels', () => {
             },
           ],
         },
-      },
-    ]
-
-    for (const { channel, payload } of channelCases) {
-      const schema = IPC_ARG_SCHEMAS[channel]!
-      const result = schema.safeParse([payload])
-      expect(
-        result.success,
-        `channel ${channel} should reject ${malicious}`,
-      ).toBe(false)
-    }
+      ]).success,
+    ).toBe(false)
   })
 })
 
@@ -142,7 +139,8 @@ describe('cleanup IPC target path schemas', () => {
   const orphanSchema = IPC_ARG_SCHEMAS['skills:clearOrphanSymlinks']!
   const brokenSchema = IPC_ARG_SCHEMAS['skills:clearBrokenSymlinkSlots']!
 
-  it('requires an absolute targetPath for orphan cleanup records', () => {
+  it('rejects orphan cleanup records that omit or relativize the reviewed target path', () => {
+    // Arrange / Act / Assert — a missing targetPath is rejected.
     expect(
       orphanSchema.safeParse([
         {
@@ -160,6 +158,7 @@ describe('cleanup IPC target path schemas', () => {
         },
       ]).success,
     ).toBe(false)
+    // Act / Assert — a relative targetPath is rejected.
     expect(
       orphanSchema.safeParse([
         {
@@ -180,7 +179,8 @@ describe('cleanup IPC target path schemas', () => {
     ).toBe(false)
   })
 
-  it('requires an absolute targetPath for broken-slot cleanup records', () => {
+  it('rejects broken-slot cleanup records that omit or relativize the reviewed target path', () => {
+    // Arrange / Act / Assert — a missing targetPath is rejected.
     expect(
       brokenSchema.safeParse([
         {
@@ -194,6 +194,7 @@ describe('cleanup IPC target path schemas', () => {
         },
       ]).success,
     ).toBe(false)
+    // Act / Assert — a relative targetPath is rejected.
     expect(
       brokenSchema.safeParse([
         {
@@ -312,10 +313,12 @@ describe('destructive reviewed-path IPC schemas', () => {
   const batchDeleteSchema = IPC_ARG_SCHEMAS['skills:deleteSkills']!
   const batchUnlinkSchema = IPC_ARG_SCHEMAS['skills:unlinkManyFromAgent']!
 
-  it('requires an absolute skillPath for every delete request', () => {
+  it('accepts an absolute skillPath for delete but rejects a missing or relative one (single and batch)', () => {
+    // Act / Assert — single delete without a skillPath is rejected.
     expect(singleDeleteSchema.safeParse([{ skillName: 'task' }]).success).toBe(
       false,
     )
+    // Act / Assert — single delete with a relative skillPath is rejected.
     expect(
       singleDeleteSchema.safeParse([
         {
@@ -325,9 +328,11 @@ describe('destructive reviewed-path IPC schemas', () => {
         },
       ]).success,
     ).toBe(false)
+    // Act / Assert — batch delete without a skillPath is rejected.
     expect(
       batchDeleteSchema.safeParse([{ items: [{ skillName: 'task' }] }]).success,
     ).toBe(false)
+    // Act / Assert — batch delete with a relative skillPath is rejected.
     expect(
       batchDeleteSchema.safeParse([
         {
@@ -341,6 +346,7 @@ describe('destructive reviewed-path IPC schemas', () => {
         },
       ]).success,
     ).toBe(false)
+    // Act / Assert — batch delete with an absolute skillPath is accepted.
     expect(
       batchDeleteSchema.safeParse([
         {
@@ -356,12 +362,14 @@ describe('destructive reviewed-path IPC schemas', () => {
     ).toBe(true)
   })
 
-  it('requires an absolute linkPath for every bulk unlink request', () => {
+  it('accepts an absolute linkPath and target for bulk unlink but rejects a missing or relative one', () => {
+    // Act / Assert — bulk unlink without a linkPath is rejected.
     expect(
       batchUnlinkSchema.safeParse([
         { agentId: 'cursor', items: [{ skillName: 'task' }] },
       ]).success,
     ).toBe(false)
+    // Act / Assert — a relative linkPath is rejected.
     expect(
       batchUnlinkSchema.safeParse([
         {
@@ -376,6 +384,7 @@ describe('destructive reviewed-path IPC schemas', () => {
         },
       ]).success,
     ).toBe(false)
+    // Act / Assert — a relative targetPath is rejected.
     expect(
       batchUnlinkSchema.safeParse([
         {
@@ -390,6 +399,7 @@ describe('destructive reviewed-path IPC schemas', () => {
         },
       ]).success,
     ).toBe(false)
+    // Act / Assert — absolute linkPath and targetPath are accepted.
     expect(
       batchUnlinkSchema.safeParse([
         {
@@ -406,19 +416,23 @@ describe('destructive reviewed-path IPC schemas', () => {
     ).toBe(true)
   })
 
-  it('requires remove-all agent path and directory identity', () => {
+  it('accepts remove-all only with an absolute agent path AND a reviewed directory identity', () => {
+    // Arrange
     const removeAllSchema = IPC_ARG_SCHEMAS['skills:removeAllFromAgent']!
 
+    // Act / Assert — a relative agentPath is rejected.
     expect(
       removeAllSchema.safeParse([
         { agentId: 'cursor', agentPath: 'relative/path' },
       ]).success,
     ).toBe(false)
+    // Act / Assert — an absolute agentPath without a reviewed identity is rejected.
     expect(
       removeAllSchema.safeParse([
         { agentId: 'cursor', agentPath: '/tmp/.cursor/skills' },
       ]).success,
     ).toBe(false)
+    // Act / Assert — an absolute agentPath plus a reviewed identity is accepted.
     expect(
       removeAllSchema.safeParse([
         {
@@ -441,25 +455,38 @@ describe('folder:* channels', () => {
   const finderSchema = IPC_ARG_SCHEMAS['folder:revealInFinder']!
   const terminalSchema = IPC_ARG_SCHEMAS['folder:openInTerminal']!
 
-  it('folder:revealInFinder accepts an absolute path', () => {
-    expect(finderSchema.safeParse(['/Users/me/.agents/skills']).success).toBe(
-      true,
-    )
+  it('lets Reveal in Finder run on an absolute folder path', () => {
+    // Arrange
+    const absolutePath = '/Users/me/.agents/skills'
+
+    // Act / Assert
+    expect(finderSchema.safeParse([absolutePath]).success).toBe(true)
   })
 
-  it('folder:revealInFinder rejects empty string', () => {
-    expect(finderSchema.safeParse(['']).success).toBe(false)
+  it('blocks Reveal in Finder on an empty path at the IPC boundary', () => {
+    // Arrange
+    const emptyPath = ''
+
+    // Act / Assert
+    expect(finderSchema.safeParse([emptyPath]).success).toBe(false)
   })
 
-  it('folder:revealInFinder rejects relative path', () => {
-    expect(finderSchema.safeParse(['relative/path']).success).toBe(false)
+  it('blocks Reveal in Finder on a relative path at the IPC boundary', () => {
+    // Arrange
+    const relativePath = 'relative/path'
+
+    // Act / Assert
+    expect(finderSchema.safeParse([relativePath]).success).toBe(false)
   })
 
-  it('folder:openInTerminal mirrors the same absolute-path guard', () => {
+  it('guards Open in Terminal with the same absolute-path-only rule', () => {
+    // Act / Assert — an absolute path is accepted.
     expect(terminalSchema.safeParse(['/Users/me/.cline/skills']).success).toBe(
       true,
     )
+    // Act / Assert — an empty path is rejected.
     expect(terminalSchema.safeParse(['']).success).toBe(false)
+    // Act / Assert — a relative path is rejected.
     expect(terminalSchema.safeParse(['./relative']).success).toBe(false)
   })
 })
@@ -472,47 +499,58 @@ describe('folder:* channels', () => {
 describe('settings:set lockstep with SettingsSchema', () => {
   const schema = IPC_ARG_SCHEMAS['settings:set']!
 
-  it('accepts the new preferredTerminal field', () => {
+  it('lets the user persist a preferredTerminal choice', () => {
+    // Arrange / Act / Assert
     expect(schema.safeParse([{ preferredTerminal: 'iterm' }]).success).toBe(
       true,
     )
   })
 
-  it('accepts customTerminalAppName within length cap', () => {
+  it('lets the user persist a custom terminal app name within the length cap', () => {
+    // Arrange / Act / Assert
     expect(schema.safeParse([{ customTerminalAppName: 'Hyper' }]).success).toBe(
       true,
     )
   })
 
-  it('accepts the bounded windowBackgroundBlurRadius field', () => {
+  it('lets the user persist a window background blur radius within bounds', () => {
+    // Arrange / Act / Assert
     expect(schema.safeParse([{ windowBackgroundBlurRadius: 24 }]).success).toBe(
       true,
     )
   })
 
-  it('accepts the auto-download preference boolean', () => {
+  it('lets the user persist the auto-download updates toggle', () => {
+    // Arrange / Act / Assert
     expect(schema.safeParse([{ autoDownloadUpdates: true }]).success).toBe(true)
   })
 
-  it('rejects a non-boolean autoDownloadUpdates at the IPC boundary', () => {
+  it('blocks a non-boolean auto-download toggle from reaching disk', () => {
+    // Arrange / Act / Assert
     expect(schema.safeParse([{ autoDownloadUpdates: 'yes' }]).success).toBe(
       false,
     )
   })
 
-  it('rejects an unknown enum value for preferredTerminal', () => {
+  it('blocks an unknown terminal preset from reaching disk', () => {
+    // Arrange / Act / Assert
     expect(
       schema.safeParse([{ preferredTerminal: 'fish-shell' }]).success,
     ).toBe(false)
   })
 
-  it('rejects customTerminalAppName longer than 64 chars', () => {
+  it('blocks a custom terminal app name longer than the 64-char cap', () => {
+    // Arrange
+    const overlongName = 'a'.repeat(65)
+
+    // Act / Assert
     expect(
-      schema.safeParse([{ customTerminalAppName: 'a'.repeat(65) }]).success,
+      schema.safeParse([{ customTerminalAppName: overlongName }]).success,
     ).toBe(false)
   })
 
-  it('rejects an invalid windowBackgroundBlurRadius value', () => {
+  it('blocks an out-of-range or fractional window background blur radius', () => {
+    // Act / Assert — below the allowed minimum is rejected.
     expect(
       schema.safeParse([
         {
@@ -520,9 +558,11 @@ describe('settings:set lockstep with SettingsSchema', () => {
         },
       ]).success,
     ).toBe(false)
+    // Act / Assert — a fractional radius is rejected.
     expect(
       schema.safeParse([{ windowBackgroundBlurRadius: 24.5 }]).success,
     ).toBe(false)
+    // Act / Assert — above the allowed maximum is rejected.
     expect(
       schema.safeParse([
         {
@@ -532,14 +572,16 @@ describe('settings:set lockstep with SettingsSchema', () => {
     ).toBe(false)
   })
 
-  it('rejects unknown extra keys (.strict())', () => {
+  it('blocks an unknown extra settings key (.strict()) from a compromised renderer', () => {
+    // Arrange / Act / Assert
     expect(
       schema.safeParse([{ defaultSkillTab: 'files', somethingElse: 'x' }])
         .success,
     ).toBe(false)
   })
 
-  it('parsing a partial without hiddenAgentIds does NOT inject a default', () => {
+  it('does not wipe a persisted hiddenAgentIds when an unrelated setting is saved', () => {
+    // Arrange
     // Regression for the wipe-on-every-write bug: when the IPC schema for
     // `hiddenAgentIds` chained `.optional()` over the disk schema's
     // `.default([])`, every settings:set call that omitted the key
@@ -547,45 +589,64 @@ describe('settings:set lockstep with SettingsSchema', () => {
     // clobbered the persisted value via `{ ...current, ...partial }` in
     // saveSettings(). Pin this so the IPC schema can never re-inherit a
     // default.
+
+    // Act
     const parsed = schema.parse([{ defaultSkillTab: 'info' }]) as [object]
+
+    // Assert
     expect('hiddenAgentIds' in parsed[0]).toBe(false)
   })
 
-  it('parsing a partial without windowBackgroundBlurRadius does NOT inject a default', () => {
+  it('does not wipe a persisted window blur radius when an unrelated setting is saved', () => {
+    // Arrange / Act
     const parsed = schema.parse([{ defaultSkillTab: 'info' }]) as [object]
+
+    // Assert
     expect('windowBackgroundBlurRadius' in parsed[0]).toBe(false)
   })
 
-  it('parsing a partial without autoDownloadUpdates does NOT inject its default', () => {
+  it('does not wipe a persisted auto-download opt-in when an unrelated setting is saved', () => {
+    // Arrange
     // Same wipe-on-every-write guard as hiddenAgentIds/blur: the IPC schema
     // declares the toggle as a bare `z.boolean().optional()` rather than
     // chaining `.optional()` over the disk schema's `.default(false)`. If it
     // re-inherited the default, every unrelated settings:set would parse to
     // `{ autoDownloadUpdates: false }` and clobber a user's persisted opt-in.
+
+    // Act
     const parsed = schema.parse([{ defaultSkillTab: 'info' }]) as [object]
+
+    // Assert
     expect('autoDownloadUpdates' in parsed[0]).toBe(false)
   })
 
-  it('accepts an explicit hiddenAgentIds array on settings:set', () => {
+  it('lets the user persist an explicit hiddenAgentIds list', () => {
+    // Arrange / Act / Assert
     expect(
       schema.safeParse([{ hiddenAgentIds: ['claude-code'] }]).success,
     ).toBe(true)
   })
 
-  it('rejects an unknown id in hiddenAgentIds at the IPC boundary', () => {
+  it('blocks an unknown agent id in hiddenAgentIds from a compromised renderer', () => {
+    // Arrange
     // The renderer should never emit a non-AgentId. Disk reads are
     // forgiving (drop stale ids); the IPC channel is strict.
+
+    // Act / Assert
     expect(
       schema.safeParse([{ hiddenAgentIds: ['definitely-not-an-agent'] }])
         .success,
     ).toBe(false)
   })
 
-  it('rejects a hiddenAgentIds payload longer than AGENT_IDS', () => {
+  it('blocks an oversized hiddenAgentIds payload longer than the agent roster', () => {
+    // Arrange
     // Defense-in-depth payload cap — a misbehaving renderer cannot push
     // an arbitrarily long list past the IPC boundary. Every legitimate
     // entry beyond AGENT_IDS.length would have to be a duplicate anyway.
     const oversized = Array.from({ length: 100 }, () => 'claude-code' as const)
+
+    // Act / Assert
     expect(schema.safeParse([{ hiddenAgentIds: oversized }]).success).toBe(
       false,
     )

--- a/src/main/ipc/skills.copyToAgents.integration.test.ts
+++ b/src/main/ipc/skills.copyToAgents.integration.test.ts
@@ -69,7 +69,8 @@ describe('skills:copyToAgents handler', () => {
     await rm(tempHome, { recursive: true, force: true })
   })
 
-  it('accepts a source skill directory path and copies it into the target agent dir', async () => {
+  it('copies a source skill into the chosen agent so its files land in the agent dir', async () => {
+    // Arrange
     const sourcePath = join(tempHome, '.agents', 'skills', 'task')
     await mkdir(sourcePath, { recursive: true })
     await writeFile(
@@ -80,8 +81,9 @@ describe('skills:copyToAgents handler', () => {
 
     const { registerSkillsHandlers } = await import('./skills')
     registerSkillsHandlers()
-
     const copyToAgentsHandler = getRegisteredHandler('skills:copyToAgents')
+
+    // Act
     const result = (await copyToAgentsHandler(
       {},
       {
@@ -95,6 +97,7 @@ describe('skills:copyToAgents handler', () => {
       failures: unknown[]
     }
 
+    // Assert
     expect(result).toEqual({
       success: true,
       copied: 1,
@@ -110,7 +113,8 @@ describe('skills:copyToAgents handler', () => {
     ).resolves.toBe('copied payload')
   })
 
-  it('preserves nested symlinks when copying a source directory', async () => {
+  it('keeps nested symlinks as symlinks when copying a source skill into an agent', async () => {
+    // Arrange
     const sourcePath = join(tempHome, '.agents', 'skills', 'task')
     await mkdir(join(sourcePath, 'docs'), { recursive: true })
     await writeFile(
@@ -122,8 +126,9 @@ describe('skills:copyToAgents handler', () => {
 
     const { registerSkillsHandlers } = await import('./skills')
     registerSkillsHandlers()
-
     const copyToAgentsHandler = getRegisteredHandler('skills:copyToAgents')
+
+    // Act
     const result = (await copyToAgentsHandler(
       {},
       {
@@ -137,6 +142,7 @@ describe('skills:copyToAgents handler', () => {
       failures: unknown[]
     }
 
+    // Assert
     expect(result).toEqual({
       success: true,
       copied: 1,

--- a/src/main/ipc/skills.removeAllFromAgent.integration.test.ts
+++ b/src/main/ipc/skills.removeAllFromAgent.integration.test.ts
@@ -110,13 +110,15 @@ describe('skills:removeAllFromAgent handler', () => {
   // for paths like `~/.config/agents/skills` that DO match an agent base).
   // Either rejection satisfies the contract — what matters is `success:
   // false` and trashItem never firing.
-  it('rejects SOURCE_DIR — the v0.13.0 regression path', async () => {
+  it('refuses to trash the shared SOURCE_DIR so it cannot cascade into every universal agent (v0.13.0 regression)', async () => {
+    // Arrange
     const sourceDir = join(tempHome, '.agents', 'skills')
     await mkdir(sourceDir, { recursive: true })
 
     const { registerSkillsHandlers } = await import('./skills')
     registerSkillsHandlers()
 
+    // Act
     const handler = getRegisteredHandler('skills:removeAllFromAgent')
     const result = await handler(
       {},
@@ -127,6 +129,7 @@ describe('skills:removeAllFromAgent handler', () => {
       },
     )
 
+    // Assert
     expect(result.success).toBe(false)
     expect(result.error).toMatch(
       /shared skills folder|path traversal|does not match the selected agent slot/i,
@@ -134,7 +137,8 @@ describe('skills:removeAllFromAgent handler', () => {
     expect(trashItemMock).not.toHaveBeenCalled()
   })
 
-  it('rejects a trailing-slash bypass of SOURCE_DIR', async () => {
+  it('refuses to trash SOURCE_DIR even when a trailing slash is appended to dodge the guard', async () => {
+    // Arrange
     // A raw string `~/.agents/skills/` would miss SHARED_AGENT_PATHS.has()
     // without the resolve() normalization in isSharedAgentPath. Post-fix
     // it's normally caught one layer earlier by validatePath, but the
@@ -145,6 +149,7 @@ describe('skills:removeAllFromAgent handler', () => {
     const { registerSkillsHandlers } = await import('./skills')
     registerSkillsHandlers()
 
+    // Act
     const handler = getRegisteredHandler('skills:removeAllFromAgent')
     const sourceIdentity = await reviewedIdentity(sourceDir)
     const result = await handler(
@@ -156,6 +161,7 @@ describe('skills:removeAllFromAgent handler', () => {
       },
     )
 
+    // Assert
     expect(result.success).toBe(false)
     expect(result.error).toMatch(
       /shared skills folder|path traversal|does not match the selected agent slot/i,
@@ -166,7 +172,8 @@ describe('skills:removeAllFromAgent handler', () => {
   // Idempotency contract: shell.trashItem throws ENOENT (unlike the old
   // fs.rm({force:true}) this handler used to call). Pre-checking with
   // fs.access lets double-clicks and out-of-band deletes resolve cleanly.
-  it('returns success with 0 count when agent dir does not exist', async () => {
+  it('treats removing an already-gone agent dir as a no-op success (idempotent double-click)', async () => {
+    // Arrange
     const cursorDir = join(tempHome, '.cursor', 'skills')
     await mkdir(cursorDir, { recursive: true })
     const staleIdentity = await reviewedIdentity(cursorDir)
@@ -175,6 +182,7 @@ describe('skills:removeAllFromAgent handler', () => {
     const { registerSkillsHandlers } = await import('./skills')
     registerSkillsHandlers()
 
+    // Act
     const handler = getRegisteredHandler('skills:removeAllFromAgent')
     const result = await handler(
       {},
@@ -185,6 +193,7 @@ describe('skills:removeAllFromAgent handler', () => {
       },
     )
 
+    // Assert
     expect(result).toEqual({ success: true, removedCount: 0 })
     expect(trashItemMock).not.toHaveBeenCalled()
   })
@@ -216,7 +225,8 @@ describe('skills:removeAllFromAgent handler', () => {
     expect(trashItemMock).not.toHaveBeenCalled()
   })
 
-  it('trashes a real agent dir and returns count of entries', async () => {
+  it('moves a real agent dir to the Trash and reports how many skills it held', async () => {
+    // Arrange
     const cursorDir = join(tempHome, '.cursor', 'skills')
     await mkdir(join(cursorDir, 'skill-a'), { recursive: true })
     await mkdir(join(cursorDir, 'skill-b'), { recursive: true })
@@ -224,6 +234,7 @@ describe('skills:removeAllFromAgent handler', () => {
     const { registerSkillsHandlers } = await import('./skills')
     registerSkillsHandlers()
 
+    // Act
     const handler = getRegisteredHandler('skills:removeAllFromAgent')
     const result = await handler(
       {},
@@ -234,6 +245,7 @@ describe('skills:removeAllFromAgent handler', () => {
       },
     )
 
+    // Assert
     expect(result).toEqual({ success: true, removedCount: 2 })
     expect(trashItemMock).toHaveBeenCalledTimes(1)
     expect(String(trashItemMock.mock.calls[0][0])).toContain(
@@ -286,7 +298,8 @@ describe('skills:removeAllFromAgent handler', () => {
   // the realpath stage follows the symlink to ~/.agents/skills and catches
   // it. Without the fallback, a user who manually symlinked their agent
   // dir to the universal source could still trip the v0.13.0 cascade.
-  it('rejects a symlink alias whose realpath lands on SOURCE_DIR', async () => {
+  it('refuses to trash an agent dir that is a symlink resolving to the shared SOURCE_DIR', async () => {
+    // Arrange
     const sourceDir = join(tempHome, '.agents', 'skills')
     const aliasDir = join(tempHome, '.cursor', 'skills')
     await mkdir(sourceDir, { recursive: true })
@@ -296,6 +309,7 @@ describe('skills:removeAllFromAgent handler', () => {
     const { registerSkillsHandlers } = await import('./skills')
     registerSkillsHandlers()
 
+    // Act
     const handler = getRegisteredHandler('skills:removeAllFromAgent')
     const result = await handler(
       {},
@@ -306,6 +320,7 @@ describe('skills:removeAllFromAgent handler', () => {
       },
     )
 
+    // Assert
     expect(result.success).toBe(false)
     expect(result.error).toMatch(/shared skills folder/)
     expect(trashItemMock).not.toHaveBeenCalled()

--- a/src/main/services/agentScanner.test.ts
+++ b/src/main/services/agentScanner.test.ts
@@ -73,7 +73,8 @@ describe('scanAgents', () => {
     })
   })
 
-  it('counts only valid symlinks, excluding broken ones', async () => {
+  it('counts a skill toward an agent only when its symlink resolves, ignoring broken links', async () => {
+    // Arrange
     // Both agent dirs exist
     accessMock.mockResolvedValue(undefined)
 
@@ -102,16 +103,19 @@ describe('scanAgents', () => {
       return 'broken'
     })
 
+    // Act
     const { scanAgents } = await import('./agentScanner')
     const agents = await scanAgents()
 
+    // Assert
     const claude = agents.find((a) => a.id === 'claude-code')!
     expect(claude.exists).toBe(true)
     expect(claude.skillCount).toBe(3)
     expect(claude.localSkillCount).toBe(0)
   })
 
-  it('returns skillCount 0 when all symlinks are broken', async () => {
+  it('counts zero skills when every symlink is broken', async () => {
+    // Arrange
     accessMock.mockResolvedValue(undefined)
 
     readdirMock.mockImplementation(async (path: string) => {
@@ -132,14 +136,17 @@ describe('scanAgents', () => {
 
     checkSymlinkStatusMock.mockResolvedValue('broken')
 
+    // Act
     const { scanAgents } = await import('./agentScanner')
     const agents = await scanAgents()
 
+    // Assert
     const claude = agents.find((a) => a.id === 'claude-code')!
     expect(claude.skillCount).toBe(0)
   })
 
-  it('counts local skills independently from symlinked skills', async () => {
+  it('tallies local folder skills separately from symlinked skills', async () => {
+    // Arrange
     accessMock.mockImplementation(async (path: string) => {
       // Agent dirs exist
       if (path === '/mock/agents/claude/skills') return
@@ -170,15 +177,18 @@ describe('scanAgents', () => {
 
     checkSymlinkStatusMock.mockResolvedValue('valid')
 
+    // Act
     const { scanAgents } = await import('./agentScanner')
     const agents = await scanAgents()
 
+    // Assert
     const claude = agents.find((a) => a.id === 'claude-code')!
     expect(claude.skillCount).toBe(1)
     expect(claude.localSkillCount).toBe(1)
   })
 
-  it('returns exists: false with zero counts when agent dir is missing', async () => {
+  it('marks an agent as not existing with zero counts when its skills dir is absent', async () => {
+    // Arrange
     accessMock.mockImplementation(async (path: string) => {
       if (path === '/mock/agents/claude/skills') {
         throw new Error('ENOENT')
@@ -189,16 +199,19 @@ describe('scanAgents', () => {
 
     readdirMock.mockResolvedValue([])
 
+    // Act
     const { scanAgents } = await import('./agentScanner')
     const agents = await scanAgents()
 
+    // Assert
     const claude = agents.find((a) => a.id === 'claude-code')!
     expect(claude.exists).toBe(false)
     expect(claude.skillCount).toBe(0)
     expect(claude.localSkillCount).toBe(0)
   })
 
-  it('sorts existing agents before non-existing agents', async () => {
+  it('lists existing agents ahead of missing ones, then alphabetically by name', async () => {
+    // Arrange
     accessMock.mockImplementation(async (path: string) => {
       // Claude doesn't exist; cursor + the universal-resolving rows (cline,
       // warp both point at /mock/source/skills in the mock) do.
@@ -210,9 +223,11 @@ describe('scanAgents', () => {
 
     readdirMock.mockResolvedValue([])
 
+    // Act
     const { scanAgents } = await import('./agentScanner')
     const agents = await scanAgents()
 
+    // Assert
     // Existing rows sort first, then alphabetically by name:
     //   Cline, Cursor, Warp (exists=true) → Claude Code (exists=false)
     expect(agents.map((a) => a.id)).toEqual([
@@ -224,13 +239,16 @@ describe('scanAgents', () => {
     expect(agents[agents.length - 1].exists).toBe(false)
   })
 
-  it('includes every agent — even ones whose Skills CLI dir resolves to the Universal source', async () => {
+  it('keeps every agent visible even when its CLI dir resolves to the Universal source', async () => {
+    // Arrange
     accessMock.mockResolvedValue(undefined)
     readdirMock.mockResolvedValue([])
 
+    // Act
     const { scanAgents } = await import('./agentScanner')
     const agents = await scanAgents()
 
+    // Assert
     // Cline + Warp currently resolve to the Universal source in the mock.
     // We still render them AND pin `exists: true` — the dedicated/universal
     // relationship is a dual-source READ, not an alias. Hiding rows or
@@ -246,7 +264,8 @@ describe('scanAgents', () => {
     expect(agents.find((a) => a.id === 'cursor')).toBeDefined()
   })
 
-  it('excludes dot-prefixed directories from local skill count', async () => {
+  it('skips dot-prefixed directories when counting local skills', async () => {
+    // Arrange
     accessMock.mockResolvedValue(undefined)
 
     readdirMock.mockImplementation(async (path: string) => {
@@ -265,15 +284,18 @@ describe('scanAgents', () => {
       return []
     })
 
+    // Act
     const { scanAgents } = await import('./agentScanner')
     const agents = await scanAgents()
 
+    // Assert
     const claude = agents.find((a) => a.id === 'claude-code')!
     // .hidden-dir is excluded, visible-skill has SKILL.md (access resolves)
     expect(claude.localSkillCount).toBe(1)
   })
 
-  it('does not count local dirs without SKILL.md', async () => {
+  it('ignores a local directory that has no SKILL.md when counting local skills', async () => {
+    // Arrange
     accessMock.mockImplementation(async (path: string) => {
       // Agent dirs exist
       if (path === '/mock/agents/claude/skills') return
@@ -294,9 +316,11 @@ describe('scanAgents', () => {
       return []
     })
 
+    // Act
     const { scanAgents } = await import('./agentScanner')
     const agents = await scanAgents()
 
+    // Assert
     const claude = agents.find((a) => a.id === 'claude-code')!
     expect(claude.localSkillCount).toBe(0)
   })

--- a/src/main/services/fileReader.test.ts
+++ b/src/main/services/fileReader.test.ts
@@ -64,7 +64,8 @@ describe('listSkillFiles', () => {
     vi.clearAllMocks()
   })
 
-  it('returns SKILL.md first, then other files sorted by relative path', async () => {
+  it('puts SKILL.md first and sorts the rest by relative path', async () => {
+    // Arrange
     mockTree({
       '/skills/my-skill': [
         makeDirent('zebra.ts'),
@@ -74,7 +75,10 @@ describe('listSkillFiles', () => {
     })
     mockStat()
 
+    // Act
     const result = await listSkillFiles('/skills/my-skill')
+
+    // Assert
     expect(result.map((f) => f.name)).toEqual([
       'SKILL.md',
       'alpha.md',
@@ -82,7 +86,8 @@ describe('listSkillFiles', () => {
     ])
   })
 
-  it('filters out unsupported file extensions', async () => {
+  it('drops files with unsupported extensions from the listing', async () => {
+    // Arrange
     mockTree({
       '/skills/my-skill': [
         makeDirent('SKILL.md'),
@@ -93,7 +98,10 @@ describe('listSkillFiles', () => {
     })
     mockStat()
 
+    // Act
     const result = await listSkillFiles('/skills/my-skill')
+
+    // Assert
     const names = result.map((f) => f.name)
     expect(names).toContain('SKILL.md')
     expect(names).toContain('script.mjs')
@@ -101,7 +109,8 @@ describe('listSkillFiles', () => {
     expect(names).not.toContain('data.bin')
   })
 
-  it('classifies png/jpg as image previewable', async () => {
+  it('flags png and jpg as image-previewable and markdown as text-previewable', async () => {
+    // Arrange
     mockTree({
       '/skills/my-skill': [
         makeDirent('SKILL.md'),
@@ -111,14 +120,18 @@ describe('listSkillFiles', () => {
     })
     mockStat()
 
+    // Act
     const result = await listSkillFiles('/skills/my-skill')
+
+    // Assert
     const byName = Object.fromEntries(result.map((f) => [f.name, f]))
     expect(byName['SKILL.md'].previewable).toBe('text')
     expect(byName['preview.png'].previewable).toBe('image')
     expect(byName['photo.JPG'].previewable).toBe('image')
   })
 
-  it('includes python and shell files (Scope B extensions)', async () => {
+  it('lists python, shell, and toml files (Scope B extensions)', async () => {
+    // Arrange
     mockTree({
       '/skills/my-skill': [
         makeDirent('SKILL.md'),
@@ -129,13 +142,17 @@ describe('listSkillFiles', () => {
     })
     mockStat()
 
+    // Act
     const names = (await listSkillFiles('/skills/my-skill')).map((f) => f.name)
+
+    // Assert
     expect(names).toContain('helper.py')
     expect(names).toContain('install.sh')
     expect(names).toContain('Config.toml')
   })
 
-  it('recurses into subdirectories and populates relativePath', async () => {
+  it('walks into subdirectories and records each file relative path', async () => {
+    // Arrange
     mockTree({
       '/skills/my-skill': [
         makeDirent('SKILL.md'),
@@ -145,12 +162,16 @@ describe('listSkillFiles', () => {
     })
     mockStat()
 
+    // Act
     const result = await listSkillFiles('/skills/my-skill')
+
+    // Assert
     const byName = Object.fromEntries(result.map((f) => [f.name, f]))
     expect(byName['helper.py'].relativePath).toBe('lib/helper.py')
   })
 
-  it('skips excluded directories entirely (node_modules, .git, __pycache__)', async () => {
+  it('never descends into node_modules, .git, or __pycache__', async () => {
+    // Arrange
     mockTree({
       '/skills/my-skill': [
         makeDirent('SKILL.md'),
@@ -165,11 +186,15 @@ describe('listSkillFiles', () => {
     })
     mockStat()
 
+    // Act
     const names = (await listSkillFiles('/skills/my-skill')).map((f) => f.name)
+
+    // Assert
     expect(names).toEqual(['SKILL.md'])
   })
 
-  it('does not follow symlinked subdirectories', async () => {
+  it('refuses to traverse a symlinked subdirectory', async () => {
+    // Arrange
     mockTree({
       '/skills/my-skill': [
         makeDirent('SKILL.md'),
@@ -179,11 +204,15 @@ describe('listSkillFiles', () => {
     })
     mockStat()
 
+    // Act
     const names = (await listSkillFiles('/skills/my-skill')).map((f) => f.name)
+
+    // Assert
     expect(names).not.toContain('secret.md')
   })
 
-  it('does not include symlinked files at the top level', async () => {
+  it('omits a symlinked file sitting at the top level', async () => {
+    // Arrange
     mockTree({
       '/skills/my-skill': [
         makeDirent('SKILL.md'),
@@ -192,11 +221,15 @@ describe('listSkillFiles', () => {
     })
     mockStat()
 
+    // Act
     const names = (await listSkillFiles('/skills/my-skill')).map((f) => f.name)
+
+    // Assert
     expect(names).toEqual(['SKILL.md'])
   })
 
-  it('caps recursion at MAX_TREE_DEPTH (depth 4 — file at depth 5 excluded)', async () => {
+  it('stops recursing past the depth cap, excluding a file one level too deep', async () => {
+    // Arrange
     mockTree({
       '/r': [makeDirent('a', { isDirectory: true })],
       '/r/a': [makeDirent('b', { isDirectory: true })],
@@ -207,11 +240,15 @@ describe('listSkillFiles', () => {
     })
     mockStat()
 
+    // Act
     const names = (await listSkillFiles('/r')).map((f) => f.name)
+
+    // Assert
     expect(names).not.toContain('too-deep.md')
   })
 
-  it('includes files at the depth cap boundary', async () => {
+  it('still lists a file sitting exactly at the depth cap boundary', async () => {
+    // Arrange
     mockTree({
       '/r': [makeDirent('a', { isDirectory: true })],
       '/r/a': [makeDirent('b', { isDirectory: true })],
@@ -221,33 +258,49 @@ describe('listSkillFiles', () => {
     })
     mockStat()
 
+    // Act
     const names = (await listSkillFiles('/r')).map((f) => f.name)
+
+    // Assert
     expect(names).toContain('ok.md')
   })
 
-  it('marks oversized text files as previewable=binary', async () => {
+  it('treats an over-sized text file as non-previewable binary', async () => {
+    // Arrange
     mockTree({
       '/skills/my-skill': [makeDirent('huge.md')],
     })
     mockStat({ '/skills/my-skill/huge.md': MAX_TEXT_FILE_BYTES + 1 })
 
+    // Act
     const result = await listSkillFiles('/skills/my-skill')
+
+    // Assert
     expect(result[0].previewable).toBe('binary')
   })
 
-  it('marks oversized images as previewable=binary', async () => {
+  it('treats an over-sized image as non-previewable binary', async () => {
+    // Arrange
     mockTree({
       '/skills/my-skill': [makeDirent('big.png')],
     })
     mockStat({ '/skills/my-skill/big.png': MAX_IMAGE_FILE_BYTES + 1 })
 
+    // Act
     const result = await listSkillFiles('/skills/my-skill')
+
+    // Assert
     expect(result[0].previewable).toBe('binary')
   })
 
-  it('returns empty array when directory does not exist', async () => {
+  it('yields an empty listing when the directory does not exist', async () => {
+    // Arrange
     mockFs.readdir.mockRejectedValue(new Error('ENOENT'))
+
+    // Act
     const result = await listSkillFiles('/non/existent/path')
+
+    // Assert
     expect(result).toEqual([])
   })
 })
@@ -257,11 +310,15 @@ describe('readSkillFile', () => {
     vi.clearAllMocks()
   })
 
-  it('returns name, content, extension, and line count', async () => {
+  it('reads a file back with its name, content, extension, and line count', async () => {
+    // Arrange
     mockStat({}, 100)
     mockFs.readFile.mockResolvedValue('line one\nline two\nline three')
 
+    // Act
     const result = await readSkillFile('/skills/my-skill/SKILL.md')
+
+    // Assert
     expect(result).not.toBeNull()
     expect(result!.name).toBe('SKILL.md')
     expect(result!.content).toBe('line one\nline two\nline three')
@@ -269,26 +326,38 @@ describe('readSkillFile', () => {
     expect(result!.lineCount).toBe(3)
   })
 
-  it('returns null when file cannot be read', async () => {
+  it('skips a file it cannot read by returning null', async () => {
+    // Arrange
     mockStat({}, 100)
     mockFs.readFile.mockRejectedValue(new Error('ENOENT'))
 
+    // Act
     const result = await readSkillFile('/skills/my-skill/missing.md')
+
+    // Assert
     expect(result).toBeNull()
   })
 
-  it('returns null when file exceeds MAX_TEXT_FILE_BYTES', async () => {
+  it('refuses to read a file larger than the text size cap', async () => {
+    // Arrange
     mockStat({}, MAX_TEXT_FILE_BYTES + 1)
 
+    // Act
     const result = await readSkillFile('/skills/my-skill/huge.md')
+
+    // Assert
     expect(result).toBeNull()
   })
 
-  it('returns correct lowercase extension for uppercase filenames', async () => {
+  it('lowercases the extension of an upper-cased filename', async () => {
+    // Arrange
     mockStat({}, 10)
     mockFs.readFile.mockResolvedValue('# uppercase')
 
+    // Act
     const result = await readSkillFile('/skills/my-skill/README.MD')
+
+    // Assert
     expect(result!.extension).toBe('.md')
   })
 })
@@ -298,55 +367,79 @@ describe('readBinaryFile', () => {
     vi.clearAllMocks()
   })
 
-  it('returns a data URL for a png file', async () => {
+  it('encodes a png file as a base64 image data URL with its byte size', async () => {
+    // Arrange
     mockStat({}, 4)
     mockFs.readFile.mockResolvedValue(Buffer.from([0x89, 0x50, 0x4e, 0x47]))
 
+    // Act
     const result = await readBinaryFile('/skills/my-skill/preview.png')
+
+    // Assert
     expect(result).not.toBeNull()
     expect(result!.mimeType).toBe('image/png')
     expect(result!.dataUrl.startsWith('data:image/png;base64,')).toBe(true)
     expect(result!.size).toBe(4)
   })
 
-  it('maps jpg/jpeg to image/jpeg', async () => {
+  it('reports both .jpg and .jpeg as image/jpeg', async () => {
+    // Arrange
     mockStat({}, 2)
     mockFs.readFile.mockResolvedValue(Buffer.from([0xff, 0xd8]))
 
+    // Act
     const a = await readBinaryFile('/skills/my-skill/photo.jpg')
     const b = await readBinaryFile('/skills/my-skill/photo.jpeg')
+
+    // Assert
     expect(a!.mimeType).toBe('image/jpeg')
     expect(b!.mimeType).toBe('image/jpeg')
   })
 
-  it('returns null for unknown extensions', async () => {
+  it('refuses to render a file with an unknown image extension', async () => {
+    // Arrange
     mockStat({}, 2)
     mockFs.readFile.mockResolvedValue(Buffer.from([0, 0]))
 
+    // Act
     const result = await readBinaryFile('/skills/my-skill/data.bin')
+
+    // Assert
     expect(result).toBeNull()
   })
 
-  it('returns null when file exceeds MAX_IMAGE_FILE_BYTES', async () => {
+  it('refuses to render an image larger than the image size cap', async () => {
+    // Arrange
     mockStat({}, MAX_IMAGE_FILE_BYTES + 1)
 
+    // Act
     const result = await readBinaryFile('/skills/my-skill/big.png')
+
+    // Assert
     expect(result).toBeNull()
   })
 
-  it('returns null on read error', async () => {
+  it('returns nothing when the image cannot be read', async () => {
+    // Arrange
     mockStat({}, 2)
     mockFs.readFile.mockRejectedValue(new Error('EACCES'))
 
+    // Act
     const result = await readBinaryFile('/skills/my-skill/locked.png')
+
+    // Assert
     expect(result).toBeNull()
   })
 
-  it('emits a non-empty base64 payload for a tiny image', async () => {
+  it('produces a base64 payload past the data-URL prefix for a tiny image', async () => {
+    // Arrange
     mockStat({}, 3)
     mockFs.readFile.mockResolvedValue(Buffer.from([1, 2, 3]))
 
+    // Act
     const result = await readBinaryFile('/skills/my-skill/tiny.png')
+
+    // Assert
     // 3 bytes -> 4 base64 chars
     expect(result!.dataUrl.length).toBeGreaterThan(
       'data:image/png;base64,'.length,

--- a/src/main/services/leaderboardService.test.ts
+++ b/src/main/services/leaderboardService.test.ts
@@ -7,43 +7,51 @@ import {
 } from './leaderboardService'
 
 describe('parseFormattedCount', () => {
-  it('parses plain numbers', () => {
+  it('reads a plain integer install count unchanged', () => {
+    // Act & Assert
     expect(parseFormattedCount('927')).toBe(927)
     expect(parseFormattedCount('0')).toBe(0)
     expect(parseFormattedCount('42')).toBe(42)
   })
 
-  it('parses K suffix', () => {
+  it('expands a K suffix to thousands (731.2K -> 731200)', () => {
+    // Act & Assert
     expect(parseFormattedCount('731.2K')).toBe(731200)
     expect(parseFormattedCount('20.0K')).toBe(20000)
     expect(parseFormattedCount('1K')).toBe(1000)
     expect(parseFormattedCount('12.3K')).toBe(12300)
   })
 
-  it('parses M suffix', () => {
+  it('expands an M suffix to millions (1.5M -> 1500000)', () => {
+    // Act & Assert
     expect(parseFormattedCount('1.5M')).toBe(1500000)
     expect(parseFormattedCount('2M')).toBe(2000000)
   })
 
-  it('parses B suffix', () => {
+  it('expands a B suffix to billions (1.2B -> 1200000000)', () => {
+    // Act & Assert
     expect(parseFormattedCount('1.2B')).toBe(1200000000)
   })
 
-  it('handles case insensitive suffixes', () => {
+  it('expands lowercase k and m suffixes the same as uppercase', () => {
+    // Act & Assert
     expect(parseFormattedCount('731.2k')).toBe(731200)
     expect(parseFormattedCount('1.5m')).toBe(1500000)
   })
 
-  it('handles whitespace', () => {
+  it('ignores surrounding whitespace around the count', () => {
+    // Act & Assert
     expect(parseFormattedCount('  731.2K  ')).toBe(731200)
     expect(parseFormattedCount(' 927 ')).toBe(927)
   })
 
-  it('handles commas in numbers', () => {
+  it('drops thousands separators from a comma-grouped number', () => {
+    // Act & Assert
     expect(parseFormattedCount('1,234')).toBe(1234)
   })
 
-  it('returns 0 for invalid input', () => {
+  it('counts unparseable input as zero', () => {
+    // Act & Assert
     expect(parseFormattedCount('')).toBe(0)
     expect(parseFormattedCount('abc')).toBe(0)
     expect(parseFormattedCount('---')).toBe(0)
@@ -51,7 +59,8 @@ describe('parseFormattedCount', () => {
 })
 
 describe('parseLeaderboardHtml', () => {
-  it('parses skill rows from anchor tags', () => {
+  it('extracts each skill row (rank, name, repo, url, install count) from anchor tags', () => {
+    // Arrange
     const html = `
       <div>
         <a href="/vercel-labs/skills/find-skills">
@@ -68,8 +77,11 @@ describe('parseLeaderboardHtml', () => {
         </a>
       </div>
     `
+
+    // Act
     const results = parseLeaderboardHtml(html)
 
+    // Assert
     expect(results).toHaveLength(2)
     expect(results[0]).toEqual({
       rank: 1,
@@ -87,7 +99,8 @@ describe('parseLeaderboardHtml', () => {
     })
   })
 
-  it('parses hot page with delta counts', () => {
+  it('reads the absolute count and ignores the delta on a hot-page row', () => {
+    // Arrange
     const html = `
       <a href="/vercel-labs/skills/find-skills">
         <div>
@@ -98,28 +111,36 @@ describe('parseLeaderboardHtml', () => {
         <div><span>927</span><span>+294</span></div>
       </a>
     `
+
+    // Act
     const results = parseLeaderboardHtml(html)
 
+    // Assert
     expect(results).toHaveLength(1)
     // +294 is excluded by the negative lookbehind (?<![+-])
     // So only 927 matches as the install count
     expect(results[0].installCount).toBe(927)
   })
 
-  it('throws when stability signature is missing', () => {
+  it('throws when the page lacks the leaderboard stability signature', () => {
+    // Arrange
     const html = '<html><body><p>This page has no leaderboard</p></body></html>'
+
+    // Act & Assert
     expect(() => parseLeaderboardHtml(html)).toThrow(
       'Leaderboard HTML structure mismatch',
     )
   })
 
-  it('throws for empty string', () => {
+  it('throws when handed an empty HTML string', () => {
+    // Act & Assert
     expect(() => parseLeaderboardHtml('')).toThrow(
       'Leaderboard HTML structure mismatch',
     )
   })
 
-  it('limits results to 50', () => {
+  it('caps the leaderboard at 50 entries even when more rows are present', () => {
+    // Arrange
     // Generate 60 skill anchors
     const anchors = Array.from(
       { length: 60 },
@@ -132,11 +153,15 @@ describe('parseLeaderboardHtml', () => {
     ).join('\n')
     const html = `<div>${anchors}</div>`
 
+    // Act
     const results = parseLeaderboardHtml(html)
+
+    // Assert
     expect(results).toHaveLength(50)
   })
 
-  it('skips anchors without h3', () => {
+  it('discards anchors that have no h3 heading', () => {
+    // Arrange
     const html = `
       <a href="/owner/repo/good-skill">
         <h3>good-skill</h3>
@@ -146,12 +171,17 @@ describe('parseLeaderboardHtml', () => {
         <span>No heading here</span>
       </a>
     `
+
+    // Act
     const results = parseLeaderboardHtml(html)
+
+    // Assert
     expect(results).toHaveLength(1)
     expect(results[0].name).toBe('good-skill')
   })
 
-  it('handles table-based layout (all-time page)', () => {
+  it('still parses rows when the all-time page wraps anchors in a table', () => {
+    // Arrange
     const html = `
       <table>
         <tr>
@@ -164,19 +194,28 @@ describe('parseLeaderboardHtml', () => {
         </tr>
       </table>
     `
+
+    // Act
     // The anchor is inside a td, which is fine for our regex
     const results = parseLeaderboardHtml(html)
+
+    // Assert
     expect(results).toHaveLength(1)
     expect(results[0].name).toBe('find-skills')
   })
 
-  it('assigns sequential ranks', () => {
+  it('numbers rows sequentially from 1 regardless of order', () => {
+    // Arrange
     const html = `
       <a href="/a/b/skill-one"><h3>skill-one</h3><span>100</span></a>
       <a href="/c/d/skill-two"><h3>skill-two</h3><span>50</span></a>
       <a href="/e/f/skill-three"><h3>skill-three</h3><span>25</span></a>
     `
+
+    // Act
     const results = parseLeaderboardHtml(html)
+
+    // Assert
     expect(results.map((r) => r.rank)).toEqual([1, 2, 3])
   })
 })
@@ -186,7 +225,8 @@ describe('fetchLeaderboard', () => {
     vi.restoreAllMocks()
   })
 
-  it('fetches and parses leaderboard HTML', async () => {
+  it('fetches the leaderboard page and returns its parsed rows with the app User-Agent', async () => {
+    // Arrange
     const mockHtml = `
       <a href="/vercel-labs/skills/find-skills">
         <h3>find-skills</h3>
@@ -197,7 +237,10 @@ describe('fetchLeaderboard', () => {
       new Response(mockHtml, { status: 200 }),
     )
 
+    // Act
     const results = await fetchLeaderboard('all-time')
+
+    // Assert
     expect(results).toHaveLength(1)
     expect(results[0].name).toBe('find-skills')
     expect(globalThis.fetch).toHaveBeenCalledWith(
@@ -210,9 +253,11 @@ describe('fetchLeaderboard', () => {
     )
   })
 
-  it('fetches correct URL for each filter', async () => {
+  it('requests the matching skills.sh URL for the all-time, trending, and hot filters', async () => {
+    // Arrange
     const spy = vi.spyOn(globalThis, 'fetch')
 
+    // Act & Assert
     spy.mockResolvedValueOnce(new Response('<h3>x</h3>', { status: 200 }))
     await fetchLeaderboard('all-time')
     expect(spy).toHaveBeenLastCalledWith(
@@ -235,11 +280,13 @@ describe('fetchLeaderboard', () => {
     )
   })
 
-  it('throws on non-200 response', async () => {
+  it('surfaces a descriptive error when the leaderboard request fails', async () => {
+    // Arrange
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response('Not Found', { status: 404, statusText: 'Not Found' }),
     )
 
+    // Act & Assert
     await expect(fetchLeaderboard('all-time')).rejects.toThrow(
       'Failed to fetch leaderboard: 404 Not Found',
     )

--- a/src/main/services/metadataParser.test.ts
+++ b/src/main/services/metadataParser.test.ts
@@ -13,86 +13,141 @@ describe('parseSkillMetadata', () => {
     vi.clearAllMocks()
   })
 
-  it('returns name and description from frontmatter', async () => {
+  it('surfaces the name and description declared in frontmatter', async () => {
+    // Arrange
     mockFs.readFile.mockResolvedValue(
       '---\nname: My Skill\ndescription: Does great things\n---\n# Content',
     )
+
+    // Act
     const result = await parseSkillMetadata('/skills/my-skill')
+
+    // Assert
     expect(result.name).toBe('My Skill')
     expect(result.description).toBe('Does great things')
   })
 
-  it('falls back to directory name when SKILL.md is missing', async () => {
+  it('names the skill after its directory when SKILL.md is missing', async () => {
+    // Arrange
     mockFs.readFile.mockRejectedValue(new Error('ENOENT'))
+
+    // Act
     const result = await parseSkillMetadata('/skills/theme-generator')
+
+    // Assert
     expect(result.name).toBe('theme-generator')
     expect(result.description).toBe('')
   })
 
-  it('uses directory name when frontmatter has no name field', async () => {
+  it('names the skill after its directory when frontmatter omits the name field', async () => {
+    // Arrange
     mockFs.readFile.mockResolvedValue('---\ndescription: A cool skill\n---\n')
+
+    // Act
     const result = await parseSkillMetadata('/skills/my-skill')
+
+    // Assert
     expect(result.name).toBe('my-skill')
     expect(result.description).toBe('A cool skill')
   })
 
-  it('returns empty description when frontmatter has no description field', async () => {
+  it('leaves the description blank when frontmatter omits the description field', async () => {
+    // Arrange
     mockFs.readFile.mockResolvedValue('---\nname: My Skill\n---\n')
+
+    // Act
     const result = await parseSkillMetadata('/skills/my-skill')
+
+    // Assert
     expect(result.name).toBe('My Skill')
     expect(result.description).toBe('')
   })
 
-  it('handles SKILL.md with no frontmatter block', async () => {
+  it('falls back to the directory name when SKILL.md has no frontmatter block', async () => {
+    // Arrange
     mockFs.readFile.mockResolvedValue('# Just a heading\nSome content')
+
+    // Act
     const result = await parseSkillMetadata('/skills/my-skill')
+
+    // Assert
     expect(result.name).toBe('my-skill')
     expect(result.description).toBe('')
   })
 
-  it('reads SKILL.md from the skill directory', async () => {
+  it('reads metadata from the SKILL.md inside the skill directory', async () => {
+    // Arrange
     mockFs.readFile.mockResolvedValue('---\nname: Test\n---\n')
+
+    // Act
     await parseSkillMetadata('/skills/test-skill')
+
+    // Assert
     expect(mockFs.readFile).toHaveBeenCalledWith(
       expect.stringMatching(/test-skill[/\\]SKILL\.md$/),
       'utf-8',
     )
   })
 
-  it('strips surrounding quotes from values', async () => {
+  it('strips surrounding single and double quotes from frontmatter values', async () => {
+    // Arrange
     mockFs.readFile.mockResolvedValue(
       '---\nname: "Quoted Name"\ndescription: \'Single quoted\'\n---\n',
     )
+
+    // Act
     const result = await parseSkillMetadata('/skills/my-skill')
+
+    // Assert
     expect(result.name).toBe('Quoted Name')
     expect(result.description).toBe('Single quoted')
   })
 
-  it('handles multiline description with pipe (|) syntax', async () => {
+  it('reads the first line of a pipe (|) block-scalar description', async () => {
+    // Arrange
     mockFs.readFile.mockResolvedValue(
       '---\nname: My Skill\ndescription: |\n  This is the first line\n---\n',
     )
+
+    // Act
     const result = await parseSkillMetadata('/skills/my-skill')
+
+    // Assert
     expect(result.description).toBe('This is the first line')
   })
 
-  it('handles multiline description with folded (>) syntax', async () => {
+  it('reads the content of a folded (>) block-scalar description', async () => {
+    // Arrange
     mockFs.readFile.mockResolvedValue(
       '---\nname: My Skill\ndescription: >\n  Folded content\n---\n',
     )
+
+    // Act
     const result = await parseSkillMetadata('/skills/my-skill')
+
+    // Assert
     expect(result.description).toBe('Folded content')
   })
 
-  it('falls back to directory name when skill path has trailing slash edge case', async () => {
+  it('strips a trailing slash before deriving the directory name fallback', async () => {
+    // Arrange
     mockFs.readFile.mockRejectedValue(new Error('ENOENT'))
+
+    // Act
     const result = await parseSkillMetadata('/skills/edge-case/')
+
+    // Assert
     expect(result.name).toBe('edge-case')
   })
 
-  it('falls back to Unknown when path is empty', async () => {
+  it('names the skill Unknown when given an empty path', async () => {
+    // Arrange
     mockFs.readFile.mockRejectedValue(new Error('ENOENT'))
+
+    // Act
     const result = await parseSkillMetadata('')
+
+    // Assert
     expect(result.name).toBe('Unknown')
   })
 })

--- a/src/main/services/pathValidation.test.ts
+++ b/src/main/services/pathValidation.test.ts
@@ -1,5 +1,3 @@
-import { resolve } from 'node:path'
-
 import { describe, expect, it } from 'vitest'
 
 import { getAllowedBases, validatePath } from './pathValidation'
@@ -7,92 +5,118 @@ import { getAllowedBases, validatePath } from './pathValidation'
 describe('validatePath', () => {
   const bases = ['/home/user/.agents/skills', '/home/user/.claude/skills']
 
-  it('allows path within first allowed base', () => {
+  it('admits a file under the first allowed base', () => {
+    // Arrange
+    // bases declared above
+
+    // Act
     const result = validatePath(
       '/home/user/.agents/skills/task/SKILL.md',
       bases,
     )
-    expect(result).toBe(resolve('/home/user/.agents/skills/task/SKILL.md'))
+
+    // Assert
+    expect(result).toBe('/home/user/.agents/skills/task/SKILL.md')
   })
 
-  it('allows path within second allowed base', () => {
+  it('admits a file under the second allowed base', () => {
+    // Arrange
+    // bases declared above
+
+    // Act
     const result = validatePath(
       '/home/user/.claude/skills/task/SKILL.md',
       bases,
     )
-    expect(result).toBe(resolve('/home/user/.claude/skills/task/SKILL.md'))
+
+    // Assert
+    expect(result).toBe('/home/user/.claude/skills/task/SKILL.md')
   })
 
-  it('allows exact base directory path', () => {
+  it('admits the base directory itself', () => {
+    // Act
     const result = validatePath('/home/user/.agents/skills', bases)
-    expect(result).toBe(resolve('/home/user/.agents/skills'))
+
+    // Assert
+    expect(result).toBe('/home/user/.agents/skills')
   })
 
-  it('allows deeply nested path within base', () => {
+  it('admits a deeply nested file inside a base', () => {
+    // Act
     const result = validatePath(
       '/home/user/.agents/skills/task/src/utils/helper.ts',
       bases,
     )
-    expect(result).toBe(
-      resolve('/home/user/.agents/skills/task/src/utils/helper.ts'),
-    )
+
+    // Assert
+    expect(result).toBe('/home/user/.agents/skills/task/src/utils/helper.ts')
   })
 
-  it('throws on path traversal with ../', () => {
+  it('rejects a ../ traversal that escapes a base', () => {
+    // Act & Assert
     expect(() =>
       validatePath('/home/user/.agents/skills/../../../etc/passwd', bases),
     ).toThrow('Path traversal attempt detected')
   })
 
-  it('throws on unrelated absolute path', () => {
+  it('rejects an unrelated absolute path', () => {
+    // Act & Assert
     expect(() => validatePath('/etc/passwd', bases)).toThrow(
       'Path traversal attempt detected',
     )
   })
 
-  it('throws on path outside all bases', () => {
+  it('rejects a path that lies outside every base', () => {
+    // Act & Assert
     expect(() => validatePath('/home/user/.ssh/id_rsa', bases)).toThrow(
       'Path traversal attempt detected',
     )
   })
 
-  it('throws on sibling directory', () => {
+  it('rejects a sibling directory of an allowed base', () => {
+    // Act & Assert
     expect(() =>
       validatePath('/home/user/.agents/config/secrets.json', bases),
     ).toThrow('Path traversal attempt detected')
   })
 
-  it('throws on empty allowed bases', () => {
+  it('rejects every path when the allowed-bases list is empty', () => {
+    // Act & Assert
     expect(() => validatePath('/home/user/.agents/skills/task', [])).toThrow(
       'Path traversal attempt detected',
     )
   })
 
-  it('normalizes path with redundant separators', () => {
+  it('collapses redundant separators before admitting a valid path', () => {
+    // Act
     const result = validatePath(
       '/home/user/.agents/skills//task///SKILL.md',
       bases,
     )
-    expect(result).toBe(resolve('/home/user/.agents/skills/task/SKILL.md'))
+
+    // Assert
+    expect(result).toBe('/home/user/.agents/skills/task/SKILL.md')
   })
 
   // Regression: right-pane expansion (subdirectory recursion) sends deeper
   // paths through validatePath. This guards against accidentally tightening
   // the check in a way that blocks legitimate subpaths like `lib/helper.py`.
   it('allows a nested subpath inside an allowed base (subdirectory recursion regression)', () => {
+    // Act
     const result = validatePath(
       '/home/user/.agents/skills/task/lib/sub/helper.py',
       bases,
     )
-    expect(result).toBe(
-      resolve('/home/user/.agents/skills/task/lib/sub/helper.py'),
-    )
+
+    // Assert
+    expect(result).toBe('/home/user/.agents/skills/task/lib/sub/helper.py')
   })
 
   // Regression: the renderer sends the skill root + a relativePath. If we
   // ever joined these client-side without revalidation, a crafted relativePath
   // could escape. validatePath must still reject the fully-joined path.
   it('rejects a joined path that escapes via ..  (relativePath traversal regression)', () => {
+    // Act & Assert
     // Simulates join(skillPath, relativePath) where relativePath is malicious.
     expect(() =>
       validatePath(
@@ -106,6 +130,7 @@ describe('validatePath', () => {
   // as files:read. If someone introduces a parallel, looser validator for
   // binary files, this test must fail.
   it('rejects a binary file path outside all bases (files:readBinary regression)', () => {
+    // Act & Assert
     expect(() => validatePath('/private/etc/shadow', bases)).toThrow(
       'Path traversal attempt detected',
     )
@@ -113,18 +138,27 @@ describe('validatePath', () => {
 })
 
 describe('getAllowedBases', () => {
-  it('returns non-empty array', () => {
+  it('exposes at least one allowed base directory', () => {
+    // Act
     const bases = getAllowedBases()
+
+    // Assert
     expect(bases.length).toBeGreaterThan(0)
   })
 
-  it('includes SOURCE_DIR as first element', () => {
+  it('lists the Universal source dir as the first allowed base', () => {
+    // Act
     const bases = getAllowedBases()
+
+    // Assert
     expect(bases[0]).toContain('.agents/skills')
   })
 
-  it('includes agent paths', () => {
+  it('includes agent skills directories alongside the source dir', () => {
+    // Act
     const bases = getAllowedBases()
+
+    // Assert
     // Should have at least SOURCE_DIR + some agents
     expect(bases.length).toBeGreaterThan(1)
   })
@@ -135,17 +169,21 @@ describe('getAllowedBases', () => {
   // against [SOURCE_DIR] only. Validating against getAllowedBases() must accept
   // every agent's skills directory so local skills can be deleted.
   it('accepts a path inside any agent skills directory (local skill regression)', () => {
+    // Arrange
     const bases = getAllowedBases()
     // The first base is SOURCE_DIR; any other base is an agent skills dir
     const agentBase = bases[1]
     expect(agentBase).toBeDefined()
     const localSkillPath = `${agentBase}/playwright-cli`
+
+    // Act & Assert
     // Should NOT throw — the renderer hands us this path when the user clicks
     // the X (delete) button on a local skill in global view
     expect(() => validatePath(localSkillPath, bases)).not.toThrow()
   })
 
   it('rejects an agent-dir skill path when only SOURCE_DIR is allowed', () => {
+    // Arrange
     // This is the pre-fix behavior of SKILLS_DELETE — kept as a guard so we
     // never reintroduce "validatePath(skillPath, [SOURCE_DIR])" for delete.
     const bases = getAllowedBases()
@@ -158,6 +196,8 @@ describe('getAllowedBases', () => {
     // resolve INTO SOURCE_DIR and the test would falsely pass.
     const nonExistentSkillName = '__validate_path_test_fixture_does_not_exist__'
     const localSkillPath = `${agentBase}/${nonExistentSkillName}`
+
+    // Act & Assert
     expect(() => validatePath(localSkillPath, [sourceDir])).toThrow(
       'Path traversal attempt detected',
     )
@@ -171,15 +211,19 @@ describe('getAllowedBases', () => {
   // and left state.skills.error stuck on the error view. The fix is to use
   // getAllowedBases() which includes SOURCE_DIR + every agent dir.
   it('accepts a SOURCE_DIR path when validating against getAllowedBases (symlink unlink regression)', () => {
+    // Arrange
     // Simulates what realpathSync returns for a symlinked agent skill: a path
     // inside SOURCE_DIR (the symlink target).
     const bases = getAllowedBases()
     const sourceDir = bases[0]
     const resolvedSymlinkTarget = `${sourceDir}/agent-browser`
+
+    // Act & Assert
     expect(() => validatePath(resolvedSymlinkTarget, bases)).not.toThrow()
   })
 
   it('rejects a SOURCE_DIR path when validating against agent paths only', () => {
+    // Arrange
     // Pre-fix behavior of SKILLS_UNLINK_FROM_AGENT — kept as a guard so we
     // never reintroduce "validatePath(linkPath, AGENTS.map(a => a.path))"
     // which fails for symlinked skills (realpath resolves them to SOURCE_DIR).
@@ -187,6 +231,8 @@ describe('getAllowedBases', () => {
     const sourceDir = bases[0]
     const agentBasesOnly = bases.slice(1) // every base except SOURCE_DIR
     const resolvedSymlinkTarget = `${sourceDir}/agent-browser`
+
+    // Act & Assert
     expect(() => validatePath(resolvedSymlinkTarget, agentBasesOnly)).toThrow(
       'Path traversal attempt detected',
     )

--- a/src/main/services/settings.test.ts
+++ b/src/main/services/settings.test.ts
@@ -21,133 +21,198 @@ describe('areSettingsEqual', () => {
     autoDownloadUpdates: false,
   }
 
-  it('returns true for identical primitive-only settings', () => {
-    expect(areSettingsEqual(baseSettings, { ...baseSettings })).toBe(true)
+  it('treats two settings with identical primitive fields as unchanged so no redundant save fires', () => {
+    // Arrange
+    const saved = baseSettings
+    const incoming = { ...baseSettings }
+
+    // Act
+    const result = areSettingsEqual(saved, incoming)
+
+    // Assert
+    expect(result).toBe(true)
   })
 
-  it('returns false when any primitive field differs', () => {
-    expect(
-      areSettingsEqual(baseSettings, {
-        ...baseSettings,
-        defaultSkillTab: 'info',
-      }),
-    ).toBe(false)
+  it('detects a changed primitive field so the new value gets persisted', () => {
+    // Arrange
+    const saved = baseSettings
+    const incoming: Settings = { ...baseSettings, defaultSkillTab: 'info' }
+
+    // Act
+    const result = areSettingsEqual(saved, incoming)
+
+    // Assert
+    expect(result).toBe(false)
   })
 
-  it('returns true when both windowSize values are undefined', () => {
-    expect(
-      areSettingsEqual(
-        { ...baseSettings, windowSize: undefined },
-        { ...baseSettings, windowSize: undefined },
-      ),
-    ).toBe(true)
+  it('treats two settings with no window size on either side as unchanged', () => {
+    // Arrange
+    const saved = { ...baseSettings, windowSize: undefined }
+    const incoming = { ...baseSettings, windowSize: undefined }
+
+    // Act
+    const result = areSettingsEqual(saved, incoming)
+
+    // Assert
+    expect(result).toBe(true)
   })
 
-  it('returns true when windowSize objects describe identical dimensions despite different references', () => {
-    // The bug this guards against: Zod parse produces a fresh object on
-    // every call, so the references are different even when values match.
-    expect(
-      areSettingsEqual(
-        { ...baseSettings, windowSize: { width: 1200, height: 800 } },
-        { ...baseSettings, windowSize: { width: 1200, height: 800 } },
-      ),
-    ).toBe(true)
+  it('treats matching window dimensions as unchanged even when Zod produced a fresh object reference', () => {
+    // Arrange: Zod parse produces a fresh object on every call, so the
+    // references differ even when the width/height values match.
+    const saved = { ...baseSettings, windowSize: { width: 1200, height: 800 } }
+    const incoming = {
+      ...baseSettings,
+      windowSize: { width: 1200, height: 800 },
+    }
+
+    // Act
+    const result = areSettingsEqual(saved, incoming)
+
+    // Assert
+    expect(result).toBe(true)
   })
 
-  it('returns false when only windowSize.width differs', () => {
-    expect(
-      areSettingsEqual(
-        { ...baseSettings, windowSize: { width: 1200, height: 800 } },
-        { ...baseSettings, windowSize: { width: 1201, height: 800 } },
-      ),
-    ).toBe(false)
+  it('detects a changed window width so the resized dimensions get persisted', () => {
+    // Arrange
+    const saved = { ...baseSettings, windowSize: { width: 1200, height: 800 } }
+    const incoming = {
+      ...baseSettings,
+      windowSize: { width: 1201, height: 800 },
+    }
+
+    // Act
+    const result = areSettingsEqual(saved, incoming)
+
+    // Assert
+    expect(result).toBe(false)
   })
 
-  it('returns false when only windowSize.height differs', () => {
-    expect(
-      areSettingsEqual(
-        { ...baseSettings, windowSize: { width: 1200, height: 800 } },
-        { ...baseSettings, windowSize: { width: 1200, height: 801 } },
-      ),
-    ).toBe(false)
+  it('detects a changed window height so the resized dimensions get persisted', () => {
+    // Arrange
+    const saved = { ...baseSettings, windowSize: { width: 1200, height: 800 } }
+    const incoming = {
+      ...baseSettings,
+      windowSize: { width: 1200, height: 801 },
+    }
+
+    // Act
+    const result = areSettingsEqual(saved, incoming)
+
+    // Assert
+    expect(result).toBe(false)
   })
 
-  it('returns false when one side has undefined windowSize and the other has a value', () => {
-    expect(
-      areSettingsEqual(
-        { ...baseSettings, windowSize: { width: 1200, height: 800 } },
-        { ...baseSettings, windowSize: undefined },
-      ),
-    ).toBe(false)
-    expect(
-      areSettingsEqual(
-        { ...baseSettings, windowSize: undefined },
-        { ...baseSettings, windowSize: { width: 1200, height: 800 } },
-      ),
-    ).toBe(false)
+  it('detects a change when one side has a window size and the other has none, in either direction', () => {
+    // Arrange
+    const withSize = {
+      ...baseSettings,
+      windowSize: { width: 1200, height: 800 },
+    }
+    const withoutSize = { ...baseSettings, windowSize: undefined }
+
+    // Act
+    const sizeThenNone = areSettingsEqual(withSize, withoutSize)
+    const noneThenSize = areSettingsEqual(withoutSize, withSize)
+
+    // Assert
+    expect(sizeThenNone).toBe(false)
+    expect(noneThenSize).toBe(false)
   })
 
-  it('returns false when one side omits the windowSize key entirely and the other has a value', () => {
-    // The asymmetric-shape bug: `Object.keys(a)` alone would skip a key
-    // that lives only on `b`, so an absent-vs-defined comparison would
-    // wrongly return `true`. Iterating the union of both objects' keys
-    // is what surfaces the difference.
-    expect(
-      areSettingsEqual(
-        { ...baseSettings },
-        { ...baseSettings, windowSize: { width: 1200, height: 800 } },
-      ),
-    ).toBe(false)
-    expect(
-      areSettingsEqual(
-        { ...baseSettings, windowSize: { width: 1200, height: 800 } },
-        { ...baseSettings },
-      ),
-    ).toBe(false)
+  it('detects a change when the windowSize key exists on only one side, not falsely matching', () => {
+    // Arrange: the asymmetric-shape bug — `Object.keys(a)` alone would skip
+    // a key that lives only on `b`, so an absent-vs-defined comparison would
+    // wrongly return `true`. Iterating the union of both keys surfaces it.
+    const withoutKey = { ...baseSettings }
+    const withKey = {
+      ...baseSettings,
+      windowSize: { width: 1200, height: 800 },
+    }
+
+    // Act
+    const missingThenPresent = areSettingsEqual(withoutKey, withKey)
+    const presentThenMissing = areSettingsEqual(withKey, withoutKey)
+
+    // Assert
+    expect(missingThenPresent).toBe(false)
+    expect(presentThenMissing).toBe(false)
   })
 
-  it('returns true when both sides omit windowSize entirely', () => {
-    expect(areSettingsEqual({ ...baseSettings }, { ...baseSettings })).toBe(
-      true,
-    )
+  it('treats two settings that both omit window size as unchanged', () => {
+    // Arrange
+    const saved = { ...baseSettings }
+    const incoming = { ...baseSettings }
+
+    // Act
+    const result = areSettingsEqual(saved, incoming)
+
+    // Assert
+    expect(result).toBe(true)
   })
 
-  it('returns true for hiddenAgentIds with identical contents in identical order', () => {
-    expect(
-      areSettingsEqual(
-        { ...baseSettings, hiddenAgentIds: ['claude-code', 'cursor'] },
-        { ...baseSettings, hiddenAgentIds: ['claude-code', 'cursor'] },
-      ),
-    ).toBe(true)
+  it('treats identical hidden-agent lists in the same order as unchanged', () => {
+    // Arrange
+    const saved: Settings = {
+      ...baseSettings,
+      hiddenAgentIds: ['claude-code', 'cursor'],
+    }
+    const incoming: Settings = {
+      ...baseSettings,
+      hiddenAgentIds: ['claude-code', 'cursor'],
+    }
+
+    // Act
+    const result = areSettingsEqual(saved, incoming)
+
+    // Assert
+    expect(result).toBe(true)
   })
 
-  it('returns true for hiddenAgentIds with identical contents in different order (set semantics)', () => {
-    // Renderer treats hiddenAgentIds as a set; equality must match that
-    // semantic so an order-only drift between disk and renderer doesn't
+  it('treats hidden-agent lists with the same members in different order as unchanged (set semantics)', () => {
+    // Arrange: renderer treats hiddenAgentIds as a set; equality must match
+    // that semantic so an order-only drift between disk and renderer doesn't
     // trigger a redundant atomic write + settings:changed broadcast.
-    expect(
-      areSettingsEqual(
-        { ...baseSettings, hiddenAgentIds: ['claude-code', 'cursor'] },
-        { ...baseSettings, hiddenAgentIds: ['cursor', 'claude-code'] },
-      ),
-    ).toBe(true)
+    const saved: Settings = {
+      ...baseSettings,
+      hiddenAgentIds: ['claude-code', 'cursor'],
+    }
+    const incoming: Settings = {
+      ...baseSettings,
+      hiddenAgentIds: ['cursor', 'claude-code'],
+    }
+
+    // Act
+    const result = areSettingsEqual(saved, incoming)
+
+    // Assert
+    expect(result).toBe(true)
   })
 
-  it('returns false when hiddenAgentIds length differs', () => {
-    expect(
-      areSettingsEqual(
-        { ...baseSettings, hiddenAgentIds: ['claude-code'] },
-        { ...baseSettings, hiddenAgentIds: ['claude-code', 'cursor'] },
-      ),
-    ).toBe(false)
+  it('detects a change when the hidden-agent list gains or loses an entry', () => {
+    // Arrange
+    const saved: Settings = { ...baseSettings, hiddenAgentIds: ['claude-code'] }
+    const incoming: Settings = {
+      ...baseSettings,
+      hiddenAgentIds: ['claude-code', 'cursor'],
+    }
+
+    // Act
+    const result = areSettingsEqual(saved, incoming)
+
+    // Assert
+    expect(result).toBe(false)
   })
 
-  it('returns false when hiddenAgentIds have same length but different members', () => {
-    expect(
-      areSettingsEqual(
-        { ...baseSettings, hiddenAgentIds: ['claude-code'] },
-        { ...baseSettings, hiddenAgentIds: ['cursor'] },
-      ),
-    ).toBe(false)
+  it('detects a change when the hidden-agent list swaps a member for a different one', () => {
+    // Arrange
+    const saved: Settings = { ...baseSettings, hiddenAgentIds: ['claude-code'] }
+    const incoming: Settings = { ...baseSettings, hiddenAgentIds: ['cursor'] }
+
+    // Act
+    const result = areSettingsEqual(saved, incoming)
+
+    // Assert
+    expect(result).toBe(false)
   })
 })

--- a/src/main/services/skillScanner.test.ts
+++ b/src/main/services/skillScanner.test.ts
@@ -192,9 +192,13 @@ describe('scanSkills local skill aggregation', () => {
   })
 
   it('keeps same local skill as valid for multiple agents', async () => {
+    // Arrange
     const { scanSkills } = await import('./skillScanner')
 
+    // Act
     const skills = await scanSkills()
+
+    // Assert
     expect(skills).toHaveLength(1)
 
     const localSkill = skills[0]
@@ -213,6 +217,7 @@ describe('scanSkills local skill aggregation', () => {
     // surface that target ON THE PER-AGENT SLOT so the renderer can show the
     // G-Stack badge for the agent that holds the gstack twin, without
     // bleeding to sibling agents that share the skill name.
+    // Arrange
     readSymlinkTargetIfPresentMock.mockImplementation(async (path: string) => {
       if (
         path ===
@@ -222,10 +227,12 @@ describe('scanSkills local skill aggregation', () => {
       }
       return undefined
     })
-
     const { scanSkills } = await import('./skillScanner')
+
+    // Act
     const skills = await scanSkills()
 
+    // Assert
     expect(skills).toHaveLength(1)
     const codex = skills[0].symlinks.find((s) => s.agentId === 'codex')
     expect(codex?.skillMdSymlinkTarget).toBe(
@@ -234,11 +241,15 @@ describe('scanSkills local skill aggregation', () => {
   })
 
   it('leaves skillMdSymlinkTarget undefined on every slot when SKILL.md is a regular file', async () => {
-    // Default mock returns undefined — explicit assertion guards against
-    // someone later changing the default and silently flipping the badge on.
+    // Arrange: default mock returns undefined — explicit assertion guards
+    // against someone later changing the default and silently flipping the
+    // badge on.
     const { scanSkills } = await import('./skillScanner')
+
+    // Act
     const skills = await scanSkills()
 
+    // Assert
     expect(skills).toHaveLength(1)
     for (const slot of skills[0].symlinks) {
       expect(slot.skillMdSymlinkTarget).toBeUndefined()
@@ -246,10 +257,10 @@ describe('scanSkills local skill aggregation', () => {
   })
 
   it('binds skillMdSymlinkTarget to the slot that detected it without bleeding to sibling agents', async () => {
-    // codex slot is a gstack-managed twin (SKILL.md symlinks into gstack);
-    // cursor slot is a plain local folder. Per-agent attribution: codex's
-    // slot must carry the target, cursor's slot must NOT — otherwise the
-    // badge would falsely appear on cursor's unrelated copy.
+    // Arrange: codex slot is a gstack-managed twin (SKILL.md symlinks into
+    // gstack); cursor slot is a plain local folder. Per-agent attribution:
+    // codex's slot must carry the target, cursor's slot must NOT — otherwise
+    // the badge would falsely appear on cursor's unrelated copy.
     readSymlinkTargetIfPresentMock.mockImplementation(async (path: string) => {
       if (
         path ===
@@ -259,10 +270,12 @@ describe('scanSkills local skill aggregation', () => {
       }
       return undefined
     })
-
     const { scanSkills } = await import('./skillScanner')
+
+    // Act
     const skills = await scanSkills()
 
+    // Assert
     expect(skills).toHaveLength(1)
     const codex = skills[0].symlinks.find((s) => s.agentId === 'codex')
     const cursor = skills[0].symlinks.find((s) => s.agentId === 'cursor')
@@ -287,9 +300,10 @@ describe('scanSkills agent-only linked symlink surfacing', () => {
   })
 
   it('surfaces valid agent symlinks whose names are not in the source directory', async () => {
-    // Codex has a valid gstack-managed symlink, but ~/.agents/skills has no
-    // matching source directory. The sidebar count includes this link, so the
-    // central agent view must include a linked card for the same on-disk entry.
+    // Arrange: Codex has a valid gstack-managed symlink, but ~/.agents/skills
+    // has no matching source directory. The sidebar count includes this link,
+    // so the central agent view must include a linked card for the same
+    // on-disk entry.
     readdirMock.mockImplementation(async (path: string) => {
       if (path === '/mock/source/skills') return []
       if (path === '/mock/agents/codex/skills') {
@@ -320,10 +334,12 @@ describe('scanSkills agent-only linked symlink surfacing', () => {
         return undefined
       },
     )
-
     const { scanSkills } = await import('./skillScanner')
+
+    // Act
     const skills = await scanSkills()
 
+    // Assert
     expect(skills).toHaveLength(1)
     const linked = skills[0]
     expect(linked.name).toBe('gstack-browse')
@@ -376,10 +392,12 @@ describe('scanSkills agent-only linked symlink surfacing', () => {
         return undefined
       },
     )
-
     const { scanSkills } = await import('./skillScanner')
+
+    // Act
     const skills = await scanSkills()
 
+    // Assert
     expect(skills).toHaveLength(1)
     const manualReview = skills[0]
     expect(manualReview.name).toBe('secure-review')
@@ -417,7 +435,7 @@ describe('scanSkills orphan symlink surfacing (issue #127)', () => {
   })
 
   it('surfaces broken symlinks whose source is missing as orphan Skill records', async () => {
-    // Source dir empty; codex has 1 broken symlink "connect-chrome".
+    // Arrange: source dir empty; codex has 1 broken symlink "connect-chrome".
     readdirMock.mockImplementation(async (path: string) => {
       if (path === '/mock/source/skills') return []
       if (path === '/mock/agents/codex/skills') {
@@ -447,10 +465,12 @@ describe('scanSkills orphan symlink surfacing (issue #127)', () => {
         return undefined
       },
     )
-
     const { scanSkills } = await import('./skillScanner')
+
+    // Act
     const skills = await scanSkills()
 
+    // Assert
     expect(skills).toHaveLength(1)
     const orphan = skills[0]
     expect(orphan.name).toBe('connect-chrome')
@@ -470,6 +490,7 @@ describe('scanSkills orphan symlink surfacing (issue #127)', () => {
   })
 
   it('collapses the same broken name across multiple agents into one orphan record', async () => {
+    // Arrange
     readdirMock.mockImplementation(async (path: string) => {
       if (path === '/mock/source/skills') return []
       if (
@@ -488,10 +509,12 @@ describe('scanSkills orphan symlink surfacing (issue #127)', () => {
     accessMock.mockRejectedValue(new Error('ENOENT'))
     statMock.mockRejectedValue(new Error('ENOENT'))
     checkSymlinkTargetFromKnownLinkMock.mockResolvedValue('broken')
-
     const { scanSkills } = await import('./skillScanner')
+
+    // Act
     const skills = await scanSkills()
 
+    // Assert
     expect(skills).toHaveLength(1)
     const orphan = skills[0]
     const codex = orphan.symlinks.find((s) => s.agentId === 'codex')
@@ -501,9 +524,9 @@ describe('scanSkills orphan symlink surfacing (issue #127)', () => {
   })
 
   it('does NOT create orphan record when name matches a live source skill', async () => {
-    // Source has "theme-generator". Codex has a broken "theme-generator"
-    // symlink — broken status belongs in the source skill's symlinks[], not
-    // in a separate orphan record.
+    // Arrange: source has "theme-generator". Codex has a broken
+    // "theme-generator" symlink — broken status belongs in the source skill's
+    // symlinks[], not in a separate orphan record.
     readdirMock.mockImplementation(async (path: string) => {
       if (path === '/mock/source/skills') {
         return [
@@ -536,11 +559,12 @@ describe('scanSkills orphan symlink surfacing (issue #127)', () => {
     })
     mockLstatDirectories(['/mock/source/skills/theme-generator'])
     checkSymlinkTargetFromKnownLinkMock.mockResolvedValue('broken')
-
     const { scanSkills } = await import('./skillScanner')
+
+    // Act
     const skills = await scanSkills()
 
-    // Exactly one record — the live source skill, no separate orphan.
+    // Assert: exactly one record — the live source skill, no separate orphan.
     expect(skills).toHaveLength(1)
     expect(skills[0].name).toBe('theme-generator')
     expect(skills[0].isSource).toBe(true)
@@ -599,7 +623,7 @@ describe('scanSkills orphan symlink surfacing (issue #127)', () => {
   })
 
   it('merges orphan broken slots into a same-named local skill (regression for #127 follow-up)', async () => {
-    // Cursor has a real folder named "frontend-design" → local skill.
+    // Arrange: Cursor has a real folder named "frontend-design" → local skill.
     // Codex has a broken symlink with the same name → source missing, orphan.
     // Naive first-wins (which the original merge used) would keep only the
     // local record and silently drop codex's broken status — recreating the
@@ -642,10 +666,12 @@ describe('scanSkills orphan symlink surfacing (issue #127)', () => {
         return 'missing'
       },
     )
-
     const { scanSkills } = await import('./skillScanner')
+
+    // Act
     const skills = await scanSkills()
 
+    // Assert
     expect(skills).toHaveLength(1)
     const merged = skills[0]
     expect(merged.name).toBe('frontend-design')

--- a/src/main/services/skillsCliService.test.ts
+++ b/src/main/services/skillsCliService.test.ts
@@ -77,18 +77,21 @@ describe('skillsCliService.cancel', () => {
   })
 
   it('kills all running CLI children on cancel()', async () => {
+    // Arrange
     const first = simulateCli({ autoClose: false })
     const second = simulateCli({ autoClose: false })
-
     const { skillsCliService } = await import('./skillsCliService')
     const searchA = skillsCliService.search('a')
     const searchB = skillsCliService.search('b')
 
+    // Act
     skillsCliService.cancel()
 
+    // Assert
     expect(first.kill).toHaveBeenCalledWith('SIGTERM')
     expect(second.kill).toHaveBeenCalledWith('SIGTERM')
 
+    // Drain the killed children so the pending search promises settle.
     first.emit('close', 0)
     second.emit('close', 0)
     await Promise.all([searchA, searchB])
@@ -108,14 +111,17 @@ describe('skillsCliService.execCli environment', () => {
   })
 
   it('adds common Node toolchain paths so Finder-launched installs can find npx', async () => {
+    // Arrange
     simulateCli({
       stdout:
         'vercel-labs/skills@find-skills\n└ https://skills.sh/vercel-labs/skills/find-skills\n',
     })
-
     const { skillsCliService } = await import('./skillsCliService')
+
+    // Act
     await skillsCliService.search('find-skills')
 
+    // Assert
     expect(spawnMock).toHaveBeenCalledWith(
       'npx',
       [`skills@${SKILLS_CLI_VERSION}`, 'find', 'find-skills'],
@@ -140,7 +146,8 @@ describe('skillsCliService.search', () => {
     process.env.PATH = ORIGINAL_PATH
   })
 
-  it('parses current skills find output with install counts', async () => {
+  it('shows search results ranked with their install counts from the current CLI output', async () => {
+    // Arrange
     simulateCli({
       stdout: [
         'Install with npx skills add <owner/repo@skill>',
@@ -152,10 +159,12 @@ describe('skillsCliService.search', () => {
         '└ https://skills.sh/google-labs-code/stitch-skills/react:components',
       ].join('\n'),
     })
-
     const { skillsCliService } = await import('./skillsCliService')
+
+    // Act
     const results = await skillsCliService.search('react')
 
+    // Assert
     expect(results).toEqual([
       {
         rank: 1,
@@ -174,17 +183,20 @@ describe('skillsCliService.search', () => {
     ])
   })
 
-  it('parses legacy skills find output without install counts', async () => {
+  it('shows search results without an install count when the legacy CLI output omits one', async () => {
+    // Arrange
     simulateCli({
       stdout: [
         'vercel-labs/agent-skills@vercel-react-best-practices',
         '└ https://skills.sh/vercel-labs/agent-skills/vercel-react-best-practices',
       ].join('\n'),
     })
-
     const { skillsCliService } = await import('./skillsCliService')
+
+    // Act
     const results = await skillsCliService.search('react')
 
+    // Assert
     expect(results).toEqual([
       {
         rank: 1,

--- a/src/main/services/symlinkChecker.test.ts
+++ b/src/main/services/symlinkChecker.test.ts
@@ -75,18 +75,21 @@ describe('checkSymlinkStatus', () => {
     realpathMock.mockImplementation(async (path: string) => path)
   })
 
-  it('returns valid when symlink exists and target is accessible', async () => {
+  it('reports a skill as valid when its symlink resolves to a reachable target', async () => {
+    // Arrange
     lstatMock.mockResolvedValue(
       createStats({ isSymbolicLink: true, isDirectory: false }),
     )
     readlinkMock.mockResolvedValue('/mock/source/skills/my-skill')
     accessMock.mockResolvedValue(undefined)
 
+    // Act
     const { checkSymlinkStatus } = await import('./symlinkChecker')
     const result = await checkSymlinkStatus(
       '/mock/agents/claude/skills/my-skill',
     )
 
+    // Assert
     expect(result).toBe('valid')
     expect(lstatMock).toHaveBeenCalledWith(
       '/mock/agents/claude/skills/my-skill',
@@ -96,22 +99,26 @@ describe('checkSymlinkStatus', () => {
     )
   })
 
-  it('returns broken when symlink exists but target is missing', async () => {
+  it('flags a skill as broken when its symlink target was deleted', async () => {
+    // Arrange
     lstatMock.mockResolvedValue(
       createStats({ isSymbolicLink: true, isDirectory: false }),
     )
     readlinkMock.mockResolvedValue('/mock/source/skills/deleted-skill')
     accessMock.mockRejectedValue(makeFsError('ENOENT'))
 
+    // Act
     const { checkSymlinkStatus } = await import('./symlinkChecker')
     const result = await checkSymlinkStatus(
       '/mock/agents/claude/skills/deleted-skill',
     )
 
+    // Assert
     expect(result).toBe('broken')
   })
 
-  it('returns inaccessible when symlink target cannot be probed safely', async () => {
+  it('marks a skill inaccessible when permission denial blocks probing its target', async () => {
+    // Arrange
     lstatMock.mockResolvedValue(
       createStats({ isSymbolicLink: true, isDirectory: false }),
     )
@@ -120,40 +127,49 @@ describe('checkSymlinkStatus', () => {
       Object.assign(new Error('EPERM'), { code: 'EPERM' }),
     )
 
+    // Act
     const { checkSymlinkStatus } = await import('./symlinkChecker')
     const result = await checkSymlinkStatus(
       '/mock/agents/claude/skills/locked-skill',
     )
 
+    // Assert
     expect(result).toBe('inaccessible')
   })
 
-  it('returns missing when path does not exist (lstat throws ENOENT)', async () => {
+  it('reports a skill as missing when nothing exists at the agent path', async () => {
+    // Arrange
     lstatMock.mockRejectedValue(makeFsError('ENOENT'))
 
+    // Act
     const { checkSymlinkStatus } = await import('./symlinkChecker')
     const result = await checkSymlinkStatus(
       '/mock/agents/claude/skills/nonexistent',
     )
 
+    // Assert
     expect(result).toBe('missing')
   })
 
-  it('returns missing when path is a real directory (not a symlink)', async () => {
+  it('treats a real directory at the agent path as missing instead of reading it as a link', async () => {
+    // Arrange
     lstatMock.mockResolvedValue(
       createStats({ isSymbolicLink: false, isDirectory: true }),
     )
 
+    // Act
     const { checkSymlinkStatus } = await import('./symlinkChecker')
     const result = await checkSymlinkStatus(
       '/mock/agents/claude/skills/local-folder',
     )
 
+    // Assert
     expect(result).toBe('missing')
     expect(readlinkMock).not.toHaveBeenCalled()
   })
 
-  it('returns valid when symlink has relative target (production fix)', async () => {
+  it('keeps a relative-target symlink valid by probing the resolved absolute path', async () => {
+    // Arrange
     const linkPath = '/mock/agents/claude/skills/my-skill'
     const relativeTarget = '../../../.agents/skills/my-skill'
     const expectedResolved = resolve(dirname(linkPath), relativeTarget)
@@ -164,9 +180,11 @@ describe('checkSymlinkStatus', () => {
     readlinkMock.mockResolvedValue(relativeTarget)
     accessMock.mockResolvedValue(undefined)
 
+    // Act
     const { checkSymlinkStatus } = await import('./symlinkChecker')
     const result = await checkSymlinkStatus(linkPath)
 
+    // Assert
     expect(result).toBe('valid')
     expect(accessMock).toHaveBeenCalledWith(expectedResolved)
   })
@@ -205,7 +223,8 @@ describe('checkSkillSymlinks', () => {
     realpathMock.mockImplementation(async (path: string) => path)
   })
 
-  it('returns correct status for each agent with broken symlink', async () => {
+  it('marks every agent broken when they all symlink to the same deleted source', async () => {
+    // Arrange
     lstatMock.mockImplementation(async (path: string) => {
       if (path === join('/mock/agents/claude/skills', 'my-skill')) {
         return createStats({ isSymbolicLink: true, isDirectory: false })
@@ -224,9 +243,11 @@ describe('checkSkillSymlinks', () => {
       }
     })
 
+    // Act
     const { checkSkillSymlinks } = await import('./symlinkChecker')
     const results = await checkSkillSymlinks('my-skill')
 
+    // Assert
     expect(results).toHaveLength(2)
     // Both symlinks point to missing target -> broken
     expect(results[0]).toMatchObject({
@@ -236,7 +257,8 @@ describe('checkSkillSymlinks', () => {
     expect(results[1]).toMatchObject({ agentId: 'cursor', status: 'broken' })
   })
 
-  it('returns broken for one agent and missing for another', async () => {
+  it('distinguishes a broken installed link from an agent that never had the skill', async () => {
+    // Arrange
     lstatMock.mockImplementation(async (path: string) => {
       if (path === join('/mock/agents/claude/skills', 'partial-skill')) {
         return createStats({ isSymbolicLink: true, isDirectory: false })
@@ -248,9 +270,11 @@ describe('checkSkillSymlinks', () => {
     readlinkMock.mockResolvedValue('/mock/source/skills/deleted-target')
     accessMock.mockRejectedValue(makeFsError('ENOENT'))
 
+    // Act
     const { checkSkillSymlinks } = await import('./symlinkChecker')
     const results = await checkSkillSymlinks('partial-skill')
 
+    // Assert
     const claude = results.find((r) => r.agentId === 'claude-code')!
     const cursor = results.find((r) => r.agentId === 'cursor')!
 
@@ -260,63 +284,90 @@ describe('checkSkillSymlinks', () => {
     expect(cursor.targetPath).toBeUndefined()
   })
 
-  it('returns valid with populated targetPath for valid symlinks', async () => {
+  it('surfaces the resolved source path on every agent that has a healthy link', async () => {
+    // Arrange
     lstatMock.mockResolvedValue(
       createStats({ isSymbolicLink: true, isDirectory: false }),
     )
     readlinkMock.mockResolvedValue('/mock/source/skills/good-skill')
     accessMock.mockResolvedValue(undefined)
 
+    // Act
     const { checkSkillSymlinks } = await import('./symlinkChecker')
     const results = await checkSkillSymlinks('good-skill')
 
+    // Assert
+    const claude = results.find((r) => r.agentId === 'claude-code')!
+    const cursor = results.find((r) => r.agentId === 'cursor')!
     expect(results).toHaveLength(2)
-    for (const r of results) {
-      expect(r.status).toBe('valid')
-      expect(r.targetPath).toBe('/mock/source/skills/good-skill')
-      expect(r.isLocal).toBe(false)
-    }
+    expect(claude.status).toBe('valid')
+    expect(claude.targetPath).toBe('/mock/source/skills/good-skill')
+    expect(claude.isLocal).toBe(false)
+    expect(cursor.status).toBe('valid')
+    expect(cursor.targetPath).toBe('/mock/source/skills/good-skill')
+    expect(cursor.isLocal).toBe(false)
   })
 
-  it('detects local folder as isLocal: true with valid status', async () => {
+  it('treats a real folder living inside an agent dir as a valid local-only skill', async () => {
+    // Arrange
     lstatMock.mockResolvedValue(
       createStats({ isSymbolicLink: false, isDirectory: true }),
     )
 
+    // Act
     const { checkSkillSymlinks } = await import('./symlinkChecker')
     const results = await checkSkillSymlinks('local-skill')
 
+    // Assert
+    const claude = results.find((r) => r.agentId === 'claude-code')!
+    const cursor = results.find((r) => r.agentId === 'cursor')!
     expect(results).toHaveLength(2)
-    for (const r of results) {
-      expect(r.status).toBe('valid')
-      expect(r.isLocal).toBe(true)
-      expect(r.targetPath).toBeUndefined()
-      expect(r.filesystemIdentity).toEqual({
-        kind: 'directory',
-        dev: 1,
-        ino: 2,
-        size: 96,
-        ctimeMs: 3,
-        mtimeMs: 4,
-      })
-    }
+    expect(claude.status).toBe('valid')
+    expect(claude.isLocal).toBe(true)
+    expect(claude.targetPath).toBeUndefined()
+    expect(claude.filesystemIdentity).toEqual({
+      kind: 'directory',
+      dev: 1,
+      ino: 2,
+      size: 96,
+      ctimeMs: 3,
+      mtimeMs: 4,
+    })
+    expect(cursor.status).toBe('valid')
+    expect(cursor.isLocal).toBe(true)
+    expect(cursor.targetPath).toBeUndefined()
+    expect(cursor.filesystemIdentity).toEqual({
+      kind: 'directory',
+      dev: 1,
+      ino: 2,
+      size: 96,
+      ctimeMs: 3,
+      mtimeMs: 4,
+    })
   })
 
-  it('returns missing for all agents when no entries exist', async () => {
+  it('reports the skill as missing on every agent when no agent has it installed', async () => {
+    // Arrange
     lstatMock.mockRejectedValue(makeFsError('ENOENT'))
 
+    // Act
     const { checkSkillSymlinks } = await import('./symlinkChecker')
     const results = await checkSkillSymlinks('nonexistent-skill')
 
+    // Assert
+    const claude = results.find((r) => r.agentId === 'claude-code')!
+    const cursor = results.find((r) => r.agentId === 'cursor')!
     expect(results).toHaveLength(2)
-    for (const r of results) {
-      expect(r.status).toBe('missing')
-      expect(r.isLocal).toBe(false)
-      expect(r.targetPath).toBeUndefined()
-    }
+    expect(claude.status).toBe('missing')
+    expect(claude.isLocal).toBe(false)
+    expect(claude.targetPath).toBeUndefined()
+    expect(cursor.status).toBe('missing')
+    expect(cursor.isLocal).toBe(false)
+    expect(cursor.targetPath).toBeUndefined()
   })
 
-  it('resolves relative symlink targets correctly (production fix)', async () => {
+  it('never leaks a raw relative target into targetPath or the access probe', async () => {
+    // Arrange
     const relativeTarget = '../../../.agents/skills/good-skill'
 
     lstatMock.mockResolvedValue(
@@ -325,9 +376,11 @@ describe('checkSkillSymlinks', () => {
     readlinkMock.mockResolvedValue(relativeTarget)
     accessMock.mockResolvedValue(undefined)
 
+    // Act
     const { checkSkillSymlinks } = await import('./symlinkChecker')
     const results = await checkSkillSymlinks('good-skill')
 
+    // Assert
     expect(results).toHaveLength(2)
     for (const r of results) {
       expect(r.status).toBe('valid')
@@ -376,12 +429,15 @@ describe('checkSkillSymlinks', () => {
     )
   })
 
-  it('populates linkPath for each agent correctly', async () => {
+  it('points each agent result at that agent own skills directory link path', async () => {
+    // Arrange
     lstatMock.mockRejectedValue(makeFsError('ENOENT'))
 
+    // Act
     const { checkSkillSymlinks } = await import('./symlinkChecker')
     const results = await checkSkillSymlinks('any-skill')
 
+    // Assert
     const claude = results.find((r) => r.agentId === 'claude-code')!
     const cursor = results.find((r) => r.agentId === 'cursor')!
 
@@ -400,7 +456,8 @@ describe('readSymlinkTargetIfPresent', () => {
     realpathMock.mockImplementation(async (path: string) => path)
   })
 
-  it('returns resolved absolute target when path is a symlink with absolute target', async () => {
+  it('surfaces a gstack absolute symlink target so the renderer can match the gstack segment', async () => {
+    // Arrange
     // gstack creates symlinks with absolute targets (verified on a real machine
     // via `readlink ~/.claude/skills/ship/SKILL.md`). This is the production case.
     lstatMock.mockResolvedValue(
@@ -408,15 +465,18 @@ describe('readSymlinkTargetIfPresent', () => {
     )
     readlinkMock.mockResolvedValue('/mock/.claude/skills/gstack/ship/SKILL.md')
 
+    // Act
     const { readSymlinkTargetIfPresent } = await import('./symlinkChecker')
     const result = await readSymlinkTargetIfPresent(
       '/mock/.claude/skills/ship/SKILL.md',
     )
 
+    // Assert
     expect(result).toBe('/mock/.claude/skills/gstack/ship/SKILL.md')
   })
 
-  it('returns resolved absolute target when path is a symlink with relative target', async () => {
+  it('absolutizes a relative symlink target so the renderer gstack-segment check still works', async () => {
+    // Arrange
     // Defensive case: if a user (or a future gstack version) creates the
     // symlink with a relative target, the helper must still return an
     // absolute path so the renderer's regex check on the gstack segment works.
@@ -429,14 +489,17 @@ describe('readSymlinkTargetIfPresent', () => {
     )
     readlinkMock.mockResolvedValue(relativeTarget)
 
+    // Act
     const { readSymlinkTargetIfPresent } = await import('./symlinkChecker')
     const result = await readSymlinkTargetIfPresent(linkPath)
 
+    // Assert
     expect(result).toBe(expectedResolved)
     expect(result).toMatch(/^\//) // Must be absolute
   })
 
-  it('returns resolved target even when symlink is broken (target does not exist)', async () => {
+  it('still surfaces the target of a broken symlink without probing the target existence', async () => {
+    // Arrange
     // The helper does NOT call access() — it only needs the target string for
     // the renderer's path-segment match. Broken symlinks still surface a target.
     lstatMock.mockResolvedValue(
@@ -446,69 +509,84 @@ describe('readSymlinkTargetIfPresent', () => {
       '/mock/.claude/skills/gstack/dangling/SKILL.md',
     )
 
+    // Act
     const { readSymlinkTargetIfPresent } = await import('./symlinkChecker')
     const result = await readSymlinkTargetIfPresent(
       '/mock/.claude/skills/dangling/SKILL.md',
     )
 
+    // Assert
     expect(result).toBe('/mock/.claude/skills/gstack/dangling/SKILL.md')
     expect(accessMock).not.toHaveBeenCalled() // No existence probe
   })
 
-  it('returns undefined when path is a regular file (not a symlink)', async () => {
+  it('reports no symlink target for a regular file and skips reading it as a link', async () => {
+    // Arrange
     lstatMock.mockResolvedValue(
       createStats({ isSymbolicLink: false, isDirectory: false }),
     )
 
+    // Act
     const { readSymlinkTargetIfPresent } = await import('./symlinkChecker')
     const result = await readSymlinkTargetIfPresent(
       '/mock/.agents/skills/foo/SKILL.md',
     )
 
+    // Assert
     expect(result).toBeUndefined()
     expect(readlinkMock).not.toHaveBeenCalled() // Skipped: not a symlink
     expect(accessMock).not.toHaveBeenCalled() // No existence probe
   })
 
-  it('returns undefined when path is a directory', async () => {
+  it('reports no symlink target for a directory and skips reading it as a link', async () => {
+    // Arrange
     lstatMock.mockResolvedValue(
       createStats({ isSymbolicLink: false, isDirectory: true }),
     )
 
+    // Act
     const { readSymlinkTargetIfPresent } = await import('./symlinkChecker')
     const result = await readSymlinkTargetIfPresent('/mock/some/dir')
 
+    // Assert
     expect(result).toBeUndefined()
     expect(readlinkMock).not.toHaveBeenCalled() // Skipped: not a symlink
     expect(accessMock).not.toHaveBeenCalled() // No existence probe
   })
 
-  it('returns undefined when path does not exist (lstat throws)', async () => {
+  it('reports no symlink target when nothing exists at the path', async () => {
+    // Arrange
     lstatMock.mockRejectedValue(makeFsError('ENOENT'))
 
+    // Act
     const { readSymlinkTargetIfPresent } = await import('./symlinkChecker')
     const result = await readSymlinkTargetIfPresent('/mock/missing/SKILL.md')
 
+    // Assert
     expect(result).toBeUndefined()
   })
 
-  it('returns undefined when readlink races with deletion (lstat ok, readlink fails)', async () => {
+  it('reports no symlink target when the link is deleted between lstat and readlink', async () => {
+    // Arrange
     lstatMock.mockResolvedValue(
       createStats({ isSymbolicLink: true, isDirectory: false }),
     )
     readlinkMock.mockRejectedValue(makeFsError('ENOENT'))
 
+    // Act
     const { readSymlinkTargetIfPresent } = await import('./symlinkChecker')
     const result = await readSymlinkTargetIfPresent(
       '/mock/race-condition/SKILL.md',
     )
 
+    // Assert
     expect(result).toBeUndefined()
   })
 })
 
 describe('countValidSymlinks', () => {
-  it('counts only valid symlinks from mixed array', async () => {
+  it('counts only the healthy links when a skill has a mix of valid, broken, and missing slots', async () => {
+    // Arrange
     const { countValidSymlinks } = await import('./symlinkChecker')
 
     const symlinks = [
@@ -546,10 +624,12 @@ describe('countValidSymlinks', () => {
       },
     ]
 
+    // Act + Assert
     expect(countValidSymlinks(symlinks as any)).toBe(2)
   })
 
-  it('returns 0 when all symlinks are broken', async () => {
+  it('counts zero healthy links when every slot for the skill is broken', async () => {
+    // Arrange
     const { countValidSymlinks } = await import('./symlinkChecker')
 
     const symlinks = [
@@ -571,11 +651,14 @@ describe('countValidSymlinks', () => {
       },
     ]
 
+    // Act + Assert
     expect(countValidSymlinks(symlinks as any)).toBe(0)
   })
 
-  it('returns 0 for empty array', async () => {
+  it('counts zero healthy links for a skill that is installed nowhere', async () => {
+    // Arrange
     const { countValidSymlinks } = await import('./symlinkChecker')
+    // Act + Assert
     expect(countValidSymlinks([])).toBe(0)
   })
 })

--- a/src/main/services/syncService.test.ts
+++ b/src/main/services/syncService.test.ts
@@ -57,12 +57,15 @@ describe('syncPreview', () => {
     statMock.mockResolvedValue({ isFile: () => true })
   })
 
-  it('returns zero counts when no source skills exist', async () => {
+  it('reports nothing to sync when there are no source skills', async () => {
+    // Arrange
     readdirMock.mockResolvedValue([])
-
     const { syncPreview } = await import('./syncService')
+
+    // Act
     const result = await syncPreview()
 
+    // Assert
     expect(result.totalSkills).toBe(0)
     expect(result.totalAgents).toBe(2)
     expect(result.toCreate).toBe(0)
@@ -70,7 +73,8 @@ describe('syncPreview', () => {
     expect(result.conflicts).toHaveLength(0)
   })
 
-  it('counts already-synced symlinks', async () => {
+  it('reports an existing symlink in every agent as already synced', async () => {
+    // Arrange
     readdirMock.mockImplementation(async (dir: string) => {
       if (dir === '/mock/source/skills') {
         return [{ name: 'my-skill', isDirectory: () => true }]
@@ -79,17 +83,20 @@ describe('syncPreview', () => {
     })
     accessMock.mockResolvedValue(undefined)
     lstatMock.mockResolvedValue(createStats({ isSymbolicLink: true }))
-
     const { syncPreview } = await import('./syncService')
+
+    // Act
     const result = await syncPreview()
 
+    // Assert
     expect(result.totalSkills).toBe(1)
     expect(result.alreadySynced).toBe(2) // 1 skill × 2 agents
     expect(result.toCreate).toBe(0)
     expect(result.conflicts).toHaveLength(0)
   })
 
-  it('counts paths that need creation when not existing', async () => {
+  it('reports a missing skill link in every agent as needing creation', async () => {
+    // Arrange
     readdirMock.mockImplementation(async (dir: string) => {
       if (dir === '/mock/source/skills') {
         return [{ name: 'new-skill', isDirectory: () => true }]
@@ -105,16 +112,19 @@ describe('syncPreview', () => {
       throw new Error(`ENOENT: ${path}`)
     })
     lstatMock.mockRejectedValue(new Error('ENOENT'))
-
     const { syncPreview } = await import('./syncService')
+
+    // Act
     const result = await syncPreview()
 
+    // Assert
     expect(result.toCreate).toBe(2) // 1 skill × 2 agents
     expect(result.alreadySynced).toBe(0)
     expect(result.conflicts).toHaveLength(0)
   })
 
-  it('detects conflicts when local folders exist', async () => {
+  it('flags a real local folder that shadows a source skill as a conflict', async () => {
+    // Arrange
     readdirMock.mockImplementation(async (dir: string) => {
       if (dir === '/mock/source/skills') {
         return [{ name: 'local-skill', isDirectory: () => true }]
@@ -124,10 +134,12 @@ describe('syncPreview', () => {
     accessMock.mockResolvedValue(undefined)
     // Local folder (not a symlink)
     lstatMock.mockResolvedValue(createStats({ isSymbolicLink: false }))
-
     const { syncPreview } = await import('./syncService')
+
+    // Act
     const result = await syncPreview()
 
+    // Assert
     expect(result.conflicts).toHaveLength(2) // 1 skill × 2 agents
     expect(result.conflicts[0]).toMatchObject({
       skillName: 'local-skill',
@@ -144,7 +156,8 @@ describe('syncPreview', () => {
     expect(result.alreadySynced).toBe(0)
   })
 
-  it('handles mixed states correctly', async () => {
+  it('tallies synced, conflict, and create states per agent across a mix of skills', async () => {
+    // Arrange
     readdirMock.mockImplementation(async (dir: string) => {
       if (dir === '/mock/source/skills') {
         return [
@@ -168,21 +181,26 @@ describe('syncPreview', () => {
       }
       throw new Error('ENOENT')
     })
-
     const { syncPreview } = await import('./syncService')
+
+    // Act
     const result = await syncPreview()
 
+    // Assert
     expect(result.alreadySynced).toBe(2) // synced-skill in both agents
     expect(result.conflicts).toHaveLength(1) // conflict-skill in claude
     expect(result.toCreate).toBe(1) // conflict-skill in cursor
   })
 
-  it('returns empty result when source dir is inaccessible', async () => {
+  it('reports an empty preview when the source dir cannot be read', async () => {
+    // Arrange
     readdirMock.mockRejectedValue(new Error('EACCES'))
-
     const { syncPreview } = await import('./syncService')
+
+    // Act
     const result = await syncPreview()
 
+    // Assert
     expect(result.totalSkills).toBe(0)
     expect(result.conflicts).toHaveLength(0)
   })
@@ -199,7 +217,8 @@ describe('syncExecute', () => {
     rmMock.mockResolvedValue(undefined)
   })
 
-  it('creates symlinks for non-existing paths', async () => {
+  it('creates a symlink for every agent missing the skill', async () => {
+    // Arrange
     readdirMock.mockImplementation(async (dir: string) => {
       if (dir === '/mock/source/skills') {
         return [{ name: 'new-skill', isDirectory: () => true }]
@@ -208,10 +227,12 @@ describe('syncExecute', () => {
     })
     accessMock.mockResolvedValue(undefined)
     lstatMock.mockRejectedValue(new Error('ENOENT'))
-
     const { syncExecute } = await import('./syncService')
+
+    // Act
     const result = await syncExecute({ replaceConflicts: [] })
 
+    // Assert
     expect(result.created).toBe(2) // 1 skill × 2 agents
     expect(result.replaced).toBe(0)
     expect(result.skipped).toBe(0)
@@ -229,7 +250,8 @@ describe('syncExecute', () => {
     )
   })
 
-  it('skips existing symlinks', async () => {
+  it('leaves an already-linked skill untouched instead of recreating it', async () => {
+    // Arrange
     readdirMock.mockImplementation(async (dir: string) => {
       if (dir === '/mock/source/skills') {
         return [{ name: 'linked-skill', isDirectory: () => true }]
@@ -238,10 +260,12 @@ describe('syncExecute', () => {
     })
     accessMock.mockResolvedValue(undefined)
     lstatMock.mockResolvedValue(createStats({ isSymbolicLink: true }))
-
     const { syncExecute } = await import('./syncService')
+
+    // Act
     const result = await syncExecute({ replaceConflicts: [] })
 
+    // Assert
     expect(result.created).toBe(0)
     expect(result.replaced).toBe(0)
     expect(result.skipped).toBe(2) // 1 skill × 2 agents, all already symlinked
@@ -252,7 +276,8 @@ describe('syncExecute', () => {
     expect(rmMock).not.toHaveBeenCalled()
   })
 
-  it('replaces approved conflicts with symlinks', async () => {
+  it('replaces a conflicting local folder with a symlink once the user approves it', async () => {
+    // Arrange
     const conflictPath = join('/mock/agents/claude/skills', 'local-skill')
 
     readdirMock.mockImplementation(async (dir: string) => {
@@ -268,10 +293,12 @@ describe('syncExecute', () => {
       }
       throw new Error('ENOENT')
     })
-
     const { syncExecute } = await import('./syncService')
+
+    // Act
     const result = await syncExecute({ replaceConflicts: [conflictPath] })
 
+    // Assert
     expect(result.replaced).toBe(1)
     expect(result.details).toEqual(
       expect.arrayContaining([
@@ -299,7 +326,8 @@ describe('syncExecute', () => {
     expect(result.created).toBe(1)
   })
 
-  it('skips unapproved conflicts', async () => {
+  it('leaves a conflicting local folder in place when the user declines to replace it', async () => {
+    // Arrange
     const conflictPath = join('/mock/agents/claude/skills', 'local-skill')
 
     readdirMock.mockImplementation(async (dir: string) => {
@@ -315,10 +343,12 @@ describe('syncExecute', () => {
       }
       throw new Error('ENOENT')
     })
-
     const { syncExecute } = await import('./syncService')
+
+    // Act
     const result = await syncExecute({ replaceConflicts: [] }) // Not approved
 
+    // Assert
     expect(result.replaced).toBe(0)
     expect(result.skipped).toBe(1) // unapproved conflict skipped
     expect(rmMock).not.toHaveBeenCalled()
@@ -342,7 +372,8 @@ describe('syncExecute', () => {
     )
   })
 
-  it('records errors when symlink creation fails', async () => {
+  it('reports a failed sync with per-agent errors when symlink creation is denied', async () => {
+    // Arrange
     readdirMock.mockImplementation(async (dir: string) => {
       if (dir === '/mock/source/skills') {
         return [{ name: 'fail-skill', isDirectory: () => true }]
@@ -352,10 +383,12 @@ describe('syncExecute', () => {
     accessMock.mockResolvedValue(undefined)
     lstatMock.mockRejectedValue(new Error('ENOENT'))
     symlinkMock.mockRejectedValue(new Error('EPERM: operation not permitted'))
-
     const { syncExecute } = await import('./syncService')
+
+    // Act
     const result = await syncExecute({ replaceConflicts: [] })
 
+    // Assert
     expect(result.success).toBe(false)
     expect(result.errors).toHaveLength(2)
     expect(result.errors[0]).toMatchObject({
@@ -372,7 +405,8 @@ describe('syncExecute', () => {
     })
   })
 
-  it('creates agent skills directory via mkdir', async () => {
+  it('creates each agent skills directory before linking into it', async () => {
+    // Arrange
     readdirMock.mockImplementation(async (dir: string) => {
       if (dir === '/mock/source/skills') {
         return [{ name: 'any-skill', isDirectory: () => true }]
@@ -381,10 +415,12 @@ describe('syncExecute', () => {
     })
     accessMock.mockResolvedValue(undefined)
     lstatMock.mockRejectedValue(new Error('ENOENT'))
-
     const { syncExecute } = await import('./syncService')
+
+    // Act
     await syncExecute({ replaceConflicts: [] })
 
+    // Assert
     expect(mkdirMock).toHaveBeenCalledWith('/mock/agents/claude/skills', {
       recursive: true,
     })
@@ -411,7 +447,8 @@ describe('scoped sync (per-agent)', () => {
     rmMock.mockResolvedValue(undefined)
   })
 
-  it('preview narrows to a single agent and echoes forAgent', async () => {
+  it('previews only the requested agent and labels the result with that agent', async () => {
+    // Arrange
     readdirMock.mockImplementation(async (dir: string) => {
       if (dir === '/mock/source/skills') {
         return [{ name: 'my-skill', isDirectory: () => true }]
@@ -421,27 +458,33 @@ describe('scoped sync (per-agent)', () => {
     // 'my-skill' already symlinked under cursor; we still expect
     // totalAgents===1 because the claude row is filtered out entirely.
     lstatMock.mockResolvedValue(createStats({ isSymbolicLink: true }))
-
     const { syncPreview } = await import('./syncService')
+
+    // Act
     const result = await syncPreview({ agentId: 'cursor' })
 
+    // Assert
     expect(result.totalSkills).toBe(1)
     expect(result.totalAgents).toBe(1)
     expect(result.alreadySynced).toBe(1) // 1 skill × 1 agent (filtered)
     expect(result.forAgent).toBe('cursor')
   })
 
-  it('preview without agentId omits forAgent', async () => {
+  it('leaves a whole-fleet preview unlabeled by any single agent', async () => {
+    // Arrange
     readdirMock.mockResolvedValue([])
-
     const { syncPreview } = await import('./syncService')
+
+    // Act
     const result = await syncPreview()
 
+    // Assert
     expect(result.forAgent).toBeUndefined()
     expect(result.totalAgents).toBe(2)
   })
 
-  it('execute creates symlinks only for the scoped agent', async () => {
+  it('links the skill only into the scoped agent and never touches the others', async () => {
+    // Arrange
     readdirMock.mockImplementation(async (dir: string) => {
       if (dir === '/mock/source/skills') {
         return [{ name: 'new-skill', isDirectory: () => true }]
@@ -449,13 +492,15 @@ describe('scoped sync (per-agent)', () => {
       return []
     })
     lstatMock.mockRejectedValue(new Error('ENOENT'))
-
     const { syncExecute } = await import('./syncService')
+
+    // Act
     const result = await syncExecute({
       replaceConflicts: [],
       agentId: 'cursor',
     })
 
+    // Assert
     expect(result.created).toBe(1)
     expect(result.details).toHaveLength(1)
     expect(result.details[0]).toMatchObject({
@@ -482,13 +527,13 @@ describe('scoped sync (per-agent)', () => {
     )
   })
 
-  it('execute with an agentId not in AGENTS is a no-op (no silent fallback to all)', async () => {
-    // Defends against typos AND against an agent that exists in the union
-    // but isn't installed/on-disk in the user's environment. The mocked
-    // AGENTS list above only includes claude-code and cursor; passing
-    // 'codex' (a valid AgentId, not in the mock) reproduces "agent not on
-    // disk" — production filterAgentsByOption returns [] and we expect
-    // zero side effects.
+  it('makes no changes when scoped to an agent that is not installed on disk, rather than syncing all', async () => {
+    // Arrange: defends against typos AND against an agent that exists in the
+    // union but isn't installed/on-disk in the user's environment. The mocked
+    // AGENTS list above only includes claude-code and cursor; passing 'codex'
+    // (a valid AgentId, not in the mock) reproduces "agent not on disk" —
+    // production filterAgentsByOption returns [] and we expect zero side
+    // effects.
     readdirMock.mockImplementation(async (dir: string) => {
       if (dir === '/mock/source/skills') {
         return [{ name: 'new-skill', isDirectory: () => true }]
@@ -496,35 +541,39 @@ describe('scoped sync (per-agent)', () => {
       return []
     })
     lstatMock.mockRejectedValue(new Error('ENOENT'))
-
     const { syncExecute } = await import('./syncService')
+
+    // Act
     const result = await syncExecute({
       replaceConflicts: [],
       agentId: 'codex',
     })
 
+    // Assert
     expect(result.created).toBe(0)
     expect(result.details).toHaveLength(0)
     expect(symlinkMock).not.toHaveBeenCalled()
     expect(mkdirMock).not.toHaveBeenCalled()
   })
 
-  it('preview with an agentId not in AGENTS echoes forAgent and returns zero agents', async () => {
-    // Symmetric counterpart to the syncExecute no-op test above. The
-    // empty-state path of CleanupAgentDialog depends on this branch:
-    // forAgent must round-trip so previewMatchesTarget keeps the dialog
-    // gated, while totalAgents collapses to 0 and lstat is never even
-    // queried because filterAgentsByOption returned [].
+  it('previews zero agents yet still labels the result when scoped to an uninstalled agent', async () => {
+    // Arrange: symmetric counterpart to the syncExecute no-op test above. The
+    // empty-state path of CleanupAgentDialog depends on this branch: forAgent
+    // must round-trip so previewMatchesTarget keeps the dialog gated, while
+    // totalAgents collapses to 0 and lstat is never even queried because
+    // filterAgentsByOption returned [].
     readdirMock.mockImplementation(async (dir: string) => {
       if (dir === '/mock/source/skills') {
         return [{ name: 'any-skill', isDirectory: () => true }]
       }
       return []
     })
-
     const { syncPreview } = await import('./syncService')
+
+    // Act
     const result = await syncPreview({ agentId: 'codex' })
 
+    // Assert
     expect(result.totalAgents).toBe(0)
     expect(result.toCreate).toBe(0)
     expect(result.alreadySynced).toBe(0)

--- a/src/main/services/trashService.integration.test.ts
+++ b/src/main/services/trashService.integration.test.ts
@@ -231,7 +231,8 @@ describe('trashService (integration)', () => {
     )
   }
 
-  it('round-trip: moves source and agent symlink into trash, then restores both', async () => {
+  it('deletes a source skill with its agent symlink and brings both back on undo', async () => {
+    // Arrange
     const { moveToTrash, restore } = await trashServicePromise
 
     const skillName = 'round-trip-skill'
@@ -242,7 +243,10 @@ describe('trashService (integration)', () => {
     await stat(sourcePath)
     await stat(linkPath)
 
+    // Act
     const deleteResult = await moveReviewedSource(moveToTrash, skillName)
+
+    // Assert
     assertTombstoned(deleteResult)
     // With both `os` and `node:os` mocked, `AGENTS` paths resolve under
     // `sharedHome` so the cursor symlink we created above is actually
@@ -281,7 +285,7 @@ describe('trashService (integration)', () => {
     await stat(sourcePath)
   })
 
-  it('moveToTrash deletes the reviewed source folder when metadata name differs from basename', async () => {
+  it('deletes the exact reviewed source folder even when the SKILL.md name differs from its basename', async () => {
     const { moveToTrash } = await trashServicePromise
 
     // Arrange
@@ -325,7 +329,7 @@ describe('trashService (integration)', () => {
     expect(manifest.sourcePath).toBe(sourcePath)
   })
 
-  it('moveToTrash deletes reviewed agent-local folder without tombstoning same-basename source', async () => {
+  it('deletes a reviewed agent-local folder without touching a same-named source skill', async () => {
     const { moveToTrash } = await trashServicePromise
 
     // Arrange
@@ -360,7 +364,7 @@ describe('trashService (integration)', () => {
     ])
   })
 
-  it('moveToTrash rejects a same-path source replacement and preserves the replacement folder', async () => {
+  it('refuses to delete a source folder that was replaced at the same path, keeping the replacement intact', async () => {
     const { moveToTrash } = await trashServicePromise
 
     // Arrange
@@ -383,7 +387,7 @@ describe('trashService (integration)', () => {
     await expect(lstat(sharedTrashDir)).rejects.toThrow(/ENOENT/)
   })
 
-  it('moveToTrash rejects a same-path local replacement and preserves the replacement folder', async () => {
+  it('refuses to delete a local folder that was replaced at the same path, keeping the replacement intact', async () => {
     const { moveToTrash } = await trashServicePromise
 
     // Arrange
@@ -407,7 +411,7 @@ describe('trashService (integration)', () => {
     await expect(lstat(sharedTrashDir)).rejects.toThrow(/ENOENT/)
   })
 
-  it('moveToTrash deletes only the reviewed local folder when another agent has the same basename', async () => {
+  it('deletes only the reviewed agent local folder when another agent holds a same-named one', async () => {
     const { moveToTrash } = await trashServicePromise
 
     // Arrange
@@ -429,20 +433,23 @@ describe('trashService (integration)', () => {
     await expect(lstat(siblingLocalPath)).resolves.toBeDefined()
   })
 
-  it('evict: idempotent — calling evict on a missing entry does not throw', async () => {
+  it('silently no-ops when evicting a tombstone that was already gone', async () => {
+    // Arrange
     const { evict, tombstoneId } = await (async () => {
       const mod = await trashServicePromise
       const { tombstoneId: makeId } = await import('@/shared/types')
       return { evict: mod.evict, tombstoneId: makeId }
     })()
 
+    // Act + Assert
     // No entry; evict should be a silent no-op.
     await expect(
       evict(tombstoneId('9999999999999-missing-00000000')),
     ).resolves.toBeUndefined()
   })
 
-  it('restore returns outcome:error when manifest is corrupted', async () => {
+  it('fails undo with a corrupt-manifest error when the trash manifest is unreadable', async () => {
+    // Arrange
     const { moveToTrash, restore } = await trashServicePromise
 
     const skillName = 'manifest-corrupt-skill'
@@ -458,7 +465,10 @@ describe('trashService (integration)', () => {
     )
     await writeFile(manifestPath, '{not json', 'utf-8')
 
+    // Act
     const restoreResult = await restore(result.tombstoneId)
+
+    // Assert
     expect(restoreResult.outcome).toBe('error')
     if (restoreResult.outcome === 'error') {
       // Assert on the stable sentinel code rather than regex-matching the
@@ -467,7 +477,8 @@ describe('trashService (integration)', () => {
     }
   })
 
-  it('restore returns outcome:error when source path is occupied (collision)', async () => {
+  it('refuses undo with a collision error when a new skill already sits at the original path', async () => {
+    // Arrange
     const { moveToTrash, restore } = await trashServicePromise
 
     const skillName = 'collision-skill'
@@ -480,14 +491,18 @@ describe('trashService (integration)', () => {
     await mkdir(sourcePath, { recursive: true })
     await writeFile(join(sourcePath, 'DUPLICATE.md'), '# dup\n', 'utf-8')
 
+    // Act
     const restoreResult = await restore(result.tombstoneId)
+
+    // Assert
     expect(restoreResult.outcome).toBe('error')
     if (restoreResult.outcome === 'error') {
       expect(restoreResult.error.code).toBe('EEXIST')
     }
   })
 
-  it('moveToTrash aborts cleanly when source does not exist and no agent has a local copy', async () => {
+  it('reports the skill as already changed when it exists in neither the source nor any agent', async () => {
+    // Arrange
     const { moveToTrash } = await trashServicePromise
     // No source-skill, no agent copy: pure ghost — moveToTrash should reject
     // with "already deleted". The previous version of this test passed a fake
@@ -495,6 +510,7 @@ describe('trashService (integration)', () => {
     // so we just verify the missing-everywhere case still surfaces ENOENT.
     const skillName = 'ghost-skill'
 
+    // Act + Assert
     await expect(
       moveToTrash(
         skillName,
@@ -504,8 +520,11 @@ describe('trashService (integration)', () => {
     ).rejects.toThrow(/already changed/i)
   })
 
-  it('produces unique tombstone ids when two calls happen in the same ms', async () => {
+  it('gives two skills deleted in the same millisecond distinct tombstone ids', async () => {
+    // Arrange
     const { moveToTrash } = await trashServicePromise
+
+    // Act
     const [a, b] = await Promise.all([
       (async () => {
         await makeSourceSkill('race-a')
@@ -516,12 +535,15 @@ describe('trashService (integration)', () => {
         return moveReviewedSource(moveToTrash, 'race-b')
       })(),
     ])
+
+    // Assert
     assertTombstoned(a)
     assertTombstoned(b)
     expect(a.tombstoneId).not.toBe(b.tombstoneId)
   })
 
-  it('startupCleanup leaves recent entries alone and sweeps old ones', async () => {
+  it('sweeps stale trash entries on startup while keeping recently deleted ones', async () => {
+    // Arrange
     const { moveToTrash, startupCleanup } = await trashServicePromise
 
     // Fresh entry: should survive the sweep.
@@ -537,24 +559,30 @@ describe('trashService (integration)', () => {
     await mkdir(oldEntryDir, { recursive: true })
     await writeFile(join(oldEntryDir, 'manifest.json'), '{}', 'utf-8')
 
+    // Act
     await startupCleanup()
 
+    // Assert
     // Old entry gone, recent entry preserved.
     await expect(stat(oldEntryDir)).rejects.toThrow()
     const recentDir = join(sharedTrashDir, recent.tombstoneId)
     await stat(recentDir) // still there
   })
 
-  it('restore is a no-op against a tombstone that was already evicted', async () => {
+  it('fails undo with a not-found error once the tombstone has been permanently evicted', async () => {
+    // Arrange
     const { moveToTrash, evict, restore } = await trashServicePromise
 
     const skillName = 'evict-then-restore'
     await makeSourceSkill(skillName)
     const result = await moveReviewedSource(moveToTrash, skillName)
     assertTombstoned(result)
-
     await evict(result.tombstoneId)
+
+    // Act
     const restoreResult = await restore(result.tombstoneId)
+
+    // Assert
     expect(restoreResult.outcome).toBe('error')
     if (restoreResult.outcome === 'error') {
       // Stable syscall code rather than the message string.
@@ -562,7 +590,8 @@ describe('trashService (integration)', () => {
     }
   })
 
-  it('manifest.symlinks array reflects readlink target of each agent link', async () => {
+  it('records a well-formed source-backed manifest capturing the deleted skill identity', async () => {
+    // Arrange
     // Limited check: we don't mock AGENTS, so the moveToTrash walk will iterate
     // the real AGENT_DEFINITIONS and compute linkPaths against ~/.agent/skills.
     // We don't assert exact content here; we only assert the manifest is a valid
@@ -571,9 +600,12 @@ describe('trashService (integration)', () => {
 
     const skillName = 'manifest-check'
     const sourcePath = await makeSourceSkill(skillName)
-    const result = await moveReviewedSource(moveToTrash, skillName)
-    assertTombstoned(result)
 
+    // Act
+    const result = await moveReviewedSource(moveToTrash, skillName)
+
+    // Assert
+    assertTombstoned(result)
     const manifestPath = join(
       sharedTrashDir,
       result.tombstoneId,
@@ -596,14 +628,18 @@ describe('trashService (integration)', () => {
     expect(manifest.deletedAt).toBeGreaterThan(0)
   })
 
-  it('writes sources inside the trash entry under a /source child (not at entry root)', async () => {
+  it('stages the deleted source under a /source child of the trash entry, not at its root', async () => {
+    // Arrange
     const { moveToTrash } = await trashServicePromise
 
     const skillName = 'nested-source'
     await makeSourceSkill(skillName)
-    const result = await moveReviewedSource(moveToTrash, skillName)
-    assertTombstoned(result)
 
+    // Act
+    const result = await moveReviewedSource(moveToTrash, skillName)
+
+    // Assert
+    assertTombstoned(result)
     // The moved source must live under entry/source.
     const trashSourceChild = join(
       sharedTrashDir,
@@ -624,7 +660,8 @@ describe('trashService (integration)', () => {
   // that `restore()` can put back agent-by-agent.)
   // ---------------------------------------------------------------------
 
-  it('moveToTrash handles a local-only skill (no source, single agent copy)', async () => {
+  it('deletes a source-less skill that lives only inside one agent dir and stages a local-only manifest', async () => {
+    // Arrange
     const { moveToTrash } = await trashServicePromise
 
     const skillName = 'architecture-decision-records'
@@ -633,11 +670,14 @@ describe('trashService (integration)', () => {
     await stat(localPath)
     await expect(stat(join(sharedSourceDir, skillName))).rejects.toThrow()
 
+    // Act
     const deleteResult = await moveReviewedLocal(
       moveToTrash,
       skillName,
       sharedAgentClaude,
     )
+
+    // Assert
     assertTombstoned(deleteResult)
     expect(deleteResult.cascadeAgents).toContain('claude-code')
     // The local copy is staged under entryDir/local-copies — count it for parity
@@ -678,17 +718,21 @@ describe('trashService (integration)', () => {
     expect(manifest.localCopies[0]?.linkPath).toBe(localPath)
   })
 
-  it('round-trip: deletes a local-only skill and restores it back into the agent dir', async () => {
+  it('deletes a local-only skill and puts the folder back in its agent dir on undo', async () => {
+    // Arrange
     const { moveToTrash, restore } = await trashServicePromise
 
     const skillName = 'local-round-trip'
     const localPath = await makeLocalSkill(skillName, sharedAgentClaude)
 
+    // Act
     const deleteResult = await moveReviewedLocal(
       moveToTrash,
       skillName,
       sharedAgentClaude,
     )
+
+    // Assert
     assertTombstoned(deleteResult)
     await expect(stat(localPath)).rejects.toThrow()
 
@@ -710,7 +754,8 @@ describe('trashService (integration)', () => {
     ).rejects.toThrow()
   })
 
-  it('source-backed flow wins when both source and a local copy exist', async () => {
+  it('takes the source-backed path and leaves a stray same-named agent folder untouched', async () => {
+    // Arrange
     // Disambiguates the dispatch in moveToTrash: if SOURCE_DIR/<name> exists,
     // we must NOT fall through to local-only even when an agent dir also has
     // a real folder by the same name (rare but possible, e.g. user manually
@@ -724,9 +769,11 @@ describe('trashService (integration)', () => {
     // local copy must be left alone untouched.
     const orphanLocal = await makeLocalSkill(skillName, sharedAgentClaude)
 
+    // Act
     const deleteResult = await moveReviewedSource(moveToTrash, skillName)
-    assertTombstoned(deleteResult)
 
+    // Assert
+    assertTombstoned(deleteResult)
     // Source went into trash entry under /source.
     await expect(stat(sourcePath)).rejects.toThrow()
     const stagedSource = join(
@@ -775,7 +822,8 @@ describe('trashService (integration)', () => {
     expect(await readlink(cursorLinkPath)).toBe(otherSourcePath)
   })
 
-  it('regression: moveToTrash no longer throws "already deleted" when only an agent-side local folder exists', async () => {
+  it('regression: deletes an agent-only local folder instead of failing with "already deleted"', async () => {
+    // Arrange
     // Direct repro of the user-reported bug. Pre-fix, the IPC handler called
     // moveToTrash with sourcePath = SOURCE_DIR/<name>, which didn't exist for
     // local-only skills, so the fs.stat probe failed with ENOENT and surfaced
@@ -787,6 +835,7 @@ describe('trashService (integration)', () => {
     const skillName = 'regression-local-only'
     await makeLocalSkill(skillName, sharedAgentClaude)
 
+    // Act + Assert
     await expect(
       moveReviewedLocal(moveToTrash, skillName, sharedAgentClaude),
     ).resolves.toMatchObject({

--- a/src/main/services/trashService.restore.test.ts
+++ b/src/main/services/trashService.restore.test.ts
@@ -166,7 +166,8 @@ describe('trashService.restore target-containment', () => {
     await mkdir(sharedClaudeAgent, { recursive: true })
   })
 
-  it('baseline: legit absolute target inside SOURCE_DIR is restored', async () => {
+  it('restores a symlink whose absolute target legitimately lives inside SOURCE_DIR', async () => {
+    // Arrange
     // Control case. Without this passing, every "should skip" case below is
     // meaningless — if the happy path plants nothing we're testing a broken
     // pipeline rather than the containment check.
@@ -179,7 +180,10 @@ describe('trashService.restore target-containment', () => {
       symlinks: [{ agentId: 'claude-code', linkPath, target }],
     })
 
+    // Act
     const result = await restore(tombstone as never)
+
+    // Assert
     expect(result.outcome).toBe('restored')
     if (result.outcome === 'restored') {
       expect(result.symlinksRestored).toBeGreaterThanOrEqual(1)
@@ -280,7 +284,8 @@ describe('trashService.restore target-containment', () => {
     await expect(readlink(linkPath)).resolves.toBe(target)
   })
 
-  it('skips symlink when manifest target absolute-escapes SOURCE_DIR', async () => {
+  it('refuses to plant a tampered symlink whose absolute target escapes SOURCE_DIR', async () => {
+    // Arrange
     const { restore } = await trashServicePromise
     const skillName = 'target-abs-escape'
     const linkPath = join(sharedClaudeAgent, skillName)
@@ -289,7 +294,10 @@ describe('trashService.restore target-containment', () => {
       symlinks: [{ agentId: 'claude-code', linkPath, target: '/etc/passwd' }],
     })
 
+    // Act
     const result = await restore(tombstone as never)
+
+    // Assert
     expect(result.outcome).toBe('restored')
     if (result.outcome === 'restored') {
       // Containment check must skip this link — 0 restored, 1 skipped.
@@ -299,7 +307,8 @@ describe('trashService.restore target-containment', () => {
     await expect(stat(linkPath)).rejects.toThrow()
   })
 
-  it('skips symlink when relative target escapes SOURCE_DIR via parent traversal', async () => {
+  it('refuses to plant a tampered symlink whose relative target traverses out of SOURCE_DIR', async () => {
+    // Arrange
     const { restore } = await trashServicePromise
     const skillName = 'target-rel-escape'
     const linkPath = join(sharedClaudeAgent, skillName)
@@ -316,7 +325,10 @@ describe('trashService.restore target-containment', () => {
       ],
     })
 
+    // Act
     const result = await restore(tombstone as never)
+
+    // Assert
     expect(result.outcome).toBe('restored')
     if (result.outcome === 'restored') {
       expect(result.symlinksRestored).toBe(0)
@@ -325,7 +337,8 @@ describe('trashService.restore target-containment', () => {
     await expect(stat(linkPath)).rejects.toThrow()
   })
 
-  it('skips symlink when target points at an unrelated path inside homedir (but outside SOURCE_DIR)', async () => {
+  it('refuses to plant a tampered symlink that points inside homedir but outside SOURCE_DIR', async () => {
+    // Arrange
     const { restore } = await trashServicePromise
     const skillName = 'target-sibling-dir'
     const linkPath = join(sharedClaudeAgent, skillName)
@@ -342,7 +355,10 @@ describe('trashService.restore target-containment', () => {
       ],
     })
 
+    // Act
     const result = await restore(tombstone as never)
+
+    // Assert
     expect(result.outcome).toBe('restored')
     if (result.outcome === 'restored') {
       expect(result.symlinksRestored).toBe(0)
@@ -351,7 +367,8 @@ describe('trashService.restore target-containment', () => {
     await expect(stat(linkPath)).rejects.toThrow()
   })
 
-  it('mixed manifest: skips tampered entries but plants legit ones', async () => {
+  it('plants the legit link and skips the tampered one when a manifest mixes both', async () => {
+    // Arrange
     // Belt-and-suspenders: a manifest with one legit + one tampered entry
     // must plant exactly one link. Catches regressions where the check
     // accidentally short-circuits the whole loop on the first bad entry.
@@ -377,7 +394,10 @@ describe('trashService.restore target-containment', () => {
       ],
     })
 
+    // Act
     const result = await restore(tombstone as never)
+
+    // Assert
     expect(result.outcome).toBe('restored')
     if (result.outcome === 'restored') {
       expect(result.symlinksRestored).toBe(1)

--- a/src/main/utils/clampSizeToWorkArea.test.ts
+++ b/src/main/utils/clampSizeToWorkArea.test.ts
@@ -3,48 +3,63 @@ import { describe, expect, it } from 'vitest'
 import { clampSizeToWorkArea } from './clampSizeToWorkArea'
 
 describe('clampSizeToWorkArea', () => {
-  it('returns the desired size when it fits inside the work area', () => {
-    expect(
-      clampSizeToWorkArea(
-        { width: 1000, height: 700 },
-        { width: 1440, height: 900 },
-      ),
-    ).toEqual({ width: 1000, height: 700 })
+  it('keeps a smaller window at its desired size so it is not needlessly shrunk', () => {
+    // Arrange
+    const desiredSize = { width: 1000, height: 700 }
+    const workArea = { width: 1440, height: 900 }
+
+    // Act
+    const result = clampSizeToWorkArea(desiredSize, workArea)
+
+    // Assert
+    expect(result).toEqual({ width: 1000, height: 700 })
   })
 
-  it('clamps width when it exceeds the work area', () => {
-    expect(
-      clampSizeToWorkArea(
-        { width: 3000, height: 700 },
-        { width: 1440, height: 900 },
-      ),
-    ).toEqual({ width: 1440, height: 700 })
+  it('shrinks an over-wide window to the work-area width so it cannot overflow off-screen', () => {
+    // Arrange
+    const desiredSize = { width: 3000, height: 700 }
+    const workArea = { width: 1440, height: 900 }
+
+    // Act
+    const result = clampSizeToWorkArea(desiredSize, workArea)
+
+    // Assert
+    expect(result).toEqual({ width: 1440, height: 700 })
   })
 
-  it('clamps height when it exceeds the work area', () => {
-    expect(
-      clampSizeToWorkArea(
-        { width: 1000, height: 2000 },
-        { width: 1440, height: 900 },
-      ),
-    ).toEqual({ width: 1000, height: 900 })
+  it('shrinks an over-tall window to the work-area height so it cannot overflow off-screen', () => {
+    // Arrange
+    const desiredSize = { width: 1000, height: 2000 }
+    const workArea = { width: 1440, height: 900 }
+
+    // Act
+    const result = clampSizeToWorkArea(desiredSize, workArea)
+
+    // Assert
+    expect(result).toEqual({ width: 1000, height: 900 })
   })
 
-  it('clamps both dimensions independently', () => {
-    expect(
-      clampSizeToWorkArea(
-        { width: 3000, height: 2000 },
-        { width: 1440, height: 900 },
-      ),
-    ).toEqual({ width: 1440, height: 900 })
+  it('clamps width and height separately so an oversized window fills but never exceeds the work area', () => {
+    // Arrange
+    const desiredSize = { width: 3000, height: 2000 }
+    const workArea = { width: 1440, height: 900 }
+
+    // Act
+    const result = clampSizeToWorkArea(desiredSize, workArea)
+
+    // Assert
+    expect(result).toEqual({ width: 1440, height: 900 })
   })
 
-  it('preserves an exact-match size', () => {
-    expect(
-      clampSizeToWorkArea(
-        { width: 1440, height: 900 },
-        { width: 1440, height: 900 },
-      ),
-    ).toEqual({ width: 1440, height: 900 })
+  it('leaves a window that exactly matches the work area unchanged', () => {
+    // Arrange
+    const desiredSize = { width: 1440, height: 900 }
+    const workArea = { width: 1440, height: 900 }
+
+    // Act
+    const result = clampSizeToWorkArea(desiredSize, workArea)
+
+    // Assert
+    expect(result).toEqual({ width: 1440, height: 900 })
   })
 })

--- a/src/main/utils/installDevelopmentDevToolsExtensions.test.ts
+++ b/src/main/utils/installDevelopmentDevToolsExtensions.test.ts
@@ -51,14 +51,17 @@ describe('installDevelopmentDevToolsExtensions', () => {
     vi.restoreAllMocks()
   })
 
-  it('installs React and Redux DevTools for local development', async () => {
+  it('installs React and Redux DevTools and logs them on a local dev launch', async () => {
+    // Arrange
     mockInstallExtension.mockResolvedValue([
       { name: 'React Developer Tools' },
       { name: 'Redux DevTools' },
     ])
 
+    // Act
     await installDevelopmentDevToolsExtensions()
 
+    // Assert
     expect(mockInstallExtension).toHaveBeenCalledWith(
       [{ id: 'react-devtools' }, { id: 'redux-devtools' }],
       {
@@ -72,37 +75,51 @@ describe('installDevelopmentDevToolsExtensions', () => {
     )
   })
 
-  it('skips packaged builds', async () => {
+  it('never downloads DevTools extensions into a packaged production build', async () => {
+    // Arrange
     mockState.isPackaged = true
 
-    expect(shouldInstallDevelopmentDevToolsExtensions()).toBe(false)
+    // Act
+    const shouldInstall = shouldInstallDevelopmentDevToolsExtensions()
     await installDevelopmentDevToolsExtensions()
 
+    // Assert
+    expect(shouldInstall).toBe(false)
     expect(mockInstallExtension).not.toHaveBeenCalled()
   })
 
-  it('skips hidden E2E launches', async () => {
+  it('never downloads DevTools extensions during a hidden E2E launch', async () => {
+    // Arrange
     mockState.isE2EBackgroundLaunch = true
 
-    expect(shouldInstallDevelopmentDevToolsExtensions()).toBe(false)
+    // Act
+    const shouldInstall = shouldInstallDevelopmentDevToolsExtensions()
     await installDevelopmentDevToolsExtensions()
 
+    // Assert
+    expect(shouldInstall).toBe(false)
     expect(mockInstallExtension).not.toHaveBeenCalled()
   })
 
-  it('skips when the local opt-out env var is enabled', async () => {
+  it('honors the local opt-out env var and skips the DevTools download', async () => {
+    // Arrange
     process.env['SKILLS_DESKTOP_DISABLE_DEVTOOLS_EXTENSIONS'] = '1'
 
-    expect(shouldInstallDevelopmentDevToolsExtensions()).toBe(false)
+    // Act
+    const shouldInstall = shouldInstallDevelopmentDevToolsExtensions()
     await installDevelopmentDevToolsExtensions()
 
+    // Assert
+    expect(shouldInstall).toBe(false)
     expect(mockInstallExtension).not.toHaveBeenCalled()
   })
 
-  it('logs installer errors without blocking startup', async () => {
+  it('warns but still finishes startup when the DevTools download fails', async () => {
+    // Arrange
     const error = new Error('chrome web store unavailable')
     mockInstallExtension.mockRejectedValue(error)
 
+    // Act + Assert
     await expect(
       installDevelopmentDevToolsExtensions(),
     ).resolves.toBeUndefined()

--- a/src/main/utils/windowBackgroundBlur.test.ts
+++ b/src/main/utils/windowBackgroundBlur.test.ts
@@ -64,39 +64,82 @@ function makeWindowMock(
  * color contract before values reach Electron.
  */
 describe('windowBackgroundBlur helpers', () => {
-  it('clamps persisted blur radius values to the supported range', () => {
-    expect(normalizeWindowBackgroundBlurRadius(-12)).toBe(0)
-    expect(normalizeWindowBackgroundBlurRadius(12.9)).toBe(12)
-    expect(normalizeWindowBackgroundBlurRadius(99)).toBe(
-      WINDOW_BACKGROUND_BLUR_MAX_RADIUS,
-    )
+  it('floors negative, truncates fractional, and caps over-max persisted blur radii to the supported range', () => {
+    // Arrange
+    const negativeRadius = -12
+    const fractionalRadius = 12.9
+    const overMaxRadius = 99
+
+    // Act
+    const flooredRadius = normalizeWindowBackgroundBlurRadius(negativeRadius)
+    const roundedRadius = normalizeWindowBackgroundBlurRadius(fractionalRadius)
+    const cappedRadius = normalizeWindowBackgroundBlurRadius(overMaxRadius)
+
+    // Assert
+    expect(flooredRadius).toBe(0)
+    expect(roundedRadius).toBe(12)
+    expect(cappedRadius).toBe(WINDOW_BACKGROUND_BLUR_MAX_RADIUS)
   })
 
-  it('uses an opaque background when blur is disabled', () => {
-    expect(getMainWindowBackgroundColor(0)).toBe(MAIN_WINDOW_OPAQUE_BACKGROUND)
+  it('paints an opaque window background when the user turns blur off', () => {
+    // Arrange
+    const blurDisabledRadius = 0
+
+    // Act
+    const backgroundColor = getMainWindowBackgroundColor(blurDisabledRadius)
+
+    // Assert
+    expect(backgroundColor).toBe(MAIN_WINDOW_OPAQUE_BACKGROUND)
   })
 
-  it('uses a clear background when blur is enabled', () => {
-    expect(getMainWindowBackgroundColor(12)).toBe(
-      MAIN_WINDOW_TRANSPARENT_BACKGROUND,
-    )
+  it('paints a see-through window background when the user turns blur on', () => {
+    // Arrange
+    const blurEnabledRadius = 12
+
+    // Act
+    const backgroundColor = getMainWindowBackgroundColor(blurEnabledRadius)
+
+    // Assert
+    expect(backgroundColor).toBe(MAIN_WINDOW_TRANSPARENT_BACKGROUND)
   })
 
-  it('maps the blur slider to real BrowserWindow opacity', () => {
-    expect(getMainWindowOpacity(0)).toBe(1)
-    expect(getMainWindowOpacity(WINDOW_BACKGROUND_BLUR_MAX_RADIUS)).toBe(0.45)
+  it('keeps the window fully opaque at zero blur and drops to 0.45 opacity at max blur', () => {
+    // Arrange
+    const blurDisabledRadius = 0
+    const maxBlurRadius = WINDOW_BACKGROUND_BLUR_MAX_RADIUS
+
+    // Act
+    const opacityAtNoBlur = getMainWindowOpacity(blurDisabledRadius)
+    const opacityAtMaxBlur = getMainWindowOpacity(maxBlurRadius)
+
+    // Assert
+    expect(opacityAtNoBlur).toBe(1)
+    expect(opacityAtMaxBlur).toBe(0.45)
   })
 
-  it('enables native blur only for non-zero radius values', () => {
-    expect(shouldUseNativeWindowBlur(0)).toBe(false)
-    expect(shouldUseNativeWindowBlur(1)).toBe(true)
+  it('turns on native blur only once the radius rises above zero', () => {
+    // Arrange
+    const blurDisabledRadius = 0
+    const blurEnabledRadius = 1
+
+    // Act
+    const blurOffUsesNative = shouldUseNativeWindowBlur(blurDisabledRadius)
+    const blurOnUsesNative = shouldUseNativeWindowBlur(blurEnabledRadius)
+
+    // Assert
+    expect(blurOffUsesNative).toBe(false)
+    expect(blurOnUsesNative).toBe(true)
   })
 
-  it('applies opaque color and zero blur when the radius is disabled', () => {
+  it('renders a solid opaque window with vibrancy off when the user disables blur', () => {
+    // Arrange
     const { window, contentView } = makeWindowMock(true)
+    const blurDisabledRadius = 0
 
-    applyWindowBackgroundBlur(window, 0)
+    // Act
+    applyWindowBackgroundBlur(window, blurDisabledRadius)
 
+    // Assert
     expect(window.setOpacity).toHaveBeenCalledWith(1)
     expect(window.setBackgroundColor).toHaveBeenCalledWith(
       MAIN_WINDOW_OPAQUE_BACKGROUND,
@@ -108,11 +151,15 @@ describe('windowBackgroundBlur helpers', () => {
     expect(contentView.setBackgroundBlur).toHaveBeenCalledWith(0)
   })
 
-  it('applies alpha color and clamped blur when Electron 42 blur is available', () => {
+  it('renders a translucent blurred window clamped to max radius when Electron 42 blur is available', () => {
+    // Arrange
     const { window, contentView } = makeWindowMock(true)
+    const overMaxRadius = WINDOW_BACKGROUND_BLUR_MAX_RADIUS + 1
 
-    applyWindowBackgroundBlur(window, WINDOW_BACKGROUND_BLUR_MAX_RADIUS + 1)
+    // Act
+    applyWindowBackgroundBlur(window, overMaxRadius)
 
+    // Assert
     expect(window.setOpacity).toHaveBeenCalledWith(0.45)
     expect(window.setBackgroundColor).toHaveBeenCalledWith(
       MAIN_WINDOW_TRANSPARENT_BACKGROUND,
@@ -126,10 +173,15 @@ describe('windowBackgroundBlur helpers', () => {
     )
   })
 
-  it('skips blur safely when Electron exposes no setBackgroundBlur method', () => {
+  it('falls back to translucency without crashing when Electron lacks setBackgroundBlur', () => {
+    // Arrange
     const { window, contentView } = makeWindowMock(false)
+    const blurEnabledRadius = 12
 
-    expect(() => applyWindowBackgroundBlur(window, 12)).not.toThrow()
+    // Act + Assert
+    expect(() =>
+      applyWindowBackgroundBlur(window, blurEnabledRadius),
+    ).not.toThrow()
     expect(window.setOpacity).toHaveBeenCalledWith(0.86)
     expect(window.setBackgroundColor).toHaveBeenCalledWith(
       MAIN_WINDOW_TRANSPARENT_BACKGROUND,
@@ -140,10 +192,15 @@ describe('windowBackgroundBlur helpers', () => {
     expect('setBackgroundBlur' in contentView).toBe(false)
   })
 
-  it('skips contentView background safely when the method is absent', () => {
+  it('still applies window-level blur without crashing when contentView lacks setBackgroundColor', () => {
+    // Arrange
     const { window, contentView } = makeWindowMock(true, false)
+    const blurEnabledRadius = 12
 
-    expect(() => applyWindowBackgroundBlur(window, 12)).not.toThrow()
+    // Act + Assert
+    expect(() =>
+      applyWindowBackgroundBlur(window, blurEnabledRadius),
+    ).not.toThrow()
     expect(window.setOpacity).toHaveBeenCalledWith(0.86)
     expect(window.setBackgroundColor).toHaveBeenCalledWith(
       MAIN_WINDOW_TRANSPARENT_BACKGROUND,

--- a/src/renderer/settings/sections/Agents.browser.test.tsx
+++ b/src/renderer/settings/sections/Agents.browser.test.tsx
@@ -119,63 +119,78 @@ async function renderAgents(
  *  - "Show all" is disabled when nothing is hidden
  */
 describe('Settings → Agents', () => {
-  it('unchecking an installed agent appends its id to hiddenAgentIds', async () => {
+  it('hides an installed agent from the sidebar when its row is unchecked', async () => {
+    // Arrange
     const { screen } = await renderAgents([])
 
+    // Act
     const claudeCheckbox = screen.getByRole('checkbox', {
       name: /Show Claude Code in sidebar/i,
     })
     await claudeCheckbox.click()
 
+    // Assert
     expect(mockSettingsSet).toHaveBeenCalledTimes(1)
     expect(mockSettingsSet).toHaveBeenCalledWith({
       hiddenAgentIds: ['claude-code'],
     })
   })
 
-  it('re-checking a hidden agent removes its id from hiddenAgentIds', async () => {
+  it('restores a hidden agent to the sidebar when its row is re-checked', async () => {
+    // Arrange
     const { screen } = await renderAgents(['claude-code'])
 
+    // Act
     const claudeCheckbox = screen.getByRole('checkbox', {
       name: /Show Claude Code in sidebar/i,
     })
     await claudeCheckbox.click()
 
+    // Assert
     expect(mockSettingsSet).toHaveBeenCalledWith({
       hiddenAgentIds: [],
     })
   })
 
-  it('"Show all" clears every hidden agent', async () => {
+  it('reveals every hidden agent at once when "Show all" is clicked', async () => {
+    // Arrange
     const { screen } = await renderAgents(['claude-code', 'cursor'])
 
+    // Act
     const showAllButton = screen.getByRole('button', { name: /Show all/i })
     await showAllButton.click()
 
+    // Assert
     expect(mockSettingsSet).toHaveBeenCalledWith({
       hiddenAgentIds: [],
     })
   })
 
-  it('"Show all" is disabled when nothing is hidden', async () => {
+  it('disables "Show all" when no agent is currently hidden', async () => {
+    // Arrange
     const { screen } = await renderAgents([])
 
+    // Act
     const showAllButton = screen.getByRole('button', { name: /Show all/i })
+
+    // Assert
     await expect.element(showAllButton).toBeDisabled()
   })
 
-  it('renders the "X visible · Y hidden" counter', async () => {
+  it('counts one visible and one hidden when a single agent is hidden', async () => {
+    // Arrange — 2 installed, 1 hidden → 1 visible · 1 hidden
     const { screen } = await renderAgents(['cursor'])
 
-    // 2 installed, 1 hidden → 1 visible · 1 hidden
-    await expect
-      .element(screen.getByText(/1 visible · 1 hidden/i))
-      .toBeInTheDocument()
+    // Act
+    const counter = screen.getByText(/1 visible · 1 hidden/i)
+
+    // Assert
+    await expect.element(counter).toBeInTheDocument()
   })
 
-  it('shows the loading placeholder while agents.loading is true and the list is empty', async () => {
-    // Settings can open before the main window has finished its first
-    // scan. Without the loading placeholder users see "No agents
+  it('shows a loading placeholder mid-scan instead of a false "no agents" message', async () => {
+    // Arrange — Settings can open before the main window has finished its
+    // first scan. Without the loading placeholder users see "No agents
     // detected" mid-scan and panic that nothing's installed.
     //
     // The component re-fires fetchAgents on mount when items is empty.
@@ -183,30 +198,36 @@ describe('Settings → Agents', () => {
     // `loading: true` flag survives long enough for the assertion.
     mockAgentsGetAll.mockReturnValueOnce(new Promise(() => {}))
     const { screen } = await renderAgents([], [], true)
-    await expect
-      .element(screen.getByText(/Loading agents/i))
-      .toBeInTheDocument()
+
+    // Act
+    const loadingPlaceholder = screen.getByText(/Loading agents/i)
+
+    // Assert
+    await expect.element(loadingPlaceholder).toBeInTheDocument()
   })
 
-  it('shows the empty-installed message when no agents are detected', async () => {
-    // Distinct copy from the loading state — once the scan finishes and
-    // genuinely finds nothing, the user gets a fresh-machine hint.
+  it('shows a fresh-machine hint once a finished scan finds no agents', async () => {
+    // Arrange — Distinct copy from the loading state: once the scan finishes
+    // and genuinely finds nothing, the user gets a fresh-machine hint.
     //
     // Override the default fixture: the empty preloaded state triggers
     // an on-mount fetchAgents() that would otherwise resolve to
     // FIXTURE_AGENTS and replace the empty list.
     mockAgentsGetAll.mockResolvedValueOnce([])
     const { screen } = await renderAgents([], [], false)
-    await expect
-      .element(screen.getByText(/No agents detected on this machine/i))
-      .toBeInTheDocument()
+
+    // Act
+    const emptyMessage = screen.getByText(/No agents detected on this machine/i)
+
+    // Assert
+    await expect.element(emptyMessage).toBeInTheDocument()
   })
 
-  it('renders a disabled disclosure for not-installed agents', async () => {
-    // The "N not installed" details/summary is the only place the user
-    // sees uninstalled agents in this pane. Ensure it shows up with the
-    // count and a disabled checkbox so a future refactor cannot
-    // accidentally make these toggleable.
+  it('keeps a not-installed agent in a non-toggleable "not installed" disclosure', async () => {
+    // Arrange — The "N not installed" details/summary is the only place the
+    // user sees uninstalled agents in this pane. Ensure it shows up with the
+    // count and a disabled checkbox so a future refactor cannot accidentally
+    // make these toggleable.
     const NOT_INSTALLED_AGENT: Agent = {
       id: 'codex' as AgentId,
       name: 'Codex',
@@ -219,28 +240,35 @@ describe('Settings → Agents', () => {
       [],
       [...FIXTURE_AGENTS, NOT_INSTALLED_AGENT],
     )
-    // Summary always renders even when <details> is collapsed.
+
+    // Act — expand the disclosure so the disabled checkbox inside is visible
+    // to the role query (collapsed <details> hides children from the
+    // accessibility tree).
+    const summary = screen.getByText(/1 not installed/i)
+    await summary.click()
+
+    // Assert — summary always renders even when <details> is collapsed, and
+    // the checkbox inside is disabled.
     await expect
       .element(screen.getByText(/1 not installed/i))
       .toBeInTheDocument()
-    // Expand the disclosure so the disabled checkbox inside is visible
-    // to the role query — collapsed <details> hides children from the
-    // accessibility tree.
-    const summary = screen.getByText(/1 not installed/i)
-    await summary.click()
     const disabledCheckbox = screen.getByRole('checkbox', {
       name: /Codex \(not installed\)/i,
     })
     await expect.element(disabledCheckbox).toBeDisabled()
   })
 
-  it('renders a "Hidden" tag inside the row of a hidden agent', async () => {
-    // Visual cue inside the row tells the user at a glance which agents
-    // are currently hidden — without it the only signal is the unchecked
-    // checkbox, easy to miss while scanning a long list.
+  it('badges a hidden agent row with a "Hidden" tag for at-a-glance scanning', async () => {
+    // Arrange — Visual cue inside the row tells the user at a glance which
+    // agents are currently hidden; without it the only signal is the
+    // unchecked checkbox, easy to miss while scanning a long list.
     const { screen } = await renderAgents(['claude-code'])
-    // The "Hidden" label is rendered inside the label wrapping the
+
+    // Act — The "Hidden" label is rendered inside the label wrapping the
     // claude-code row. There is exactly one match in this fixture.
-    await expect.element(screen.getByText(/^Hidden$/)).toBeInTheDocument()
+    const hiddenTag = screen.getByText(/^Hidden$/)
+
+    // Assert
+    await expect.element(hiddenTag).toBeInTheDocument()
   })
 })

--- a/src/renderer/settings/sections/Appearance.browser.test.tsx
+++ b/src/renderer/settings/sections/Appearance.browser.test.tsx
@@ -41,7 +41,8 @@ async function createStore(
 }
 
 describe('Settings → Appearance', () => {
-  it('dispatches settings:set when the opacity slider changes', async () => {
+  it('persists the new window blur radius when the opacity slider moves', async () => {
+    // Arrange
     const store = await createStore()
     const { Appearance } = await import('./Appearance')
     const screen = await render(
@@ -50,9 +51,11 @@ describe('Settings → Appearance', () => {
       </Provider>,
     )
 
+    // Act
     const slider = screen.getByRole('slider', { name: /Opacity/i })
     await slider.fill('24')
 
+    // Assert
     await expect.element(screen.getByText('72% / 24px')).toBeVisible()
     await expect.poll(() => mockSettingsSet.mock.calls.length).toBe(1)
     expect(mockSettingsSet).toHaveBeenCalledWith({
@@ -60,7 +63,8 @@ describe('Settings → Appearance', () => {
     })
   })
 
-  it('cancels a pending slider persist when a settings broadcast arrives', async () => {
+  it('does not persist a slider drag that an incoming settings broadcast overrides', async () => {
+    // Arrange
     const store = await createStore(12)
     const { setSettings } =
       await import('@/renderer/src/redux/slices/settingsSlice')
@@ -71,6 +75,7 @@ describe('Settings → Appearance', () => {
       </Provider>,
     )
 
+    // Act
     const slider = screen.getByRole('slider', { name: /Opacity/i })
     await slider.fill('24')
     store.dispatch(
@@ -80,6 +85,7 @@ describe('Settings → Appearance', () => {
       }),
     )
 
+    // Assert
     await new Promise((resolve) => window.setTimeout(resolve, 180))
     expect(mockSettingsSet).not.toHaveBeenCalled()
   })

--- a/src/renderer/settings/sections/AutoUpdates.browser.test.tsx
+++ b/src/renderer/settings/sections/AutoUpdates.browser.test.tsx
@@ -42,6 +42,7 @@ async function createStore(
 
 describe('Settings → Auto Updates', () => {
   it('persists opting into automatic background downloads', async () => {
+    // Arrange
     const store = await createStore()
     const { AutoUpdates } = await import('./AutoUpdates')
     const screen = await render(
@@ -50,18 +51,20 @@ describe('Settings → Auto Updates', () => {
       </Provider>,
     )
 
+    // Act
     await screen
       .getByRole('checkbox', { name: /Download updates automatically/i })
       .click()
 
+    // Assert
     await expect.poll(() => mockSettingsSet.mock.calls.length).toBe(1)
     expect(mockSettingsSet).toHaveBeenCalledWith({ autoDownloadUpdates: true })
   })
 
   it('persists turning automatic background downloads back off', async () => {
-    // Pin the `checked === true` coercion's false-path: an already-checked
-    // box, when clicked, must persist `false` — never the indeterminate
-    // sentinel Radix can report.
+    // Arrange — Pin the `checked === true` coercion's false-path: an
+    // already-checked box, when clicked, must persist `false` — never the
+    // indeterminate sentinel Radix can report.
     const store = await createStore({ autoDownloadUpdates: true })
     const { AutoUpdates } = await import('./AutoUpdates')
     const screen = await render(
@@ -70,15 +73,18 @@ describe('Settings → Auto Updates', () => {
       </Provider>,
     )
 
+    // Act
     await screen
       .getByRole('checkbox', { name: /Download updates automatically/i })
       .click()
 
+    // Assert
     await expect.poll(() => mockSettingsSet.mock.calls.length).toBe(1)
     expect(mockSettingsSet).toHaveBeenCalledWith({ autoDownloadUpdates: false })
   })
 
   it('reflects a persisted opt-in as an already-checked box', async () => {
+    // Arrange
     const store = await createStore({ autoDownloadUpdates: true })
     const { AutoUpdates } = await import('./AutoUpdates')
     const screen = await render(
@@ -87,12 +93,12 @@ describe('Settings → Auto Updates', () => {
       </Provider>,
     )
 
-    await expect
-      .element(
-        screen.getByRole('checkbox', {
-          name: /Download updates automatically/i,
-        }),
-      )
-      .toBeChecked()
+    // Act
+    const checkbox = screen.getByRole('checkbox', {
+      name: /Download updates automatically/i,
+    })
+
+    // Assert
+    await expect.element(checkbox).toBeChecked()
   })
 })

--- a/src/renderer/src/App.browser.test.tsx
+++ b/src/renderer/src/App.browser.test.tsx
@@ -85,11 +85,15 @@ async function renderAppWithBlur(windowBackgroundBlurRadius: number) {
 
 describe('App window surface', () => {
   it('keeps the renderer surface solid while Electron owns opacity', async () => {
+    // Arrange — render the shell with a non-zero blur radius persisted
     const screen = await renderAppWithBlur(24)
+
+    // Act — read the painted window-background surface element
     const surface = screen
       .getByTestId('window-background-surface')
       .element() as HTMLElement
 
+    // Assert — the renderer surface stays opaque and never flags translucency
     expect(surface.style.backgroundColor).toBe('var(--background)')
     expect(surface.dataset['windowTranslucent']).toBeUndefined()
   })

--- a/src/renderer/src/bootstrap.test.ts
+++ b/src/renderer/src/bootstrap.test.ts
@@ -138,18 +138,33 @@ beforeEach(() => {
 })
 
 describe('bootstrap — pre-hydration theme IIFE', () => {
-  it('drift guard: index.html contains PERSIST_STORAGE_KEY literal', () => {
+  it('keeps the inline bootstrap reading the storage key so first paint stays in sync with persisted state', () => {
+    // Arrange — read index.html as shipped
     const html = readFileSync(HTML_PATH, 'utf8')
+
+    // Act — (the file content is the subject under inspection)
+
+    // Assert — the bootstrap still references the literal storage key
     expect(html).toContain(`'${PERSIST_STORAGE_KEY}'`)
   })
 
-  it('drift guard: index.html contains COLOR_PRESET_CHROMA literal', () => {
+  it('keeps the inline bootstrap referencing the color-preset chroma so renamed constants fail loudly', () => {
+    // Arrange — read index.html as shipped
     const html = readFileSync(HTML_PATH, 'utf8')
+
+    // Act — (the file content is the subject under inspection)
+
+    // Assert — the bootstrap still references the literal chroma constant
     expect(html).toContain(`'${COLOR_PRESET_CHROMA}'`)
   })
 
-  it('no storage → keeps default .dark, sets no CSS vars', () => {
+  it('paints the default dark theme with no CSS vars when storage is empty', () => {
+    // Arrange — beforeEach already cleared storage and set the .dark baseline
+
+    // Act
     runBootstrap()
+
+    // Assert — stays on default .dark and writes no theme CSS variables
     const root = document.documentElement
     expect(root.classList.contains('dark')).toBe(true)
     expect(root.classList.contains('light')).toBe(false)
@@ -157,28 +172,39 @@ describe('bootstrap — pre-hydration theme IIFE', () => {
     expect(root.style.getPropertyValue('--theme-chroma')).toBe('')
   })
 
-  it('malformed JSON → falls back to default .dark', () => {
+  it('falls back to the default dark theme when persisted state is malformed JSON', () => {
+    // Arrange — corrupt the persisted blob so JSON.parse will throw
     localStorage.setItem(PERSIST_STORAGE_KEY, 'not-json{')
+
+    // Act
     runBootstrap()
+
+    // Assert — parse failure keeps .dark and writes no hue variable
     expect(document.documentElement.classList.contains('dark')).toBe(true)
     expect(document.documentElement.style.getPropertyValue('--theme-hue')).toBe(
       '',
     )
   })
 
-  it('null theme slot → bails without touching DOM', () => {
+  it('leaves the DOM untouched when the persisted theme slot is null', () => {
+    // Arrange — valid envelope but an explicitly null theme
     localStorage.setItem(
       PERSIST_STORAGE_KEY,
       JSON.stringify({ version: 1, state: { theme: null } }),
     )
+
+    // Act
     runBootstrap()
+
+    // Assert — a null theme bails early, keeping .dark and no hue variable
     expect(document.documentElement.classList.contains('dark')).toBe(true)
     expect(document.documentElement.style.getPropertyValue('--theme-hue')).toBe(
       '',
     )
   })
 
-  it('v1 color preset (cyan dark) → applies hue, chroma, keeps .dark', () => {
+  it('applies hue and chroma and keeps dark mode for a v1 color preset', () => {
+    // Arrange — a v1 cyan color preset in dark mode
     localStorage.setItem(
       PERSIST_STORAGE_KEY,
       JSON.stringify({
@@ -193,7 +219,11 @@ describe('bootstrap — pre-hydration theme IIFE', () => {
         },
       }),
     )
+
+    // Act
     runBootstrap()
+
+    // Assert — the stored hue/chroma paint through and .dark is preserved
     const root = document.documentElement
     expect(root.style.getPropertyValue('--theme-hue')).toBe('195')
     expect(Number(root.style.getPropertyValue('--theme-chroma'))).toBeCloseTo(
@@ -203,7 +233,8 @@ describe('bootstrap — pre-hydration theme IIFE', () => {
     expect(root.classList.contains('light')).toBe(false)
   })
 
-  it('v1 neutral preset (neutral-light) → chroma 0, flips to .light', () => {
+  it('zeroes chroma and flips to light mode for a v1 neutral preset', () => {
+    // Arrange — a v1 neutral-light preset in light mode
     localStorage.setItem(
       PERSIST_STORAGE_KEY,
       JSON.stringify({
@@ -213,17 +244,22 @@ describe('bootstrap — pre-hydration theme IIFE', () => {
         },
       }),
     )
+
+    // Act
     runBootstrap()
+
+    // Assert — chroma collapses to 0 and the baseline .dark flips to .light
     const root = document.documentElement
     expect(root.style.getPropertyValue('--theme-chroma')).toBe('0')
     expect(root.classList.contains('light')).toBe(true)
     expect(root.classList.contains('dark')).toBe(false)
   })
 
-  it('v0 color preset (legacy presetType=color, no chroma) → chroma derived from COLOR_PRESET_CHROMA', () => {
+  it('derives chroma from the legacy presetType so v0 color users skip the neutral-dark flash', () => {
     // Regression guard for post-landing finding MAJOR-2: the v1 bootstrap
     // only read `t.chroma`, so any user still on v0 storage saw a
     // neutral-dark flash for ~100ms until ACTION_HYDRATE_COMPLETE fired.
+    // Arrange — a v0 envelope with legacy presetType=color and no chroma field
     localStorage.setItem(
       PERSIST_STORAGE_KEY,
       JSON.stringify({
@@ -238,7 +274,11 @@ describe('bootstrap — pre-hydration theme IIFE', () => {
         },
       }),
     )
+
+    // Act
     runBootstrap()
+
+    // Assert — chroma is derived from COLOR_PRESET_CHROMA and .dark is kept
     const root = document.documentElement
     expect(root.style.getPropertyValue('--theme-hue')).toBe('195')
     expect(Number(root.style.getPropertyValue('--theme-chroma'))).toBeCloseTo(
@@ -247,7 +287,8 @@ describe('bootstrap — pre-hydration theme IIFE', () => {
     expect(root.classList.contains('dark')).toBe(true)
   })
 
-  it('v0 neutral preset (legacy presetType=neutral, no chroma) → chroma 0', () => {
+  it('zeroes chroma for a legacy v0 neutral preset', () => {
+    // Arrange — a v0 envelope with legacy presetType=neutral and no chroma field
     localStorage.setItem(
       PERSIST_STORAGE_KEY,
       JSON.stringify({
@@ -262,7 +303,11 @@ describe('bootstrap — pre-hydration theme IIFE', () => {
         },
       }),
     )
+
+    // Act
     runBootstrap()
+
+    // Assert — legacy neutral yields chroma 0 and flips to .light
     const root = document.documentElement
     expect(root.style.getPropertyValue('--theme-chroma')).toBe('0')
     expect(root.classList.contains('light')).toBe(true)

--- a/src/renderer/src/components/dashboard/utils/findEmptySpot.test.ts
+++ b/src/renderer/src/components/dashboard/utils/findEmptySpot.test.ts
@@ -26,34 +26,63 @@ function buildWidget(
 }
 
 describe('findEmptySpot', () => {
-  it('returns origin on an empty page', () => {
-    expect(findEmptySpot([], { w: 6, h: 2 })).toEqual({ x: 0, y: 0 })
+  it('drops the first widget into the top-left corner of an empty page', () => {
+    // Arrange
+    const noWidgets: WidgetInstance[] = []
+
+    // Act
+    const spot = findEmptySpot(noWidgets, { w: 6, h: 2 })
+
+    // Assert
+    expect(spot).toEqual({ x: 0, y: 0 })
   })
 
-  it('places a widget below an existing full-width widget', () => {
+  it('stacks a new full-width widget on the row below an existing one', () => {
+    // Arrange
     const widgets = [buildWidget({ x: 0, y: 0, w: 6, h: 2 })]
-    expect(findEmptySpot(widgets, { w: 6, h: 2 })).toEqual({ x: 0, y: 2 })
+
+    // Act
+    const spot = findEmptySpot(widgets, { w: 6, h: 2 })
+
+    // Assert
+    expect(spot).toEqual({ x: 0, y: 2 })
   })
 
   it('packs a small widget beside a half-width one on the same row', () => {
-    // 3-wide widget on the left → next 3-wide widget can sit at x=3.
+    // Arrange — 3-wide widget on the left → next 3-wide widget can sit at x=3.
     const widgets = [buildWidget({ x: 0, y: 0, w: 3, h: 2 })]
-    expect(findEmptySpot(widgets, { w: 3, h: 2 })).toEqual({ x: 3, y: 0 })
+
+    // Act
+    const spot = findEmptySpot(widgets, { w: 3, h: 2 })
+
+    // Assert
+    expect(spot).toEqual({ x: 3, y: 0 })
   })
 
-  it('returns null when the page is at MAX_WIDGETS_PER_PAGE', () => {
-    // 4 widgets of any size → full page per the macOS-style overflow rule.
+  it('refuses to place a widget once the page already holds MAX_WIDGETS_PER_PAGE', () => {
+    // Arrange — 4 widgets of any size → full page per the macOS-style overflow rule.
     const widgets = [
       buildWidget({ x: 0, y: 0, w: 3, h: 1 }),
       buildWidget({ x: 3, y: 0, w: 3, h: 1 }),
       buildWidget({ x: 0, y: 1, w: 3, h: 1 }),
       buildWidget({ x: 3, y: 1, w: 3, h: 1 }),
     ]
-    expect(findEmptySpot(widgets, { w: 3, h: 1 })).toBeNull()
+
+    // Act
+    const spot = findEmptySpot(widgets, { w: 3, h: 1 })
+
+    // Assert
+    expect(spot).toBeNull()
   })
 
-  it('returns null when the requested width exceeds the grid', () => {
-    // 6-col grid; asking for width 7 can never fit.
-    expect(findEmptySpot([], { w: 7, h: 1 })).toBeNull()
+  it('refuses to place a widget wider than the grid itself', () => {
+    // Arrange — 6-col grid; asking for width 7 can never fit.
+    const noWidgets: WidgetInstance[] = []
+
+    // Act
+    const spot = findEmptySpot(noWidgets, { w: 7, h: 1 })
+
+    // Assert
+    expect(spot).toBeNull()
   })
 })

--- a/src/renderer/src/components/dashboard/utils/resolveSeedPreviewType.test.ts
+++ b/src/renderer/src/components/dashboard/utils/resolveSeedPreviewType.test.ts
@@ -73,7 +73,7 @@ describe('resolveSeedPreviewType', () => {
     expect(seed).toBe('stats')
   })
 
-  it('returns undefined when the catalog is empty', () => {
+  it('seeds nothing when the catalog has no widgets to preview', () => {
     // Arrange
     const availableWidgets: readonly WidgetDefinition[] = []
 
@@ -87,7 +87,7 @@ describe('resolveSeedPreviewType', () => {
     expect(seed).toBeUndefined()
   })
 
-  it('returns undefined when Welcome is dismissed and there is no second widget', () => {
+  it('seeds nothing when Welcome is dismissed and no second widget remains to fall back to', () => {
     // Arrange
     const availableWidgets = [makeDefinition('welcome')]
 

--- a/src/renderer/src/components/dashboard/utils/widgetPresets.test.ts
+++ b/src/renderer/src/components/dashboard/utils/widgetPresets.test.ts
@@ -3,8 +3,11 @@ import { describe, expect, it } from 'vitest'
 import { buildDefaultDashboardPages } from './widgetPresets'
 
 describe('buildDefaultDashboardPages', () => {
-  it('produces four pages with the expected names in order', () => {
+  it('lays out the default dashboard as Overview, Discovery, Actions, Personal in that tab order', () => {
+    // Arrange / Act
     const pages = buildDefaultDashboardPages()
+
+    // Assert
     expect(pages.map((page) => page.name)).toEqual([
       'Overview',
       'Discovery',
@@ -13,8 +16,11 @@ describe('buildDefaultDashboardPages', () => {
     ])
   })
 
-  it('Overview page starts with Welcome and has a stats pair', () => {
+  it('opens the Overview page on Welcome followed by the stats, health, and coverage widgets', () => {
+    // Arrange / Act
     const [overviewPage] = buildDefaultDashboardPages()
+
+    // Assert
     expect(overviewPage.widgets.map((widget) => widget.type)).toEqual([
       'welcome',
       'stats',
@@ -23,23 +29,31 @@ describe('buildDefaultDashboardPages', () => {
     ])
   })
 
-  it('gives every widget a unique id', () => {
+  it('keeps every default widget addressable by never reusing a widget id', () => {
+    // Arrange / Act
     const pages = buildDefaultDashboardPages()
     const widgetIds = pages.flatMap((page) =>
       page.widgets.map((widget) => widget.id),
     )
-    // Set size equals array length only when every id is unique.
+
+    // Assert — Set size equals array length only when every id is unique.
     expect(new Set(widgetIds).size).toBe(widgetIds.length)
   })
 
-  it('gives every page a unique id', () => {
+  it('keeps every default page addressable by never reusing a page id', () => {
+    // Arrange / Act
     const pages = buildDefaultDashboardPages()
     const pageIds = pages.map((page) => page.id)
+
+    // Assert
     expect(new Set(pageIds).size).toBe(pageIds.length)
   })
 
-  it('assigns non-negative grid coordinates to every widget', () => {
+  it('places every default widget on-grid with a positive footprint', () => {
+    // Arrange / Act
     const pages = buildDefaultDashboardPages()
+
+    // Assert
     for (const page of pages) {
       for (const widget of page.widgets) {
         expect(widget.x).toBeGreaterThanOrEqual(0)

--- a/src/renderer/src/components/dashboard/widgets/BookmarksWidget.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/widgets/BookmarksWidget.browser.test.tsx
@@ -46,8 +46,10 @@ async function renderBookmarksWidget(
 
 describe('BookmarksWidget', () => {
   it('keeps long bookmark text reachable alongside the remove control', async () => {
+    // Arrange + Act
     const { screen } = await renderBookmarksWidget()
 
+    // Assert
     await expect.element(screen.getByText('very-long-skill-name')).toBeVisible()
     await expect.element(screen.getByText('laststance/skills')).toBeVisible()
 
@@ -59,13 +61,16 @@ describe('BookmarksWidget', () => {
   })
 
   it('still removes the bookmark through the compact control', async () => {
+    // Arrange
     const { screen, store } = await renderBookmarksWidget('task' as SkillName)
     const removeButton = screen
       .getByRole('button', { name: /Remove bookmark task/i })
       .element() as HTMLButtonElement
 
+    // Act
     removeButton.click()
 
+    // Assert
     expect(store.getState().bookmarks.items).toEqual([])
   })
 })

--- a/src/renderer/src/components/layout/MainContent.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.browser.test.tsx
@@ -246,33 +246,43 @@ function makeAgentLocalSkill(name: string, agentId: AgentId): Skill {
 }
 
 describe('MainContent bulk-select toggle button', () => {
-  it('shows "Select" and aria-pressed=false by default', async () => {
+  it('labels the bulk toggle "Select" and unpressed before the user enters bulk mode', async () => {
+    // Arrange
     const { screen } = await renderMainContent()
 
+    // Act
     const toggle = screen.getByRole('button', {
       name: /Enter bulk select mode/i,
     })
+
+    // Assert
     await expect.element(toggle).toHaveTextContent(/Select/)
     await expect.element(toggle).toHaveAttribute('aria-pressed', 'false')
   })
 
-  it('clicking "Select" enters bulk select mode', async () => {
+  it('enters bulk select mode when the user clicks Select', async () => {
+    // Arrange
     const { screen, store } = await renderMainContent()
 
+    // Act
     await screen
       .getByRole('button', { name: /Enter bulk select mode/i })
       .click()
 
+    // Assert
     expect(store.getState().ui.bulkSelectMode).toBe(true)
   })
 
-  it('after entering mode the label flips to "Cancel" and aria-pressed=true', async () => {
+  it('flips the bulk toggle to a pressed "Cancel" once bulk mode is active', async () => {
+    // Arrange
     const { screen, store } = await renderMainContent()
     const { enterBulkSelectMode } =
       await import('@/renderer/src/redux/slices/uiSlice')
 
+    // Act
     store.dispatch(enterBulkSelectMode())
 
+    // Assert
     const toggle = screen.getByRole('button', {
       name: /Exit bulk select mode/i,
     })
@@ -280,7 +290,8 @@ describe('MainContent bulk-select toggle button', () => {
     await expect.element(toggle).toHaveAttribute('aria-pressed', 'true')
   })
 
-  it('clicking "Cancel" exits mode AND clears accumulated selection', async () => {
+  it('clears the accumulated selection when the user clicks Cancel to leave bulk mode', async () => {
+    // Arrange
     const { screen, store } = await renderMainContent()
     const { enterBulkSelectMode } =
       await import('@/renderer/src/redux/slices/uiSlice')
@@ -292,31 +303,39 @@ describe('MainContent bulk-select toggle button', () => {
     store.dispatch(toggleSelection('tdd' as SkillName))
     expect(store.getState().skills.selectedSkillNames.length).toBe(2)
 
+    // Act
     await screen.getByRole('button', { name: /Exit bulk select mode/i }).click()
 
+    // Assert
     expect(store.getState().ui.bulkSelectMode).toBe(false)
     expect(store.getState().skills.selectedSkillNames).toEqual([])
   })
 })
 
 describe('MainContent keyboard shortcuts (Cmd+A)', () => {
-  it('Cmd+A is a no-op when bulkSelectMode=false (guards against hidden selection)', async () => {
+  it('ignores Cmd+A outside bulk mode so nothing gets silently selected', async () => {
+    // Arrange
     const { store } = await renderMainContent()
 
+    // Act
     dispatchKey({ key: 'a', metaKey: true })
 
+    // Assert
     expect(store.getState().skills.selectedSkillNames).toEqual([])
   })
 
-  it('Ctrl+A is also a no-op when bulkSelectMode=false', async () => {
+  it('ignores Ctrl+A outside bulk mode so nothing gets silently selected', async () => {
+    // Arrange
     const { store } = await renderMainContent()
 
+    // Act
     dispatchKey({ key: 'a', ctrlKey: true })
 
+    // Assert
     expect(store.getState().skills.selectedSkillNames).toEqual([])
   })
 
-  it('Cmd+A dispatches selectAll over visible names when bulkSelectMode=true', async () => {
+  it('selects every visible skill on Cmd+A while in bulk mode', async () => {
     const { screen, store } = await renderMainContent()
     const { enterBulkSelectMode } =
       await import('@/renderer/src/redux/slices/uiSlice')
@@ -345,6 +364,7 @@ describe('MainContent keyboard shortcuts (Cmd+A)', () => {
       },
     ]
 
+    // Arrange
     // Seeding via the thunk's fulfilled action avoids mocking the IPC call
     // and exercises the real reducer path that fills `items` in production.
     store.dispatch(fetchSkills.fulfilled(skillFixtures, 'req-id'))
@@ -352,19 +372,22 @@ describe('MainContent keyboard shortcuts (Cmd+A)', () => {
 
     await waitForBulkSelectReady(screen)
 
+    // Act
     dispatchKey({ key: 'a', metaKey: true })
 
+    // Assert
     const selectedNames = store.getState().skills.selectedSkillNames
     expect(selectedNames).toContain('task')
     expect(selectedNames).toContain('tdd')
     expect(selectedNames.length).toBe(2)
   })
 
-  it('Cmd+A is ignored when focus is inside an editable target', async () => {
+  it('does not select skills on Cmd+A while typing in a text field', async () => {
     const { screen, store } = await renderMainContent()
     const { enterBulkSelectMode } =
       await import('@/renderer/src/redux/slices/uiSlice')
 
+    // Arrange
     store.dispatch(enterBulkSelectMode())
     // Wait for the bulk-mode render to commit so `bulkSelectModeRef.current`
     // is true when keydown fires. Without this wait the guard can pass via
@@ -374,6 +397,7 @@ describe('MainContent keyboard shortcuts (Cmd+A)', () => {
     const textInput = document.createElement('input')
     document.body.appendChild(textInput)
     try {
+      // Act
       textInput.focus()
       textInput.dispatchEvent(
         new KeyboardEvent('keydown', {
@@ -383,6 +407,7 @@ describe('MainContent keyboard shortcuts (Cmd+A)', () => {
         }),
       )
 
+      // Assert
       expect(store.getState().skills.selectedSkillNames).toEqual([])
     } finally {
       // Removal in `finally` so a failing assertion doesn't leak a focused
@@ -394,7 +419,8 @@ describe('MainContent keyboard shortcuts (Cmd+A)', () => {
 })
 
 describe('MainContent keyboard shortcuts (Esc 2-step)', () => {
-  it('first Esc with non-empty selection clears selection only (mode stays on)', async () => {
+  it('clears the selection but stays in bulk mode on the first Esc when skills are selected', async () => {
+    // Arrange
     const { screen, store } = await renderMainContent()
     const { enterBulkSelectMode } =
       await import('@/renderer/src/redux/slices/uiSlice')
@@ -406,13 +432,17 @@ describe('MainContent keyboard shortcuts (Esc 2-step)', () => {
     expect(store.getState().skills.selectedSkillNames.length).toBe(1)
 
     await waitForBulkSelectReady(screen)
+
+    // Act
     dispatchKey({ key: 'Escape' })
 
+    // Assert
     expect(store.getState().skills.selectedSkillNames).toEqual([])
     expect(store.getState().ui.bulkSelectMode).toBe(true)
   })
 
-  it('second Esc with empty selection exits bulk select mode', async () => {
+  it('leaves bulk mode on Esc once the selection is already empty', async () => {
+    // Arrange
     const { screen, store } = await renderMainContent()
     const { enterBulkSelectMode } =
       await import('@/renderer/src/redux/slices/uiSlice')
@@ -420,21 +450,28 @@ describe('MainContent keyboard shortcuts (Esc 2-step)', () => {
     store.dispatch(enterBulkSelectMode())
 
     await waitForBulkSelectReady(screen)
+
+    // Act
     dispatchKey({ key: 'Escape' })
 
+    // Assert
     expect(store.getState().ui.bulkSelectMode).toBe(false)
   })
 
-  it('Esc is a no-op when bulkSelectMode=false', async () => {
+  it('ignores Esc entirely when the user is not in bulk mode', async () => {
+    // Arrange
     const { store } = await renderMainContent()
 
+    // Act
     dispatchKey({ key: 'Escape' })
 
+    // Assert
     expect(store.getState().ui.bulkSelectMode).toBe(false)
     expect(store.getState().skills.selectedSkillNames).toEqual([])
   })
 
-  it('Esc is ignored when focus is inside an editable target', async () => {
+  it('does not clear the selection on Esc while the user is typing in a text field', async () => {
+    // Arrange
     const { screen, store } = await renderMainContent()
     const { enterBulkSelectMode } =
       await import('@/renderer/src/redux/slices/uiSlice')
@@ -450,11 +487,13 @@ describe('MainContent keyboard shortcuts (Esc 2-step)', () => {
     const textInput = document.createElement('input')
     document.body.appendChild(textInput)
     try {
+      // Act
       textInput.focus()
       textInput.dispatchEvent(
         new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
       )
 
+      // Assert
       expect(store.getState().skills.selectedSkillNames).toEqual(['task'])
       expect(store.getState().ui.bulkSelectMode).toBe(true)
     } finally {
@@ -463,7 +502,7 @@ describe('MainContent keyboard shortcuts (Esc 2-step)', () => {
   })
 })
 
-describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
+describe('MainContent bulk delete — uniform delete pipeline', () => {
   // After the CLI removal path was retired (npx skills spawn was unreliable
   // for ~/.agents/skills targets), every global-view bulk delete — including
   // skills tracked in `~/.agents/.skill-lock.json` via a `source` field —
@@ -494,7 +533,8 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
     }
   }
 
-  it('routes both source-tracked and plain skills through deleteSkills in one call', async () => {
+  it('deletes both source-tracked and plain skills through a single delete call', async () => {
+    // Arrange
     const { screen, store } = await renderMainContent()
     const { enterBulkSelectMode, setBulkConfirm } =
       await import('@/renderer/src/redux/slices/uiSlice')
@@ -541,8 +581,10 @@ describe('MainContent handleConfirmBulk — uniform delete pipeline', () => {
       }),
     )
 
+    // Act
     await screen.getByRole('button', { name: /^Delete$/ }).click()
 
+    // Assert
     // Single IPC call carrying BOTH reviewed row identities — partition is gone,
     // no second pipeline. Assert the payload verbatim so thunk tweaks surface.
     await expect.poll(() => mockSkillsDeleteSkills.mock.calls.length).toBe(1)
@@ -1327,7 +1369,8 @@ describe('MainContent SkillTypeFilter dropdown options', () => {
   // (source view never offers it), and each option writes the Redux state that
   // selectors use to narrow the visible list.
 
-  it('renders the Orphan radio item with a destructive dot when an agent is selected', async () => {
+  it('offers an Orphan filter marked with a destructive dot when an agent is selected', async () => {
+    // Arrange
     const { screen, store } = await renderMainContent()
     const { fetchAgents } =
       await import('@/renderer/src/redux/slices/agentsSlice')
@@ -1350,11 +1393,13 @@ describe('MainContent SkillTypeFilter dropdown options', () => {
     )
     store.dispatch(selectAgent('cursor'))
 
+    // Act
     // Open the dropdown from the agent-only skill type trigger.
     await screen
       .getByRole('button', { name: /Skill type filter: All/i })
       .click()
 
+    // Assert
     const orphanItem = screen.getByRole('menuitemradio', { name: /Orphan/i })
     await expect.element(orphanItem).toBeInTheDocument()
     // The colored dot is a sibling span; assert the className substring is
@@ -1368,7 +1413,8 @@ describe('MainContent SkillTypeFilter dropdown options', () => {
     ).not.toBeNull()
   })
 
-  it('renders the G-Stack radio item with a sky dot when an agent is selected', async () => {
+  it('offers a G-Stack filter marked with a sky dot when an agent is selected', async () => {
+    // Arrange
     const { screen, store } = await renderMainContent()
     const { fetchAgents } =
       await import('@/renderer/src/redux/slices/agentsSlice')
@@ -1391,11 +1437,13 @@ describe('MainContent SkillTypeFilter dropdown options', () => {
     )
     store.dispatch(selectAgent('cursor'))
 
+    // Act
     // Open the dropdown — G-Stack sits beside Symlinked/Local as a type filter.
     await screen
       .getByRole('button', { name: /Skill type filter: All/i })
       .click()
 
+    // Assert
     const gstackItem = screen.getByRole('menuitemradio', { name: /G-Stack/i })
     await expect.element(gstackItem).toBeInTheDocument()
     const dot = gstackItem.element().querySelector('.bg-gstack')
@@ -1405,7 +1453,8 @@ describe('MainContent SkillTypeFilter dropdown options', () => {
     ).not.toBeNull()
   })
 
-  it('selecting Orphan narrows visible list to skills with isOrphan=true', async () => {
+  it('narrows the visible list to only orphan skills when the Orphan filter is chosen', async () => {
+    // Arrange
     const { screen, store } = await renderMainContent()
     const { fetchAgents } =
       await import('@/renderer/src/redux/slices/agentsSlice')
@@ -1469,11 +1518,13 @@ describe('MainContent SkillTypeFilter dropdown options', () => {
     store.dispatch(selectAgent('cursor'))
     store.dispatch(fetchSkills.fulfilled([orphanSkill, linkedSkill], 'req-id'))
 
+    // Act
     await screen
       .getByRole('button', { name: /Skill type filter: All/i })
       .click()
     await screen.getByRole('menuitemradio', { name: /Orphan/i }).click()
 
+    // Assert
     // Slice state — single source of truth that the selector reads from.
     expect(store.getState().ui.skillTypeFilter).toBe('orphan')
 
@@ -1484,7 +1535,8 @@ describe('MainContent SkillTypeFilter dropdown options', () => {
     expect(filtered.map((skill) => skill.name)).toEqual(['orphan-one'])
   })
 
-  it('toggling an exclude checkbox updates state while keeping the dropdown open', async () => {
+  it('keeps the dropdown open and reveals Clear excludes when a type is excluded', async () => {
+    // Arrange
     const { screen, store } = await renderMainContent()
     const { fetchAgents } =
       await import('@/renderer/src/redux/slices/agentsSlice')
@@ -1507,11 +1559,13 @@ describe('MainContent SkillTypeFilter dropdown options', () => {
     )
     store.dispatch(selectAgent('cursor'))
 
+    // Act
     await screen
       .getByRole('button', { name: /Skill type filter: All/i })
       .click()
     await screen.getByRole('menuitemcheckbox', { name: /Local/i }).click()
 
+    // Assert
     expect(store.getState().ui.excludedSkillTypeFilters).toEqual(['local'])
     await expect
       .element(screen.getByRole('menuitem', { name: /Clear excludes/i }))
@@ -1520,7 +1574,8 @@ describe('MainContent SkillTypeFilter dropdown options', () => {
 })
 
 describe('MainContent repo facet dropdown', () => {
-  it('selects a repository from source-count options', async () => {
+  it('filters by a repository when its source-count option is picked', async () => {
+    // Arrange
     const { screen, store } = await renderMainContent()
     const { fetchSkills } =
       await import('@/renderer/src/redux/slices/skillsSlice')
@@ -1536,6 +1591,7 @@ describe('MainContent repo facet dropdown', () => {
       ),
     )
 
+    // Act
     await screen
       .getByRole('button', { name: /Filter by source repository/i })
       .click()
@@ -1545,6 +1601,7 @@ describe('MainContent repo facet dropdown', () => {
       })
       .click()
 
+    // Assert
     expect(store.getState().ui.selectedSources).toEqual([
       repositoryId('pbakaus/impeccable'),
     ])
@@ -1557,7 +1614,8 @@ describe('MainContent filter pills (Agent + Source orthogonal)', () => {
   // simultaneously. These tests pin the contract: each pill renders only
   // when its own state is set, and clearing one does not touch the other.
 
-  it('renders the Source pill with repo name and clears state on click', async () => {
+  it('shows a Source pill naming the repo and hides it again when the pill is cleared', async () => {
+    // Arrange
     const { screen, store } = await renderMainContent()
     const { setSelectedSources } =
       await import('@/renderer/src/redux/slices/uiSlice')
@@ -1565,21 +1623,26 @@ describe('MainContent filter pills (Agent + Source orthogonal)', () => {
     // No source filter active: pill must not render.
     expect(screen.getByTestId('source-filter-pill').query()).toBeNull()
 
+    // Act — turn on the source filter
     store.dispatch(setSelectedSources([repositoryId('vercel-labs/skills')]))
 
+    // Assert — the pill appears, naming the repo
     const pill = screen.getByTestId('source-filter-pill')
     await expect.element(pill).toBeInTheDocument()
     await expect.element(pill).toHaveTextContent(/from/)
     await expect.element(pill).toHaveTextContent('vercel-labs/skills')
 
+    // Act — clear the filter via the pill's Clear button
     // Clear button inside the pill resets the slice field.
     await pill.getByRole('button', { name: /Clear/i }).click()
 
+    // Assert — filter is empty and the pill is gone
     await expect.poll(() => store.getState().ui.selectedSources).toEqual([])
     expect(screen.getByTestId('source-filter-pill').query()).toBeNull()
   })
 
-  it('Agent + Source pills both render when both filters are active', async () => {
+  it('shows both the Agent and Source pills when an agent and a source are filtered together', async () => {
+    // Arrange
     const { screen, store } = await renderMainContent()
     const { fetchAgents } =
       await import('@/renderer/src/redux/slices/agentsSlice')
@@ -1602,9 +1665,12 @@ describe('MainContent filter pills (Agent + Source orthogonal)', () => {
         'req-id',
       ),
     )
+
+    // Act
     store.dispatch(selectAgent('claude-code'))
     store.dispatch(setSelectedSources([repositoryId('vercel-labs/skills')]))
 
+    // Assert
     await expect
       .element(screen.getByTestId('agent-filter-pill'))
       .toHaveTextContent('Claude Code')
@@ -1613,7 +1679,8 @@ describe('MainContent filter pills (Agent + Source orthogonal)', () => {
       .toHaveTextContent('vercel-labs/skills')
   })
 
-  it('clearing the Source pill leaves the Agent pill intact (orthogonal)', async () => {
+  it('keeps the Agent pill and agent filter when only the Source pill is cleared', async () => {
+    // Arrange
     const { screen, store } = await renderMainContent()
     const { fetchAgents } =
       await import('@/renderer/src/redux/slices/agentsSlice')
@@ -1638,12 +1705,14 @@ describe('MainContent filter pills (Agent + Source orthogonal)', () => {
     store.dispatch(selectAgent('claude-code'))
     store.dispatch(setSelectedSources([repositoryId('vercel-labs/skills')]))
 
+    // Act
     // Clear ONLY the source pill.
     await screen
       .getByTestId('source-filter-pill')
       .getByRole('button', { name: /Clear/i })
       .click()
 
+    // Assert
     // Agent pill must still be rendered with its label intact; selectedSources
     // must be empty. This pins Issue 4 from the design review: source clear
     // does not bleed into agent state.

--- a/src/renderer/src/components/marketplace/MarketplaceDetailPanel.browser.test.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceDetailPanel.browser.test.tsx
@@ -89,24 +89,32 @@ function createWillNavigateEvent(url: string): Event & { url: string } {
 }
 
 describe('MarketplaceDetailPanel routing', () => {
-  it('renders dashboard when no preview skill is selected', async () => {
+  it('shows the Marketplace dashboard heading when nothing is selected for preview', async () => {
+    // Arrange
     const store = await createStore()
     const { MarketplaceDetailPanel } = await import('./MarketplaceDetailPanel')
+
+    // Act
     const screen = await renderWithStore(<MarketplaceDetailPanel />, store)
 
+    // Assert
     await expect
       .element(screen.getByRole('heading', { name: 'Marketplace' }))
       .toBeInTheDocument()
   })
 
-  it('renders preview pane when previewSkill is set', async () => {
+  it('opens the skill preview with a Back to Dashboard escape hatch after a skill is chosen', async () => {
+    // Arrange
     const store = await createStore()
     const { setPreviewSkill } =
       await import('@/renderer/src/redux/slices/marketplaceSlice')
     const { MarketplaceDetailPanel } = await import('./MarketplaceDetailPanel')
     store.dispatch(setPreviewSkill(makeSkill({ name: 'lint' as SkillName })))
 
+    // Act
     const screen = await renderWithStore(<MarketplaceDetailPanel />, store)
+
+    // Assert
     await expect
       .element(screen.getByRole('button', { name: 'Back to Dashboard' }))
       .toBeInTheDocument()
@@ -114,17 +122,22 @@ describe('MarketplaceDetailPanel routing', () => {
 })
 
 describe('MarketplaceDashboard empty state', () => {
-  it('shows loading copy while trending leaderboard data is not loaded yet', async () => {
+  it('shows a loading message before trending skills have been fetched', async () => {
+    // Arrange
     const store = await createStore()
     const { MarketplaceDashboard } = await import('./MarketplaceDashboard')
 
+    // Act
     const screen = await renderWithStore(<MarketplaceDashboard />, store)
+
+    // Assert
     await expect
       .element(screen.getByText('Loading trending skills...'))
       .toBeInTheDocument()
   })
 
-  it('shows empty-result copy when trending leaderboard is fulfilled with no skills', async () => {
+  it('shows an empty-state message when trending skills load but return nothing', async () => {
+    // Arrange
     const store = await createStore()
     const { loadLeaderboard } =
       await import('@/renderer/src/redux/slices/marketplaceSlice')
@@ -137,7 +150,10 @@ describe('MarketplaceDashboard empty state', () => {
       ),
     )
 
+    // Act
     const screen = await renderWithStore(<MarketplaceDashboard />, store)
+
+    // Assert
     await expect
       .element(screen.getByText('No trending skills available'))
       .toBeInTheDocument()
@@ -145,7 +161,8 @@ describe('MarketplaceDashboard empty state', () => {
 })
 
 describe('MarketplaceSkillPreview will-navigate allowlist', () => {
-  it('prevents cross-origin navigation and allows skills.sh navigation', async () => {
+  it('blocks navigation to other origins and to skills.sh on a non-standard port while letting skills.sh through', async () => {
+    // Arrange
     const store = await createStore()
     const { MarketplaceSkillPreview } =
       await import('./MarketplaceSkillPreview')
@@ -167,18 +184,24 @@ describe('MarketplaceSkillPreview will-navigate allowlist', () => {
       return
     }
 
+    // Act — dispatch a foreign origin
     const blockedEvent = createWillNavigateEvent('https://evil.com/path')
     webview.dispatchEvent(blockedEvent)
+    // Assert — the foreign origin is cancelled
     expect(blockedEvent.defaultPrevented).toBe(true)
 
+    // Act — dispatch skills.sh on a custom port
     const blockedCustomPortEvent = createWillNavigateEvent(
       'https://skills.sh:444/trending',
     )
     webview.dispatchEvent(blockedCustomPortEvent)
+    // Assert — the custom-port URL is still cancelled
     expect(blockedCustomPortEvent.defaultPrevented).toBe(true)
 
+    // Act — dispatch canonical skills.sh
     const allowedEvent = createWillNavigateEvent('https://skills.sh/trending')
     webview.dispatchEvent(allowedEvent)
+    // Assert — canonical skills.sh is allowed through
     expect(allowedEvent.defaultPrevented).toBe(false)
   })
 })

--- a/src/renderer/src/components/marketplace/SkillRowMarketplace.browser.test.tsx
+++ b/src/renderer/src/components/marketplace/SkillRowMarketplace.browser.test.tsx
@@ -91,29 +91,53 @@ async function renderRow(skill: SkillSearchResult, isInstalled: boolean) {
  * have to delete a test that explicitly says "no destructive action."
  */
 describe('SkillRowMarketplace — installed row has no destructive action', () => {
-  it('renders no Remove button when isInstalled=true', async () => {
+  it('offers no Remove button on an already-installed skill', async () => {
+    // Arrange
     const { screen } = await renderRow(makeSkill(), true)
+
+    // Act
     // Exact-match 'Remove' so we don't false-positive on the bookmark
     // toggle's "Remove <name> from bookmarks" aria-label.
-    expect(screen.getByRole('button', { name: 'Remove' }).query()).toBeNull()
+    const removeButton = screen.getByRole('button', { name: 'Remove' }).query()
+
+    // Assert
+    expect(removeButton).toBeNull()
   })
 
-  it('renders no Uninstall button when isInstalled=true', async () => {
+  it('offers no Uninstall button on an already-installed skill', async () => {
+    // Arrange
     const { screen } = await renderRow(makeSkill(), true)
-    expect(
-      screen.getByRole('button', { name: /uninstall/i }).query(),
-    ).toBeNull()
+
+    // Act
+    const uninstallButton = screen
+      .getByRole('button', { name: /uninstall/i })
+      .query()
+
+    // Assert
+    expect(uninstallButton).toBeNull()
   })
 
-  it('renders no Trash icon button when isInstalled=true', async () => {
+  it('offers no Trash or Delete icon button on an already-installed skill', async () => {
+    // Arrange
     const { screen } = await renderRow(makeSkill(), true)
-    expect(screen.getByRole('button', { name: /trash/i }).query()).toBeNull()
-    expect(screen.getByRole('button', { name: /delete/i }).query()).toBeNull()
+
+    // Act
+    const trashButton = screen.getByRole('button', { name: /trash/i }).query()
+    const deleteButton = screen.getByRole('button', { name: /delete/i }).query()
+
+    // Assert
+    expect(trashButton).toBeNull()
+    expect(deleteButton).toBeNull()
   })
 
-  it('renders the static Installed badge with a discoverable uninstall hint', async () => {
+  it('shows an Installed badge whose hint spells out the npx remove --global command', async () => {
+    // Arrange
     const skill = makeSkill({ name: 'lint' as SkillName })
+
+    // Act
     const { screen } = await renderRow(skill, true)
+
+    // Assert
     // Static informational badge uses role="img" — `role="status"` is for
     // live regions that announce dynamic state changes, not labels. The
     // aria-label includes `--global` so the recipe matches how the app
@@ -130,15 +154,19 @@ describe('SkillRowMarketplace — installed row has no destructive action', () =
       .toBeInTheDocument()
   })
 
-  it('still renders an Install button when isInstalled=false (sanity)', async () => {
+  it('shows an Install button on a not-yet-installed skill', async () => {
+    // Arrange
     const { screen } = await renderRow(makeSkill(), false)
+
+    // Act
     // Exact 'Install' (not /install/i) — the regex would also match the
     // Installed badge's "<name> is installed …" aria-label if both states
     // ever rendered together. Anchoring on the button's exact accessible
     // name keeps this assertion truthful regardless of future layout shifts.
-    await expect
-      .element(screen.getByRole('button', { name: 'Install' }))
-      .toBeInTheDocument()
+    const installButton = screen.getByRole('button', { name: 'Install' })
+
+    // Assert
+    await expect.element(installButton).toBeInTheDocument()
   })
 })
 
@@ -149,9 +177,14 @@ describe('SkillRowMarketplace — installed row has no destructive action', () =
  * it. Two cases lock both directions: unbookmarked → bookmarked and back.
  */
 describe('SkillRowMarketplace — bookmark toggle', () => {
-  it('toggles unbookmarked → bookmarked via star click', async () => {
+  it('bookmarks a skill and saves it when the star is clicked', async () => {
+    // Arrange
     const { screen, store } = await renderRow(makeSkill(), false)
+
+    // Act
     await screen.getByRole('button', { name: 'Bookmark task' }).click()
+
+    // Assert
     await expect
       .element(
         screen.getByRole('button', { name: 'Remove task from bookmarks' }),
@@ -162,13 +195,18 @@ describe('SkillRowMarketplace — bookmark toggle', () => {
     ])
   })
 
-  it('toggles bookmarked → unbookmarked on second click', async () => {
+  it('removes a skill from the saved list when its star is clicked a second time', async () => {
+    // Arrange
     const { screen, store } = await renderRow(makeSkill(), false)
     const bookmarkButton = screen.getByRole('button', { name: 'Bookmark task' })
     await bookmarkButton.click()
+
+    // Act
     await screen
       .getByRole('button', { name: 'Remove task from bookmarks' })
       .click()
+
+    // Assert
     await expect
       .element(screen.getByRole('button', { name: 'Bookmark task' }))
       .toBeInTheDocument()

--- a/src/renderer/src/components/sidebar/AgentItem.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/AgentItem.browser.test.tsx
@@ -92,42 +92,53 @@ async function renderItem(hiddenAgentIds: AgentId[] = []) {
  * button (mirrors the production right-click flow).
  */
 describe('Sidebar → AgentItem context menu', () => {
-  it('shows "Hide from sidebar" when the agent is currently visible', async () => {
+  it('offers "Hide from sidebar" in the right-click menu of a visible agent', async () => {
+    // Arrange
     const { screen } = await renderItem([])
-    // Open the dropdown via right-click on the agent row trigger.
     const trigger = screen.getByRole('button', {
       name: /Filter skills by Claude Code/i,
     })
     const triggerElement = trigger.element()
+
+    // Act
+    // Open the dropdown via right-click on the agent row trigger.
     triggerElement.dispatchEvent(
       new MouseEvent('contextmenu', { bubbles: true, cancelable: true }),
     )
+
+    // Assert
     await expect
       .element(screen.getByText(/^Hide from sidebar$/))
       .toBeInTheDocument()
   })
 
-  it('shows "Show in sidebar" when the agent is currently hidden', async () => {
+  it('offers "Show in sidebar" in the right-click menu of an already-hidden agent', async () => {
     // Hidden state flips the menu copy — without this branch users would
     // see "Hide from sidebar" on an already-hidden item with no obvious
     // way to restore it from the sidebar context menu.
+    // Arrange
     const { screen } = await renderItem(['claude-code'])
     const trigger = screen.getByRole('button', {
       name: /Filter skills by Claude Code/i,
     })
     const triggerElement = trigger.element()
+
+    // Act
     triggerElement.dispatchEvent(
       new MouseEvent('contextmenu', { bubbles: true, cancelable: true }),
     )
+
+    // Assert
     await expect
       .element(screen.getByText(/^Show in sidebar$/))
       .toBeInTheDocument()
   })
 
-  it('selecting "Hide from sidebar" dispatches settings:set with the agent appended', async () => {
+  it('hides the agent from the sidebar when "Hide from sidebar" is clicked', async () => {
     // The whole point of the menu item — clicking it must reach the IPC
     // boundary with the toggled array. Without this assertion the menu
     // could silently no-op and only Settings → Agents would work.
+    // Arrange
     const { screen } = await renderItem([])
     const trigger = screen.getByRole('button', {
       name: /Filter skills by Claude Code/i,
@@ -137,14 +148,19 @@ describe('Sidebar → AgentItem context menu', () => {
       new MouseEvent('contextmenu', { bubbles: true, cancelable: true }),
     )
     const hideItem = screen.getByText(/^Hide from sidebar$/)
+
+    // Act
     await hideItem.click()
+
+    // Assert
     expect(mockSettingsSet).toHaveBeenCalledWith({
       hiddenAgentIds: ['claude-code'],
     })
   })
 
-  it('selecting "Show in sidebar" dispatches settings:set with the agent removed', async () => {
+  it('restores the agent to the sidebar when "Show in sidebar" is clicked', async () => {
     // Inverse path — toggling an already-hidden agent must remove it.
+    // Arrange
     const { screen } = await renderItem(['claude-code'])
     const trigger = screen.getByRole('button', {
       name: /Filter skills by Claude Code/i,
@@ -154,7 +170,11 @@ describe('Sidebar → AgentItem context menu', () => {
       new MouseEvent('contextmenu', { bubbles: true, cancelable: true }),
     )
     const showItem = screen.getByText(/^Show in sidebar$/)
+
+    // Act
     await showItem.click()
+
+    // Assert
     expect(mockSettingsSet).toHaveBeenCalledWith({
       hiddenAgentIds: [],
     })
@@ -162,16 +182,18 @@ describe('Sidebar → AgentItem context menu', () => {
 })
 
 describe('Sidebar → AgentItem navigation', () => {
-  it('switches Marketplace back to Installed when an installed agent is clicked', async () => {
+  it('switches Marketplace back to Installed and selects the agent when clicked', async () => {
+    // Arrange
     const { screen, store } = await renderItem([])
     const { setActiveTab } = await import('@/renderer/src/redux/slices/uiSlice')
-
     store.dispatch(setActiveTab('marketplace'))
 
+    // Act
     await screen
       .getByRole('button', { name: /Filter skills by Claude Code/i })
       .click()
 
+    // Assert
     expect(store.getState().ui.activeTab).toBe('installed')
     expect(store.getState().ui.selectedAgentId).toBe('claude-code')
   })

--- a/src/renderer/src/components/sidebar/AgentsSection.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/AgentsSection.browser.test.tsx
@@ -135,30 +135,45 @@ async function renderSection(
  *  - "(n)" header counter reflects ONLY visible agents
  */
 describe('Sidebar → AgentsSection', () => {
-  it('shows the loading placeholder while agents.loading is true', async () => {
+  it('shows a loading placeholder while agents are still being fetched', async () => {
     // Pre-seed the loading flag and force the on-mount fetchAgents() to never
     // resolve so the placeholder survives the assertion window.
+    // Arrange
     mockAgentsGetAll.mockReturnValueOnce(new Promise(() => {}))
+
+    // Act
     const { screen } = await renderSection([], [], true)
+
+    // Assert
     await expect.element(screen.getByText(/Loading\.\.\./i)).toBeInTheDocument()
   })
 
-  it('shows "No agents detected" when nothing is installed', async () => {
+  it('shows "No agents detected" on a fresh machine with nothing installed', async () => {
     // totalInstalled === 0 branch — happens on a fresh machine where no agent
     // directories exist yet.
+    // Arrange
     mockAgentsGetAll.mockResolvedValueOnce([])
+
+    // Act
     const { screen } = await renderSection([], [], false)
+
+    // Assert
     await expect
       .element(screen.getByText(/No agents detected/i))
       .toBeInTheDocument()
   })
 
-  it('shows the all-hidden hint when every installed agent is hidden', async () => {
+  it('guides the user back to Settings when every installed agent is hidden', async () => {
     // Distinct fall-through: totalInstalled > 0 but visibleInstalled.length === 0.
     // The user has installed agents but hidden every one; copy points back at
     // Settings → Agents so they can recover without leaving the sidebar.
+    // Arrange
     const allHidden: AgentId[] = ['claude-code', 'cursor']
+
+    // Act
     const { screen } = await renderSection(allHidden)
+
+    // Assert
     await expect
       .element(screen.getByText(/All installed agents are hidden/i))
       .toBeInTheDocument()
@@ -167,32 +182,43 @@ describe('Sidebar → AgentsSection', () => {
       .toBeInTheDocument()
   })
 
-  it('renders the "N hidden" disclosure when at least one agent is hidden', async () => {
+  it('discloses how many agents are hidden when at least one is hidden', async () => {
     // The disclosure exists ONLY when hiddenInstalled.length > 0 — the inverse
     // case (no hidden agents → no disclosure) is implicitly covered by the
     // visible-counter test below.
+    // Arrange + Act
     const { screen } = await renderSection(['cursor'])
+
+    // Assert
     await expect.element(screen.getByText(/^1 hidden$/)).toBeInTheDocument()
   })
 
-  it('header counter reflects ONLY visible agents, not the total installed set', async () => {
+  it('counts only visible agents in the header, excluding hidden ones', async () => {
     // With one hidden of two installed, the "(n)" counter must show "(1)"
     // rather than "(2)" — otherwise the user can't tell at a glance that a
     // hide is in effect.
+    // Arrange + Act
     const { screen } = await renderSection(['cursor'])
+
+    // Assert
     await expect.element(screen.getByText(/^\(1\)$/)).toBeInTheDocument()
   })
 
-  it('renders the "N not installed" disclosure alongside hidden when both exist', async () => {
+  it('shows hidden and not-installed disclosures side by side when both apply', async () => {
     // missingAgents.length > 0 path coexists with hiddenInstalled.length > 0;
     // both disclosures must render. Pinning the dual case here guards against
     // a future refactor that conflates the two lists.
     //
     // Override the fetchAgents resolution too — the on-mount effect would
     // otherwise resolve with FIXTURE_AGENTS and drop the NOT_INSTALLED seed.
+    // Arrange
     const itemsWithMissing = [...FIXTURE_AGENTS, NOT_INSTALLED_AGENT]
     mockAgentsGetAll.mockResolvedValueOnce(itemsWithMissing)
+
+    // Act
     const { screen } = await renderSection(['cursor'], itemsWithMissing)
+
+    // Assert
     await expect.element(screen.getByText(/^1 hidden$/)).toBeInTheDocument()
     await expect
       .element(screen.getByText(/^1 not installed$/))

--- a/src/renderer/src/components/sidebar/CleanupAgentDialog.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/CleanupAgentDialog.browser.test.tsx
@@ -79,17 +79,20 @@ async function renderClosedThenOpen(agentId: AgentId) {
 }
 
 describe('CleanupAgentDialog', () => {
-  it('stays closed and skips preview when no agent target is active', async () => {
+  it('stays hidden and runs no preview when no cleanup target is set', async () => {
+    // Arrange
     const store = await createStore()
     const { CleanupAgentDialog } = await import('./CleanupAgentDialog')
 
+    // Act
     const screen = await render(
       <Provider store={store}>
         <CleanupAgentDialog />
       </Provider>,
     )
-
     await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // Assert
     expect(mockSyncPreview).toHaveBeenCalledTimes(0)
     expect(screen.getByText(/Cleanup missing skills/i).query()).toBeNull()
     expect(
@@ -97,9 +100,11 @@ describe('CleanupAgentDialog', () => {
     ).toBeNull()
   })
 
-  it('opens from the closed state without changing the hook order', async () => {
+  it('opens with the agent name, preview, and skill count when a target is set', async () => {
+    // Arrange + Act
     const { screen } = await renderClosedThenOpen('claude-code')
 
+    // Assert
     await expect
       .poll(() =>
         mockSyncPreview.mock.calls.some(

--- a/src/renderer/src/components/sidebar/SourceCard.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/SourceCard.browser.test.tsx
@@ -81,16 +81,18 @@ async function renderSourceCard() {
 
 describe('Sidebar → SourceCard navigation', () => {
   it('switches Marketplace back to Installed and clears filters when clicked', async () => {
+    // Arrange
     const { screen, store } = await renderSourceCard()
     const { selectAgent, setActiveTab, setSearchQuery } =
       await import('@/renderer/src/redux/slices/uiSlice')
-
     store.dispatch(setActiveTab('marketplace'))
     store.dispatch(selectAgent('claude-code'))
     store.dispatch(setSearchQuery('task'))
 
+    // Act
     await screen.getByText('~/.agents/skills').click()
 
+    // Assert
     expect(store.getState().ui.activeTab).toBe('installed')
     expect(store.getState().ui.selectedAgentId).toBeNull()
     expect(store.getState().ui.searchQuery).toBe('')

--- a/src/renderer/src/components/skills/AddSymlinkModal.browser.test.tsx
+++ b/src/renderer/src/components/skills/AddSymlinkModal.browser.test.tsx
@@ -155,12 +155,14 @@ async function renderModal(options: { skill: Skill; agents: Agent[] }) {
 }
 
 describe('AddSymlinkModal actions', () => {
-  it('renders both Add Symlink and Copy Skill files actions', async () => {
+  it('offers both Add Symlink and Copy Skill files as ways to attach a skill', async () => {
+    // Arrange / Act
     const { screen } = await renderModal({
       skill: makeSkill(),
       agents: [makeAgent({ id: 'codex', name: 'Codex' })],
     })
 
+    // Assert
     await expect
       .element(screen.getByRole('button', { name: /^Add Symlink$/i }))
       .toBeInTheDocument()
@@ -169,21 +171,23 @@ describe('AddSymlinkModal actions', () => {
       .toBeInTheDocument()
   })
 
-  it('dispatches createSymlinks with the existing skill path when Add Symlink is clicked', async () => {
+  it('links the skill into the chosen agent from its existing source path when Add Symlink is clicked', async () => {
+    // Arrange
     mockCreateSymlinks.mockResolvedValue({
       success: true,
       created: 1,
       failures: [],
     })
-
     const { screen } = await renderModal({
       skill: makeSkill(),
       agents: [makeAgent({ id: 'codex', name: 'Codex' })],
     })
 
+    // Act
     await screen.getByRole('checkbox', { name: /Codex/i }).click()
     await screen.getByRole('button', { name: /^Add Symlink$/i }).click()
 
+    // Assert
     await expect.poll(() => mockCreateSymlinks.mock.calls.length).toBe(1)
     expect(mockCreateSymlinks.mock.calls[0][0]).toEqual({
       skillName: 'task',
@@ -192,21 +196,23 @@ describe('AddSymlinkModal actions', () => {
     })
   })
 
-  it('dispatches copyToAgents with sourcePath when Copy Skill files is clicked', async () => {
+  it('copies the skill files into the chosen agent from the source dir when Copy Skill files is clicked', async () => {
+    // Arrange
     mockCopyToAgents.mockResolvedValue({
       success: true,
       copied: 1,
       failures: [],
     })
-
     const { screen } = await renderModal({
       skill: makeSkill(),
       agents: [makeAgent({ id: 'codex', name: 'Codex' })],
     })
 
+    // Act
     await screen.getByRole('checkbox', { name: /Codex/i }).click()
     await screen.getByRole('button', { name: /Copy Skill files/i }).click()
 
+    // Assert
     await expect.poll(() => mockCopyToAgents.mock.calls.length).toBe(1)
     expect(mockCopyToAgents.mock.calls[0][0]).toEqual({
       skillName: 'task',
@@ -216,25 +222,28 @@ describe('AddSymlinkModal actions', () => {
   })
 
   it('shows a warning toast when copying succeeds only for some agents', async () => {
+    // Arrange
     mockCopyToAgents.mockResolvedValue({
       success: false,
       copied: 1,
       failures: [{ agentId: 'cursor', error: 'Already exists' }],
     })
-
     const { screen } = await renderModal({
       skill: makeSkill(),
       agents: [makeAgent({ id: 'codex', name: 'Codex' })],
     })
 
+    // Act
     await screen.getByRole('checkbox', { name: /Codex/i }).click()
     await screen.getByRole('button', { name: /Copy Skill files/i }).click()
 
+    // Assert
     await expect.poll(() => toastWarning.mock.calls.length).toBe(1)
     expect(toastSuccess).not.toHaveBeenCalled()
   })
 
   it('clears selected agents when the modal closes externally and reopens', async () => {
+    // Arrange
     const firstSkill = makeSkill({ name: 'task' as SkillName })
     const secondSkill = makeSkill({
       name: 'review' as SkillName,
@@ -246,15 +255,16 @@ describe('AddSymlinkModal actions', () => {
     })
     const { setSkillToAddSymlinks } =
       await import('@/renderer/src/redux/slices/skillsSlice')
-
     await screen.getByRole('checkbox', { name: /Codex/i }).click()
     await expect
       .element(screen.getByRole('checkbox', { name: /Codex/i }))
       .toBeChecked()
 
+    // Act: close the modal externally, then reopen it for a different skill.
     store.dispatch(setSkillToAddSymlinks(null))
     store.dispatch(setSkillToAddSymlinks(secondSkill))
 
+    // Assert
     await expect
       .element(screen.getByRole('dialog', { name: /Add Skill to Agents/i }))
       .toBeInTheDocument()
@@ -266,6 +276,7 @@ describe('AddSymlinkModal actions', () => {
 
 describe('AddSymlinkModal occupied-agent states', () => {
   it('disables linked, local, and broken destinations with their reason labels', async () => {
+    // Arrange
     const skill = makeSkill({
       symlinks: [
         {
@@ -295,6 +306,7 @@ describe('AddSymlinkModal occupied-agent states', () => {
       ],
     })
 
+    // Act
     const { screen } = await renderModal({
       skill,
       agents: [
@@ -305,6 +317,7 @@ describe('AddSymlinkModal occupied-agent states', () => {
       ],
     })
 
+    // Assert
     await expect
       .element(screen.getByRole('checkbox', { name: /Claude Code/i }))
       .toBeDisabled()
@@ -331,14 +344,16 @@ describe('AddSymlinkModal occupied-agent states', () => {
 
 describe('AddSymlinkModal busy state', () => {
   it('keeps the modal open and disables both actions while adding symlinks', async () => {
+    // Arrange
     const skill = makeSkill()
     const { screen, store } = await renderModal({
       skill,
       agents: [makeAgent({ id: 'codex', name: 'Codex' })],
     })
-
     const { createSymlinks } =
       await import('@/renderer/src/redux/slices/skillsSlice')
+
+    // Act: enter the in-flight add-symlinks state.
     store.dispatch(
       createSymlinks.pending('adding-request', {
         skill,
@@ -346,6 +361,7 @@ describe('AddSymlinkModal busy state', () => {
       }),
     )
 
+    // Assert: both actions are disabled while the add is in flight.
     await expect
       .element(screen.getByRole('button', { name: /Adding/i }))
       .toBeDisabled()
@@ -353,8 +369,10 @@ describe('AddSymlinkModal busy state', () => {
       .element(screen.getByRole('button', { name: /Copy Skill files/i }))
       .toBeDisabled()
 
+    // Act: attempt to close the busy modal.
     await screen.getByRole('button', { name: /^Close$/i }).click()
 
+    // Assert: the modal stays open with the skill still selected.
     await expect
       .element(screen.getByRole('dialog', { name: /Add Skill to Agents/i }))
       .toBeInTheDocument()
@@ -362,14 +380,16 @@ describe('AddSymlinkModal busy state', () => {
   })
 
   it('keeps the modal open and disables both actions while copying files', async () => {
+    // Arrange
     const skill = makeSkill()
     const { screen, store } = await renderModal({
       skill,
       agents: [makeAgent({ id: 'codex', name: 'Codex' })],
     })
-
     const { copyToAgents } =
       await import('@/renderer/src/redux/slices/skillsSlice')
+
+    // Act: enter the in-flight copy-files state.
     store.dispatch(
       copyToAgents.pending('copying-request', {
         skill,
@@ -378,6 +398,7 @@ describe('AddSymlinkModal busy state', () => {
       }),
     )
 
+    // Assert: both actions are disabled while the copy is in flight.
     await expect
       .element(screen.getByRole('button', { name: /^Add Symlink$/i }))
       .toBeDisabled()
@@ -385,8 +406,10 @@ describe('AddSymlinkModal busy state', () => {
       .element(screen.getByRole('button', { name: /Copying/i }))
       .toBeDisabled()
 
+    // Act: attempt to close the busy modal.
     await screen.getByRole('button', { name: /^Close$/i }).click()
 
+    // Assert: the modal stays open with the skill still selected.
     await expect
       .element(screen.getByRole('dialog', { name: /Add Skill to Agents/i }))
       .toBeInTheDocument()

--- a/src/renderer/src/components/skills/CopyToAgentsModal.browser.test.tsx
+++ b/src/renderer/src/components/skills/CopyToAgentsModal.browser.test.tsx
@@ -138,6 +138,7 @@ async function renderModal(options: {
 
 describe('CopyToAgentsModal source guards', () => {
   it('disables copy actions when the selected source is a broken symlink', async () => {
+    // Arrange
     const skill = makeSkill([
       {
         agentId: 'claude-code',
@@ -149,6 +150,7 @@ describe('CopyToAgentsModal source guards', () => {
       },
     ])
 
+    // Act
     const { screen } = await renderModal({
       skill,
       agents: [
@@ -158,6 +160,7 @@ describe('CopyToAgentsModal source guards', () => {
       selectedAgentId: 'claude-code',
     })
 
+    // Assert
     await expect
       .element(screen.getByText(/selected source is unavailable/i))
       .toBeInTheDocument()

--- a/src/renderer/src/components/skills/FileContent.browser.test.tsx
+++ b/src/renderer/src/components/skills/FileContent.browser.test.tsx
@@ -25,6 +25,7 @@ function makeTextContent(
 
 describe('FileContent Markdown modes', () => {
   it('renders Markdown files in code mode first, then switches to Reading Mode', async () => {
+    // Arrange
     const { FileContent } = await import('./FileContent')
     const screen = await render(
       <FileContent
@@ -35,13 +36,16 @@ describe('FileContent Markdown modes', () => {
       />,
     )
 
+    // Assert: code mode is the initial view, so the heading is not rendered yet.
     await expect
       .element(screen.getByRole('radio', { name: /Show Markdown source/i }))
       .toBeInTheDocument()
     expect(screen.getByRole('heading', { name: 'Install' }).query()).toBeNull()
 
+    // Act
     await screen.getByRole('radio', { name: /Show rendered Markdown/i }).click()
 
+    // Assert
     await expect
       .element(screen.getByRole('heading', { name: 'Install' }))
       .toBeInTheDocument()
@@ -50,6 +54,7 @@ describe('FileContent Markdown modes', () => {
   })
 
   it('keeps Markdown that starts with a horizontal rule in Reading Mode', async () => {
+    // Arrange
     const { FileContent } = await import('./FileContent')
     const screen = await render(
       <FileContent
@@ -59,8 +64,10 @@ describe('FileContent Markdown modes', () => {
       />,
     )
 
+    // Act
     await screen.getByRole('radio', { name: /Show rendered Markdown/i }).click()
 
+    // Assert
     await expect
       .element(screen.getByRole('heading', { name: 'Keep Me' }))
       .toBeInTheDocument()
@@ -68,6 +75,7 @@ describe('FileContent Markdown modes', () => {
   })
 
   it('renders language-less code fences as block code without AST attributes', async () => {
+    // Arrange
     const { FileContent } = await import('./FileContent')
     const screen = await render(
       <FileContent
@@ -78,8 +86,10 @@ describe('FileContent Markdown modes', () => {
       />,
     )
 
+    // Act
     await screen.getByRole('radio', { name: /Show rendered Markdown/i }).click()
 
+    // Assert
     const blockCode = screen.getByText(/npx skills list --json/).query()
     const inlineCode = screen.getByText('skill', { exact: true }).query()
 
@@ -91,6 +101,7 @@ describe('FileContent Markdown modes', () => {
   })
 
   it('renders language-tagged code fences as block code', async () => {
+    // Arrange
     const { FileContent } = await import('./FileContent')
     const screen = await render(
       <FileContent
@@ -100,8 +111,10 @@ describe('FileContent Markdown modes', () => {
       />,
     )
 
+    // Act
     await screen.getByRole('radio', { name: /Show rendered Markdown/i }).click()
 
+    // Assert
     const blockCode = screen.getByText(/const ok = true/).query()
 
     expect(blockCode).toBeInstanceOf(HTMLElement)
@@ -109,6 +122,7 @@ describe('FileContent Markdown modes', () => {
   })
 
   it('locks Reading Mode to vertical scrolling when Markdown is wider than the pane', async () => {
+    // Arrange
     const { FileContent } = await import('./FileContent')
     const wideInline = 'very-long-inline-token-'.repeat(30)
     const wideBlock = 'wide command '.repeat(40)
@@ -120,8 +134,10 @@ describe('FileContent Markdown modes', () => {
       />,
     )
 
+    // Act
     await screen.getByRole('radio', { name: /Show rendered Markdown/i }).click()
 
+    // Assert
     const scrollPane = screen.container.querySelector(
       '[data-markdown-reading-scroll]',
     )
@@ -143,7 +159,10 @@ describe('FileContent Markdown modes', () => {
   })
 
   it('adds a bottom spacer after source code so the final line can breathe', async () => {
+    // Arrange
     const { FileContent } = await import('./FileContent')
+
+    // Act
     const screen = await render(
       <FileContent
         content={makeTextContent({
@@ -155,6 +174,7 @@ describe('FileContent Markdown modes', () => {
       />,
     )
 
+    // Assert
     const scrollPane = screen.container.querySelector(
       '[data-file-preview-scroll]',
     )

--- a/src/renderer/src/components/skills/SearchBox.browser.test.tsx
+++ b/src/renderer/src/components/skills/SearchBox.browser.test.tsx
@@ -30,37 +30,46 @@ async function renderSearchBox() {
 }
 
 describe('SearchBox scope toggle', () => {
-  it('clicking the Repo toggle dispatches setSearchScope("repo")', async () => {
+  it('switches search to repository scope when the Repo toggle is clicked', async () => {
+    // Arrange
     const { screen, store } = await renderSearchBox()
 
+    // Act
     await screen.getByRole('radio', { name: /Search by repository/i }).click()
 
+    // Assert
     await expect.poll(() => store.getState().ui.searchScope).toBe('repo')
   })
 
-  it('typing in the input dispatches setSearchQuery', async () => {
+  it('filters skills by the text the user types into the search box', async () => {
+    // Arrange
     const { screen, store } = await renderSearchBox()
-
     // The placeholder defaults to the name-mode copy.
     const input = screen.getByPlaceholder('Search skills...')
+
+    // Act
     await input.fill('react')
 
+    // Assert
     await expect.poll(() => store.getState().ui.searchQuery).toBe('react')
   })
 
-  it('aria-label flips to the repository copy when scope=repo', async () => {
+  it('relabels the search box for screen readers as repository search when scope flips to repo', async () => {
+    // Arrange
     const { screen, store } = await renderSearchBox()
     const { setSearchScope } =
       await import('@/renderer/src/redux/slices/uiSlice')
 
-    // Default is 'name'; verify both states so a regression renaming one
-    // copy without the other (the original aria-label bug) is caught.
+    // Assert: default is 'name'; verify both states so a regression renaming
+    // one copy without the other (the original aria-label bug) is caught.
     await expect
       .element(screen.getByRole('searchbox', { name: 'Search skills by name' }))
       .toBeInTheDocument()
 
+    // Act
     store.dispatch(setSearchScope('repo'))
 
+    // Assert
     await expect
       .element(
         screen.getByRole('searchbox', { name: 'Search skills by repository' }),
@@ -68,17 +77,21 @@ describe('SearchBox scope toggle', () => {
       .toBeInTheDocument()
   })
 
-  it('placeholder flips to the repository copy when scope=repo', async () => {
+  it('shows the repository search hint in the input when scope flips to repo', async () => {
+    // Arrange
     const { screen, store } = await renderSearchBox()
     const { setSearchScope } =
       await import('@/renderer/src/redux/slices/uiSlice')
 
+    // Assert: name-mode placeholder is shown before the scope changes.
     await expect
       .element(screen.getByPlaceholder('Search skills...'))
       .toBeInTheDocument()
 
+    // Act
     store.dispatch(setSearchScope('repo'))
 
+    // Assert
     await expect
       .element(screen.getByPlaceholder('Search by repository...'))
       .toBeInTheDocument()

--- a/src/renderer/src/components/skills/SkillDetail.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillDetail.browser.test.tsx
@@ -143,11 +143,14 @@ async function renderSkillDetail(
 
 describe('SkillDetail Info path copy', () => {
   it('copies the single source path when no agent is selected', async () => {
+    // Arrange
     const { screen } = await renderSkillDetail()
 
+    // Act
     await expect.element(screen.getByText('Path')).toBeInTheDocument()
     await screen.getByRole('button', { name: /^Copy path$/i }).click()
 
+    // Assert
     expect(mockWriteText).toHaveBeenCalledWith(SOURCE_PATH)
     await expect
       .element(screen.getByRole('button', { name: /^Copy path$/i }))
@@ -155,23 +158,29 @@ describe('SkillDetail Info path copy', () => {
   })
 
   it('copies source and symlink paths independently in agent view', async () => {
+    // Arrange
     const { screen } = await renderSkillDetail('cursor' as AgentId)
 
+    // Act
     await screen
       .getByRole('button', { name: /Copy Source Files path/i })
       .click()
     await screen.getByRole('button', { name: /Copy Symlink path/i }).click()
 
+    // Assert
     expect(mockWriteText).toHaveBeenNthCalledWith(1, SOURCE_PATH)
     expect(mockWriteText).toHaveBeenNthCalledWith(2, CURSOR_PATH)
   })
 
   it('toasts when copying the source path fails', async () => {
+    // Arrange
     mockWriteText.mockRejectedValueOnce(new Error('copy failed'))
     const { screen } = await renderSkillDetail()
 
+    // Act
     await screen.getByRole('button', { name: /^Copy path$/i }).click()
 
+    // Assert
     expect(mockWriteText).toHaveBeenCalledWith(SOURCE_PATH)
     await expect
       .poll(() => toastErrorMock.mock.calls[0]?.[0])

--- a/src/renderer/src/components/skills/SkillItem.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillItem.browser.test.tsx
@@ -104,9 +104,14 @@ async function renderSkillItem(skill: Skill) {
 }
 
 describe('SkillItem bulk-select checkbox visibility', () => {
-  it('hides the checkbox when bulkSelectMode=false (default clean list)', async () => {
+  it('hides the bulk-select checkbox in a normal clean list', async () => {
+    // Arrange
     const { screen } = await renderSkillItem(makeSkill())
 
+    // Act
+    // (no interaction — bulk select mode is off by default)
+
+    // Assert
     // `.query()` returns the matched element or null synchronously. Using
     // this over `getBy(...).not.toBeInTheDocument()` avoids the strict-single-
     // match locator resolution error path, so a future regression that
@@ -115,31 +120,38 @@ describe('SkillItem bulk-select checkbox visibility', () => {
     expect(screen.getByRole('checkbox').query()).toBeNull()
   })
 
-  it('renders the checkbox when bulkSelectMode=true', async () => {
+  it('reveals the bulk-select checkbox after entering bulk select mode', async () => {
+    // Arrange
     const { screen, store } = await renderSkillItem(makeSkill())
     const { enterBulkSelectMode } =
       await import('@/renderer/src/redux/slices/uiSlice')
 
+    // Act
     store.dispatch(enterBulkSelectMode())
 
+    // Assert
     await expect.element(screen.getByRole('checkbox')).toBeInTheDocument()
   })
 
-  it('checkbox aria-label is "Select {name}" when not ticked', async () => {
+  it('labels the unticked bulk checkbox "Select {name}" for screen readers', async () => {
+    // Arrange
     const { screen, store } = await renderSkillItem(
       makeSkill({ name: 'task' as SkillName }),
     )
     const { enterBulkSelectMode } =
       await import('@/renderer/src/redux/slices/uiSlice')
 
+    // Act
     store.dispatch(enterBulkSelectMode())
 
+    // Assert
     await expect
       .element(screen.getByRole('checkbox', { name: /Select task/i }))
       .toBeInTheDocument()
   })
 
-  it('checkbox aria-label flips to "Deselect {name}" once ticked', async () => {
+  it('flips the checkbox label to "Deselect {name}" once the skill is ticked', async () => {
+    // Arrange
     const { screen, store } = await renderSkillItem(
       makeSkill({ name: 'task' as SkillName }),
     )
@@ -148,23 +160,28 @@ describe('SkillItem bulk-select checkbox visibility', () => {
     const { toggleSelection } =
       await import('@/renderer/src/redux/slices/skillsSlice')
 
+    // Act
     store.dispatch(enterBulkSelectMode())
     store.dispatch(toggleSelection('task' as SkillName))
 
+    // Assert
     await expect
       .element(screen.getByRole('checkbox', { name: /Deselect task/i }))
       .toBeInTheDocument()
   })
 
-  it('exiting bulk mode removes the checkbox from the DOM', async () => {
+  it('removes the bulk-select checkbox when exiting bulk select mode', async () => {
+    // Arrange
     const { screen, store } = await renderSkillItem(makeSkill())
     const { enterBulkSelectMode, exitBulkSelectMode } =
       await import('@/renderer/src/redux/slices/uiSlice')
-
     store.dispatch(enterBulkSelectMode())
     await expect.element(screen.getByRole('checkbox')).toBeInTheDocument()
 
+    // Act
     store.dispatch(exitBulkSelectMode())
+
+    // Assert
     // Poll until the checkbox unmounts — exit dispatch is sync but the
     // re-render that removes the node happens on the next commit cycle.
     await expect.poll(() => screen.getByRole('checkbox').query()).toBeNull()
@@ -350,7 +367,8 @@ describe('SkillItem delete button', () => {
   // fork was retired (npx skills spawn was unreliable for ~/.agents/skills);
   // stale lock-file entries are the accepted trade-off.
 
-  it('aria-label reads "Delete {name}" for a source-tracked skill', async () => {
+  it('offers a "Delete {name}" button for a source-tracked skill', async () => {
+    // Arrange
     const { screen } = await renderSkillItem(
       makeSkill({
         name: 'brainstorming' as SkillName,
@@ -358,22 +376,32 @@ describe('SkillItem delete button', () => {
       }),
     )
 
+    // Act
+    // (no interaction — assert the delete affordance is present)
+
+    // Assert
     await expect
       .element(screen.getByRole('button', { name: /^Delete brainstorming$/i }))
       .toBeInTheDocument()
   })
 
-  it('aria-label reads "Delete {name}" for a plain skill', async () => {
+  it('offers a "Delete {name}" button for a plain skill', async () => {
+    // Arrange
     const { screen } = await renderSkillItem(
       makeSkill({ name: 'local-skill' as SkillName }),
     )
 
+    // Act
+    // (no interaction — assert the delete affordance is present)
+
+    // Assert
     await expect
       .element(screen.getByRole('button', { name: /^Delete local-skill$/i }))
       .toBeInTheDocument()
   })
 
-  it('clicking the X opens bulkConfirm regardless of whether the skill is source-tracked', async () => {
+  it('opens the trash confirm dialog when deleting a source-tracked skill', async () => {
+    // Arrange
     const { screen, store } = await renderSkillItem(
       makeSkill({
         name: 'brainstorming' as SkillName,
@@ -381,10 +409,12 @@ describe('SkillItem delete button', () => {
       }),
     )
 
+    // Act
     await screen
       .getByRole('button', { name: /^Delete brainstorming$/i })
       .click()
 
+    // Assert
     // Same trash + UndoToast dialog as plain skills — the handler no longer
     // forks on whether the skill is source-tracked. The payload shape must
     // match what BulkConfirmDialog expects (kind='delete', no agent).
@@ -408,13 +438,16 @@ describe('SkillItem delete button', () => {
     })
   })
 
-  it('clicking the X on a plain skill opens bulkConfirm (trash + undo path)', async () => {
+  it('opens the trash confirm dialog when deleting a plain skill', async () => {
+    // Arrange
     const { screen, store } = await renderSkillItem(
       makeSkill({ name: 'local-skill' as SkillName }),
     )
 
+    // Act
     await screen.getByRole('button', { name: /^Delete local-skill$/i }).click()
 
+    // Assert
     expect(store.getState().ui.bulkConfirm).toEqual({
       kind: 'delete',
       skillNames: ['local-skill'],
@@ -435,15 +468,18 @@ describe('SkillItem delete button', () => {
     })
   })
 
-  it('X button click does not trigger inspector selection (stopPropagation)', async () => {
+  it('does not open the inspector pane when the delete button is clicked', async () => {
+    // Arrange
     const { screen, store } = await renderSkillItem(
       makeSkill({ name: 'brainstorming' as SkillName }),
     )
 
+    // Act
     await screen
       .getByRole('button', { name: /^Delete brainstorming$/i })
       .click()
 
+    // Assert
     // If propagation leaked, the Card's onClick would fire `selectSkill(skill)`
     // and the inspector pane would open on the very skill we're deleting — an
     // obvious UX sin. The handler calls `e.stopPropagation()` specifically to
@@ -472,7 +508,8 @@ describe('SkillItem Add button routing', () => {
       .toBeInTheDocument()
   })
 
-  it('shows Add button in agent view when the skill exists in selected agent', async () => {
+  it('shows the Add button in agent view when the skill exists in the selected agent', async () => {
+    // Arrange
     const { screen, store } = await renderSkillItem(
       makeSkill({
         symlinks: [
@@ -489,14 +526,17 @@ describe('SkillItem Add button routing', () => {
     )
     const { selectAgent } = await import('@/renderer/src/redux/slices/uiSlice')
 
+    // Act
     store.dispatch(selectAgent('cursor'))
 
+    // Assert
     await expect
       .element(screen.getByRole('button', { name: /^Add$/i }))
       .toBeInTheDocument()
   })
 
-  it('in agent view, Add click opens copy modal target (skillToCopy)', async () => {
+  it('opens the copy-to-agent modal when Add is clicked in agent view', async () => {
+    // Arrange
     const { screen, store } = await renderSkillItem(
       makeSkill({
         symlinks: [
@@ -513,18 +553,23 @@ describe('SkillItem Add button routing', () => {
     )
     const { selectAgent } = await import('@/renderer/src/redux/slices/uiSlice')
 
+    // Act
     store.dispatch(selectAgent('cursor'))
     await screen.getByRole('button', { name: /^Add$/i }).click()
 
+    // Assert
     expect(store.getState().skills.skillToCopy?.name).toBe('task')
     expect(store.getState().skills.skillToAddSymlinks).toBeNull()
   })
 
-  it('in global view, Add click keeps existing add-symlink routing', async () => {
+  it('opens the add-symlink modal when Add is clicked in global view', async () => {
+    // Arrange
     const { screen, store } = await renderSkillItem(makeSkill())
 
+    // Act
     await screen.getByRole('button', { name: /^Add$/i }).click()
 
+    // Assert
     expect(store.getState().skills.skillToAddSymlinks?.name).toBe('task')
     expect(store.getState().skills.skillToCopy).toBeNull()
   })
@@ -532,6 +577,7 @@ describe('SkillItem Add button routing', () => {
 
 describe('SkillItem G-Stack badge', () => {
   it('shows a G-Stack badge link in supported agent view for gstack-managed skills', async () => {
+    // Arrange
     const { screen, store } = await renderSkillItem(
       makeSkill({
         symlinks: [
@@ -548,8 +594,10 @@ describe('SkillItem G-Stack badge', () => {
     )
     const { selectAgent } = await import('@/renderer/src/redux/slices/uiSlice')
 
+    // Act
     store.dispatch(selectAgent('claude-code'))
 
+    // Assert
     const gstackLink = screen.getByRole('link', { name: /G-Stack/i })
     await expect.element(gstackLink).toBeInTheDocument()
     await expect
@@ -563,6 +611,7 @@ describe('SkillItem G-Stack badge', () => {
   })
 
   it('hides the G-Stack badge in global view', async () => {
+    // Arrange
     const { screen } = await renderSkillItem(
       makeSkill({
         symlinks: [
@@ -578,10 +627,15 @@ describe('SkillItem G-Stack badge', () => {
       }),
     )
 
+    // Act
+    // (no agent selected — global view is the default)
+
+    // Assert
     expect(screen.getByRole('link', { name: /G-Stack/i }).query()).toBeNull()
   })
 
   it('shows badge for gstack-managed sibling skills (local skill whose SKILL.md symlinks into gstack)', async () => {
+    // Arrange
     // Real production scenario: ~/.claude/skills/ship/ is a real directory
     // whose only entry is a SKILL.md symlink → ~/.claude/skills/gstack/ship/SKILL.md.
     // The skill's linkPath/targetPath alone do NOT contain "gstack" — only
@@ -607,8 +661,10 @@ describe('SkillItem G-Stack badge', () => {
     )
     const { selectAgent } = await import('@/renderer/src/redux/slices/uiSlice')
 
+    // Act
     store.dispatch(selectAgent('claude-code'))
 
+    // Assert
     const gstackLink = screen.getByRole('link', { name: /G-Stack/i })
     await expect.element(gstackLink).toBeInTheDocument()
     await expect
@@ -617,6 +673,7 @@ describe('SkillItem G-Stack badge', () => {
   })
 
   it('hides the badge when skillMdSymlinkTarget points outside the gstack tree', async () => {
+    // Arrange
     // Negative coverage at the wired-up SkillItem level: a local skill with
     // skillMdSymlinkTarget set but pointing at a user-managed path (no
     // `gstack` segment) must NOT receive the badge. The pure helper covers
@@ -643,8 +700,10 @@ describe('SkillItem G-Stack badge', () => {
     )
     const { selectAgent } = await import('@/renderer/src/redux/slices/uiSlice')
 
+    // Act
     store.dispatch(selectAgent('claude-code'))
 
+    // Assert
     expect(screen.getByRole('link', { name: /G-Stack/i }).query()).toBeNull()
   })
 })
@@ -655,16 +714,19 @@ describe('SkillItem bulk-select checkbox stopPropagation', () => {
   // fires alongside the toggle — a click on the checkbox would both tick AND
   // flip selectedSkill, which is never what the user wants.
 
-  it('toggling the checkbox does not set selectedSkill', async () => {
+  it('ticks the row for bulk select without opening the inspector pane', async () => {
+    // Arrange
     const { screen, store } = await renderSkillItem(
       makeSkill({ name: 'task' as SkillName }),
     )
     const { enterBulkSelectMode } =
       await import('@/renderer/src/redux/slices/uiSlice')
 
+    // Act
     store.dispatch(enterBulkSelectMode())
     await screen.getByRole('checkbox', { name: /Select task/i }).click()
 
+    // Assert
     // Checkbox tick → selection updated in the skills slice, Inspector stays
     // closed. If stopPropagation regressed, selectedSkill would be set here.
     expect(store.getState().skills.selectedSkillNames).toEqual(['task'])

--- a/src/renderer/src/components/skills/SkillsList.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillsList.browser.test.tsx
@@ -127,6 +127,7 @@ async function renderSkillsList(skillsState: {
 
 describe('SkillsList loading branch — scroll-preservation regression', () => {
   it('shows the "Loading skills..." placeholder on initial fetch (loading=true, items=[])', async () => {
+    // Arrange
     // Pin getAll on a never-resolving promise so the on-mount fetchSkills
     // useEffect cannot flip loading→false before the assertion polls the
     // DOM. Without this the fulfilled reducer would land first and the
@@ -134,14 +135,17 @@ describe('SkillsList loading branch — scroll-preservation regression', () => {
     // placeholder — a flake unrelated to the bug under test.
     mockGetAll.mockReturnValue(new Promise(() => {}))
 
+    // Act
     const screen = await renderSkillsList({ loading: true, items: [] })
 
+    // Assert
     await expect
       .element(screen.getByText('Loading skills...'))
       .toBeInTheDocument()
   })
 
   it('keeps the list mounted during background refetch (loading=true, items=[skill])', async () => {
+    // Arrange
     // Background refetch after a mutation: Redux flips loading=true while
     // items still contain the previous data. The fix at SkillsList.tsx:93
     // (`if (loading && skills.length === 0)`) ensures the existing <List>
@@ -150,11 +154,13 @@ describe('SkillsList loading branch — scroll-preservation regression', () => {
     // placeholder shows — this assertion catches that regression.
     mockGetAll.mockReturnValue(new Promise(() => {}))
 
+    // Act
     const screen = await renderSkillsList({
       loading: true,
       items: [makeSkill({ name: 'task' as SkillName })],
     })
 
+    // Assert
     expect(screen.getByText('Loading skills...').query()).toBeNull()
   })
 })

--- a/src/renderer/src/components/skills/SourceLink.browser.test.tsx
+++ b/src/renderer/src/components/skills/SourceLink.browser.test.tsx
@@ -51,35 +51,43 @@ async function renderSourceLink(options: RenderOptions = {}) {
 
 describe('SourceLink role split', () => {
   it('clicking the repo text replaces the source filter with that repo', async () => {
+    // Arrange
     const { screen, store } = await renderSourceLink({
       source: REPO,
       sourceUrl: REPO_URL,
     })
 
+    // Act
     await screen
       .getByRole('button', {
         name: /Filter skills by repository pbakaus\/impeccable/i,
       })
       .click()
 
+    // Assert
     await expect.poll(() => store.getState().ui.selectedSources).toEqual([REPO])
   })
 
-  it('the icon anchor points at the .git-stripped GitHub URL with target=_blank', async () => {
+  it('opens the repo on GitHub in a new tab via the .git-stripped URL', async () => {
+    // Arrange
     const { screen } = await renderSourceLink({
       source: REPO,
       sourceUrl: REPO_URL,
     })
 
+    // Act
     const anchor = screen.getByRole('link', {
       name: /Open pbakaus\/impeccable on GitHub/i,
     })
+
+    // Assert
     await expect.element(anchor).toHaveAttribute('href', REPO_HREF)
     await expect.element(anchor).toHaveAttribute('target', '_blank')
     await expect.element(anchor).toHaveAttribute('rel', 'noreferrer')
   })
 
-  it('clicks on either affordance do not bubble to the surrounding row', async () => {
+  it('keeps the surrounding row from being selected when either affordance is clicked', async () => {
+    // Arrange
     const onParentClick = vi.fn()
     const { screen, store } = await renderSourceLink({
       source: REPO,
@@ -87,13 +95,17 @@ describe('SourceLink role split', () => {
       onParentClick,
     })
 
+    // Act
     // Button click via Playwright driver — exercises the real React handler.
     await screen
       .getByRole('button', { name: /Filter skills by repository/i })
       .click()
+
+    // Assert
     expect(onParentClick).not.toHaveBeenCalled()
     await expect.poll(() => store.getState().ui.selectedSources).toEqual([REPO])
 
+    // Act
     // Anchor click via dispatchEvent — Playwright's `.click()` on a
     // `target="_blank"` anchor would try to open a new browser context.
     // A synthetic MouseEvent reaches the React handler the same way for
@@ -106,12 +118,19 @@ describe('SourceLink role split', () => {
       cancelable: true,
     })
     anchorElement.dispatchEvent(clickEvent)
+
+    // Assert
     expect(onParentClick).not.toHaveBeenCalled()
   })
 
-  it('Local skill renders the "Local" label with no button or anchor', async () => {
+  it('shows a plain "Local" label with no filter button or external link for a local skill', async () => {
+    // Arrange
     const { screen } = await renderSourceLink()
 
+    // Act
+    // (no interaction — assert the rendered affordances for a local skill)
+
+    // Assert
     await expect.element(screen.getByText('Local')).toBeInTheDocument()
     // Use `.query()` (returns null when missing) instead of `getBy(...).not.
     // toBeInTheDocument()` to avoid the strict-single-match throw — see
@@ -120,12 +139,12 @@ describe('SourceLink role split', () => {
     expect(screen.getByRole('link').query()).toBeNull()
   })
 
-  it('keyboard Tab focuses the filter button and the external link independently', async () => {
+  it('lets keyboard users focus the filter button and the external link independently', async () => {
+    // Arrange
     const { screen } = await renderSourceLink({
       source: REPO,
       sourceUrl: REPO_URL,
     })
-
     const filterButton = screen.getByRole('button', {
       name: /Filter skills by repository/i,
     })
@@ -133,15 +152,21 @@ describe('SourceLink role split', () => {
       name: /Open pbakaus\/impeccable on GitHub/i,
     })
 
+    // Act
     // Both elements are inherently focusable — `<button>` and `<a href>` —
     // so a regression that swaps either for a `<span>` (or adds tabindex=-1)
     // would surface here.
     const buttonElement = filterButton.element() as HTMLButtonElement
     buttonElement.focus()
+
+    // Assert
     expect(document.activeElement).toBe(buttonElement)
 
+    // Act
     const anchorElement = externalAnchor.element() as HTMLAnchorElement
     anchorElement.focus()
+
+    // Assert
     expect(document.activeElement).toBe(anchorElement)
   })
 })

--- a/src/renderer/src/components/skills/agentSelectionHelpers.test.ts
+++ b/src/renderer/src/components/skills/agentSelectionHelpers.test.ts
@@ -25,7 +25,8 @@ function makeAgent(overrides: Partial<Agent> & Pick<Agent, 'id'>): Agent {
 }
 
 describe('getTargetAgentsForSelection', () => {
-  it('keeps installed agents first and appends not-installed agents', () => {
+  it('lists installed agents ahead of not-installed ones in the picker', () => {
+    // Arrange
     const agents: Agent[] = [
       makeAgent({ id: 'cursor', exists: true }),
       makeAgent({ id: 'amp', exists: false }),
@@ -33,8 +34,10 @@ describe('getTargetAgentsForSelection', () => {
       makeAgent({ id: 'augment', exists: false }),
     ]
 
+    // Act
     const result = getTargetAgentsForSelection(agents)
 
+    // Assert
     expect(result.map((agent) => agent.id)).toEqual([
       'cursor',
       'codex',
@@ -43,25 +46,30 @@ describe('getTargetAgentsForSelection', () => {
     ])
   })
 
-  it('excludes the source agent when excludeAgentId is provided', () => {
+  it('hides the source agent from its own copy-target list', () => {
+    // Arrange
     const agents: Agent[] = [
       makeAgent({ id: 'claude-code', exists: true }),
       makeAgent({ id: 'cursor', exists: true }),
       makeAgent({ id: 'amp', exists: false }),
     ]
 
+    // Act
     const result = getTargetAgentsForSelection(agents, {
       excludeAgentId: 'claude-code',
     })
 
+    // Assert
     expect(result.map((agent) => agent.id)).toEqual(['cursor', 'amp'])
   })
 })
 
 describe('buildCopyAgentOptionViewModel', () => {
-  it('marks a selected available agent as checked and enabled', () => {
+  it('shows a selected available agent as pre-checked and clickable', () => {
+    // Arrange
     const agent = makeAgent({ id: 'codex', exists: true, name: 'Codex' })
 
+    // Act
     const result = buildCopyAgentOptionViewModel(agent, {
       occupiedAgentReasonById: new Map(),
       selectedAgentIds: ['codex' as AgentId],
@@ -69,6 +77,7 @@ describe('buildCopyAgentOptionViewModel', () => {
       isSourceUnavailable: false,
     })
 
+    // Assert
     expect(result).toEqual({
       agentId: 'codex',
       name: 'Codex',
@@ -78,9 +87,11 @@ describe('buildCopyAgentOptionViewModel', () => {
     })
   })
 
-  it('uses occupancy as the checked/disabled reason before install status', () => {
+  it('locks an occupied agent row as a broken-link target before considering install status', () => {
+    // Arrange
     const agent = makeAgent({ id: 'cursor', exists: false, name: 'Cursor' })
 
+    // Act
     const result = buildCopyAgentOptionViewModel(agent, {
       occupiedAgentReasonById: new Map([['cursor' as AgentId, 'broken']]),
       selectedAgentIds: [],
@@ -88,6 +99,7 @@ describe('buildCopyAgentOptionViewModel', () => {
       isSourceUnavailable: false,
     })
 
+    // Assert
     expect(result).toMatchObject({
       checked: true,
       disabled: true,
@@ -95,9 +107,11 @@ describe('buildCopyAgentOptionViewModel', () => {
     })
   })
 
-  it('labels inaccessible occupancy as manual review instead of broken cleanup', () => {
+  it('flags an inaccessible agent row as manual review rather than broken cleanup', () => {
+    // Arrange
     const agent = makeAgent({ id: 'cursor', exists: true, name: 'Cursor' })
 
+    // Act
     const result = buildCopyAgentOptionViewModel(agent, {
       occupiedAgentReasonById: new Map([['cursor' as AgentId, 'inaccessible']]),
       selectedAgentIds: [],
@@ -105,6 +119,7 @@ describe('buildCopyAgentOptionViewModel', () => {
       isSourceUnavailable: false,
     })
 
+    // Assert
     expect(result).toMatchObject({
       checked: true,
       disabled: true,
@@ -112,9 +127,11 @@ describe('buildCopyAgentOptionViewModel', () => {
     })
   })
 
-  it('disables otherwise-free rows while copying or source is unavailable', () => {
+  it('greys out an otherwise-selectable row while a copy is in flight or the source is gone', () => {
+    // Arrange
     const agent = makeAgent({ id: 'amp', exists: false, name: 'Amp' })
 
+    // Act
     const result = buildCopyAgentOptionViewModel(agent, {
       occupiedAgentReasonById: new Map(),
       selectedAgentIds: [],
@@ -122,6 +139,7 @@ describe('buildCopyAgentOptionViewModel', () => {
       isSourceUnavailable: true,
     })
 
+    // Assert
     expect(result).toMatchObject({
       checked: false,
       disabled: true,
@@ -131,39 +149,47 @@ describe('buildCopyAgentOptionViewModel', () => {
 })
 
 describe('getAddAgentSecondaryLabel', () => {
-  it('uses occupied reason before install status', () => {
-    expect(
-      getAddAgentSecondaryLabel({
-        occupiedReason: 'broken',
-        exists: false,
-      }),
-    ).toBe('broken link')
+  it('shows the broken-link reason on an occupied row even when the agent is not installed', () => {
+    // Arrange / Act
+    const label = getAddAgentSecondaryLabel({
+      occupiedReason: 'broken',
+      exists: false,
+    })
+
+    // Assert
+    expect(label).toBe('broken link')
   })
 
-  it('returns manual review copy for inaccessible destinations', () => {
-    expect(
-      getAddAgentSecondaryLabel({
-        occupiedReason: 'inaccessible',
-        exists: true,
-      }),
-    ).toBe('manual review required')
+  it('shows manual-review copy on an inaccessible destination row', () => {
+    // Arrange / Act
+    const label = getAddAgentSecondaryLabel({
+      occupiedReason: 'inaccessible',
+      exists: true,
+    })
+
+    // Assert
+    expect(label).toBe('manual review required')
   })
 
-  it('returns not installed for free missing agents', () => {
-    expect(
-      getAddAgentSecondaryLabel({
-        occupiedReason: undefined,
-        exists: false,
-      }),
-    ).toBe('not installed')
+  it('shows the not-installed hint on a free agent missing from disk', () => {
+    // Arrange / Act
+    const label = getAddAgentSecondaryLabel({
+      occupiedReason: undefined,
+      exists: false,
+    })
+
+    // Assert
+    expect(label).toBe('not installed')
   })
 
-  it('returns undefined for free installed agents', () => {
-    expect(
-      getAddAgentSecondaryLabel({
-        occupiedReason: undefined,
-        exists: true,
-      }),
-    ).toBeUndefined()
+  it('shows no secondary label on a free, already-installed agent row', () => {
+    // Arrange / Act
+    const label = getAddAgentSecondaryLabel({
+      occupiedReason: undefined,
+      exists: true,
+    })
+
+    // Assert
+    expect(label).toBeUndefined()
   })
 })

--- a/src/renderer/src/components/skills/bookmarkHelpers.test.ts
+++ b/src/renderer/src/components/skills/bookmarkHelpers.test.ts
@@ -26,67 +26,100 @@ function makeSkill(overrides: Partial<Skill> = {}): Skill {
 }
 
 describe('canBookmarkSkill', () => {
-  it('returns true when skill has source', () => {
-    expect(
-      canBookmarkSkill(
-        makeSkill({ source: repositoryId('pbakaus/impeccable') }),
-      ),
-    ).toBe(true)
+  it('allows bookmarking a skill that has a source repo', () => {
+    // Arrange
+    const skill = makeSkill({ source: repositoryId('pbakaus/impeccable') })
+
+    // Act
+    const canBookmark = canBookmarkSkill(skill)
+
+    // Assert
+    expect(canBookmark).toBe(true)
   })
 
-  it('returns true when source is undefined (local skill)', () => {
-    expect(canBookmarkSkill(makeSkill({ source: undefined }))).toBe(true)
+  it('allows bookmarking a local skill that has no source repo', () => {
+    // Arrange
+    const skill = makeSkill({ source: undefined })
+
+    // Act
+    const canBookmark = canBookmarkSkill(skill)
+
+    // Assert
+    expect(canBookmark).toBe(true)
   })
 
-  it('returns true when source is empty string', () => {
-    expect(canBookmarkSkill(makeSkill({ source: repositoryId('') }))).toBe(true)
+  it('allows bookmarking a skill whose source is an empty string', () => {
+    // Arrange
+    const skill = makeSkill({ source: repositoryId('') })
+
+    // Act
+    const canBookmark = canBookmarkSkill(skill)
+
+    // Assert
+    expect(canBookmark).toBe(true)
   })
 })
 
 describe('skillToBookmarkData', () => {
-  it('derives url from sourceUrl by stripping .git suffix', () => {
-    const result = skillToBookmarkData(
-      makeSkill({
-        source: repositoryId('pbakaus/impeccable'),
-        sourceUrl: 'https://github.com/pbakaus/impeccable.git',
-      }),
-    )
+  it('saves a clean repo link by stripping the .git suffix off the source URL', () => {
+    // Arrange
+    const skill = makeSkill({
+      source: repositoryId('pbakaus/impeccable'),
+      sourceUrl: 'https://github.com/pbakaus/impeccable.git',
+    })
+
+    // Act
+    const result = skillToBookmarkData(skill)
+
+    // Assert
     expect(result).toEqual({
       repo: 'pbakaus/impeccable',
       url: 'https://github.com/pbakaus/impeccable',
     })
   })
 
-  it('uses sourceUrl as-is when no .git suffix', () => {
-    const result = skillToBookmarkData(
-      makeSkill({
-        source: repositoryId('laststance/skills'),
-        sourceUrl: 'https://github.com/laststance/skills',
-      }),
-    )
+  it('keeps a source URL that has no .git suffix unchanged when saving the bookmark', () => {
+    // Arrange
+    const skill = makeSkill({
+      source: repositoryId('laststance/skills'),
+      sourceUrl: 'https://github.com/laststance/skills',
+    })
+
+    // Act
+    const result = skillToBookmarkData(skill)
+
+    // Assert
     expect(result).toEqual({
       repo: 'laststance/skills',
       url: 'https://github.com/laststance/skills',
     })
   })
 
-  it('falls back to GitHub URL when sourceUrl is undefined', () => {
-    const result = skillToBookmarkData(
-      makeSkill({
-        source: repositoryId('laststance/skills'),
-        sourceUrl: undefined,
-      }),
-    )
+  it('builds a GitHub link from the repo when the skill carries no source URL', () => {
+    // Arrange
+    const skill = makeSkill({
+      source: repositoryId('laststance/skills'),
+      sourceUrl: undefined,
+    })
+
+    // Act
+    const result = skillToBookmarkData(skill)
+
+    // Assert
     expect(result).toEqual({
       repo: 'laststance/skills',
       url: 'https://github.com/laststance/skills',
     })
   })
 
-  it('uses empty string for repo when source is undefined', () => {
-    const result = skillToBookmarkData(
-      makeSkill({ source: undefined, sourceUrl: undefined }),
-    )
+  it('saves an empty repo when the skill has neither a source nor a source URL', () => {
+    // Arrange
+    const skill = makeSkill({ source: undefined, sourceUrl: undefined })
+
+    // Act
+    const result = skillToBookmarkData(skill)
+
+    // Assert
     expect(result).toEqual({
       repo: '',
       url: 'https://github.com/',

--- a/src/renderer/src/components/skills/bulkDeleteHelpers.test.ts
+++ b/src/renderer/src/components/skills/bulkDeleteHelpers.test.ts
@@ -17,45 +17,55 @@ import {
 } from './bulkDeleteHelpers'
 
 describe('getToolbarState', () => {
-  it('returns the global-single variant for a single selection in global view', () => {
+  it('offers a destructive "Delete skill" button for one skill in global view', () => {
+    // Arrange / Act
     const result = getToolbarState({
       view: 'global',
       agentId: null,
       count: 1,
       visibleCount: 1,
     })
+
+    // Assert
     expect(result.variantKey).toBe('global-single')
     expect(result.primaryLabel).toBe('Delete skill')
     expect(result.isDestructive).toBe(true)
     expect(result.isPrimaryDisabled).toBe(false)
   })
 
-  it('returns the global-multi variant with the count embedded', () => {
+  it('shows the selected count in the "Delete N skills" button in global view', () => {
+    // Arrange / Act
     const result = getToolbarState({
       view: 'global',
       agentId: null,
       count: 7,
       visibleCount: 7,
     })
+
+    // Assert
     expect(result.variantKey).toBe('global-multi')
     expect(result.primaryLabel).toBe('Delete 7 skills')
     expect(result.primaryAriaLabel).toBe('Move 7 selected skills to app trash')
     expect(result.isDestructive).toBe(true)
   })
 
-  it('returns the agent-single variant (non-destructive) with placeholder label when no display name', () => {
+  it('offers a non-destructive unlink button with a generic agent label when the display name is unknown', () => {
+    // Arrange / Act
     const result = getToolbarState({
       view: 'agent',
       agentId: 'cursor' as AgentId,
       count: 1,
       visibleCount: 1,
     })
+
+    // Assert
     expect(result.variantKey).toBe('agent-single')
     expect(result.primaryLabel).toBe('Unlink from agent')
     expect(result.isDestructive).toBe(false)
   })
 
-  it('embeds the agentDisplayName directly into the agent-single label', () => {
+  it('names the agent in the single-skill unlink button when a display name is given', () => {
+    // Arrange / Act
     const result = getToolbarState({
       view: 'agent',
       agentId: 'cursor' as AgentId,
@@ -63,23 +73,29 @@ describe('getToolbarState', () => {
       visibleCount: 1,
       agentDisplayName: 'Cursor',
     })
+
+    // Assert
     expect(result.primaryLabel).toBe('Unlink from Cursor')
     expect(result.primaryAriaLabel).toBe('Unlink selected skill from Cursor')
   })
 
-  it('returns the agent-multi variant with the count and placeholder label', () => {
+  it('shows the selected count in a non-destructive multi-skill unlink button with a generic agent label', () => {
+    // Arrange / Act
     const result = getToolbarState({
       view: 'agent',
       agentId: 'cursor' as AgentId,
       count: 4,
       visibleCount: 4,
     })
+
+    // Assert
     expect(result.variantKey).toBe('agent-multi')
     expect(result.primaryLabel).toBe('Unlink 4 from agent')
     expect(result.isDestructive).toBe(false)
   })
 
-  it('embeds the agentDisplayName into the agent-multi label', () => {
+  it('names the agent in the multi-skill unlink button when a display name is given', () => {
+    // Arrange / Act
     const result = getToolbarState({
       view: 'agent',
       agentId: 'cursor' as AgentId,
@@ -87,24 +103,30 @@ describe('getToolbarState', () => {
       visibleCount: 4,
       agentDisplayName: 'Cursor',
     })
+
+    // Assert
     expect(result.primaryLabel).toBe('Unlink 4 from Cursor')
     expect(result.primaryAriaLabel).toBe('Unlink 4 selected skills from Cursor')
   })
 
-  it('disables the primary button when visibleCount is 0 (hidden-only selection)', () => {
+  it('disables the delete button when a search filter hides every selected skill in global view', () => {
+    // Arrange / Act
     const result = getToolbarState({
       view: 'global',
       agentId: null,
       count: 5, // user has 5 selected globally
       visibleCount: 0, // but search filter leaves none visible
     })
+
+    // Assert
     expect(result.variantKey).toBe('global-zero')
     expect(result.isPrimaryDisabled).toBe(true)
     expect(result.primaryLabel).toBe('No visible skills')
     expect(result.primaryAriaLabel).toBe('No visible selected skills to delete')
   })
 
-  it('uses unlink-specific zero-visible copy in agent view', () => {
+  it('disables the button with unlink-specific copy when no selected skill is visible in agent view', () => {
+    // Arrange / Act
     const result = getToolbarState({
       view: 'agent',
       agentId: 'cursor' as AgentId,
@@ -112,6 +134,8 @@ describe('getToolbarState', () => {
       visibleCount: 0,
       agentDisplayName: 'Cursor',
     })
+
+    // Assert
     expect(result.variantKey).toBe('agent-zero')
     expect(result.isPrimaryDisabled).toBe(true)
     expect(result.primaryLabel).toBe('No visible skills')
@@ -120,13 +144,16 @@ describe('getToolbarState', () => {
     )
   })
 
-  it('labels the primary button with visible action targets when filters hide selected rows', () => {
+  it('counts only the visible selected skills in the delete button when filters hide some rows', () => {
+    // Arrange / Act
     const result = getToolbarState({
       view: 'global',
       agentId: null,
       count: 5,
       visibleCount: 2,
     })
+
+    // Assert
     expect(result.isPrimaryDisabled).toBe(false)
     expect(result.primaryLabel).toBe('Delete 2 skills')
     expect(result.primaryAriaLabel).toBe(
@@ -193,7 +220,8 @@ describe('countOrphanSymlinksRemoved', () => {
 })
 
 describe('formatCascadeSummary', () => {
-  it('formats a fully successful delete with symlinks', () => {
+  it('reports the deleted skill count and the total symlinks swept on a full success', () => {
+    // Arrange
     const result: BulkDeleteResult = {
       items: [
         {
@@ -213,12 +241,15 @@ describe('formatCascadeSummary', () => {
       ],
     }
 
-    expect(formatCascadeSummary(result)).toBe(
-      'Deleted 2 skills. 3 symlinks removed.',
-    )
+    // Act
+    const summary = formatCascadeSummary(result)
+
+    // Assert
+    expect(summary).toBe('Deleted 2 skills. 3 symlinks removed.')
   })
 
-  it('handles the partial-failure case with explicit "K of N"', () => {
+  it('reports a partial failure as "Deleted K of N skills"', () => {
+    // Arrange
     const result: BulkDeleteResult = {
       items: [
         {
@@ -236,12 +267,15 @@ describe('formatCascadeSummary', () => {
       ],
     }
 
-    expect(formatCascadeSummary(result)).toBe(
-      'Deleted 1 of 2 skills. 1 symlink removed.',
-    )
+    // Act
+    const summary = formatCascadeSummary(result)
+
+    // Assert
+    expect(summary).toBe('Deleted 1 of 2 skills. 1 symlink removed.')
   })
 
-  it('omits the symlinks phrase when no symlinks cascaded', () => {
+  it('drops the symlinks sentence when a delete cascaded no symlinks', () => {
+    // Arrange
     const result: BulkDeleteResult = {
       items: [
         {
@@ -254,10 +288,15 @@ describe('formatCascadeSummary', () => {
       ],
     }
 
-    expect(formatCascadeSummary(result)).toBe('Deleted 1 skill.')
+    // Act
+    const summary = formatCascadeSummary(result)
+
+    // Assert
+    expect(summary).toBe('Deleted 1 skill.')
   })
 
-  it('uses singular "skill"/"symlink" for count === 1', () => {
+  it('uses singular "skill" and "symlink" wording when exactly one of each is removed', () => {
+    // Arrange
     const result: BulkDeleteResult = {
       items: [
         {
@@ -270,15 +309,18 @@ describe('formatCascadeSummary', () => {
       ],
     }
 
-    expect(formatCascadeSummary(result)).toBe(
-      'Deleted 1 skill. 1 symlink removed.',
-    )
+    // Act
+    const summary = formatCascadeSummary(result)
+
+    // Assert
+    expect(summary).toBe('Deleted 1 skill. 1 symlink removed.')
   })
 
-  it('keeps orphan-cleared distinct from the Undo-facing "Deleted" phrase', () => {
+  it('excludes irreversible orphan cleanup from the undoable "Deleted" count', () => {
     // Issue #71 PR-1: orphan-cleared has no tombstoneId so Undo can't restore
     // it — therefore the "Deleted N" wording must NOT include it (otherwise
     // the toast lies about how many rows the user can bring back).
+    // Arrange
     const result: BulkDeleteResult = {
       items: [
         {
@@ -297,17 +339,22 @@ describe('formatCascadeSummary', () => {
       ],
     }
 
+    // Act
     // 1 truly-deleted (undoable) + 2 orphan symlinks swept (irreversible) +
     // 1 cascaded symlink from the deleted row. Three independent phrases.
-    expect(formatCascadeSummary(result)).toBe(
+    const summary = formatCascadeSummary(result)
+
+    // Assert
+    expect(summary).toBe(
       'Deleted 1 skill. Cleaned up 2 orphan symlinks. 1 symlink removed.',
     )
   })
 
-  it('reports orphan-only batches without any "Deleted" phrase', () => {
+  it('omits the "Deleted" phrase entirely for an orphan-only cleanup batch', () => {
     // The all-orphan case: e.g. user deleted the source first, then bulk
     // selected the broken-symlink rows in agent view to clean them up.
     // Nothing was tombstoned, so "Deleted" stays out of the message entirely.
+    // Arrange
     const result: BulkDeleteResult = {
       items: [
         {
@@ -329,12 +376,17 @@ describe('formatCascadeSummary', () => {
       ],
     }
 
-    expect(formatCascadeSummary(result)).toBe('Cleaned up 4 orphan symlinks.')
+    // Act
+    const summary = formatCascadeSummary(result)
+
+    // Assert
+    expect(summary).toBe('Cleaned up 4 orphan symlinks.')
   })
 
-  it('reports mixed orphan + error as separate phrases (no K-of-N form)', () => {
+  it('reports an orphan cleanup and a failed deletion as two standalone phrases, not a K-of-N form', () => {
     // No tombstoned rows means the K-of-N "Deleted X of Y" form has nothing
     // to attach to; the error count gets its own standalone phrase instead.
+    // Arrange
     const result: BulkDeleteResult = {
       items: [
         {
@@ -351,9 +403,11 @@ describe('formatCascadeSummary', () => {
       ],
     }
 
-    expect(formatCascadeSummary(result)).toBe(
-      'Cleaned up 2 orphan symlinks. 1 deletion failed.',
-    )
+    // Act
+    const summary = formatCascadeSummary(result)
+
+    // Assert
+    expect(summary).toBe('Cleaned up 2 orphan symlinks. 1 deletion failed.')
   })
 
   it('counts symlinks already unlinked when a multi-agent cleanup fails partway', () => {
@@ -381,80 +435,108 @@ describe('formatCascadeSummary', () => {
 })
 
 describe('formatUnlinkSummary', () => {
-  it('formats an all-success unlink', () => {
+  it('names the agent and the unlinked skill count when every unlink succeeds', () => {
+    // Arrange
     const result: BulkUnlinkResult = {
       items: [
         { skillName: 'task', outcome: 'unlinked' },
         { skillName: 'theme', outcome: 'unlinked' },
       ],
     }
-    expect(formatUnlinkSummary(result, 'Cursor')).toBe(
-      'Unlinked 2 skills from Cursor.',
-    )
+
+    // Act
+    const summary = formatUnlinkSummary(result, 'Cursor')
+
+    // Assert
+    expect(summary).toBe('Unlinked 2 skills from Cursor.')
   })
 
-  it('formats a partial-failure unlink', () => {
+  it('reports a partial unlink failure as "Unlinked K of N skills"', () => {
+    // Arrange
     const result: BulkUnlinkResult = {
       items: [
         { skillName: 'task', outcome: 'unlinked' },
         { skillName: 'locked', outcome: 'error', error: { message: 'EACCES' } },
       ],
     }
-    expect(formatUnlinkSummary(result, 'Cursor')).toBe(
-      'Unlinked 1 of 2 skills from Cursor.',
-    )
+
+    // Act
+    const summary = formatUnlinkSummary(result, 'Cursor')
+
+    // Assert
+    expect(summary).toBe('Unlinked 1 of 2 skills from Cursor.')
   })
 
-  it('uses singular skill for count === 1', () => {
+  it('uses singular "skill" wording when only one skill is unlinked', () => {
+    // Arrange
     const result: BulkUnlinkResult = {
       items: [{ skillName: 'task', outcome: 'unlinked' }],
     }
-    expect(formatUnlinkSummary(result, 'Cursor')).toBe(
-      'Unlinked 1 skill from Cursor.',
-    )
+
+    // Act
+    const summary = formatUnlinkSummary(result, 'Cursor')
+
+    // Assert
+    expect(summary).toBe('Unlinked 1 skill from Cursor.')
   })
 })
 
 describe('computeRangeSelection', () => {
   const visible: SkillName[] = ['alpha', 'browser', 'task', 'theme', 'zebra']
 
-  it('returns the inclusive slice when anchor is below target', () => {
-    expect(computeRangeSelection('task', 'zebra', visible)).toEqual([
-      'task',
-      'theme',
-      'zebra',
-    ])
+  it('shift-selects every row between an earlier anchor and a later click, inclusive', () => {
+    // Arrange / Act
+    const range = computeRangeSelection('task', 'zebra', visible)
+
+    // Assert
+    expect(range).toEqual(['task', 'theme', 'zebra'])
   })
 
-  it('returns the inclusive slice when anchor is above target', () => {
-    expect(computeRangeSelection('zebra', 'task', visible)).toEqual([
-      'task',
-      'theme',
-      'zebra',
-    ])
+  it('shift-selects the same inclusive range when the anchor sits below the clicked row', () => {
+    // Arrange / Act
+    const range = computeRangeSelection('zebra', 'task', visible)
+
+    // Assert
+    expect(range).toEqual(['task', 'theme', 'zebra'])
   })
 
-  it('returns a single-item range when anchor === target', () => {
-    expect(computeRangeSelection('task', 'task', visible)).toEqual(['task'])
+  it('selects just the clicked row when the anchor and target are the same row', () => {
+    // Arrange / Act
+    const range = computeRangeSelection('task', 'task', visible)
+
+    // Assert
+    expect(range).toEqual(['task'])
   })
 
-  it('falls back to just [target] when anchor is null', () => {
-    expect(computeRangeSelection(null, 'task', visible)).toEqual(['task'])
+  it('selects just the clicked row when there is no prior anchor', () => {
+    // Arrange / Act
+    const range = computeRangeSelection(null, 'task', visible)
+
+    // Assert
+    expect(range).toEqual(['task'])
   })
 
-  it('falls back to just [target] when anchor is filtered out', () => {
-    expect(
-      computeRangeSelection('removed-by-search', 'zebra', visible),
-    ).toEqual(['zebra'])
+  it('selects just the clicked row when the anchor was filtered out by search', () => {
+    // Arrange / Act
+    const range = computeRangeSelection('removed-by-search', 'zebra', visible)
+
+    // Assert
+    expect(range).toEqual(['zebra'])
   })
 
-  it('falls back to just [target] when target is missing (edge case)', () => {
-    expect(computeRangeSelection('task', 'missing', visible)).toEqual([
-      'missing',
-    ])
+  it('selects just the clicked row when the clicked target is not in the visible list', () => {
+    // Arrange / Act
+    const range = computeRangeSelection('task', 'missing', visible)
+
+    // Assert
+    expect(range).toEqual(['missing'])
   })
 
-  it('handles the first and last items correctly', () => {
-    expect(computeRangeSelection('alpha', 'zebra', visible)).toEqual(visible)
+  it('shift-selects the whole visible list when spanning from the first row to the last', () => {
+    // Arrange / Act
+    const range = computeRangeSelection('alpha', 'zebra', visible)
+
+    // Assert
+    expect(range).toEqual(visible)
   })
 })

--- a/src/renderer/src/components/skills/filePreviewLanguage.test.ts
+++ b/src/renderer/src/components/skills/filePreviewLanguage.test.ts
@@ -7,65 +7,122 @@ import {
 } from './filePreviewLanguage'
 
 describe('filePreviewLanguage', () => {
-  it('maps common skill file extensions to Shiki language ids', () => {
-    expect(languageFromExtension('.ts')).toBe('typescript')
-    expect(languageFromExtension('.tsx')).toBe('tsx')
-    expect(languageFromExtension('.TS')).toBe('typescript')
-    expect(languageFromExtension('.TSX')).toBe('tsx')
-    expect(languageFromExtension('ts')).toBe('typescript')
-    expect(languageFromExtension('.env.example')).toBe('dotenv')
-    expect(languageFromExtension('.svg')).toBe('xml')
-    expect(languageFromExtension('')).toBeUndefined()
-    expect(languageFromExtension(null)).toBeUndefined()
-    expect(languageFromExtension(undefined)).toBeUndefined()
+  it('highlights each common skill file extension with the right Shiki language, case- and dot-insensitively', () => {
+    // Arrange — common extensions in mixed case, with and without a leading dot,
+    // plus the empty/null/undefined inputs that must yield no language.
+    // Act
+    const dotTs = languageFromExtension('.ts')
+    const dotTsx = languageFromExtension('.tsx')
+    const upperDotTs = languageFromExtension('.TS')
+    const upperDotTsx = languageFromExtension('.TSX')
+    const bareTs = languageFromExtension('ts')
+    const dotEnvExample = languageFromExtension('.env.example')
+    const dotSvg = languageFromExtension('.svg')
+    const empty = languageFromExtension('')
+    const nullExtension = languageFromExtension(null)
+    const undefinedExtension = languageFromExtension(undefined)
+
+    // Assert
+    expect(dotTs).toBe('typescript')
+    expect(dotTsx).toBe('tsx')
+    expect(upperDotTs).toBe('typescript')
+    expect(upperDotTsx).toBe('tsx')
+    expect(bareTs).toBe('typescript')
+    expect(dotEnvExample).toBe('dotenv')
+    expect(dotSvg).toBe('xml')
+    expect(empty).toBeUndefined()
+    expect(nullExtension).toBeUndefined()
+    expect(undefinedExtension).toBeUndefined()
   })
 
-  it('maps known file extensions to correct Shiki language IDs for preview', () => {
-    expect(languageForPreview({ name: 'file.ts', extension: '.ts' })).toBe(
-      'typescript',
-    )
-    expect(languageForPreview({ name: 'file.tsx', extension: '.tsx' })).toBe(
-      'tsx',
-    )
-    expect(languageForPreview({ name: 'file.js', extension: '.js' })).toBe(
-      'javascript',
-    )
-    expect(languageForPreview({ name: 'file.json', extension: '.json' })).toBe(
-      'json',
-    )
+  it('highlights a preview file with the Shiki language that matches its extension', () => {
+    // Arrange — known preview files spanning TS, TSX, JS, and JSON.
+    // Act
+    const tsLanguage = languageForPreview({ name: 'file.ts', extension: '.ts' })
+    const tsxLanguage = languageForPreview({
+      name: 'file.tsx',
+      extension: '.tsx',
+    })
+    const jsLanguage = languageForPreview({ name: 'file.js', extension: '.js' })
+    const jsonLanguage = languageForPreview({
+      name: 'file.json',
+      extension: '.json',
+    })
+
+    // Assert
+    expect(tsLanguage).toBe('typescript')
+    expect(tsxLanguage).toBe('tsx')
+    expect(jsLanguage).toBe('javascript')
+    expect(jsonLanguage).toBe('json')
   })
 
-  it('falls back to safe text highlighting for unknown extensions', () => {
-    expect(
-      languageForPreview({
-        name: 'notes.custom',
-        extension: '.custom',
-      }),
-    ).toBe('text')
+  it('falls back to plain text highlighting for an unknown extension instead of failing', () => {
+    // Arrange — a preview file with an extension Shiki does not recognize.
+    // Act
+    const language = languageForPreview({
+      name: 'notes.custom',
+      extension: '.custom',
+    })
+
+    // Assert
+    expect(language).toBe('text')
   })
 
-  it('detects Markdown files for Reading Mode', () => {
-    expect(isMarkdownPreview({ name: 'SKILL.md', extension: '.md' })).toBe(true)
-    expect(
-      isMarkdownPreview({ name: 'README.markdown', extension: '.markdown' }),
-    ).toBe(true)
-    expect(
-      isMarkdownPreview({ name: 'README.mdown', extension: '.mdown' }),
-    ).toBe(true)
-    expect(isMarkdownPreview({ name: 'SKILL.MD', extension: '.MD' })).toBe(true)
-    expect(isMarkdownPreview({ name: 'Skill.Md', extension: '.Md' })).toBe(true)
-    expect(isMarkdownPreview({ name: 'SKILL.md', extension: 'md' })).toBe(true)
-    expect(isMarkdownPreview({ name: 'README', extension: '' })).toBe(true)
-    expect(
-      isMarkdownPreview({ name: 'component.tsx', extension: '.tsx' }),
-    ).toBe(false)
-    expect(
-      isMarkdownPreview({ name: 'readme.md.txt', extension: '.txt' }),
-    ).toBe(false)
-    expect(isMarkdownPreview({ name: 'notes', extension: '' })).toBe(false)
-    expect(isMarkdownPreview({ name: 'notes', extension: null })).toBe(false)
-    expect(isMarkdownPreview({ name: 'notes', extension: undefined })).toBe(
-      false,
-    )
+  it('opens Markdown variants and extensionless READMEs in Reading Mode, but not look-alike files', () => {
+    // Arrange — Markdown extensions in several spellings/cases plus an
+    // extensionless README (all should be Markdown), alongside non-Markdown
+    // look-alikes (.tsx, a ".md.txt" name, and missing/null/undefined
+    // extensions that should NOT be Markdown).
+    // Act
+    const dotMd = isMarkdownPreview({ name: 'SKILL.md', extension: '.md' })
+    const dotMarkdown = isMarkdownPreview({
+      name: 'README.markdown',
+      extension: '.markdown',
+    })
+    const dotMdown = isMarkdownPreview({
+      name: 'README.mdown',
+      extension: '.mdown',
+    })
+    const upperDotMd = isMarkdownPreview({ name: 'SKILL.MD', extension: '.MD' })
+    const mixedDotMd = isMarkdownPreview({ name: 'Skill.Md', extension: '.Md' })
+    const bareMd = isMarkdownPreview({ name: 'SKILL.md', extension: 'md' })
+    const extensionlessReadme = isMarkdownPreview({
+      name: 'README',
+      extension: '',
+    })
+    const tsxFile = isMarkdownPreview({
+      name: 'component.tsx',
+      extension: '.tsx',
+    })
+    const mdDotTxtFile = isMarkdownPreview({
+      name: 'readme.md.txt',
+      extension: '.txt',
+    })
+    const extensionlessNotes = isMarkdownPreview({
+      name: 'notes',
+      extension: '',
+    })
+    const nullExtensionNotes = isMarkdownPreview({
+      name: 'notes',
+      extension: null,
+    })
+    const undefinedExtensionNotes = isMarkdownPreview({
+      name: 'notes',
+      extension: undefined,
+    })
+
+    // Assert
+    expect(dotMd).toBe(true)
+    expect(dotMarkdown).toBe(true)
+    expect(dotMdown).toBe(true)
+    expect(upperDotMd).toBe(true)
+    expect(mixedDotMd).toBe(true)
+    expect(bareMd).toBe(true)
+    expect(extensionlessReadme).toBe(true)
+    expect(tsxFile).toBe(false)
+    expect(mdDotTxtFile).toBe(false)
+    expect(extensionlessNotes).toBe(false)
+    expect(nullExtensionNotes).toBe(false)
+    expect(undefinedExtensionNotes).toBe(false)
   })
 })

--- a/src/renderer/src/components/skills/skillItemHelpers.test.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.test.ts
@@ -49,9 +49,12 @@ function makeSkill(
 
 describe('getSkillItemVisibility', () => {
   describe('global view (no agent selected)', () => {
-    it('shows delete and add buttons, hides unlink', () => {
+    it('offers Delete and Add but no Unlink in the global view of a skill with no symlinks', () => {
+      // Arrange — global view (no agent selected), skill with no symlinks.
+      // Act
       const result = getSkillItemVisibility(null, makeSkill([]))
 
+      // Assert
       expect(result.showDeleteButton).toBe(true)
       expect(result.showAddButton).toBe(true)
       expect(result.showUnlinkButton).toBe(false)
@@ -60,10 +63,14 @@ describe('getSkillItemVisibility', () => {
       expect(result.selectedLocalSkillInfo).toBeNull()
     })
 
-    it('shows delete and add even when symlinks exist', () => {
+    it('keeps Delete and Add (still no Unlink) in the global view even when symlinks exist', () => {
+      // Arrange — global view, skill with an existing symlink.
       const symlinks = [makeSymlink({ agentId: 'cursor' })]
+
+      // Act
       const result = getSkillItemVisibility(null, makeSkill(symlinks))
 
+      // Assert
       expect(result.showDeleteButton).toBe(true)
       expect(result.showAddButton).toBe(true)
       expect(result.showUnlinkButton).toBe(false)
@@ -71,37 +78,52 @@ describe('getSkillItemVisibility', () => {
   })
 
   describe('agent filtered view (agent selected)', () => {
-    it('hides delete button and keeps add hidden when selected agent has no skill', () => {
+    it('hides both Delete and Add when the selected agent has no copy of the skill', () => {
+      // Arrange — an agent is selected but the skill has no symlinks for it.
+      // Act
       const result = getSkillItemVisibility('cursor', makeSkill([]))
 
+      // Assert
       expect(result.showDeleteButton).toBe(false)
       expect(result.showAddButton).toBe(false)
     })
 
-    it('shows add button when selected agent has a valid symlink', () => {
+    it('offers Add when the selected agent already has a valid symlink', () => {
+      // Arrange — selected agent has a valid (non-local) symlink.
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: false }),
       ]
+
+      // Act
       const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
 
+      // Assert
       expect(result.showAddButton).toBe(true)
     })
 
-    it('shows add button when selected agent has a local skill', () => {
+    it('offers Add when the selected agent has a local copy of the skill', () => {
+      // Arrange — selected agent has a local skill.
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: true }),
       ]
+
+      // Act
       const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
 
+      // Assert
       expect(result.showAddButton).toBe(true)
     })
 
-    it('shows unlink button when valid symlink exists for selected agent', () => {
+    it('offers Unlink and marks the skill linked when the selected agent has a valid symlink', () => {
+      // Arrange — selected agent has a valid (non-local) symlink.
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: false }),
       ]
+
+      // Act
       const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
 
+      // Assert
       expect(result.showUnlinkButton).toBe(true)
       expect(result.isLinked).toBe(true)
       expect(result.selectedAgentSymlink).toBe(symlinks[0])
@@ -111,11 +133,15 @@ describe('getSkillItemVisibility', () => {
       // Broken rows can become live after scan. The normal per-row unlink
       // lacks reviewed target revalidation, so cleanup must route through the
       // exact broken-slot IPC instead of this generic affordance.
+      // Arrange — selected agent has only a broken symlink.
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'broken', isLocal: false }),
       ]
+
+      // Act
       const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
 
+      // Assert
       expect(result.showUnlinkButton).toBe(false)
       // isLinked still requires status==='valid'; broken does NOT count as
       // linked.
@@ -126,12 +152,16 @@ describe('getSkillItemVisibility', () => {
       // Live source skill with one healthy and one broken agent link — the
       // source exists, but the reviewed link path can still be stale by the
       // time the user clicks. The cleanup IPC owns the safe path.
+      // Arrange — selected agent broken, another agent valid.
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'broken', isLocal: false }),
         makeSymlink({ agentId: 'codex', status: 'valid', isLocal: false }),
       ]
+
+      // Act
       const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
 
+      // Assert
       expect(result.showUnlinkButton).toBe(false)
       expect(result.isLinked).toBe(false)
     })
@@ -140,79 +170,108 @@ describe('getSkillItemVisibility', () => {
       // The source exists through another agent, but Cursor's visible row is a
       // broken slot. Add/Copy would route through a generic source-copy flow
       // instead of the reviewed cleanup path for this exact broken link.
+      // Arrange — selected agent broken, another agent valid.
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'broken', isLocal: false }),
         makeSymlink({ agentId: 'codex', status: 'valid', isLocal: false }),
       ]
+
+      // Act
       const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
 
+      // Assert
       expect(result.showAddButton).toBe(false)
       expect(result.showCopyButton).toBe(false)
     })
 
-    it('hides unlink button when no symlink for selected agent', () => {
+    it('hides Unlink and exposes no selected symlink when the skill has none for the selected agent', () => {
+      // Arrange — the skill is symlinked for a different agent, not the selected one.
       const symlinks = [
         makeSymlink({ agentId: 'codex', status: 'valid', isLocal: false }),
       ]
+
+      // Act
       const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
 
+      // Assert
       expect(result.showUnlinkButton).toBe(false)
       expect(result.selectedAgentSymlink).toBeNull()
     })
 
-    it('shows unlink button for local skills (isLocal=true)', () => {
+    it('offers Unlink for a local skill and routes it through the local-skill slot, not the symlink slot', () => {
+      // Arrange — selected agent has a local skill.
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: true }),
       ]
+
+      // Act
       const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
 
+      // Assert
       expect(result.showUnlinkButton).toBe(true)
       expect(result.selectedAgentSymlink).toBeNull()
       expect(result.selectedLocalSkillInfo).toBe(symlinks[0])
     })
 
-    it('detects local skill when isLocal=true for selected agent', () => {
+    it('flags a local skill as local (not linked) and surfaces its local-skill info for the selected agent', () => {
+      // Arrange — selected agent has a local skill.
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: true }),
       ]
+
+      // Act
       const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
 
+      // Assert
       expect(result.isLocalSkill).toBe(true)
       expect(result.isLinked).toBe(false)
       expect(result.selectedLocalSkillInfo).toBe(symlinks[0])
     })
 
-    it('isLocalSkill is false for symlinked skills', () => {
+    it('treats a symlinked skill as linked rather than local for the selected agent', () => {
+      // Arrange — selected agent has a valid (non-local) symlink.
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: false }),
       ]
+
+      // Act
       const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
 
+      // Assert
       expect(result.isLocalSkill).toBe(false)
       expect(result.isLinked).toBe(true)
       expect(result.selectedLocalSkillInfo).toBeNull()
     })
 
-    it('isLocalSkill is false in global view', () => {
+    it('never reports a local skill in the global view (local-skill state needs a selected agent)', () => {
+      // Arrange — global view (no agent selected) over a local skill.
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: true }),
       ]
+
+      // Act
       const result = getSkillItemVisibility(null, makeSkill(symlinks))
 
+      // Assert
       expect(result.isLocalSkill).toBe(false)
       expect(result.selectedLocalSkillInfo).toBeNull()
     })
 
-    it('hides unlink button for missing symlinks', () => {
+    it('hides Unlink for a missing symlink on the selected agent', () => {
+      // Arrange — selected agent has a missing symlink.
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'missing', isLocal: false }),
       ]
+
+      // Act
       const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
 
+      // Assert
       expect(result.showUnlinkButton).toBe(false)
     })
 
     it('hides normal unlink for inaccessible symlinks while keeping manual-review state visible', () => {
+      // Arrange — selected agent has an inaccessible symlink.
       const symlinks = [
         makeSymlink({
           agentId: 'cursor',
@@ -220,14 +279,18 @@ describe('getSkillItemVisibility', () => {
           isLocal: false,
         }),
       ]
+
+      // Act
       const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
 
+      // Assert
       expect(result.showUnlinkButton).toBe(false)
       expect(result.isInaccessibleSkill).toBe(true)
       expect(result.selectedAgentSymlink).toBe(symlinks[0])
     })
 
     it('hides Add and Copy for inaccessible symlinks so unverifiable targets cannot fan out', () => {
+      // Arrange — selected agent has an inaccessible symlink.
       const symlinks = [
         makeSymlink({
           agentId: 'cursor',
@@ -235,8 +298,11 @@ describe('getSkillItemVisibility', () => {
           isLocal: false,
         }),
       ]
+
+      // Act
       const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
 
+      // Assert
       expect(result.showAddButton).toBe(false)
       expect(result.showCopyButton).toBe(false)
       expect(result.isInaccessibleSkill).toBe(true)
@@ -244,49 +310,75 @@ describe('getSkillItemVisibility', () => {
   })
 
   describe('showCopyButton', () => {
-    it('returns false when no agent is selected (global view)', () => {
+    it('hides Copy in the global view since there is no single agent to copy from', () => {
+      // Arrange — global view (no agent selected) over a valid symlink.
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: false }),
       ]
+
+      // Act
       const result = getSkillItemVisibility(null, makeSkill(symlinks))
+
+      // Assert
       expect(result.showCopyButton).toBe(false)
     })
 
-    it('returns false when selected agent has no symlink for the skill', () => {
+    it('hides Copy when the skill is symlinked for a different agent than the selected one', () => {
+      // Arrange — skill is valid for cursor, but codex is selected.
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: false }),
       ]
+
+      // Act
       const result = getSkillItemVisibility('codex', makeSkill(symlinks))
+
+      // Assert
       expect(result.showCopyButton).toBe(false)
     })
 
-    it('returns true when a specific agent is selected with a valid symlink', () => {
+    it('offers Copy when the selected agent has a valid symlink to copy from', () => {
+      // Arrange — selected agent has a valid (non-local) symlink.
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: false }),
       ]
+
+      // Act
       const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
+
+      // Assert
       expect(result.showCopyButton).toBe(true)
     })
 
-    it('returns true when a specific agent is selected with a local skill', () => {
+    it('offers Copy when the selected agent has a local skill to copy from', () => {
+      // Arrange — selected agent has a local skill.
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: true }),
       ]
+
+      // Act
       const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
+
+      // Assert
       expect(result.showCopyButton).toBe(true)
     })
 
-    it('returns false when agent is selected but no symlink exists for that agent', () => {
+    it('hides Copy when the selected agent has no copy of the skill at all', () => {
+      // Arrange — skill is valid for codex, but cursor is selected.
       const symlinks = [
         makeSymlink({ agentId: 'codex', status: 'valid', isLocal: false }),
       ]
+
+      // Act
       const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
+
+      // Assert
       expect(result.showCopyButton).toBe(false)
     })
   })
 
   describe('showGStackBadge', () => {
-    it('shows badge for gstack-backed symlink in supported agent view', () => {
+    it('shows the G-Stack badge for a gstack-backed symlink in a supported agent view', () => {
+      // Arrange — claude-code symlink whose target lives under a gstack tree.
       const symlinks = [
         makeSymlink({
           agentId: 'claude-code',
@@ -297,16 +389,20 @@ describe('getSkillItemVisibility', () => {
         }),
       ]
 
+      // Act
       const result = getSkillItemVisibility('claude-code', makeSkill(symlinks))
+
+      // Assert
       expect(result.showGStackBadge).toBe(true)
     })
 
-    it('shows badge for codex-managed gstack symlinks (multi-agent coverage)', () => {
+    it('shows the G-Stack badge for codex-managed gstack symlinks too, not only claude-code', () => {
       // symlinkChecker resolves relative readlink results to absolute paths
       // before populating `targetPath`, so the renderer always sees the
       // resolved form (e.g. `/Users/me/.codex/skills/gstack/task`). This
       // guards multi-agent coverage of GSTACK_BADGE_AGENT_IDS — earlier
       // versions only matched on `claude-code`.
+      // Arrange — codex symlink whose target lives under a gstack tree.
       const symlinks = [
         makeSymlink({
           agentId: 'codex',
@@ -317,11 +413,15 @@ describe('getSkillItemVisibility', () => {
         }),
       ]
 
+      // Act
       const result = getSkillItemVisibility('codex', makeSkill(symlinks))
+
+      // Assert
       expect(result.showGStackBadge).toBe(true)
     })
 
-    it('hides badge in global view even when gstack path exists', () => {
+    it('hides the G-Stack badge in the global view even when a gstack path exists', () => {
+      // Arrange — global view (no agent) over a gstack-backed symlink.
       const symlinks = [
         makeSymlink({
           agentId: 'claude-code',
@@ -331,11 +431,15 @@ describe('getSkillItemVisibility', () => {
         }),
       ]
 
+      // Act
       const result = getSkillItemVisibility(null, makeSkill(symlinks))
+
+      // Assert
       expect(result.showGStackBadge).toBe(false)
     })
 
-    it('hides badge for non-supported agents', () => {
+    it('hides the G-Stack badge for an agent that does not support gstack', () => {
+      // Arrange — gemini-cli (unsupported) symlink under a gstack tree.
       const symlinks = [
         makeSymlink({
           agentId: 'gemini-cli',
@@ -346,16 +450,20 @@ describe('getSkillItemVisibility', () => {
         }),
       ]
 
+      // Act
       const result = getSkillItemVisibility('gemini-cli', makeSkill(symlinks))
+
+      // Assert
       expect(result.showGStackBadge).toBe(false)
     })
 
-    it('shows badge for local skill whose SKILL.md symlinks into gstack tree', () => {
+    it('shows the G-Stack badge for a local skill whose SKILL.md symlinks into the gstack tree', () => {
       // Real production case: ~/.claude/skills/ship/ is a real folder whose
       // only entry is a SKILL.md symlink into ~/.claude/skills/gstack/ship/.
       // Neither the linkPath (the real folder) nor any agent symlink contains
       // the "gstack" segment — only the resolved SKILL.md target does.
       // Without the fourth candidate, the badge would be hidden.
+      // Arrange — local claude-code skill whose SKILL.md points into gstack.
       const symlinks = [
         makeSymlink({
           agentId: 'claude-code',
@@ -368,13 +476,17 @@ describe('getSkillItemVisibility', () => {
         }),
       ]
 
+      // Act
       const result = getSkillItemVisibility('claude-code', makeSkill(symlinks))
+
+      // Assert
       expect(result.showGStackBadge).toBe(true)
     })
 
-    it('hides badge when SKILL.md target does not contain the gstack segment', () => {
+    it('hides the G-Stack badge when the SKILL.md target points somewhere other than the gstack tree', () => {
       // A user-installed local skill whose SKILL.md happens to be a symlink
       // into a different location (not gstack) — no badge should show.
+      // Arrange — local claude-code skill whose SKILL.md points outside gstack.
       const symlinks = [
         makeSymlink({
           agentId: 'claude-code',
@@ -387,15 +499,19 @@ describe('getSkillItemVisibility', () => {
         }),
       ]
 
+      // Act
       const result = getSkillItemVisibility('claude-code', makeSkill(symlinks))
+
+      // Assert
       expect(result.showGStackBadge).toBe(false)
     })
 
-    it('falls back to existing candidates when skillMdSymlinkTarget is undefined (regression)', () => {
+    it('still shows the G-Stack badge from the agent symlink target when skillMdSymlinkTarget is absent (legacy records)', () => {
       // Guards the existing 3-candidate path — agent symlink whose targetPath
       // contains "gstack" must still flip the badge on, exactly as before.
       // skillMdSymlinkTarget defaults to undefined via makeSkill(), simulating
       // a Skill record produced before the new field landed.
+      // Arrange — claude-code gstack symlink with no skillMdSymlinkTarget.
       const symlinks = [
         makeSymlink({
           agentId: 'claude-code',
@@ -406,7 +522,10 @@ describe('getSkillItemVisibility', () => {
         }),
       ]
 
+      // Act
       const result = getSkillItemVisibility('claude-code', makeSkill(symlinks))
+
+      // Assert
       expect(result.showGStackBadge).toBe(true)
     })
   })
@@ -416,75 +535,100 @@ describe('getSkillItemVisibility', () => {
     // so users can sweep orphans surfaced by the new amber-border row UI.
     // Add stays gated because there is no live source to point a new
     // symlink at. The original #127 hide-everything stance is gone.
-    it('shows global delete button for orphan-only skill so user can sweep the row', () => {
+    it('shows global Delete for an orphan-only skill so the user can sweep the dangling row', () => {
       // Source removed, broken symlinks across two agents, no real folders.
       // Delete clears all dangling agent symlinks plus the now-empty source
       // tombstone in one shot — the bulk version of the Cleanup-per-agent
       // flow.
+      // Arrange — orphan skill: broken symlinks on two agents, no live source.
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'broken', isLocal: false }),
         makeSymlink({ agentId: 'codex', status: 'broken', isLocal: false }),
       ]
+
+      // Act
       const result = getSkillItemVisibility(null, makeSkill(symlinks))
 
+      // Assert
       expect(result.showDeleteButton).toBe(true)
     })
 
-    it('keeps global delete button visible when at least one agent has a valid copy', () => {
+    it('keeps global Delete when at least one agent still holds a valid copy', () => {
+      // Arrange — one valid and one broken agent symlink (not an orphan).
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: false }),
         makeSymlink({ agentId: 'codex', status: 'broken', isLocal: false }),
       ]
+
+      // Act
       const result = getSkillItemVisibility(null, makeSkill(symlinks))
 
+      // Assert
       expect(result.showDeleteButton).toBe(true)
     })
 
-    it('keeps global delete button visible when at least one agent has a local copy', () => {
+    it('keeps global Delete when at least one agent still holds a local copy', () => {
+      // Arrange — one broken symlink and one local copy (not an orphan).
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'broken', isLocal: false }),
         makeSymlink({ agentId: 'codex', status: 'valid', isLocal: true }),
       ]
+
+      // Act
       const result = getSkillItemVisibility(null, makeSkill(symlinks))
 
+      // Assert
       expect(result.showDeleteButton).toBe(true)
     })
 
-    it('global Delete is shown regardless of explicit isOrphan override', () => {
+    it('keeps global Delete but still gates Add when a skill is explicitly marked orphan', () => {
       // After the loosen, Delete is purely a global-view concern (`!selectedAgentId`).
       // The explicit isOrphan override no longer suppresses it — the override
       // only steers Add visibility now.
+      // Arrange — valid symlink but the skill is force-flagged isOrphan: true.
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: false }),
       ]
+
+      // Act
       const result = getSkillItemVisibility(
         null,
         makeSkill(symlinks, { isOrphan: true }),
       )
+
+      // Assert
       expect(result.showDeleteButton).toBe(true)
       // …and the orphan override DOES still gate Add as designed.
       expect(result.showAddButton).toBe(false)
     })
 
-    it('hides Add button for orphan skill in global view', () => {
+    it('hides Add for an orphan skill in the global view since there is no live source to link to', () => {
       // Add (AddSymlinkModal / CopyToAgentsModal) requires a live source
       // dir to symlink _to_; for orphans the source is gone.
+      // Arrange — orphan skill: broken symlinks on two agents, no live source.
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'broken', isLocal: false }),
         makeSymlink({ agentId: 'codex', status: 'broken', isLocal: false }),
       ]
+
+      // Act
       const result = getSkillItemVisibility(null, makeSkill(symlinks))
 
+      // Assert
       expect(result.showAddButton).toBe(false)
     })
 
-    it('hides Add and normal Unlink for orphan skill in agent view', () => {
+    it('hides Add, Unlink, and Copy for an orphan skill in the agent view', () => {
+      // Arrange — orphan skill: broken symlinks on two agents, no live source.
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'broken', isLocal: false }),
         makeSymlink({ agentId: 'codex', status: 'broken', isLocal: false }),
       ]
+
+      // Act
       const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
 
+      // Assert
       // Add stays gated: even though the broken cursor entry passes the
       // `valid|broken` filter, there is no live source to symlink TO.
       expect(result.showAddButton).toBe(false)
@@ -497,34 +641,43 @@ describe('getSkillItemVisibility', () => {
       expect(result.showCopyButton).toBe(false)
     })
 
-    it('keeps Add button visible when isOrphan is false (non-orphan, valid symlinks)', () => {
+    it('keeps Add available in both views for a non-orphan skill with valid symlinks', () => {
       // Sanity check: the && !isOrphan term must NOT regress the
       // happy path where Add was always available.
+      // Arrange — non-orphan skill with a single valid symlink.
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: false }),
       ]
-      const globalResult = getSkillItemVisibility(null, makeSkill(symlinks))
-      expect(globalResult.showAddButton).toBe(true)
 
+      // Act
+      const globalResult = getSkillItemVisibility(null, makeSkill(symlinks))
       const agentResult = getSkillItemVisibility('cursor', makeSkill(symlinks))
+
+      // Assert
+      expect(globalResult.showAddButton).toBe(true)
       expect(agentResult.showAddButton).toBe(true)
     })
   })
 
   describe('regression: dual delete buttons', () => {
-    it('never shows both delete button and unlink button simultaneously', () => {
+    it('shows Unlink but not Delete in the agent view, never both X and Trash at once', () => {
       // This was the bug: both X (delete) and Trash (unlink) showed in agent view
+      // Arrange — agent selected over a valid symlink.
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: false }),
       ]
+
+      // Act
       const result = getSkillItemVisibility('cursor', makeSkill(symlinks))
 
+      // Assert
       // When agent is selected, delete must be hidden
       expect(result.showDeleteButton).toBe(false)
       expect(result.showUnlinkButton).toBe(true)
     })
 
-    it('delete and unlink are mutually exclusive for all agent ids', () => {
+    it('never shows Delete and Unlink together, whether or not an agent is selected', () => {
+      // Arrange — a valid symlink for claude-code.
       const symlinks = [
         makeSymlink({
           agentId: 'claude-code',
@@ -533,17 +686,17 @@ describe('getSkillItemVisibility', () => {
         }),
       ]
 
-      // With agent selected
+      // Act
       const agentView = getSkillItemVisibility(
         'claude-code',
         makeSkill(symlinks),
       )
+      const globalView = getSkillItemVisibility(null, makeSkill(symlinks))
+
+      // Assert
       expect(agentView.showDeleteButton && agentView.showUnlinkButton).toBe(
         false,
       )
-
-      // Without agent selected
-      const globalView = getSkillItemVisibility(null, makeSkill(symlinks))
       expect(globalView.showDeleteButton && globalView.showUnlinkButton).toBe(
         false,
       )

--- a/src/renderer/src/components/skills/skillsListHelpers.test.ts
+++ b/src/renderer/src/components/skills/skillsListHelpers.test.ts
@@ -5,183 +5,227 @@ import { repositoryId } from '@/shared/types'
 import { getEmptyListMessage } from './skillsListHelpers'
 
 describe('getEmptyListMessage', () => {
-  it('returns the search message with repo context when searchQuery and source are active', () => {
+  it('names the active repo in the empty state when a search and a single source are both active', () => {
     // Search still wins as the user's most recent narrowing action, but the
     // active repo facet is named so the empty state explains the intersection.
-    expect(
-      getEmptyListMessage({
-        searchQuery: 'react',
-        selectedSources: [repositoryId('vercel-labs/skills')],
-        selectedAgentId: 'cursor',
-        skillTypeFilter: 'local',
-      }),
-    ).toBe('No skills match your search in vercel-labs/skills')
+    // Arrange: a search query plus a single selected source repo.
+    // Act
+    const message = getEmptyListMessage({
+      searchQuery: 'react',
+      selectedSources: [repositoryId('vercel-labs/skills')],
+      selectedAgentId: 'cursor',
+      skillTypeFilter: 'local',
+    })
+
+    // Assert
+    expect(message).toBe('No skills match your search in vercel-labs/skills')
   })
 
-  it('returns the source message when only a single source is selected', () => {
-    expect(
-      getEmptyListMessage({
-        searchQuery: '',
-        selectedSources: [repositoryId('vercel-labs/skills')],
-        selectedAgentId: null,
-        skillTypeFilter: 'all',
-      }),
-    ).toBe('No skills from vercel-labs/skills')
+  it('names the single selected repo in the empty state when only that source is filtered', () => {
+    // Arrange: only a single selected source repo, no search/agent narrowing.
+    // Act
+    const message = getEmptyListMessage({
+      searchQuery: '',
+      selectedSources: [repositoryId('vercel-labs/skills')],
+      selectedAgentId: null,
+      skillTypeFilter: 'all',
+    })
+
+    // Assert
+    expect(message).toBe('No skills from vercel-labs/skills')
   })
 
-  it('collapses multiple selected sources to "the selected repositories"', () => {
+  it('summarizes several selected repos as "the selected repositories" instead of listing each', () => {
     // With >1 repo in the include filter, naming each would bloat the empty
     // state; the helper summarizes instead of listing.
-    expect(
-      getEmptyListMessage({
-        searchQuery: '',
-        selectedSources: [
-          repositoryId('vercel-labs/skills'),
-          repositoryId('pbakaus/impeccable'),
-        ],
-        selectedAgentId: null,
-        skillTypeFilter: 'all',
-      }),
-    ).toBe('No skills from the selected repositories')
+    // Arrange: two selected source repos.
+    // Act
+    const message = getEmptyListMessage({
+      searchQuery: '',
+      selectedSources: [
+        repositoryId('vercel-labs/skills'),
+        repositoryId('pbakaus/impeccable'),
+      ],
+      selectedAgentId: null,
+      skillTypeFilter: 'all',
+    })
+
+    // Assert
+    expect(message).toBe('No skills from the selected repositories')
   })
 
-  it('adds the multi-source summary to a search result', () => {
-    expect(
-      getEmptyListMessage({
-        searchQuery: 'react',
-        selectedSources: [
-          repositoryId('vercel-labs/skills'),
-          repositoryId('pbakaus/impeccable'),
-        ],
-        selectedAgentId: 'cursor',
-        skillTypeFilter: 'all',
-      }),
-    ).toBe('No skills match your search in the selected repositories')
+  it('appends the multi-repo summary to a search empty state when several sources are filtered', () => {
+    // Arrange: a search query plus two selected source repos.
+    // Act
+    const message = getEmptyListMessage({
+      searchQuery: 'react',
+      selectedSources: [
+        repositoryId('vercel-labs/skills'),
+        repositoryId('pbakaus/impeccable'),
+      ],
+      selectedAgentId: 'cursor',
+      skillTypeFilter: 'all',
+    })
+
+    // Assert
+    expect(message).toBe(
+      'No skills match your search in the selected repositories',
+    )
   })
 
-  it('source message wins over agent + type when both are set (search empty)', () => {
+  it('prefers the source message over the agent+type message when the search box is empty', () => {
     // The pill is a more specific, more recent action than the persistent
     // agent tab. Order in the ladder is search > source > agent+type > agent.
-    expect(
-      getEmptyListMessage({
-        searchQuery: '',
-        selectedSources: [repositoryId('pbakaus/impeccable')],
-        selectedAgentId: 'claude-code',
-        skillTypeFilter: 'symlinked',
-      }),
-    ).toBe('No skills from pbakaus/impeccable')
+    // Arrange: a selected source repo competing with a selected agent + type.
+    // Act
+    const message = getEmptyListMessage({
+      searchQuery: '',
+      selectedSources: [repositoryId('pbakaus/impeccable')],
+      selectedAgentId: 'claude-code',
+      skillTypeFilter: 'symlinked',
+    })
+
+    // Assert
+    expect(message).toBe('No skills from pbakaus/impeccable')
   })
 
-  it('adds repository context to a search result when both query and source are active', () => {
-    expect(
-      getEmptyListMessage({
-        searchQuery: 'trace',
-        selectedSources: [repositoryId('laststance/skills')],
-        selectedAgentId: 'cursor',
-        skillTypeFilter: 'all',
-      }),
-    ).toBe('No skills match your search in laststance/skills')
+  it('names the active repo in a search empty state when both a query and a single source are set', () => {
+    // Arrange: a search query plus a single selected source repo.
+    // Act
+    const message = getEmptyListMessage({
+      searchQuery: 'trace',
+      selectedSources: [repositoryId('laststance/skills')],
+      selectedAgentId: 'cursor',
+      skillTypeFilter: 'all',
+    })
+
+    // Assert
+    expect(message).toBe('No skills match your search in laststance/skills')
   })
 
-  it('returns the agent + type message when both are set (no source / search)', () => {
-    expect(
-      getEmptyListMessage({
-        searchQuery: '',
-        selectedSources: [],
-        selectedAgentId: 'cursor',
-        skillTypeFilter: 'local',
-      }),
-    ).toBe('No local skills for this agent')
+  it('shows the agent-and-type empty state when an agent and a type filter are set without a source or search', () => {
+    // Arrange: a selected agent plus a local type filter, no source/search.
+    // Act
+    const message = getEmptyListMessage({
+      searchQuery: '',
+      selectedSources: [],
+      selectedAgentId: 'cursor',
+      skillTypeFilter: 'local',
+    })
+
+    // Assert
+    expect(message).toBe('No local skills for this agent')
   })
 
-  it('adds excluded skill types to the selected source message', () => {
-    expect(
-      getEmptyListMessage({
-        searchQuery: '',
-        selectedSources: [repositoryId('vercel-labs/skills')],
-        selectedAgentId: 'cursor',
-        skillTypeFilter: 'all',
-        excludedSkillTypeFilters: ['gstack', 'orphan'],
-      }),
-    ).toBe(
+  it('appends the excluded skill types to the selected-source empty state', () => {
+    // Arrange: a selected source repo with two excluded skill types.
+    // Act
+    const message = getEmptyListMessage({
+      searchQuery: '',
+      selectedSources: [repositoryId('vercel-labs/skills')],
+      selectedAgentId: 'cursor',
+      skillTypeFilter: 'all',
+      excludedSkillTypeFilters: ['gstack', 'orphan'],
+    })
+
+    // Assert
+    expect(message).toBe(
       'No skills from vercel-labs/skills while excluding G-Stack and orphan',
     )
   })
 
-  it('adds excluded skill types to the agent-only message', () => {
-    expect(
-      getEmptyListMessage({
-        searchQuery: '',
-        selectedSources: [],
-        selectedAgentId: 'cursor',
-        skillTypeFilter: 'all',
-        excludedSkillTypeFilters: ['local', 'gstack', 'orphan'],
-      }),
-    ).toBe(
+  it('appends the excluded skill types to the agent-only empty state, Oxford-comma joined', () => {
+    // Arrange: a selected agent with three excluded skill types.
+    // Act
+    const message = getEmptyListMessage({
+      searchQuery: '',
+      selectedSources: [],
+      selectedAgentId: 'cursor',
+      skillTypeFilter: 'all',
+      excludedSkillTypeFilters: ['local', 'gstack', 'orphan'],
+    })
+
+    // Assert
+    expect(message).toBe(
       'No skills installed for this agent while excluding local, G-Stack, and orphan',
     )
   })
 
-  it('returns the symlinked variant when type filter is symlinked', () => {
-    expect(
-      getEmptyListMessage({
-        searchQuery: '',
-        selectedSources: [],
-        selectedAgentId: 'claude-code',
-        skillTypeFilter: 'symlinked',
-      }),
-    ).toBe('No symlinked skills for this agent')
+  it('shows the symlinked-only empty state when the type filter is symlinked', () => {
+    // Arrange: a selected agent with the symlinked type filter.
+    // Act
+    const message = getEmptyListMessage({
+      searchQuery: '',
+      selectedSources: [],
+      selectedAgentId: 'claude-code',
+      skillTypeFilter: 'symlinked',
+    })
+
+    // Assert
+    expect(message).toBe('No symlinked skills for this agent')
   })
 
-  it('returns the G-Stack variant when type filter is gstack', () => {
-    expect(
-      getEmptyListMessage({
-        searchQuery: '',
-        selectedSources: [],
-        selectedAgentId: 'cursor',
-        skillTypeFilter: 'gstack',
-      }),
-    ).toBe('No G-Stack skills for this agent')
+  it('shows the G-Stack-only empty state when the type filter is gstack', () => {
+    // Arrange: a selected agent with the gstack type filter.
+    // Act
+    const message = getEmptyListMessage({
+      searchQuery: '',
+      selectedSources: [],
+      selectedAgentId: 'cursor',
+      skillTypeFilter: 'gstack',
+    })
+
+    // Assert
+    expect(message).toBe('No G-Stack skills for this agent')
   })
 
-  it('returns the agent-only message when selectedAgentId is set and type is all', () => {
-    expect(
-      getEmptyListMessage({
-        searchQuery: '',
-        selectedSources: [],
-        selectedAgentId: 'cursor',
-        skillTypeFilter: 'all',
-      }),
-    ).toBe('No skills installed for this agent')
+  it('shows the generic agent empty state when an agent is selected and no type filter narrows it', () => {
+    // Arrange: a selected agent with the all type filter (no narrowing).
+    // Act
+    const message = getEmptyListMessage({
+      searchQuery: '',
+      selectedSources: [],
+      selectedAgentId: 'cursor',
+      skillTypeFilter: 'all',
+    })
+
+    // Assert
+    expect(message).toBe('No skills installed for this agent')
   })
 
-  it('returns the fallback when no narrowing is active', () => {
+  it('shows the generic fallback message when nothing is narrowing the list', () => {
     // The "no agent, no source, no search" fallback is unusual — typically
     // means filteredSkills is empty because skills.length is 0, which is
     // handled by an earlier branch in SkillsList. Still worth locking the
     // string so the fallback never accidentally returns undefined.
-    expect(
-      getEmptyListMessage({
-        searchQuery: '',
-        selectedSources: [],
-        selectedAgentId: null,
-        skillTypeFilter: 'all',
-      }),
-    ).toBe('No skills match your filter')
+    // Arrange: no search, no source, no agent, no type narrowing.
+    // Act
+    const message = getEmptyListMessage({
+      searchQuery: '',
+      selectedSources: [],
+      selectedAgentId: null,
+      skillTypeFilter: 'all',
+    })
+
+    // Assert
+    expect(message).toBe('No skills match your filter')
   })
 
-  it('treats whitespace-only searchQuery as a non-empty query (current behavior)', () => {
+  it('treats a whitespace-only query as a real search rather than an empty one', () => {
     // Document the current contract: the helper checks `length > 0`, so
     // a single space counts. SkillsList trims-on-input is the right place
     // to change this if the UX wants to ignore whitespace; the helper only
     // mirrors the upstream value verbatim.
-    expect(
-      getEmptyListMessage({
-        searchQuery: ' ',
-        selectedSources: [],
-        selectedAgentId: null,
-        skillTypeFilter: 'all',
-      }),
-    ).toBe('No skills match your search')
+    // Arrange: a single-space search query.
+    // Act
+    const message = getEmptyListMessage({
+      searchQuery: ' ',
+      selectedSources: [],
+      selectedAgentId: null,
+      skillTypeFilter: 'all',
+    })
+
+    // Assert
+    expect(message).toBe('No skills match your search')
   })
 })

--- a/src/renderer/src/components/skills/sourceLinkHelpers.test.ts
+++ b/src/renderer/src/components/skills/sourceLinkHelpers.test.ts
@@ -6,33 +6,54 @@ import { getSourceLinkModel } from './sourceLinkHelpers'
 
 describe('getSourceLinkModel', () => {
   describe('local (no source)', () => {
-    it('returns local when source is undefined', () => {
-      expect(getSourceLinkModel()).toEqual({ kind: 'local' })
+    it('marks a skill with no source repo as local', () => {
+      // Arrange — a skill installed without any source repository.
+      // Act
+      const model = getSourceLinkModel()
+
+      // Assert
+      expect(model).toEqual({ kind: 'local' })
     })
 
-    it('returns local even when sourceUrl is provided but source is missing', () => {
-      expect(getSourceLinkModel(undefined, 'https://github.com/x/y')).toEqual({
-        kind: 'local',
-      })
+    it('still marks a skill as local when a sourceUrl exists but the source repo is missing', () => {
+      // Arrange — a stray sourceUrl with no owning source repo.
+      // Act
+      const model = getSourceLinkModel(undefined, 'https://github.com/x/y')
+
+      // Assert
+      expect(model).toEqual({ kind: 'local' })
     })
 
-    it('returns local when source is empty string', () => {
-      expect(getSourceLinkModel(repositoryId(''))).toEqual({ kind: 'local' })
+    it('treats an empty-string source as a local skill', () => {
+      // Arrange — an empty source repo id.
+      // Act
+      const model = getSourceLinkModel(repositoryId(''))
+
+      // Assert
+      expect(model).toEqual({ kind: 'local' })
     })
   })
 
   describe('text (source without URL)', () => {
-    it('returns text when source is present but sourceUrl is undefined', () => {
-      expect(getSourceLinkModel(repositoryId('pbakaus/impeccable'))).toEqual({
+    it('shows the source repo as plain text when there is no URL to link to', () => {
+      // Arrange — a source repo id with no accompanying URL.
+      // Act
+      const model = getSourceLinkModel(repositoryId('pbakaus/impeccable'))
+
+      // Assert
+      expect(model).toEqual({
         kind: 'text',
         source: 'pbakaus/impeccable',
       })
     })
 
-    it('returns text when sourceUrl is empty string', () => {
-      expect(
-        getSourceLinkModel(repositoryId('pbakaus/impeccable'), ''),
-      ).toEqual({
+    it('shows the source repo as plain text when the URL is an empty string', () => {
+      // Arrange — a source repo id with an empty URL.
+      // Act
+      const model = getSourceLinkModel(repositoryId('pbakaus/impeccable'), '')
+
+      // Assert
+      expect(model).toEqual({
         kind: 'text',
         source: 'pbakaus/impeccable',
       })
@@ -40,39 +61,48 @@ describe('getSourceLinkModel', () => {
   })
 
   describe('link (source with URL)', () => {
-    it('strips trailing .git from sourceUrl', () => {
-      expect(
-        getSourceLinkModel(
-          repositoryId('pbakaus/impeccable'),
-          'https://github.com/pbakaus/impeccable.git',
-        ),
-      ).toEqual({
+    it('drops a trailing .git so the rendered link points at the browsable repo page', () => {
+      // Arrange — a clone URL that ends in .git.
+      // Act
+      const model = getSourceLinkModel(
+        repositoryId('pbakaus/impeccable'),
+        'https://github.com/pbakaus/impeccable.git',
+      )
+
+      // Assert
+      expect(model).toEqual({
         kind: 'link',
         source: 'pbakaus/impeccable',
         href: 'https://github.com/pbakaus/impeccable',
       })
     })
 
-    it('leaves non-.git URLs unchanged', () => {
-      expect(
-        getSourceLinkModel(
-          repositoryId('pbakaus/impeccable'),
-          'https://github.com/pbakaus/impeccable',
-        ),
-      ).toEqual({
+    it('keeps a plain repo URL intact when it has no .git suffix', () => {
+      // Arrange — a browsable repo URL with no .git suffix.
+      // Act
+      const model = getSourceLinkModel(
+        repositoryId('pbakaus/impeccable'),
+        'https://github.com/pbakaus/impeccable',
+      )
+
+      // Assert
+      expect(model).toEqual({
         kind: 'link',
         source: 'pbakaus/impeccable',
         href: 'https://github.com/pbakaus/impeccable',
       })
     })
 
-    it('only strips .git at the end, not mid-string', () => {
-      expect(
-        getSourceLinkModel(
-          repositoryId('foo/bar.git-assets'),
-          'https://github.com/foo/bar.git-assets',
-        ),
-      ).toEqual({
+    it('only strips .git at the very end so a mid-string ".git-assets" repo survives', () => {
+      // Arrange — a repo whose name legitimately contains ".git" mid-string.
+      // Act
+      const model = getSourceLinkModel(
+        repositoryId('foo/bar.git-assets'),
+        'https://github.com/foo/bar.git-assets',
+      )
+
+      // Assert
+      expect(model).toEqual({
         kind: 'link',
         source: 'foo/bar.git-assets',
         href: 'https://github.com/foo/bar.git-assets',

--- a/src/renderer/src/components/theme/ThemeSelector.browser.test.tsx
+++ b/src/renderer/src/components/theme/ThemeSelector.browser.test.tsx
@@ -45,12 +45,17 @@ async function renderThemeSelector() {
 }
 
 describe('ThemeSelector — Pattern 1 layout', () => {
-  it('renders the trigger button with an accessible name', async () => {
+  it('exposes the theme trigger by accessible name for screen-reader users', async () => {
+    // Arrange
     const { screen } = await renderThemeSelector()
 
-    await expect
-      .element(screen.getByRole('button', { name: /Theme and color options/i }))
-      .toBeInTheDocument()
+    // Act
+    const trigger = screen.getByRole('button', {
+      name: /Theme and color options/i,
+    })
+
+    // Assert
+    await expect.element(trigger).toBeInTheDocument()
   })
 
   it('renders all 17 accent swatch buttons when the menu opens', async () => {
@@ -129,10 +134,9 @@ describe('ThemeSelector — Pattern 1 layout', () => {
       .toBeInTheDocument()
   })
 
-  it('clicking a color swatch dispatches setTheme(presetName) with correct hue/chroma', async () => {
+  it('applies the Cyan accent hue and chroma when its swatch is picked', async () => {
     // Arrange
     const { screen, store } = await renderThemeSelector()
-    const { THEME_PRESETS } = await import('@/shared/constants')
 
     // Act
     await screen
@@ -140,14 +144,15 @@ describe('ThemeSelector — Pattern 1 layout', () => {
       .click()
     await screen.getByRole('button', { name: 'Select Cyan theme' }).click()
 
-    // Assert
+    // Assert — hard-coded from THEME_PRESETS.cyan so a drifted hue/chroma in
+    // constants.ts is caught here instead of mirrored into the expectation.
     const { theme } = store.getState()
     expect(theme.preset).toBe('cyan')
-    expect(theme.hue).toBe(THEME_PRESETS.cyan.hue)
-    expect(theme.chroma).toBe(THEME_PRESETS.cyan.chroma)
+    expect(theme.hue).toBe(195)
+    expect(theme.chroma).toBe(0.16)
   })
 
-  it('aria-pressed reflects the currently selected color preset', async () => {
+  it('marks only the active accent swatch as pressed for assistive tech', async () => {
     // Arrange — seed a non-default preset before opening the menu so the
     // component reads it on first render. Guards against a regression where
     // aria-pressed was hard-wired to the initial state and never updated.
@@ -169,7 +174,7 @@ describe('ThemeSelector — Pattern 1 layout', () => {
       .toHaveAttribute('aria-pressed', 'false')
   })
 
-  it('clicking Zinc family in Dark mode dispatches setTheme("zinc-dark")', async () => {
+  it('picks the dark Zinc partner when the Zinc family is chosen in Dark mode', async () => {
     // Arrange — initial mode is dark; user opens the dropdown.
     const { screen, store } = await renderThemeSelector()
 
@@ -185,7 +190,7 @@ describe('ThemeSelector — Pattern 1 layout', () => {
     expect(theme.mode).toBe('dark')
   })
 
-  it('clicking Zinc family in Light mode dispatches setTheme("zinc-light")', async () => {
+  it('picks the light Zinc partner when the Zinc family is chosen in Light mode', async () => {
     // Arrange — pin Light before opening the menu.
     const { screen, store } = await renderThemeSelector()
     const { setModePreference } =
@@ -204,7 +209,7 @@ describe('ThemeSelector — Pattern 1 layout', () => {
     expect(theme.mode).toBe('light')
   })
 
-  it('clicking the Light segmented item dispatches setModePreference("light")', async () => {
+  it('switches the app to Light appearance when the Light segment is clicked', async () => {
     // Arrange
     const { screen, store } = await renderThemeSelector()
     expect(store.getState().theme.modePreference).toBe('dark')
@@ -220,7 +225,7 @@ describe('ThemeSelector — Pattern 1 layout', () => {
     expect(store.getState().theme.modePreference).toBe('light')
   })
 
-  it('clicking the Dark segmented item dispatches setModePreference("dark")', async () => {
+  it('switches the app to Dark appearance when the Dark segment is clicked', async () => {
     // Arrange — start from Light so the Dark click is observable.
     const { screen, store } = await renderThemeSelector()
     const { setModePreference } =
@@ -238,7 +243,7 @@ describe('ThemeSelector — Pattern 1 layout', () => {
     expect(store.getState().theme.modePreference).toBe('dark')
   })
 
-  it('clicking the Auto segmented item dispatches setModePreference("system")', async () => {
+  it('follows the OS appearance when the Auto segment is clicked', async () => {
     // Arrange
     const { screen, store } = await renderThemeSelector()
 

--- a/src/renderer/src/components/ui/FilterPill.browser.test.tsx
+++ b/src/renderer/src/components/ui/FilterPill.browser.test.tsx
@@ -11,7 +11,8 @@ import { FilterPill } from './FilterPill'
  * tests exercise the integration; this file stays focused on the primitive.
  */
 describe('FilterPill', () => {
-  it('renders "Showing skills <label>" and calls onClear on Clear click', async () => {
+  it('shows "Showing skills <label>" and clears the filter when Clear is clicked', async () => {
+    // Arrange
     const onClear = vi.fn()
     const screen = await render(
       <FilterPill
@@ -24,14 +25,18 @@ describe('FilterPill', () => {
         testId="agent-filter-pill"
       />,
     )
-
     const pill = screen.getByTestId('agent-filter-pill')
+
+    // Assert
     await expect.element(pill).toBeInTheDocument()
     await expect
       .element(pill)
       .toHaveTextContent('Showing skills for Claude Code')
 
+    // Act
     await pill.getByRole('button', { name: /Clear/i }).click()
+
+    // Assert
     expect(onClear).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/hooks/useCodePreview.browser.test.tsx
+++ b/src/renderer/src/hooks/useCodePreview.browser.test.tsx
@@ -68,15 +68,18 @@ afterEach(() => {
 })
 
 describe('useCodePreview', () => {
-  it('loads files and auto-selects first file content', async () => {
+  it('auto-selects and previews the first file when a skill is opened', async () => {
+    // Arrange
     const file = makeFile()
     const body = makeTextContent()
     listMock.mockResolvedValue([file])
     readMock.mockResolvedValue(body)
 
+    // Act
     const { useCodePreview } = await import('./useCodePreview')
     const { result } = await renderHook(() => useCodePreview('/skills/tdd'))
 
+    // Assert
     // Poll the loaded content instead of `loading === false`. `loading` starts
     // false and transitions true→false, so a `loading === false` poll can race
     // past the effect and observe the pre-load snapshot.
@@ -88,12 +91,15 @@ describe('useCodePreview', () => {
     expect(result.current.loading).toBe(false)
   })
 
-  it('handles empty skill by leaving content empty', async () => {
+  it('shows an empty preview and reads no file content when the skill has no files', async () => {
+    // Arrange
     listMock.mockResolvedValue([])
 
+    // Act
     const { useCodePreview } = await import('./useCodePreview')
     const { result } = await renderHook(() => useCodePreview('/skills/empty'))
 
+    // Assert
     // `content` is `{kind:'empty'}` before AND after the effect for this case,
     // so gate on the IPC call count instead to prove the effect actually ran.
     await expect.poll(() => listMock.mock.calls.length).toBe(1)
@@ -103,7 +109,8 @@ describe('useCodePreview', () => {
     expect(readMock).not.toHaveBeenCalled()
   })
 
-  it('setActiveFile fetches selected file content', async () => {
+  it('previews a different file when the user selects it', async () => {
+    // Arrange
     const first = makeFile()
     const second = makeFile({
       name: 'notes.md',
@@ -126,15 +133,18 @@ describe('useCodePreview', () => {
       .poll(() => result.current.content)
       .toEqual({ kind: 'text', data: firstBody })
 
+    // Act
     await act(async () => {
       await result.current.setActiveFile(second.path)
     })
 
+    // Assert
     expect(result.current.activeFile).toBe(second.path)
     expect(result.current.content).toEqual({ kind: 'text', data: secondBody })
   })
 
-  it('setActiveFile is a no-op when clicking the already-active file', async () => {
+  it('does not re-fetch when the user re-selects the file already being previewed', async () => {
+    // Arrange
     const file = makeFile()
     listMock.mockResolvedValue([file])
     readMock.mockResolvedValue(makeTextContent())
@@ -147,15 +157,18 @@ describe('useCodePreview', () => {
     await expect.poll(() => result.current.activeFile).toBe(file.path)
     expect(readMock).toHaveBeenCalledTimes(1)
 
+    // Act
     await act(async () => {
       await result.current.setActiveFile(file.path)
     })
 
+    // Assert
     // No extra read — the guard short-circuited before the IPC call
     expect(readMock).toHaveBeenCalledTimes(1)
   })
 
-  it('race guard: user selection wins over slow initial-load setContent', async () => {
+  it('keeps the user-selected file showing when a slow initial-load read finally resolves', async () => {
+    // Arrange
     const first = makeFile()
     const second = makeFile({
       name: 'notes.md',
@@ -193,22 +206,29 @@ describe('useCodePreview', () => {
       .poll(() => readMock.mock.calls.some((c) => c[0] === first.path))
       .toBe(true)
 
+    // Act
     await act(async () => {
       await result.current.setActiveFile(second.path)
     })
+
+    // Assert
     expect(result.current.activeFile).toBe(second.path)
     expect(result.current.content).toEqual({ kind: 'text', data: secondBody })
 
+    // Act
     // Now the slow initial read resolves — it must NOT clobber user's selection.
     await act(async () => {
       resolveFirst?.(makeTextContent())
       await Promise.resolve()
     })
+
+    // Assert
     expect(result.current.activeFile).toBe(second.path)
     expect(result.current.content).toEqual({ kind: 'text', data: secondBody })
   })
 
-  it('race guard: subsequent user selection wins over slow prior setActiveFile', async () => {
+  it('keeps the latest selection showing when a slow earlier selection finally resolves', async () => {
+    // Arrange
     const first = makeFile()
     const second = makeFile({
       name: 'notes.md',
@@ -247,6 +267,7 @@ describe('useCodePreview', () => {
       .poll(() => result.current.content)
       .toEqual({ kind: 'text', data: firstBody })
 
+    // Act
     // Fire the slow click — don't await so the fetch stays pending.
     let slowPromise: Promise<void> | null = null
     await act(async () => {
@@ -255,25 +276,34 @@ describe('useCodePreview', () => {
       // the next setActiveFile call reads `activeFile` via closure.
       await Promise.resolve()
     })
+
+    // Assert
     expect(result.current.activeFile).toBe(second.path)
 
+    // Act
     // Fire the winning click — this one resolves quickly.
     await act(async () => {
       await result.current.setActiveFile(third.path)
     })
+
+    // Assert
     expect(result.current.activeFile).toBe(third.path)
     expect(result.current.content).toEqual({ kind: 'text', data: thirdBody })
 
+    // Act
     // Now resolve the hanging read(second). Guard must drop its result.
     await act(async () => {
       resolveSecond?.(makeTextContent({ name: 'notes.md', content: 'stale' }))
       await slowPromise
     })
+
+    // Assert
     expect(result.current.activeFile).toBe(third.path)
     expect(result.current.content).toEqual({ kind: 'text', data: thirdBody })
   })
 
-  it('skillPath change resets state synchronously', async () => {
+  it('clears the previous file preview immediately when the user switches to another skill', async () => {
+    // Arrange
     const fileA = makeFile({
       path: '/skills/a/SKILL.md',
       relativePath: 'SKILL.md',
@@ -309,8 +339,10 @@ describe('useCodePreview', () => {
       .poll(() => result.current.content)
       .toEqual({ kind: 'text', data: bodyA })
 
+    // Act
     rerender({ path: '/skills/b' })
 
+    // Assert
     // Synchronous reset branch: the render-phase `setUserSelectedFile(null)`
     // + `setContent({kind:'empty'})` in useCodePreview fire when
     // `prevSkillPathRef.current !== skillPath`. With the listMock for path B
@@ -320,6 +352,7 @@ describe('useCodePreview', () => {
     await expect.poll(() => result.current.loading).toBe(true)
     expect(result.current.content).toEqual({ kind: 'empty' })
 
+    // Act
     // Unblock path B's IPC and verify the eventual happy path. Wrapping the
     // resolver call in `act()` keeps effect flushing under React's control
     // and sidesteps TS's closure-narrowing of `resolveListB` to `null`.
@@ -327,6 +360,8 @@ describe('useCodePreview', () => {
       resolveListB?.([fileB])
       await Promise.resolve()
     })
+
+    // Assert
     await expect
       .poll(() => result.current.content)
       .toEqual({ kind: 'text', data: bodyB })
@@ -334,7 +369,8 @@ describe('useCodePreview', () => {
     expect(result.current.loading).toBe(false)
   })
 
-  it('routes image files through readBinary', async () => {
+  it('previews an image file through the binary reader without calling the text reader', async () => {
+    // Arrange
     const image = makeFile({
       name: 'logo.png',
       path: '/skills/tdd/logo.png',
@@ -351,16 +387,19 @@ describe('useCodePreview', () => {
     listMock.mockResolvedValue([image])
     readBinaryMock.mockResolvedValue(binary)
 
+    // Act
     const { useCodePreview } = await import('./useCodePreview')
     const { result } = await renderHook(() => useCodePreview('/skills/tdd'))
 
+    // Assert
     await expect
       .poll(() => result.current.content)
       .toEqual({ kind: 'image', data: binary })
     expect(readMock).not.toHaveBeenCalled()
   })
 
-  it('falls back to binary placeholder for oversized files', async () => {
+  it('shows a placeholder instead of reading content for an oversized file', async () => {
+    // Arrange
     const big = makeFile({
       name: 'dump.bin',
       path: '/skills/tdd/dump.bin',
@@ -371,9 +410,11 @@ describe('useCodePreview', () => {
     })
     listMock.mockResolvedValue([big])
 
+    // Act
     const { useCodePreview } = await import('./useCodePreview')
     const { result } = await renderHook(() => useCodePreview('/skills/tdd'))
 
+    // Assert
     await expect
       .poll(() => result.current.content)
       .toEqual({

--- a/src/renderer/src/hooks/useLifecycleEffects.browser.test.tsx
+++ b/src/renderer/src/hooks/useLifecycleEffects.browser.test.tsx
@@ -9,69 +9,90 @@ import { useUpdateEffect } from './useUpdateEffect'
 
 describe('lifecycle effect hooks', () => {
   describe('useInitialEffect', () => {
-    it('runs on mount only', async () => {
+    it('runs the effect once on mount and never again on re-render', async () => {
+      // Arrange
       const effect = vi.fn()
+      // Act
       const { rerender } = await renderHook(() => useInitialEffect(effect))
-
+      // Assert
       expect(effect).toHaveBeenCalledOnce()
-      await rerender()
-      await rerender()
 
+      // Act
+      await rerender()
+      await rerender()
+      // Assert
       expect(effect).toHaveBeenCalledOnce()
     })
   })
 
   describe('useUpdateEffect', () => {
-    it('skips mount and runs after every re-render when deps are omitted', async () => {
+    it('skips the mount run and fires on every re-render when deps are omitted', async () => {
+      // Arrange
       const effect = vi.fn()
+      // Act
       const { rerender } = await renderHook(() => useUpdateEffect(effect))
-
+      // Assert
       expect(effect).not.toHaveBeenCalled()
-      await rerender()
-      await rerender()
 
+      // Act
+      await rerender()
+      await rerender()
+      // Assert
       expect(effect).toHaveBeenCalledTimes(2)
     })
 
-    it('runs after a dependency changes post-mount', async () => {
+    it('skips the mount run and fires only when a dependency changes', async () => {
+      // Arrange
       const effect = vi.fn()
       let value = 0
+      // Act
       const { rerender } = await renderHook(() =>
         useUpdateEffect(effect, [value]),
       )
-
+      // Assert
       expect(effect).not.toHaveBeenCalled()
+
+      // Act
       await rerender()
+      // Assert
       expect(effect).not.toHaveBeenCalled()
 
+      // Act
       value = 1
       await rerender()
+      // Assert
       expect(effect).toHaveBeenCalledOnce()
     })
 
-    it('rejects empty dependency lists at the type level', async () => {
+    it('rejects an empty dependency list at compile time and never runs the effect', async () => {
+      // Arrange
       const effect = vi.fn()
+      // Act
       await renderHook(() =>
         // @ts-expect-error - omit deps for every update, or pass non-empty deps.
         useUpdateEffect(effect, []),
       )
-
+      // Assert
       expect(effect).not.toHaveBeenCalled()
     })
   })
 
   describe('useUnmountEffect', () => {
-    it('runs only on unmount', async () => {
+    it('runs the callback only when the component unmounts', async () => {
+      // Arrange
       const callback = vi.fn()
       const { unmount } = await renderHook(() => useUnmountEffect(callback))
-
+      // Assert
       expect(callback).not.toHaveBeenCalled()
-      unmount()
 
+      // Act
+      unmount()
+      // Assert
       expect(callback).toHaveBeenCalledOnce()
     })
 
-    it('uses the latest callback when unmounting after re-render', async () => {
+    it('runs the latest callback on unmount, not the one captured at mount', async () => {
+      // Arrange
       const initialCallback = vi.fn()
       const latestCallback = vi.fn()
       let callback = initialCallback
@@ -79,76 +100,95 @@ describe('lifecycle effect hooks', () => {
         useUnmountEffect(callback),
       )
 
+      // Act
       callback = latestCallback
       await rerender()
       unmount()
 
+      // Assert
       expect(initialCallback).not.toHaveBeenCalled()
       expect(latestCallback).toHaveBeenCalledOnce()
     })
   })
 
   describe('useRenderEffect', () => {
-    it('runs on every render when deps are omitted', async () => {
+    it('runs the effect on mount and on every re-render when deps are omitted', async () => {
+      // Arrange
       const effect = vi.fn()
       const { rerender } = await renderHook(() => useRenderEffect(effect))
-
+      // Assert
       expect(effect).toHaveBeenCalledTimes(1)
-      await rerender()
-      await rerender()
 
+      // Act
+      await rerender()
+      await rerender()
+      // Assert
       expect(effect).toHaveBeenCalledTimes(3)
     })
 
-    it('runs on mount and non-empty dependency changes', async () => {
+    it('runs the effect on mount and only when a non-empty dependency changes', async () => {
+      // Arrange
       const effect = vi.fn()
       let value = 0
       const { rerender } = await renderHook(() =>
         useRenderEffect(effect, [value]),
       )
-
+      // Assert
       expect(effect).toHaveBeenCalledTimes(1)
+
+      // Act
       await rerender()
+      // Assert
       expect(effect).toHaveBeenCalledTimes(1)
 
+      // Act
       value = 1
       await rerender()
+      // Assert
       expect(effect).toHaveBeenCalledTimes(2)
     })
 
-    it('rejects empty dependency lists at the type level', async () => {
+    it('rejects an empty dependency list at compile time but still runs once on mount', async () => {
+      // Arrange
       const effect = vi.fn()
+      // Act
       await renderHook(() =>
         // @ts-expect-error - useInitialEffect owns mount-only `[]` semantics.
         useRenderEffect(effect, []),
       )
-
+      // Assert
       expect(effect).toHaveBeenCalledOnce()
     })
   })
 
   describe('useCycleEffect', () => {
-    it('matches useEffect with empty deps', async () => {
+    it('behaves like useEffect with empty deps by running once on mount only', async () => {
+      // Arrange
       const effect = vi.fn()
       const { rerender } = await renderHook(() => useCycleEffect(effect, []))
-
+      // Assert
       expect(effect).toHaveBeenCalledOnce()
-      await rerender()
 
+      // Act
+      await rerender()
+      // Assert
       expect(effect).toHaveBeenCalledOnce()
     })
 
-    it('matches useEffect with non-empty deps', async () => {
+    it('behaves like useEffect with non-empty deps by re-running when a dependency changes', async () => {
+      // Arrange
       const effect = vi.fn()
       let value = 0
       const { rerender } = await renderHook(() =>
         useCycleEffect(effect, [value]),
       )
-
+      // Assert
       expect(effect).toHaveBeenCalledTimes(1)
+
+      // Act
       value = 1
       await rerender()
-
+      // Assert
       expect(effect).toHaveBeenCalledTimes(2)
     })
   })

--- a/src/renderer/src/hooks/useOpenFolder.browser.test.tsx
+++ b/src/renderer/src/hooks/useOpenFolder.browser.test.tsx
@@ -31,18 +31,22 @@ afterEach(() => {
 })
 
 describe('useOpenFolder', () => {
-  it('does not toast on successful revealInFinder', async () => {
+  it('does not show an error toast when revealInFinder succeeds', async () => {
+    // Arrange
     revealMock.mockResolvedValue({ ok: true })
     const { useOpenFolder } = await import('./useOpenFolder')
     const { result } = await renderHook(() => useOpenFolder())
 
+    // Act
     await result.current.revealInFinder('/x' as never)
 
+    // Assert
     expect(revealMock).toHaveBeenCalledWith('/x')
     expect(toastErrorMock).not.toHaveBeenCalled()
   })
 
-  it('toasts the error message on failed revealInFinder', async () => {
+  it('shows the failure message as an error toast when revealInFinder fails', async () => {
+    // Arrange
     revealMock.mockResolvedValue({
       ok: false,
       reason: 'launch-failed',
@@ -51,24 +55,30 @@ describe('useOpenFolder', () => {
     const { useOpenFolder } = await import('./useOpenFolder')
     const { result } = await renderHook(() => useOpenFolder())
 
+    // Act
     await result.current.revealInFinder('/x' as never)
 
+    // Assert
     expect(toastErrorMock).toHaveBeenCalledTimes(1)
     expect(toastErrorMock).toHaveBeenCalledWith('boom')
   })
 
-  it('does not toast on successful openInTerminal', async () => {
+  it('does not show an error toast when openInTerminal succeeds', async () => {
+    // Arrange
     openTerminalMock.mockResolvedValue({ ok: true })
     const { useOpenFolder } = await import('./useOpenFolder')
     const { result } = await renderHook(() => useOpenFolder())
 
+    // Act
     await result.current.openInTerminal('/x' as never)
 
+    // Assert
     expect(openTerminalMock).toHaveBeenCalledWith('/x')
     expect(toastErrorMock).not.toHaveBeenCalled()
   })
 
-  it('toasts the error message on failed openInTerminal', async () => {
+  it('shows the failure message as an error toast when openInTerminal fails', async () => {
+    // Arrange
     openTerminalMock.mockResolvedValue({
       ok: false,
       reason: 'not-found',
@@ -77,49 +87,59 @@ describe('useOpenFolder', () => {
     const { useOpenFolder } = await import('./useOpenFolder')
     const { result } = await renderHook(() => useOpenFolder())
 
+    // Act
     await result.current.openInTerminal('/missing' as never)
 
+    // Assert
     expect(toastErrorMock).toHaveBeenCalledWith('Folder not found: /missing')
   })
 
-  it('toasts a fallback message when revealInFinder rejects (e.g. main rethrows EPERM)', async () => {
+  it('shows a fallback error toast when revealInFinder rejects (e.g. main rethrows EPERM)', async () => {
     // The main process rethrows unexpected errors (EPERM, etc.) past the
     // structured `{ok:false}` boundary — see folder.ts. Without try/catch
     // here the user would get no feedback at all on those paths.
+    // Arrange
     revealMock.mockRejectedValue(new Error('EPERM'))
     const { useOpenFolder } = await import('./useOpenFolder')
     const { result } = await renderHook(() => useOpenFolder())
 
+    // Act
     await result.current.revealInFinder('/locked' as never)
 
+    // Assert
     expect(toastErrorMock).toHaveBeenCalledTimes(1)
     expect(toastErrorMock).toHaveBeenCalledWith(
       'Failed to reveal folder in Finder',
     )
   })
 
-  it('toasts a fallback message when openInTerminal rejects', async () => {
+  it('shows a fallback error toast when openInTerminal rejects', async () => {
+    // Arrange
     openTerminalMock.mockRejectedValue(new Error('EPERM'))
     const { useOpenFolder } = await import('./useOpenFolder')
     const { result } = await renderHook(() => useOpenFolder())
 
+    // Act
     await result.current.openInTerminal('/locked' as never)
 
+    // Assert
     expect(toastErrorMock).toHaveBeenCalledWith(
       'Failed to open folder in terminal',
     )
   })
 
-  it('returns referentially-stable callbacks across re-renders', async () => {
+  it('keeps the same callback references across re-renders so consumers do not re-run effects', async () => {
+    // Arrange
     revealMock.mockResolvedValue({ ok: true })
     const { useOpenFolder } = await import('./useOpenFolder')
     const { result, rerender } = await renderHook(() => useOpenFolder())
-
     const firstReveal = result.current.revealInFinder
     const firstOpen = result.current.openInTerminal
 
+    // Act
     await rerender()
 
+    // Assert
     expect(result.current.revealInFinder).toBe(firstReveal)
     expect(result.current.openInTerminal).toBe(firstOpen)
   })

--- a/src/renderer/src/lib/syncHelpers.test.ts
+++ b/src/renderer/src/lib/syncHelpers.test.ts
@@ -39,21 +39,35 @@ function buildPreview(
 }
 
 describe('shouldShowSyncConfirm', () => {
-  it('returns false when preview is null', () => {
-    expect(shouldShowSyncConfirm(null)).toBe(false)
+  it('keeps the sync confirm dialog hidden when there is no preview to confirm', () => {
+    // Arrange
+    const noPreview = null
+    // Act
+    const shouldShow = shouldShowSyncConfirm(noPreview)
+    // Assert
+    expect(shouldShow).toBe(false)
   })
 
-  it('returns true when toCreate > 0 and no conflicts', () => {
+  it('opens the sync confirm dialog when there are new symlinks to create and no conflicts', () => {
+    // Arrange
     const preview = buildPreview({ toCreate: 8 })
-    expect(shouldShowSyncConfirm(preview)).toBe(true)
+    // Act
+    const shouldShow = shouldShowSyncConfirm(preview)
+    // Assert
+    expect(shouldShow).toBe(true)
   })
 
-  it('returns false when toCreate is 0 (already synced)', () => {
+  it('keeps the sync confirm dialog hidden when everything is already synced', () => {
+    // Arrange
     const preview = buildPreview({ toCreate: 0, alreadySynced: 50 })
-    expect(shouldShowSyncConfirm(preview)).toBe(false)
+    // Act
+    const shouldShow = shouldShowSyncConfirm(preview)
+    // Assert
+    expect(shouldShow).toBe(false)
   })
 
-  it('returns false when conflicts exist (conflict dialog handles this)', () => {
+  it('defers to the conflict dialog instead of the confirm dialog when conflicts exist', () => {
+    // Arrange
     const preview = buildPreview({
       toCreate: 3,
       conflicts: [
@@ -65,21 +79,34 @@ describe('shouldShowSyncConfirm', () => {
         },
       ],
     })
-    expect(shouldShowSyncConfirm(preview)).toBe(false)
+    // Act
+    const shouldShow = shouldShowSyncConfirm(preview)
+    // Assert
+    expect(shouldShow).toBe(false)
   })
 
-  it('returns false when both toCreate is 0 and no conflicts', () => {
+  it('keeps the sync confirm dialog hidden when there is nothing to create and no conflicts', () => {
+    // Arrange
     const preview = buildPreview({ toCreate: 0, conflicts: [] })
-    expect(shouldShowSyncConfirm(preview)).toBe(false)
+    // Act
+    const shouldShow = shouldShowSyncConfirm(preview)
+    // Assert
+    expect(shouldShow).toBe(false)
   })
 })
 
 describe('shouldShowSyncResult', () => {
-  it('returns false when result is null', () => {
-    expect(shouldShowSyncResult(null)).toBe(false)
+  it('keeps the sync result dialog hidden when no sync has run yet', () => {
+    // Arrange
+    const noResult = null
+    // Act
+    const shouldShow = shouldShowSyncResult(noResult)
+    // Assert
+    expect(shouldShow).toBe(false)
   })
 
-  it('returns true when a valid result is provided', () => {
+  it('opens the sync result dialog after a successful sync completes', () => {
+    // Arrange
     const result: SyncExecuteResult = {
       success: true,
       created: 3,
@@ -90,10 +117,14 @@ describe('shouldShowSyncResult', () => {
         { skillName: 'my-skill', agentName: 'Claude Code', action: 'created' },
       ],
     }
-    expect(shouldShowSyncResult(result)).toBe(true)
+    // Act
+    const shouldShow = shouldShowSyncResult(result)
+    // Assert
+    expect(shouldShow).toBe(true)
   })
 
-  it('returns true even when result has errors', () => {
+  it('still opens the sync result dialog when the sync finished with errors', () => {
+    // Arrange
     const result: SyncExecuteResult = {
       success: false,
       created: 0,
@@ -109,84 +140,121 @@ describe('shouldShowSyncResult', () => {
         },
       ],
     }
-    expect(shouldShowSyncResult(result)).toBe(true)
+    // Act
+    const shouldShow = shouldShowSyncResult(result)
+    // Assert
+    expect(shouldShow).toBe(true)
   })
 })
 
 describe('getSyncResultPresentation', () => {
-  it('returns success icon and "No changes were made" when result is empty', () => {
+  it('shows a green success state saying nothing changed when no symlinks were touched', () => {
+    // Arrange
+    const emptyResult = buildResult()
+    // Act
     const { HeaderIcon, iconColor, description } =
-      getSyncResultPresentation(buildResult())
+      getSyncResultPresentation(emptyResult)
+    // Assert
     expect(HeaderIcon).toBe(CheckCircle2)
     expect(iconColor).toBe('text-emerald-500')
     expect(description).toBe('No changes were made')
   })
 
-  it('returns success icon when only created > 0', () => {
-    const { HeaderIcon, iconColor, description } = getSyncResultPresentation(
-      buildResult({ created: 3 }),
-    )
+  it('shows a green success state counting the symlinks created', () => {
+    // Arrange
+    const createdOnlyResult = buildResult({ created: 3 })
+    // Act
+    const { HeaderIcon, iconColor, description } =
+      getSyncResultPresentation(createdOnlyResult)
+    // Assert
     expect(HeaderIcon).toBe(CheckCircle2)
     expect(iconColor).toBe('text-emerald-500')
     expect(description).toBe('Created 3 symlinks')
   })
 
-  it('uses singular "symlink" when created is 1', () => {
-    const { description } = getSyncResultPresentation(
-      buildResult({ created: 1 }),
-    )
+  it('pluralizes "symlink" in the singular when exactly one was created', () => {
+    // Arrange
+    const oneCreatedResult = buildResult({ created: 1 })
+    // Act
+    const { description } = getSyncResultPresentation(oneCreatedResult)
+    // Assert
     expect(description).toBe('Created 1 symlink')
   })
 
-  it('uses singular "conflict" when replaced is 1', () => {
-    const { description } = getSyncResultPresentation(
-      buildResult({ replaced: 1 }),
-    )
+  it('pluralizes "conflict" in the singular when exactly one was replaced', () => {
+    // Arrange
+    const oneReplacedResult = buildResult({ replaced: 1 })
+    // Act
+    const { description } = getSyncResultPresentation(oneReplacedResult)
+    // Assert
     expect(description).toBe('Replaced 1 conflict')
   })
 
-  it('joins multiple non-zero parts with comma', () => {
-    const { description } = getSyncResultPresentation(
-      buildResult({
-        created: 2,
-        replaced: 3,
-        errors: [{ path: '/a', error: 'x' }],
-      }),
-    )
+  it('combines created, replaced, and failed counts into one comma-separated summary', () => {
+    // Arrange
+    const mixedResult = buildResult({
+      created: 2,
+      replaced: 3,
+      errors: [{ path: '/a', error: 'x' }],
+    })
+    // Act
+    const { description } = getSyncResultPresentation(mixedResult)
+    // Assert
     expect(description).toBe(
       'Created 2 symlinks, Replaced 3 conflicts, 1 failed',
     )
   })
 
-  it('returns XCircle + destructive when there are only errors', () => {
-    const { HeaderIcon, iconColor, description } = getSyncResultPresentation(
-      buildResult({ errors: [{ path: '/a', error: 'boom' }] }),
-    )
+  it('shows a red error state when every change failed', () => {
+    // Arrange
+    const allFailedResult = buildResult({
+      errors: [{ path: '/a', error: 'boom' }],
+    })
+    // Act
+    const { HeaderIcon, iconColor, description } =
+      getSyncResultPresentation(allFailedResult)
+    // Assert
     expect(HeaderIcon).toBe(XCircle)
     expect(iconColor).toBe('text-destructive')
     expect(description).toBe('1 failed')
   })
 
-  it('returns AlertTriangle + amber when errors and successes coexist (partial)', () => {
-    const { HeaderIcon, iconColor } = getSyncResultPresentation(
-      buildResult({ created: 2, errors: [{ path: '/a', error: 'boom' }] }),
-    )
+  it('shows an amber partial-failure state when some changes succeeded and some failed', () => {
+    // Arrange
+    const partialFailureResult = buildResult({
+      created: 2,
+      errors: [{ path: '/a', error: 'boom' }],
+    })
+    // Act
+    const { HeaderIcon, iconColor } =
+      getSyncResultPresentation(partialFailureResult)
+    // Assert
     expect(HeaderIcon).toBe(AlertTriangle)
     expect(iconColor).toBe('text-amber-500')
   })
 
-  it('treats replaced > 0 as success for partial detection', () => {
+  it('counts a replaced conflict as a success so it shows the amber partial state alongside errors', () => {
+    // Arrange
+    const replacedWithErrorResult = buildResult({
+      replaced: 1,
+      errors: [{ path: '/a', error: 'boom' }],
+    })
+    // Act
     const { HeaderIcon, iconColor } = getSyncResultPresentation(
-      buildResult({ replaced: 1, errors: [{ path: '/a', error: 'boom' }] }),
+      replacedWithErrorResult,
     )
+    // Assert
     expect(HeaderIcon).toBe(AlertTriangle)
     expect(iconColor).toBe('text-amber-500')
   })
 
-  it('skipped-only is treated as success (all clean, nothing to do)', () => {
-    const { HeaderIcon, iconColor, description } = getSyncResultPresentation(
-      buildResult({ skipped: 5 }),
-    )
+  it('shows a green success state saying nothing changed when everything was already up to date', () => {
+    // Arrange
+    const skippedOnlyResult = buildResult({ skipped: 5 })
+    // Act
+    const { HeaderIcon, iconColor, description } =
+      getSyncResultPresentation(skippedOnlyResult)
+    // Assert
     expect(HeaderIcon).toBe(CheckCircle2)
     expect(iconColor).toBe('text-emerald-500')
     expect(description).toBe('No changes were made')

--- a/src/renderer/src/lib/utils.test.ts
+++ b/src/renderer/src/lib/utils.test.ts
@@ -3,25 +3,52 @@ import { describe, expect, it } from 'vitest'
 import { formatInstallCount, toggleArrayMember } from './utils'
 
 describe('formatInstallCount', () => {
-  it('returns em dash when count is undefined', () => {
-    expect(formatInstallCount(undefined)).toBe('—')
+  it('shows an em dash when the install count is unknown', () => {
+    // Arrange
+    const unknownCount = undefined
+    // Act
+    const label = formatInstallCount(unknownCount)
+    // Assert
+    expect(label).toBe('—')
   })
 
-  it('returns raw number string for values below 1K', () => {
-    expect(formatInstallCount(0)).toBe('0')
-    expect(formatInstallCount(999)).toBe('999')
+  it('shows small install counts as a plain number without K notation', () => {
+    // Arrange
+    const zeroCount = 0
+    const justBelowOneThousand = 999
+    // Act
+    const zeroLabel = formatInstallCount(zeroCount)
+    const belowThousandLabel = formatInstallCount(justBelowOneThousand)
+    // Assert
+    expect(zeroLabel).toBe('0')
+    expect(belowThousandLabel).toBe('999')
   })
 
-  it('formats 1K boundary as K notation', () => {
-    expect(formatInstallCount(1_000)).toBe('1.0K')
+  it('abbreviates one thousand installs as 1.0K', () => {
+    // Arrange
+    const oneThousand = 1_000
+    // Act
+    const label = formatInstallCount(oneThousand)
+    // Assert
+    expect(label).toBe('1.0K')
   })
 
-  it('rounds near 1M boundary to M notation', () => {
-    expect(formatInstallCount(999_999)).toBe('1.0M')
+  it('rounds a count just below one million up to 1.0M', () => {
+    // Arrange
+    const justBelowOneMillion = 999_999
+    // Act
+    const label = formatInstallCount(justBelowOneMillion)
+    // Assert
+    expect(label).toBe('1.0M')
   })
 
-  it('formats 1M boundary as M notation', () => {
-    expect(formatInstallCount(1_000_000)).toBe('1.0M')
+  it('abbreviates one million installs as 1.0M', () => {
+    // Arrange
+    const oneMillion = 1_000_000
+    // Act
+    const label = formatInstallCount(oneMillion)
+    // Assert
+    expect(label).toBe('1.0M')
   })
 })
 
@@ -38,19 +65,39 @@ describe('formatInstallCount', () => {
  */
 describe('toggleArrayMember', () => {
   it('appends a value when it is not already present', () => {
-    expect(toggleArrayMember(['a', 'b'], 'c')).toEqual(['a', 'b', 'c'])
+    // Arrange
+    const members = ['a', 'b']
+    // Act
+    const toggled = toggleArrayMember(members, 'c')
+    // Assert
+    expect(toggled).toEqual(['a', 'b', 'c'])
   })
 
   it('removes a value when it is already present', () => {
-    expect(toggleArrayMember(['a', 'b'], 'a')).toEqual(['b'])
+    // Arrange
+    const members = ['a', 'b']
+    // Act
+    const toggled = toggleArrayMember(members, 'a')
+    // Assert
+    expect(toggled).toEqual(['b'])
   })
 
   it('appends to an empty array', () => {
-    expect(toggleArrayMember<string>([], 'x')).toEqual(['x'])
+    // Arrange
+    const members: string[] = []
+    // Act
+    const toggled = toggleArrayMember<string>(members, 'x')
+    // Assert
+    expect(toggled).toEqual(['x'])
   })
 
   it('returns an empty array when removing the only member', () => {
-    expect(toggleArrayMember(['x'], 'x')).toEqual([])
+    // Arrange
+    const members = ['x']
+    // Act
+    const toggled = toggleArrayMember(members, 'x')
+    // Assert
+    expect(toggled).toEqual([])
   })
 
   it('returns a new reference even when the result is structurally equal to the input', () => {
@@ -58,17 +105,23 @@ describe('toggleArrayMember', () => {
     // a fresh reference for `setSettings` to be detected as a change
     // by Redux's default ===-equality checks. Aliasing the input would
     // silently drop optimistic updates.
+    // Arrange
     const input = ['a', 'b']
+    // Act
     const removed = toggleArrayMember(input, 'a')
     const appended = toggleArrayMember(input, 'c')
+    // Assert
     expect(removed).not.toBe(input)
     expect(appended).not.toBe(input)
   })
 
   it('does not mutate the input array', () => {
+    // Arrange
     const input = ['a', 'b']
+    // Act
     toggleArrayMember(input, 'a')
     toggleArrayMember(input, 'c')
+    // Assert
     expect(input).toEqual(['a', 'b'])
   })
 })

--- a/src/renderer/src/redux/listener.test.ts
+++ b/src/renderer/src/redux/listener.test.ts
@@ -50,12 +50,15 @@ beforeEach(() => {
 })
 
 describe('theme listener — applyThemeToDOM', () => {
-  it('writes --theme-hue, --theme-chroma, and .dark on setTheme(cyan)', async () => {
+  it('paints a color preset onto <html> in dark mode when the user picks Cyan', async () => {
+    // Arrange
     const store = await createThemedStore()
     const { setTheme } = await import('./slices/themeSlice')
 
+    // Act
     store.dispatch(setTheme('cyan'))
 
+    // Assert
     const root = document.documentElement
     expect(root.style.getPropertyValue('--theme-hue')).toBe('195')
     // chroma value depends on COLOR_PRESET_CHROMA; just assert it's non-zero.
@@ -66,57 +69,63 @@ describe('theme listener — applyThemeToDOM', () => {
     expect(root.classList.contains('light')).toBe(false)
   })
 
-  it('resets --theme-chroma to 0 when switching to a neutral preset', async () => {
+  it('drains color back to grayscale when the user switches to a neutral preset', async () => {
+    // Arrange — start on a colored preset so chroma is non-zero
     const store = await createThemedStore()
     const { setTheme } = await import('./slices/themeSlice')
-
     store.dispatch(setTheme('rose'))
     expect(
       Number(document.documentElement.style.getPropertyValue('--theme-chroma')),
     ).toBeGreaterThan(0)
 
+    // Act
     store.dispatch(setTheme('neutral-dark'))
+
+    // Assert
     expect(
       document.documentElement.style.getPropertyValue('--theme-chroma'),
     ).toBe('0')
   })
 
-  it('setModePreference flips .dark ↔ .light classes', async () => {
+  it('toggles the <html> dark/light classes when the user flips the mode preference', async () => {
+    // Arrange — start with a color preset so we can flip mode independently
     const store = await createThemedStore()
     const { setTheme, setModePreference } = await import('./slices/themeSlice')
-
-    // Start with a color preset so we can flip independently.
     store.dispatch(setTheme('violet'))
     expect(document.documentElement.classList.contains('dark')).toBe(true)
 
+    // Act — flip to light
     store.dispatch(setModePreference('light'))
+
+    // Assert
     expect(document.documentElement.classList.contains('dark')).toBe(false)
     expect(document.documentElement.classList.contains('light')).toBe(true)
 
+    // Act — flip back to dark
     store.dispatch(setModePreference('dark'))
+
+    // Assert
     expect(document.documentElement.classList.contains('dark')).toBe(true)
     expect(document.documentElement.classList.contains('light')).toBe(false)
   })
 
-  it('applies persisted theme on ACTION_HYDRATE_COMPLETE', async () => {
-    // Simulate storage-middleware finishing hydration with a saved color
-    // preset. The listener reads `state.theme` at that instant and projects
-    // it onto <html>. Without this path, first paint post-hydration is blank.
+  it('repaints the persisted theme onto <html> when hydration completes', async () => {
+    // Arrange — simulate storage-middleware finishing hydration with a saved
+    // color preset. The listener reads `state.theme` at that instant and
+    // projects it onto <html>. Without this path, first paint post-hydration
+    // is blank. Reset the DOM first so we only observe the hydrate effect.
     const store = await createThemedStore()
     const { setTheme } = await import('./slices/themeSlice')
-
-    // Seed state as if hydration just completed with a color preset.
     store.dispatch(setTheme('blue'))
-
-    // Fire the hydrate-complete action explicitly (separate from setTheme).
-    // Reset DOM first so we only observe the hydrate effect.
     const root = document.documentElement
     root.style.removeProperty('--theme-hue')
     root.style.removeProperty('--theme-chroma')
     root.classList.remove('dark', 'light')
 
+    // Act
     store.dispatch({ type: ACTION_HYDRATE_COMPLETE })
 
+    // Assert
     expect(root.style.getPropertyValue('--theme-hue')).toBe('250')
     expect(
       Number(root.style.getPropertyValue('--theme-chroma')),
@@ -144,13 +153,16 @@ describe('theme listener — applyThemeToDOM', () => {
         getDefault().prepend(listenerMiddleware.middleware),
     })
 
+    // Arrange — select the agent that is about to be hidden
     store.dispatch(selectAgent('claude-code'))
     expect(store.getState().ui.selectedAgentId).toBe('claude-code')
 
+    // Act — hide the currently-selected agent via Settings
     store.dispatch(
       setSettings({ ...DEFAULT_SETTINGS, hiddenAgentIds: ['claude-code'] }),
     )
 
+    // Assert
     expect(store.getState().ui.selectedAgentId).toBeNull()
   })
 
@@ -171,11 +183,15 @@ describe('theme listener — applyThemeToDOM', () => {
         getDefault().prepend(listenerMiddleware.middleware),
     })
 
+    // Arrange — select cursor, the agent that will NOT be hidden
     store.dispatch(selectAgent('cursor'))
+
+    // Act — hide a different agent (claude-code)
     store.dispatch(
       setSettings({ ...DEFAULT_SETTINGS, hiddenAgentIds: ['claude-code'] }),
     )
 
+    // Assert
     expect(store.getState().ui.selectedAgentId).toBe('cursor')
   })
 
@@ -197,13 +213,17 @@ describe('theme listener — applyThemeToDOM', () => {
         getDefault().prepend(listenerMiddleware.middleware),
     })
 
-    // Capture the ui slice reference before the settings update — if the
-    // listener's no-op short-circuit holds, the reducer is never re-run
+    // Arrange — capture the ui slice reference before the settings update; if
+    // the listener's no-op short-circuit holds, the reducer is never re-run
     // and the ui slice keeps the same reference.
     const uiBefore = store.getState().ui
+
+    // Act — a hide lands while no agent is selected
     store.dispatch(
       setSettings({ ...DEFAULT_SETTINGS, hiddenAgentIds: ['claude-code'] }),
     )
+
+    // Assert — ui slice untouched (same reference) and selection still null
     expect(store.getState().ui).toBe(uiBefore)
     expect(store.getState().ui.selectedAgentId).toBeNull()
   })
@@ -306,29 +326,29 @@ describe('theme listener — applyThemeToDOM', () => {
     expect(store.getState().theme.modePreference).toBe('light')
   })
 
-  it('rapid preset switches write to the DOM in dispatch order (no stale/async reordering)', async () => {
-    // Regression guard for the "stale listener write" class of bug — if the
-    // listener ever queues async writes (via Promise.resolve, microtask,
+  it('paints rapid preset switches onto <html> in dispatch order without stale reordering', async () => {
+    // Arrange — regression guard for the "stale listener write" class of bug:
+    // if the listener ever queues async writes (via Promise.resolve, microtask,
     // requestAnimationFrame, etc.), the order of setProperty calls could
-    // diverge from dispatch order and the final DOM could reflect an
-    // earlier preset. Asserting only on final state would miss that: we
-    // also spy on setProperty and pin the `--theme-hue` call sequence to
-    // the dispatched sequence, which is what actually catches reordering.
+    // diverge from dispatch order and the final DOM could reflect an earlier
+    // preset. Asserting only on final state would miss that: we also spy on
+    // setProperty and pin the `--theme-hue` call sequence to the dispatched
+    // sequence, which is what actually catches reordering.
     const store = await createThemedStore()
     const { setTheme } = await import('./slices/themeSlice')
-
     const setPropertySpy = vi.spyOn(
       document.documentElement.style,
       'setProperty',
     )
 
+    // Act
     store.dispatch(setTheme('rose'))
     store.dispatch(setTheme('cyan'))
     store.dispatch(setTheme('violet'))
     store.dispatch(setTheme('neutral-light'))
 
-    // Extract --theme-hue writes in the order they happened. Expected
-    // sequence mirrors the four dispatches above (350 → 195 → 300 → 0).
+    // Assert — extract --theme-hue writes in the order they happened; the
+    // expected sequence mirrors the four dispatches above (350 → 195 → 300 → 0).
     const hueWrites = setPropertySpy.mock.calls
       .filter(([prop]) => prop === '--theme-hue')
       .map(([, value]) => value)

--- a/src/renderer/src/redux/migrations.test.ts
+++ b/src/renderer/src/redux/migrations.test.ts
@@ -1,11 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { WIDGET_REGISTRY } from '@/renderer/src/components/dashboard/widgets/registry'
-import {
-  COLOR_PRESET_CHROMA,
-  PERSIST_STATE_VERSION,
-  THEME_PRESETS,
-} from '@/shared/constants'
+import { COLOR_PRESET_CHROMA, PERSIST_STATE_VERSION } from '@/shared/constants'
 
 import {
   migrateState,
@@ -39,9 +35,9 @@ type LegacyTheme = ThemeState & {
  */
 
 describe('migrateState — v0 → v1 correctness', () => {
-  it('derives chroma from THEME_PRESETS when preset name is known but presetType is missing', () => {
-    // Tampered v0 payload: valid preset but no presetType. Pre-fix this
-    // landed as { preset: 'cyan', chroma: 0 } — grayscale cyan. Post-fix
+  it('keeps a known preset in full color when the legacy presetType is missing', () => {
+    // Arrange — tampered v0 payload: valid preset but no presetType. Pre-fix
+    // this landed as { preset: 'cyan', chroma: 0 } — grayscale cyan. Post-fix
     // the preset config wins.
     const state = {
       theme: {
@@ -50,14 +46,19 @@ describe('migrateState — v0 → v1 correctness', () => {
         preset: 'cyan',
       } as unknown as LegacyTheme,
     }
+
+    // Act
     const result = migrateState(state, 0)
+
+    // Assert
     expect(result.theme).toBeDefined()
     expect(result.theme!.preset).toBe('cyan')
-    expect(result.theme!.chroma).toBe(THEME_PRESETS.cyan.chroma)
-    expect(result.theme!.hue).toBe(THEME_PRESETS.cyan.hue)
+    expect(result.theme!.chroma).toBe(0.16)
+    expect(result.theme!.hue).toBe(195)
   })
 
-  it('falls back to presetType when preset name is unknown', () => {
+  it('rescues an unknown preset name to neutral-dark while honoring its legacy color presetType', () => {
+    // Arrange
     const state = {
       theme: {
         hue: 42,
@@ -66,21 +67,31 @@ describe('migrateState — v0 → v1 correctness', () => {
         presetType: 'color',
       } as unknown as LegacyTheme,
     }
+
+    // Act
     const result = migrateState(state, 0)
+
+    // Assert
     expect(result.theme).toBeDefined()
     expect(result.theme!.preset).toBe('neutral-dark')
     // unknown preset ⇒ THEME_PRESETS['neutral-dark'].chroma === 0, so
     // the `||` short-circuits to the presetType branch (0.16 for color).
-    expect(result.theme!.chroma).toBe(COLOR_PRESET_CHROMA)
+    expect(result.theme!.chroma).toBe(0.16)
   })
 
-  it('drops malformed theme slot so reducer defaults take over', () => {
+  it('drops a malformed theme slot so reducer defaults take over', () => {
+    // Arrange
     const state = { theme: null as unknown as LegacyTheme }
+
+    // Act
     const result = migrateState(state, 0)
+
+    // Assert
     expect(result.theme).toBeUndefined()
   })
 
-  it('v1+ input passes through untouched', () => {
+  it('leaves an already-current theme untouched when the stored version is up to date', () => {
+    // Arrange
     const state = {
       theme: {
         hue: 300,
@@ -91,7 +102,11 @@ describe('migrateState — v0 → v1 correctness', () => {
       },
     }
     const before = { ...state.theme }
+
+    // Act
     const result = migrateState(state, PERSIST_STATE_VERSION)
+
+    // Assert
     expect(result.theme).toEqual(before)
   })
 })
@@ -137,61 +152,86 @@ describe('migrateState — v1 → v2 dashboard widget min-size clamp', () => {
    * render, jolting neighboring widgets. The migration clamps in the store
    * so the post-rehydrate state already satisfies the new floor.
    */
-  it('clamps quick-actions widget h: 2 up to 3', () => {
+  it('grows an undersized Quick Actions widget up to its new height floor', () => {
+    // Arrange
     const state = makeDashboardState([
       {
         widgets: [{ id: 'w1', type: 'quick-actions', x: 0, y: 0, w: 6, h: 2 }],
       },
     ])
+
+    // Act
     migrateState(state, 1)
+
+    // Assert
     expect(state.dashboard.pages[0].widgets[0].h).toBe(3)
     expect(state.dashboard.pages[0].widgets[0].w).toBe(6)
   })
 
-  it('clamps quick-actions widget w: 2 up to 3', () => {
-    // The w-branch lives next to the h-branch and never had its own assertion
-    // before. If a future bump moves minSize.w independently of minSize.h, the
-    // test that only checks h would silently miss the regression.
+  it('grows an undersized Quick Actions widget up to its new width floor', () => {
+    // Arrange — the w-branch lives next to the h-branch and never had its own
+    // assertion before. If a future bump moves minSize.w independently of
+    // minSize.h, the test that only checks h would silently miss the regression.
     const state = makeDashboardState([
       {
         widgets: [{ id: 'w1', type: 'quick-actions', x: 0, y: 0, w: 2, h: 5 }],
       },
     ])
+
+    // Act
     migrateState(state, 1)
+
+    // Assert
     expect(state.dashboard.pages[0].widgets[0].w).toBe(3)
     expect(state.dashboard.pages[0].widgets[0].h).toBe(5)
   })
 
-  it('leaves quick-actions widget h: 3 untouched (no over-clamp)', () => {
+  it('leaves a Quick Actions widget already at the height floor unchanged', () => {
+    // Arrange
     const state = makeDashboardState([
       {
         widgets: [{ id: 'w1', type: 'quick-actions', x: 0, y: 0, w: 6, h: 3 }],
       },
     ])
+
+    // Act
     migrateState(state, 1)
+
+    // Assert
     expect(state.dashboard.pages[0].widgets[0].h).toBe(3)
   })
 
-  it('leaves quick-actions widget h: 5 untouched (clamp is upward-only)', () => {
+  it('does not shrink a Quick Actions widget taller than the floor (clamp is upward-only)', () => {
+    // Arrange
     const state = makeDashboardState([
       {
         widgets: [{ id: 'w1', type: 'quick-actions', x: 0, y: 0, w: 6, h: 5 }],
       },
     ])
+
+    // Act
     migrateState(state, 1)
+
+    // Assert
     expect(state.dashboard.pages[0].widgets[0].h).toBe(5)
   })
 
-  it('does not touch widgets whose minSize did not change (e.g., stats)', () => {
+  it('leaves widgets whose minSize did not change untouched (e.g., stats)', () => {
+    // Arrange
     const state = makeDashboardState([
       { widgets: [{ id: 'w1', type: 'stats', x: 0, y: 0, w: 3, h: 2 }] },
     ])
+
+    // Act
     migrateState(state, 1)
+
+    // Assert
     expect(state.dashboard.pages[0].widgets[0].h).toBe(2)
     expect(state.dashboard.pages[0].widgets[0].w).toBe(3)
   })
 
-  it('handles missing dashboard slice gracefully', () => {
+  it('does not throw when the dashboard slice is missing', () => {
+    // Arrange
     const state = {
       theme: {
         hue: 0,
@@ -201,23 +241,31 @@ describe('migrateState — v1 → v2 dashboard widget min-size clamp', () => {
         preset: 'neutral-dark' as const,
       },
     }
+
+    // Act & Assert
     expect(() => migrateState(state, 1)).not.toThrow()
   })
 
-  it('handles malformed dashboard slice gracefully', () => {
+  it('does not throw when the dashboard slice is malformed', () => {
+    // Arrange
     const state = {
       dashboard: 'not-an-object' as unknown,
     }
+
+    // Act & Assert
     expect(() => migrateState(state, 1)).not.toThrow()
   })
 
-  it('handles dashboard with no pages array gracefully', () => {
+  it('does not throw when the dashboard has no pages array', () => {
+    // Arrange
     const state = { dashboard: {} as unknown }
+
+    // Act & Assert
     expect(() => migrateState(state, 1)).not.toThrow()
   })
 
-  it('survives null page entry without throwing (no total-wipe)', () => {
-    // A null entry inside dashboard.pages used to crash on the next
+  it('skips a null page entry and still clamps the surviving page (no total-wipe)', () => {
+    // Arrange — a null entry inside dashboard.pages used to crash on the next
     // dereference. When migrate() throws, the storage middleware calls
     // removeItem(key) and the user loses every persisted slice. The guard
     // skips the bad entry and migrates the rest.
@@ -235,14 +283,19 @@ describe('migrateState — v1 → v2 dashboard widget min-size clamp', () => {
         ],
       } as unknown,
     }
+
+    // Act
     expect(() => migrateState(state, 1)).not.toThrow()
+
+    // Assert
     const dashboard = state.dashboard as {
       pages: Array<{ widgets: Array<{ h: number }> } | null>
     }
     expect(dashboard.pages[1]?.widgets[0].h).toBe(3)
   })
 
-  it('survives null widget entry without throwing (no total-wipe)', () => {
+  it('skips a null widget entry and still clamps the surviving widget (no total-wipe)', () => {
+    // Arrange
     const state = {
       dashboard: {
         pages: [
@@ -257,14 +310,19 @@ describe('migrateState — v1 → v2 dashboard widget min-size clamp', () => {
         ],
       } as unknown,
     }
+
+    // Act
     expect(() => migrateState(state, 1)).not.toThrow()
+
+    // Assert
     const dashboard = state.dashboard as {
       pages: Array<{ widgets: Array<{ h: number } | null> }>
     }
     expect(dashboard.pages[0].widgets[1]?.h).toBe(3)
   })
 
-  it('clamps across multiple pages and multiple widgets', () => {
+  it('clamps every undersized widget across multiple pages while leaving others alone', () => {
+    // Arrange
     const state = makeDashboardState([
       {
         widgets: [
@@ -277,7 +335,11 @@ describe('migrateState — v1 → v2 dashboard widget min-size clamp', () => {
         widgets: [{ id: 'w3', type: 'quick-actions', x: 0, y: 0, w: 3, h: 2 }],
       },
     ])
+
+    // Act
     migrateState(state, 1)
+
+    // Assert
     expect(state.dashboard.pages[0].widgets[0].h).toBe(3)
     expect(state.dashboard.pages[0].widgets[1].h).toBe(2) // stats untouched
     expect(state.dashboard.pages[1].widgets[0].h).toBe(3)
@@ -399,7 +461,7 @@ describe('migrateState — v2 → v3 theme modePreference seeding', () => {
 
     // Assert
     expect(result.theme!.preset).toBe('cyan')
-    expect(result.theme!.chroma).toBe(THEME_PRESETS.cyan.chroma)
+    expect(result.theme!.chroma).toBe(0.16)
     expect(result.theme!.mode).toBe('dark')
     expect(result.theme!.modePreference).toBe('dark')
   })
@@ -445,43 +507,63 @@ describe('migrateState — v3 → v4 dashboard health min-size clamp', () => {
    * persisted on the old floor so react-grid-layout doesn't re-clamp (and shove
    * neighbors) on first render.
    */
-  it('clamps health widget h: 2 up to 3', () => {
+  it('grows an undersized Symlink Health widget up to its new height floor', () => {
+    // Arrange
     const state = makeDashboardState([
       { widgets: [{ id: 'w1', type: 'health', x: 3, y: 3, w: 3, h: 2 }] },
     ])
+
+    // Act
     migrateState(state, 3)
+
+    // Assert
     expect(state.dashboard.pages[0].widgets[0].h).toBe(3)
     expect(state.dashboard.pages[0].widgets[0].w).toBe(3)
   })
 
-  it('leaves health widget h: 3 untouched (no over-clamp)', () => {
+  it('leaves a Symlink Health widget already at the height floor unchanged', () => {
+    // Arrange
     const state = makeDashboardState([
       { widgets: [{ id: 'w1', type: 'health', x: 3, y: 3, w: 3, h: 3 }] },
     ])
+
+    // Act
     migrateState(state, 3)
+
+    // Assert
     expect(state.dashboard.pages[0].widgets[0].h).toBe(3)
   })
 
-  it('leaves health widget h: 4 untouched (clamp is upward-only)', () => {
+  it('does not shrink a Symlink Health widget taller than the floor (clamp is upward-only)', () => {
+    // Arrange
     const state = makeDashboardState([
       { widgets: [{ id: 'w1', type: 'health', x: 3, y: 3, w: 3, h: 4 }] },
     ])
+
+    // Act
     migrateState(state, 3)
+
+    // Assert
     expect(state.dashboard.pages[0].widgets[0].h).toBe(4)
   })
 
-  it('does not touch widgets outside the v4 floor map (e.g., stats)', () => {
-    // stats shares health's old { w: 3, h: 2 } footprint but is absent from
-    // V4_WIDGET_MIN_SIZES, so the v3 → v4 clamp must leave it alone.
+  it('leaves widgets outside the v4 floor map untouched (e.g., stats)', () => {
+    // Arrange — stats shares health's old { w: 3, h: 2 } footprint but is absent
+    // from V4_WIDGET_MIN_SIZES, so the v3 → v4 clamp must leave it alone.
     const state = makeDashboardState([
       { widgets: [{ id: 'w1', type: 'stats', x: 0, y: 3, w: 3, h: 2 }] },
     ])
+
+    // Act
     migrateState(state, 3)
+
+    // Assert
     expect(state.dashboard.pages[0].widgets[0].h).toBe(2)
     expect(state.dashboard.pages[0].widgets[0].w).toBe(3)
   })
 
-  it('handles missing dashboard slice gracefully', () => {
+  it('does not throw when the dashboard slice is missing', () => {
+    // Arrange
     const state = {
       theme: {
         hue: 0,
@@ -491,18 +573,24 @@ describe('migrateState — v3 → v4 dashboard health min-size clamp', () => {
         preset: 'neutral-dark' as const,
       },
     }
+
+    // Act & Assert
     expect(() => migrateState(state, 3)).not.toThrow()
   })
 
-  it('clamps health when migrating across the full v1 → v4 chain', () => {
-    // Guards that `case 3` is actually wired into the switch: a layout
+  it('clamps the Symlink Health widget when migrating across the full v1 → v4 chain', () => {
+    // Arrange — guards that `case 3` is actually wired into the switch: a layout
     // persisted way back at v1 must still pick up the v4 health floor in a
     // single migrateState() call (v1 → v2 leaves health alone, v2 → v3 is
     // theme-only, v3 → v4 clamps it).
     const state = makeDashboardState([
       { widgets: [{ id: 'w1', type: 'health', x: 3, y: 3, w: 3, h: 2 }] },
     ])
+
+    // Act
     migrateState(state, 1)
+
+    // Assert
     expect(state.dashboard.pages[0].widgets[0].h).toBe(3)
   })
 })
@@ -521,7 +609,10 @@ describe('V2_WIDGET_MIN_SIZES drift guard', () => {
   // not fail this test. That is correct for a frozen v2 floor — the right
   // response to a future registry bump is to add `V3_WIDGET_MIN_SIZES`
   // alongside a `migrateV2ToV3`, not to retroactively expand v2's scope.
-  it('mirror entries match WIDGET_REGISTRY minSize', () => {
+  it('stays in sync with the live registry so persisted v2 layouts never violate runtime minimums', () => {
+    // Act & Assert — every frozen v2 floor entry must still match the
+    // registry's current minSize; a desync fails here before users see
+    // neighbors shoved by the runtime clamp.
     for (const [type, min] of Object.entries(V2_WIDGET_MIN_SIZES)) {
       const registryEntry =
         WIDGET_REGISTRY[type as keyof typeof WIDGET_REGISTRY]
@@ -545,7 +636,10 @@ describe('V4_WIDGET_MIN_SIZES drift guard', () => {
   // constraint after upgrade. One-way by design (see the V2 guard note): a
   // future bump of a widget NOT in the v4 map is the trigger to add a V5 floor
   // + migrateV4ToV5, not to retroactively widen v4's scope.
-  it('mirror entries match WIDGET_REGISTRY minSize', () => {
+  it('stays in sync with the live registry so persisted v4 layouts never violate runtime minimums', () => {
+    // Act & Assert — every frozen v4 floor entry must still match the
+    // registry's current minSize; a desync fails here before users see
+    // neighbors shoved by the runtime clamp.
     for (const [type, min] of Object.entries(V4_WIDGET_MIN_SIZES)) {
       const registryEntry =
         WIDGET_REGISTRY[type as keyof typeof WIDGET_REGISTRY]
@@ -562,11 +656,11 @@ describe('V4_WIDGET_MIN_SIZES drift guard', () => {
 })
 
 describe('migrateState — drift guard', () => {
-  it('handles every version below PERSIST_STATE_VERSION', () => {
-    // If PERSIST_STATE_VERSION is bumped without adding a matching
-    // migrateVNToV(N+1) branch, the switch's default-case throw fires
-    // here. Keep each iteration producing a valid theme so regressions
-    // in a specific version's handler surface as a concrete failure.
+  it('migrates from every supported version without throwing when a new schema version ships', () => {
+    // Act & Assert — if PERSIST_STATE_VERSION is bumped without adding a
+    // matching migrateVNToV(N+1) branch, the switch's default-case throw fires
+    // here. Keep each iteration producing a valid theme so regressions in a
+    // specific version's handler surface as a concrete failure.
     for (let v = 0; v < PERSIST_STATE_VERSION; v++) {
       const state = {
         theme: {
@@ -581,10 +675,9 @@ describe('migrateState — drift guard', () => {
     }
   })
 
-  it('throws for an unknown source version', () => {
-    // Explicit guard: a negative or out-of-band version (corrupted
-    // localStorage) should fail fast with a clear error pointing at the
-    // missing migration branch.
+  it('fails fast with a clear error for a corrupted out-of-band source version', () => {
+    // Arrange — a negative or out-of-band version (corrupted localStorage)
+    // should fail fast with a clear error pointing at the missing branch.
     const state = {
       theme: {
         hue: 0,
@@ -594,6 +687,8 @@ describe('migrateState — drift guard', () => {
         preset: 'neutral-dark' as const,
       },
     }
+
+    // Act & Assert
     expect(() => migrateState(state, -1)).toThrow(/no path from v-1/)
   })
 })

--- a/src/renderer/src/redux/selectors.test.ts
+++ b/src/renderer/src/redux/selectors.test.ts
@@ -169,68 +169,100 @@ const makeSkill = (
 })
 
 describe('selectFilteredSkills', () => {
-  it('returns all source-dir skills when no agent is selected (SourceCard view)', () => {
+  it('shows every source-dir skill in the SourceCard view when no agent is selected', () => {
+    // Arrange
     const skills = [
       makeSkill('task', 'claude-code'),
       makeSkill('browse', 'cursor'),
     ]
     const state = buildState({ skills })
-    expect(selectFilteredSkills(state as never)).toHaveLength(2)
+
+    // Act
+    const result = selectFilteredSkills(state as never)
+
+    // Assert
+    expect(result).toHaveLength(2)
   })
 
   it('hides agent-local-only skills from the SourceCard view (no agent selected)', () => {
-    // Regression: clicking the SourceCard ("~/.agents/skills") used to leak
-    // every claude-/cursor-local skill into the list because the selector
-    // skipped filtering when selectedAgentId was null. Source-only filter
-    // keeps the SourceCard view consistent with its label.
+    // Arrange — regression: clicking the SourceCard ("~/.agents/skills") used
+    // to leak every claude-/cursor-local skill into the list because the
+    // selector skipped filtering when selectedAgentId was null. Source-only
+    // filter keeps the SourceCard view consistent with its label.
     const skills = [
       makeSkill('task', 'claude-code'), // source skill
       makeSkill('local-only', 'claude-code', true), // agent-local
     ]
     const state = buildState({ skills })
+
+    // Act
     const result = selectFilteredSkills(state as never)
+
+    // Assert
     expect(result.map((s) => s.name)).toEqual(['task'])
   })
 
-  it('filters by search query (name match)', () => {
+  it('narrows the list to skills whose name matches the search query', () => {
+    // Arrange
     const skills = [
       makeSkill('task', 'claude-code'),
       makeSkill('browse', 'cursor'),
     ]
     const state = buildState({ skills, searchQuery: 'task' })
+
+    // Act
     const result = selectFilteredSkills(state as never)
+
+    // Assert
     expect(result).toHaveLength(1)
     expect(result[0].name).toBe('task')
   })
 
-  it('does not match description, only name', () => {
+  it('matches the search query against the name only, never the description', () => {
+    // Arrange
     const skills = [
       makeSkill('task', 'claude-code'),
       makeSkill('browse', 'cursor'),
     ]
     const state = buildState({ skills, searchQuery: 'browse skill' })
+
+    // Act
     const result = selectFilteredSkills(state as never)
+
+    // Assert
     expect(result).toHaveLength(0)
   })
 
-  it('search is case-insensitive', () => {
+  it('matches the search query case-insensitively', () => {
+    // Arrange
     const skills = [makeSkill('Task', 'claude-code')]
     const state = buildState({ skills, searchQuery: 'TASK' })
-    expect(selectFilteredSkills(state as never)).toHaveLength(1)
+
+    // Act
+    const result = selectFilteredSkills(state as never)
+
+    // Assert
+    expect(result).toHaveLength(1)
   })
 
-  it('filters by selected agent', () => {
+  it('narrows the list to skills linked into the selected agent', () => {
+    // Arrange
     const skills = [
       makeSkill('task', 'claude-code'),
       makeSkill('browse', 'cursor'),
     ]
     const state = buildState({ skills, selectedAgentId: 'cursor' })
+
+    // Act
     const result = selectFilteredSkills(state as never)
+
+    // Assert
     expect(result).toHaveLength(1)
     expect(result[0].name).toBe('browse')
   })
 
-  it('combines agent filter and search query', () => {
+  it('intersects the agent filter with the search query', () => {
+    // Arrange
     const skills = [
       makeSkill('task', 'claude-code'),
       makeSkill('browse', 'cursor'),
@@ -241,7 +273,11 @@ describe('selectFilteredSkills', () => {
       selectedAgentId: 'cursor',
       searchQuery: 'browse',
     })
+
+    // Act
     const result = selectFilteredSkills(state as never)
+
+    // Assert
     expect(result).toHaveLength(1)
     expect(result[0].name).toBe('browse')
   })
@@ -252,6 +288,7 @@ describe('selectFilteredSkills', () => {
     // surface this row so the right-click "Cleanup missing skills..." flow
     // (PR #71) has something to act on. Hiding it would silently strand the
     // orphan symlink in the agent dir.
+    // Arrange
     const skill: Skill = {
       name: 'broken-skill',
       description: 'broken',
@@ -271,7 +308,11 @@ describe('selectFilteredSkills', () => {
       isOrphan: true,
     }
     const state = buildState({ skills: [skill], selectedAgentId: 'cursor' })
+
+    // Act
     const result = selectFilteredSkills(state as never)
+
+    // Assert
     expect(result).toHaveLength(1)
     expect(result[0].name).toBe('broken-skill')
     expect(result[0].isOrphan).toBe(true)
@@ -281,6 +322,7 @@ describe('selectFilteredSkills', () => {
     // status:'missing' is the scanner's way of representing an agent slot
     // with NO on-disk symlink at all — there's nothing to surface or clean
     // up, so it must not pollute the per-agent list.
+    // Arrange
     const skill: Skill = {
       name: 'unlinked-skill',
       description: 'unlinked',
@@ -300,38 +342,54 @@ describe('selectFilteredSkills', () => {
       isOrphan: false,
     }
     const state = buildState({ skills: [skill], selectedAgentId: 'cursor' })
+
+    // Act & Assert
     expect(selectFilteredSkills(state as never)).toHaveLength(0)
   })
 
-  it('returns empty array when no skills match', () => {
+  it('shows an empty list when nothing matches the filters', () => {
+    // Arrange
     const skills = [makeSkill('task', 'claude-code')]
     const state = buildState({ skills, searchQuery: 'nonexistent' })
+
+    // Act & Assert
     expect(selectFilteredSkills(state as never)).toHaveLength(0)
   })
 
-  it('sorts skills A→Z by default (asc)', () => {
+  it('orders skills A→Z by default', () => {
+    // Arrange
     const skills = [
       makeSkill('zebra', 'claude-code'),
       makeSkill('alpha', 'claude-code'),
       makeSkill('middle', 'claude-code'),
     ]
     const state = buildState({ skills })
+
+    // Act
     const result = selectFilteredSkills(state as never)
+
+    // Assert
     expect(result.map((s) => s.name)).toEqual(['alpha', 'middle', 'zebra'])
   })
 
-  it('sorts skills Z→A when desc', () => {
+  it('orders skills Z→A when the sort order is descending', () => {
+    // Arrange
     const skills = [
       makeSkill('alpha', 'claude-code'),
       makeSkill('zebra', 'claude-code'),
       makeSkill('middle', 'claude-code'),
     ]
     const state = buildState({ skills, sortOrder: 'desc' })
+
+    // Act
     const result = selectFilteredSkills(state as never)
+
+    // Assert
     expect(result.map((s) => s.name)).toEqual(['zebra', 'middle', 'alpha'])
   })
 
-  it('filters by skillTypeFilter=symlinked in agent view', () => {
+  it('shows only symlinked skills in the agent view when the Symlinked filter is active', () => {
+    // Arrange
     const skills = [
       makeSkill('linked-one', 'cursor'),
       makeSkill('local-one', 'cursor', true),
@@ -341,12 +399,17 @@ describe('selectFilteredSkills', () => {
       selectedAgentId: 'cursor',
       skillTypeFilter: 'symlinked',
     })
+
+    // Act
     const result = selectFilteredSkills(state as never)
+
+    // Assert
     expect(result).toHaveLength(1)
     expect(result[0].name).toBe('linked-one')
   })
 
-  it('filters by skillTypeFilter=local in agent view', () => {
+  it('shows only local skills in the agent view when the Local filter is active', () => {
+    // Arrange
     const skills = [
       makeSkill('linked-one', 'cursor'),
       makeSkill('local-one', 'cursor', true),
@@ -356,12 +419,17 @@ describe('selectFilteredSkills', () => {
       selectedAgentId: 'cursor',
       skillTypeFilter: 'local',
     })
+
+    // Act
     const result = selectFilteredSkills(state as never)
+
+    // Assert
     expect(result).toHaveLength(1)
     expect(result[0].name).toBe('local-one')
   })
 
   it('subtracts excluded local skills from the all-types agent list', () => {
+    // Arrange
     const skills = [
       makeSkill('linked-one', 'cursor'),
       makeSkill('local-one', 'cursor', true),
@@ -371,13 +439,17 @@ describe('selectFilteredSkills', () => {
       selectedAgentId: 'cursor',
       excludedSkillTypeFilters: ['local'],
     })
+
+    // Act
     const result = selectFilteredSkills(state as never)
+
+    // Assert
     expect(result.map((s) => s.name)).toEqual(['linked-one'])
   })
 
-  it('filters by skillTypeFilter=gstack across symlinked and local G-Stack slots', () => {
-    // The G-Stack filter should match the same two production shapes as the
-    // card badge: direct agent symlinks into `skills/gstack/` and local
+  it('surfaces both symlinked and local G-Stack skills when the G-Stack filter is active', () => {
+    // Arrange — the G-Stack filter should match the same two production shapes
+    // as the card badge: direct agent symlinks into `skills/gstack/` and local
     // sibling skills whose SKILL.md points into that tree.
     const linkedGStack = makeSkill('linked-gstack', 'cursor')
     linkedGStack.symlinks = [
@@ -409,7 +481,10 @@ describe('selectFilteredSkills', () => {
       skillTypeFilter: 'gstack',
     })
 
+    // Act
     const result = selectFilteredSkills(state as never)
+
+    // Assert
     expect(result.map((skill) => skill.name)).toEqual([
       'linked-gstack',
       'local-gstack',
@@ -417,6 +492,7 @@ describe('selectFilteredSkills', () => {
   })
 
   it('subtracts local rows from the G-Stack include population', () => {
+    // Arrange
     const linkedGStack = makeSkill('linked-gstack', 'cursor')
     linkedGStack.symlinks = [
       {
@@ -442,13 +518,17 @@ describe('selectFilteredSkills', () => {
       excludedSkillTypeFilters: ['local'],
     })
 
+    // Act
     const result = selectFilteredSkills(state as never)
+
+    // Assert
     expect(result.map((skill) => skill.name)).toEqual(['linked-gstack'])
   })
 
-  it('keeps gstack filtering scoped to the selected agent slot', () => {
-    // Same skill name can exist as a G-Stack-managed sibling in one agent and
-    // as a plain linked skill in another; the selected agent owns the answer.
+  it('keeps G-Stack filtering scoped to the selected agent slot', () => {
+    // Arrange — same skill name can exist as a G-Stack-managed sibling in one
+    // agent and as a plain linked skill in another; the selected agent owns
+    // the answer.
     const mixedSkill = makeSkill('mixed-skill', 'cursor')
     mixedSkill.symlinks = [
       mixedSkill.symlinks[0]!,
@@ -469,13 +549,15 @@ describe('selectFilteredSkills', () => {
       skillTypeFilter: 'gstack',
     })
 
+    // Act & Assert
     expect(selectFilteredSkills(state as never)).toHaveLength(0)
   })
 
-  it('filters by skillTypeFilter=orphan in agent view (skill.isOrphan === true)', () => {
-    // Mixed list: a normal symlinked skill (NOT orphan), a local skill (NOT
-    // orphan), and an orphan whose source dir vanished but still has a broken
-    // symlink under cursor. The Orphan filter must surface only the orphan.
+  it('surfaces only orphan skills in the agent view when the Orphan filter is active', () => {
+    // Arrange — mixed list: a normal symlinked skill (NOT orphan), a local
+    // skill (NOT orphan), and an orphan whose source dir vanished but still has
+    // a broken symlink under cursor. The Orphan filter must surface only the
+    // orphan.
     const orphanSkill: Skill = {
       name: 'orphan-one',
       description: 'orphan',
@@ -504,13 +586,17 @@ describe('selectFilteredSkills', () => {
       selectedAgentId: 'cursor',
       skillTypeFilter: 'orphan',
     })
+
+    // Act
     const result = selectFilteredSkills(state as never)
+
+    // Assert
     expect(result.map((s) => s.name)).toEqual(['orphan-one'])
   })
 
-  it('orphan filter respects agent-slot gate (Pass 1 — orphan with no slot for selected agent is dropped)', () => {
-    // Codex-flagged correctness contract: an orphan whose remaining broken
-    // slot points at agent A must NOT surface when the user is viewing
+  it('hides an orphan stranded in another agent from the selected agent Orphan view', () => {
+    // Arrange — Codex-flagged correctness contract: an orphan whose remaining
+    // broken slot points at agent A must NOT surface when the user is viewing
     // agent B. Pass 1 (agent-slot gate) drops the row before Pass 2
     // (skill.isOrphan check) ever runs.
     const orphanForAgentA: Skill = {
@@ -536,12 +622,14 @@ describe('selectFilteredSkills', () => {
       selectedAgentId: 'cursor',
       skillTypeFilter: 'orphan',
     })
+
+    // Act & Assert
     expect(selectFilteredSkills(state as never)).toHaveLength(0)
   })
 
-  it('orphan filter returns empty when no orphan skills exist for selected agent', () => {
-    // Empty-state contract: when the user picks Orphan but every visible
-    // skill is healthy (isOrphan === false), the list is empty and the
+  it('shows the empty Orphan state when the selected agent has no orphan skills', () => {
+    // Arrange — empty-state contract: when the user picks Orphan but every
+    // visible skill is healthy (isOrphan === false), the list is empty and the
     // empty-state copy ("No orphan skills for this agent") takes over.
     const skills = [
       makeSkill('linked-one', 'cursor'),
@@ -552,10 +640,13 @@ describe('selectFilteredSkills', () => {
       selectedAgentId: 'cursor',
       skillTypeFilter: 'orphan',
     })
+
+    // Act & Assert
     expect(selectFilteredSkills(state as never)).toHaveLength(0)
   })
 
-  it('returns empty when search + type filter combined exclude all', () => {
+  it('shows an empty list when the search query and type filter together exclude everything', () => {
+    // Arrange
     const skills = [
       makeSkill('linked-one', 'cursor'),
       makeSkill('local-one', 'cursor', true),
@@ -566,27 +657,36 @@ describe('selectFilteredSkills', () => {
       skillTypeFilter: 'local',
       searchQuery: 'linked',
     })
+
+    // Act
     const result = selectFilteredSkills(state as never)
+
+    // Assert
     expect(result).toHaveLength(0)
   })
 
   it.each(['all', 'symlinked', 'local', 'gstack', 'orphan'] as const)(
-    'skillTypeFilter=%s is ignored in SourceCard view (no agent selected)',
+    'ignores the skillTypeFilter (%s) in the SourceCard view where source-only filtering rules',
     (skillTypeFilter) => {
-      // SourceCard view applies its own source-only filter, so skillTypeFilter
-      // is moot here. `local-task` is hidden because it lives outside SOURCE_DIR,
-      // not because of the symlinked/local filter.
+      // Arrange — SourceCard view applies its own source-only filter, so
+      // skillTypeFilter is moot here. `local-task` is hidden because it lives
+      // outside SOURCE_DIR, not because of the symlinked/local filter.
       const skills = [
         makeSkill('task', 'claude-code'),
         makeSkill('local-task', 'cursor', true),
       ]
       const state = buildState({ skills, skillTypeFilter })
+
+      // Act
       const result = selectFilteredSkills(state as never)
+
+      // Assert
       expect(result.map((s) => s.name)).toEqual(['task'])
     },
   )
 
-  it('searchScope=repo matches against skill.source (repository slug)', () => {
+  it('matches a repo-scope query against the skill repository slug', () => {
+    // Arrange
     const skills = [
       makeSkill('task', 'claude-code', false, 'vercel-labs/skills'),
       makeSkill('browse', 'cursor', false, 'pbakaus/impeccable'),
@@ -597,14 +697,19 @@ describe('selectFilteredSkills', () => {
       searchQuery: 'figma',
       searchScope: 'repo',
     })
+
+    // Act
     const result = selectFilteredSkills(state as never)
+
+    // Assert
     expect(result.map((s) => s.name)).toEqual(['mcp'])
   })
 
-  it('searchScope=repo excludes Local skills (no source) even if name matches', () => {
-    // Critical regression guard: in repo mode, a skill without `source` must
-    // never appear, otherwise the result becomes inconsistent ("I searched a
-    // repo and got a non-repo skill") and the toggle loses its meaning.
+  it('drops source-less Local skills from repo-scope search even when their name matches', () => {
+    // Arrange — critical regression guard: in repo mode, a skill without
+    // `source` must never appear, otherwise the result becomes inconsistent
+    // ("I searched a repo and got a non-repo skill") and the toggle loses its
+    // meaning.
     const skills = [
       makeSkill('task', 'cursor'), // no source — Local-flavored
       makeSkill('task-from-repo', 'cursor', false, 'vercel-labs/skills'),
@@ -614,11 +719,16 @@ describe('selectFilteredSkills', () => {
       searchQuery: 'task',
       searchScope: 'repo',
     })
+
+    // Act
     const result = selectFilteredSkills(state as never)
+
+    // Assert
     expect(result.map((s) => s.name)).toEqual([])
   })
 
-  it('selectedSource pill alone narrows to the matching repo with no query', () => {
+  it('narrows to a single repo when only the source pill is set and no query is typed', () => {
+    // Arrange
     const skills = [
       makeSkill('a', 'claude-code', false, 'vercel-labs/skills'),
       makeSkill('b', 'claude-code', false, 'vercel-labs/skills'),
@@ -628,13 +738,17 @@ describe('selectFilteredSkills', () => {
       skills,
       selectedSources: [repositoryId('vercel-labs/skills')],
     })
+
+    // Act
     const result = selectFilteredSkills(state as never)
+
+    // Assert
     expect(result.map((s) => s.name)).toEqual(['a', 'b'])
   })
 
-  it('selectedSource pill stacks with searchScope=name + query', () => {
-    // Scope is 'name' (default) — the pill narrows population to one repo,
-    // then the name query narrows further within that population.
+  it('stacks the source pill with a name-scope query so both narrow the list', () => {
+    // Arrange — scope is 'name' (default): the pill narrows population to one
+    // repo, then the name query narrows further within that population.
     const skills = [
       makeSkill('alpha', 'claude-code', false, 'vercel-labs/skills'),
       makeSkill('beta', 'claude-code', false, 'vercel-labs/skills'),
@@ -646,14 +760,18 @@ describe('selectFilteredSkills', () => {
       searchQuery: 'alpha',
       searchScope: 'name',
     })
+
+    // Act
     const result = selectFilteredSkills(state as never)
+
+    // Assert
     expect(result.map((s) => s.name)).toEqual(['alpha'])
   })
 
-  it('selectedSource pill stacks with selectedAgentId (orthogonal filters)', () => {
-    // Per Issue 4 decision: the source pill is independent of the agent pill.
-    // Selecting an agent must not silently reset the pill, and the resulting
-    // list intersects both filters.
+  it('intersects the source pill with the agent filter as independent constraints', () => {
+    // Arrange — per Issue 4 decision: the source pill is independent of the
+    // agent pill. Selecting an agent must not silently reset the pill, and the
+    // resulting list intersects both filters.
     const skills = [
       makeSkill('a', 'cursor', false, 'vercel-labs/skills'),
       makeSkill('b', 'claude-code', false, 'vercel-labs/skills'),
@@ -664,13 +782,17 @@ describe('selectFilteredSkills', () => {
       selectedAgentId: 'cursor',
       selectedSources: [repositoryId('vercel-labs/skills')],
     })
+
+    // Act
     const result = selectFilteredSkills(state as never)
+
+    // Assert
     expect(result.map((s) => s.name)).toEqual(['a'])
   })
 
-  it('searchScope=name preserves the original name-match behavior', () => {
-    // Regression guard: explicitly setting scope='name' must behave identically
-    // to the pre-feature default so the toggle round-trips cleanly.
+  it('matches a name-scope query exactly as the pre-toggle default did', () => {
+    // Arrange — regression guard: explicitly setting scope='name' must behave
+    // identically to the pre-feature default so the toggle round-trips cleanly.
     const skills = [
       makeSkill('task', 'claude-code', false, 'vercel-labs/skills'),
       makeSkill('browse', 'cursor', false, 'vercel-labs/skills'),
@@ -680,16 +802,20 @@ describe('selectFilteredSkills', () => {
       searchQuery: 'task',
       searchScope: 'name',
     })
+
+    // Act
     const result = selectFilteredSkills(state as never)
+
+    // Assert
     expect(result.map((s) => s.name)).toEqual(['task'])
   })
 
-  it('searchScope=repo with empty query does not exclude Local skills', () => {
-    // The repo-scope filter only kicks in when there's a non-empty query.
-    // An empty query in repo scope must still surface Local skills, because
-    // the toggle is about what the query matches against, not a standalone
-    // "show only repo skills" filter. Guards against a regression where the
-    // scope itself was treated as a population filter.
+  it('keeps Local skills visible under repo scope when the query is empty', () => {
+    // Arrange — the repo-scope filter only kicks in when there's a non-empty
+    // query. An empty query in repo scope must still surface Local skills,
+    // because the toggle is about what the query matches against, not a
+    // standalone "show only repo skills" filter. Guards against a regression
+    // where the scope itself was treated as a population filter.
     //
     // Use the agent view (selectedAgentId set) to actually exercise the
     // local-skill path: the SourceCard view (no agent) drops every isLocal
@@ -705,15 +831,18 @@ describe('selectFilteredSkills', () => {
       searchQuery: '',
       searchScope: 'repo',
     })
+
+    // Act
     const result = selectFilteredSkills(state as never)
-    // Both surface — agent filter narrows to cursor, neither query nor
+
+    // Assert — both surface: agent filter narrows to cursor, neither query nor
     // scope are doing any filtering work with an empty query.
     expect(result.map((s) => s.name)).toEqual(['local-task', 'repo-task'])
   })
 
-  it('selectedSource pill stacks with searchScope=repo + matching query', () => {
-    // Three-way compound: pill narrows to one repo, scope=repo searches
-    // within source strings, query matches that source — confirms the
+  it('composes the source pill, repo scope, and a matching query without short-circuiting', () => {
+    // Arrange — three-way compound: pill narrows to one repo, scope=repo
+    // searches within source strings, query matches that source — confirms the
     // filters compose without short-circuiting each other (per Issue 4).
     const skills = [
       makeSkill('a', 'claude-code', false, 'vercel-labs/skills'),
@@ -726,15 +855,19 @@ describe('selectFilteredSkills', () => {
       searchQuery: 'vercel',
       searchScope: 'repo',
     })
+
+    // Act
     const result = selectFilteredSkills(state as never)
+
+    // Assert
     expect(result.map((s) => s.name)).toEqual(['a', 'b'])
   })
 
-  it('selectedSource pill + searchScope=repo with non-matching query returns empty', () => {
-    // Edge case: the pill says "in vercel-labs/skills" but the user types
-    // 'figma' in repo scope. The compound filter must return empty — the
-    // pill-narrowed population doesn't have a source matching 'figma',
-    // so neither pill nor scope can produce a hit on its own.
+  it('returns empty when the source pill and a repo-scope query point at different repos', () => {
+    // Arrange — edge case: the pill says "in vercel-labs/skills" but the user
+    // types 'figma' in repo scope. The compound filter must return empty — the
+    // pill-narrowed population doesn't have a source matching 'figma', so
+    // neither pill nor scope can produce a hit on its own.
     const skills = [
       makeSkill('a', 'claude-code', false, 'vercel-labs/skills'),
       makeSkill('b', 'claude-code', false, 'figma/mcp-server-guide'),
@@ -745,11 +878,16 @@ describe('selectFilteredSkills', () => {
       searchQuery: 'figma',
       searchScope: 'repo',
     })
+
+    // Act
     const result = selectFilteredSkills(state as never)
+
+    // Assert
     expect(result.map((s) => s.name)).toEqual([])
   })
 
-  it('repo facet options count repos after agent/type gates and ignore source pill plus query', () => {
+  it('counts repo facets after the agent and type gates while ignoring the source pill and query', () => {
+    // Arrange
     const skills = [
       makeSkill('alpha', 'cursor', false, 'vercel-labs/skills'),
       makeSkill('beta', 'cursor', false, 'vercel-labs/skills'),
@@ -765,17 +903,23 @@ describe('selectFilteredSkills', () => {
       searchScope: 'repo',
     })
 
+    // Act & Assert
     expect(selectRepoFacetOptions(state as never)).toEqual([
       { source: repositoryId('pbakaus/impeccable'), count: 1 },
       { source: repositoryId('vercel-labs/skills'), count: 2 },
     ])
   })
 
-  it('is memoized (returns same reference for same inputs)', () => {
+  it('returns the same array reference on repeat reads so consumers do not re-render needlessly', () => {
+    // Arrange
     const skills = [makeSkill('task', 'claude-code')]
     const state = buildState({ skills })
+
+    // Act
     const result1 = selectFilteredSkills(state as never)
     const result2 = selectFilteredSkills(state as never)
+
+    // Assert
     expect(result1).toBe(result2)
   })
 })
@@ -788,64 +932,89 @@ const makeBookmark = (name: string, repo: string): BookmarkedSkill => ({
 })
 
 describe('selectBookmarksWithInstallStatus', () => {
-  it('marks bookmarked skill as installed when name matches', () => {
+  it('flags a bookmarked skill as installed when a matching skill name exists', () => {
+    // Arrange
     const state = buildState({
       skills: [makeSkill('task', 'claude-code')],
       bookmarks: [makeBookmark('task', 'vercel-labs/skills')],
     })
+
+    // Act
     const result = selectBookmarksWithInstallStatus(state as never)
+
+    // Assert
     expect(result).toHaveLength(1)
     expect(result[0].isInstalled).toBe(true)
   })
 
-  it('marks bookmarked skill as not installed when no match', () => {
+  it('flags a bookmarked skill as not installed when no matching skill exists', () => {
+    // Arrange
     const state = buildState({
       skills: [makeSkill('browse', 'claude-code')],
       bookmarks: [makeBookmark('task', 'vercel-labs/skills')],
     })
+
+    // Act
     const result = selectBookmarksWithInstallStatus(state as never)
+
+    // Assert
     expect(result).toHaveLength(1)
     expect(result[0].isInstalled).toBe(false)
   })
 
-  it('returns empty array when no bookmarks', () => {
+  it('shows an empty bookmarks list when nothing is bookmarked', () => {
+    // Arrange
     const state = buildState({
       skills: [makeSkill('task', 'claude-code')],
       bookmarks: [],
     })
+
+    // Act & Assert
     expect(selectBookmarksWithInstallStatus(state as never)).toHaveLength(0)
   })
 
-  it('is memoized (returns same reference for same inputs)', () => {
+  it('returns the same array reference on repeat reads so consumers do not re-render needlessly', () => {
+    // Arrange
     const state = buildState({
       skills: [makeSkill('task', 'claude-code')],
       bookmarks: [makeBookmark('task', 'vercel-labs/skills')],
     })
+
+    // Act
     const result1 = selectBookmarksWithInstallStatus(state as never)
     const result2 = selectBookmarksWithInstallStatus(state as never)
+
+    // Assert
     expect(result1).toBe(result2)
   })
 })
 
 describe('selectVisibleSkillNames', () => {
-  it('projects selectFilteredSkills into an ordered name array', () => {
+  it('lists the visible skill names in display order', () => {
+    // Arrange
     const skills = [
       makeSkill('zebra', 'claude-code'),
       makeSkill('alpha', 'claude-code'),
     ]
     const state = buildState({ skills })
+
+    // Act & Assert
     expect(selectVisibleSkillNames(state as never)).toEqual(['alpha', 'zebra'])
   })
 
-  it('returns [] when the filter produces no rows', () => {
+  it('lists no names when the filter produces no rows', () => {
+    // Arrange
     const skills = [makeSkill('task', 'claude-code')]
     const state = buildState({ skills, searchQuery: 'unmatched' })
+
+    // Act & Assert
     expect(selectVisibleSkillNames(state as never)).toEqual([])
   })
 })
 
 describe('selectBulkSelectableVisibleSkillNames', () => {
   it('keeps broken agent rows visible but excludes them from bulk unlink names', () => {
+    // Arrange
     const brokenSkill: Skill = {
       ...makeSkill('broken-skill', 'cursor'),
       isSource: false,
@@ -867,16 +1036,19 @@ describe('selectBulkSelectableVisibleSkillNames', () => {
       selectedAgentId: 'cursor',
     })
 
+    // Act & Assert — the broken row stays in the visible list…
     expect(selectVisibleSkillNames(state as never)).toEqual([
       'broken-skill',
       'valid-skill',
     ])
+    // …but is excluded from the bulk-unlink candidate names
     expect(selectBulkSelectableVisibleSkillNames(state as never)).toEqual([
       'valid-skill',
     ])
   })
 
   it('excludes inaccessible agent rows from bulk unlink names', () => {
+    // Arrange
     const inaccessibleSkill: Skill = {
       ...makeSkill('manual-review', 'cursor'),
       symlinks: [
@@ -895,11 +1067,14 @@ describe('selectBulkSelectableVisibleSkillNames', () => {
       selectedAgentId: 'cursor',
     })
 
+    // Act & Assert — the row is still visible…
     expect(selectFilteredSkills(state as never)).toHaveLength(1)
+    // …but excluded from the bulk-unlink candidate names
     expect(selectBulkSelectableVisibleSkillNames(state as never)).toEqual([])
   })
 
   it('excludes local agent folders from bulk unlink names', () => {
+    // Arrange
     const localSkill: Skill = {
       ...makeSkill('local-only', 'cursor'),
       symlinks: [
@@ -918,10 +1093,12 @@ describe('selectBulkSelectableVisibleSkillNames', () => {
       selectedAgentId: 'cursor',
     })
 
+    // Act & Assert — the local folder stays in the visible list…
     expect(selectVisibleSkillNames(state as never)).toEqual([
       'local-only',
       'valid-symlink',
     ])
+    // …but is excluded from the bulk-unlink candidate names
     expect(selectBulkSelectableVisibleSkillNames(state as never)).toEqual([
       'valid-symlink',
     ])
@@ -929,21 +1106,28 @@ describe('selectBulkSelectableVisibleSkillNames', () => {
 })
 
 describe('selectSelectedCount', () => {
-  it('returns 0 when nothing is ticked', () => {
+  it('shows a zero selection count when nothing is ticked', () => {
+    // Arrange
     const state = buildState({})
+
+    // Act & Assert
     expect(selectSelectedCount(state as never)).toBe(0)
   })
 
-  it('returns the array length regardless of visibility', () => {
+  it('counts every ticked skill even when some are scrolled out of the visible list', () => {
+    // Arrange
     const state = buildState({
       selectedSkillNames: ['a', 'b', 'c'],
     })
+
+    // Act & Assert
     expect(selectSelectedCount(state as never)).toBe(3)
   })
 })
 
 describe('selectSelectedVisibleNames', () => {
-  it('intersects selected names with the visible list, preserving visible order', () => {
+  it('lists the ticked names that are currently visible in visible order, dropping ghosts', () => {
+    // Arrange
     const skills = [
       makeSkill('alpha', 'claude-code'),
       makeSkill('browser', 'claude-code'),
@@ -953,26 +1137,32 @@ describe('selectSelectedVisibleNames', () => {
       skills,
       selectedSkillNames: ['task', 'alpha', 'ghost'],
     })
-    // visible order is alphabetical: alpha, browser, task — intersect yields alpha, task
+
+    // Act & Assert — visible order is alphabetical (alpha, browser, task);
+    // intersecting the selection yields alpha, task and drops 'ghost'
     expect(selectSelectedVisibleNames(state as never)).toEqual([
       'alpha',
       'task',
     ])
   })
 
-  it('returns an empty array when selection is entirely hidden', () => {
+  it('lists no names when the whole selection is hidden by the active filter', () => {
+    // Arrange
     const skills = [makeSkill('task', 'claude-code')]
     const state = buildState({
       skills,
       searchQuery: 'task',
       selectedSkillNames: ['something-else'],
     })
+
+    // Act & Assert
     expect(selectSelectedVisibleNames(state as never)).toEqual([])
   })
 })
 
 describe('selectSelectedVisibleCount', () => {
-  it('returns the count of selected-AND-visible names', () => {
+  it('counts only the ticked skills that are currently visible', () => {
+    // Arrange
     const skills = [
       makeSkill('alpha', 'claude-code'),
       makeSkill('browser', 'claude-code'),
@@ -982,12 +1172,15 @@ describe('selectSelectedVisibleCount', () => {
       skills,
       selectedSkillNames: ['alpha', 'task', 'hidden'],
     })
+
+    // Act & Assert
     expect(selectSelectedVisibleCount(state as never)).toBe(2)
   })
 })
 
 describe('selectHiddenSelectedCount', () => {
-  it('returns the number of selected names that are NOT in the visible list', () => {
+  it('counts the ticked skills scrolled or filtered out of the visible list', () => {
+    // Arrange
     const skills = [
       makeSkill('alpha', 'claude-code'),
       makeSkill('browser', 'claude-code'),
@@ -996,10 +1189,13 @@ describe('selectHiddenSelectedCount', () => {
       skills,
       selectedSkillNames: ['alpha', 'hidden-1', 'hidden-2'],
     })
+
+    // Act & Assert
     expect(selectHiddenSelectedCount(state as never)).toBe(2)
   })
 
-  it('returns 0 when all selected names are visible', () => {
+  it('reports zero hidden selections when every ticked skill is visible', () => {
+    // Arrange
     const skills = [
       makeSkill('alpha', 'claude-code'),
       makeSkill('browser', 'claude-code'),
@@ -1008,10 +1204,13 @@ describe('selectHiddenSelectedCount', () => {
       skills,
       selectedSkillNames: ['alpha', 'browser'],
     })
+
+    // Act & Assert
     expect(selectHiddenSelectedCount(state as never)).toBe(0)
   })
 
-  it('does not count visible but ineligible agent rows as hidden by filter', () => {
+  it('does not count a visible-but-ineligible agent row as hidden by the filter', () => {
+    // Arrange
     const skills = [
       makeSkill('valid-task', 'cursor'),
       makeSkill('broken-task', 'cursor', false, undefined, 'broken'),
@@ -1022,12 +1221,14 @@ describe('selectHiddenSelectedCount', () => {
       selectedSkillNames: ['valid-task', 'broken-task'],
     })
 
+    // Act & Assert
     expect(selectHiddenSelectedCount(state as never)).toBe(0)
   })
 })
 
 describe('selectVisibleIneligibleSelectedCount', () => {
-  it('counts selected rows that are visible but excluded from bulk action', () => {
+  it('counts ticked rows that are visible yet excluded from the bulk action', () => {
+    // Arrange
     const skills = [
       makeSkill('valid-task', 'cursor'),
       makeSkill('broken-task', 'cursor', false, undefined, 'broken'),
@@ -1038,47 +1239,68 @@ describe('selectVisibleIneligibleSelectedCount', () => {
       selectedSkillNames: ['valid-task', 'broken-task', 'hidden-task'],
     })
 
+    // Act & Assert
     expect(selectVisibleIneligibleSelectedCount(state as never)).toBe(1)
   })
 })
 
 describe('selectInFlightDeleteNamesSet', () => {
-  it('wraps the array in a Set for O(1) lookup', () => {
+  it('exposes in-flight delete names as a Set for fast membership checks', () => {
+    // Arrange
     const state = buildState({
       inFlightDeleteNames: ['a', 'b', 'c'],
     })
+
+    // Act
     const result = selectInFlightDeleteNamesSet(state as never)
+
+    // Assert
     expect(result.has('a')).toBe(true)
     expect(result.has('z')).toBe(false)
     expect(result.size).toBe(3)
   })
 
-  it('is memoized — returns the same Set reference for the same input array', () => {
+  it('returns the same Set reference on repeat reads so consumers do not re-render needlessly', () => {
+    // Arrange
     const state = buildState({
       inFlightDeleteNames: ['a'],
     })
+
+    // Act
     const result1 = selectInFlightDeleteNamesSet(state as never)
     const result2 = selectInFlightDeleteNamesSet(state as never)
+
+    // Assert
     expect(result1).toBe(result2)
   })
 })
 
 describe('selectSelectedSkillNamesSet', () => {
-  it('wraps selectedSkillNames in a Set', () => {
+  it('exposes the ticked skill names as a Set for fast membership checks', () => {
+    // Arrange
     const state = buildState({
       selectedSkillNames: ['x', 'y'],
     })
+
+    // Act
     const result = selectSelectedSkillNamesSet(state as never)
+
+    // Assert
     expect(result.has('x')).toBe(true)
     expect(result.size).toBe(2)
   })
 
-  it('is memoized', () => {
+  it('returns the same Set reference on repeat reads so consumers do not re-render needlessly', () => {
+    // Arrange
     const state = buildState({
       selectedSkillNames: ['x'],
     })
+
+    // Act
     const result1 = selectSelectedSkillNamesSet(state as never)
     const result2 = selectSelectedSkillNamesSet(state as never)
+
+    // Assert
     expect(result1).toBe(result2)
   })
 })

--- a/src/renderer/src/redux/slices/agentsSlice.test.ts
+++ b/src/renderer/src/redux/slices/agentsSlice.test.ts
@@ -42,9 +42,14 @@ describe('agentsSlice', () => {
     vi.resetAllMocks()
   })
 
-  it('has correct initial state', async () => {
+  it('starts with no agents loaded and nothing pending deletion', async () => {
+    // Arrange
     const store = await createTestStore()
+
+    // Act
     const state = store.getState().agents
+
+    // Assert
     expect(state.items).toEqual([])
     expect(state.loading).toBe(false)
     expect(state.error).toBeNull()
@@ -52,29 +57,40 @@ describe('agentsSlice', () => {
     expect(state.deleting).toBe(false)
   })
 
-  it('setAgentToDelete sets and clears pending delete', async () => {
+  it('arms the delete confirmation for an agent and disarms it on cancel', async () => {
+    // Arrange
     const { setAgentToDelete } = await import('./agentsSlice')
     const store = await createTestStore()
+
+    // Act
     store.dispatch(setAgentToDelete(sampleAgent))
+
+    // Assert
     expect(store.getState().agents.agentToDelete).toEqual(sampleAgent)
 
+    // Act
     store.dispatch(setAgentToDelete(null))
+
+    // Assert
     expect(store.getState().agents.agentToDelete).toBeNull()
   })
 
   // --- fetchAgents thunk ---
-  it('fetchAgents sets loading during pending', async () => {
+  it('shows a loading state while the agent scan is in flight', async () => {
+    // Arrange
     let resolve!: (value: Agent[]) => void
     mockGetAll.mockReturnValue(
       new Promise<Agent[]>((r) => {
         resolve = r
       }),
     )
-
     const store = await createTestStore()
     const { fetchAgents } = await import('./agentsSlice')
+
+    // Act
     const promise = store.dispatch(fetchAgents())
 
+    // Assert
     expect(store.getState().agents.loading).toBe(true)
     expect(store.getState().agents.error).toBeNull()
 
@@ -82,44 +98,53 @@ describe('agentsSlice', () => {
     await promise
   })
 
-  it('fetchAgents populates items on fulfilled', async () => {
+  it('lists the scanned agents and clears loading once the scan finishes', async () => {
+    // Arrange
     mockGetAll.mockResolvedValue([sampleAgent])
-
     const store = await createTestStore()
     const { fetchAgents } = await import('./agentsSlice')
+
+    // Act
     await store.dispatch(fetchAgents())
 
+    // Assert
     const state = store.getState().agents
     expect(state.items).toHaveLength(1)
     expect(state.items[0].name).toBe('Claude Code')
     expect(state.loading).toBe(false)
   })
 
-  it('fetchAgents sets error on rejected', async () => {
+  it('surfaces the failure message when the agent scan throws', async () => {
+    // Arrange
     mockGetAll.mockRejectedValue(new Error('Permission denied'))
-
     const store = await createTestStore()
     const { fetchAgents } = await import('./agentsSlice')
+
+    // Act
     await store.dispatch(fetchAgents())
 
+    // Assert
     const state = store.getState().agents
     expect(state.loading).toBe(false)
     expect(state.error).toBe('Permission denied')
   })
 
   // --- removeAllSymlinksFromAgent thunk ---
-  it('removeAllSymlinksFromAgent clears agentToDelete on fulfilled', async () => {
+  it('clears the pending agent and forwards the reviewed identity after a successful removal', async () => {
+    // Arrange
     mockRemoveAllFromAgent.mockResolvedValue({
       success: true,
       removedCount: 5,
     })
-
     const store = await createTestStore()
     const { setAgentToDelete, removeAllSymlinksFromAgent } =
       await import('./agentsSlice')
     store.dispatch(setAgentToDelete(sampleAgent))
+
+    // Act
     await store.dispatch(removeAllSymlinksFromAgent(sampleAgent))
 
+    // Assert
     expect(store.getState().agents.agentToDelete).toBeNull()
     expect(store.getState().agents.deleting).toBe(false)
     expect(mockRemoveAllFromAgent).toHaveBeenCalledWith({
@@ -129,13 +154,16 @@ describe('agentsSlice', () => {
     })
   })
 
-  it('removeAllSymlinksFromAgent rejects when reviewed agent identity is missing', async () => {
+  it('refuses to delete and asks for a rescan when the reviewed agent identity is missing', async () => {
+    // Arrange
     const staleAgent: Agent = { ...sampleAgent, filesystemIdentity: undefined }
-
     const store = await createTestStore()
     const { removeAllSymlinksFromAgent } = await import('./agentsSlice')
+
+    // Act
     await store.dispatch(removeAllSymlinksFromAgent(staleAgent))
 
+    // Assert
     expect(store.getState().agents.deleting).toBe(false)
     expect(store.getState().agents.error).toBe(
       'Agent skills folder changed since review. Rescan before deleting.',
@@ -143,45 +171,54 @@ describe('agentsSlice', () => {
     expect(mockRemoveAllFromAgent).not.toHaveBeenCalled()
   })
 
-  it('removeAllSymlinksFromAgent sets deleting during pending', async () => {
+  it('shows a deleting state while the symlink removal is in flight', async () => {
+    // Arrange
     let resolve!: (value: { success: boolean; removedCount: number }) => void
     mockRemoveAllFromAgent.mockReturnValue(
       new Promise((r) => {
         resolve = r
       }),
     )
-
     const store = await createTestStore()
     const { removeAllSymlinksFromAgent } = await import('./agentsSlice')
+
+    // Act
     const promise = store.dispatch(removeAllSymlinksFromAgent(sampleAgent))
 
+    // Assert
     expect(store.getState().agents.deleting).toBe(true)
 
     resolve({ success: true, removedCount: 3 })
     await promise
   })
 
-  it('removeAllSymlinksFromAgent sets error on failure', async () => {
+  it('surfaces the backend error when symlink removal reports failure', async () => {
+    // Arrange
     mockRemoveAllFromAgent.mockResolvedValue({
       success: false,
       error: 'Directory locked',
     })
-
     const store = await createTestStore()
     const { removeAllSymlinksFromAgent } = await import('./agentsSlice')
+
+    // Act
     await store.dispatch(removeAllSymlinksFromAgent(sampleAgent))
 
+    // Assert
     expect(store.getState().agents.deleting).toBe(false)
     expect(store.getState().agents.error).toBe('Directory locked')
   })
 
-  it('removeAllSymlinksFromAgent sets error on rejection', async () => {
+  it('surfaces the thrown error when symlink removal rejects', async () => {
+    // Arrange
     mockRemoveAllFromAgent.mockRejectedValue(new Error('Unexpected error'))
-
     const store = await createTestStore()
     const { removeAllSymlinksFromAgent } = await import('./agentsSlice')
+
+    // Act
     await store.dispatch(removeAllSymlinksFromAgent(sampleAgent))
 
+    // Assert
     expect(store.getState().agents.deleting).toBe(false)
     expect(store.getState().agents.error).toBe('Unexpected error')
   })

--- a/src/renderer/src/redux/slices/bookmarkSlice.test.ts
+++ b/src/renderer/src/redux/slices/bookmarkSlice.test.ts
@@ -10,15 +10,23 @@ async function createTestStore() {
 }
 
 describe('bookmarkSlice', () => {
-  it('has correct initial state', async () => {
+  it('starts with an empty saved list', async () => {
+    // Arrange
     const store = await createTestStore()
-    expect(store.getState().bookmarks.items).toEqual([])
+
+    // Act
+    const items = store.getState().bookmarks.items
+
+    // Assert
+    expect(items).toEqual([])
   })
 
-  it('addBookmark adds a skill to bookmarks', async () => {
+  it('bookmarking a skill makes it appear in the saved list with its repo and url', async () => {
+    // Arrange
     const { addBookmark } = await import('./bookmarkSlice')
     const store = await createTestStore()
 
+    // Act
     store.dispatch(
       addBookmark({
         name: 'task',
@@ -27,6 +35,7 @@ describe('bookmarkSlice', () => {
       }),
     )
 
+    // Assert
     const items = store.getState().bookmarks.items
     expect(items).toHaveLength(1)
     expect(items[0].name).toBe('task')
@@ -35,10 +44,12 @@ describe('bookmarkSlice', () => {
     expect(items[0].bookmarkedAt).toBeTruthy()
   })
 
-  it('addBookmark sets bookmarkedAt as ISO string', async () => {
+  it('stamps the saved skill with an ISO-formatted bookmark time', async () => {
+    // Arrange
     const { addBookmark } = await import('./bookmarkSlice')
     const store = await createTestStore()
 
+    // Act
     store.dispatch(
       addBookmark({
         name: 'task',
@@ -47,29 +58,35 @@ describe('bookmarkSlice', () => {
       }),
     )
 
+    // Assert
     const { bookmarkedAt } = store.getState().bookmarks.items[0]
     expect(new Date(bookmarkedAt).toISOString()).toBe(bookmarkedAt)
   })
 
-  it('addBookmark ignores duplicate by name', async () => {
+  it('keeps a single entry when the same skill is bookmarked twice', async () => {
+    // Arrange
     const { addBookmark } = await import('./bookmarkSlice')
     const store = await createTestStore()
-
     const payload = {
       name: 'task',
       repo: repositoryId('vercel-labs/skills'),
       url: 'https://skills.sh/task',
     }
+
+    // Act
     store.dispatch(addBookmark(payload))
     store.dispatch(addBookmark(payload))
 
+    // Assert
     expect(store.getState().bookmarks.items).toHaveLength(1)
   })
 
-  it('addBookmark allows different skills', async () => {
+  it('saves two distinct skills as separate entries', async () => {
+    // Arrange
     const { addBookmark } = await import('./bookmarkSlice')
     const store = await createTestStore()
 
+    // Act
     store.dispatch(
       addBookmark({
         name: 'task',
@@ -85,13 +102,14 @@ describe('bookmarkSlice', () => {
       }),
     )
 
+    // Assert
     expect(store.getState().bookmarks.items).toHaveLength(2)
   })
 
-  it('removeBookmark removes by name', async () => {
+  it('removing a bookmark drops only that skill and leaves the rest saved', async () => {
+    // Arrange
     const { addBookmark, removeBookmark } = await import('./bookmarkSlice')
     const store = await createTestStore()
-
     store.dispatch(
       addBookmark({
         name: 'task',
@@ -107,17 +125,19 @@ describe('bookmarkSlice', () => {
       }),
     )
 
+    // Act
     store.dispatch(removeBookmark('task'))
 
+    // Assert
     const items = store.getState().bookmarks.items
     expect(items).toHaveLength(1)
     expect(items[0].name).toBe('tdd')
   })
 
-  it('removeBookmark is no-op for non-existent name', async () => {
+  it('leaves the saved list unchanged when removing a name that was never bookmarked', async () => {
+    // Arrange
     const { addBookmark, removeBookmark } = await import('./bookmarkSlice')
     const store = await createTestStore()
-
     store.dispatch(
       addBookmark({
         name: 'task',
@@ -126,15 +146,19 @@ describe('bookmarkSlice', () => {
       }),
     )
 
+    // Act
     store.dispatch(removeBookmark('nonexistent'))
 
+    // Assert
     expect(store.getState().bookmarks.items).toHaveLength(1)
   })
 
-  it('selectBookmarkItems returns items array', async () => {
+  it('exposes the saved skill through the bookmark items state', async () => {
+    // Arrange
     const { addBookmark } = await import('./bookmarkSlice')
     const store = await createTestStore()
 
+    // Act
     store.dispatch(
       addBookmark({
         name: 'task',
@@ -143,15 +167,16 @@ describe('bookmarkSlice', () => {
       }),
     )
 
+    // Assert
     const items = store.getState().bookmarks.items
     expect(items).toHaveLength(1)
     expect(items[0].name).toBe('task')
   })
 
-  it('selectIsBookmarked returns true for bookmarked skill', async () => {
+  it('reports a skill as bookmarked only when it is in the saved list', async () => {
+    // Arrange
     const { addBookmark, selectIsBookmarked } = await import('./bookmarkSlice')
     const store = await createTestStore()
-
     store.dispatch(
       addBookmark({
         name: 'task',
@@ -160,11 +185,18 @@ describe('bookmarkSlice', () => {
       }),
     )
 
-    expect(
-      selectIsBookmarked(store.getState() as unknown as RootState, 'task'),
-    ).toBe(true)
-    expect(
-      selectIsBookmarked(store.getState() as unknown as RootState, 'other'),
-    ).toBe(false)
+    // Act
+    const isTaskBookmarked = selectIsBookmarked(
+      store.getState() as unknown as RootState,
+      'task',
+    )
+    const isOtherBookmarked = selectIsBookmarked(
+      store.getState() as unknown as RootState,
+      'other',
+    )
+
+    // Assert
+    expect(isTaskBookmarked).toBe(true)
+    expect(isOtherBookmarked).toBe(false)
   })
 })

--- a/src/renderer/src/redux/slices/dashboardSlice.test.ts
+++ b/src/renderer/src/redux/slices/dashboardSlice.test.ts
@@ -13,9 +13,14 @@ async function createTestStore() {
 
 describe('dashboardSlice', () => {
   describe('initial state', () => {
-    it('starts empty and uninitialized', async () => {
+    it('starts with no pages, not in edit mode, and before first-run seeding', async () => {
+      // Arrange
       const store = await createTestStore()
+
+      // Act
       const state = store.getState().dashboard
+
+      // Assert
       expect(state.pages).toEqual([])
       expect(state.currentPageId).toBeNull()
       expect(state.isEditMode).toBe(false)
@@ -25,12 +30,15 @@ describe('dashboardSlice', () => {
   })
 
   describe('seedDefaultsIfEmpty', () => {
-    it('populates the four default pages on first call', async () => {
+    it('lays out the four default pages and selects the first on first run', async () => {
+      // Arrange
       const { seedDefaultsIfEmpty } = await import('./dashboardSlice')
       const store = await createTestStore()
 
+      // Act
       store.dispatch(seedDefaultsIfEmpty())
 
+      // Assert
       const state = store.getState().dashboard
       expect(state.pages.map((page) => page.name)).toEqual([
         'Overview',
@@ -42,219 +50,266 @@ describe('dashboardSlice', () => {
       expect(state.initialized).toBe(true)
     })
 
-    it('is a no-op once initialized', async () => {
+    it('leaves an already-seeded dashboard untouched on a second seed', async () => {
+      // Arrange
       const { seedDefaultsIfEmpty } = await import('./dashboardSlice')
       const store = await createTestStore()
-
       store.dispatch(seedDefaultsIfEmpty())
       const firstPages = store.getState().dashboard.pages
+
+      // Act
       store.dispatch(seedDefaultsIfEmpty())
       const secondPages = store.getState().dashboard.pages
 
+      // Assert
       // Same reference → reducer didn't rebuild the pages.
       expect(secondPages).toBe(firstPages)
     })
   })
 
   describe('setCurrentPage', () => {
-    it('switches to an existing page', async () => {
+    it('navigates to the selected page', async () => {
+      // Arrange
       const { seedDefaultsIfEmpty, setCurrentPage } =
         await import('./dashboardSlice')
       const store = await createTestStore()
-
       store.dispatch(seedDefaultsIfEmpty())
       const discoveryPage = store.getState().dashboard.pages[1]
+
+      // Act
       store.dispatch(setCurrentPage(discoveryPage.id))
 
+      // Assert
       expect(store.getState().dashboard.currentPageId).toBe(discoveryPage.id)
     })
 
-    it('ignores unknown page ids (guards against stale references)', async () => {
+    it('stays on the current page when asked to navigate to a stale page id', async () => {
+      // Arrange
       const { seedDefaultsIfEmpty, setCurrentPage } =
         await import('./dashboardSlice')
       const store = await createTestStore()
-
       store.dispatch(seedDefaultsIfEmpty())
       const initialPageId = store.getState().dashboard.currentPageId
+
+      // Act
       store.dispatch(setCurrentPage('p_not_a_real_id' as DashboardPageId))
 
+      // Assert
       expect(store.getState().dashboard.currentPageId).toBe(initialPageId)
     })
   })
 
   describe('toggleEditMode', () => {
-    it('flips isEditMode on every call', async () => {
+    it('enters and leaves edit mode on alternating toggles', async () => {
+      // Arrange
       const { toggleEditMode } = await import('./dashboardSlice')
       const store = await createTestStore()
 
+      // Assert
       expect(store.getState().dashboard.isEditMode).toBe(false)
+
+      // Act
       store.dispatch(toggleEditMode())
+
+      // Assert
       expect(store.getState().dashboard.isEditMode).toBe(true)
+
+      // Act
       store.dispatch(toggleEditMode())
+
+      // Assert
       expect(store.getState().dashboard.isEditMode).toBe(false)
     })
   })
 
   describe('addWidget', () => {
-    it('appends a widget with registry default size when the page has room', async () => {
+    it('drops the new widget onto the current page when it still has room', async () => {
+      // Arrange
       const { addWidget, seedDefaultsIfEmpty, setCurrentPage } =
         await import('./dashboardSlice')
       const store = await createTestStore()
-
       store.dispatch(seedDefaultsIfEmpty())
-      // Actions page has 1 widget → room for more.
+      // Actions page seeds with 1 widget → room for more.
       const actionsPage = store.getState().dashboard.pages[2]
       store.dispatch(setCurrentPage(actionsPage.id))
-      const countBefore = actionsPage.widgets.length
 
+      // Act
       store.dispatch(addWidget({ type: 'stats' }))
 
+      // Assert
       const currentPage = store.getState().dashboard.pages[2]
-      expect(currentPage.widgets.length).toBe(countBefore + 1)
+      expect(currentPage.widgets.length).toBe(2)
       const appendedWidget = currentPage.widgets[currentPage.widgets.length - 1]
       expect(appendedWidget.type).toBe('stats')
     })
 
-    it('creates a new overflow page when the current page is full', async () => {
+    it('spills the new widget onto a fresh page and opens it when the current page is full', async () => {
+      // Arrange
       const { addWidget, seedDefaultsIfEmpty, setCurrentPage } =
         await import('./dashboardSlice')
       const store = await createTestStore()
-
       store.dispatch(seedDefaultsIfEmpty())
-      // Overview has 4 widgets — hits MAX_WIDGETS_PER_PAGE.
+      // Overview seeds with 4 widgets — hits MAX_WIDGETS_PER_PAGE.
       const overviewPage = store.getState().dashboard.pages[0]
       store.dispatch(setCurrentPage(overviewPage.id))
-      const pagesBefore = store.getState().dashboard.pages.length
 
+      // Act
       store.dispatch(addWidget({ type: 'stats' }))
 
+      // Assert
       const state = store.getState().dashboard
-      expect(state.pages.length).toBe(pagesBefore + 1)
+      // 4 seeded pages + 1 auto-created overflow page.
+      expect(state.pages.length).toBe(5)
       // Auto-created page becomes the current page.
       expect(state.currentPageId).toBe(state.pages[state.pages.length - 1].id)
     })
   })
 
   describe('removeWidget', () => {
-    it('removes the widget from its containing page', async () => {
+    it('takes the removed widget off its page while leaving the page in place', async () => {
+      // Arrange
       const { removeWidget, seedDefaultsIfEmpty } =
         await import('./dashboardSlice')
       const store = await createTestStore()
-
       store.dispatch(seedDefaultsIfEmpty())
       const overviewPage = store.getState().dashboard.pages[0]
       const targetWidgetId = overviewPage.widgets[0].id
+
+      // Act
       store.dispatch(removeWidget(targetWidgetId))
 
+      // Assert
       const overviewAfter = store.getState().dashboard.pages[0]
       expect(overviewAfter.widgets.some((w) => w.id === targetWidgetId)).toBe(
         false,
       )
     })
 
-    it('deletes the page when the last widget on it is removed and other pages exist', async () => {
+    it('removes the now-empty page when its last widget is deleted and other pages remain', async () => {
+      // Arrange
       const { removeWidget, seedDefaultsIfEmpty } =
         await import('./dashboardSlice')
       const store = await createTestStore()
-
       store.dispatch(seedDefaultsIfEmpty())
-      // Actions page has a single widget.
+      // Actions page seeds with a single widget.
       const actionsPage = store.getState().dashboard.pages[2]
       const onlyWidgetId = actionsPage.widgets[0].id
-      const pagesBefore = store.getState().dashboard.pages.length
 
+      // Act
       store.dispatch(removeWidget(onlyWidgetId))
 
-      expect(store.getState().dashboard.pages.length).toBe(pagesBefore - 1)
+      // Assert
+      // 4 seeded pages, the emptied Actions page is dropped → 3 remain.
+      expect(store.getState().dashboard.pages.length).toBe(3)
     })
   })
 
   describe('page management', () => {
-    it('addPage appends a new empty page and switches to it', async () => {
+    it('adds an empty page and navigates straight to it', async () => {
+      // Arrange
       const { addPage, seedDefaultsIfEmpty } = await import('./dashboardSlice')
       const store = await createTestStore()
-
       store.dispatch(seedDefaultsIfEmpty())
-      const pagesBefore = store.getState().dashboard.pages.length
 
+      // Act
       store.dispatch(addPage())
 
+      // Assert
       const state = store.getState().dashboard
-      expect(state.pages.length).toBe(pagesBefore + 1)
+      // 4 seeded pages + 1 newly added page.
+      expect(state.pages.length).toBe(5)
       const lastPage = state.pages[state.pages.length - 1]
       expect(lastPage.widgets).toEqual([])
       expect(state.currentPageId).toBe(lastPage.id)
     })
 
-    it('renamePage updates the name of an existing page', async () => {
+    it('renames a page to the new title', async () => {
+      // Arrange
       const { renamePage, seedDefaultsIfEmpty } =
         await import('./dashboardSlice')
       const store = await createTestStore()
-
       store.dispatch(seedDefaultsIfEmpty())
       const discoveryPage = store.getState().dashboard.pages[1]
+
+      // Act
       store.dispatch(
         renamePage({ pageId: discoveryPage.id, name: 'Exploration' }),
       )
 
+      // Assert
       expect(store.getState().dashboard.pages[1].name).toBe('Exploration')
     })
 
-    it('removePage drops a non-last page', async () => {
+    it('deletes a page when it is not the last one left', async () => {
+      // Arrange
       const { removePage, seedDefaultsIfEmpty } =
         await import('./dashboardSlice')
       const store = await createTestStore()
-
       store.dispatch(seedDefaultsIfEmpty())
       const discoveryPage = store.getState().dashboard.pages[1]
+
+      // Act
       store.dispatch(removePage(discoveryPage.id))
 
+      // Assert
       const pages = store.getState().dashboard.pages
       expect(pages.some((p) => p.id === discoveryPage.id)).toBe(false)
     })
 
-    it('removePage refuses to delete the last remaining page', async () => {
+    it('keeps the last remaining page when asked to delete it', async () => {
+      // Arrange
       const { addPage, removePage } = await import('./dashboardSlice')
       const store = await createTestStore()
-
       // Create a single page manually (skipping seed) to isolate the guard.
       store.dispatch(addPage({ name: 'Solo' }))
       const solePage = store.getState().dashboard.pages[0]
+
+      // Act
       store.dispatch(removePage(solePage.id))
 
+      // Assert
       expect(store.getState().dashboard.pages).toHaveLength(1)
     })
   })
 
   describe('dismissWelcome', () => {
-    it('sets welcomeDismissed to true and survives resetToDefaults', async () => {
+    it('keeps the welcome message dismissed even after a reset to defaults', async () => {
+      // Arrange
       const { dismissWelcome, resetToDefaults } =
         await import('./dashboardSlice')
       const store = await createTestStore()
 
+      // Act
       store.dispatch(dismissWelcome())
+
+      // Assert
       expect(store.getState().dashboard.welcomeDismissed).toBe(true)
 
+      // Act
       // Reset wipes arrangements but must preserve dismissal state.
       store.dispatch(resetToDefaults())
+
+      // Assert
       expect(store.getState().dashboard.welcomeDismissed).toBe(true)
     })
   })
 
   describe('resetToDefaults', () => {
-    it('rebuilds the default preset and exits edit mode', async () => {
+    it('restores the default page layout and leaves edit mode', async () => {
+      // Arrange
       const { resetToDefaults, seedDefaultsIfEmpty, toggleEditMode, addPage } =
         await import('./dashboardSlice')
       const store = await createTestStore()
-
       store.dispatch(seedDefaultsIfEmpty())
       store.dispatch(toggleEditMode())
       store.dispatch(addPage({ name: 'Custom' }))
       expect(store.getState().dashboard.pages.length).toBe(5)
       expect(store.getState().dashboard.isEditMode).toBe(true)
 
+      // Act
       store.dispatch(resetToDefaults())
 
+      // Assert
       const state = store.getState().dashboard
       expect(state.pages.length).toBe(4)
       expect(state.isEditMode).toBe(false)

--- a/src/renderer/src/redux/slices/marketplaceSlice.test.ts
+++ b/src/renderer/src/redux/slices/marketplaceSlice.test.ts
@@ -39,9 +39,14 @@ describe('marketplaceSlice', () => {
     vi.resetAllMocks()
   })
 
-  it('has correct initial state', async () => {
+  it('opens the Marketplace tab on a clean, idle search panel', async () => {
+    // Arrange
     const store = await createTestStore()
+
+    // Act
     const state = store.getState().marketplace
+
+    // Assert
     expect(state.status).toBe('idle')
     expect(state.searchQuery).toBe('')
     expect(state.searchResults).toEqual([])
@@ -51,120 +56,156 @@ describe('marketplaceSlice', () => {
   })
 
   // --- Sync reducers ---
-  it('setMarketplaceSearchQuery updates query', async () => {
+  it('reflects what the user typed into the marketplace search box', async () => {
+    // Arrange
     const { setMarketplaceSearchQuery } = await import('./marketplaceSlice')
     const store = await createTestStore()
+
+    // Act
     store.dispatch(setMarketplaceSearchQuery('react'))
+
+    // Assert
     expect(store.getState().marketplace.searchQuery).toBe('react')
   })
 
-  it('selectSkillForInstall sets and clears selection', async () => {
+  it('highlights a skill chosen to install, then deselects it when dismissed', async () => {
+    // Arrange
     const { selectSkillForInstall } = await import('./marketplaceSlice')
     const store = await createTestStore()
+
+    // Act + Assert — selecting a skill marks it for install
     store.dispatch(selectSkillForInstall(sampleResult))
     expect(store.getState().marketplace.selectedSkill).toEqual(sampleResult)
 
+    // Act + Assert — passing null dismisses the install selection
     store.dispatch(selectSkillForInstall(null))
     expect(store.getState().marketplace.selectedSkill).toBeNull()
   })
 
-  it('setPreviewSkill sets and clears preview selection', async () => {
+  it('opens a skill in the preview pane, then closes the preview when dismissed', async () => {
+    // Arrange
     const { setPreviewSkill } = await import('./marketplaceSlice')
     const store = await createTestStore()
+
+    // Act + Assert — selecting a skill shows its preview
     store.dispatch(setPreviewSkill(sampleResult))
     expect(store.getState().marketplace.previewSkill).toEqual(sampleResult)
 
+    // Act + Assert — passing null closes the preview
     store.dispatch(setPreviewSkill(null))
     expect(store.getState().marketplace.previewSkill).toBeNull()
   })
 
-  it('cancelOperation calls IPC cancel and resets state', async () => {
+  it('aborts the in-flight CLI operation and returns the panel to idle when the user cancels', async () => {
+    // Arrange
     const { cancelOperation } = await import('./marketplaceSlice')
     const store = await createTestStore()
+
+    // Act
     store.dispatch(cancelOperation())
+
+    // Assert
     expect(mockCancel).toHaveBeenCalled()
     expect(store.getState().marketplace.status).toBe('idle')
   })
 
-  it('clearError resets error and status', async () => {
+  it('dismisses a surfaced error banner and lets the user search again', async () => {
+    // Arrange — drive the panel into the error state via a failing search
     const { clearError } = await import('./marketplaceSlice')
     const store = await createTestStore()
-    // Simulate error state by searching then failing
     mockSearch.mockRejectedValue(new Error('fail'))
     const { searchSkills } = await import('./marketplaceSlice')
     await store.dispatch(searchSkills('test'))
     expect(store.getState().marketplace.status).toBe('error')
 
+    // Act
     store.dispatch(clearError())
+
+    // Assert
     expect(store.getState().marketplace.error).toBeNull()
     expect(store.getState().marketplace.status).toBe('idle')
   })
 
-  it('clearSearchResults empties results and query', async () => {
+  it('empties the results list and the search box when results are cleared', async () => {
+    // Arrange
     const { setMarketplaceSearchQuery, clearSearchResults } =
       await import('./marketplaceSlice')
     const store = await createTestStore()
     store.dispatch(setMarketplaceSearchQuery('react'))
+
+    // Act
     store.dispatch(clearSearchResults())
 
+    // Assert
     expect(store.getState().marketplace.searchResults).toEqual([])
     expect(store.getState().marketplace.searchQuery).toBe('')
   })
 
   // --- searchSkills thunk ---
-  it('searchSkills sets searching during pending', async () => {
+  it('shows a searching spinner state while the search request is in flight', async () => {
+    // Arrange — keep the search request pending so the spinner state is observable
     let resolve!: (value: SkillSearchResult[]) => void
     mockSearch.mockReturnValue(
       new Promise<SkillSearchResult[]>((r) => {
         resolve = r
       }),
     )
-
     const store = await createTestStore()
     const { searchSkills } = await import('./marketplaceSlice')
+
+    // Act
     const promise = store.dispatch(searchSkills('react'))
 
+    // Assert
     expect(store.getState().marketplace.status).toBe('searching')
 
     resolve([sampleResult])
     await promise
   })
 
-  it('searchSkills populates results on fulfilled', async () => {
+  it('lists the matching skills once the search resolves', async () => {
+    // Arrange
     mockSearch.mockResolvedValue([sampleResult])
-
     const store = await createTestStore()
     const { searchSkills } = await import('./marketplaceSlice')
+
+    // Act
     await store.dispatch(searchSkills('task'))
 
+    // Assert
     const state = store.getState().marketplace
     expect(state.status).toBe('idle')
     expect(state.searchResults).toHaveLength(1)
     expect(state.searchResults[0].name).toBe('task')
   })
 
-  it('searchSkills sets error on rejected', async () => {
+  it('surfaces the failure message when a search request errors out', async () => {
+    // Arrange
     mockSearch.mockRejectedValue(new Error('API timeout'))
-
     const store = await createTestStore()
     const { searchSkills } = await import('./marketplaceSlice')
+
+    // Act
     await store.dispatch(searchSkills('test'))
 
+    // Assert
     expect(store.getState().marketplace.status).toBe('error')
     expect(store.getState().marketplace.error).toBe('API timeout')
   })
 
   // --- installSkill thunk ---
-  it('installSkill sets installing during pending', async () => {
+  it('shows an installing state while the install request is in flight', async () => {
+    // Arrange — keep the install request pending so the installing state is observable
     let resolve!: (value: { success: boolean }) => void
     mockInstall.mockReturnValue(
       new Promise((r) => {
         resolve = r
       }),
     )
-
     const store = await createTestStore()
     const { installSkill } = await import('./marketplaceSlice')
+
+    // Act
     const promise = store.dispatch(
       installSkill({
         repo: repositoryId('vercel-labs/skill-task'),
@@ -173,19 +214,22 @@ describe('marketplaceSlice', () => {
       }),
     )
 
+    // Assert
     expect(store.getState().marketplace.status).toBe('installing')
 
     resolve({ success: true })
     await promise
   })
 
-  it('installSkill clears selection on fulfilled', async () => {
+  it('clears the install selection and returns to idle once the install succeeds', async () => {
+    // Arrange
     mockInstall.mockResolvedValue({ success: true })
-
     const store = await createTestStore()
     const { selectSkillForInstall, installSkill } =
       await import('./marketplaceSlice')
     store.dispatch(selectSkillForInstall(sampleResult))
+
+    // Act
     await store.dispatch(
       installSkill({
         repo: repositoryId('vercel-labs/skill-task'),
@@ -194,15 +238,18 @@ describe('marketplaceSlice', () => {
       }),
     )
 
+    // Assert
     expect(store.getState().marketplace.selectedSkill).toBeNull()
     expect(store.getState().marketplace.status).toBe('idle')
   })
 
-  it('installSkill sets error on rejected', async () => {
+  it('surfaces the failure message when an install request errors out', async () => {
+    // Arrange
     mockInstall.mockRejectedValue(new Error('Install failed'))
-
     const store = await createTestStore()
     const { installSkill } = await import('./marketplaceSlice')
+
+    // Act
     await store.dispatch(
       installSkill({
         repo: repositoryId('vercel-labs/skill-task'),
@@ -211,23 +258,27 @@ describe('marketplaceSlice', () => {
       }),
     )
 
+    // Assert
     expect(store.getState().marketplace.status).toBe('error')
     expect(store.getState().marketplace.error).toBe('Install failed')
   })
 
   // --- loadLeaderboard thunk ---
-  it('loadLeaderboard sets loading state for new filter', async () => {
+  it('shows a loading leaderboard for a filter that has never been fetched', async () => {
+    // Arrange — keep the leaderboard request pending so the loading state is observable
     let resolve!: (value: SkillSearchResult[]) => void
     mockLeaderboard.mockReturnValue(
       new Promise<SkillSearchResult[]>((r) => {
         resolve = r
       }),
     )
-
     const store = await createTestStore()
     const { loadLeaderboard } = await import('./marketplaceSlice')
+
+    // Act
     const promise = store.dispatch(loadLeaderboard('all-time'))
 
+    // Assert
     const lb = store.getState().marketplace.leaderboard['all-time']
     expect(lb?.status).toBe('loading')
     expect(lb?.skills).toEqual([])
@@ -236,13 +287,16 @@ describe('marketplaceSlice', () => {
     await promise
   })
 
-  it('loadLeaderboard populates per-filter cache on fulfilled', async () => {
+  it('caches the fetched leaderboard rows under their filter key once loaded', async () => {
+    // Arrange
     mockLeaderboard.mockResolvedValue([sampleResult])
-
     const store = await createTestStore()
     const { loadLeaderboard } = await import('./marketplaceSlice')
+
+    // Act
     await store.dispatch(loadLeaderboard('trending'))
 
+    // Assert
     const lb = store.getState().marketplace.leaderboard['trending']
     expect(lb?.status).toBe('idle')
     expect(lb?.skills).toHaveLength(1)
@@ -250,22 +304,25 @@ describe('marketplaceSlice', () => {
     expect(lb?.lastFetched).toBeGreaterThan(0)
   })
 
-  it('loadLeaderboard skips fetch when cache is fresh', async () => {
+  it('serves a fresh leaderboard from cache instead of refetching the same filter', async () => {
+    // Arrange
     mockLeaderboard.mockResolvedValue([sampleResult])
-
     const store = await createTestStore()
     const { loadLeaderboard } = await import('./marketplaceSlice')
 
-    // First fetch populates cache
+    // Act — first dispatch populates the cache
     await store.dispatch(loadLeaderboard('all-time'))
     expect(mockLeaderboard).toHaveBeenCalledTimes(1)
 
-    // Second fetch skips (cache is fresh)
+    // Act — second dispatch is served from the still-fresh cache
     await store.dispatch(loadLeaderboard('all-time'))
+
+    // Assert — no second IPC call was made
     expect(mockLeaderboard).toHaveBeenCalledTimes(1)
   })
 
-  it('loadLeaderboard stores different data per filter', async () => {
+  it('keeps each leaderboard filter cached separately so they do not overwrite each other', async () => {
+    // Arrange
     const trendingResult: SkillSearchResult = {
       ...sampleResult,
       name: 'trending-skill',
@@ -273,25 +330,24 @@ describe('marketplaceSlice', () => {
     mockLeaderboard
       .mockResolvedValueOnce([sampleResult])
       .mockResolvedValueOnce([trendingResult])
-
     const store = await createTestStore()
     const { loadLeaderboard } = await import('./marketplaceSlice')
 
+    // Act
     await store.dispatch(loadLeaderboard('all-time'))
     await store.dispatch(loadLeaderboard('trending'))
 
+    // Assert — each filter key holds its own rows
     const state = store.getState().marketplace
     expect(state.leaderboard['all-time']?.skills[0].name).toBe('task')
     expect(state.leaderboard['trending']?.skills[0].name).toBe('trending-skill')
   })
 
-  it('loadLeaderboard keeps stale data on error', async () => {
+  it('leaves the last good leaderboard on screen when a stale-cache refetch fails', async () => {
+    // Arrange — first fetch populates the cache
     mockLeaderboard.mockResolvedValueOnce([sampleResult])
-
     const store = await createTestStore()
     const { loadLeaderboard } = await import('./marketplaceSlice')
-
-    // First fetch succeeds
     await store.dispatch(loadLeaderboard('hot'))
     expect(
       store.getState().marketplace.leaderboard['hot']?.skills,
@@ -303,25 +359,28 @@ describe('marketplaceSlice', () => {
     vi.useFakeTimers()
     vi.setSystemTime(Date.now() + 31 * 60 * 1000)
 
-    // Second fetch fails
+    // Act — the stale-cache refetch fails
     mockLeaderboard.mockRejectedValueOnce(new Error('Network error'))
     await store.dispatch(loadLeaderboard('hot'))
 
     vi.useRealTimers()
 
-    // Should still have the stale data but status is error
+    // Assert — the stale rows remain but the status flips to error
     const state = store.getState().marketplace.leaderboard['hot']
     expect(state?.skills).toHaveLength(1)
     expect(state?.status).toBe('error')
   })
 
-  it('loadLeaderboard sets error when no cache exists', async () => {
+  it('shows an error and no rows when the first-ever leaderboard fetch fails', async () => {
+    // Arrange
     mockLeaderboard.mockRejectedValue(new Error('Offline'))
-
     const store = await createTestStore()
     const { loadLeaderboard } = await import('./marketplaceSlice')
+
+    // Act
     await store.dispatch(loadLeaderboard('all-time'))
 
+    // Assert
     const lb = store.getState().marketplace.leaderboard['all-time']
     expect(lb?.status).toBe('error')
     expect(lb?.error).toBe('Offline')

--- a/src/renderer/src/redux/slices/settingsSlice.test.ts
+++ b/src/renderer/src/redux/slices/settingsSlice.test.ts
@@ -23,16 +23,24 @@ async function createTestStore() {
 }
 
 describe('settingsSlice', () => {
-  it('initial state matches DEFAULT_SETTINGS (with empty hiddenAgentIds)', async () => {
+  it('starts from the default settings with no agents hidden', async () => {
+    // Arrange
     const store = await createTestStore()
-    expect(store.getState().settings).toEqual(DEFAULT_SETTINGS)
-    expect(store.getState().settings.hiddenAgentIds).toEqual([])
+
+    // Act
+    const settings = store.getState().settings
+
+    // Assert
+    expect(settings).toEqual(DEFAULT_SETTINGS)
+    expect(settings.hiddenAgentIds).toEqual([])
   })
 
-  it('setSettings replaces the entire settings object idempotently', async () => {
+  it('applies an updated settings object so the new tab and hidden agents take effect', async () => {
+    // Arrange
     const { setSettings } = await import('./settingsSlice')
     const store = await createTestStore()
 
+    // Act
     store.dispatch(
       setSettings({
         ...DEFAULT_SETTINGS,
@@ -41,6 +49,7 @@ describe('settingsSlice', () => {
       }),
     )
 
+    // Assert
     expect(store.getState().settings.defaultSkillTab).toBe('info')
     expect(store.getState().settings.hiddenAgentIds).toEqual(['claude-code'])
   })
@@ -54,11 +63,11 @@ describe('settingsSlice', () => {
  *    default `===` comparison can short-circuit downstream re-renders
  */
 describe('selectHiddenAgentIds', () => {
-  it('returns the persisted hiddenAgentIds array', async () => {
+  it('exposes the persisted hidden agents exactly as stored', async () => {
+    // Arrange
     const { selectHiddenAgentIds } = await import('./settingsSlice')
     const { setSettings } = await import('./settingsSlice')
     const store = await createTestStore()
-
     store.dispatch(
       setSettings({
         ...DEFAULT_SETTINGS,
@@ -66,18 +75,23 @@ describe('selectHiddenAgentIds', () => {
       }),
     )
 
-    expect(selectHiddenAgentIds(store.getState() as RootState)).toEqual([
-      'claude-code',
-      'cursor',
-    ])
+    // Act
+    const hiddenAgentIds = selectHiddenAgentIds(store.getState() as RootState)
+
+    // Assert
+    expect(hiddenAgentIds).toEqual(['claude-code', 'cursor'])
   })
 
-  it('returns the same reference across consecutive reads when state is unchanged', async () => {
+  it('returns a stable array reference between reads so subscribers skip needless re-renders', async () => {
+    // Arrange
     const { selectHiddenAgentIds } = await import('./settingsSlice')
     const store = await createTestStore()
 
+    // Act
     const firstRead = selectHiddenAgentIds(store.getState() as RootState)
     const secondRead = selectHiddenAgentIds(store.getState() as RootState)
+
+    // Assert
     expect(firstRead).toBe(secondRead)
   })
 })

--- a/src/renderer/src/redux/slices/skillsSlice.test.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.test.ts
@@ -149,9 +149,14 @@ describe('skillsSlice', () => {
     vi.resetAllMocks()
   })
 
-  it('has correct initial state', async () => {
+  it('opens with an empty, idle skills list and no pending bulk operations', async () => {
+    // Arrange
     const store = await createTestStore()
+
+    // Act
     const state = store.getState().skills
+
+    // Assert
     expect(state.items).toEqual([])
     expect(state.selectedSkill).toBeNull()
     expect(state.loading).toBe(false)
@@ -169,96 +174,122 @@ describe('skillsSlice', () => {
   })
 
   // --- Sync reducers (kept from pre-v2.4) ---
-  it('selectSkill sets selectedSkill', async () => {
+  it('opens the detail pane for the clicked skill, then closes it when deselected', async () => {
+    // Arrange
     const { selectSkill } = await import('./skillsSlice')
     const store = await createTestStore()
+
+    // Act + Assert — clicking a skill opens its detail
     store.dispatch(selectSkill(sampleSkill))
     expect(store.getState().skills.selectedSkill).toEqual(sampleSkill)
 
+    // Act + Assert — deselecting closes it
     store.dispatch(selectSkill(null))
     expect(store.getState().skills.selectedSkill).toBeNull()
   })
 
-  it('setSkillToUnlink sets and clears pending unlink', async () => {
+  it('opens the unlink confirm for the chosen skill, then closes it when dismissed', async () => {
+    // Arrange
     const { setSkillToUnlink } = await import('./skillsSlice')
     const store = await createTestStore()
+
+    // Act + Assert — selecting a skill/symlink arms the unlink confirm
     store.dispatch(
       setSkillToUnlink({ skill: sampleSkill, symlink: sampleSymlink }),
     )
     expect(store.getState().skills.skillToUnlink).not.toBeNull()
 
+    // Act + Assert — passing null dismisses it
     store.dispatch(setSkillToUnlink(null))
     expect(store.getState().skills.skillToUnlink).toBeNull()
   })
 
-  it('setSkillToAddSymlinks sets and clears pending add and resets modal selections', async () => {
+  it('opens the Add modal on a clean agent checklist and clears it again on close', async () => {
+    // Arrange — a stale agent tick exists before the modal opens
     const { setSkillToAddSymlinks, toggleAddAgentSelection } =
       await import('./skillsSlice')
     const store = await createTestStore()
     store.dispatch(toggleAddAgentSelection('codex' as AgentId))
+
+    // Act + Assert — opening the Add modal resets the checklist to empty
     store.dispatch(setSkillToAddSymlinks(sampleSkill))
     expect(store.getState().skills.skillToAddSymlinks).toEqual(sampleSkill)
     expect(store.getState().skills.selectedAddAgentIds).toEqual([])
 
+    // Act + Assert — closing the modal clears the checklist again
     store.dispatch(toggleAddAgentSelection('cursor' as AgentId))
     store.dispatch(setSkillToAddSymlinks(null))
     expect(store.getState().skills.skillToAddSymlinks).toBeNull()
     expect(store.getState().skills.selectedAddAgentIds).toEqual([])
   })
 
-  it('toggleAddAgentSelection toggles the Add modal agent list', async () => {
+  it('ticks and un-ticks an agent in the Add modal checklist', async () => {
+    // Arrange
     const { toggleAddAgentSelection } = await import('./skillsSlice')
     const store = await createTestStore()
 
+    // Act + Assert — first toggle ticks the agent
     store.dispatch(toggleAddAgentSelection('codex' as AgentId))
     expect(store.getState().skills.selectedAddAgentIds).toEqual(['codex'])
 
+    // Act + Assert — second toggle un-ticks it
     store.dispatch(toggleAddAgentSelection('codex' as AgentId))
     expect(store.getState().skills.selectedAddAgentIds).toEqual([])
   })
 
-  it('setSkillToCopy sets and clears pending copy', async () => {
+  it('opens the Copy modal for a skill, then clears the copy checklist on close', async () => {
+    // Arrange
     const { setSkillToCopy, toggleCopyAgentSelection } =
       await import('./skillsSlice')
     const store = await createTestStore()
+
+    // Act + Assert — opening arms the Copy modal
     store.dispatch(setSkillToCopy(sampleSkill))
     expect(store.getState().skills.skillToCopy).toEqual(sampleSkill)
 
+    // Act + Assert — closing clears both the target and the checklist
     store.dispatch(toggleCopyAgentSelection('cursor' as AgentId))
     store.dispatch(setSkillToCopy(null))
     expect(store.getState().skills.skillToCopy).toBeNull()
     expect(store.getState().skills.selectedCopyAgentIds).toEqual([])
   })
 
-  it('toggleCopyAgentSelection toggles the Copy modal agent list', async () => {
+  it('ticks, un-ticks, and bulk-clears agents in the Copy modal checklist', async () => {
+    // Arrange
     const { toggleCopyAgentSelection, clearCopyAgentSelection } =
       await import('./skillsSlice')
     const store = await createTestStore()
 
+    // Act + Assert — first toggle ticks the agent
     store.dispatch(toggleCopyAgentSelection('codex' as AgentId))
     expect(store.getState().skills.selectedCopyAgentIds).toEqual(['codex'])
 
+    // Act + Assert — second toggle un-ticks it
     store.dispatch(toggleCopyAgentSelection('codex' as AgentId))
     expect(store.getState().skills.selectedCopyAgentIds).toEqual([])
 
+    // Act + Assert — clearing wipes the whole checklist at once
     store.dispatch(toggleCopyAgentSelection('cursor' as AgentId))
     store.dispatch(clearCopyAgentSelection())
     expect(store.getState().skills.selectedCopyAgentIds).toEqual([])
   })
 
   // --- fetchSkills thunk ---
-  it('fetchSkills sets loading during pending', async () => {
+  it('shows a loading state while the skills inventory is being fetched', async () => {
+    // Arrange — keep the fetch pending so the loading state is observable
     let resolve!: (value: Skill[]) => void
     mockGetAll.mockReturnValue(
       new Promise<Skill[]>((r) => {
         resolve = r
       }),
     )
-
     const store = await createTestStore()
     const { fetchSkills } = await import('./skillsSlice')
+
+    // Act
     const promise = store.dispatch(fetchSkills())
 
+    // Assert
     expect(store.getState().skills.loading).toBe(true)
     expect(store.getState().skills.error).toBeNull()
 
@@ -266,64 +297,77 @@ describe('skillsSlice', () => {
     await promise
   })
 
-  it('fetchSkills populates items on fulfilled', async () => {
+  it('lists the fetched skills once the inventory load resolves', async () => {
+    // Arrange
     mockGetAll.mockResolvedValue([sampleSkill])
-
     const store = await createTestStore()
     const { fetchSkills } = await import('./skillsSlice')
+
+    // Act
     await store.dispatch(fetchSkills())
 
+    // Assert
     const state = store.getState().skills
     expect(state.items).toHaveLength(1)
     expect(state.items[0].name).toBe('task')
     expect(state.loading).toBe(false)
   })
 
-  it('fetchSkills sets error on rejected', async () => {
+  it('surfaces the failure message when the skills inventory load fails', async () => {
+    // Arrange
     mockGetAll.mockRejectedValue(new Error('Network error'))
-
     const store = await createTestStore()
     const { fetchSkills } = await import('./skillsSlice')
+
+    // Act
     await store.dispatch(fetchSkills())
 
+    // Assert
     const state = store.getState().skills
     expect(state.loading).toBe(false)
     expect(state.error).toBe('Network error')
   })
 
   // --- unlinkSkillFromAgent thunk ---
-  it('unlinkSkillFromAgent clears selectedSkill on fulfilled', async () => {
+  it('closes the detail pane and unlink confirm once a single unlink succeeds', async () => {
+    // Arrange
     mockUnlinkFromAgent.mockResolvedValue({ success: true })
-
     const store = await createTestStore()
     const { selectSkill, unlinkSkillFromAgent } = await import('./skillsSlice')
     store.dispatch(selectSkill(sampleSkill))
+
+    // Act
     await store.dispatch(
       unlinkSkillFromAgent({ skill: sampleSkill, symlink: sampleSymlink }),
     )
 
+    // Assert
     expect(store.getState().skills.selectedSkill).toBeNull()
     expect(store.getState().skills.skillToUnlink).toBeNull()
     expect(store.getState().skills.unlinking).toBe(false)
   })
 
-  it('unlinkSkillFromAgent sets error on failure response', async () => {
+  it('surfaces the failure message when a single unlink is rejected by the OS', async () => {
+    // Arrange
     mockUnlinkFromAgent.mockResolvedValue({
       success: false,
       error: 'Permission denied',
     })
-
     const store = await createTestStore()
     const { unlinkSkillFromAgent } = await import('./skillsSlice')
+
+    // Act
     await store.dispatch(
       unlinkSkillFromAgent({ skill: sampleSkill, symlink: sampleSymlink }),
     )
 
+    // Assert
     expect(store.getState().skills.unlinking).toBe(false)
     expect(store.getState().skills.error).toBe('Permission denied')
   })
 
-  it('unlinkSkillFromAgent passes reviewed local directory identity for local slots', async () => {
+  it('sends the reviewed local directory identity to IPC when unlinking a local slot', async () => {
+    // Arrange
     mockUnlinkFromAgent.mockResolvedValue({ success: true })
     const localSymlink: SymlinkInfo = {
       ...sampleSymlink,
@@ -331,13 +375,15 @@ describe('skillsSlice', () => {
       targetPath: undefined,
       filesystemIdentity: directoryIdentity,
     }
-
     const store = await createTestStore()
     const { unlinkSkillFromAgent } = await import('./skillsSlice')
+
+    // Act
     await store.dispatch(
       unlinkSkillFromAgent({ skill: sampleSkill, symlink: localSymlink }),
     )
 
+    // Assert
     expect(mockUnlinkFromAgent).toHaveBeenCalledWith({
       skillName: 'task',
       agentId: 'claude-code',
@@ -395,18 +441,20 @@ describe('skillsSlice', () => {
   })
 
   // --- createSymlinks thunk ---
-  it('createSymlinks clears skillToAddSymlinks on fulfilled', async () => {
+  it('closes the Add modal and clears its checklist once symlinks are created', async () => {
+    // Arrange
     mockCreateSymlinks.mockResolvedValue({
       success: true,
       created: 2,
       failures: [],
     })
-
     const store = await createTestStore()
     const { setSkillToAddSymlinks, toggleAddAgentSelection, createSymlinks } =
       await import('./skillsSlice')
     store.dispatch(setSkillToAddSymlinks(sampleSkill))
     store.dispatch(toggleAddAgentSelection('cursor' as AgentId))
+
+    // Act
     await store.dispatch(
       createSymlinks({
         skill: sampleSkill,
@@ -414,35 +462,39 @@ describe('skillsSlice', () => {
       }),
     )
 
+    // Assert
     expect(store.getState().skills.skillToAddSymlinks).toBeNull()
     expect(store.getState().skills.selectedAddAgentIds).toEqual([])
     expect(store.getState().skills.addingSymlinks).toBe(false)
   })
 
-  it('createSymlinks sets error when all fail', async () => {
+  it('surfaces an error when every requested symlink fails to create', async () => {
+    // Arrange
     mockCreateSymlinks.mockResolvedValue({
       success: false,
       created: 0,
       failures: ['cursor'],
     })
-
     const store = await createTestStore()
     const { createSymlinks } = await import('./skillsSlice')
+
+    // Act
     await store.dispatch(
       createSymlinks({ skill: sampleSkill, agentIds: ['cursor' as AgentId] }),
     )
 
+    // Assert
     expect(store.getState().skills.error).toBe('Failed to create any symlinks')
   })
 
   // --- copyToAgents thunk ---
-  it('copyToAgents clears copy-related modal targets on fulfilled', async () => {
+  it('closes both the Copy and Add modals and clears their checklists once the copy succeeds', async () => {
+    // Arrange
     mockCopyToAgents.mockResolvedValue({
       success: true,
       copied: 1,
       failures: [],
     })
-
     const store = await createTestStore()
     const {
       setSkillToAddSymlinks,
@@ -455,6 +507,8 @@ describe('skillsSlice', () => {
     store.dispatch(setSkillToAddSymlinks(sampleSkill))
     store.dispatch(toggleAddAgentSelection('cursor' as AgentId))
     store.dispatch(toggleCopyAgentSelection('codex' as AgentId))
+
+    // Act
     await store.dispatch(
       copyToAgents({
         skill: sampleSkill,
@@ -463,6 +517,7 @@ describe('skillsSlice', () => {
       }),
     )
 
+    // Assert
     expect(store.getState().skills.skillToCopy).toBeNull()
     expect(store.getState().skills.skillToAddSymlinks).toBeNull()
     expect(store.getState().skills.selectedAddAgentIds).toEqual([])
@@ -470,15 +525,17 @@ describe('skillsSlice', () => {
     expect(store.getState().skills.copying).toBe(false)
   })
 
-  it('copyToAgents sets error when all fail', async () => {
+  it('surfaces an error when the copy fails for every target agent', async () => {
+    // Arrange
     mockCopyToAgents.mockResolvedValue({
       success: false,
       copied: 0,
       failures: ['codex'],
     })
-
     const store = await createTestStore()
     const { copyToAgents } = await import('./skillsSlice')
+
+    // Act
     await store.dispatch(
       copyToAgents({
         skill: sampleSkill,
@@ -487,6 +544,7 @@ describe('skillsSlice', () => {
       }),
     )
 
+    // Assert
     expect(store.getState().skills.error).toBe('Failed to copy to any agent')
   })
 })
@@ -496,33 +554,44 @@ describe('skillsSlice bulk selection reducers (v2.4)', () => {
     vi.resetAllMocks()
   })
 
-  it('toggleSelection adds a name and sets the anchor', async () => {
+  it('selects a clicked row and pins it as the range anchor', async () => {
+    // Arrange
     const { toggleSelection } = await import('./skillsSlice')
     const store = await createTestStore()
 
+    // Act
     store.dispatch(toggleSelection('task'))
+
+    // Assert
     expect(store.getState().skills.selectedSkillNames).toEqual(['task'])
     expect(store.getState().skills.selectionAnchor).toBe('task')
   })
 
-  it('toggleSelection removes a name on the second toggle', async () => {
+  it('deselects a row on a second click but keeps it as the anchor', async () => {
+    // Arrange
     const { toggleSelection } = await import('./skillsSlice')
     const store = await createTestStore()
 
+    // Act
     store.dispatch(toggleSelection('task'))
     store.dispatch(toggleSelection('task'))
+
+    // Assert
     expect(store.getState().skills.selectedSkillNames).toEqual([])
     // Anchor remains — matches macOS Finder "last clicked row" semantics
     expect(store.getState().skills.selectionAnchor).toBe('task')
   })
 
-  it('selectRange unions into existing selection preserving order', async () => {
+  it('shift-clicking a range adds the spanned rows in order and moves the anchor to the end', async () => {
+    // Arrange
     const { toggleSelection, selectRange } = await import('./skillsSlice')
     const store = await createTestStore()
 
+    // Act
     store.dispatch(toggleSelection('task'))
     store.dispatch(selectRange(['task', 'theme', 'browser']))
 
+    // Assert
     expect(store.getState().skills.selectedSkillNames).toEqual([
       'task',
       'theme',
@@ -532,14 +601,17 @@ describe('skillsSlice bulk selection reducers (v2.4)', () => {
     expect(store.getState().skills.selectionAnchor).toBe('browser')
   })
 
-  it('selectRange does not duplicate names already selected', async () => {
+  it('keeps each row once when a shift-click range overlaps the existing selection', async () => {
+    // Arrange
     const { toggleSelection, selectRange } = await import('./skillsSlice')
     const store = await createTestStore()
 
+    // Act
     store.dispatch(toggleSelection('task'))
     store.dispatch(toggleSelection('browser'))
     store.dispatch(selectRange(['task', 'theme', 'browser']))
 
+    // Assert
     expect(store.getState().skills.selectedSkillNames).toEqual([
       'task',
       'browser',
@@ -547,13 +619,16 @@ describe('skillsSlice bulk selection reducers (v2.4)', () => {
     ])
   })
 
-  it('selectAll replaces the entire selection', async () => {
+  it('replaces the whole selection and moves the anchor to the last row when select-all runs', async () => {
+    // Arrange
     const { toggleSelection, selectAll } = await import('./skillsSlice')
     const store = await createTestStore()
 
+    // Act
     store.dispatch(toggleSelection('zebra'))
     store.dispatch(selectAll(['task', 'theme', 'browser']))
 
+    // Assert
     expect(store.getState().skills.selectedSkillNames).toEqual([
       'task',
       'theme',
@@ -562,39 +637,48 @@ describe('skillsSlice bulk selection reducers (v2.4)', () => {
     expect(store.getState().skills.selectionAnchor).toBe('browser')
   })
 
-  it('selectAll with empty array clears selection and anchor', async () => {
+  it('clears the selection and anchor when select-all is given an empty list', async () => {
+    // Arrange
     const { toggleSelection, selectAll } = await import('./skillsSlice')
     const store = await createTestStore()
 
+    // Act
     store.dispatch(toggleSelection('task'))
     store.dispatch(selectAll([]))
 
+    // Assert
     expect(store.getState().skills.selectedSkillNames).toEqual([])
     expect(store.getState().skills.selectionAnchor).toBeNull()
   })
 
-  it('clearSelection resets names and anchor', async () => {
+  it('clears the selection and anchor when the user clears the selection', async () => {
+    // Arrange
     const { toggleSelection, clearSelection } = await import('./skillsSlice')
     const store = await createTestStore()
 
+    // Act
     store.dispatch(toggleSelection('task'))
     store.dispatch(toggleSelection('theme'))
     store.dispatch(clearSelection())
 
+    // Assert
     expect(store.getState().skills.selectedSkillNames).toEqual([])
     expect(store.getState().skills.selectionAnchor).toBeNull()
   })
 
-  it('setBulkProgress sets and clears the progress counter', async () => {
+  it('shows the bulk progress counter during an operation and hides it when cleared', async () => {
+    // Arrange
     const { setBulkProgress } = await import('./skillsSlice')
     const store = await createTestStore()
 
+    // Act + Assert — setting a counter shows progress
     store.dispatch(setBulkProgress({ current: 3, total: 10 }))
     expect(store.getState().skills.bulkProgress).toEqual({
       current: 3,
       total: 10,
     })
 
+    // Act + Assert — clearing hides it
     store.dispatch(setBulkProgress(null))
     expect(store.getState().skills.bulkProgress).toBeNull()
   })
@@ -605,7 +689,8 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
     vi.resetAllMocks()
   })
 
-  it('sets bulkDeleting and reconciles inFlightDeleteNames against live items on pending', async () => {
+  it('marks only the still-present skills as deleting and drops a ghost name while a bulk delete is in flight', async () => {
+    // Arrange
     const store = await createTestStore()
     await seedItems(store, [sampleSkill, secondSkill])
     // Hold the thunk pending indefinitely
@@ -615,9 +700,9 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
         resolve = r
       }),
     )
-
     const { deleteSelectedSkills } = await import('./skillsSlice')
-    // Include a ghost name that is NOT in state.items — reconciliation should drop it
+
+    // Act — include a ghost name that is NOT in state.items; reconciliation should drop it
     const promise = store.dispatch(
       deleteSelectedSkills([
         deleteTarget('task'),
@@ -626,6 +711,7 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
       ]),
     )
 
+    // Assert
     expect(store.getState().skills.bulkDeleting).toBe(true)
     expect(store.getState().skills.inFlightDeleteNames).toEqual([
       'task',
@@ -659,7 +745,8 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
     await promise
   })
 
-  it('passes reviewed skillPath through deleteSkills IPC', async () => {
+  it('sends the reviewed source path through the deleteSkills IPC call', async () => {
+    // Arrange
     const store = await createTestStore()
     mockDeleteSkills.mockResolvedValue({
       items: [
@@ -672,8 +759,9 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
         },
       ],
     } satisfies BulkDeleteResult)
-
     const { deleteSelectedSkills } = await import('./skillsSlice')
+
+    // Act
     await store.dispatch(
       deleteSelectedSkills([
         {
@@ -685,6 +773,7 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
       ]),
     )
 
+    // Assert
     expect(mockDeleteSkills).toHaveBeenCalledWith({
       items: [
         {
@@ -696,7 +785,8 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
     })
   })
 
-  it('clears selection, anchor, inFlight, and progress on fulfilled', async () => {
+  it('resets the selection, anchor, busy flag, and progress counter once a bulk delete completes', async () => {
+    // Arrange
     const store = await createTestStore()
     await seedItems(store, [sampleSkill])
     mockDeleteSkills.mockResolvedValue({
@@ -710,14 +800,15 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
         },
       ],
     } satisfies BulkDeleteResult)
-
     const { deleteSelectedSkills, toggleSelection, setBulkProgress } =
       await import('./skillsSlice')
     store.dispatch(toggleSelection('task'))
     store.dispatch(setBulkProgress({ current: 1, total: 1 }))
 
+    // Act
     await store.dispatch(deleteSelectedSkills([deleteTarget('task')]))
 
+    // Assert
     const state = store.getState().skills
     expect(state.bulkDeleting).toBe(false)
     expect(state.inFlightDeleteNames).toEqual([])
@@ -726,7 +817,8 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
     expect(state.bulkProgress).toBeNull()
   })
 
-  it('clears selection and anchor when delete returns orphan-cleared', async () => {
+  it('resets the selection and anchor when a delete instead clears an orphan symlink', async () => {
+    // Arrange
     const store = await createTestStore()
     await seedItems(store, [sampleSkill])
     mockDeleteSkills.mockResolvedValue({
@@ -739,14 +831,15 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
         },
       ],
     } satisfies BulkDeleteResult)
-
     const { deleteSelectedSkills, toggleSelection, setBulkProgress } =
       await import('./skillsSlice')
     store.dispatch(toggleSelection('task'))
     store.dispatch(setBulkProgress({ current: 1, total: 1 }))
 
+    // Act
     await store.dispatch(deleteSelectedSkills([deleteTarget('task')]))
 
+    // Assert
     const state = store.getState().skills
     expect(state.bulkDeleting).toBe(false)
     expect(state.inFlightDeleteNames).toEqual([])
@@ -755,14 +848,17 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
     expect(state.bulkProgress).toBeNull()
   })
 
-  it('clears in-flight and sets error on rejected', async () => {
+  it('clears the in-flight delete state and surfaces the error when a bulk delete is rejected', async () => {
+    // Arrange
     const store = await createTestStore()
     await seedItems(store, [sampleSkill])
     mockDeleteSkills.mockRejectedValue(new Error('EACCES'))
-
     const { deleteSelectedSkills } = await import('./skillsSlice')
+
+    // Act
     await store.dispatch(deleteSelectedSkills([deleteTarget('task')]))
 
+    // Assert
     const state = store.getState().skills
     expect(state.bulkDeleting).toBe(false)
     expect(state.inFlightDeleteNames).toEqual([])
@@ -775,7 +871,8 @@ describe('skillsSlice clearSelectedOrphanSymlinks thunk', () => {
     vi.resetAllMocks()
   })
 
-  it('sets bulkDeleting and reconciles orphan inFlightDeleteNames against live items on pending', async () => {
+  it('marks only the still-present orphan as clearing and drops a ghost name while cleanup is in flight', async () => {
+    // Arrange
     const store = await createTestStore()
     await seedItems(store, [sampleSkill, secondSkill])
     let resolve!: (value: ClearOrphanSymlinksResult) => void
@@ -784,8 +881,9 @@ describe('skillsSlice clearSelectedOrphanSymlinks thunk', () => {
         resolve = r
       }),
     )
-
     const { clearSelectedOrphanSymlinks } = await import('./skillsSlice')
+
+    // Act — 'ghost' is not in state.items so reconciliation should drop it
     const promise = store.dispatch(
       clearSelectedOrphanSymlinks([
         {
@@ -811,6 +909,7 @@ describe('skillsSlice clearSelectedOrphanSymlinks thunk', () => {
       ]),
     )
 
+    // Assert
     expect(store.getState().skills.bulkDeleting).toBe(true)
     expect(store.getState().skills.inFlightDeleteNames).toEqual(['task'])
 
@@ -827,7 +926,8 @@ describe('skillsSlice clearSelectedOrphanSymlinks thunk', () => {
     await promise
   })
 
-  it('clears orphan selection, anchor, inFlight, and progress on fulfilled', async () => {
+  it('resets the orphan selection, anchor, busy flag, and progress counter once cleanup completes', async () => {
+    // Arrange
     const store = await createTestStore()
     await seedItems(store, [sampleSkill])
     mockClearOrphanSymlinks.mockResolvedValue({
@@ -840,12 +940,12 @@ describe('skillsSlice clearSelectedOrphanSymlinks thunk', () => {
         },
       ],
     } satisfies ClearOrphanSymlinksResult)
-
     const { clearSelectedOrphanSymlinks, setBulkProgress, toggleSelection } =
       await import('./skillsSlice')
     store.dispatch(toggleSelection('task'))
     store.dispatch(setBulkProgress({ current: 1, total: 1 }))
 
+    // Act
     await store.dispatch(
       clearSelectedOrphanSymlinks([
         {
@@ -861,6 +961,7 @@ describe('skillsSlice clearSelectedOrphanSymlinks thunk', () => {
       ]),
     )
 
+    // Assert
     const state = store.getState().skills
     expect(state.bulkDeleting).toBe(false)
     expect(state.inFlightDeleteNames).toEqual([])
@@ -869,7 +970,8 @@ describe('skillsSlice clearSelectedOrphanSymlinks thunk', () => {
     expect(state.bulkProgress).toBeNull()
   })
 
-  it('keeps failed orphan rows selected while clearing busy state on fulfilled', async () => {
+  it('keeps a failed orphan row selected for retry while ending the busy state', async () => {
+    // Arrange
     const store = await createTestStore()
     await seedItems(store, [sampleSkill])
     mockClearOrphanSymlinks.mockResolvedValue({
@@ -881,11 +983,11 @@ describe('skillsSlice clearSelectedOrphanSymlinks thunk', () => {
         },
       ],
     } satisfies ClearOrphanSymlinksResult)
-
     const { clearSelectedOrphanSymlinks, toggleSelection } =
       await import('./skillsSlice')
     store.dispatch(toggleSelection('task'))
 
+    // Act
     await store.dispatch(
       clearSelectedOrphanSymlinks([
         {
@@ -901,6 +1003,7 @@ describe('skillsSlice clearSelectedOrphanSymlinks thunk', () => {
       ]),
     )
 
+    // Assert
     const state = store.getState().skills
     expect(state.bulkDeleting).toBe(false)
     expect(state.inFlightDeleteNames).toEqual([])
@@ -908,12 +1011,14 @@ describe('skillsSlice clearSelectedOrphanSymlinks thunk', () => {
     expect(state.selectionAnchor).toBe('task')
   })
 
-  it('clears orphan in-flight state and sets error on rejected', async () => {
+  it('clears the in-flight orphan state and surfaces the error when cleanup is rejected', async () => {
+    // Arrange
     const store = await createTestStore()
     await seedItems(store, [sampleSkill])
     mockClearOrphanSymlinks.mockRejectedValue(new Error('Permission denied'))
-
     const { clearSelectedOrphanSymlinks } = await import('./skillsSlice')
+
+    // Act
     await store.dispatch(
       clearSelectedOrphanSymlinks([
         {
@@ -929,6 +1034,7 @@ describe('skillsSlice clearSelectedOrphanSymlinks thunk', () => {
       ]),
     )
 
+    // Assert
     const state = store.getState().skills
     expect(state.bulkDeleting).toBe(false)
     expect(state.inFlightDeleteNames).toEqual([])
@@ -941,7 +1047,8 @@ describe('skillsSlice clearSelectedBrokenSymlinkSlots thunk', () => {
     vi.resetAllMocks()
   })
 
-  it('sets bulkUnlinking and reconciles broken-slot inFlightUnlinkNames on pending', async () => {
+  it('matches a broken slot to its live skill by display name, not on-disk basename, while cleanup is in flight', async () => {
+    // Arrange
     const store = await createTestStore()
     await seedItems(store, [sampleSkill])
     let resolve!: (value: ClearBrokenSymlinkSlotsResult) => void
@@ -950,8 +1057,9 @@ describe('skillsSlice clearSelectedBrokenSymlinkSlots thunk', () => {
         resolve = r
       }),
     )
-
     const { clearSelectedBrokenSymlinkSlots } = await import('./skillsSlice')
+
+    // Act
     const promise = store.dispatch(
       clearSelectedBrokenSymlinkSlots({
         items: [
@@ -976,6 +1084,7 @@ describe('skillsSlice clearSelectedBrokenSymlinkSlots thunk', () => {
       }),
     )
 
+    // Assert
     expect(store.getState().skills.bulkUnlinking).toBe(true)
     expect(store.getState().skills.inFlightUnlinkNames).toEqual(['task'])
 
@@ -992,7 +1101,8 @@ describe('skillsSlice clearSelectedBrokenSymlinkSlots thunk', () => {
     await promise
   })
 
-  it('clears broken-slot busy state on fulfilled', async () => {
+  it('ends the broken-slot busy state once the cleanup completes', async () => {
+    // Arrange
     const store = await createTestStore()
     await seedItems(store, [sampleSkill])
     mockClearBrokenSymlinkSlots.mockResolvedValue({
@@ -1005,8 +1115,9 @@ describe('skillsSlice clearSelectedBrokenSymlinkSlots thunk', () => {
         },
       ],
     } satisfies ClearBrokenSymlinkSlotsResult)
-
     const { clearSelectedBrokenSymlinkSlots } = await import('./skillsSlice')
+
+    // Act
     await store.dispatch(
       clearSelectedBrokenSymlinkSlots({
         items: [
@@ -1021,19 +1132,22 @@ describe('skillsSlice clearSelectedBrokenSymlinkSlots thunk', () => {
       }),
     )
 
+    // Assert
     const state = store.getState().skills
     expect(state.bulkUnlinking).toBe(false)
     expect(state.inFlightUnlinkNames).toEqual([])
   })
 
-  it('clears broken-slot busy state and sets error on rejected', async () => {
+  it('ends the broken-slot busy state and surfaces the error when cleanup is rejected', async () => {
+    // Arrange
     const store = await createTestStore()
     await seedItems(store, [sampleSkill])
     mockClearBrokenSymlinkSlots.mockRejectedValue(
       new Error('Permission denied'),
     )
-
     const { clearSelectedBrokenSymlinkSlots } = await import('./skillsSlice')
+
+    // Act
     await store.dispatch(
       clearSelectedBrokenSymlinkSlots({
         items: [
@@ -1048,6 +1162,7 @@ describe('skillsSlice clearSelectedBrokenSymlinkSlots thunk', () => {
       }),
     )
 
+    // Assert
     const state = store.getState().skills
     expect(state.bulkUnlinking).toBe(false)
     expect(state.inFlightUnlinkNames).toEqual([])
@@ -1060,7 +1175,8 @@ describe('skillsSlice unlinkSelectedFromAgent thunk', () => {
     vi.resetAllMocks()
   })
 
-  it('sets bulkUnlinking and reconciles inFlightUnlinkNames against live items on pending', async () => {
+  it('marks only the still-present skills as unlinking and drops a ghost name while a bulk unlink is in flight', async () => {
+    // Arrange
     const store = await createTestStore()
     await seedItems(store, [sampleSkill, secondSkill, thirdSkill])
     let resolve!: (value: BulkUnlinkResult) => void
@@ -1069,8 +1185,9 @@ describe('skillsSlice unlinkSelectedFromAgent thunk', () => {
         resolve = r
       }),
     )
-
     const { unlinkSelectedFromAgent } = await import('./skillsSlice')
+
+    // Act — 'ghost' is not in state.items so reconciliation should drop it
     const promise = store.dispatch(
       unlinkSelectedFromAgent({
         agentId: 'cursor' as AgentId,
@@ -1082,6 +1199,7 @@ describe('skillsSlice unlinkSelectedFromAgent thunk', () => {
       }),
     )
 
+    // Assert
     expect(store.getState().skills.bulkUnlinking).toBe(true)
     expect(store.getState().skills.inFlightUnlinkNames).toEqual([
       'task',
@@ -1097,13 +1215,15 @@ describe('skillsSlice unlinkSelectedFromAgent thunk', () => {
     await promise
   })
 
-  it('passes reviewed linkPath through unlinkManyFromAgent IPC', async () => {
+  it('sends the reviewed agent slot path through the unlinkManyFromAgent IPC call', async () => {
+    // Arrange
     const store = await createTestStore()
     mockUnlinkManyFromAgent.mockResolvedValue({
       items: [{ skillName: 'metadata-title', outcome: 'unlinked' }],
     } satisfies BulkUnlinkResult)
-
     const { unlinkSelectedFromAgent } = await import('./skillsSlice')
+
+    // Act
     await store.dispatch(
       unlinkSelectedFromAgent({
         agentId: 'cursor' as AgentId,
@@ -1119,6 +1239,7 @@ describe('skillsSlice unlinkSelectedFromAgent thunk', () => {
       }),
     )
 
+    // Assert
     expect(mockUnlinkManyFromAgent).toHaveBeenCalledWith({
       agentId: 'cursor',
       items: [
@@ -1131,17 +1252,18 @@ describe('skillsSlice unlinkSelectedFromAgent thunk', () => {
     })
   })
 
-  it('clears selection, anchor, and inFlight on fulfilled', async () => {
+  it('resets the selection, anchor, and busy flag once a bulk unlink completes', async () => {
+    // Arrange
     const store = await createTestStore()
     await seedItems(store, [sampleSkill])
     mockUnlinkManyFromAgent.mockResolvedValue({
       items: [{ skillName: 'task', outcome: 'unlinked' }],
     } satisfies BulkUnlinkResult)
-
     const { unlinkSelectedFromAgent, toggleSelection } =
       await import('./skillsSlice')
     store.dispatch(toggleSelection('task'))
 
+    // Act
     await store.dispatch(
       unlinkSelectedFromAgent({
         agentId: 'cursor' as AgentId,
@@ -1149,6 +1271,7 @@ describe('skillsSlice unlinkSelectedFromAgent thunk', () => {
       }),
     )
 
+    // Assert
     const state = store.getState().skills
     expect(state.bulkUnlinking).toBe(false)
     expect(state.inFlightUnlinkNames).toEqual([])
@@ -1156,12 +1279,14 @@ describe('skillsSlice unlinkSelectedFromAgent thunk', () => {
     expect(state.selectionAnchor).toBeNull()
   })
 
-  it('clears in-flight and sets error on rejected', async () => {
+  it('clears the in-flight unlink state and surfaces the error when a bulk unlink is rejected', async () => {
+    // Arrange
     const store = await createTestStore()
     await seedItems(store, [sampleSkill])
     mockUnlinkManyFromAgent.mockRejectedValue(new Error('Permission denied'))
-
     const { unlinkSelectedFromAgent } = await import('./skillsSlice')
+
+    // Act
     await store.dispatch(
       unlinkSelectedFromAgent({
         agentId: 'cursor' as AgentId,
@@ -1169,6 +1294,7 @@ describe('skillsSlice unlinkSelectedFromAgent thunk', () => {
       }),
     )
 
+    // Assert
     const state = store.getState().skills
     expect(state.bulkUnlinking).toBe(false)
     expect(state.inFlightUnlinkNames).toEqual([])
@@ -1181,7 +1307,8 @@ describe('skillsSlice undoLastBulkDelete thunk', () => {
     vi.resetAllMocks()
   })
 
-  it('calls restoreDeletedSkill serially for each tombstone', async () => {
+  it('restores each tombstone one at a time in the order they were deleted', async () => {
+    // Arrange
     const calls: TombstoneId[] = []
     mockRestoreDeletedSkill.mockImplementation(
       async ({ tombstoneId: id }: { tombstoneId: TombstoneId }) => {
@@ -1193,20 +1320,23 @@ describe('skillsSlice undoLastBulkDelete thunk', () => {
         } satisfies RestoreDeletedSkillResult
       },
     )
-
     const store = await createTestStore()
     const { undoLastBulkDelete } = await import('./skillsSlice')
     const ids = [
       tombstoneId('1-task-aaaaaaaa'),
       tombstoneId('1-theme-bbbbbbbb'),
     ]
+
+    // Act
     await store.dispatch(undoLastBulkDelete(ids))
 
+    // Assert
     expect(calls).toEqual(ids)
     expect(mockRestoreDeletedSkill).toHaveBeenCalledTimes(2)
   })
 
-  it('returns per-item outcomes aligned with input order', async () => {
+  it('reports each undo result in the same order as the requested tombstones', async () => {
+    // Arrange
     mockRestoreDeletedSkill
       .mockResolvedValueOnce({
         outcome: 'restored',
@@ -1217,15 +1347,17 @@ describe('skillsSlice undoLastBulkDelete thunk', () => {
         outcome: 'error',
         error: { message: 'Trash entry missing' },
       } satisfies RestoreDeletedSkillResult)
-
     const store = await createTestStore()
     const { undoLastBulkDelete } = await import('./skillsSlice')
     const ids = [
       tombstoneId('1-task-aaaaaaaa'),
       tombstoneId('1-theme-bbbbbbbb'),
     ]
+
+    // Act
     const action = await store.dispatch(undoLastBulkDelete(ids))
 
+    // Assert
     if (!undoLastBulkDelete.fulfilled.match(action)) {
       throw new Error('Expected undoLastBulkDelete to fulfill, got rejected')
     }
@@ -1239,15 +1371,18 @@ describe('skillsSlice undoLastBulkDelete thunk', () => {
   // restored-items in the same batch (see Batch 6 / CodeRabbit thread #18).
   // As a result `state.skills.error` is NOT set on IPC rejection — callers
   // must inspect the per-item payload to build a "N of M restored" toast.
-  it('catches IPC rejection as per-item error outcome without slice-level error', async () => {
+  it('reports a failed restore as a per-item error without tripping the slice-level error banner', async () => {
+    // Arrange
     mockRestoreDeletedSkill.mockRejectedValue(new Error('Disk full'))
-
     const store = await createTestStore()
     const { undoLastBulkDelete } = await import('./skillsSlice')
+
+    // Act
     const action = await store.dispatch(
       undoLastBulkDelete([tombstoneId('1-task-aaaaaaaa')]),
     )
 
+    // Assert
     if (!undoLastBulkDelete.fulfilled.match(action)) {
       throw new Error('Expected undoLastBulkDelete to fulfill, got rejected')
     }

--- a/src/renderer/src/redux/slices/themeSlice.test.ts
+++ b/src/renderer/src/redux/slices/themeSlice.test.ts
@@ -47,9 +47,14 @@ describe('themeSlice', () => {
     vi.unstubAllGlobals()
   })
 
-  it('has correct initial state', async () => {
+  it('boots into the neutral-dark theme with no tint applied', async () => {
+    // Arrange
     const store = await createTestStore()
+
+    // Act
     const state = store.getState().theme
+
+    // Assert
     expect(state.hue).toBe(0)
     expect(state.chroma).toBe(0)
     expect(state.mode).toBe('dark')
@@ -57,10 +62,15 @@ describe('themeSlice', () => {
     expect(state.preset).toBe('neutral-dark')
   })
 
-  it('setTheme applies hue and chroma from THEME_PRESETS for color presets', async () => {
+  it('tints the app to the chosen color swatch while keeping the current dark mode', async () => {
+    // Arrange
     const { setTheme } = await import('./themeSlice')
     const store = await createTestStore()
+
+    // Act
     store.dispatch(setTheme('violet'))
+
+    // Assert
     const state = store.getState().theme
     expect(state.preset).toBe('violet')
     expect(state.hue).toBe(300)
@@ -69,10 +79,15 @@ describe('themeSlice', () => {
     expect(state.mode).toBe('dark')
   })
 
-  it('setTheme forces mode for neutral presets', async () => {
+  it('switches to light mode when the user picks the neutral-light preset', async () => {
+    // Arrange
     const { setTheme } = await import('./themeSlice')
     const store = await createTestStore()
+
+    // Act
     store.dispatch(setTheme('neutral-light'))
+
+    // Assert
     const state = store.getState().theme
     expect(state.preset).toBe('neutral-light')
     expect(state.chroma).toBe(0)
@@ -235,26 +250,35 @@ describe('themeSlice', () => {
     })
   })
 
-  it('switching color → neutral drops chroma to 0', async () => {
+  it('removes the color tint when switching from a color swatch back to a neutral preset', async () => {
+    // Arrange
     const { setTheme } = await import('./themeSlice')
     const store = await createTestStore()
+
+    // Act + Assert — a color preset applies chroma
     store.dispatch(setTheme('rose'))
     expect(store.getState().theme.chroma).toBe(COLOR_PRESET_CHROMA)
+
+    // Act + Assert — switching to neutral drops chroma back to zero
     store.dispatch(setTheme('neutral-dark'))
     expect(store.getState().theme.chroma).toBe(0)
   })
 
-  it('setTheme falls back to neutral-dark when preset key is unknown', async () => {
+  it('falls back to neutral-dark instead of crashing on a stale unknown preset key', async () => {
     // Guards against the "stale preset from disk" crash: if a user has
     // `preset: 'mono-dark'` (a name proposed in a plan but never shipped),
     // THEME_PRESETS[preset] is undefined and `config.hue` would throw. The
     // guard must short-circuit to neutral-dark before that access.
+    // Arrange
     const { setTheme } = await import('./themeSlice')
     const store = await createTestStore()
-    // Force-cast an invalid preset name. Migration has its own guard; this
-    // exercises the reducer-level guard in case migration is bypassed (e.g.
-    // a dev action dispatch, or a future slice that lets users type names).
+
+    // Act — force-cast an invalid preset name. Migration has its own guard;
+    // this exercises the reducer-level guard in case migration is bypassed
+    // (e.g. a dev action dispatch, or a future slice that lets users type names).
     store.dispatch(setTheme('mono-dark' as never))
+
+    // Assert
     const state = store.getState().theme
     expect(state.preset).toBe('neutral-dark')
     expect(state.chroma).toBe(0)

--- a/src/renderer/src/redux/slices/uiSlice.test.ts
+++ b/src/renderer/src/redux/slices/uiSlice.test.ts
@@ -132,15 +132,26 @@ const previewNoConflicts: SyncPreviewResult = {
 }
 
 describe('uiSlice activeTab', () => {
-  it('starts with activeTab=installed', async () => {
+  it('opens on the Installed tab by default', async () => {
+    // Arrange
     const store = await createTestStore()
-    expect(store.getState().ui.activeTab).toBe('installed')
+
+    // Act
+    const activeTab = store.getState().ui.activeTab
+
+    // Assert
+    expect(activeTab).toBe('installed')
   })
 
-  it('setActiveTab switches tab value', async () => {
+  it('switches to the Marketplace tab when the user clicks it', async () => {
+    // Arrange
     const store = await createTestStore()
     const { setActiveTab } = await import('./uiSlice')
+
+    // Act
     store.dispatch(setActiveTab('marketplace'))
+
+    // Assert
     expect(store.getState().ui.activeTab).toBe('marketplace')
   })
 })
@@ -216,54 +227,72 @@ describe('uiSlice symlink cleanup dialog', () => {
 })
 
 describe('uiSlice skill type excludes', () => {
-  it('starts with no excluded skill types', async () => {
+  it('starts with no skill types excluded', async () => {
+    // Arrange
     const store = await createTestStore()
-    expect(store.getState().ui.excludedSkillTypeFilters).toEqual([])
+
+    // Act
+    const excluded = store.getState().ui.excludedSkillTypeFilters
+
+    // Assert
+    expect(excluded).toEqual([])
   })
 
-  it('toggles an available excluded skill type on and off', async () => {
+  it('excludes a skill type when ticked and re-includes it when unticked', async () => {
+    // Arrange
     const store = await createTestStore()
     const { toggleExcludedSkillTypeFilter } = await import('./uiSlice')
 
+    // Act + Assert — ticking adds the exclude
     store.dispatch(toggleExcludedSkillTypeFilter('local'))
     expect(store.getState().ui.excludedSkillTypeFilters).toEqual(['local'])
 
+    // Act + Assert — unticking removes it
     store.dispatch(toggleExcludedSkillTypeFilter('local'))
     expect(store.getState().ui.excludedSkillTypeFilters).toEqual([])
   })
 
-  it('ignores an excluded skill type unavailable for the active include filter', async () => {
+  it('refuses to exclude a skill type that the active include filter does not offer', async () => {
+    // Arrange
     const store = await createTestStore()
     const { setSkillTypeFilter, toggleExcludedSkillTypeFilter } =
       await import('./uiSlice')
 
+    // Act — include only local, then try to exclude the unavailable symlinked type
     store.dispatch(setSkillTypeFilter('local'))
     store.dispatch(toggleExcludedSkillTypeFilter('symlinked'))
 
+    // Assert
     expect(store.getState().ui.excludedSkillTypeFilters).toEqual([])
   })
 
-  it('prunes stale excludes when the include filter changes', async () => {
+  it('drops excludes that no longer apply when the include filter narrows', async () => {
+    // Arrange
     const store = await createTestStore()
     const { setSkillTypeFilter, toggleExcludedSkillTypeFilter } =
       await import('./uiSlice')
 
+    // Act — exclude two types, then narrow the include filter to local
     store.dispatch(toggleExcludedSkillTypeFilter('local'))
     store.dispatch(toggleExcludedSkillTypeFilter('gstack'))
     store.dispatch(setSkillTypeFilter('local'))
 
+    // Assert — only the still-applicable exclude survives
     expect(store.getState().ui.excludedSkillTypeFilters).toEqual(['gstack'])
   })
 
-  it('selectAgent resets include and exclude filters together', async () => {
+  it('resets both the include and exclude skill-type filters when the user swaps agents', async () => {
+    // Arrange
     const store = await createTestStore()
     const { selectAgent, setSkillTypeFilter, toggleExcludedSkillTypeFilter } =
       await import('./uiSlice')
-
     store.dispatch(setSkillTypeFilter('gstack'))
     store.dispatch(toggleExcludedSkillTypeFilter('local'))
+
+    // Act
     store.dispatch(selectAgent('cursor' as AgentId))
 
+    // Assert
     expect(store.getState().ui.skillTypeFilter).toBe('all')
     expect(store.getState().ui.excludedSkillTypeFilters).toEqual([])
   })
@@ -274,33 +303,37 @@ describe('uiSlice sync thunks', () => {
     vi.resetAllMocks()
   })
 
-  it('sets isSyncing=false when preview has conflicts (regression for disabled buttons bug)', async () => {
+  it('keeps the sync buttons enabled when a preview comes back with conflicts (regression for disabled buttons bug)', async () => {
+    // Arrange
     mockSyncPreview.mockResolvedValue(previewWithConflicts)
-
     const store = await createTestStore()
     const { fetchSyncPreview } = await import('./uiSlice')
+
+    // Act
     await store.dispatch(fetchSyncPreview())
 
+    // Assert
     const state = store.getState().ui
     expect(state.isSyncing).toBe(false)
     expect(state.syncPreview).not.toBeNull()
     expect(state.syncPreview!.conflicts).toHaveLength(1)
   })
 
-  it('sets isSyncing=true during pending state', async () => {
-    // Create a promise we control to keep the thunk pending
+  it('shows the syncing spinner while the preview request is in flight', async () => {
+    // Arrange — keep the preview request pending so the spinner state is observable
     let resolve!: (value: SyncPreviewResult) => void
     mockSyncPreview.mockReturnValue(
       new Promise<SyncPreviewResult>((r) => {
         resolve = r
       }),
     )
-
     const store = await createTestStore()
     const { fetchSyncPreview } = await import('./uiSlice')
+
+    // Act
     const promise = store.dispatch(fetchSyncPreview())
 
-    // While pending, isSyncing should be true
+    // Assert
     expect(store.getState().ui.isSyncing).toBe(true)
 
     // Resolve to clean up
@@ -308,30 +341,37 @@ describe('uiSlice sync thunks', () => {
     await promise
   })
 
-  it('sets isSyncing=false when preview is rejected', async () => {
+  it('stops the syncing spinner and shows no preview when the preview request fails', async () => {
+    // Arrange
     mockSyncPreview.mockRejectedValue(new Error('Network error'))
-
     const store = await createTestStore()
     const { fetchSyncPreview } = await import('./uiSlice')
+
+    // Act
     await store.dispatch(fetchSyncPreview())
 
+    // Assert
     expect(store.getState().ui.isSyncing).toBe(false)
     expect(store.getState().ui.syncPreview).toBeNull()
   })
 
-  it('populates syncPreview on fulfillment', async () => {
+  it('shows the sync preview once the preview request resolves', async () => {
+    // Arrange
     mockSyncPreview.mockResolvedValue(previewNoConflicts)
-
     const store = await createTestStore()
     const { fetchSyncPreview } = await import('./uiSlice')
+
+    // Act
     await store.dispatch(fetchSyncPreview())
 
+    // Assert
     const state = store.getState().ui
     expect(state.syncPreview).toEqual(previewNoConflicts)
     expect(state.isSyncing).toBe(false)
   })
 
-  it('clears syncPreview and isSyncing on executeSyncAction fulfilled', async () => {
+  it('replaces the preview with a results dialog once the sync runs to completion', async () => {
+    // Arrange
     mockSyncPreview.mockResolvedValue(previewWithConflicts)
     mockSyncExecute.mockResolvedValue({
       success: true,
@@ -343,21 +383,19 @@ describe('uiSlice sync thunks', () => {
         { skillName: 'skill-a', agentName: 'Claude Code', action: 'created' },
       ],
     } satisfies SyncExecuteResult)
-
     const store = await createTestStore()
     const { fetchSyncPreview, executeSyncAction } = await import('./uiSlice')
-
-    // First: load preview
     await store.dispatch(fetchSyncPreview())
     expect(store.getState().ui.syncPreview).not.toBeNull()
 
-    // Then: execute sync
+    // Act — execute the sync
     await store.dispatch(
       executeSyncAction({
         replaceConflicts: ['/home/user/.cursor/skills/agent-browser'],
       }),
     )
 
+    // Assert — preview is dismissed and a populated result drives the dialog
     const state = store.getState().ui
     expect(state.syncPreview).toBeNull()
     expect(state.isSyncing).toBe(false)
@@ -367,18 +405,22 @@ describe('uiSlice sync thunks', () => {
     expect(state.syncResult!.details).toHaveLength(1)
   })
 
-  it('sets syncResult to null on executeSyncAction rejected', async () => {
+  it('shows no results dialog when the sync execution fails', async () => {
+    // Arrange
     mockSyncExecute.mockRejectedValue(new Error('Permission denied'))
-
     const store = await createTestStore()
     const { executeSyncAction } = await import('./uiSlice')
+
+    // Act
     await store.dispatch(executeSyncAction({ replaceConflicts: [] }))
 
+    // Assert
     expect(store.getState().ui.isSyncing).toBe(false)
     expect(store.getState().ui.syncResult).toBeNull()
   })
 
-  it('clears syncResult via clearSyncResult action', async () => {
+  it('dismisses the sync results dialog when the user closes it', async () => {
+    // Arrange
     mockSyncExecute.mockResolvedValue({
       success: true,
       created: 1,
@@ -389,19 +431,20 @@ describe('uiSlice sync thunks', () => {
         { skillName: 's', agentName: 'Claude Code', action: 'created' },
       ],
     } satisfies SyncExecuteResult)
-
     const store = await createTestStore()
     const { executeSyncAction, clearSyncResult } = await import('./uiSlice')
-
     await store.dispatch(executeSyncAction({ replaceConflicts: [] }))
     expect(store.getState().ui.syncResult).not.toBeNull()
 
+    // Act
     store.dispatch(clearSyncResult())
+
+    // Assert
     expect(store.getState().ui.syncResult).toBeNull()
   })
 
-  it('clears syncResult when fetchSyncPreview.pending fires (prevents overlapping dialogs)', async () => {
-    // First: populate syncResult via a completed sync
+  it('dismisses a stale results dialog when a new preview starts (prevents overlapping dialogs)', async () => {
+    // Arrange — populate syncResult via a completed sync
     mockSyncExecute.mockResolvedValue({
       success: true,
       created: 1,
@@ -412,14 +455,12 @@ describe('uiSlice sync thunks', () => {
         { skillName: 's', agentName: 'Claude Code', action: 'created' },
       ],
     } satisfies SyncExecuteResult)
-
     const store = await createTestStore()
     const { executeSyncAction, fetchSyncPreview } = await import('./uiSlice')
-
     await store.dispatch(executeSyncAction({ replaceConflicts: [] }))
     expect(store.getState().ui.syncResult).not.toBeNull()
 
-    // Now: start a new preview. Pending should clear the old result.
+    // Act — start a new preview; the pending phase should clear the old result
     let resolve!: (value: SyncPreviewResult) => void
     mockSyncPreview.mockReturnValue(
       new Promise<SyncPreviewResult>((r) => {
@@ -428,23 +469,25 @@ describe('uiSlice sync thunks', () => {
     )
     const promise = store.dispatch(fetchSyncPreview())
 
-    // While pending, syncResult should already be cleared
+    // Assert
     expect(store.getState().ui.syncResult).toBeNull()
 
     resolve(previewNoConflicts)
     await promise
   })
 
-  it('clears syncPreview via setSyncPreview(null)', async () => {
+  it('dismisses the sync preview when it is cleared programmatically', async () => {
+    // Arrange
     mockSyncPreview.mockResolvedValue(previewWithConflicts)
-
     const store = await createTestStore()
     const { fetchSyncPreview, setSyncPreview } = await import('./uiSlice')
-
     await store.dispatch(fetchSyncPreview())
     expect(store.getState().ui.syncPreview).not.toBeNull()
 
+    // Act
     store.dispatch(setSyncPreview(null))
+
+    // Assert
     expect(store.getState().ui.syncPreview).toBeNull()
   })
 })
@@ -458,32 +501,44 @@ describe('uiSlice bookmark detail modal', () => {
     isInstalled: false,
   }
 
-  it('sets selectedBookmarkForDetail', async () => {
+  it('opens the bookmark detail modal for the chosen bookmark', async () => {
+    // Arrange
     const store = await createTestStore()
     const { setSelectedBookmarkForDetail } = await import('./uiSlice')
 
+    // Act
     store.dispatch(setSelectedBookmarkForDetail(sampleBookmark))
 
+    // Assert
     expect(store.getState().ui.selectedBookmarkForDetail).toEqual(
       sampleBookmark,
     )
   })
 
-  it('clears selectedBookmarkForDetail', async () => {
+  it('closes the bookmark detail modal when dismissed', async () => {
+    // Arrange
     const store = await createTestStore()
     const { setSelectedBookmarkForDetail, clearSelectedBookmarkForDetail } =
       await import('./uiSlice')
-
     store.dispatch(setSelectedBookmarkForDetail(sampleBookmark))
     expect(store.getState().ui.selectedBookmarkForDetail).not.toBeNull()
 
+    // Act
     store.dispatch(clearSelectedBookmarkForDetail())
+
+    // Assert
     expect(store.getState().ui.selectedBookmarkForDetail).toBeNull()
   })
 
-  it('starts with null selectedBookmarkForDetail', async () => {
+  it('starts with the bookmark detail modal closed', async () => {
+    // Arrange
     const store = await createTestStore()
-    expect(store.getState().ui.selectedBookmarkForDetail).toBeNull()
+
+    // Act
+    const selectedBookmark = store.getState().ui.selectedBookmarkForDetail
+
+    // Assert
+    expect(selectedBookmark).toBeNull()
   })
 })
 
@@ -508,59 +563,76 @@ describe('uiSlice undoToast (v2.4 bulk delete)', () => {
         : 'Unlinked 2 skills from Cursor.',
   })
 
-  it('starts with undoToast=null', async () => {
+  it('starts with no undo toast on screen', async () => {
+    // Arrange
     const store = await createTestStore()
-    expect(store.getState().ui.undoToast).toBeNull()
+
+    // Act
+    const undoToast = store.getState().ui.undoToast
+
+    // Assert
+    expect(undoToast).toBeNull()
   })
 
-  it('setUndoToast populates the state', async () => {
+  it('shows an undo toast after a bulk delete completes', async () => {
+    // Arrange
     const store = await createTestStore()
     const { setUndoToast } = await import('./uiSlice')
-
     const toast = makeToast('delete')
+
+    // Act
     store.dispatch(setUndoToast(toast))
 
+    // Assert
     expect(store.getState().ui.undoToast).toEqual(toast)
   })
 
-  it('clearUndoToast resets to null', async () => {
+  it('dismisses the undo toast when it is cleared', async () => {
+    // Arrange
     const store = await createTestStore()
     const { setUndoToast, clearUndoToast } = await import('./uiSlice')
-
     store.dispatch(setUndoToast(makeToast()))
     expect(store.getState().ui.undoToast).not.toBeNull()
 
+    // Act
     store.dispatch(clearUndoToast())
+
+    // Assert
     expect(store.getState().ui.undoToast).toBeNull()
   })
 
-  it('selectAgent clears an active undoToast (context switch invalidates it)', async () => {
+  it('dismisses an active undo toast when the user switches agents (context switch invalidates it)', async () => {
+    // Arrange
     const store = await createTestStore()
     const { setUndoToast, selectAgent } = await import('./uiSlice')
-
     store.dispatch(setUndoToast(makeToast()))
     expect(store.getState().ui.undoToast).not.toBeNull()
 
+    // Act
     store.dispatch(selectAgent('cursor' as AgentId))
+
+    // Assert
     expect(store.getState().ui.undoToast).toBeNull()
   })
 
-  it('setActiveTab clears an active undoToast (tab switch invalidates it)', async () => {
+  it('dismisses an active undo toast when the user switches tabs (tab switch invalidates it)', async () => {
+    // Arrange
     const store = await createTestStore()
     const { setUndoToast, setActiveTab } = await import('./uiSlice')
-
     store.dispatch(setUndoToast(makeToast()))
+
+    // Act
     store.dispatch(setActiveTab('marketplace'))
 
+    // Assert
     expect(store.getState().ui.undoToast).toBeNull()
   })
 
-  it('fetchSyncPreview.pending clears undoToast', async () => {
+  it('dismisses the undo toast when a sync preview starts', async () => {
+    // Arrange
     const store = await createTestStore()
     const { setUndoToast, fetchSyncPreview } = await import('./uiSlice')
-
     store.dispatch(setUndoToast(makeToast()))
-
     // Keep preview pending so .pending is the only case that runs.
     let resolve!: (value: SyncPreviewResult) => void
     mockSyncPreview.mockReturnValue(
@@ -568,22 +640,24 @@ describe('uiSlice undoToast (v2.4 bulk delete)', () => {
         resolve = r
       }),
     )
+
+    // Act
     const promise = store.dispatch(fetchSyncPreview())
 
+    // Assert
     expect(store.getState().ui.undoToast).toBeNull()
 
     resolve(previewNoConflicts)
     await promise
   })
 
-  it('deleteSelectedSkills.pending clears undoToast (combined store)', async () => {
+  it('dismisses the undo toast when a new bulk delete begins (combined store)', async () => {
+    // Arrange
     const store = await createCombinedStore()
     const { setUndoToast } = await import('./uiSlice')
     const { deleteSelectedSkills } = await import('./skillsSlice')
-
     store.dispatch(setUndoToast(makeToast()))
     expect(store.getState().ui.undoToast).not.toBeNull()
-
     // Hold pending so we observe the state during the .pending phase
     let resolve!: (value: BulkDeleteResult) => void
     mockDeleteSkills.mockReturnValue(
@@ -591,28 +665,32 @@ describe('uiSlice undoToast (v2.4 bulk delete)', () => {
         resolve = r
       }),
     )
+
+    // Act
     const promise = store.dispatch(deleteSelectedSkills([deleteTarget('task')]))
 
+    // Assert
     expect(store.getState().ui.undoToast).toBeNull()
 
     resolve({ items: [] })
     await promise
   })
 
-  it('clearSelectedOrphanSymlinks.pending clears undoToast (combined store)', async () => {
+  it('dismisses the undo toast when an orphan-symlink cleanup begins (combined store)', async () => {
+    // Arrange
     const store = await createCombinedStore()
     const { setUndoToast } = await import('./uiSlice')
     const { clearSelectedOrphanSymlinks } = await import('./skillsSlice')
-
     store.dispatch(setUndoToast(makeToast()))
     expect(store.getState().ui.undoToast).not.toBeNull()
-
     let resolve!: (value: ClearOrphanSymlinksResult) => void
     mockClearOrphanSymlinks.mockReturnValue(
       new Promise<ClearOrphanSymlinksResult>((r) => {
         resolve = r
       }),
     )
+
+    // Act
     const promise = store.dispatch(
       clearSelectedOrphanSymlinks([
         {
@@ -628,26 +706,28 @@ describe('uiSlice undoToast (v2.4 bulk delete)', () => {
       ]),
     )
 
+    // Assert
     expect(store.getState().ui.undoToast).toBeNull()
 
     resolve({ items: [] })
     await promise
   })
 
-  it('clearSelectedBrokenSymlinkSlots.pending clears undoToast (combined store)', async () => {
+  it('dismisses the undo toast when a broken-slot cleanup begins (combined store)', async () => {
+    // Arrange
     const store = await createCombinedStore()
     const { setUndoToast } = await import('./uiSlice')
     const { clearSelectedBrokenSymlinkSlots } = await import('./skillsSlice')
-
     store.dispatch(setUndoToast(makeToast()))
     expect(store.getState().ui.undoToast).not.toBeNull()
-
     let resolve!: (value: ClearBrokenSymlinkSlotsResult) => void
     mockClearBrokenSymlinkSlots.mockReturnValue(
       new Promise<ClearBrokenSymlinkSlotsResult>((r) => {
         resolve = r
       }),
     )
+
+    // Act
     const promise = store.dispatch(
       clearSelectedBrokenSymlinkSlots({
         items: [
@@ -662,26 +742,28 @@ describe('uiSlice undoToast (v2.4 bulk delete)', () => {
       }),
     )
 
+    // Assert
     expect(store.getState().ui.undoToast).toBeNull()
 
     resolve({ items: [] })
     await promise
   })
 
-  it('unlinkSelectedFromAgent.pending clears undoToast (combined store)', async () => {
+  it('dismisses the undo toast when a bulk unlink begins (combined store)', async () => {
+    // Arrange
     const store = await createCombinedStore()
     const { setUndoToast } = await import('./uiSlice')
     const { unlinkSelectedFromAgent } = await import('./skillsSlice')
-
     store.dispatch(setUndoToast(makeToast('unlink')))
     expect(store.getState().ui.undoToast).not.toBeNull()
-
     let resolve!: (value: BulkUnlinkResult) => void
     mockUnlinkManyFromAgent.mockReturnValue(
       new Promise<BulkUnlinkResult>((r) => {
         resolve = r
       }),
     )
+
+    // Act
     const promise = store.dispatch(
       unlinkSelectedFromAgent({
         agentId: 'cursor' as AgentId,
@@ -689,6 +771,7 @@ describe('uiSlice undoToast (v2.4 bulk delete)', () => {
       }),
     )
 
+    // Assert
     expect(store.getState().ui.undoToast).toBeNull()
 
     resolve({ items: [] })
@@ -701,103 +784,129 @@ describe('uiSlice bulkSelectMode', () => {
     vi.resetAllMocks()
   })
 
-  it('starts with bulkSelectMode=false (default is clean list)', async () => {
+  it('starts with bulk-select mode off (default is a clean list)', async () => {
+    // Arrange
     const store = await createTestStore()
-    expect(store.getState().ui.bulkSelectMode).toBe(false)
+
+    // Act
+    const bulkSelectMode = store.getState().ui.bulkSelectMode
+
+    // Assert
+    expect(bulkSelectMode).toBe(false)
   })
 
-  it('enterBulkSelectMode flips the flag to true', async () => {
+  it('turns on bulk-select mode when the user enters it', async () => {
+    // Arrange
     const store = await createTestStore()
     const { enterBulkSelectMode } = await import('./uiSlice')
 
+    // Act
     store.dispatch(enterBulkSelectMode())
+
+    // Assert
     expect(store.getState().ui.bulkSelectMode).toBe(true)
   })
 
-  it('exitBulkSelectMode flips the flag back to false', async () => {
+  it('turns off bulk-select mode when the user exits it', async () => {
+    // Arrange
     const store = await createTestStore()
     const { enterBulkSelectMode, exitBulkSelectMode } =
       await import('./uiSlice')
-
     store.dispatch(enterBulkSelectMode())
+
+    // Act
     store.dispatch(exitBulkSelectMode())
+
+    // Assert
     expect(store.getState().ui.bulkSelectMode).toBe(false)
   })
 
-  it('setActiveTab clears bulkSelectMode (tab switch exits mode)', async () => {
+  it('exits bulk-select mode when the user switches tabs', async () => {
+    // Arrange
     const store = await createTestStore()
     const { enterBulkSelectMode, setActiveTab } = await import('./uiSlice')
-
     store.dispatch(enterBulkSelectMode())
     expect(store.getState().ui.bulkSelectMode).toBe(true)
 
+    // Act
     store.dispatch(setActiveTab('marketplace'))
+
+    // Assert
     expect(store.getState().ui.bulkSelectMode).toBe(false)
   })
 
-  it('selectAgent clears bulkSelectMode (agent swap exits mode)', async () => {
+  it('exits bulk-select mode when the user swaps agents', async () => {
+    // Arrange
     const store = await createTestStore()
     const { enterBulkSelectMode, selectAgent } = await import('./uiSlice')
-
     store.dispatch(enterBulkSelectMode())
+
+    // Act
     store.dispatch(selectAgent('cursor' as AgentId))
+
+    // Assert
     expect(store.getState().ui.bulkSelectMode).toBe(false)
   })
 
-  it('fetchSyncPreview.pending clears bulkSelectMode', async () => {
+  it('exits bulk-select mode when a sync preview starts', async () => {
+    // Arrange
     const store = await createTestStore()
     const { enterBulkSelectMode, fetchSyncPreview } = await import('./uiSlice')
-
     store.dispatch(enterBulkSelectMode())
-
     let resolve!: (value: SyncPreviewResult) => void
     mockSyncPreview.mockReturnValue(
       new Promise<SyncPreviewResult>((r) => {
         resolve = r
       }),
     )
+
+    // Act
     const promise = store.dispatch(fetchSyncPreview())
 
+    // Assert
     expect(store.getState().ui.bulkSelectMode).toBe(false)
 
     resolve(previewNoConflicts)
     await promise
   })
 
-  it('deleteSelectedSkills.pending clears bulkSelectMode (combined store)', async () => {
+  it('exits bulk-select mode when a bulk delete begins (combined store)', async () => {
+    // Arrange
     const store = await createCombinedStore()
     const { enterBulkSelectMode } = await import('./uiSlice')
     const { deleteSelectedSkills } = await import('./skillsSlice')
-
     store.dispatch(enterBulkSelectMode())
-
     let resolve!: (value: BulkDeleteResult) => void
     mockDeleteSkills.mockReturnValue(
       new Promise<BulkDeleteResult>((r) => {
         resolve = r
       }),
     )
+
+    // Act
     const promise = store.dispatch(deleteSelectedSkills([deleteTarget('task')]))
 
+    // Assert
     expect(store.getState().ui.bulkSelectMode).toBe(false)
 
     resolve({ items: [] })
     await promise
   })
 
-  it('clearSelectedOrphanSymlinks.pending clears bulkSelectMode (combined store)', async () => {
+  it('exits bulk-select mode when an orphan-symlink cleanup begins (combined store)', async () => {
+    // Arrange
     const store = await createCombinedStore()
     const { enterBulkSelectMode } = await import('./uiSlice')
     const { clearSelectedOrphanSymlinks } = await import('./skillsSlice')
-
     store.dispatch(enterBulkSelectMode())
-
     let resolve!: (value: ClearOrphanSymlinksResult) => void
     mockClearOrphanSymlinks.mockReturnValue(
       new Promise<ClearOrphanSymlinksResult>((r) => {
         resolve = r
       }),
     )
+
+    // Act
     const promise = store.dispatch(
       clearSelectedOrphanSymlinks([
         {
@@ -813,25 +922,27 @@ describe('uiSlice bulkSelectMode', () => {
       ]),
     )
 
+    // Assert
     expect(store.getState().ui.bulkSelectMode).toBe(false)
 
     resolve({ items: [] })
     await promise
   })
 
-  it('clearSelectedBrokenSymlinkSlots.pending clears bulkSelectMode (combined store)', async () => {
+  it('exits bulk-select mode when a broken-slot cleanup begins (combined store)', async () => {
+    // Arrange
     const store = await createCombinedStore()
     const { enterBulkSelectMode } = await import('./uiSlice')
     const { clearSelectedBrokenSymlinkSlots } = await import('./skillsSlice')
-
     store.dispatch(enterBulkSelectMode())
-
     let resolve!: (value: ClearBrokenSymlinkSlotsResult) => void
     mockClearBrokenSymlinkSlots.mockReturnValue(
       new Promise<ClearBrokenSymlinkSlotsResult>((r) => {
         resolve = r
       }),
     )
+
+    // Act
     const promise = store.dispatch(
       clearSelectedBrokenSymlinkSlots({
         items: [
@@ -846,25 +957,27 @@ describe('uiSlice bulkSelectMode', () => {
       }),
     )
 
+    // Assert
     expect(store.getState().ui.bulkSelectMode).toBe(false)
 
     resolve({ items: [] })
     await promise
   })
 
-  it('unlinkSelectedFromAgent.pending clears bulkSelectMode (combined store)', async () => {
+  it('exits bulk-select mode when a bulk unlink begins (combined store)', async () => {
+    // Arrange
     const store = await createCombinedStore()
     const { enterBulkSelectMode } = await import('./uiSlice')
     const { unlinkSelectedFromAgent } = await import('./skillsSlice')
-
     store.dispatch(enterBulkSelectMode())
-
     let resolve!: (value: BulkUnlinkResult) => void
     mockUnlinkManyFromAgent.mockReturnValue(
       new Promise<BulkUnlinkResult>((r) => {
         resolve = r
       }),
     )
+
+    // Act
     const promise = store.dispatch(
       unlinkSelectedFromAgent({
         agentId: 'cursor' as AgentId,
@@ -872,6 +985,7 @@ describe('uiSlice bulkSelectMode', () => {
       }),
     )
 
+    // Assert
     expect(store.getState().ui.bulkSelectMode).toBe(false)
 
     resolve({ items: [] })
@@ -883,21 +997,29 @@ describe('uiSlice bulkSelectMode', () => {
   // branches; if "already-true enter" started side-effecting, toggling rapidly
   // could wipe unrelated state. The invariant is a plain boolean assignment.
 
-  it('enterBulkSelectMode is idempotent when already true', async () => {
+  it('stays in bulk-select mode when entered twice in a row', async () => {
+    // Arrange
     const store = await createTestStore()
     const { enterBulkSelectMode } = await import('./uiSlice')
 
+    // Act
     store.dispatch(enterBulkSelectMode())
     store.dispatch(enterBulkSelectMode())
+
+    // Assert
     expect(store.getState().ui.bulkSelectMode).toBe(true)
   })
 
-  it('exitBulkSelectMode is idempotent when already false', async () => {
+  it('stays out of bulk-select mode when exited twice in a row', async () => {
+    // Arrange
     const store = await createTestStore()
     const { exitBulkSelectMode } = await import('./uiSlice')
 
+    // Act
     store.dispatch(exitBulkSelectMode())
     store.dispatch(exitBulkSelectMode())
+
+    // Assert
     expect(store.getState().ui.bulkSelectMode).toBe(false)
   })
 })
@@ -950,13 +1072,16 @@ describe('uiSlice atomic-clear contract on context switch', () => {
     )
   }
 
-  it('setActiveTab atomically clears bulkSelectMode + undoToast + bulkConfirm', async () => {
+  it('clears bulk-select mode, the undo toast, and the bulk-confirm dialog together when switching tabs', async () => {
+    // Arrange
     const store = await createTestStore()
     await seedAllEphemeralState(store)
     const { setActiveTab } = await import('./uiSlice')
 
+    // Act
     store.dispatch(setActiveTab('marketplace'))
 
+    // Assert
     expect(store.getState().ui).toMatchObject({
       bulkSelectMode: false,
       undoToast: null,
@@ -964,13 +1089,16 @@ describe('uiSlice atomic-clear contract on context switch', () => {
     })
   })
 
-  it('selectAgent atomically clears bulkSelectMode + undoToast + bulkConfirm', async () => {
+  it('clears bulk-select mode, the undo toast, and the bulk-confirm dialog together when swapping agents', async () => {
+    // Arrange
     const store = await createTestStore()
     await seedAllEphemeralState(store)
     const { selectAgent } = await import('./uiSlice')
 
+    // Act
     store.dispatch(selectAgent('cursor' as AgentId))
 
+    // Assert
     expect(store.getState().ui).toMatchObject({
       bulkSelectMode: false,
       undoToast: null,
@@ -978,19 +1106,22 @@ describe('uiSlice atomic-clear contract on context switch', () => {
     })
   })
 
-  it('fetchSyncPreview.pending atomically clears all ephemeral UI state', async () => {
+  it('clears all ephemeral UI state together when a sync preview starts', async () => {
+    // Arrange
     const store = await createTestStore()
     await seedAllEphemeralState(store)
     const { fetchSyncPreview } = await import('./uiSlice')
-
     let resolve!: (value: SyncPreviewResult) => void
     mockSyncPreview.mockReturnValue(
       new Promise<SyncPreviewResult>((r) => {
         resolve = r
       }),
     )
+
+    // Act
     const promise = store.dispatch(fetchSyncPreview())
 
+    // Assert
     expect(store.getState().ui).toMatchObject({
       bulkSelectMode: false,
       undoToast: null,
@@ -1001,19 +1132,22 @@ describe('uiSlice atomic-clear contract on context switch', () => {
     await promise
   })
 
-  it('deleteSelectedSkills.pending atomically clears all ephemeral UI state', async () => {
+  it('clears all ephemeral UI state together when a bulk delete begins', async () => {
+    // Arrange
     const store = await createCombinedStore()
     await seedAllEphemeralState(store)
     const { deleteSelectedSkills } = await import('./skillsSlice')
-
     let resolve!: (value: BulkDeleteResult) => void
     mockDeleteSkills.mockReturnValue(
       new Promise<BulkDeleteResult>((r) => {
         resolve = r
       }),
     )
+
+    // Act
     const promise = store.dispatch(deleteSelectedSkills([deleteTarget('a')]))
 
+    // Assert
     expect(store.getState().ui).toMatchObject({
       bulkSelectMode: false,
       undoToast: null,
@@ -1024,37 +1158,42 @@ describe('uiSlice atomic-clear contract on context switch', () => {
     await promise
   })
 
-  it('deleteSelectedSkills.pending preserves the Symlink Health cleanup dialog it may be running inside', async () => {
+  it('keeps the Symlink Health cleanup dialog open while a bulk delete runs inside it', async () => {
+    // Arrange
     const store = await createCombinedStore()
     const { openSymlinkCleanupDialog } = await import('./uiSlice')
     const { deleteSelectedSkills } = await import('./skillsSlice')
     store.dispatch(openSymlinkCleanupDialog())
-
     let resolve!: (value: BulkDeleteResult) => void
     mockDeleteSkills.mockReturnValue(
       new Promise<BulkDeleteResult>((r) => {
         resolve = r
       }),
     )
+
+    // Act
     const promise = store.dispatch(deleteSelectedSkills([deleteTarget('a')]))
 
+    // Assert
     expect(store.getState().ui.symlinkCleanupDialogOpen).toBe(true)
 
     resolve({ items: [] })
     await promise
   })
 
-  it('unlinkSelectedFromAgent.pending atomically clears all ephemeral UI state', async () => {
+  it('clears all ephemeral UI state together when a bulk unlink begins', async () => {
+    // Arrange
     const store = await createCombinedStore()
     await seedAllEphemeralState(store)
     const { unlinkSelectedFromAgent } = await import('./skillsSlice')
-
     let resolve!: (value: BulkUnlinkResult) => void
     mockUnlinkManyFromAgent.mockReturnValue(
       new Promise<BulkUnlinkResult>((r) => {
         resolve = r
       }),
     )
+
+    // Act
     const promise = store.dispatch(
       unlinkSelectedFromAgent({
         agentId: 'cursor' as AgentId,
@@ -1062,6 +1201,7 @@ describe('uiSlice atomic-clear contract on context switch', () => {
       }),
     )
 
+    // Assert
     expect(store.getState().ui).toMatchObject({
       bulkSelectMode: false,
       undoToast: null,
@@ -1072,18 +1212,20 @@ describe('uiSlice atomic-clear contract on context switch', () => {
     await promise
   })
 
-  it('unlinkSelectedFromAgent.pending preserves the Symlink Health cleanup dialog it may be running inside', async () => {
+  it('keeps the Symlink Health cleanup dialog open while a bulk unlink runs inside it', async () => {
+    // Arrange
     const store = await createCombinedStore()
     const { openSymlinkCleanupDialog } = await import('./uiSlice')
     const { unlinkSelectedFromAgent } = await import('./skillsSlice')
     store.dispatch(openSymlinkCleanupDialog())
-
     let resolve!: (value: BulkUnlinkResult) => void
     mockUnlinkManyFromAgent.mockReturnValue(
       new Promise<BulkUnlinkResult>((r) => {
         resolve = r
       }),
     )
+
+    // Act
     const promise = store.dispatch(
       unlinkSelectedFromAgent({
         agentId: 'cursor' as AgentId,
@@ -1091,6 +1233,7 @@ describe('uiSlice atomic-clear contract on context switch', () => {
       }),
     )
 
+    // Assert
     expect(store.getState().ui.symlinkCleanupDialogOpen).toBe(true)
 
     resolve({ items: [] })
@@ -1110,39 +1253,44 @@ describe('uiSlice bulkSelectMode on rejection', () => {
     vi.resetAllMocks()
   })
 
-  it('fetchSyncPreview.rejected leaves bulkSelectMode=false (no auto re-enter)', async () => {
+  it('does not re-enter bulk-select mode after a sync preview fails', async () => {
+    // Arrange
     const store = await createTestStore()
     const { enterBulkSelectMode, fetchSyncPreview } = await import('./uiSlice')
-
     store.dispatch(enterBulkSelectMode())
     mockSyncPreview.mockRejectedValue(new Error('Network error'))
 
+    // Act
     await store.dispatch(fetchSyncPreview())
 
+    // Assert
     expect(store.getState().ui.bulkSelectMode).toBe(false)
   })
 
-  it('deleteSelectedSkills.rejected keeps bulkSelectMode=false (no auto re-enter)', async () => {
+  it('does not re-enter bulk-select mode after a bulk delete fails', async () => {
+    // Arrange
     const store = await createCombinedStore()
     const { enterBulkSelectMode } = await import('./uiSlice')
     const { deleteSelectedSkills } = await import('./skillsSlice')
-
     store.dispatch(enterBulkSelectMode())
     mockDeleteSkills.mockRejectedValue(new Error('FS error'))
 
+    // Act
     await store.dispatch(deleteSelectedSkills([deleteTarget('task')]))
 
+    // Assert
     expect(store.getState().ui.bulkSelectMode).toBe(false)
   })
 
-  it('unlinkSelectedFromAgent.rejected keeps bulkSelectMode=false', async () => {
+  it('does not re-enter bulk-select mode after a bulk unlink fails', async () => {
+    // Arrange
     const store = await createCombinedStore()
     const { enterBulkSelectMode } = await import('./uiSlice')
     const { unlinkSelectedFromAgent } = await import('./skillsSlice')
-
     store.dispatch(enterBulkSelectMode())
     mockUnlinkManyFromAgent.mockRejectedValue(new Error('Permission denied'))
 
+    // Act
     await store.dispatch(
       unlinkSelectedFromAgent({
         agentId: 'cursor' as AgentId,
@@ -1150,6 +1298,7 @@ describe('uiSlice bulkSelectMode on rejection', () => {
       }),
     )
 
+    // Assert
     expect(store.getState().ui.bulkSelectMode).toBe(false)
   })
 })
@@ -1180,9 +1329,15 @@ describe('uiSlice source filter (selectedSources)', () => {
     }
   }
 
-  it('starts with an empty source include-filter', async () => {
+  it('starts with an empty source include-filter (shows all sources)', async () => {
+    // Arrange
     const store = await createTestStore()
-    expect(store.getState().ui.selectedSources).toEqual([])
+
+    // Act
+    const selectedSources = store.getState().ui.selectedSources
+
+    // Assert
+    expect(selectedSources).toEqual([])
   })
 
   it('toggleSource adds a repo to the empty include-filter', async () => {

--- a/src/renderer/src/redux/slices/updateSlice.test.ts
+++ b/src/renderer/src/redux/slices/updateSlice.test.ts
@@ -9,9 +9,14 @@ async function createTestStore() {
 }
 
 describe('updateSlice', () => {
-  it('has correct initial state', async () => {
+  it('starts idle with no pending update and nothing dismissed', async () => {
+    // Arrange
     const store = await createTestStore()
+
+    // Act
     const state = store.getState().update
+
+    // Assert
     expect(state.status).toBe('idle')
     expect(state.version).toBeNull()
     expect(state.releaseNotes).toBeNull()
@@ -20,20 +25,27 @@ describe('updateSlice', () => {
     expect(state.dismissed).toBe(false)
   })
 
-  it('setChecking sets status and clears error', async () => {
+  it('clears a prior error when a fresh update check begins', async () => {
+    // Arrange
     const { setChecking, setError } = await import('./updateSlice')
     const store = await createTestStore()
     store.dispatch(setError('previous error'))
+
+    // Act
     store.dispatch(setChecking())
 
+    // Assert
     const state = store.getState().update
     expect(state.status).toBe('checking')
     expect(state.error).toBeNull()
   })
 
-  it('setAvailable stores version and release notes', async () => {
+  it('announces an available update with its version and release notes', async () => {
+    // Arrange
     const { setAvailable } = await import('./updateSlice')
     const store = await createTestStore()
+
+    // Act
     store.dispatch(
       setAvailable({
         version: semanticVersion('1.2.0'),
@@ -41,6 +53,7 @@ describe('updateSlice', () => {
       }),
     )
 
+    // Assert
     const state = store.getState().update
     expect(state.status).toBe('available')
     expect(state.version).toBe('1.2.0')
@@ -48,43 +61,63 @@ describe('updateSlice', () => {
     expect(state.dismissed).toBe(false)
   })
 
-  it('setAvailable handles missing releaseNotes', async () => {
+  it('leaves release notes empty when an available update omits them', async () => {
+    // Arrange
     const { setAvailable } = await import('./updateSlice')
     const store = await createTestStore()
+
+    // Act
     store.dispatch(setAvailable({ version: semanticVersion('1.2.0') }))
 
+    // Assert
     expect(store.getState().update.releaseNotes).toBeNull()
   })
 
-  it('setAvailable resets dismissed flag', async () => {
+  it('re-surfaces a previously dismissed banner when a new update arrives', async () => {
+    // Arrange
     const { setAvailable, dismiss } = await import('./updateSlice')
     const store = await createTestStore()
     store.dispatch(dismiss())
     expect(store.getState().update.dismissed).toBe(true)
 
+    // Act
     store.dispatch(setAvailable({ version: semanticVersion('1.3.0') }))
+
+    // Assert
     expect(store.getState().update.dismissed).toBe(false)
   })
 
-  it('setNotAvailable resets status to idle', async () => {
+  it('returns to idle when the check finds no update available', async () => {
+    // Arrange
     const { setChecking, setNotAvailable } = await import('./updateSlice')
     const store = await createTestStore()
     store.dispatch(setChecking())
+
+    // Act
     store.dispatch(setNotAvailable())
 
+    // Assert
     expect(store.getState().update.status).toBe('idle')
   })
 
-  it('setDownloading sets status', async () => {
+  it('shows a downloading state once the update download starts', async () => {
+    // Arrange
     const { setDownloading } = await import('./updateSlice')
     const store = await createTestStore()
+
+    // Act
     store.dispatch(setDownloading())
+
+    // Assert
     expect(store.getState().update.status).toBe('downloading')
   })
 
-  it('setProgress updates status and percent', async () => {
+  it('reflects download progress as a percentage while downloading', async () => {
+    // Arrange
     const { setProgress } = await import('./updateSlice')
     const store = await createTestStore()
+
+    // Act
     store.dispatch(
       setProgress({
         percent: 42,
@@ -94,14 +127,18 @@ describe('updateSlice', () => {
       }),
     )
 
+    // Assert
     const state = store.getState().update
     expect(state.status).toBe('downloading')
     expect(state.progress).toBe(42)
   })
 
-  it('setReady sets version, notes, and progress to 100', async () => {
+  it('marks the update ready to install with full progress and release details', async () => {
+    // Arrange
     const { setReady } = await import('./updateSlice')
     const store = await createTestStore()
+
+    // Act
     store.dispatch(
       setReady({
         version: semanticVersion('2.0.0'),
@@ -109,6 +146,7 @@ describe('updateSlice', () => {
       }),
     )
 
+    // Assert
     const state = store.getState().update
     expect(state.status).toBe('ready')
     expect(state.version).toBe('2.0.0')
@@ -116,24 +154,34 @@ describe('updateSlice', () => {
     expect(state.progress).toBe(100)
   })
 
-  it('setError stores error message', async () => {
+  it('surfaces the failure message when the update flow errors', async () => {
+    // Arrange
     const { setError } = await import('./updateSlice')
     const store = await createTestStore()
+
+    // Act
     store.dispatch(setError('Download failed'))
 
+    // Assert
     const state = store.getState().update
     expect(state.status).toBe('error')
     expect(state.error).toBe('Download failed')
   })
 
-  it('dismiss sets dismissed flag', async () => {
+  it('hides the update banner when the user dismisses it', async () => {
+    // Arrange
     const { dismiss } = await import('./updateSlice')
     const store = await createTestStore()
+
+    // Act
     store.dispatch(dismiss())
+
+    // Assert
     expect(store.getState().update.dismissed).toBe(true)
   })
 
-  it('reset returns to initial state', async () => {
+  it('clears an in-progress update back to the idle starting point', async () => {
+    // Arrange
     const { setAvailable, setDownloading, setProgress, reset } =
       await import('./updateSlice')
     const store = await createTestStore()
@@ -153,7 +201,10 @@ describe('updateSlice', () => {
       }),
     )
 
+    // Act
     store.dispatch(reset())
+
+    // Assert
     const state = store.getState().update
     expect(state.status).toBe('idle')
     expect(state.version).toBeNull()

--- a/src/renderer/src/redux/store.test.ts
+++ b/src/renderer/src/redux/store.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { COLOR_PRESET_CHROMA, THEME_PRESETS } from '@/shared/constants'
+import { THEME_PRESETS } from '@/shared/constants'
 
 import type { MigratableState } from './migrations'
 
@@ -23,7 +23,8 @@ async function migrate(
 }
 
 describe('migrateState (v0 → v3 theme chain)', () => {
-  it('migrates a valid color preset (cyan dark) to the latest shape', async () => {
+  it('upgrades a legacy color preset (cyan dark) into the full current theme shape', async () => {
+    // Arrange
     const state = {
       theme: {
         hue: 195,
@@ -32,17 +33,22 @@ describe('migrateState (v0 → v3 theme chain)', () => {
         presetType: 'color',
       },
     }
+
+    // Act
     const result = await migrate(state, 0)
+
+    // Assert
     expect(result.theme).toEqual({
       hue: 195,
-      chroma: COLOR_PRESET_CHROMA,
+      chroma: 0.16,
       mode: 'dark',
       modePreference: 'dark',
       preset: 'cyan',
     })
   })
 
-  it('migrates a valid neutral preset (neutral-light) to the latest shape', async () => {
+  it('upgrades a legacy neutral preset (neutral-light) into the full current theme shape', async () => {
+    // Arrange
     const state = {
       theme: {
         hue: 0,
@@ -51,7 +57,11 @@ describe('migrateState (v0 → v3 theme chain)', () => {
         presetType: 'neutral',
       },
     }
+
+    // Act
     const result = await migrate(state, 0)
+
+    // Assert
     expect(result.theme).toEqual({
       hue: 0,
       chroma: 0,
@@ -61,9 +71,9 @@ describe('migrateState (v0 → v3 theme chain)', () => {
     })
   })
 
-  it('falls back to neutral-dark when preset is an unknown string', async () => {
-    // Simulates a user whose persisted state has a preset name that was
-    // later removed or renamed (plan proposed `mono-dark` which was never
+  it('rescues a preset name that was renamed away to neutral-dark', async () => {
+    // Arrange — simulates a user whose persisted state has a preset name that
+    // was later removed or renamed (plan proposed `mono-dark` which was never
     // shipped; this guards against that class of drift).
     const state = {
       theme: {
@@ -73,40 +83,64 @@ describe('migrateState (v0 → v3 theme chain)', () => {
         presetType: 'neutral',
       },
     }
+
+    // Act
     const result = await migrate(state, 0)
+
+    // Assert
     expect(result.theme?.preset).toBe('neutral-dark')
   })
 
-  it('falls back to neutral-dark when preset field is missing', async () => {
+  it('rescues a missing preset field to neutral-dark', async () => {
+    // Arrange
     const state = {
       theme: { hue: 0, mode: 'dark', presetType: 'neutral' },
     }
+
+    // Act
     const result = await migrate(state, 0)
+
+    // Assert
     expect(result.theme?.preset).toBe('neutral-dark')
   })
 
   it('drops a null theme slot so the reducer initial state takes over', async () => {
+    // Arrange
     const state = { theme: null }
+
+    // Act
     const result = await migrate(state, 0)
+
+    // Assert
     expect(result.theme).toBeUndefined()
   })
 
-  it('drops a non-object theme slot (tampered storage)', async () => {
+  it('drops a non-object theme slot from tampered storage', async () => {
+    // Arrange
     const state = { theme: 'garbage' }
+
+    // Act
     const result = await migrate(state as never, 0)
+
+    // Assert
     expect(result.theme).toBeUndefined()
   })
 
-  it('handles an undefined theme slot as a no-op', async () => {
+  it('leaves an undefined theme slot alone instead of fabricating one', async () => {
+    // Arrange
     const state = {}
+
+    // Act
     const result = await migrate(state, 0)
+
+    // Assert
     expect(result.theme).toBeUndefined()
   })
 
-  it('skips migration entirely when oldVersion is already at the current schema version', async () => {
-    // Storage-middleware guarantees migrate is only called when versions
-    // differ, but if someone tampered with the stored `version` field we
-    // must not overwrite a valid current-schema state with legacy defaults.
+  it('preserves a tampered current-schema theme when the stored version already matches', async () => {
+    // Arrange — storage-middleware guarantees migrate is only called when
+    // versions differ, but if someone tampered with the stored `version` field
+    // we must not overwrite a valid current-schema state with legacy defaults.
     const { PERSIST_STATE_VERSION } = await import('@/shared/constants')
     const currentState = {
       theme: {
@@ -117,11 +151,16 @@ describe('migrateState (v0 → v3 theme chain)', () => {
         preset: 'cyan',
       },
     }
+
+    // Act
     const result = await migrate(currentState, PERSIST_STATE_VERSION)
+
+    // Assert
     expect(result.theme).toEqual(currentState.theme)
   })
 
-  it('coerces non-numeric hue to 0', async () => {
+  it('repairs a non-numeric hue to a safe 0', async () => {
+    // Arrange
     const state = {
       theme: {
         hue: 'not-a-number',
@@ -130,11 +169,16 @@ describe('migrateState (v0 → v3 theme chain)', () => {
         presetType: 'neutral',
       },
     }
+
+    // Act
     const result = await migrate(state as never, 0)
+
+    // Assert
     expect(result.theme?.hue).toBe(0)
   })
 
-  it('coerces an invalid mode to dark', async () => {
+  it('repairs an invalid mode to dark', async () => {
+    // Arrange
     const state = {
       theme: {
         hue: 0,
@@ -143,11 +187,16 @@ describe('migrateState (v0 → v3 theme chain)', () => {
         presetType: 'neutral',
       },
     }
+
+    // Act
     const result = await migrate(state as never, 0)
+
+    // Assert
     expect(result.theme?.mode).toBe('dark')
   })
 
-  it('translates presetType=color to COLOR_PRESET_CHROMA', async () => {
+  it('paints a legacy color preset with full chroma', async () => {
+    // Arrange
     const state = {
       theme: {
         hue: 300,
@@ -156,21 +205,30 @@ describe('migrateState (v0 → v3 theme chain)', () => {
         presetType: 'color',
       },
     }
+
+    // Act
     const result = await migrate(state, 0)
-    expect(result.theme?.chroma).toBe(COLOR_PRESET_CHROMA)
+
+    // Assert
+    expect(result.theme?.chroma).toBe(0.16)
   })
 
-  it('translates presetType=neutral (or missing) to chroma=0', async () => {
+  it('leaves a legacy neutral preset (or missing presetType) grayscale', async () => {
+    // Arrange
     const state = {
       theme: { hue: 0, mode: 'dark', preset: 'neutral-dark' },
     }
+
+    // Act
     const result = await migrate(state, 0)
+
+    // Assert
     expect(result.theme?.chroma).toBe(0)
   })
 
-  it('every preset name in THEME_PRESETS survives migration unchanged', async () => {
-    // Regression guard: if a future refactor removes a preset key from
-    // THEME_PRESETS, this test catches it before shipping.
+  it('keeps every shipped preset name selectable after migration', async () => {
+    // Act & Assert — regression guard: if a future refactor removes a preset
+    // key from THEME_PRESETS, this test catches it before shipping.
     for (const name of Object.keys(THEME_PRESETS)) {
       const config = THEME_PRESETS[name as keyof typeof THEME_PRESETS]
       const state = {

--- a/src/renderer/src/styles/contrast.test.ts
+++ b/src/renderer/src/styles/contrast.test.ts
@@ -111,26 +111,30 @@ describe('WCAG contrast — unified OKLCH palette', () => {
       for (const mode of modes) {
         const tokens = mode === 'dark' ? DARK_TOKENS : LIGHT_TOKENS
 
-        it(`${mode}: foreground on background >= 4.5 (AA text)`, () => {
-          expect(
-            contrast(
-              tokens.foreground,
-              tokens.background,
-              config.chroma,
-              config.hue,
-            ),
-          ).toBeGreaterThanOrEqual(4.5)
+        it(`${mode}: keeps body text readable on the background (AA 4.5:1)`, () => {
+          // Arrange — foreground vs background tokens for this preset × mode
+          // Act
+          const ratio = contrast(
+            tokens.foreground,
+            tokens.background,
+            config.chroma,
+            config.hue,
+          )
+          // Assert — body copy clears the WCAG AA normal-text floor
+          expect(ratio).toBeGreaterThanOrEqual(4.5)
         })
 
-        it(`${mode}: card-foreground on card >= 4.5 (AA text)`, () => {
-          expect(
-            contrast(
-              tokens.cardForeground,
-              tokens.card,
-              config.chroma,
-              config.hue,
-            ),
-          ).toBeGreaterThanOrEqual(4.5)
+        it(`${mode}: keeps card text readable on its card surface (AA 4.5:1)`, () => {
+          // Arrange — card-foreground vs card tokens for this preset × mode
+          // Act
+          const ratio = contrast(
+            tokens.cardForeground,
+            tokens.card,
+            config.chroma,
+            config.hue,
+          )
+          // Assert — card body copy clears the WCAG AA normal-text floor
+          expect(ratio).toBeGreaterThanOrEqual(4.5)
         })
 
         // `primary` surfaces `<Button variant="default">` (used in the
@@ -139,15 +143,17 @@ describe('WCAG contrast — unified OKLCH palette', () => {
         // as "large text" and permits the 3.0:1 minimum for both the UI
         // background and its label. If `primary` is ever adopted for
         // small (<14px regular) body copy, bump this to 4.5.
-        it(`${mode}: primary-foreground on primary >= 3.0 (UI / large-text)`, () => {
-          expect(
-            contrast(
-              tokens.primaryForeground,
-              tokens.primary,
-              config.chroma,
-              config.hue,
-            ),
-          ).toBeGreaterThanOrEqual(3.0)
+        it(`${mode}: keeps the primary button label legible on its fill (UI/large-text 3.0:1)`, () => {
+          // Arrange — primary-foreground label vs primary fill for this preset × mode
+          // Act
+          const ratio = contrast(
+            tokens.primaryForeground,
+            tokens.primary,
+            config.chroma,
+            config.hue,
+          )
+          // Assert — the 14px-bold button label clears the WCAG UI/large-text floor
+          expect(ratio).toBeGreaterThanOrEqual(3.0)
         })
 
         // `muted-foreground` on `muted` drives secondary info (path hints
@@ -156,15 +162,17 @@ describe('WCAG contrast — unified OKLCH palette', () => {
         // WCAG 2.1 UI/large-text threshold of 3.0:1 applies. The moment
         // muted carries primary body copy (e.g., a paragraph in an
         // empty-state screen), this assertion must be raised to 4.5.
-        it(`${mode}: muted-foreground on muted >= 3.0 (UI / secondary text)`, () => {
-          expect(
-            contrast(
-              tokens.mutedForeground,
-              tokens.muted,
-              config.chroma,
-              config.hue,
-            ),
-          ).toBeGreaterThanOrEqual(3.0)
+        it(`${mode}: keeps muted secondary text legible on its muted surface (UI/secondary 3.0:1)`, () => {
+          // Arrange — muted-foreground vs muted tokens for this preset × mode
+          // Act
+          const ratio = contrast(
+            tokens.mutedForeground,
+            tokens.muted,
+            config.chroma,
+            config.hue,
+          )
+          // Assert — secondary supporting text clears the WCAG UI/secondary floor
+          expect(ratio).toBeGreaterThanOrEqual(3.0)
         })
       }
     })
@@ -192,14 +200,22 @@ describe('WCAG contrast — globals.css drift guard', () => {
   }
 
   for (const [token, spec] of Object.entries(DARK_TOKENS)) {
-    it(`.dark ${token} L=${spec.L} step=${spec.step} matches globals.css`, () => {
-      expect(darkBlock).toContain(expectedFragment(spec))
+    it(`flags drift if the .dark ${token} L/chroma stops matching globals.css`, () => {
+      // Arrange — the expected oklch fragment for this dark token
+      const expectedOklchFragment = expectedFragment(spec)
+      // Act — (darkBlock is the .dark CSS text extracted above)
+      // Assert — the mirrored L/step still appears verbatim in globals.css
+      expect(darkBlock).toContain(expectedOklchFragment)
     })
   }
 
   for (const [token, spec] of Object.entries(LIGHT_TOKENS)) {
-    it(`.light ${token} L=${spec.L} step=${spec.step} matches globals.css`, () => {
-      expect(lightBlock).toContain(expectedFragment(spec))
+    it(`flags drift if the .light ${token} L/chroma stops matching globals.css`, () => {
+      // Arrange — the expected oklch fragment for this light token
+      const expectedOklchFragment = expectedFragment(spec)
+      // Act — (lightBlock is the .light CSS text extracted above)
+      // Assert — the mirrored L/step still appears verbatim in globals.css
+      expect(lightBlock).toContain(expectedOklchFragment)
     })
   }
 })

--- a/src/renderer/src/utils/getLocationViewModel.test.ts
+++ b/src/renderer/src/utils/getLocationViewModel.test.ts
@@ -33,7 +33,8 @@ const makeSkill = (
 })
 
 describe('getLocationViewModel', () => {
-  it('omits symlinkPath when no agent is selected', () => {
+  it('shows only the source path when no agent is selected', () => {
+    // Arrange — a sourced skill linked into opencode, but nothing selected
     const skill = makeSkill('/u/me/.agents/skills/foo', [
       makeSymlink(
         'opencode',
@@ -42,13 +43,18 @@ describe('getLocationViewModel', () => {
       ),
     ])
 
-    expect(getLocationViewModel(skill, null)).toEqual({
+    // Act
+    const viewModel = getLocationViewModel(skill, null)
+
+    // Assert — with no selection there is no agent symlink to surface
+    expect(viewModel).toEqual({
       sourcePath: '/u/me/.agents/skills/foo',
       symlinkPath: undefined,
     })
   })
 
-  it('omits symlinkPath when the selected agent has no symlink for this skill', () => {
+  it('shows only the source path when the selected agent has no symlink for this skill', () => {
+    // Arrange — skill is linked into opencode but the selected agent is cursor
     const skill = makeSkill('/u/me/.agents/skills/foo', [
       makeSymlink(
         'opencode',
@@ -57,13 +63,18 @@ describe('getLocationViewModel', () => {
       ),
     ])
 
-    expect(getLocationViewModel(skill, 'cursor')).toEqual({
+    // Act
+    const viewModel = getLocationViewModel(skill, 'cursor')
+
+    // Assert — cursor has no link here, so no symlink path is shown
+    expect(viewModel).toEqual({
       sourcePath: '/u/me/.agents/skills/foo',
       symlinkPath: undefined,
     })
   })
 
-  it('omits symlinkPath for a local skill where linkPath equals skill.path', () => {
+  it('hides the symlink path for a local skill whose link path equals its own path', () => {
+    // Arrange — a local (non-sourced) cursor skill that links to itself
     const skill = makeSkill(
       '/u/me/.cursor/skills/foo',
       [
@@ -77,13 +88,18 @@ describe('getLocationViewModel', () => {
       false,
     )
 
-    expect(getLocationViewModel(skill, 'cursor')).toEqual({
+    // Act
+    const viewModel = getLocationViewModel(skill, 'cursor')
+
+    // Assert — a self-referential local link is not shown as a separate path
+    expect(viewModel).toEqual({
       sourcePath: '/u/me/.cursor/skills/foo',
       symlinkPath: undefined,
     })
   })
 
-  it('returns symlinkPath when the selected agent links to a different path', () => {
+  it('shows the symlink path when the selected agent links to a different path', () => {
+    // Arrange — skill sourced in .agents and linked into both opencode and claude
     const skill = makeSkill('/u/me/.agents/skills/foo', [
       makeSymlink(
         'opencode',
@@ -97,7 +113,11 @@ describe('getLocationViewModel', () => {
       ),
     ])
 
-    expect(getLocationViewModel(skill, 'opencode')).toEqual({
+    // Act
+    const viewModel = getLocationViewModel(skill, 'opencode')
+
+    // Assert — opencode's distinct link path surfaces alongside the source
+    expect(viewModel).toEqual({
       sourcePath: '/u/me/.agents/skills/foo',
       symlinkPath: '/u/me/.opencode/skills/foo',
     })

--- a/src/renderer/src/utils/getReleaseNotesUrl.test.ts
+++ b/src/renderer/src/utils/getReleaseNotesUrl.test.ts
@@ -4,13 +4,27 @@ import { getReleaseNotesUrl } from './getReleaseNotesUrl'
 
 describe('getReleaseNotesUrl', () => {
   it('builds the GitHub releases tag URL with a v-prefix', () => {
-    expect(getReleaseNotesUrl('0.13.4')).toBe(
+    // Arrange — a bare semver with no leading v
+    const version = '0.13.4'
+
+    // Act
+    const url = getReleaseNotesUrl(version)
+
+    // Assert — the tag segment gains exactly one v prefix
+    expect(url).toBe(
       'https://github.com/laststance/skills-desktop/releases/tag/v0.13.4',
     )
   })
 
   it('strips a leading v from the input so the tag never gets a doubled prefix', () => {
-    expect(getReleaseNotesUrl('v1.0.0')).toBe(
+    // Arrange — a version that already carries a leading v
+    const version = 'v1.0.0'
+
+    // Act
+    const url = getReleaseNotesUrl(version)
+
+    // Assert — the existing v is consumed, not doubled into "vv1.0.0"
+    expect(url).toBe(
       'https://github.com/laststance/skills-desktop/releases/tag/v1.0.0',
     )
   })

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -8,38 +8,51 @@ import {
 } from './constants'
 
 describe('AGENT_DEFINITIONS', () => {
-  it('has unique ids', () => {
+  it('never collides two agents on the same app-state id', () => {
+    // Arrange
     const ids = AGENT_DEFINITIONS.map((a) => a.id)
-    expect(new Set(ids).size).toBe(ids.length)
+    // Act
+    const uniqueIdCount = new Set(ids).size
+    // Assert
+    expect(uniqueIdCount).toBe(ids.length)
   })
 
-  it('has unique cliIds', () => {
+  it('never collides two agents on the same --agent CLI flag', () => {
+    // Arrange
     const cliIds = AGENT_DEFINITIONS.map((a) => a.cliId)
-    expect(new Set(cliIds).size).toBe(cliIds.length)
+    // Act
+    const uniqueCliIdCount = new Set(cliIds).size
+    // Assert
+    expect(uniqueCliIdCount).toBe(cliIds.length)
   })
 
-  it('windsurf uses .codeium/windsurf installDir (matches skills CLI globalSkillsDir)', () => {
+  it('installs Windsurf skills under .codeium/windsurf to match the skills CLI globalSkillsDir', () => {
+    // Arrange / Act
     const windsurf = AGENT_DEFINITIONS.find((a) => a.id === 'windsurf')
+    // Assert
     expect(windsurf).toBeDefined()
     expect(windsurf!.installDir).toBe('.codeium/windsurf')
   })
 
-  it('all installDirs start with a dot', () => {
+  it('keeps every install target inside a dot-prefixed home subdir', () => {
+    // Arrange / Act / Assert
     for (const agent of AGENT_DEFINITIONS) {
       expect(agent.installDir.startsWith('.')).toBe(true)
     }
   })
 
-  it('all scanDirs start with a dot', () => {
+  it('keeps every scan target inside a dot-prefixed home subdir', () => {
     // scanDir is required on every entry (no optional fallback). New
     // agents added via /cli-upgrade must declare scanDir explicitly,
     // which forces consideration of universal-source aliasing.
+    // Arrange / Act / Assert
     for (const agent of AGENT_DEFINITIONS) {
       expect(agent.scanDir.startsWith('.')).toBe(true)
     }
   })
 
-  it('syncs CLI globalSkillsDir parents for shared/universal agents', () => {
+  it('keeps shared/universal agents pointed at the CLI globalSkillsDir parents', () => {
+    // Arrange / Act
     const cline = AGENT_DEFINITIONS.find((a) => a.id === 'cline')
     const warp = AGENT_DEFINITIONS.find((a) => a.id === 'warp')
     const amp = AGENT_DEFINITIONS.find((a) => a.id === 'amp')
@@ -48,6 +61,7 @@ describe('AGENT_DEFINITIONS', () => {
     const deepAgents = AGENT_DEFINITIONS.find((a) => a.id === 'deepagents')
     const replit = AGENT_DEFINITIONS.find((a) => a.id === 'replit')
 
+    // Assert
     expect(cline?.installDir).toBe('.agents')
     expect(warp?.installDir).toBe('.agents')
     expect(amp?.installDir).toBe('.config/agents')
@@ -61,11 +75,13 @@ describe('AGENT_DEFINITIONS', () => {
   // installDir points at the universal source; without a divergent
   // scanDir, the scanner would surface every source skill as their
   // "local skills".
-  it('Cline, Warp, and Dexto diverge scanDir from installDir to avoid aliasing the universal source', () => {
+  it('does not surface the whole universal source as Cline, Warp, or Dexto local skills', () => {
+    // Arrange / Act
     const cline = AGENT_DEFINITIONS.find((a) => a.id === 'cline')
     const warp = AGENT_DEFINITIONS.find((a) => a.id === 'warp')
     const dexto = AGENT_DEFINITIONS.find((a) => a.id === 'dexto')
 
+    // Assert
     expect(cline?.installDir).toBe('.agents')
     expect(cline?.scanDir).toBe('.cline')
     expect(warp?.installDir).toBe('.agents')
@@ -74,35 +90,35 @@ describe('AGENT_DEFINITIONS', () => {
     expect(dexto?.scanDir).toBe('.dexto')
   })
 
-  it('includes 10 community agents added in CLI v1.5.5', () => {
-    const expectedNewAgents = [
-      'aider-desk',
-      'codearts-agent',
-      'codemaker',
-      'codestudio',
-      'devin',
-      'dexto',
-      'forgecode',
-      'hermes-agent',
-      'rovodev',
-      'tabnine-cli',
-    ] as const
+  it('exposes every community agent added in CLI v1.5.5', () => {
+    // Act
     const ids = AGENT_DEFINITIONS.map((a) => a.id)
-    for (const expectedId of expectedNewAgents) {
-      expect(ids).toContain(expectedId)
-    }
+    // Assert
+    expect(ids).toContain('aider-desk')
+    expect(ids).toContain('codearts-agent')
+    expect(ids).toContain('codemaker')
+    expect(ids).toContain('codestudio')
+    expect(ids).toContain('devin')
+    expect(ids).toContain('dexto')
+    expect(ids).toContain('forgecode')
+    expect(ids).toContain('hermes-agent')
+    expect(ids).toContain('rovodev')
+    expect(ids).toContain('tabnine-cli')
   })
 })
 
 describe('UNIVERSAL_AGENT_IDS', () => {
-  it('all entries are valid AgentIds in AGENT_DEFINITIONS', () => {
+  it('lists only agents that exist in AGENT_DEFINITIONS', () => {
+    // Arrange
     const allIds = AGENT_DEFINITIONS.map((a) => a.id)
+    // Act / Assert
     for (const id of UNIVERSAL_AGENT_IDS) {
       expect(allIds).toContain(id)
     }
   })
 
-  it('contains expected Universal agents', () => {
+  it('treats the 13 shared-source agents as Universal and excludes Replit', () => {
+    // Arrange / Act / Assert
     expect(UNIVERSAL_AGENT_IDS).toContain('amp')
     expect(UNIVERSAL_AGENT_IDS).toContain('antigravity')
     expect(UNIVERSAL_AGENT_IDS).toContain('cline')
@@ -121,14 +137,17 @@ describe('UNIVERSAL_AGENT_IDS', () => {
 })
 
 describe('GSTACK constants', () => {
-  it('gstack badge agent ids are valid AgentIds in AGENT_DEFINITIONS', () => {
+  it('badges only agents that exist in AGENT_DEFINITIONS', () => {
+    // Arrange
     const allIds = AGENT_DEFINITIONS.map((a) => a.id)
+    // Act / Assert
     for (const id of GSTACK_BADGE_AGENT_IDS) {
       expect(allIds).toContain(id)
     }
   })
 
-  it('gstack repository URL points to the canonical GitHub repository', () => {
+  it('links the gstack badge to the canonical GitHub repository', () => {
+    // Arrange / Act / Assert
     expect(GSTACK_REPOSITORY_URL).toBe('https://github.com/garrytan/gstack')
   })
 })

--- a/src/shared/errorMessages.test.ts
+++ b/src/shared/errorMessages.test.ts
@@ -4,98 +4,143 @@ import { friendlyErrorMessage } from './errorMessages'
 
 describe('friendlyErrorMessage', () => {
   describe('string inputs', () => {
-    it('returns permission denied for EACCES string', () => {
-      expect(
-        friendlyErrorMessage('EACCES: permission denied, open /file'),
-      ).toBe("You don't have permission to do this.")
+    it('tells the user they lack permission when the raw error is EACCES', () => {
+      // Arrange
+      const rawError = 'EACCES: permission denied, open /file'
+      // Act
+      const message = friendlyErrorMessage(rawError)
+      // Assert
+      expect(message).toBe("You don't have permission to do this.")
     })
 
-    it('returns file not found for ENOENT string', () => {
-      expect(friendlyErrorMessage('ENOENT: no such file or directory')).toBe(
-        'The file or folder no longer exists.',
-      )
+    it('tells the user the target is gone when the raw error is ENOENT', () => {
+      // Arrange
+      const rawError = 'ENOENT: no such file or directory'
+      // Act
+      const message = friendlyErrorMessage(rawError)
+      // Assert
+      expect(message).toBe('The file or folder no longer exists.')
     })
 
-    it('returns file exists for EEXIST string', () => {
-      expect(friendlyErrorMessage('EEXIST: file already exists')).toBe(
-        'A file with this name already exists.',
-      )
+    it('tells the user the name is taken when the raw error is EEXIST', () => {
+      // Arrange
+      const rawError = 'EEXIST: file already exists'
+      // Act
+      const message = friendlyErrorMessage(rawError)
+      // Assert
+      expect(message).toBe('A file with this name already exists.')
     })
 
-    it('returns no disk space for ENOSPC string', () => {
-      expect(friendlyErrorMessage('ENOSPC: no space left on device')).toBe(
-        'Not enough disk space.',
-      )
+    it('tells the user the disk is full when the raw error is ENOSPC', () => {
+      // Arrange
+      const rawError = 'ENOSPC: no space left on device'
+      // Act
+      const message = friendlyErrorMessage(rawError)
+      // Assert
+      expect(message).toBe('Not enough disk space.')
     })
 
-    it('returns timed out for ETIMEDOUT string', () => {
-      expect(friendlyErrorMessage('ETIMEDOUT: connection timed out')).toBe(
-        'The operation timed out. Please try again.',
-      )
+    it('tells the user to retry when the raw error is ETIMEDOUT', () => {
+      // Arrange
+      const rawError = 'ETIMEDOUT: connection timed out'
+      // Act
+      const message = friendlyErrorMessage(rawError)
+      // Assert
+      expect(message).toBe('The operation timed out. Please try again.')
     })
 
-    it('returns network error for ENOTFOUND string', () => {
-      expect(friendlyErrorMessage('ENOTFOUND: dns lookup failed')).toBe(
-        'Could not connect. Check your internet connection.',
-      )
+    it('tells the user to check their connection when the raw error is ENOTFOUND', () => {
+      // Arrange
+      const rawError = 'ENOTFOUND: dns lookup failed'
+      // Act
+      const message = friendlyErrorMessage(rawError)
+      // Assert
+      expect(message).toBe('Could not connect. Check your internet connection.')
     })
 
-    it('returns fallback for unrecognized string', () => {
-      expect(friendlyErrorMessage('some unknown error')).toBe(
-        'Something went wrong. Please try again.',
-      )
+    it('falls back to the generic message for an unrecognized error string', () => {
+      // Arrange
+      const rawError = 'some unknown error'
+      // Act
+      const message = friendlyErrorMessage(rawError)
+      // Assert
+      expect(message).toBe('Something went wrong. Please try again.')
     })
 
-    it('returns fallback for empty string', () => {
-      expect(friendlyErrorMessage('')).toBe(
-        'Something went wrong. Please try again.',
-      )
+    it('falls back to the generic message for an empty error string', () => {
+      // Arrange
+      const rawError = ''
+      // Act
+      const message = friendlyErrorMessage(rawError)
+      // Assert
+      expect(message).toBe('Something went wrong. Please try again.')
     })
   })
 
   describe('Error object inputs', () => {
-    it('extracts message from Error with EACCES', () => {
-      expect(friendlyErrorMessage(new Error('EACCES: permission denied'))).toBe(
-        "You don't have permission to do this.",
-      )
+    it('maps an EACCES Error object to the no-permission message', () => {
+      // Arrange
+      const rawError = new Error('EACCES: permission denied')
+      // Act
+      const message = friendlyErrorMessage(rawError)
+      // Assert
+      expect(message).toBe("You don't have permission to do this.")
     })
 
-    it('extracts message from Error with ENOENT', () => {
-      expect(friendlyErrorMessage(new Error('ENOENT: no such file'))).toBe(
-        'The file or folder no longer exists.',
-      )
+    it('maps an ENOENT Error object to the missing-target message', () => {
+      // Arrange
+      const rawError = new Error('ENOENT: no such file')
+      // Act
+      const message = friendlyErrorMessage(rawError)
+      // Assert
+      expect(message).toBe('The file or folder no longer exists.')
     })
 
-    it('extracts message from Error with unknown message', () => {
-      expect(friendlyErrorMessage(new Error('unexpected failure'))).toBe(
-        'Something went wrong. Please try again.',
-      )
+    it('falls back to the generic message for an Error object with an unknown message', () => {
+      // Arrange
+      const rawError = new Error('unexpected failure')
+      // Act
+      const message = friendlyErrorMessage(rawError)
+      // Assert
+      expect(message).toBe('Something went wrong. Please try again.')
     })
   })
 
   describe('non-string, non-Error inputs', () => {
-    it('returns fallback for null', () => {
-      expect(friendlyErrorMessage(null)).toBe(
-        'Something went wrong. Please try again.',
-      )
+    it('falls back to the generic message for null', () => {
+      // Arrange
+      const rawError = null
+      // Act
+      const message = friendlyErrorMessage(rawError)
+      // Assert
+      expect(message).toBe('Something went wrong. Please try again.')
     })
 
-    it('returns fallback for undefined', () => {
-      expect(friendlyErrorMessage(undefined)).toBe(
-        'Something went wrong. Please try again.',
-      )
+    it('falls back to the generic message for undefined', () => {
+      // Arrange
+      const rawError = undefined
+      // Act
+      const message = friendlyErrorMessage(rawError)
+      // Assert
+      expect(message).toBe('Something went wrong. Please try again.')
     })
 
-    it('returns fallback for number', () => {
-      expect(friendlyErrorMessage(42)).toBe(
-        'Something went wrong. Please try again.',
-      )
+    it('falls back to the generic message for a number', () => {
+      // Arrange
+      const rawError = 42
+      // Act
+      const message = friendlyErrorMessage(rawError)
+      // Assert
+      expect(message).toBe('Something went wrong. Please try again.')
     })
 
-    it('returns fallback for object without ENOENT', () => {
-      expect(friendlyErrorMessage({ code: 'UNKNOWN' })).toBe(
-        'Something went wrong. Please try again.',
-      )
+    it('falls back to the generic message for an object that carries no error code', () => {
+      // Arrange
+      const rawError = { code: 'UNKNOWN' }
+      // Act
+      const message = friendlyErrorMessage(rawError)
+      // Assert
+      expect(message).toBe('Something went wrong. Please try again.')
     })
   })
 })

--- a/src/shared/featureFlags.test.ts
+++ b/src/shared/featureFlags.test.ts
@@ -4,24 +4,38 @@ import { FEATURE_FLAGS } from './featureFlags'
 import type { FeatureFlag } from './featureFlags'
 
 describe('FEATURE_FLAGS', () => {
-  it('ENABLE_MARKETPLACE_UI is a boolean', () => {
-    expect(typeof FEATURE_FLAGS.ENABLE_MARKETPLACE_UI).toBe('boolean')
+  it('gates the marketplace UI behind a boolean toggle', () => {
+    // Arrange / Act
+    const flagType = typeof FEATURE_FLAGS.ENABLE_MARKETPLACE_UI
+    // Assert
+    expect(flagType).toBe('boolean')
   })
 
-  it('ENABLE_DASHBOARD_EXPERIMENTAL is a boolean', () => {
-    expect(typeof FEATURE_FLAGS.ENABLE_DASHBOARD_EXPERIMENTAL).toBe('boolean')
+  it('gates the experimental dashboard behind a boolean toggle', () => {
+    // Arrange / Act
+    const flagType = typeof FEATURE_FLAGS.ENABLE_DASHBOARD_EXPERIMENTAL
+    // Assert
+    expect(flagType).toBe('boolean')
   })
 
-  it('contains the ENABLE_MARKETPLACE_UI key', () => {
-    expect('ENABLE_MARKETPLACE_UI' in FEATURE_FLAGS).toBe(true)
+  it('exposes the marketplace UI toggle key', () => {
+    // Arrange / Act
+    const hasMarketplaceKey = 'ENABLE_MARKETPLACE_UI' in FEATURE_FLAGS
+    // Assert
+    expect(hasMarketplaceKey).toBe(true)
   })
 
-  it('contains the ENABLE_DASHBOARD_EXPERIMENTAL key', () => {
-    expect('ENABLE_DASHBOARD_EXPERIMENTAL' in FEATURE_FLAGS).toBe(true)
+  it('exposes the experimental dashboard toggle key', () => {
+    // Arrange / Act
+    const hasDashboardKey = 'ENABLE_DASHBOARD_EXPERIMENTAL' in FEATURE_FLAGS
+    // Assert
+    expect(hasDashboardKey).toBe(true)
   })
 
-  it('has no unexpected keys', () => {
+  it('ships exactly the two known toggles and no stray flags', () => {
+    // Arrange / Act
     const keys = Object.keys(FEATURE_FLAGS)
+    // Assert
     expect(keys).toEqual([
       'ENABLE_MARKETPLACE_UI',
       'ENABLE_DASHBOARD_EXPERIMENTAL',
@@ -30,8 +44,10 @@ describe('FEATURE_FLAGS', () => {
 })
 
 describe('FeatureFlag type', () => {
-  it('ENABLE_MARKETPLACE_UI is a valid FeatureFlag value at runtime', () => {
+  it('accepts a known flag name as a FeatureFlag value', () => {
+    // Arrange
     const flag: FeatureFlag = 'ENABLE_MARKETPLACE_UI'
+    // Act / Assert
     expect(flag).toBe('ENABLE_MARKETPLACE_UI')
   })
 })

--- a/src/shared/fileTypes.test.ts
+++ b/src/shared/fileTypes.test.ts
@@ -3,78 +3,168 @@ import { describe, expect, it } from 'vitest'
 import { classifyFile, shouldExcludeDir } from './fileTypes'
 
 describe('classifyFile', () => {
-  it('returns "text" for markdown', () => {
-    expect(classifyFile('SKILL.md')).toBe('text')
+  it('renders a markdown file as readable text', () => {
+    // Arrange
+    const fileName = 'SKILL.md'
+    // Act
+    const kind = classifyFile(fileName)
+    // Assert
+    expect(kind).toBe('text')
   })
 
-  it('returns "text" for python', () => {
-    expect(classifyFile('helper.py')).toBe('text')
+  it('renders a python file as readable text', () => {
+    // Arrange
+    const fileName = 'helper.py'
+    // Act
+    const kind = classifyFile(fileName)
+    // Assert
+    expect(kind).toBe('text')
   })
 
-  it('returns "text" for shell scripts', () => {
-    expect(classifyFile('install.sh')).toBe('text')
+  it('renders a shell script as readable text', () => {
+    // Arrange
+    const fileName = 'install.sh'
+    // Act
+    const kind = classifyFile(fileName)
+    // Assert
+    expect(kind).toBe('text')
   })
 
-  it('returns "text" for toml', () => {
-    expect(classifyFile('pyproject.toml')).toBe('text')
+  it('renders a toml file as readable text', () => {
+    // Arrange
+    const fileName = 'pyproject.toml'
+    // Act
+    const kind = classifyFile(fileName)
+    // Assert
+    expect(kind).toBe('text')
   })
 
-  it('returns "text" for .env.example (multi-dot extension)', () => {
-    expect(classifyFile('.env.example')).toBe('text')
+  it('renders a multi-dot .env.example file as readable text', () => {
+    // Arrange
+    const fileName = '.env.example'
+    // Act
+    const kind = classifyFile(fileName)
+    // Assert
+    expect(kind).toBe('text')
   })
 
-  it('returns "text" for svg (we prefer showing the markup)', () => {
-    expect(classifyFile('logo.svg')).toBe('text')
+  it('renders an svg as text so the user sees the markup', () => {
+    // Arrange
+    const fileName = 'logo.svg'
+    // Act
+    const kind = classifyFile(fileName)
+    // Assert
+    expect(kind).toBe('text')
   })
 
-  it('returns "image" for png', () => {
-    expect(classifyFile('preview.png')).toBe('image')
+  it('renders a png as an image preview', () => {
+    // Arrange
+    const fileName = 'preview.png'
+    // Act
+    const kind = classifyFile(fileName)
+    // Assert
+    expect(kind).toBe('image')
   })
 
-  it('returns "image" for webp', () => {
-    expect(classifyFile('hero.webp')).toBe('image')
+  it('renders a webp as an image preview', () => {
+    // Arrange
+    const fileName = 'hero.webp'
+    // Act
+    const kind = classifyFile(fileName)
+    // Assert
+    expect(kind).toBe('image')
   })
 
-  it('returns "image" regardless of extension case', () => {
-    expect(classifyFile('LOGO.PNG')).toBe('image')
+  it('renders an uppercase image extension as an image preview', () => {
+    // Arrange
+    const fileName = 'LOGO.PNG'
+    // Act
+    const kind = classifyFile(fileName)
+    // Assert
+    expect(kind).toBe('image')
   })
 
-  it('returns "binary" for unknown extensions', () => {
-    expect(classifyFile('data.bin')).toBe('binary')
+  it('treats an unknown extension as a non-previewable binary', () => {
+    // Arrange
+    const fileName = 'data.bin'
+    // Act
+    const kind = classifyFile(fileName)
+    // Assert
+    expect(kind).toBe('binary')
   })
 
-  it('returns "binary" for files with no extension', () => {
-    expect(classifyFile('Makefile')).toBe('binary')
+  it('treats an extensionless file as a non-previewable binary', () => {
+    // Arrange
+    const fileName = 'Makefile'
+    // Act
+    const kind = classifyFile(fileName)
+    // Assert
+    expect(kind).toBe('binary')
   })
 
-  it('returns "binary" for executables', () => {
-    expect(classifyFile('tool.exe')).toBe('binary')
+  it('treats an executable as a non-previewable binary', () => {
+    // Arrange
+    const fileName = 'tool.exe'
+    // Act
+    const kind = classifyFile(fileName)
+    // Assert
+    expect(kind).toBe('binary')
   })
 })
 
 describe('shouldExcludeDir', () => {
-  it('excludes node_modules', () => {
-    expect(shouldExcludeDir('node_modules')).toBe(true)
+  it('skips node_modules when walking a skill tree', () => {
+    // Arrange
+    const dirName = 'node_modules'
+    // Act
+    const excluded = shouldExcludeDir(dirName)
+    // Assert
+    expect(excluded).toBe(true)
   })
 
-  it('excludes .git', () => {
-    expect(shouldExcludeDir('.git')).toBe(true)
+  it('skips .git when walking a skill tree', () => {
+    // Arrange
+    const dirName = '.git'
+    // Act
+    const excluded = shouldExcludeDir(dirName)
+    // Assert
+    expect(excluded).toBe(true)
   })
 
-  it('excludes __pycache__', () => {
-    expect(shouldExcludeDir('__pycache__')).toBe(true)
+  it('skips __pycache__ when walking a skill tree', () => {
+    // Arrange
+    const dirName = '__pycache__'
+    // Act
+    const excluded = shouldExcludeDir(dirName)
+    // Assert
+    expect(excluded).toBe(true)
   })
 
-  it('does not exclude src', () => {
-    expect(shouldExcludeDir('src')).toBe(false)
+  it('walks into a src directory', () => {
+    // Arrange
+    const dirName = 'src'
+    // Act
+    const excluded = shouldExcludeDir(dirName)
+    // Assert
+    expect(excluded).toBe(false)
   })
 
-  it('does not exclude scripts', () => {
-    expect(shouldExcludeDir('scripts')).toBe(false)
+  it('walks into a scripts directory', () => {
+    // Arrange
+    const dirName = 'scripts'
+    // Act
+    const excluded = shouldExcludeDir(dirName)
+    // Assert
+    expect(excluded).toBe(false)
   })
 
-  it('is case-sensitive (NODE_MODULES does not match)', () => {
+  it('walks into an uppercase NODE_MODULES directory because matching is case-sensitive', () => {
     // POSIX filesystems are case-sensitive; this mirrors that.
-    expect(shouldExcludeDir('NODE_MODULES')).toBe(false)
+    // Arrange
+    const dirName = 'NODE_MODULES'
+    // Act
+    const excluded = shouldExcludeDir(dirName)
+    // Assert
+    expect(excluded).toBe(false)
   })
 })

--- a/src/shared/ipc-contract.test.ts
+++ b/src/shared/ipc-contract.test.ts
@@ -4,8 +4,9 @@ import { IPC_CHANNELS } from './ipc-channels'
 import type { IpcEventContract, IpcInvokeContract } from './ipc-contract'
 
 describe('IPC contract alignment', () => {
-  it('all IPC_CHANNELS invoke values are valid contract keys', () => {
+  it('forces a security review by tripping when an invoke channel is added or removed', () => {
     // Exhaustive compile-time check: missing or extra keys fail compilation
+    // Arrange
     const invokeMapping = {
       [IPC_CHANNELS.SKILLS_GET_ALL]: true,
       [IPC_CHANNELS.SKILLS_UNLINK_FROM_AGENT]: true,
@@ -41,16 +42,21 @@ describe('IPC contract alignment', () => {
       [IPC_CHANNELS.WINDOW_GET_MAIN_BOUNDS]: true,
     } as const satisfies Record<keyof IpcInvokeContract, true>
 
+    // Act
+    const invokeChannelKeys = Object.keys(invokeMapping)
+
     // Runtime assertion: mapping covers exactly the contract keys.
     // SECURITY: increment this number only after a security review of the new
     // IPC channel (input validation, authz scope, side-effect blast radius).
     // The `satisfies` clause above is a structural guard; this length check is
     // the trip-wire that forces a human PR diff when a channel is added.
-    expect(Object.keys(invokeMapping)).toHaveLength(32)
+    // Assert
+    expect(invokeChannelKeys).toHaveLength(32)
   })
 
-  it('all IPC_CHANNELS event values are valid event contract keys', () => {
+  it('forces a review by tripping when a push-event channel is added or removed', () => {
     // Exhaustive compile-time check: missing or extra keys fail compilation
+    // Arrange
     const eventMapping = {
       [IPC_CHANNELS.SKILLS_CLI_PROGRESS]: true,
       [IPC_CHANNELS.SKILLS_DELETE_PROGRESS]: true,
@@ -63,7 +69,11 @@ describe('IPC contract alignment', () => {
       [IPC_CHANNELS.SETTINGS_CHANGED]: true,
     } as const satisfies Record<keyof IpcEventContract, true>
 
+    // Act
+    const eventChannelKeys = Object.keys(eventMapping)
+
     // Runtime assertion: mapping covers exactly the contract keys
-    expect(Object.keys(eventMapping)).toHaveLength(9)
+    // Assert
+    expect(eventChannelKeys).toHaveLength(9)
   })
 })

--- a/src/shared/marketplaceUrlPolicy.test.ts
+++ b/src/shared/marketplaceUrlPolicy.test.ts
@@ -3,17 +3,57 @@ import { describe, expect, it } from 'vitest'
 import { isAllowedSkillsUrl } from './marketplaceUrlPolicy'
 
 describe('isAllowedSkillsUrl', () => {
-  it('allows https://skills.sh URLs with default HTTPS port', () => {
-    expect(isAllowedSkillsUrl('https://skills.sh/trending')).toBe(true)
-    expect(isAllowedSkillsUrl('https://skills.sh:443/hot')).toBe(true)
+  it('opens a skills.sh HTTPS link on the implicit default port', () => {
+    // Arrange
+    const url = 'https://skills.sh/trending'
+    // Act
+    const allowed = isAllowedSkillsUrl(url)
+    // Assert
+    expect(allowed).toBe(true)
   })
 
-  it('rejects non-allowlisted URLs', () => {
-    expect(isAllowedSkillsUrl('https://skills.sh:444/trending')).toBe(false)
-    expect(isAllowedSkillsUrl('http://skills.sh/trending')).toBe(false)
-    expect(isAllowedSkillsUrl('https://skills.sh.evil.com/trending')).toBe(
-      false,
-    )
-    expect(isAllowedSkillsUrl('notaurl')).toBe(false)
+  it('opens a skills.sh HTTPS link on the explicit 443 port', () => {
+    // Arrange
+    const url = 'https://skills.sh:443/hot'
+    // Act
+    const allowed = isAllowedSkillsUrl(url)
+    // Assert
+    expect(allowed).toBe(true)
+  })
+
+  it('blocks a skills.sh link on a non-standard port', () => {
+    // Arrange
+    const url = 'https://skills.sh:444/trending'
+    // Act
+    const allowed = isAllowedSkillsUrl(url)
+    // Assert
+    expect(allowed).toBe(false)
+  })
+
+  it('blocks a plain-HTTP skills.sh link', () => {
+    // Arrange
+    const url = 'http://skills.sh/trending'
+    // Act
+    const allowed = isAllowedSkillsUrl(url)
+    // Assert
+    expect(allowed).toBe(false)
+  })
+
+  it('blocks a look-alike subdomain that only ends in skills.sh', () => {
+    // Arrange
+    const url = 'https://skills.sh.evil.com/trending'
+    // Act
+    const allowed = isAllowedSkillsUrl(url)
+    // Assert
+    expect(allowed).toBe(false)
+  })
+
+  it('blocks a string that is not a parseable URL', () => {
+    // Arrange
+    const url = 'notaurl'
+    // Act
+    const allowed = isAllowedSkillsUrl(url)
+    // Assert
+    expect(allowed).toBe(false)
   })
 })

--- a/src/shared/settings.test.ts
+++ b/src/shared/settings.test.ts
@@ -20,8 +20,10 @@ import {
  * settings.json on disk.
  */
 describe('SettingsSchema', () => {
-  it('parsing an empty object fills in every default field', () => {
+  it('fills in every default field when parsing an empty settings object', () => {
+    // Arrange / Act
     const parsed = SettingsSchema.parse({})
+    // Assert
     expect(parsed.defaultSkillTab).toBe('files')
     expect(parsed.preferredTerminal).toBe('terminal')
     expect(parsed.windowBackgroundBlurRadius).toBe(
@@ -29,22 +31,26 @@ describe('SettingsSchema', () => {
     )
   })
 
-  it('legacy settings.json with only defaultSkillTab gets preferredTerminal default', () => {
+  it('backfills the preferredTerminal default for a legacy settings.json that predates the field', () => {
     // Simulates a user who upgraded from a pre-feature build — their
     // settings.json on disk has no `preferredTerminal` key. Without a
     // `.default()` they would crash on validation.
+    // Arrange / Act
     const parsed = SettingsSchema.parse({ defaultSkillTab: 'info' })
+    // Assert
     expect(parsed.preferredTerminal).toBe('terminal')
     expect(parsed.defaultSkillTab).toBe('info')
   })
 
   it('rejects an unknown preferredTerminal value', () => {
+    // Arrange / Act / Assert
     expect(() =>
       SettingsSchema.parse({ preferredTerminal: 'fish-shell' }),
     ).toThrow()
   })
 
   it('accepts every curated terminal id', () => {
+    // Arrange / Act / Assert
     for (const id of [
       'terminal',
       'iterm',
@@ -61,21 +67,26 @@ describe('SettingsSchema', () => {
     }
   })
 
-  it('trims customTerminalAppName and rejects empty post-trim', () => {
+  it('rejects a customTerminalAppName that is only whitespace after trimming', () => {
+    // Arrange / Act / Assert
     expect(() =>
       SettingsSchema.parse({ customTerminalAppName: '   ' }),
     ).toThrow()
   })
 
-  it('rejects customTerminalAppName longer than 64 chars', () => {
+  it('rejects a customTerminalAppName longer than 64 chars', () => {
+    // Arrange / Act / Assert
     expect(() =>
       SettingsSchema.parse({ customTerminalAppName: 'a'.repeat(65) }),
     ).toThrow()
   })
 
-  it('accepts customTerminalAppName at exactly 64 chars', () => {
+  it('accepts a customTerminalAppName at exactly the 64-char limit', () => {
+    // Arrange
     const sixtyFour = 'a'.repeat(64)
+    // Act
     const parsed = SettingsSchema.parse({ customTerminalAppName: sixtyFour })
+    // Assert
     expect(parsed.customTerminalAppName).toBe(sixtyFour)
   })
 
@@ -85,38 +96,50 @@ describe('SettingsSchema', () => {
    * are duplicated by design (so they don't cost a Zod parse at boot) but
    * MUST stay in lockstep with the schema.
    */
-  it('DEFAULT_SETTINGS matches SettingsSchema.parse({})', () => {
-    expect(DEFAULT_SETTINGS).toEqual(SettingsSchema.parse({}))
+  it('keeps DEFAULT_SETTINGS in lockstep with what the schema produces from an empty object', () => {
+    // Arrange / Act
+    const schemaDefaults = SettingsSchema.parse({})
+    // Assert
+    expect(DEFAULT_SETTINGS).toEqual(schemaDefaults)
   })
 
   it('defaults autoDownloadUpdates to off so a fresh install keeps manual confirm-via-UI downloads', () => {
+    // Arrange / Act
     const parsed = SettingsSchema.parse({})
+    // Assert
     expect(parsed.autoDownloadUpdates).toBe(false)
   })
 
   it('persists opting into background downloads', () => {
+    // Arrange / Act
     const parsed = SettingsSchema.parse({
       autoDownloadUpdates: true,
     })
+    // Assert
     expect(parsed.autoDownloadUpdates).toBe(true)
   })
 
   it('rejects a non-boolean autoDownloadUpdates', () => {
+    // Arrange / Act / Assert
     expect(() => SettingsSchema.parse({ autoDownloadUpdates: 'yes' })).toThrow()
   })
 
-  it('windowSize is optional and defaults to undefined', () => {
+  it('leaves windowSize unset when none is stored', () => {
+    // Arrange / Act
     const parsed = SettingsSchema.parse({})
+    // Assert
     expect(parsed.windowSize).toBeUndefined()
   })
 
   it('accepts a windowSize at the minimum dimension', () => {
+    // Arrange / Act
     const parsed = SettingsSchema.parse({
       windowSize: {
         width: WINDOW_SIZE_MIN_DIMENSION,
         height: WINDOW_SIZE_MIN_DIMENSION,
       },
     })
+    // Assert
     expect(parsed.windowSize).toEqual({
       width: WINDOW_SIZE_MIN_DIMENSION,
       height: WINDOW_SIZE_MIN_DIMENSION,
@@ -124,6 +147,7 @@ describe('SettingsSchema', () => {
   })
 
   it('rejects a windowSize below the minimum dimension', () => {
+    // Arrange / Act / Assert
     expect(() =>
       SettingsSchema.parse({
         windowSize: {
@@ -143,6 +167,7 @@ describe('SettingsSchema', () => {
   })
 
   it('rejects a non-integer windowSize', () => {
+    // Arrange / Act / Assert
     expect(() =>
       SettingsSchema.parse({
         windowSize: {
@@ -154,15 +179,18 @@ describe('SettingsSchema', () => {
   })
 
   it('accepts a windowBackgroundBlurRadius within the bounded range', () => {
+    // Arrange / Act
     const parsed = SettingsSchema.parse({
       windowBackgroundBlurRadius: WINDOW_BACKGROUND_BLUR_MAX_RADIUS,
     })
+    // Assert
     expect(parsed.windowBackgroundBlurRadius).toBe(
       WINDOW_BACKGROUND_BLUR_MAX_RADIUS,
     )
   })
 
   it('rejects a windowBackgroundBlurRadius outside the bounded range', () => {
+    // Arrange / Act / Assert
     expect(() =>
       SettingsSchema.parse({
         windowBackgroundBlurRadius: WINDOW_BACKGROUND_BLUR_MIN_RADIUS - 1,
@@ -176,89 +204,109 @@ describe('SettingsSchema', () => {
   })
 
   it('rejects a non-integer windowBackgroundBlurRadius', () => {
+    // Arrange / Act / Assert
     expect(() =>
       SettingsSchema.parse({ windowBackgroundBlurRadius: 12.5 }),
     ).toThrow()
   })
 
-  it('hiddenAgentIds defaults to an empty array on a fresh parse', () => {
+  it('hides no agents by default on a fresh parse', () => {
+    // Arrange / Act
     const parsed = SettingsSchema.parse({})
+    // Assert
     expect(parsed.hiddenAgentIds).toEqual([])
   })
 
-  it('accepts an installed agent id in hiddenAgentIds', () => {
+  it('keeps a hidden agent id that matches an installed agent', () => {
+    // Arrange
     const firstAgentId = AGENT_DEFINITIONS[0]!.id
+    // Act
     const parsed = SettingsSchema.parse({ hiddenAgentIds: [firstAgentId] })
+    // Assert
     expect(parsed.hiddenAgentIds).toEqual([firstAgentId])
   })
 
-  it('drops unknown agent ids from hiddenAgentIds without rejecting the file', () => {
+  it('drops an unknown hidden agent id instead of rejecting the whole settings file', () => {
     // The schema is forgiving on disk reads — strict z.enum here would
     // throw the WHOLE settings file out (and reset every other field to
     // defaults) when one stale id slips in.
+    // Arrange / Act
     const parsed = SettingsSchema.parse({
       hiddenAgentIds: ['bogus-agent'],
     })
+    // Assert
     expect(parsed.hiddenAgentIds).toEqual([])
   })
 
-  it('preserves valid hiddenAgentIds while dropping stale ids alongside', () => {
+  it('keeps the valid hidden agent ids and drops the stale ones beside them', () => {
     // Regression for the `/cli-upgrade`-removed-an-agent scenario: with
     // strict z.enum the whole array (and everything else in settings.json)
     // would reject. The transform must filter, not throw.
+    // Arrange
     const firstAgentId = AGENT_DEFINITIONS[0]!.id
+    // Act
     const parsed = SettingsSchema.parse({
       hiddenAgentIds: [firstAgentId, 'removed-agent'],
     })
+    // Assert
     expect(parsed.hiddenAgentIds).toEqual([firstAgentId])
   })
 
-  it('preserves all other settings fields when hiddenAgentIds contains stale ids', () => {
+  it('does not reset every other settings field when hiddenAgentIds carries a stale id', () => {
     // The blast radius of a strict-enum failure was every field in the
     // file dropping back to defaults. Pin the boundary here so a future
     // refactor can't quietly resurrect that behavior.
+    // Arrange / Act
     const parsed = SettingsSchema.parse({
       defaultSkillTab: 'info',
       preferredTerminal: 'iterm',
       hiddenAgentIds: ['removed-agent'],
     })
+    // Assert
     expect(parsed.defaultSkillTab).toBe('info')
     expect(parsed.preferredTerminal).toBe('iterm')
     expect(parsed.hiddenAgentIds).toEqual([])
   })
 
   it('rejects a non-array hiddenAgentIds', () => {
+    // Arrange / Act / Assert
     expect(() =>
       SettingsSchema.parse({ hiddenAgentIds: 'claude-code' }),
     ).toThrow()
   })
 
-  it('drops non-string elements without rejecting the file', () => {
+  it('drops non-string hiddenAgentIds entries instead of rejecting the whole settings file', () => {
     // Regression for the array-element-validation cliff: with the prior
     // `z.array(z.string())` element schema, a single non-string entry
     // (e.g. a hand-edited `123`) would fail BEFORE `.transform()` ran,
     // taking the whole settings parse down with it. Element type is
     // `z.unknown()` so the typeof-string filter inside transform can
     // do its job — same forgiving contract as the stale-id case.
+    // Arrange
     const firstAgentId = AGENT_DEFINITIONS[0]!.id
+    // Act
     const parsed = SettingsSchema.parse({
       defaultSkillTab: 'info',
       hiddenAgentIds: [firstAgentId, 123, null, { not: 'a string' }],
     })
+    // Assert
     expect(parsed.defaultSkillTab).toBe('info')
     expect(parsed.hiddenAgentIds).toEqual([firstAgentId])
   })
 
-  it('deduplicates hiddenAgentIds on parse', () => {
+  it('collapses duplicate hiddenAgentIds so the settings-equality check stays honest', () => {
     // A hand-edited settings.json containing duplicates would otherwise
     // false-positive the length-then-membership equality check in
     // `areSettingsEqual` (e.g. ['cursor','cursor'] vs ['cursor','claude-code']
     // would compare equal and silently drop the legitimate write). The
     // disk schema deduplicates so the equality contract stays honest.
+    // Arrange
     const firstAgentId = AGENT_DEFINITIONS[0]!.id
+    // Act
     const parsed = SettingsSchema.parse({
       hiddenAgentIds: [firstAgentId, firstAgentId],
     })
+    // Assert
     expect(parsed.hiddenAgentIds).toEqual([firstAgentId])
   })
 })
@@ -268,7 +316,8 @@ describe('SettingsSchema', () => {
  * native backplate and the real Electron window opacity on the same curve.
  */
 describe('window background appearance helpers', () => {
-  it('clamps blur radius values before opacity math', () => {
+  it('clamps an out-of-range blur radius and floors a fractional one before opacity math', () => {
+    // Arrange / Act / Assert
     expect(normalizeWindowBackgroundBlurRadius(-12)).toBe(
       WINDOW_BACKGROUND_BLUR_MIN_RADIUS,
     )
@@ -278,17 +327,26 @@ describe('window background appearance helpers', () => {
     )
   })
 
-  it('maps disabled blur to an opaque app surface', () => {
-    expect(getWindowBackgroundOpacity(0)).toBe(WINDOW_BACKGROUND_OPACITY_MAX)
+  it('keeps the app surface fully opaque when blur is disabled', () => {
+    // Arrange / Act
+    const opacity = getWindowBackgroundOpacity(0)
+    // Assert
+    expect(opacity).toBe(WINDOW_BACKGROUND_OPACITY_MAX)
   })
 
-  it('maps maximum blur to the minimum readable surface opacity', () => {
-    expect(getWindowBackgroundOpacity(WINDOW_BACKGROUND_BLUR_MAX_RADIUS)).toBe(
-      WINDOW_BACKGROUND_OPACITY_MIN,
+  it('drops the app surface to the minimum readable opacity at maximum blur', () => {
+    // Arrange / Act
+    const opacity = getWindowBackgroundOpacity(
+      WINDOW_BACKGROUND_BLUR_MAX_RADIUS,
     )
+    // Assert
+    expect(opacity).toBe(WINDOW_BACKGROUND_OPACITY_MIN)
   })
 
-  it('maps mid slider values to visibly different opacity', () => {
-    expect(getWindowBackgroundOpacity(24)).toBe(0.72)
+  it('gives a mid-slider blur a visibly distinct surface opacity', () => {
+    // Arrange / Act
+    const opacity = getWindowBackgroundOpacity(24)
+    // Assert
+    expect(opacity).toBe(0.72)
   })
 })


### PR DESCRIPTION
## Summary

Brings **95 non-compliant test files** up to the project's six testing rules (CLAUDE.md → Testing). Already-compliant files were left byte-for-byte untouched.

The six rules applied:
1. **DAMP over DRY** — kept fixture/builder helpers (`makeSkill`, `createTestStore`, `renderX`); inlined only over-DRY assertion loops that hid what each test verifies.
2. **Hard-coded expected values.**
3. **AAA pattern** — reordered into Arrange / Act / Assert where possible.
4. **`// Arrange` / `// Act` / `// Assert` comments** added.
5. **Test names describe observable behavior / spec**, not implementation (`returns true when…` → `allows bookmarking a skill that has a source repo`).
6. **Names reveal what feature breaks** when the test fails.

## Scope

- **81 vitest specs** (`*.test.ts`, `*.test.tsx`, `*.browser.test.tsx`)
- **14 Playwright e2e specs** (`*.e2e.ts`) — rules adapted to Playwright idioms
- **20 already-compliant files skipped** (HealthWidget, WidgetPicker, formatRepositoryFacetLabel, SymlinkCleanupDialog, …) — verified each already contains `// Arrange`

## Behavior preservation

This is a **pure test-readability refactor** — no production code changed (diff is test-only). Verified behavior is preserved by independent checks:

- ✅ No assertions dropped (per-file `expect(` count vs HEAD: no decreases)
- ✅ No test blocks dropped (`it`/`test`/`describe` count vs HEAD: no decreases)
- ✅ No tests silently disabled (no `.only` / `.skip` / `xit` / `xdescribe` introduced)
- ✅ No assertion-strength downgrades (STRONG matchers net **+25**, WEAK matchers net **+2** — no strong→weak swaps)

## Gates (all green)

| Gate | Result |
| --- | --- |
| `pnpm lint` | ✅ |
| `pnpm typecheck` (root) | ✅ |
| `tsc -p e2e/tsconfig.json` | ✅ |
| `pnpm test` (vitest) | ✅ 101 files / 1341 tests |
| `pnpm fallow:dead-code` | ✅ No issues |
| storybook build | ✅ |
| `pnpm test:e2e` (Playwright) | ✅ 51 specs |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * E2E・統合・単体テストを大幅に整理。Arrange/Act/Assert コメントと説明的なケース名を導入し可読性を向上。シンボリックリンク・同期・削除・復元・UI回帰・設定・テーマ・ファイル処理などのカバレッジを明確化・拡充し、期待値の検証粒度を強化しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/skills-desktop/pull/187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->