### PR TITLE
Fix Info tab scroll clipping

### DIFF
--- a/src/renderer/src/components/skills/SkillDetail.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillDetail.browser.test.tsx
@@ -4,13 +4,40 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import { DEFAULT_SETTINGS } from '@/shared/settings'
-import type { Agent, AgentId, Skill, SymlinkInfo } from '@/shared/types'
+import type {
+  Agent,
+  AgentId,
+  AgentName,
+  Skill,
+  SymlinkInfo,
+} from '@/shared/types'
 
 const SOURCE_PATH = '/home/user/.agents/skills/task'
 const CURSOR_PATH = '/home/user/.cursor/skills/task'
+const DETAIL_PANEL_TEST_HEIGHT_PX = 280
+const DETAIL_DRAG_REGION_HEIGHT_PX = 32
+const VISIBLE_BOUNDS_TOLERANCE_PX = 1
 const mockWriteText = vi.fn()
 const toastErrorMock = vi.fn()
 let originalClipboardDescriptor: PropertyDescriptor | undefined
+
+const OVERFLOW_AGENT_ROWS = [
+  { id: 'claude-code', name: 'Claude Code' },
+  { id: 'cursor', name: 'Cursor' },
+  { id: 'codex', name: 'Codex' },
+  { id: 'gemini-cli', name: 'Gemini CLI' },
+  { id: 'opencode', name: 'OpenCode' },
+  { id: 'github-copilot', name: 'GitHub Copilot' },
+  { id: 'cline', name: 'Cline' },
+  { id: 'windsurf', name: 'Windsurf' },
+  { id: 'junie', name: 'Junie' },
+  { id: 'antigravity', name: 'Antigravity' },
+  { id: 'kiro-cli', name: 'Kiro CLI' },
+  { id: 'mcpjam', name: 'MCPJam' },
+  { id: 'openclaw', name: 'OpenClaw' },
+  { id: 'warp', name: 'Warp' },
+  { id: 'devin', name: 'Devin for Terminal' },
+] satisfies Array<{ id: AgentId; name: AgentName }>
 
 vi.mock('sonner', () => ({
   toast: {
@@ -70,6 +97,66 @@ function makeSkill(): Skill {
   }
 }
 
+/**
+ * Build enough Info rows to overflow the fixed-height detail shell used by the regression test.
+ * @returns Agents and skill rows that force the Info tab to need vertical scrolling.
+ * @example
+ * const { agents, skill } = makeOverflowSkillFixture()
+ */
+function makeOverflowSkillFixture(): { agents: Agent[]; skill: Skill } {
+  const agents = OVERFLOW_AGENT_ROWS.map(({ id, name }) =>
+    makeAgent({
+      id,
+      name,
+      path: `/home/user/.${id}/skills`,
+      skillCount: 1,
+    }),
+  )
+  const symlinks: SymlinkInfo[] = OVERFLOW_AGENT_ROWS.map(({ id, name }) => ({
+    agentId: id,
+    agentName: name,
+    status: 'valid',
+    targetPath: SOURCE_PATH,
+    linkPath: id === 'cursor' ? CURSOR_PATH : `/home/user/.${id}/skills/task`,
+    isLocal: false,
+  }))
+
+  return {
+    agents,
+    skill: {
+      ...makeSkill(),
+      symlinkCount: symlinks.length,
+      symlinks,
+    },
+  }
+}
+
+/**
+ * Install the Tailwind layout subset this isolated browser test needs to reproduce the app shell.
+ * @returns Style element for removal after the layout assertion finishes.
+ * @example
+ * const styleElement = installSkillDetailLayoutStyles()
+ */
+function installSkillDetailLayoutStyles(): HTMLStyleElement {
+  const styleElement = document.createElement('style')
+  styleElement.textContent = `
+    *, ::before, ::after { box-sizing: border-box; }
+    .flex { display: flex; }
+    .flex-col { flex-direction: column; }
+    .flex-1 { flex: 1 1 0%; }
+    .min-h-0 { min-height: 0; }
+    .h-full { height: 100%; }
+    .shrink-0 { flex-shrink: 0; }
+    .overflow-auto { overflow: auto; }
+    .p-4 { padding: 16px; }
+    .px-4 { padding-left: 16px; padding-right: 16px; }
+    .pt-4 { padding-top: 16px; }
+    .pb-6 { padding-bottom: 24px; }
+  `
+  document.head.append(styleElement)
+  return styleElement
+}
+
 beforeEach(() => {
   mockWriteText.mockReset()
   mockWriteText.mockResolvedValue(undefined)
@@ -96,11 +183,16 @@ afterEach(() => {
 /**
  * Render SkillDetail on the Info tab with the smallest real Redux state shape.
  * @param selectedAgentId - Optional selected agent; when present, Location shows both source and symlink paths.
+ * @param skill - Skill fixture rendered in the right detail panel.
+ * @param options - Optional installed-agent rows and shell chrome for layout regressions.
  * @returns Render handle and Redux store.
+ * @example
+ * await renderSkillDetail('cursor' as AgentId, makeSkill(), { withDetailShell: true })
  */
 async function renderSkillDetail(
   selectedAgentId: AgentId | null = null,
   skill: Skill = makeSkill(),
+  options: { agents?: Agent[]; withDetailShell?: boolean } = {},
 ) {
   const { default: settingsReducer } =
     await import('@/renderer/src/redux/slices/settingsSlice')
@@ -120,7 +212,7 @@ async function renderSkillDetail(
     },
     preloadedState: {
       agents: {
-        items: [makeAgent()],
+        items: options.agents ?? [makeAgent()],
         loading: false,
         error: null,
         agentToDelete: null,
@@ -132,11 +224,31 @@ async function renderSkillDetail(
   store.dispatch(setSettings({ ...DEFAULT_SETTINGS, defaultSkillTab: 'info' }))
   store.dispatch(selectAgent(selectedAgentId))
 
-  const screen = await render(
-    <Provider store={store}>
-      <SkillDetail skill={skill} />
-    </Provider>,
+  const skillDetail = <SkillDetail skill={skill} />
+  const content = options.withDetailShell ? (
+    <div
+      data-testid="detail-shell"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: `${DETAIL_PANEL_TEST_HEIGHT_PX}px`,
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        data-testid="detail-drag-region"
+        style={{
+          flexShrink: 0,
+          height: `${DETAIL_DRAG_REGION_HEIGHT_PX}px`,
+        }}
+      />
+      {skillDetail}
+    </div>
+  ) : (
+    skillDetail
   )
+
+  const screen = await render(<Provider store={store}>{content}</Provider>)
 
   return { screen, store }
 }
@@ -218,5 +330,46 @@ describe('SkillDetail Info path copy', () => {
     await expect
       .element(inaccessibleRow as HTMLElement)
       .toHaveTextContent(/Inaccessible:\s*1/)
+  })
+
+  it('keeps Location paths visible after scrolling the Info tab inside detail chrome', async () => {
+    // Arrange
+    const layoutStyleElement = installSkillDetailLayoutStyles()
+    const { agents, skill } = makeOverflowSkillFixture()
+    try {
+      const { screen } = await renderSkillDetail('cursor' as AgentId, skill, {
+        agents,
+        withDetailShell: true,
+      })
+      const detailShell = screen.container.querySelector(
+        '[data-testid="detail-shell"]',
+      )
+      const infoScroller = screen.container.querySelector(
+        '[data-skill-info-scroll]',
+      )
+      const symlinkPath = screen.getByText(CURSOR_PATH).element()
+
+      expect(detailShell).toBeInstanceOf(HTMLElement)
+      expect(infoScroller).toBeInstanceOf(HTMLElement)
+
+      // Act
+      const scrollPane = infoScroller as HTMLElement
+      scrollPane.scrollTop = scrollPane.scrollHeight
+      await new Promise<void>((resolve) => {
+        requestAnimationFrame(() => resolve())
+      })
+
+      // Assert
+      expect(scrollPane.scrollHeight).toBeGreaterThan(scrollPane.clientHeight)
+      expect(
+        Math.round((detailShell as HTMLElement).getBoundingClientRect().height),
+      ).toBe(DETAIL_PANEL_TEST_HEIGHT_PX)
+      expect(symlinkPath.getBoundingClientRect().bottom).toBeLessThanOrEqual(
+        (detailShell as HTMLElement).getBoundingClientRect().bottom +
+          VISIBLE_BOUNDS_TOLERANCE_PX,
+      )
+    } finally {
+      layoutStyleElement.remove()
+    }
   })
 })

--- a/src/renderer/src/components/skills/SkillDetail.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillDetail.browser.test.tsx
@@ -3,6 +3,7 @@ import { Provider } from 'react-redux'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
+import { installLayoutStyles } from '@/renderer/src/test/installLayoutStyles'
 import { DEFAULT_SETTINGS } from '@/shared/settings'
 import type {
   Agent,
@@ -129,32 +130,6 @@ function makeOverflowSkillFixture(): { agents: Agent[]; skill: Skill } {
       symlinks,
     },
   }
-}
-
-/**
- * Install the Tailwind layout subset this isolated browser test needs to reproduce the app shell.
- * @returns Style element for removal after the layout assertion finishes.
- * @example
- * const styleElement = installSkillDetailLayoutStyles()
- */
-function installSkillDetailLayoutStyles(): HTMLStyleElement {
-  const styleElement = document.createElement('style')
-  styleElement.textContent = `
-    *, ::before, ::after { box-sizing: border-box; }
-    .flex { display: flex; }
-    .flex-col { flex-direction: column; }
-    .flex-1 { flex: 1 1 0%; }
-    .min-h-0 { min-height: 0; }
-    .h-full { height: 100%; }
-    .shrink-0 { flex-shrink: 0; }
-    .overflow-auto { overflow: auto; }
-    .p-4 { padding: 16px; }
-    .px-4 { padding-left: 16px; padding-right: 16px; }
-    .pt-4 { padding-top: 16px; }
-    .pb-6 { padding-bottom: 24px; }
-  `
-  document.head.append(styleElement)
-  return styleElement
 }
 
 beforeEach(() => {
@@ -334,7 +309,7 @@ describe('SkillDetail Info path copy', () => {
 
   it('keeps Location paths visible after scrolling the Info tab inside detail chrome', async () => {
     // Arrange
-    const layoutStyleElement = installSkillDetailLayoutStyles()
+    const layoutStyleElement = installLayoutStyles()
     const { agents, skill } = makeOverflowSkillFixture()
     try {
       const { screen } = await renderSkillDetail('cursor' as AgentId, skill, {

--- a/src/renderer/src/components/skills/SkillDetail.tsx
+++ b/src/renderer/src/components/skills/SkillDetail.tsx
@@ -66,7 +66,8 @@ export const SkillDetail = React.memo(function SkillDetail({
   ).length
 
   return (
-    <div className="flex flex-col h-full">
+    // Fill DetailPanel's remaining height after its drag strip so tab scrollers are not clipped.
+    <div className="flex min-h-0 flex-1 flex-col">
       {/* Header with skill name */}
       <div className="p-4 border-b border-border">
         <h2 className="text-lg font-semibold truncate">{skill.name}</h2>
@@ -232,7 +233,7 @@ const InfoView = React.memo(function InfoView({
   const { copiedPath, copyPath } = useLocationPathClipboard()
 
   return (
-    <div className="p-4 overflow-auto h-full">
+    <div data-skill-info-scroll className="h-full overflow-auto px-4 pt-4 pb-6">
       <SourceLink source={skill.source} sourceUrl={skill.sourceUrl} />
 
       <div className="flex gap-4 text-sm mb-4">

--- a/src/renderer/src/test/installLayoutStyles.ts
+++ b/src/renderer/src/test/installLayoutStyles.ts
@@ -1,0 +1,25 @@
+/**
+ * Installs the minimal Tailwind layout rules isolated browser tests need when they do not boot globals.css.
+ * @returns Style element that the caller removes in a finally block.
+ * @example
+ * const styleElement = installLayoutStyles()
+ */
+export function installLayoutStyles(): HTMLStyleElement {
+  const styleElement = document.createElement('style')
+  styleElement.textContent = `
+    *, ::before, ::after { box-sizing: border-box; }
+    .flex { display: flex; }
+    .flex-col { flex-direction: column; }
+    .flex-1 { flex: 1 1 0%; }
+    .min-h-0 { min-height: 0; }
+    .h-full { height: 100%; }
+    .shrink-0 { flex-shrink: 0; }
+    .overflow-auto { overflow: auto; }
+    .p-4 { padding: 16px; }
+    .px-4 { padding-left: 16px; padding-right: 16px; }
+    .pt-4 { padding-top: 16px; }
+    .pb-6 { padding-bottom: 24px; }
+  `
+  document.head.append(styleElement)
+  return styleElement
+}


### PR DESCRIPTION
## Summary
- constrain SkillDetail to the remaining DetailPanel height so the Info tab scroller is not clipped by the drag strip
- add bottom spacing and a data hook for the Info scroll pane
- add a browser regression test that scrolls a dense Info tab to the Location paths inside detail chrome

## Validation
- pnpm exec vitest run src/renderer/src/components/skills/SkillDetail.browser.test.tsx --project browser
- pnpm lint
- pnpm typecheck
- pnpm validate
- Electron dev app + playwright-cli CDP check for Cursor / playwright-cli Info tab bottom scroll

## Notes
- pnpm validate initially hit a transient WidgetPicker browser-mode timeout, then the WidgetPicker file passed alone and a full validate rerun passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * スキル詳細パネルのレイアウトを調整し、Infoタブのスクロール時に表示要素がパネル境界をはみ出さないようにしました。ドラッグハンドル分の高さも考慮しています。

* **Tests**
  * Infoタブのスクロール挙動と表示保持を検証する回帰テストを追加しました。テスト用の縦スクロールフィクスチャと最小限のレイアウトスタイル注入を導入し、後処理でクリーンアップします。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->