### PR TITLE
Fix release notes toast dismissal

### DIFF
--- a/src/renderer/src/hooks/useReleaseNotesToast.browser.test.tsx
+++ b/src/renderer/src/hooks/useReleaseNotesToast.browser.test.tsx
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook } from 'vitest-browser-react'
+
+import { RELEASE_NOTES_LAST_SEEN_VERSION_KEY } from '@/shared/constants'
+
+const toastMock = vi.fn()
+const windowOpenMock = vi.fn()
+
+vi.mock('sonner', () => ({
+  toast: (...args: unknown[]) => toastMock(...args),
+}))
+
+beforeEach(() => {
+  toastMock.mockReset()
+  windowOpenMock.mockReset()
+  window.localStorage.clear()
+  vi.stubGlobal('__APP_VERSION__', '0.21.1')
+  vi.stubGlobal('open', windowOpenMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  window.localStorage.clear()
+})
+
+describe('useReleaseNotesToast', () => {
+  it('shows a dismissible post-update release notes toast with the View action', async () => {
+    // Arrange
+    window.localStorage.setItem(RELEASE_NOTES_LAST_SEEN_VERSION_KEY, '0.21.0')
+    const { useReleaseNotesToast } = await import('./useReleaseNotesToast')
+
+    // Act
+    await renderHook(() => useReleaseNotesToast())
+
+    // Assert
+    await expect.poll(() => toastMock.mock.calls.length).toBe(1)
+    expect(toastMock.mock.calls[0]?.[1]).toMatchObject({
+      description: 'See what changed in this release.',
+      duration: 8000,
+      closeButton: true,
+      classNames: {
+        title: 'text-popover-foreground pl-7',
+      },
+      action: {
+        label: 'View',
+      },
+    })
+  })
+})

--- a/src/renderer/src/hooks/useReleaseNotesToast.browser.test.tsx
+++ b/src/renderer/src/hooks/useReleaseNotesToast.browser.test.tsx
@@ -24,6 +24,34 @@ afterEach(() => {
 })
 
 describe('useReleaseNotesToast', () => {
+  it('does not show the release notes toast on first install', async () => {
+    // Arrange
+    const { useReleaseNotesToast } = await import('./useReleaseNotesToast')
+
+    // Act
+    await renderHook(() => useReleaseNotesToast())
+
+    // Assert
+    await expect
+      .poll(() =>
+        window.localStorage.getItem(RELEASE_NOTES_LAST_SEEN_VERSION_KEY),
+      )
+      .toBe('0.21.1')
+    expect(toastMock).not.toHaveBeenCalled()
+  })
+
+  it('does not show the release notes toast when the current version was already seen', async () => {
+    // Arrange
+    window.localStorage.setItem(RELEASE_NOTES_LAST_SEEN_VERSION_KEY, '0.21.1')
+    const { useReleaseNotesToast } = await import('./useReleaseNotesToast')
+
+    // Act
+    await renderHook(() => useReleaseNotesToast())
+
+    // Assert
+    expect(toastMock).not.toHaveBeenCalled()
+  })
+
   it('shows a dismissible post-update release notes toast with the View action', async () => {
     // Arrange
     window.localStorage.setItem(RELEASE_NOTES_LAST_SEEN_VERSION_KEY, '0.21.0')
@@ -34,6 +62,7 @@ describe('useReleaseNotesToast', () => {
 
     // Assert
     await expect.poll(() => toastMock.mock.calls.length).toBe(1)
+    expect(toastMock.mock.calls[0]?.[0]).toBe('Updated to v0.21.1')
     expect(toastMock.mock.calls[0]?.[1]).toMatchObject({
       description: 'See what changed in this release.',
       duration: 8000,
@@ -45,5 +74,22 @@ describe('useReleaseNotesToast', () => {
         label: 'View',
       },
     })
+
+    const toastAction = toastMock.mock.calls[0]?.[1]?.action
+    expect(toastAction).toMatchObject({ label: 'View' })
+    if (typeof toastAction !== 'object' || toastAction === null) {
+      throw new Error('Expected the release notes toast to expose an action')
+    }
+    const actionOnClick = 'onClick' in toastAction ? toastAction.onClick : null
+    expect(actionOnClick).toBeTypeOf('function')
+    if (typeof actionOnClick !== 'function') {
+      throw new Error('Expected the View action to be clickable')
+    }
+    actionOnClick()
+    expect(windowOpenMock).toHaveBeenCalledWith(
+      'https://github.com/laststance/skills-desktop/releases/tag/v0.21.1',
+      '_blank',
+      'noopener,noreferrer',
+    )
   })
 })

--- a/src/renderer/src/hooks/useReleaseNotesToast.ts
+++ b/src/renderer/src/hooks/useReleaseNotesToast.ts
@@ -44,6 +44,10 @@ export function useReleaseNotesToast(): void {
         toast(`Updated to v${currentVersion}`, {
           description: 'See what changed in this release.',
           duration: 8000,
+          closeButton: true,
+          classNames: {
+            title: 'text-popover-foreground pl-7',
+          },
           action: {
             label: 'View',
             onClick: () => {

--- a/src/renderer/src/hooks/useReleaseNotesToast.ts
+++ b/src/renderer/src/hooks/useReleaseNotesToast.ts
@@ -46,6 +46,7 @@ export function useReleaseNotesToast(): void {
           duration: 8000,
           closeButton: true,
           classNames: {
+            // Sonner seats the 20px × at 8px from the left; pl-7 reserves that 28px on the 4px grid.
             title: 'text-popover-foreground pl-7',
           },
           action: {


### PR DESCRIPTION
## Summary
- add a close button to the post-update release notes toast
- preserve spacing so the left-top close affordance does not overlap the title
- cover the toast options with a browser hook test

## Tests
- pnpm validate
- kill-port 9222 || true && pnpm test:e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * リリースノート表示のトースト通知に閉じるボタンを追加し、タイトルの表示スタイルを調整しました。

* **テスト**
  * リリースノートトースト表示の挙動（初回、既に同一バージョン、更新後の表示）を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->