### PR TITLE
Fix installed list scrollbar gutter spacing

### DIFF
--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -1186,7 +1186,7 @@ export const MainContent = React.memo(
               agentDisplayName={selectedAgent?.name}
             />
 
-            <div className="flex-1 min-h-0 overflow-auto p-4">
+            <div className="flex-1 min-h-0 overflow-hidden py-4 pl-4 pr-[5px]">
               <SkillsList />
             </div>
           </TabsContent>

--- a/src/renderer/src/components/skills/SkillsList.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillsList.browser.test.tsx
@@ -172,6 +172,51 @@ function requireHTMLElement(
   return element
 }
 
+/**
+ * Measure the Installed list card and reserved scrollbar gutter geometry.
+ * @param deleteButtonAriaLabel - Exact aria-label for the row delete button.
+ * @param cardLabel - Human-readable card label for failure output.
+ * @returns DOM list element plus rounded gutter and spacing metrics.
+ * @example
+ * const metrics = measureInstalledListLayout('Delete skill-0', 'first skill card')
+ */
+function measureInstalledListLayout(
+  deleteButtonAriaLabel: string,
+  cardLabel: string,
+) {
+  const shell = requireHTMLElement(
+    document.querySelector('[data-testid="installed-list-shell"]'),
+    'installed list shell',
+  )
+  const list = requireHTMLElement(
+    document.querySelector('[role="list"]'),
+    'virtualized list',
+  )
+  const deleteButton = requireHTMLElement(
+    Array.from(document.querySelectorAll('button')).find(
+      (button) => button.getAttribute('aria-label') === deleteButtonAriaLabel,
+    ) ?? null,
+    `${cardLabel} delete button`,
+  )
+  const card = requireHTMLElement(deleteButton.closest('.group'), cardLabel)
+  const shellRect = shell.getBoundingClientRect()
+  const listRect = list.getBoundingClientRect()
+  const cardRect = card.getBoundingClientRect()
+  const reservedGutterWidthPx = list.offsetWidth - list.clientWidth
+  const reservedGutterLeftPx = listRect.right - reservedGutterWidthPx
+
+  return {
+    list,
+    reservedGutterWidthPx,
+    leftGutterPx: Math.round(cardRect.left - shellRect.left),
+    rightGutterPx: Math.round(shellRect.right - cardRect.right),
+    reservedGutterLeftSpacingPx: Math.round(
+      reservedGutterLeftPx - cardRect.right,
+    ),
+    reservedGutterRightSpacingPx: Math.round(shellRect.right - listRect.right),
+  }
+}
+
 describe('SkillsList loading branch — scroll-preservation regression', () => {
   it('shows the "Loading skills..." placeholder on initial fetch (loading=true, items=[])', async () => {
     // Arrange
@@ -230,41 +275,16 @@ describe('SkillsList scrollbar gutter layout', () => {
       await expect.element(screen.getByText('skill-0')).toBeInTheDocument()
 
       // Assert
-      const shell = requireHTMLElement(
-        document.querySelector('[data-testid="installed-list-shell"]'),
-        'installed list shell',
-      )
-      const list = requireHTMLElement(
-        document.querySelector('[role="list"]'),
-        'virtualized list',
-      )
-      const deleteButton = requireHTMLElement(
-        document.querySelector('button[aria-label="Delete skill-0"]'),
-        'first delete button',
-      )
-      const card = requireHTMLElement(
-        deleteButton.closest('.group'),
+      const metrics = measureInstalledListLayout(
+        'Delete skill-0',
         'first skill card',
       )
-      const shellRect = shell.getBoundingClientRect()
-      const listRect = list.getBoundingClientRect()
-      const cardRect = card.getBoundingClientRect()
-      const scrollbarWidthPx = list.offsetWidth - list.clientWidth
-      const scrollbarLeftPx = listRect.right - scrollbarWidthPx
-      const leftGutterPx = Math.round(cardRect.left - shellRect.left)
-      const rightGutterPx = Math.round(shellRect.right - cardRect.right)
-      const scrollbarLeftSpacingPx = Math.round(
-        scrollbarLeftPx - cardRect.right,
-      )
-      const scrollbarRightSpacingPx = Math.round(
-        shellRect.right - listRect.right,
-      )
 
-      expect(scrollbarWidthPx).toBe(6)
-      expect(leftGutterPx).toBe(16)
-      expect(rightGutterPx).toBe(16)
-      expect(scrollbarLeftSpacingPx).toBe(5)
-      expect(scrollbarRightSpacingPx).toBe(5)
+      expect(metrics.reservedGutterWidthPx).toBe(6)
+      expect(metrics.leftGutterPx).toBe(16)
+      expect(metrics.rightGutterPx).toBe(16)
+      expect(metrics.reservedGutterLeftSpacingPx).toBe(5)
+      expect(metrics.reservedGutterRightSpacingPx).toBe(5)
     } finally {
       layoutStyleElement.remove()
     }
@@ -287,42 +307,19 @@ describe('SkillsList scrollbar gutter layout', () => {
       await expect.element(screen.getByText('single-skill')).toBeInTheDocument()
 
       // Assert
-      const shell = requireHTMLElement(
-        document.querySelector('[data-testid="installed-list-shell"]'),
-        'installed list shell',
-      )
-      const list = requireHTMLElement(
-        document.querySelector('[role="list"]'),
-        'virtualized list',
-      )
-      const deleteButton = requireHTMLElement(
-        document.querySelector('button[aria-label="Delete single-skill"]'),
-        'single skill delete button',
-      )
-      const card = requireHTMLElement(
-        deleteButton.closest('.group'),
+      const metrics = measureInstalledListLayout(
+        'Delete single-skill',
         'single skill card',
       )
-      const shellRect = shell.getBoundingClientRect()
-      const listRect = list.getBoundingClientRect()
-      const cardRect = card.getBoundingClientRect()
-      const reservedGutterWidthPx = list.offsetWidth - list.clientWidth
-      const reservedGutterLeftPx = listRect.right - reservedGutterWidthPx
-      const leftGutterPx = Math.round(cardRect.left - shellRect.left)
-      const rightGutterPx = Math.round(shellRect.right - cardRect.right)
-      const reservedGutterLeftSpacingPx = Math.round(
-        reservedGutterLeftPx - cardRect.right,
-      )
-      const reservedGutterRightSpacingPx = Math.round(
-        shellRect.right - listRect.right,
-      )
 
-      expect(list.scrollHeight).toBeLessThanOrEqual(list.clientHeight)
-      expect(reservedGutterWidthPx).toBe(6)
-      expect(leftGutterPx).toBe(16)
-      expect(rightGutterPx).toBe(16)
-      expect(reservedGutterLeftSpacingPx).toBe(5)
-      expect(reservedGutterRightSpacingPx).toBe(5)
+      expect(metrics.list.scrollHeight).toBeLessThanOrEqual(
+        metrics.list.clientHeight,
+      )
+      expect(metrics.reservedGutterWidthPx).toBe(6)
+      expect(metrics.leftGutterPx).toBe(16)
+      expect(metrics.rightGutterPx).toBe(16)
+      expect(metrics.reservedGutterLeftSpacingPx).toBe(5)
+      expect(metrics.reservedGutterRightSpacingPx).toBe(5)
     } finally {
       layoutStyleElement.remove()
     }

--- a/src/renderer/src/components/skills/SkillsList.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillsList.browser.test.tsx
@@ -269,4 +269,62 @@ describe('SkillsList scrollbar gutter layout', () => {
       layoutStyleElement.remove()
     }
   })
+
+  it('keeps installed skill cards and reserved scrollbar gutter balanced when vertical scrolling is unnecessary', async () => {
+    // Arrange
+    const layoutStyleElement = installLayoutStyles()
+    mockGetAll.mockReturnValue(new Promise(() => {}))
+    const visibleSkills = [
+      makeSkill({
+        name: 'single-skill' as SkillName,
+        description: 'A short list should not need vertical scrolling.',
+      }),
+    ]
+
+    try {
+      // Act
+      const screen = await renderInstalledListShell({ items: visibleSkills })
+      await expect.element(screen.getByText('single-skill')).toBeInTheDocument()
+
+      // Assert
+      const shell = requireHTMLElement(
+        document.querySelector('[data-testid="installed-list-shell"]'),
+        'installed list shell',
+      )
+      const list = requireHTMLElement(
+        document.querySelector('[role="list"]'),
+        'virtualized list',
+      )
+      const deleteButton = requireHTMLElement(
+        document.querySelector('button[aria-label="Delete single-skill"]'),
+        'single skill delete button',
+      )
+      const card = requireHTMLElement(
+        deleteButton.closest('.group'),
+        'single skill card',
+      )
+      const shellRect = shell.getBoundingClientRect()
+      const listRect = list.getBoundingClientRect()
+      const cardRect = card.getBoundingClientRect()
+      const reservedGutterWidthPx = list.offsetWidth - list.clientWidth
+      const reservedGutterLeftPx = listRect.right - reservedGutterWidthPx
+      const leftGutterPx = Math.round(cardRect.left - shellRect.left)
+      const rightGutterPx = Math.round(shellRect.right - cardRect.right)
+      const reservedGutterLeftSpacingPx = Math.round(
+        reservedGutterLeftPx - cardRect.right,
+      )
+      const reservedGutterRightSpacingPx = Math.round(
+        shellRect.right - listRect.right,
+      )
+
+      expect(list.scrollHeight).toBeLessThanOrEqual(list.clientHeight)
+      expect(reservedGutterWidthPx).toBe(6)
+      expect(leftGutterPx).toBe(16)
+      expect(rightGutterPx).toBe(16)
+      expect(reservedGutterLeftSpacingPx).toBe(5)
+      expect(reservedGutterRightSpacingPx).toBe(5)
+    } finally {
+      layoutStyleElement.remove()
+    }
+  })
 })

--- a/src/renderer/src/components/skills/SkillsList.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillsList.browser.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
+import { installLayoutStyles } from '@/renderer/src/test/installLayoutStyles'
 import type { Skill, SkillName } from '@/shared/types'
 
 const mockGetAll = vi.fn()
@@ -125,6 +126,52 @@ async function renderSkillsList(skillsState: {
   )
 }
 
+/**
+ * Render SkillsList in the same scroll shell used by the Installed tab.
+ * @param skillsState - Skill slice fields needed for the visible rows.
+ * @returns vitest-browser-react screen for locator queries.
+ * @example
+ * await renderInstalledListShell({ items: [makeSkill()] })
+ */
+async function renderInstalledListShell(skillsState: {
+  loading?: boolean
+  items?: Skill[]
+}) {
+  const store = await createStore(skillsState)
+  const { SkillsList } = await import('./SkillsList')
+  return render(
+    <Provider store={store}>
+      <TooltipProvider>
+        <div
+          data-testid="installed-list-shell"
+          className="overflow-hidden py-4 pl-4 pr-[5px]"
+          style={{ height: 360, width: 800 }}
+        >
+          <SkillsList />
+        </div>
+      </TooltipProvider>
+    </Provider>,
+  )
+}
+
+/**
+ * Require a DOM node to be an HTMLElement before layout measurement.
+ * @param element - Candidate node from querySelector or closest.
+ * @param label - Human-readable selector name for failure output.
+ * @returns HTMLElement safe for getBoundingClientRect measurement.
+ * @example
+ * const card = requireHTMLElement(document.querySelector('.group'), 'card')
+ */
+function requireHTMLElement(
+  element: Element | null,
+  label: string,
+): HTMLElement {
+  if (!(element instanceof HTMLElement)) {
+    throw new Error(`${label} should exist for layout measurement`)
+  }
+  return element
+}
+
 describe('SkillsList loading branch — scroll-preservation regression', () => {
   it('shows the "Loading skills..." placeholder on initial fetch (loading=true, items=[])', async () => {
     // Arrange
@@ -162,5 +209,64 @@ describe('SkillsList loading branch — scroll-preservation regression', () => {
 
     // Assert
     expect(screen.getByText('Loading skills...').query()).toBeNull()
+  })
+})
+
+describe('SkillsList scrollbar gutter layout', () => {
+  it('keeps installed skill cards and scrollbar spacing balanced when the vertical scrollbar is visible', async () => {
+    // Arrange
+    const layoutStyleElement = installLayoutStyles()
+    mockGetAll.mockReturnValue(new Promise(() => {}))
+    const visibleSkills = Array.from({ length: 8 }, (_value, index) =>
+      makeSkill({
+        name: `skill-${index}` as SkillName,
+        description: `Skill ${index} with enough body copy to use the normal installed card height.`,
+      }),
+    )
+
+    try {
+      // Act
+      const screen = await renderInstalledListShell({ items: visibleSkills })
+      await expect.element(screen.getByText('skill-0')).toBeInTheDocument()
+
+      // Assert
+      const shell = requireHTMLElement(
+        document.querySelector('[data-testid="installed-list-shell"]'),
+        'installed list shell',
+      )
+      const list = requireHTMLElement(
+        document.querySelector('[role="list"]'),
+        'virtualized list',
+      )
+      const deleteButton = requireHTMLElement(
+        document.querySelector('button[aria-label="Delete skill-0"]'),
+        'first delete button',
+      )
+      const card = requireHTMLElement(
+        deleteButton.closest('.group'),
+        'first skill card',
+      )
+      const shellRect = shell.getBoundingClientRect()
+      const listRect = list.getBoundingClientRect()
+      const cardRect = card.getBoundingClientRect()
+      const scrollbarWidthPx = list.offsetWidth - list.clientWidth
+      const scrollbarLeftPx = listRect.right - scrollbarWidthPx
+      const leftGutterPx = Math.round(cardRect.left - shellRect.left)
+      const rightGutterPx = Math.round(shellRect.right - cardRect.right)
+      const scrollbarLeftSpacingPx = Math.round(
+        scrollbarLeftPx - cardRect.right,
+      )
+      const scrollbarRightSpacingPx = Math.round(
+        shellRect.right - listRect.right,
+      )
+
+      expect(scrollbarWidthPx).toBe(6)
+      expect(leftGutterPx).toBe(16)
+      expect(rightGutterPx).toBe(16)
+      expect(scrollbarLeftSpacingPx).toBe(5)
+      expect(scrollbarRightSpacingPx).toBe(5)
+    } finally {
+      layoutStyleElement.remove()
+    }
   })
 })

--- a/src/renderer/src/components/skills/SkillsList.tsx
+++ b/src/renderer/src/components/skills/SkillsList.tsx
@@ -50,7 +50,7 @@ function SkillRow({
 }: RowComponentProps<SkillRowProps>): React.ReactElement {
   return (
     <div style={style}>
-      <div className="pb-3 pr-2">
+      <div className="pb-3 pr-[5px]">
         <SkillItem skill={data[index]} />
       </div>
     </div>
@@ -95,7 +95,14 @@ export const SkillsList = React.memo(function SkillsList(): React.ReactElement {
     [filteredSkills, selectedAgentId],
   )
   const rowProps = useMemo(() => ({ data: filteredSkills }), [filteredSkills])
-  const listStyle = useMemo(() => ({ width: '100%', height: '100%' }), [])
+  const listStyle = useMemo<React.CSSProperties>(
+    () => ({
+      width: '100%',
+      height: '100%',
+      scrollbarGutter: 'stable',
+    }),
+    [],
+  )
 
   if (loading && skills.length === 0) {
     return (
@@ -144,6 +151,7 @@ export const SkillsList = React.memo(function SkillsList(): React.ReactElement {
 
   return (
     <List<SkillRowProps>
+      className="skills-list-scrollbar"
       rowComponent={SkillRow}
       rowCount={filteredSkills.length}
       rowHeight={getRowHeight}

--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -181,6 +181,11 @@
     background: var(--muted-foreground);
   }
 
+  .skills-list-scrollbar::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+
   /* Shiki emits semantic CSS variables for light/dark token colors. Scoping
    * them to the skill preview keeps Markdown/code panes aligned with the app
    * theme without leaking highlighter styles into other UI. */

--- a/src/renderer/src/test/installLayoutStyles.ts
+++ b/src/renderer/src/test/installLayoutStyles.ts
@@ -14,11 +14,21 @@ export function installLayoutStyles(): HTMLStyleElement {
     .min-h-0 { min-height: 0; }
     .h-full { height: 100%; }
     .shrink-0 { flex-shrink: 0; }
+    .overflow-hidden { overflow: hidden; }
     .overflow-auto { overflow: auto; }
     .p-4 { padding: 16px; }
+    .py-4 { padding-top: 16px; padding-bottom: 16px; }
+    .pl-4 { padding-left: 16px; }
+    .pr-0 { padding-right: 0; }
+    .pr-1 { padding-right: 4px; }
+    .pr-\\[5px\\] { padding-right: 5px; }
+    .pr-2 { padding-right: 8px; }
     .px-4 { padding-left: 16px; padding-right: 16px; }
     .pt-4 { padding-top: 16px; }
+    .pb-3 { padding-bottom: 12px; }
     .pb-6 { padding-bottom: 24px; }
+    ::-webkit-scrollbar { width: 8px; height: 8px; }
+    .skills-list-scrollbar::-webkit-scrollbar { width: 6px; height: 6px; }
   `
   document.head.append(styleElement)
   return styleElement


### PR DESCRIPTION
## Summary
- Balance the Installed list gutter so skill cards sit 16px from both shell edges even with a visible scrollbar.
- Give the Installed list a scoped 6px scrollbar and keep scrollbar-side spacing balanced at 5px on each side.
- Add a browser regression test that measures card gutters, scrollbar width, and scrollbar-side spacing.

## Verification
- `pnpm exec vitest run src/renderer/src/components/skills/SkillsList.browser.test.tsx --project browser`
- `pnpm validate`
- `pnpm test:e2e`
- Electron CDP measurement: card gutters `16px / 16px`, scrollbar spacing `5px / 5px`, scrollbar width `6px`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * スキル一覧のスクロール挙動とレイアウト安定性を改善しました（表示ズレやスクロール幅の変動を抑制）。
  * スクロールバーの太さを細く統一し、周辺の余白・左右スペーシングを調整して見た目を整えました。

* **テスト**
  * スクロール表示とガター（余白）挙動を検証するテストを追加し、回帰を防止します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->