### PR TITLE
Refactor conditional branches with ts-pattern

### DIFF
--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
@@ -146,87 +146,85 @@ function symlinkCleanupDialogReducer(
   state: SymlinkCleanupDialogState,
   action: SymlinkCleanupDialogAction,
 ): SymlinkCleanupDialogState {
-  switch (action.type) {
-    case 'reset':
-      return INITIAL_DIALOG_STATE
-    case 'scanning':
-      return {
-        ...INITIAL_DIALOG_STATE,
-        phase: 'scanning',
-      }
-    case 'ready': {
-      const selectedItemIds = getSymlinkCleanupPlanItems(action.plan).map(
+  // Cleanup actions are a closed union; every transition must update phase, selection, and errors.
+  return match(action)
+    .returnType<SymlinkCleanupDialogState>()
+    .with({ type: 'reset' }, () => INITIAL_DIALOG_STATE)
+    .with({ type: 'scanning' }, () => ({
+      ...INITIAL_DIALOG_STATE,
+      phase: 'scanning',
+    }))
+    .with({ type: 'ready' }, ({ plan, message }) => {
+      const selectedItemIds = getSymlinkCleanupPlanItems(plan).map(
         (item) => item.id,
       )
       return {
         phase: 'ready',
-        plan: action.plan,
+        plan,
         selectedItemIds,
         rowErrors: {},
         summary: null,
-        message: action.message ?? null,
+        message: message ?? null,
         staleAfterMutation: false,
       }
-    }
-    case 'no-safe-cleanup':
-      return {
-        phase: 'no-safe-cleanup',
-        plan: action.plan,
-        selectedItemIds: [],
-        rowErrors: {},
-        summary: null,
-        message: action.message ?? null,
-        staleAfterMutation: false,
-      }
-    case 'stale':
-      return {
-        ...state,
-        phase: 'stale',
-        message: action.message,
-        staleAfterMutation: action.staleAfterMutation ?? false,
-      }
-    case 'cleaning':
-      return {
-        ...state,
-        phase: 'cleaning',
-        rowErrors: {},
-        message: null,
-      }
-    case 'error':
-      return {
+    })
+    .with({ type: 'no-safe-cleanup' }, ({ plan, message }) => ({
+      phase: 'no-safe-cleanup',
+      plan,
+      selectedItemIds: [],
+      rowErrors: {},
+      summary: null,
+      message: message ?? null,
+      staleAfterMutation: false,
+    }))
+    .with({ type: 'stale' }, ({ message, staleAfterMutation }) => ({
+      ...state,
+      phase: 'stale',
+      message,
+      staleAfterMutation: staleAfterMutation ?? false,
+    }))
+    .with({ type: 'cleaning' }, () => ({
+      ...state,
+      phase: 'cleaning',
+      rowErrors: {},
+      message: null,
+    }))
+    .with(
+      { type: 'error' },
+      ({ message, plan, rowErrors, selectedItemIds, summary }) => ({
         ...state,
         phase: 'error',
-        message: action.message,
-        rowErrors: action.rowErrors ?? state.rowErrors,
-        selectedItemIds: action.selectedItemIds ?? state.selectedItemIds,
-        summary: action.summary ?? state.summary,
-        plan: action.plan ?? state.plan,
-      }
-    case 'complete':
-      return {
-        ...state,
-        phase: 'complete',
-        selectedItemIds: [],
-        rowErrors: {},
-        summary: action.summary,
-        message: null,
-      }
-    case 'toggle-item': {
+        message,
+        rowErrors: rowErrors ?? state.rowErrors,
+        selectedItemIds: selectedItemIds ?? state.selectedItemIds,
+        summary: summary ?? state.summary,
+        plan: plan ?? state.plan,
+      }),
+    )
+    .with({ type: 'complete' }, ({ summary }) => ({
+      ...state,
+      phase: 'complete',
+      selectedItemIds: [],
+      rowErrors: {},
+      summary,
+      message: null,
+    }))
+    .with({ type: 'toggle-item' }, ({ itemId }) => {
       const selected = new Set(state.selectedItemIds)
-      if (selected.has(action.itemId)) {
-        selected.delete(action.itemId)
+      if (selected.has(itemId)) {
+        selected.delete(itemId)
       } else {
-        selected.add(action.itemId)
+        selected.add(itemId)
       }
       return {
         ...state,
         selectedItemIds: Array.from(selected),
       }
-    }
-    case 'set-section': {
+    })
+    .with({ type: 'set-section' }, ({ checked, itemIds }) => {
       const selected = new Set(state.selectedItemIds)
-      for (const itemId of action.itemIds) {
-        if (action.checked) {
+      for (const itemId of itemIds) {
+        if (checked) {
           selected.add(itemId)
         } else {
           selected.delete(itemId)
@@ -236,8 +234,8 @@ function symlinkCleanupDialogReducer(
         ...state,
         selectedItemIds: Array.from(selected),
       }
-    }
-  }
+    })
+    .exhaustive()
 }
 
 /**

--- a/src/renderer/src/components/skills/SourceLink.tsx
+++ b/src/renderer/src/components/skills/SourceLink.tsx
@@ -1,5 +1,6 @@
 import { ExternalLink } from 'lucide-react'
 import React from 'react'
+import { match } from 'ts-pattern'
 
 import { useAppDispatch } from '@/renderer/src/redux/hooks'
 import { setSelectedSources } from '@/renderer/src/redux/slices/uiSlice'
@@ -47,58 +48,56 @@ export const SourceLink = React.memo(function SourceLink({
   const dispatch = useAppDispatch()
   const model = getSourceLinkModel(source, sourceUrl)
 
-  if (model.kind === 'local') {
-    return (
+  // SourceLinkModel has three render modes; new modes must add explicit JSX here.
+  return match(model)
+    .with({ kind: 'local' }, () => (
       <span className="text-sm text-muted-foreground/70 mb-2 block">Local</span>
-    )
-  }
-
-  if (model.kind === 'text') {
-    return (
+    ))
+    .with({ kind: 'text' }, ({ source }) => (
       <span className="text-sm text-muted-foreground inline-flex items-center gap-1 mb-2">
-        {model.source}
+        {source}
       </span>
-    )
-  }
+    ))
+    .with({ kind: 'link' }, ({ href, source }) => {
+      // Stop both clicks from reaching the surrounding `<Card>`'s onClick so
+      // filtering/opening a repository never toggles skill selection.
+      const handleFilterClick = (
+        event: React.MouseEvent<HTMLButtonElement>,
+      ): void => {
+        event.stopPropagation()
+        // Replace active repo filters with this focused "show me this repo"
+        // jump, rather than adding another filter to the existing selection.
+        dispatch(setSelectedSources([source]))
+      }
 
-  // Stop both clicks from reaching the surrounding `<Card>`'s onClick — that
-  // would silently toggle skill selection when the user just wanted to filter
-  // or open the repository.
-  const handleFilterClick = (
-    event: React.MouseEvent<HTMLButtonElement>,
-  ): void => {
-    event.stopPropagation()
-    // Replace any active repo filter with just this one — a SourceLink click is
-    // a focused "show me this repo" jump, not an additive toggle.
-    dispatch(setSelectedSources([model.source]))
-  }
+      const handleExternalClick = (
+        event: React.MouseEvent<HTMLAnchorElement>,
+      ): void => {
+        event.stopPropagation()
+      }
 
-  const handleExternalClick = (
-    event: React.MouseEvent<HTMLAnchorElement>,
-  ): void => {
-    event.stopPropagation()
-  }
-
-  return (
-    <span className="inline-flex items-center gap-1 mb-2">
-      <button
-        type="button"
-        onClick={handleFilterClick}
-        aria-label={`Filter skills by repository ${model.source}`}
-        className="text-sm text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
-      >
-        {model.source}
-      </button>
-      <a
-        href={model.href}
-        target="_blank"
-        rel="noreferrer"
-        onClick={handleExternalClick}
-        aria-label={`Open ${model.source} on GitHub`}
-        className="text-muted-foreground hover:text-foreground transition-colors inline-flex items-center"
-      >
-        <ExternalLink className="h-3 w-3" />
-      </a>
-    </span>
-  )
+      return (
+        <span className="inline-flex items-center gap-1 mb-2">
+          <button
+            type="button"
+            onClick={handleFilterClick}
+            aria-label={`Filter skills by repository ${source}`}
+            className="text-sm text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+          >
+            {source}
+          </button>
+          <a
+            href={href}
+            target="_blank"
+            rel="noreferrer"
+            onClick={handleExternalClick}
+            aria-label={`Open ${source} on GitHub`}
+            className="text-muted-foreground hover:text-foreground transition-colors inline-flex items-center"
+          >
+            <ExternalLink className="h-3 w-3" />
+          </a>
+        </span>
+      )
+    })
+    .exhaustive()
 })

--- a/src/renderer/src/components/skills/bulkDeleteCopy.tsx
+++ b/src/renderer/src/components/skills/bulkDeleteCopy.tsx
@@ -1,4 +1,5 @@
 import type React from 'react'
+import { match } from 'ts-pattern'
 
 import type { SourceFilterSummary } from '@/renderer/src/redux/slices/uiSlice'
 import { pluralize } from '@/renderer/src/utils/pluralize'
@@ -57,20 +58,52 @@ export const renderBulkDeleteDescription = ({
   orphanRescanCount?: number
   sourceSummary: SourceFilterSummary | null
 }): React.ReactNode => {
-  const base =
+  const hasBaseTrashCopy =
     orphanCleanupCount === 0 &&
     orphanRescanCount === 0 &&
     staleDeleteCount === 0
-      ? `This moves the ${pluralize(totalCount, 'skill')} to the app trash and removes every symlink pointing to ${pluralize(totalCount, 'it', 'them')}. You can restore within 15 seconds from the notification.`
-      : trashCount > 0 && orphanCleanupCount === 0
-        ? `This moves ${trashCount} ${pluralize(trashCount, 'skill')} to the app trash with a 15-second restore window.`
-        : trashCount === 0 && orphanCleanupCount > 0
-          ? `This removes reviewed dangling symlinks for ${orphanCleanupCount} orphan ${pluralize(orphanCleanupCount, 'skill')}. Source skill files are already missing, and this cleanup cannot be undone from the notification.`
-          : trashCount > 0 && orphanCleanupCount > 0
-            ? `This moves ${trashCount} ${pluralize(trashCount, 'skill')} to the app trash with a 15-second restore window and removes reviewed dangling symlinks for ${orphanCleanupCount} orphan ${pluralize(orphanCleanupCount, 'skill')}. Orphan cleanup cannot be undone from the notification.`
-            : orphanRescanCount > 0 && staleDeleteCount === 0
-              ? 'No selected orphan skills are cleanup-ready.'
-              : 'No selected skills are ready to delete.'
+  const hasTrashRows = trashCount > 0
+  const hasOrphanCleanupRows = orphanCleanupCount > 0
+  const hasOnlyOrphanRescan = orphanRescanCount > 0 && staleDeleteCount === 0
+  // Bulk delete copy exhaustively covers preflight buckets before scope/rescan details append.
+  const base = match({
+    hasBaseTrashCopy,
+    hasTrashRows,
+    hasOrphanCleanupRows,
+    hasOnlyOrphanRescan,
+  })
+    .with({ hasBaseTrashCopy: true }, () => {
+      return `This moves the ${pluralize(totalCount, 'skill')} to the app trash and removes every symlink pointing to ${pluralize(totalCount, 'it', 'them')}. You can restore within 15 seconds from the notification.`
+    })
+    .with(
+      { hasTrashRows: true, hasOrphanCleanupRows: false },
+      () =>
+        `This moves ${trashCount} ${pluralize(trashCount, 'skill')} to the app trash with a 15-second restore window.`,
+    )
+    .with(
+      { hasTrashRows: false, hasOrphanCleanupRows: true },
+      () =>
+        `This removes reviewed dangling symlinks for ${orphanCleanupCount} orphan ${pluralize(orphanCleanupCount, 'skill')}. Source skill files are already missing, and this cleanup cannot be undone from the notification.`,
+    )
+    .with(
+      { hasTrashRows: true, hasOrphanCleanupRows: true },
+      () =>
+        `This moves ${trashCount} ${pluralize(trashCount, 'skill')} to the app trash with a 15-second restore window and removes reviewed dangling symlinks for ${orphanCleanupCount} orphan ${pluralize(orphanCleanupCount, 'skill')}. Orphan cleanup cannot be undone from the notification.`,
+    )
+    .with(
+      { hasOnlyOrphanRescan: true },
+      () => 'No selected orphan skills are cleanup-ready.',
+    )
+    .with(
+      {
+        hasBaseTrashCopy: false,
+        hasTrashRows: false,
+        hasOrphanCleanupRows: false,
+        hasOnlyOrphanRescan: false,
+      },
+      () => 'No selected skills are ready to delete.',
+    )
+    .exhaustive()
 
   const scopeSentences: string[] = []
   if (staleDeleteCount > 0) {

--- a/src/renderer/src/components/skills/bulkDeleteHelpers.ts
+++ b/src/renderer/src/components/skills/bulkDeleteHelpers.ts
@@ -1,4 +1,4 @@
-import { match } from 'ts-pattern'
+import { match, P } from 'ts-pattern'
 
 import { pluralize } from '@/renderer/src/utils/pluralize'
 import type {
@@ -83,8 +83,12 @@ export const getToolbarState = ({
   // The primary button acts only on selected rows that survived the current
   // filter, while the adjacent selection summary owns the total hidden count.
   const actionCount = visibleCount
-  const countKind: ToolbarCountKind =
-    actionCount === 0 ? 'zero' : actionCount === 1 ? 'single' : 'multi'
+  // ToolbarCountKind exhaustively buckets every visible count into zero, single, or multi copy.
+  const countKind: ToolbarCountKind = match(actionCount)
+    .with(0, () => 'zero' as const)
+    .with(1, () => 'single' as const)
+    .with(P.number, () => 'multi' as const)
+    .exhaustive()
   const isPrimaryDisabled = visibleCount === 0
   const ariaSelectionScope =
     count === visibleCount ? 'selected' : 'visible selected'

--- a/src/renderer/src/redux/slices/uiSlice.ts
+++ b/src/renderer/src/redux/slices/uiSlice.ts
@@ -1,5 +1,6 @@
 import type { PayloadAction } from '@reduxjs/toolkit'
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit'
+import { match } from 'ts-pattern'
 
 import type { RootState } from '@/renderer/src/redux/store'
 import type {
@@ -282,18 +283,15 @@ export const executeSyncAction = createAsyncThunk(
 export function getAvailableExcludeTypes(
   skillTypeFilter: SkillTypeFilter,
 ): ExcludableSkillTypeFilter[] {
-  switch (skillTypeFilter) {
-    case 'all':
-      return ['symlinked', 'local', 'gstack', 'orphan']
-    case 'symlinked':
-      return ['gstack', 'orphan']
-    case 'local':
-      return ['gstack']
-    case 'gstack':
-      return ['symlinked', 'local', 'orphan']
-    case 'orphan':
-      return ['gstack']
-  }
+  // SkillTypeFilter has five include modes; new modes must declare valid exclusions here.
+  return match(skillTypeFilter)
+    .returnType<ExcludableSkillTypeFilter[]>()
+    .with('all', () => ['symlinked', 'local', 'gstack', 'orphan'])
+    .with('symlinked', () => ['gstack', 'orphan'])
+    .with('local', () => ['gstack'])
+    .with('gstack', () => ['symlinked', 'local', 'orphan'])
+    .with('orphan', () => ['gstack'])
+    .exhaustive()
 }
 
 const uiSlice = createSlice({


### PR DESCRIPTION
## Summary
- Convert selected JSX/discriminated-union dispatches to exhaustive ts-pattern matches
- Replace nested bulk-delete copy branching and toolbar count bucketing with explicit match branches
- Preserve behavior while making future union variants fail at compile time

## Verification
- pnpm validate
- kill-port 9222 && pnpm test:e2e


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * コード内の分岐ロジックを改善し、型安全性を高めました。複数の機能モジュールにおいて、内部的な条件分岐の実装パターンを統一・最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->