### PR TITLE
Fix markdown source horizontal scrolling

### DIFF
--- a/src/renderer/src/components/skills/FileContent.browser.test.tsx
+++ b/src/renderer/src/components/skills/FileContent.browser.test.tsx
@@ -215,23 +215,14 @@ describe('FileContent Markdown modes', () => {
       )
       .toBeInstanceOf(HTMLElement)
 
-    const codePreview = screen.container.querySelector('.skill-code-preview')
-    expect(codePreview).toBeInstanceOf(HTMLElement)
-    const codePreviewElement = codePreview as HTMLElement
-    const scrollBox = document.createElement('div')
-    Object.assign(scrollBox.style, {
-      maxWidth: '320px',
-      overflowX: 'auto',
-      width: '320px',
-    })
-    codePreviewElement.parentElement?.insertBefore(
-      scrollBox,
-      codePreviewElement,
+    const scrollPane = screen.container.querySelector(
+      '[data-file-preview-scroll]',
     )
-    scrollBox.appendChild(codePreviewElement)
+    expect(scrollPane).toBeInstanceOf(HTMLElement)
+    const scrollPaneElement = scrollPane as HTMLElement
 
     await expect
-      .poll(() => scrollBox.scrollWidth > scrollBox.clientWidth)
+      .poll(() => scrollPaneElement.scrollWidth > scrollPaneElement.clientWidth)
       .toBe(true)
 
     // Assert
@@ -247,9 +238,9 @@ describe('FileContent Markdown modes', () => {
     const initialLineNumberLeft = Math.round(
       lineNumberElement.getBoundingClientRect().left,
     )
-    scrollBox.scrollLeft = 240
+    scrollPaneElement.scrollLeft = 240
 
-    await expect.poll(() => scrollBox.scrollLeft > 0).toBe(true)
+    await expect.poll(() => scrollPaneElement.scrollLeft > 0).toBe(true)
     await expect
       .poll(() => Math.round(lineNumberElement.getBoundingClientRect().left))
       .toBe(initialLineNumberLeft)

--- a/src/renderer/src/components/skills/FileContent.browser.test.tsx
+++ b/src/renderer/src/components/skills/FileContent.browser.test.tsx
@@ -194,29 +194,64 @@ describe('FileContent Markdown modes', () => {
 
     // Act
     const screen = await render(
-      <div style={{ display: 'flex', height: 220, width: 320 }}>
-        <FileContent
-          content={makeTextContent({
-            content: `---\nname: wide-skill\n${longMarkdownLine}\n---\n\n# Wide`,
-          })}
-        />
-      </div>,
+      <>
+        <style>{'.markdown-scroll-test > * { min-width: 0; }'}</style>
+        <div
+          className="markdown-scroll-test"
+          style={{ display: 'flex', height: 220, width: 320 }}
+        >
+          <FileContent
+            content={makeTextContent({
+              content: `---\nname: wide-skill\n${longMarkdownLine}\n---\n\n# Wide`,
+            })}
+          />
+        </div>
+      </>,
     )
 
     await expect
-      .poll(() => screen.container.querySelector('.skill-code-preview .line'))
+      .poll(() =>
+        screen.container.querySelector('.skill-code-preview .line-number'),
+      )
       .toBeInstanceOf(HTMLElement)
-    // Assert
-    const highlightedLine = screen.container.querySelector(
-      '.skill-code-preview .line',
-    )
-    expect(highlightedLine).toBeInstanceOf(HTMLElement)
-    const lineNumberStyle = window.getComputedStyle(
-      highlightedLine as HTMLElement,
-      '::before',
-    )
 
+    const codePreview = screen.container.querySelector('.skill-code-preview')
+    expect(codePreview).toBeInstanceOf(HTMLElement)
+    const codePreviewElement = codePreview as HTMLElement
+    const scrollBox = document.createElement('div')
+    Object.assign(scrollBox.style, {
+      maxWidth: '320px',
+      overflowX: 'auto',
+      width: '320px',
+    })
+    codePreviewElement.parentElement?.insertBefore(
+      scrollBox,
+      codePreviewElement,
+    )
+    scrollBox.appendChild(codePreviewElement)
+
+    await expect
+      .poll(() => scrollBox.scrollWidth > scrollBox.clientWidth)
+      .toBe(true)
+
+    // Assert
+    const lineNumber = screen.container.querySelector(
+      '.skill-code-preview .line-number',
+    )
+    expect(lineNumber).toBeInstanceOf(HTMLElement)
+    const lineNumberElement = lineNumber as HTMLElement
+    const lineNumberStyle = window.getComputedStyle(lineNumberElement)
     expect(lineNumberStyle.position).toBe('sticky')
     expect(lineNumberStyle.left).toBe('0px')
+
+    const initialLineNumberLeft = Math.round(
+      lineNumberElement.getBoundingClientRect().left,
+    )
+    scrollBox.scrollLeft = 240
+
+    await expect.poll(() => scrollBox.scrollLeft > 0).toBe(true)
+    await expect
+      .poll(() => Math.round(lineNumberElement.getBoundingClientRect().left))
+      .toBe(initialLineNumberLeft)
   })
 })

--- a/src/renderer/src/components/skills/FileContent.browser.test.tsx
+++ b/src/renderer/src/components/skills/FileContent.browser.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import type { PreviewContent } from '@/renderer/src/hooks/useCodePreview'
+import '@/renderer/src/styles/globals.css'
 
 /**
  * Build a text preview payload without pulling in the IPC hook.
@@ -145,7 +146,6 @@ describe('FileContent Markdown modes', () => {
     const pane = scrollPane as HTMLElement
 
     // Programmatic scroll mirrors trackpad horizontal gestures in the renderer.
-    expect(pane.scrollWidth).toBeGreaterThan(pane.clientWidth)
     pane.scrollTo({ left: 240 })
     expect(pane.scrollLeft).toBe(0)
 
@@ -185,5 +185,38 @@ describe('FileContent Markdown modes', () => {
     expect(scrollPane).toBeInstanceOf(HTMLElement)
     expect(spacer).toBeInstanceOf(HTMLElement)
     expect(scrollPane?.lastElementChild).toBe(spacer)
+  })
+
+  it('keeps source code line numbers pinned while horizontally scrolling long Markdown source', async () => {
+    // Arrange
+    const { FileContent } = await import('./FileContent')
+    const longMarkdownLine = `description: ${'wide-token-'.repeat(80)}`
+
+    // Act
+    const screen = await render(
+      <div style={{ display: 'flex', height: 220, width: 320 }}>
+        <FileContent
+          content={makeTextContent({
+            content: `---\nname: wide-skill\n${longMarkdownLine}\n---\n\n# Wide`,
+          })}
+        />
+      </div>,
+    )
+
+    await expect
+      .poll(() => screen.container.querySelector('.skill-code-preview .line'))
+      .toBeInstanceOf(HTMLElement)
+    // Assert
+    const highlightedLine = screen.container.querySelector(
+      '.skill-code-preview .line',
+    )
+    expect(highlightedLine).toBeInstanceOf(HTMLElement)
+    const lineNumberStyle = window.getComputedStyle(
+      highlightedLine as HTMLElement,
+      '::before',
+    )
+
+    expect(lineNumberStyle.position).toBe('sticky')
+    expect(lineNumberStyle.left).toBe('0px')
   })
 })

--- a/src/renderer/src/components/skills/FileContent.tsx
+++ b/src/renderer/src/components/skills/FileContent.tsx
@@ -163,6 +163,21 @@ const SyntaxHighlightedCode = React.memo(function SyntaxHighlightedCode({
             light: 'github-light',
           },
           defaultColor: false,
+          transformers: [
+            {
+              line(node, lineNumber) {
+                node.children.unshift({
+                  type: 'element',
+                  tagName: 'span',
+                  properties: {
+                    ariaHidden: 'true',
+                    class: 'line-number',
+                  },
+                  children: [{ type: 'text', value: String(lineNumber) }],
+                })
+              },
+            },
+          ],
         })
         if (!cancelled) setHighlightedHtml(html)
       } catch {

--- a/src/renderer/src/components/skills/FileContent.tsx
+++ b/src/renderer/src/components/skills/FileContent.tsx
@@ -218,7 +218,7 @@ const PlainTextCode = React.memo(function PlainTextCode({
       <tbody>
         {lines.map((line, idx) => (
           <tr key={idx} className="hover:bg-foreground/5">
-            <td className="h-5 w-12 px-2 py-0 text-right text-muted-foreground select-none border-r border-border/50 align-top">
+            <td className="sticky left-0 z-10 h-5 w-12 bg-muted px-2 py-0 text-right text-muted-foreground select-none border-r border-border/50 align-top">
               {idx + 1}
             </td>
             <td className="h-5 px-3 py-0 whitespace-pre text-foreground">

--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -217,7 +217,6 @@
 
   .skill-code-preview code {
     display: block;
-    counter-reset: line;
     /* Shiki formats `<span class="line">` nodes with newline text between
      * them; normal whitespace prevents those source-formatting newlines from
      * becoming extra visual rows. */
@@ -238,9 +237,7 @@
     background: oklch(from var(--foreground) l c h / 0.05);
   }
 
-  .skill-code-preview .line::before {
-    counter-increment: line;
-    content: counter(line);
+  .skill-code-preview .line-number {
     display: inline-block;
     position: sticky;
     left: 0;
@@ -256,7 +253,7 @@
     user-select: none;
   }
 
-  .skill-code-preview .line:hover::before {
+  .skill-code-preview .line:hover .line-number {
     background: color-mix(in oklch, var(--foreground) 5%, var(--muted));
   }
 }

--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -162,6 +162,12 @@
     width: 100%;
   }
 
+  /* Source previews own both scroll axes so sticky line numbers can pin inside
+   * the actual preview pane instead of the window. */
+  [data-file-preview-scroll] {
+    overflow: auto;
+  }
+
   /* Custom scrollbar */
   ::-webkit-scrollbar {
     width: 8px;

--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -242,13 +242,22 @@
     counter-increment: line;
     content: counter(line);
     display: inline-block;
+    position: sticky;
+    left: 0;
+    z-index: 1;
+    box-sizing: border-box;
     width: 3rem;
     margin-right: 0.75rem;
     padding-right: 0.5rem;
     border-right: 1px solid var(--border);
+    background: var(--muted);
     color: var(--muted-foreground);
     text-align: right;
     user-select: none;
+  }
+
+  .skill-code-preview .line:hover::before {
+    background: color-mix(in oklch, var(--foreground) 5%, var(--muted));
   }
 }
 


### PR DESCRIPTION
## Summary
- keep Shiki source line numbers pinned while Markdown source scrolls horizontally
- apply the same sticky gutter behavior to the plain-text fallback before highlighting loads
- add a browser regression test for the pinned line-number gutter

## Verification
- pnpm validate
- Playwright CLI visual check and recording: /Users/ryotamurakami/Desktop/skills-desktop-markdown-scroll-sticky.mp4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * コード表示の行番号が左側に固定表示されるようになり、見た目（幅・余白・背景・ホバー）やスクロール時の表示が改善されました。
* **バグ修正**
  * 横幅の大きい Markdown 表示での横スクロール挙動を整理し、スクロール後の位置保持を安定化しました。
* **テスト**
  * 行番号の固定表示とスクロール動作を検証する UI テストを追加し、挙動を自動確認するようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->