### PR TITLE
Hide Settings window titlebar

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,6 +9,7 @@ import {
   session,
 } from 'electron'
 
+import { MACOS_TRAFFIC_LIGHT_POSITION_PX } from '@/shared/constants'
 import { isAllowedSkillsUrl } from '@/shared/marketplaceUrlPolicy'
 
 import { registerAllHandlers } from './ipc/handlers'
@@ -94,7 +95,7 @@ function createWindow(): void {
     // to reveal the desktop behind the app when the Appearance slider is on.
     transparent: true,
     titleBarStyle: 'hiddenInset',
-    trafficLightPosition: { x: 16, y: 16 },
+    trafficLightPosition: MACOS_TRAFFIC_LIGHT_POSITION_PX,
     webPreferences: {
       ...getSecureWebPreferences(),
       // Main-window-only: <webview> is used by the marketplace tab to

--- a/src/main/services/settingsWindow.test.ts
+++ b/src/main/services/settingsWindow.test.ts
@@ -1,0 +1,93 @@
+import type { BrowserWindowConstructorOptions } from 'electron'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+type MockBrowserWindowInstance = {
+  focus: ReturnType<typeof vi.fn>
+  isDestroyed: ReturnType<typeof vi.fn>
+  isMinimized: ReturnType<typeof vi.fn>
+  loadFile: ReturnType<typeof vi.fn>
+  loadURL: ReturnType<typeof vi.fn>
+  on: ReturnType<typeof vi.fn>
+  options: BrowserWindowConstructorOptions
+  restore: ReturnType<typeof vi.fn>
+  show: ReturnType<typeof vi.fn>
+  webContents: {
+    setWindowOpenHandler: ReturnType<typeof vi.fn>
+  }
+}
+
+const electronMock = vi.hoisted(() => {
+  const instances: MockBrowserWindowInstance[] = []
+  const BrowserWindow = vi.fn(function MockBrowserWindow(
+    options: BrowserWindowConstructorOptions,
+  ) {
+    const instance: MockBrowserWindowInstance = {
+      focus: vi.fn(),
+      isDestroyed: vi.fn(() => false),
+      isMinimized: vi.fn(() => false),
+      loadFile: vi.fn(),
+      loadURL: vi.fn(),
+      on: vi.fn(),
+      options,
+      restore: vi.fn(),
+      show: vi.fn(),
+      webContents: { setWindowOpenHandler: vi.fn() },
+    }
+    instances.push(instance)
+    return instance
+  })
+
+  return {
+    BrowserWindow,
+    instances,
+    openExternal: vi.fn(),
+  }
+})
+
+vi.mock('electron', () => ({
+  app: { isPackaged: false },
+  BrowserWindow: electronMock.BrowserWindow,
+  shell: { openExternal: electronMock.openExternal },
+}))
+
+/**
+ * Imports a fresh settings window module after clearing its singleton state.
+ * @returns Fresh Settings window module exports.
+ * @example
+ * const { createOrFocusSettingsWindow } = await importFreshSettingsWindow()
+ */
+async function importFreshSettingsWindow(): Promise<{
+  createOrFocusSettingsWindow: () => void
+}> {
+  vi.resetModules()
+  return import('./settingsWindow')
+}
+
+describe('createOrFocusSettingsWindow', () => {
+  beforeEach(() => {
+    electronMock.BrowserWindow.mockClear()
+    electronMock.instances.length = 0
+    delete process.env['ELECTRON_RENDERER_URL']
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    delete process.env['ELECTRON_RENDERER_URL']
+  })
+
+  it("opens Settings without Electron's standard title bar frame while keeping macOS traffic lights", async () => {
+    // Arrange
+    const { createOrFocusSettingsWindow } = await importFreshSettingsWindow()
+
+    // Act
+    createOrFocusSettingsWindow()
+
+    // Assert
+    expect(electronMock.BrowserWindow).toHaveBeenCalledTimes(1)
+    expect(electronMock.instances[0]?.options).toMatchObject({
+      title: 'Settings',
+      titleBarStyle: 'hiddenInset',
+      trafficLightPosition: { x: 16, y: 16 },
+    })
+  })
+})

--- a/src/main/services/settingsWindow.ts
+++ b/src/main/services/settingsWindow.ts
@@ -5,6 +5,7 @@ import { app, BrowserWindow } from 'electron'
 import { attachExternalLinkHandler } from '@/main/utils/attachExternalLinkHandler'
 import { isE2EBackgroundLaunch } from '@/main/utils/e2eEnv'
 import { getSecureWebPreferences } from '@/main/utils/secureWebPreferences'
+import { MACOS_TRAFFIC_LIGHT_POSITION_PX } from '@/shared/constants'
 
 /**
  * Single-instance reference to the Settings window. Held at module scope
@@ -19,9 +20,10 @@ let settingsWindow: BrowserWindow | null = null
  * separate `settings/index.html` Rollup entry — see
  * `electron.vite.config.ts` for the multi-entry config.
  *
- * Window chrome: standard macOS title bar (NOT hidden-inset like the
- * main window) so the title "Settings" reads naturally; not minimizable,
+ * Window chrome: hidden-inset like the main window so Electron's default
+ * header frame never stacks above the Settings UI; not minimizable,
  * maximizable, or fullscreen-able to match Inkdrop's pattern.
+ * @returns void.
  * @example
  * // Wired into the App menu and the sidebar gear icon button.
  * createOrFocusSettingsWindow()
@@ -44,6 +46,8 @@ export function createOrFocusSettingsWindow(): void {
     maximizable: false,
     fullscreenable: false,
     backgroundColor: '#0A0F1C',
+    titleBarStyle: 'hiddenInset',
+    trafficLightPosition: MACOS_TRAFFIC_LIGHT_POSITION_PX,
     webPreferences: getSecureWebPreferences(),
   })
 

--- a/src/renderer/settings/SettingsApp.tsx
+++ b/src/renderer/settings/SettingsApp.tsx
@@ -65,10 +65,15 @@ export const SettingsApp = React.memo(
     const [activeSection, setActiveSection] = useState<Section>('general')
 
     return (
-      <div className="flex h-screen bg-background text-foreground window-glow">
+      <div className="relative flex h-screen bg-background text-foreground window-glow">
+        {/* Hidden titlebar leaves full-size content; this keeps a native drag target without drawing a header. */}
+        <div
+          aria-hidden="true"
+          className="absolute inset-x-0 top-0 h-12 drag-region"
+        />
         <nav
           aria-label="Settings sections"
-          className="w-50 shrink-0 border-r border-border bg-sidebar/30 py-4"
+          className="w-50 shrink-0 border-r border-border bg-sidebar/30 pt-14 pb-4"
         >
           <ul className="flex flex-col gap-0.5 px-2">
             {NAV_ITEMS.map((item) => {
@@ -96,7 +101,7 @@ export const SettingsApp = React.memo(
           </ul>
         </nav>
         <ScrollArea className="flex-1">
-          <div className="px-8 py-6">
+          <div className="px-8 pt-14 pb-6">
             {match(activeSection)
               .with('general', () => <General />)
               .with('appearance', () => <Appearance />)

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -805,6 +805,12 @@ export const SKILLS_CLI_VERSION = '1.5.5'
 export const SKILLS_SH_HOSTNAME = 'skills.sh'
 
 /**
+ * Native macOS traffic-light inset for hidden-inset BrowserWindows (px).
+ * Shared by main and Settings windows so their chrome alignment cannot drift.
+ */
+export const MACOS_TRAFFIC_LIGHT_POSITION_PX = { x: 16, y: 16 } as const
+
+/**
  * Undo window for bulk skill deletes (ms). The trashService tombstone TTL and
  * the renderer undo-toast duration must stay in lockstep — if the on-disk
  * tombstone expires before the toast, a user's "undo" click races an empty


### PR DESCRIPTION
## Summary
- hide the Electron default Settings titlebar by switching the Settings BrowserWindow to hidden-inset chrome
- add a transparent top drag region and offset Settings content so macOS traffic lights do not overlap the nav/content
- share the macOS traffic-light inset between the main and Settings windows, and add a regression test for the Settings BrowserWindow options

## Validation
- `pnpm exec vitest run src/main/services/settingsWindow.test.ts`
- `pnpm validate`
- `pnpm dev` + `playwright-cli` Settings window check: app surface starts at y=0, drag region is 48px, first Settings nav button starts at y=56

## Notes
- No version bump: release/version ownership stays with `/electron-release`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * macOSの設定ウィンドウのタイトルバー表示を最適化しました
  * 設定ウィンドウのレイアウトを調整し、ウィンドウ制御ボタン（トラフィックライト）の位置を統一しました

* **テスト**
  * 設定ウィンドウの動作を検証するテストを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->