### PR TITLE
refactor: extract colorful domain types

### DIFF
--- a/src/main/services/settings.ts
+++ b/src/main/services/settings.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_SETTINGS,
   SettingsSchema,
   type Settings,
+  type SettingsPatch,
 } from '@/shared/settings'
 
 /**
@@ -140,9 +141,7 @@ export function areSettingsEqual(a: Settings, b: Settings): boolean {
  * await saveSettings({ defaultSkillTab: 'info' })
  * // => { defaultSkillTab: 'info' }
  */
-export async function saveSettings(
-  partial: Partial<Settings>,
-): Promise<Settings> {
+export async function saveSettings(partial: SettingsPatch): Promise<Settings> {
   const current = getSettings()
   const merged = SettingsSchema.parse({ ...current, ...partial })
   // No-op guard: when nothing actually changed (e.g. tapping the

--- a/src/main/services/skillScanner.ts
+++ b/src/main/services/skillScanner.ts
@@ -59,6 +59,9 @@ interface SkillLockContent {
 
 type AgentDefinition = (typeof AGENTS)[number]
 
+/** Partial slot update used only while merging scanner observations into a grouped skill record. */
+type SymlinkInfoPatch = Partial<SymlinkInfo>
+
 interface AgentSymlinkStatusHit {
   agent: AgentDefinition
   name: SkillName
@@ -97,7 +100,7 @@ function createMissingSymlinkSlots(name: SkillName): SymlinkInfo[] {
 function updateAgentSymlinkSlot(
   skill: Skill,
   agentId: AgentDefinition['id'],
-  patch: Partial<SymlinkInfo>,
+  patch: SymlinkInfoPatch,
 ): void {
   const slot = skill.symlinks.findIndex(
     (symlink) => symlink.agentId === agentId,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,7 +1,7 @@
 import { contextBridge } from 'electron'
 
 import { IPC_CHANNELS } from '@/shared/ipc-channels'
-import type { Settings } from '@/shared/settings'
+import type { Settings, SettingsPatch } from '@/shared/settings'
 import type {
   AbsolutePath,
   ClearOrphanSymlinksOptions,
@@ -132,8 +132,7 @@ contextBridge.exposeInMainWorld('electron', {
   settings: {
     open: async () => typedInvoke('settings:open'),
     get: async () => typedInvoke('settings:get'),
-    set: async (partial: Partial<Settings>) =>
-      typedInvoke('settings:set', partial),
+    set: async (partial: SettingsPatch) => typedInvoke('settings:set', partial),
     onChanged: createIpcListener<Settings>(IPC_CHANNELS.SETTINGS_CHANGED),
   },
   // Folder actions — main-process-only because both `shell.openPath` and

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.tsx
@@ -17,6 +17,7 @@ import {
   getSymlinkCleanupPlanItems,
 } from '@/renderer/src/components/dashboard/utils/buildSymlinkCleanupPlan'
 import type {
+  BrokenSlotsByAgent,
   BrokenSlotCleanupPlanItem,
   OrphanCleanupPlanItem,
   SymlinkCleanupItemId,
@@ -292,6 +293,19 @@ function getSelectedPlanItems(
 }
 
 /**
+ * Flattens grouped broken-slot rows while preserving the cleanup plan's row-id type.
+ * @param brokenSlotsByAgent - Agent-keyed broken-slot rows from the cleanup plan.
+ * @returns Broken-slot rows in stable grouped order.
+ * @example
+ * getBrokenSlotPlanItems(plan.brokenSlotsByAgent).map((item) => item.id)
+ */
+function getBrokenSlotPlanItems(
+  brokenSlotsByAgent: BrokenSlotsByAgent,
+): BrokenSlotCleanupPlanItem[] {
+  return Object.values(brokenSlotsByAgent).flatMap((items) => items ?? [])
+}
+
+/**
  * Checks whether a selected row still describes the exact cleanup target the user reviewed.
  * @param reviewedItem - Row from the visible review plan.
  * @param freshItem - Row rebuilt from a just-fetched scanner snapshot.
@@ -392,6 +406,27 @@ function collectFailedRows(params: {
   }
 
   return { failedItemIds, rowErrors }
+}
+
+/**
+ * Keeps only errors still visible after the post-cleanup rescan without widening branded ids to strings.
+ * @param rowErrors - Errors keyed by cleanup row id from the attempted cleanup.
+ * @param visibleFailedItemIds - Failed row ids still present in the refreshed plan.
+ * @returns Row errors for failed rows that the retry UI can still display.
+ * @example
+ * pickVisibleRowErrors(errors, failedIds)
+ */
+function pickVisibleRowErrors(
+  rowErrors: Record<SymlinkCleanupItemId, string>,
+  visibleFailedItemIds: readonly SymlinkCleanupItemId[],
+): Record<SymlinkCleanupItemId, string> {
+  const visibleRowErrors: Record<SymlinkCleanupItemId, string> = {}
+  for (const itemId of visibleFailedItemIds) {
+    if (Object.prototype.hasOwnProperty.call(rowErrors, itemId)) {
+      visibleRowErrors[itemId] = rowErrors[itemId]
+    }
+  }
+  return visibleRowErrors
 }
 
 /**
@@ -810,10 +845,9 @@ export const SymlinkCleanupDialog = React.memo(
             })
             return
           }
-          const visibleRowErrors = Object.fromEntries(
-            Object.entries(rowErrors).filter(([itemId]) =>
-              visibleFailedItemIds.includes(itemId as SymlinkCleanupItemId),
-            ),
+          const visibleRowErrors = pickVisibleRowErrors(
+            rowErrors,
+            visibleFailedItemIds,
           )
           if (
             Object.keys(visibleRowErrors).length !== visibleFailedItemIds.length
@@ -1150,17 +1184,15 @@ const ReviewContent = React.memo(function ReviewContent({
         selectedItemIdSet={selectedItemIdSet}
         onSetSection={onSetSection}
       >
-        {Object.values(plan?.brokenSlotsByAgent ?? {}).flatMap((items) =>
-          (items ?? []).map((item) => (
-            <CleanupRow
-              key={item.id}
-              item={item}
-              checked={selectedItemIdSet.has(item.id)}
-              error={rowErrors[item.id]}
-              onToggleItem={onToggleItem}
-            />
-          )),
-        )}
+        {getBrokenSlotPlanItems(plan?.brokenSlotsByAgent ?? {}).map((item) => (
+          <CleanupRow
+            key={item.id}
+            item={item}
+            checked={selectedItemIdSet.has(item.id)}
+            error={rowErrors[item.id]}
+            onToggleItem={onToggleItem}
+          />
+        ))}
       </CleanupSection>
     </div>
   )

--- a/src/renderer/src/components/dashboard/WidgetPicker.tsx
+++ b/src/renderer/src/components/dashboard/WidgetPicker.tsx
@@ -84,6 +84,7 @@ export const WidgetPicker = React.memo(function WidgetPicker({
   // initial focus onto the seed row so the focused row and the preview always
   // agree (and keyboard users land on the same widget the stage shows).
   const seedRowRef = useRef<HTMLButtonElement>(null)
+  const isOpeningAutoFocusRef = useRef<boolean>(false)
 
   // One-click-add must fire at most once per open: the close animation keeps the
   // rows clickable for a frame, so a fast double-click could add the widget
@@ -99,7 +100,11 @@ export const WidgetPicker = React.memo(function WidgetPicker({
     hasAddedRef.current = false
     if (!seedRowRef.current) return
     event.preventDefault()
+    isOpeningAutoFocusRef.current = true
     seedRowRef.current.focus()
+    requestAnimationFrame(() => {
+      isOpeningAutoFocusRef.current = false
+    })
   }, [])
 
   // Wrap `onOpenChange` so the close transition (Esc, overlay click, X button,
@@ -180,6 +185,12 @@ export const WidgetPicker = React.memo(function WidgetPicker({
                       // Radix/browser autofocus can jump to a later row on the
                       // open frame. Before any real preview override exists,
                       // let only the seed row claim focus-driven preview.
+                      if (
+                        isOpeningAutoFocusRef.current &&
+                        widgetDefinition.type !== seedPreviewType
+                      ) {
+                        return
+                      }
                       if (
                         activePreviewType === null &&
                         widgetDefinition.type !== seedPreviewType

--- a/src/renderer/src/components/dashboard/WidgetPicker.tsx
+++ b/src/renderer/src/components/dashboard/WidgetPicker.tsx
@@ -178,7 +178,7 @@ export const WidgetPicker = React.memo(function WidgetPicker({
                     type="button"
                     ref={isSeedRow ? seedRowRef : undefined}
                     onClick={() => handleAddWidget(widgetDefinition.type)}
-                    onMouseEnter={() =>
+                    onPointerMove={() =>
                       dispatch(setActivePreviewType(widgetDefinition.type))
                     }
                     onFocus={() => {

--- a/src/renderer/src/components/dashboard/WidgetPicker.tsx
+++ b/src/renderer/src/components/dashboard/WidgetPicker.tsx
@@ -84,7 +84,6 @@ export const WidgetPicker = React.memo(function WidgetPicker({
   // initial focus onto the seed row so the focused row and the preview always
   // agree (and keyboard users land on the same widget the stage shows).
   const seedRowRef = useRef<HTMLButtonElement>(null)
-  const isOpeningAutoFocusRef = useRef<boolean>(false)
 
   // One-click-add must fire at most once per open: the close animation keeps the
   // rows clickable for a frame, so a fast double-click could add the widget
@@ -100,11 +99,7 @@ export const WidgetPicker = React.memo(function WidgetPicker({
     hasAddedRef.current = false
     if (!seedRowRef.current) return
     event.preventDefault()
-    isOpeningAutoFocusRef.current = true
     seedRowRef.current.focus()
-    requestAnimationFrame(() => {
-      isOpeningAutoFocusRef.current = false
-    })
   }, [])
 
   // Wrap `onOpenChange` so the close transition (Esc, overlay click, X button,
@@ -178,25 +173,12 @@ export const WidgetPicker = React.memo(function WidgetPicker({
                     type="button"
                     ref={isSeedRow ? seedRowRef : undefined}
                     onClick={() => handleAddWidget(widgetDefinition.type)}
-                    onPointerMove={() =>
+                    onPointerMove={() => {
+                      if (activePreviewType === widgetDefinition.type) return
                       dispatch(setActivePreviewType(widgetDefinition.type))
-                    }
+                    }}
                     onFocus={() => {
-                      // Radix/browser autofocus can jump to a later row on the
-                      // open frame. Before any real preview override exists,
-                      // let only the seed row claim focus-driven preview.
-                      if (
-                        isOpeningAutoFocusRef.current &&
-                        widgetDefinition.type !== seedPreviewType
-                      ) {
-                        return
-                      }
-                      if (
-                        activePreviewType === null &&
-                        widgetDefinition.type !== seedPreviewType
-                      ) {
-                        return
-                      }
+                      if (activePreviewType === widgetDefinition.type) return
                       dispatch(setActivePreviewType(widgetDefinition.type))
                     }}
                     aria-current={isActive ? 'true' : undefined}

--- a/src/renderer/src/components/dashboard/types.ts
+++ b/src/renderer/src/components/dashboard/types.ts
@@ -38,12 +38,42 @@ export type WidgetInstanceId = Brand<string, 'WidgetInstanceId'>
  */
 export type DashboardPageId = Brand<string, 'DashboardPageId'>
 
+/**
+ * @description Human-readable tab name shown in the dashboard page strip.
+ * @example "Overview"
+ */
+export type DashboardPageName = string
+
 // ============================================================================
 // Placement
 // ----------------------------------------------------------------------------
 // `x`/`y`/`w`/`h` are 6-col grid cells (not pixels). See `GRID_COLS` /
 // `GRID_ROW_HEIGHT_PX` in utils. Kept small-integer to match react-grid-layout.
 // ============================================================================
+
+/**
+ * @description Zero-based grid column where a widget begins.
+ * @example 3
+ */
+export type GridColumnStart = number
+
+/**
+ * @description Zero-based grid row where a widget begins.
+ * @example 6
+ */
+export type GridRowStart = number
+
+/**
+ * @description Width of a widget measured in dashboard grid columns.
+ * @example 6
+ */
+export type GridColumnSpan = number
+
+/**
+ * @description Height of a widget measured in dashboard grid rows.
+ * @example 3
+ */
+export type GridRowSpan = number
 
 /**
  * A single placed widget on a page.
@@ -54,10 +84,10 @@ export type DashboardPageId = Brand<string, 'DashboardPageId'>
 export interface WidgetInstance {
   id: WidgetInstanceId
   type: WidgetType
-  x: number
-  y: number
-  w: number
-  h: number
+  x: GridColumnStart
+  y: GridRowStart
+  w: GridColumnSpan
+  h: GridRowSpan
 }
 
 /**
@@ -66,7 +96,7 @@ export interface WidgetInstance {
  */
 export interface DashboardPage {
   id: DashboardPageId
-  name: string
+  name: DashboardPageName
   widgets: WidgetInstance[]
 }
 
@@ -82,8 +112,8 @@ export interface DashboardPage {
  * Grid size bounds for a widget, in 6-col cells.
  */
 export interface WidgetSize {
-  w: number
-  h: number
+  w: GridColumnSpan
+  h: GridRowSpan
 }
 
 /**

--- a/src/renderer/src/components/dashboard/utils/buildSymlinkCleanupPlan.test.ts
+++ b/src/renderer/src/components/dashboard/utils/buildSymlinkCleanupPlan.test.ts
@@ -12,6 +12,7 @@ import type {
 import {
   buildSymlinkCleanupPlan,
   createBrokenSlotCleanupItemId,
+  createOrphanCleanupItemId,
   getLinkNameFromPath,
   getSymlinkCleanupPlanItems,
 } from './buildSymlinkCleanupPlan'
@@ -267,6 +268,17 @@ describe('buildSymlinkCleanupPlan', () => {
 
     // Assert
     expect(itemId).toBe('broken:cursor:name%3Awith%2Fslash')
+  })
+
+  it('keeps orphan cleanup id literals stable for persisted row state', () => {
+    // Arrange
+    const skillName = 'name:with/slash' as SkillName
+
+    // Act
+    const itemId = createOrphanCleanupItemId(skillName)
+
+    // Assert
+    expect(itemId).toBe('orphan:name%3Awith%2Fslash')
   })
 })
 

--- a/src/renderer/src/components/dashboard/utils/buildSymlinkCleanupPlan.ts
+++ b/src/renderer/src/components/dashboard/utils/buildSymlinkCleanupPlan.ts
@@ -14,7 +14,7 @@ import type {
 
 /**
  * @description Stable review-row identifier generated for Symlink Health cleanup selection.
- * @example "broken:cursor:agent%3Askill"
+ * @example "broken:cursor:my-skill" or "broken:cursor:name%3Awith%2Fslash" when escaped.
  */
 export type SymlinkCleanupItemId = Brand<string, 'SymlinkCleanupItemId'>
 

--- a/src/renderer/src/components/dashboard/utils/buildSymlinkCleanupPlan.ts
+++ b/src/renderer/src/components/dashboard/utils/buildSymlinkCleanupPlan.ts
@@ -1,14 +1,22 @@
 import type {
   AbsolutePath,
+  AgentCount,
   AgentId,
   AgentName,
+  Brand,
   IsoTimestamp,
   Skill,
+  SkillCount,
   SkillName,
+  SymlinkCount,
   SymlinkInfo,
 } from '@/shared/types'
 
-export type SymlinkCleanupItemId = string
+/**
+ * @description Stable review-row identifier generated for Symlink Health cleanup selection.
+ * @example "broken:cursor:agent%3Askill"
+ */
+export type SymlinkCleanupItemId = Brand<string, 'SymlinkCleanupItemId'>
 
 export interface OrphanCleanupPlanItem {
   id: SymlinkCleanupItemId
@@ -20,7 +28,7 @@ export interface OrphanCleanupPlanItem {
     linkPath: AbsolutePath
     targetPath: AbsolutePath
   }>
-  symlinkCount: number
+  symlinkCount: SymlinkCount
 }
 
 export interface BrokenSlotCleanupPlanItem {
@@ -39,15 +47,23 @@ export type SymlinkCleanupPlanItem =
   | OrphanCleanupPlanItem
   | BrokenSlotCleanupPlanItem
 
+/**
+ * @description Broken cleanup rows grouped by owning agent for sectioned dashboard rendering.
+ * @example { cursor: [{ kind: 'broken-slot', id: 'broken:cursor:task', ... }] }
+ */
+export type BrokenSlotsByAgent = Partial<
+  Record<AgentId, BrokenSlotCleanupPlanItem[]>
+>
+
 export interface SymlinkCleanupPlan {
   generatedAt: IsoTimestamp
   orphanRecords: OrphanCleanupPlanItem[]
-  brokenSlotsByAgent: Partial<Record<AgentId, BrokenSlotCleanupPlanItem[]>>
+  brokenSlotsByAgent: BrokenSlotsByAgent
   totals: {
-    orphanRecords: number
-    orphanSymlinks: number
-    brokenSlots: number
-    affectedAgents: number
+    orphanRecords: SkillCount
+    orphanSymlinks: SymlinkCount
+    brokenSlots: SymlinkCount
+    affectedAgents: AgentCount
   }
 }
 
@@ -72,7 +88,7 @@ function encodeCleanupIdSegment(value: string): string {
 export function createOrphanCleanupItemId(
   skillName: SkillName,
 ): SymlinkCleanupItemId {
-  return `orphan:${encodeCleanupIdSegment(skillName)}`
+  return `orphan:${encodeCleanupIdSegment(skillName)}` as SymlinkCleanupItemId
 }
 
 /**
@@ -87,7 +103,7 @@ export function createBrokenSlotCleanupItemId(
   agentId: AgentId,
   linkName: SkillName,
 ): SymlinkCleanupItemId {
-  return `broken:${encodeCleanupIdSegment(agentId)}:${encodeCleanupIdSegment(linkName)}`
+  return `broken:${encodeCleanupIdSegment(agentId)}:${encodeCleanupIdSegment(linkName)}` as SymlinkCleanupItemId
 }
 
 /**
@@ -151,9 +167,7 @@ export function buildSymlinkCleanupPlan(
   skills: readonly Skill[],
 ): SymlinkCleanupPlan {
   const orphanRecords: OrphanCleanupPlanItem[] = []
-  const brokenSlotsByAgent: Partial<
-    Record<AgentId, BrokenSlotCleanupPlanItem[]>
-  > = {}
+  const brokenSlotsByAgent: BrokenSlotsByAgent = {}
   const affectedAgentIds = new Set<AgentId>()
 
   for (const skill of skills) {

--- a/src/renderer/src/components/dashboard/utils/findEmptySpot.ts
+++ b/src/renderer/src/components/dashboard/utils/findEmptySpot.ts
@@ -1,4 +1,6 @@
 import type {
+  GridColumnStart,
+  GridRowStart,
   WidgetInstance,
   WidgetSize,
 } from '@/renderer/src/components/dashboard/types'
@@ -27,7 +29,7 @@ import {
 export function findEmptySpot(
   widgets: readonly WidgetInstance[],
   size: WidgetSize,
-): { x: number; y: number } | null {
+): { x: GridColumnStart; y: GridRowStart } | null {
   // Page-fullness shortcut: macOS-style overflow kicks in once the user's
   // visible-widget budget is exhausted, even if the grid is technically free.
   if (widgets.length >= MAX_WIDGETS_PER_PAGE) return null
@@ -62,8 +64,8 @@ export function findEmptySpot(
  */
 function fitsAt(
   occupied: ReadonlySet<string>,
-  originX: number,
-  originY: number,
+  originX: GridColumnStart,
+  originY: GridRowStart,
   size: WidgetSize,
 ): boolean {
   for (let dx = 0; dx < size.w; dx++) {

--- a/src/renderer/src/components/dashboard/utils/widgetPresets.ts
+++ b/src/renderer/src/components/dashboard/utils/widgetPresets.ts
@@ -1,5 +1,10 @@
 import type {
   DashboardPage,
+  DashboardPageName,
+  GridColumnSpan,
+  GridColumnStart,
+  GridRowSpan,
+  GridRowStart,
   WidgetInstance,
   WidgetType,
 } from '@/renderer/src/components/dashboard/types'
@@ -18,14 +23,14 @@ import { newDashboardPageId, newWidgetInstanceId } from './ids'
 
 /** Specification for a page-to-be-built — layout is laid out by hand per preset. */
 interface PageSpec {
-  name: string
+  name: DashboardPageName
   widgets: readonly {
     type: WidgetType
-    x: number
-    y: number
+    x: GridColumnStart
+    y: GridRowStart
     /** Optional size overrides. If omitted, the registry default is used. */
-    w?: number
-    h?: number
+    w?: GridColumnSpan
+    h?: GridRowSpan
   }[]
 }
 

--- a/src/renderer/src/components/skills/FileContent.tsx
+++ b/src/renderer/src/components/skills/FileContent.tsx
@@ -12,7 +12,7 @@ import type { PreviewContent } from '@/renderer/src/hooks/useCodePreview'
 import { useCycleEffect } from '@/renderer/src/hooks/useCycleEffect'
 import { cn } from '@/renderer/src/lib/utils'
 import { formatBytes } from '@/shared/fileTypes'
-import type { SkillFileContent } from '@/shared/types'
+import type { FileName, FileSizeBytes, SkillFileContent } from '@/shared/types'
 
 import { isMarkdownPreview, languageForPreview } from './filePreviewLanguage'
 import { codeToHtml } from './shikiPreview'
@@ -566,8 +566,8 @@ const EmptyState = React.memo(function EmptyState(): React.ReactElement {
 })
 
 interface BinaryPlaceholderProps {
-  fileName: string
-  size: number
+  fileName: FileName
+  size: FileSizeBytes
 }
 
 const BinaryPlaceholder = React.memo(function BinaryPlaceholder({

--- a/src/renderer/src/components/skills/filePreviewLanguage.ts
+++ b/src/renderer/src/components/skills/filePreviewLanguage.ts
@@ -42,6 +42,14 @@ export type ShikiPreviewLanguage =
   | 'yaml'
   | 'zsh'
 
+/** Minimal file metadata needed to choose a Shiki grammar without depending on full file content. */
+type PreviewLanguageFileInput = Pick<SkillFileContent, 'extension' | 'name'>
+
+/** Minimal file metadata needed to decide whether the reading-mode toggle is available. */
+type MarkdownPreviewFileInput = Pick<SkillFileContent, 'name'> & {
+  extension?: string | null
+}
+
 /**
  * Normalize user/file-system extensions into the lookup key shape.
  * @param extension - Optional file extension, with or without a leading dot.
@@ -131,7 +139,7 @@ export function languageFromExtension(
  * // => 'markdown'
  */
 export function languageForPreview(
-  file: Pick<SkillFileContent, 'extension' | 'name'>,
+  file: PreviewLanguageFileInput,
 ): ShikiPreviewLanguage {
   // Extension wins because the main process already normalizes special cases.
   const byExtension = languageFromExtension(file.extension)
@@ -152,9 +160,7 @@ export function languageForPreview(
  * @example
  * isMarkdownPreview({ name: 'SKILL.md', extension: '.md' }) // => true
  */
-export function isMarkdownPreview(
-  file: Pick<SkillFileContent, 'name'> & { extension?: string | null },
-): boolean {
+export function isMarkdownPreview(file: MarkdownPreviewFileInput): boolean {
   const extension = normalizeFileExtension(file.extension)
   if (
     extension === '.md' ||

--- a/src/renderer/src/hooks/useCodePreview.ts
+++ b/src/renderer/src/hooks/useCodePreview.ts
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 
 import type {
   AbsolutePath,
+  FileName,
+  FileSizeBytes,
   SkillBinaryContent,
   SkillFile,
   SkillFileContent,
@@ -14,7 +16,7 @@ import type {
 export type PreviewContent =
   | { kind: 'text'; data: SkillFileContent }
   | { kind: 'image'; data: SkillBinaryContent }
-  | { kind: 'binary'; fileName: string; size: number }
+  | { kind: 'binary'; fileName: FileName; size: FileSizeBytes }
   | { kind: 'empty' }
 
 interface UseCodePreviewReturn {

--- a/src/renderer/src/hooks/useUpdateSettings.ts
+++ b/src/renderer/src/hooks/useUpdateSettings.ts
@@ -2,7 +2,7 @@ import { useCallback } from 'react'
 
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import { setSettings } from '@/renderer/src/redux/slices/settingsSlice'
-import type { Settings } from '@/shared/settings'
+import type { SettingsPatch } from '@/shared/settings'
 
 /**
  * Encapsulates the optimistic-dispatch + IPC-write pair used whenever
@@ -29,12 +29,12 @@ import type { Settings } from '@/shared/settings'
  * const updateSettings = useUpdateSettings()
  * updateSettings({ defaultSkillTab: 'info' })
  */
-export function useUpdateSettings(): (partial: Partial<Settings>) => void {
+export function useUpdateSettings(): (partial: SettingsPatch) => void {
   const dispatch = useAppDispatch()
   const settings = useAppSelector((state) => state.settings)
 
   return useCallback(
-    (partial: Partial<Settings>): void => {
+    (partial: SettingsPatch): void => {
       dispatch(setSettings({ ...settings, ...partial }))
       void window.electron.settings.set(partial)
     },

--- a/src/renderer/src/redux/listener.ts
+++ b/src/renderer/src/redux/listener.ts
@@ -12,6 +12,10 @@ import { fetchSyncPreview, selectAgent, setActiveTab } from './slices/uiSlice'
 
 export const listenerMiddleware = createListenerMiddleware()
 
+type ListenerEffectApi = Parameters<
+  Parameters<typeof listenerMiddleware.startListening>[0]['effect']
+>[1]
+
 // Type for state accessed in listeners (avoids circular RootState import)
 interface ListenerState {
   theme: ThemeState
@@ -58,11 +62,7 @@ let systemThemeListenerInstalled = false
  * doesn't always implement matchMedia) so the listener stays safe to
  * import everywhere.
  */
-function installSystemThemeListener(
-  listenerApi: Parameters<
-    Parameters<typeof listenerMiddleware.startListening>[0]['effect']
-  >[1],
-): void {
+function installSystemThemeListener(listenerApi: ListenerEffectApi): void {
   if (systemThemeListenerInstalled) return
   if (
     typeof window === 'undefined' ||

--- a/src/renderer/src/redux/migrations.ts
+++ b/src/renderer/src/redux/migrations.ts
@@ -1,4 +1,7 @@
-import type { WidgetType } from '@/renderer/src/components/dashboard/types'
+import type {
+  WidgetSize,
+  WidgetType,
+} from '@/renderer/src/components/dashboard/types'
 import {
   COLOR_PRESET_CHROMA,
   PERSIST_STATE_VERSION,
@@ -36,7 +39,7 @@ export interface MigratableState {
  */
 export const V2_WIDGET_MIN_SIZES = {
   'quick-actions': { w: 3, h: 3 },
-} as const satisfies Partial<Record<WidgetType, { w: number; h: number }>>
+} as const satisfies Partial<Record<WidgetType, WidgetSize>>
 
 /**
  * v4 floor — the Symlink Health widget's `minSize.h` grew 2 → 3 (PR #185 added
@@ -48,7 +51,7 @@ export const V2_WIDGET_MIN_SIZES = {
  */
 export const V4_WIDGET_MIN_SIZES = {
   health: { w: 2, h: 3 },
-} as const satisfies Partial<Record<WidgetType, { w: number; h: number }>>
+} as const satisfies Partial<Record<WidgetType, WidgetSize>>
 
 /**
  * v0 → v1 migration for the theme slice. The old shape carried a
@@ -109,7 +112,7 @@ function migrateV0ToV1(state: MigratableState): void {
  */
 function clampPersistedWidgetSizes(
   state: MigratableState,
-  floors: Partial<Record<string, { w: number; h: number }>>,
+  floors: Partial<Record<string, WidgetSize>>,
   migrationName: string,
 ): void {
   if (!state.dashboard || typeof state.dashboard !== 'object') return

--- a/src/renderer/src/redux/slices/dashboardSlice.ts
+++ b/src/renderer/src/redux/slices/dashboardSlice.ts
@@ -4,6 +4,11 @@ import { createSlice } from '@reduxjs/toolkit'
 import type {
   DashboardPage,
   DashboardPageId,
+  DashboardPageName,
+  GridColumnSpan,
+  GridColumnStart,
+  GridRowSpan,
+  GridRowStart,
   WidgetInstance,
   WidgetInstanceId,
   WidgetType,
@@ -38,6 +43,18 @@ interface DashboardState {
   welcomeDismissed: boolean
   /** True once defaults have been populated. Prevents re-seeding on every load. */
   initialized: boolean
+}
+
+/**
+ * Layout payload emitted by React Grid Layout when the user drags or resizes widgets.
+ * @example { i: 'w_abc', x: 0, y: 0, w: 6, h: 2 }
+ */
+interface DashboardLayoutItem {
+  i: string
+  x: GridColumnStart
+  y: GridRowStart
+  w: GridColumnSpan
+  h: GridRowSpan
 }
 
 const initialState: DashboardState = {
@@ -101,13 +118,7 @@ const dashboardSlice = createSlice({
       state,
       action: PayloadAction<{
         pageId: DashboardPageId
-        layout: readonly {
-          i: string
-          x: number
-          y: number
-          w: number
-          h: number
-        }[]
+        layout: readonly DashboardLayoutItem[]
       }>,
     ) => {
       const page = state.pages.find((p) => p.id === action.payload.pageId)
@@ -193,7 +204,10 @@ const dashboardSlice = createSlice({
      * Create a new empty page and switch to it. User-driven — auto-overflow
      * uses `addWidget`'s fallback path instead.
      */
-    addPage: (state, action: PayloadAction<{ name?: string } | undefined>) => {
+    addPage: (
+      state,
+      action: PayloadAction<{ name?: DashboardPageName } | undefined>,
+    ) => {
       const newPage: DashboardPage = {
         id: newDashboardPageId(),
         name: action.payload?.name ?? `Page ${state.pages.length + 1}`,
@@ -208,7 +222,10 @@ const dashboardSlice = createSlice({
      */
     renamePage: (
       state,
-      action: PayloadAction<{ pageId: DashboardPageId; name: string }>,
+      action: PayloadAction<{
+        pageId: DashboardPageId
+        name: DashboardPageName
+      }>,
     ) => {
       const page = state.pages.find((p) => p.id === action.payload.pageId)
       if (page) page.name = action.payload.name

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -1,4 +1,4 @@
-import type { Settings } from '../../../shared/settings'
+import type { Settings, SettingsPatch } from '../../../shared/settings'
 import type {
   AbsolutePath,
   Skill,
@@ -134,7 +134,7 @@ declare global {
       settings: {
         open: () => Promise<void>
         get: () => Promise<Settings>
-        set: (partial: Partial<Settings>) => Promise<Settings>
+        set: (partial: SettingsPatch) => Promise<Settings>
         onChanged: (callback: (settings: Settings) => void) => () => void
       }
       folder: {

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -1,4 +1,4 @@
-import type { Settings } from './settings'
+import type { Settings, SettingsPatch } from './settings'
 import type {
   AbsolutePath,
   Agent,
@@ -130,7 +130,7 @@ export interface IpcInvokeContract {
   'shell:openExternal': { args: [HttpUrl]; result: void }
   'settings:open': { args: []; result: void }
   'settings:get': { args: []; result: Settings }
-  'settings:set': { args: [Partial<Settings>]; result: Settings }
+  'settings:set': { args: [SettingsPatch]; result: Settings }
   // Folder actions are intentionally typed as `Promise<FolderActionResult>`
   // (never throws) so the renderer can render a toast without try/catch.
   // Main-process exceptions get caught at the typedHandle boundary and

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -205,6 +205,12 @@ export const SettingsSchema = z.object({
 export type Settings = z.infer<typeof SettingsSchema>
 
 /**
+ * @description Partial settings payload accepted by the `settings:set` IPC write boundary.
+ * @example { defaultSkillTab: 'info' }
+ */
+export type SettingsPatch = Partial<Settings>
+
+/**
  * Default settings used when `settings.json` is missing or fails
  * Zod validation. Kept here (not derived from `.parse({})`) so the
  * defaults are visible to both main and renderer without instantiating

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -52,7 +52,7 @@ export interface FilesystemEntryIdentity {
   /** Inode/file id from fs.Stats, paired with dev for stable same-object checks. */
   ino: number
   /** Entry size from fs.Stats, used as fallback identity on filesystems without ino. */
-  size: number
+  size: FileSizeBytes
   /** Metadata change timestamp from fs.Stats; strict gates also compare it to reject reused-inode same-path replacements. */
   ctimeMs: number
   /** Modification timestamp from fs.Stats, used as fallback identity. */
@@ -117,6 +117,72 @@ export type PixelWidth = number
  * @example 800
  */
 export type PixelHeight = number
+
+/**
+ * @description File basename or display name including its extension when one exists.
+ * @example "SKILL.md"
+ */
+export type FileName = string
+
+/**
+ * @description Base64 data URL that can be assigned directly to media `src` attributes.
+ * @example "data:image/png;base64,iVBORw0KGgo..."
+ */
+export type DataUrl = string
+
+/**
+ * @description Raw file size in bytes as reported by filesystem readers.
+ * @example 48201
+ */
+export type FileSizeBytes = number
+
+/**
+ * @description Number of text lines in a previewed file.
+ * @example 42
+ */
+export type LineCount = number
+
+/**
+ * @description Count of skill records, directories, or skill-like entries.
+ * @example 15
+ */
+export type SkillCount = number
+
+/**
+ * @description Count of agents included in a scan, sync, or dashboard operation.
+ * @example 3
+ */
+export type AgentCount = number
+
+/**
+ * @description Raw byte count transferred or expected by a download operation.
+ * @example 10485760
+ */
+export type ByteCount = number
+
+/**
+ * @description Download throughput measured in bytes per second.
+ * @example 524288
+ */
+export type BytesPerSecond = number
+
+/**
+ * @description Completion percentage in the inclusive 0..100 range.
+ * @example 45.2
+ */
+export type ProgressPercent = number
+
+/**
+ * @description 1-based index of the item currently processed in a batch operation.
+ * @example 3
+ */
+export type BatchItemIndex = number
+
+/**
+ * @description Total item count in a batch operation.
+ * @example 12
+ */
+export type BatchItemCount = number
 
 /**
  * A non-negative count of agent symlinks. Used in two senses, both of which
@@ -261,9 +327,9 @@ export interface Agent {
   /** Whether the agent's skills directory exists on disk */
   exists: boolean
   /** Number of valid symlinked skills. @example 12 */
-  skillCount: number
+  skillCount: SkillCount
   /** Number of local skills (real folders, not symlinks). @example 2 */
-  localSkillCount: number
+  localSkillCount: SkillCount
   /** Directory identity for destructive "remove all" confirmation guards. */
   filesystemIdentity?: FilesystemEntryIdentity
 }
@@ -401,7 +467,7 @@ export interface SourceStats {
   /** Absolute path to the source directory. @example "/Users/me/.agents/skills" */
   path: AbsolutePath
   /** Total number of skill directories. @example 15 */
-  skillCount: number
+  skillCount: SkillCount
   /** Human-readable total size. @example "2.4 MB" */
   totalSize: HumanFileSize
   /** ISO 8601 last-modified timestamp. @example "2026-04-10T08:00:00.000Z" */
@@ -444,7 +510,7 @@ export interface SkillMetadata {
  */
 export interface SkillFile {
   /** File name with extension. @example "SKILL.md" */
-  name: string
+  name: FileName
   /** Absolute path to the file. @example "/Users/me/.agents/skills/tdd/SKILL.md" */
   path: AbsolutePath
   /** POSIX-style path relative to the skill root. @example "lib/helper.py" */
@@ -452,7 +518,7 @@ export interface SkillFile {
   /** File extension with leading dot (lowercase). @example ".md" */
   extension: FileExtension
   /** File size in bytes. @example 1024 */
-  size: number
+  size: FileSizeBytes
   /** How the renderer should display this file. */
   previewable: FilePreviewKind
 }
@@ -463,13 +529,13 @@ export interface SkillFile {
  */
 export interface SkillFileContent {
   /** File name with extension. @example "SKILL.md" */
-  name: string
+  name: FileName
   /** Full text content of the file */
   content: string
   /** File extension without dot. @example "md" */
   extension: FileExtension
   /** Number of lines in the file. @example 42 */
-  lineCount: number
+  lineCount: LineCount
 }
 
 /**
@@ -485,13 +551,13 @@ export interface SkillFileContent {
  */
 export interface SkillBinaryContent {
   /** File name with extension. @example "preview.png" */
-  name: string
+  name: FileName
   /** base64-encoded data URL ready to use in `<img src>`. */
-  dataUrl: string
+  dataUrl: DataUrl
   /** MIME type derived from the file extension. @example "image/png" */
   mimeType: MimeType
   /** File size in bytes. @example 48201 */
-  size: number
+  size: FileSizeBytes
 }
 
 /**
@@ -526,9 +592,9 @@ export interface UpdateInfo {
  */
 export interface DeleteProgressPayload {
   /** 1-based index of the item just processed. @example 3 */
-  current: number
+  current: BatchItemIndex
   /** Total items in this batch. @example 12 */
-  total: number
+  total: BatchItemCount
 }
 
 /**
@@ -537,13 +603,13 @@ export interface DeleteProgressPayload {
  */
 export interface DownloadProgress {
   /** Download completion percentage (0–100). @example 45.2 */
-  percent: number
+  percent: ProgressPercent
   /** Current download speed in bytes per second. @example 524288 */
-  bytesPerSecond: number
+  bytesPerSecond: BytesPerSecond
   /** Total download size in bytes. @example 10485760 */
-  total: number
+  total: ByteCount
   /** Bytes transferred so far. @example 4739174 */
-  transferred: number
+  transferred: ByteCount
 }
 
 /**
@@ -831,7 +897,7 @@ export interface DeleteSkillResult {
   /** true if both the source and all symlinks were removed. */
   success: boolean
   /** Count of agent symlinks that pointed at the skill before deletion. @example 3 */
-  symlinksRemoved: number
+  symlinksRemoved: SymlinkCount
   /** Agent IDs whose symlinks were removed during the delete. Empty if the skill had no symlinks. @example ["cursor", "codex"] */
   cascadeAgents: AgentId[]
   /** Failure reason when `success` is false. */
@@ -892,13 +958,13 @@ export type BulkDeleteItemResult =
       skillName: SkillName
       outcome: 'deleted'
       tombstoneId: TombstoneId
-      symlinksRemoved: number
+      symlinksRemoved: SymlinkCount
       cascadeAgents: AgentId[]
     }
   | {
       skillName: SkillName
       outcome: 'orphan-cleared'
-      symlinksRemoved: number
+      symlinksRemoved: SymlinkCount
       cascadeAgents: AgentId[]
     }
   | {
@@ -906,7 +972,7 @@ export type BulkDeleteItemResult =
       outcome: 'error'
       error: { message: string; code?: string }
       /** Unlinks committed to disk before the failing iteration threw, if any. */
-      symlinksRemoved?: number
+      symlinksRemoved?: SymlinkCount
       /** Agents whose links were removed before the throw, for partial-cleanup reporting. */
       cascadeAgents?: AgentId[]
     }
@@ -947,7 +1013,7 @@ export type ClearOrphanSymlinkItemResult =
   | {
       skillName: SkillName
       outcome: 'orphan-cleared'
-      symlinksRemoved: number
+      symlinksRemoved: SymlinkCount
       cascadeAgents: AgentId[]
     }
   | {
@@ -955,7 +1021,7 @@ export type ClearOrphanSymlinkItemResult =
       outcome: 'error'
       error: { message: string; code?: string }
       /** Unlinks committed to disk before the failing iteration threw, if any. */
-      symlinksRemoved?: number
+      symlinksRemoved?: SymlinkCount
       /** Agents whose links were removed before the throw, for partial-cleanup reporting. */
       cascadeAgents?: AgentId[]
     }
@@ -1068,7 +1134,11 @@ export interface RestoreDeletedSkillOptions {
  * @example { outcome: 'error', error: { message: 'Trash entry missing' } }
  */
 export type RestoreDeletedSkillResult =
-  | { outcome: 'restored'; symlinksRestored: number; symlinksSkipped: number }
+  | {
+      outcome: 'restored'
+      symlinksRestored: SymlinkCount
+      symlinksSkipped: SymlinkCount
+    }
   | { outcome: 'error'; error: { message: string; code?: string } }
 
 /**
@@ -1095,7 +1165,7 @@ export interface CreateSymlinksResult {
   /** true if every requested agent now has a valid symlink. */
   success: boolean
   /** Number of agents for which a symlink was newly created. @example 2 */
-  created: number
+  created: SymlinkCount
   /** Per-agent failure list (empty on full success). */
   failures: Array<{ agentId: AgentId; error: string }>
 }
@@ -1125,7 +1195,7 @@ export interface CopyToAgentsResult {
   /** true if every target agent received a copy. */
   success: boolean
   /** Number of agents successfully copied to. @example 2 */
-  copied: number
+  copied: AgentCount
   /** Per-agent failure list (empty on full success). */
   failures: Array<{ agentId: AgentId; error: string }>
 }
@@ -1173,9 +1243,9 @@ export interface SyncPreviewOptions {
  */
 export interface SyncPreviewResult {
   /** Number of source skills considered. @example 5 */
-  totalSkills: number
+  totalSkills: SkillCount
   /** Number of agents considered (1 when scoped to one agent). @example 3 */
-  totalAgents: number
+  totalAgents: AgentCount
   /** Symlinks that would be created on execute (excludes conflicts). @example 10 */
   toCreate: SymlinkCount
   /** Symlinks already in place — nothing to do for these. @example 5 */


### PR DESCRIPTION
## Summary
- Extract shared domain aliases for counts, byte sizes, progress, file metadata, dashboard grid cells, and settings patches.
- Thread `SettingsPatch` through IPC/preload/main/renderer without changing the runtime Zod schema or persisted shape.
- Brand `SymlinkCleanupItemId` at factory boundaries and preserve branded IDs through cleanup retry/error filtering.
- Keep single-use helper aliases local to avoid generic alias soup.

## Verification
- pnpm typecheck
- pnpm lint
- pnpm exec vitest run src/renderer/src/components/dashboard/utils/buildSymlinkCleanupPlan.test.ts src/main/ipc/ipc-schemas.test.ts src/main/services/settings.test.ts
- pnpm validate

## Review Notes
- Subagent cross-review found one row-error edge case; fixed by preserving visible row errors by key presence rather than message truthiness.
- Runtime behavior, IPC wire shape, Redux persisted shape, and filesystem behavior are intended to remain unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 共有型の大幅整理：数値/ファイル単位の型別名追加、ダッシュボード座標型導入、各種ペイロードの型強化。設定パッチ用の公開型（SettingsPatch）を追加し書き込み契約を統一。
* **Bug Fixes**
  * ウィジェット一覧のプレビュー/フォーカス挙動を簡素化。
  * シンボリックリンククリーンアップ画面で壊れた行表示とエラー絞り込みを改善し視認性向上。
* **Tests**
  * クリーンアップ行IDの安定性を検証するテストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->