### PR TITLE
chore: remove stale comments

### DIFF
--- a/e2e/helpers/redux.ts
+++ b/e2e/helpers/redux.ts
@@ -3,11 +3,8 @@ import type { Page } from '@playwright/test'
 /**
  * Action type that the `skillsSlice` `fetchAll` thunk dispatches on success.
  *
- * This is duplicated from `src/renderer/src/store/skillsSlice.ts` because
- * `helpers/*` runs in the Playwright Node context — it cannot import the
- * renderer bundle. Keeping the literal in one place (here) gives `grep`-able
- * coupling: if the slice ever renames the thunk, the only spot a stale
- * literal lingers is this constant.
+ * Kept in the Playwright helper because `helpers/*` runs in Node and cannot
+ * import the renderer bundle; one literal keeps thunk renames grep-able.
  *
  * @see refreshSkillsState for the consumer.
  */
@@ -83,7 +80,7 @@ export async function getStoreState<T, A = undefined>(
 
 /**
  * Read the refreshed symlink status for `skillName` against `agentId` directly
- * from the renderer store. Used by Phase-2 specs after `refreshSkillsState` to
+ * from the renderer store. Used by IPC specs after `refreshSkillsState` to
  * confirm an IPC-driven mutation (copy / unlink) propagated correctly.
  *
  * Returns `undefined` when the skill is not present in the store OR the agent

--- a/e2e/spec/bulk-delete.e2e.ts
+++ b/e2e/spec/bulk-delete.e2e.ts
@@ -109,10 +109,10 @@ function deleteItemsFor(isolatedHome: string, skillNames: string[]) {
 }
 
 /**
- * Phase-2 spec covering the `BULK_PROGRESS_THRESHOLD` boundary in
+ * Spec covering the `BULK_PROGRESS_THRESHOLD` boundary in
  * `SKILLS_DELETE_BATCH`. The handler emits one `skills:deleteProgress` event
  * per item ONLY when the batch size meets or exceeds the threshold (10) —
- * smaller batches skip the event to avoid toast churn (see skills.ts:269).
+ * smaller batches skip the event to avoid toast churn.
  *
  * Two tests, both pre-staging dummy source-backed skills procedurally so the
  * tests don't depend on the global-setup skill catalog. Each test runs in a

--- a/e2e/spec/copy.e2e.ts
+++ b/e2e/spec/copy.e2e.ts
@@ -48,7 +48,7 @@ interface RootState {
 const AZURE_AI_NAME = 'azure-ai'
 
 /**
- * First Phase-2 spec — covers the `SKILLS_COPY_TO_AGENTS` IPC end-to-end.
+ * Covers the `SKILLS_COPY_TO_AGENTS` IPC end-to-end.
  *
  * Drives the IPC directly (`window.electron.skills.copyToAgents`) instead of
  * walking the AddSymlinkModal because the modal interaction is already covered
@@ -553,8 +553,7 @@ test('the Copy to Agents modal copies a skill to the agent whose checkbox is tic
     timeout: 5_000,
   })
 
-  // Tick the target agent's checkbox. aria-label is the agent's display
-  // name (see CopyToAgentsModal.tsx:165 — `<Checkbox aria-label={agent.name} />`).
+  // Tick the target agent's checkbox. aria-label is the agent's display name.
   await appWindow
     .getByRole('checkbox', { name: modalSelection.targetAgentName })
     .check()

--- a/e2e/spec/delete.e2e.ts
+++ b/e2e/spec/delete.e2e.ts
@@ -156,7 +156,7 @@ const azureSnapshotSelector = (state: unknown): AzureSnapshot => {
 }
 
 /**
- * Phase-2 spec covering `SKILLS_DELETE` + `SKILLS_RESTORE_DELETED` end-to-end.
+ * Spec covering `SKILLS_DELETE` + `SKILLS_RESTORE_DELETED` end-to-end.
  *
  * Two tests, both using the source-backed flow (azure-ai is installed by
  * global-setup with a real source dir under `~/.agents/skills/` and at least
@@ -371,9 +371,8 @@ interface LocalOnlyManifest {
 
 /**
  * Local-only delete branch — exercises the second arm of `moveToTrash`'s
- * dispatcher in `trashService.ts:265-273`. Source dir at
- * `~/.agents/skills/<name>` is intentionally absent; the skill exists ONLY
- * as a real folder under one or more agent dirs. The handler must:
+ * dispatcher. Source dir at `~/.agents/skills/<name>` is intentionally absent;
+ * the skill exists ONLY as a real folder under one or more agent dirs. The handler must:
  *
  *   1. Probe `~/.agents/skills/<name>` → ENOENT, NOT throw.
  *   2. `scanLocalCopies(skillName)` finds the real folder(s).
@@ -383,7 +382,7 @@ interface LocalOnlyManifest {
  * Codex is chosen over claude/cursor because the QA Safety contract in
  * CLAUDE.md flags those two as the user's live working sets — even though
  * this test runs under an isolated tempdir HOME, picking codex keeps the
- * pattern consistent with the spirit of the rule for any human reviewer.
+ * pattern consistent with the spirit of the rule for manual audit.
  *
  * The renderer-side scanSkills surfaces local-only skills with `isLocal: true`
  * symlink rows, so a post-delete `state.skills.items` lookup is the canonical
@@ -423,8 +422,7 @@ test('deleting a skill that lives only inside an agent folder trashes it as a lo
   // Assert — codex folder moved to trash under local-copies/ with a
   // kind="local-only" manifest (no source/ subdir).
   expect(ipcResult.success).toBe(true)
-  // The local-only return reuses `symlinksRemoved` to mean "agent folders
-  // moved" — see trashService.ts:660-664. One agent staged, so 1.
+  // The local-only return reuses `symlinksRemoved` to mean "agent folders moved".
   expect(ipcResult.symlinksRemoved).toBe(1)
   expect(ipcResult.cascadeAgents).toEqual(['codex'])
 
@@ -566,8 +564,7 @@ test('cleaning up a broken orphan symlink removes the dangling link without crea
 
 /**
  * Undo-window TTL eviction — `moveToTrash` schedules `setTimeout(evict,
- * UNDO_WINDOW_MS)` after staging the entry (see `trashService.ts:484-487` for
- * source-backed and `:648-651` for local-only). After the timer fires:
+ * UNDO_WINDOW_MS)` after staging the entry. After the timer fires:
  *
  *   1. The entry dir is removed from `.trash/`.
  *   2. The internal `evictTimers` map drops the id (idempotent next call).

--- a/e2e/spec/folder-actions.e2e.ts
+++ b/e2e/spec/folder-actions.e2e.ts
@@ -80,10 +80,8 @@ test('right-clicking an agent shows the safe folder actions above the destructiv
 
   // Assert — all four items are visible and the safe folder actions sit above
   // Cleanup/Delete on the y-axis.
-  // Folder actions render above Cleanup/Delete by design (see AgentItem.tsx
-  // comment on line 158-159) — keyboard nav (Down then Enter) lands on a
-  // safe action first. Asserting both the new and existing items pins the
-  // ordering contract.
+  // Folder actions render above Cleanup/Delete by design: keyboard nav
+  // (Down then Enter) lands on a safe action first.
   const reveal = appWindow.getByRole('menuitem', { name: 'Reveal in Finder' })
   const openTerm = appWindow.getByRole('menuitem', { name: 'Open in Terminal' })
   const cleanup = appWindow.getByRole('menuitem', {
@@ -154,11 +152,10 @@ test('Settings → Preferred terminal picker lists all 8 IDs and reveals custom 
 
   // Act — choose the 'custom' option.
   // The custom-name <input> is rendered conditionally on
-  // `settings.preferredTerminal === 'custom'` (General.tsx:163). The
-  // load-bearing assertion is that selecting 'custom' makes the input
-  // visible — we don't assert the pre-state because settings.json may be
-  // persisted into the snapshot HOME from a prior dev session, which
-  // would make a "starts hidden" precondition flaky.
+  // `settings.preferredTerminal === 'custom'`. The load-bearing assertion is
+  // that selecting 'custom' makes the input visible — we don't assert the
+  // pre-state because settings.json may be persisted into the snapshot HOME
+  // from a prior dev session.
   await picker.selectOption('custom')
 
   // Assert — the custom terminal name input becomes visible.

--- a/e2e/spec/hide-agents.e2e.ts
+++ b/e2e/spec/hide-agents.e2e.ts
@@ -9,7 +9,7 @@ import { getStoreState, waitForInitialScan } from '../helpers/redux'
 import { readSettingsFile, writeSettingsFile } from '../helpers/settings-file'
 
 /**
- * PR #144 — Hide unused agents from the sidebar.
+ * Hide unused agents from the sidebar.
  *
  * Coverage strategy: the feature crosses three boundaries that each fail
  * differently, so each gets its own test rather than a single flow that
@@ -68,8 +68,7 @@ test('toggling Cursor in Settings → Agents hides it from the sidebar and persi
   // Arrange — pre-stage `~/.cursor/skills` so Cursor reports `exists: true`
   // in the agent scan. Without this, all 21 agents land in the "21 not
   // installed" disclosure and the "Show Cursor in sidebar" checkbox renders
-  // disabled. Same recipe as folder-actions.e2e.ts:65 for the AgentItem
-  // context-menu test.
+  // disabled.
   mkdirSync(join(isolatedHome, '.cursor', 'skills'), { recursive: true })
 
   await waitForInitialScan(appWindow)
@@ -115,7 +114,6 @@ test('toggling Cursor in Settings → Agents hides it from the sidebar and persi
   // Open Settings — spawns a second BrowserWindow. Capture the window
   // event BEFORE clicking; Electron fires it synchronously when the new
   // webContents is created and racing it surfaces as a flaky timeout.
-  // Pattern mirrors folder-actions.e2e.ts:122.
   const settingsWindowPromise = electronApp.waitForEvent('window')
   await appWindow.getByLabel('Open settings').click()
   const settingsWindow = await settingsWindowPromise

--- a/e2e/spec/regression.e2e.ts
+++ b/e2e/spec/regression.e2e.ts
@@ -93,7 +93,7 @@ function filesystemIdentityForPath(path: string): E2EFilesystemIdentity {
 }
 
 /**
- * Phase-2 final spec — three regressions, each guarding a separate fix that
+ * Three regressions, each guarding a separate fix that
  * shipped in the recent release window:
  *
  * 1. Selection clear on tab/agent switch (commit 2f05684) — `redux/listener.ts`
@@ -164,8 +164,8 @@ test('selection survives no further than a tab switch or agent switch (regressio
 })
 
 /**
- * Phase-4 D1 (issue #114) — selection clears when `fetchSyncPreview.pending`
- * fires. This is the THIRD leg of the listener matcher in `redux/listener.ts:79`
+ * Selection clears when `fetchSyncPreview.pending`
+ * fires. This is the THIRD leg of the listener matcher
  * (`isAnyOf(setActiveTab, selectAgent, fetchSyncPreview.pending)`); the test
  * above pins the first two legs but the thunk leg has been silently uncovered.
  *
@@ -391,7 +391,7 @@ test('refuses to delete every skill from a directory shared by multiple agents (
 })
 
 /**
- * Phase-4 B1 (issue #114) — IRON RULE refusal preserves BOTH symlink aliases
+ * IRON RULE refusal preserves BOTH symlink aliases
  * and legitimate per-agent local skills inside a shared scanDir.
  *
  * The previous test verifies the refusal copy + the trivial sentinel survives.
@@ -469,7 +469,7 @@ test('refuses to delete a shared directory and leaves both aliased symlinks and 
 })
 
 /**
- * Phase-4 B2 (issue #114) — IRON RULE refusal must trigger even when
+ * IRON RULE refusal must trigger even when
  * SOURCE_DIR itself is a symlink (macOS firmlink edge).
  *
  * On macOS, paths like `/var → /private/var` are firmlinks: a path can be
@@ -763,9 +763,8 @@ test('broken symlinks show up as orphan skill rows in the list (regression #127)
  * truncation entirely, inflating the wrapper to ~325px and bleeding the long
  * path into the center panel.
  *
- * The fix is the `[&>div]:!block` modifier on `ScrollAreaPrimitive.Viewport`
- * in `src/renderer/src/components/ui/scroll-area.tsx:39`, which forces Radix's
- * inline `display: table` to `block`. The `!important` is required because
+ * The fix is the viewport child `block!` modifier, which forces Radix's inline
+ * `display: table` to `block`. The `!important` is required because
  * Radix sets `display` via inline style — class rules don't outrank inline
  * styles without it. With `display: block`, the wrapper takes exactly the
  * viewport width and `truncate` can clip again.
@@ -867,11 +866,9 @@ test('sidebar inner ScrollArea wrapper does not inflate beyond aside width (regr
  * v0.16.0 — Skills list scroll position survives a background refetch
  * (regression 5619bb7).
  *
- * Pre-fix `SkillsList.tsx:93` was `if (loading) return <Loading />`. ANY
- * refetch (post-sync, manual refresh, post-mutation) flipped
- * `state.skills.loading` to `true` and unmounted the entire react-window
- * `<List>` until the next `fulfilled`. Mid-scroll users saw the list reset
- * to the top, losing their position and any in-progress reading.
+ * Pre-fix behavior returned a full loading state for every refetch, unmounting
+ * the react-window `<List>` until the next `fulfilled`. Mid-scroll users saw
+ * the list reset to the top, losing their position and any in-progress reading.
  *
  * Post-fix the guard became `if (loading && skills.length === 0)` — the
  * Loading state only renders on the FIRST fetch (when `items` is still
@@ -896,8 +893,8 @@ test('sidebar inner ScrollArea wrapper does not inflate beyond aside width (regr
  *
  * Why a single test rather than two (UI-driven vs synthetic)? UI-driven
  * coverage of the same code path is part of the sync test suite (T4); this
- * regression test isolates the guard at SkillsList.tsx:93 specifically, so a
- * UI flow would only add brittleness (button visibility / disabled state)
+ * regression test isolates the loading-with-existing-items guard specifically,
+ * so a UI flow would only add brittleness (button visibility / disabled state)
  * without strengthening the assertion against this guard.
  */
 test('skills list scroll position survives a background refetch (regression 5619bb7)', async ({
@@ -919,9 +916,9 @@ test('skills list scroll position survives a background refetch (regression 5619
   ).toBeGreaterThan(0)
 
   // Resolve the scrollable container. The wrapper around `<SkillsList />` is
-  // `<div class="flex-1 min-h-0 overflow-auto p-4">` (MainContent.tsx:598)
-  // and react-window v2 may add its own inner scroll container. Find the
-  // first descendant inside the active TabsContent panel whose
+  // `<div class="flex-1 min-h-0 overflow-auto p-4">`, and react-window v2
+  // may add its own inner scroll container. Find the first descendant inside
+  // the active TabsContent panel whose
   // `scrollHeight > clientHeight` — that's the ACTUAL scroller regardless of
   // which layer wins. Returning a unique data-attr-tag on the resolved
   // element lets us read it back deterministically after the dispatch
@@ -999,7 +996,7 @@ test('skills list scroll position survives a background refetch (regression 5619
     scrollTopAfter,
     'data-e2e-scroll-target attribute lost — the element was removed from the DOM. ' +
       'SkillsList remounted instead of staying mounted with stale data. ' +
-      'Check the `loading && skills.length === 0` guard at SkillsList.tsx:93.',
+      'Check the `loading && skills.length === 0` guard.',
   ).not.toBeNull()
   if (scrollTopAfter === null) return
   expect(

--- a/e2e/spec/smoke.e2e.ts
+++ b/e2e/spec/smoke.e2e.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '../fixtures/electron-app'
 
 /**
- * Phase-1 smoke test. Confirms:
+ * Smoke test. Confirms:
  *   1. The production build at `out/main/index.mjs` launches under Playwright
  *   2. The first window mounts and reaches DOMContentLoaded
  *   3. `window.__store__` and `window.__ipcEvents__` are exposed

--- a/e2e/spec/unlink-agent.e2e.ts
+++ b/e2e/spec/unlink-agent.e2e.ts
@@ -155,7 +155,7 @@ function expectPathMissing(path: string): void {
 }
 
 /**
- * Phase-2 spec covering the three unlink-style IPCs that operate on agent-side
+ * Spec covering the three unlink-style IPCs that operate on agent-side
  * link paths without writing to trash:
  *   - `SKILLS_UNLINK_FROM_AGENT`        (single)
  *   - `SKILLS_UNLINK_MANY_FROM_AGENT`   (batch)
@@ -291,8 +291,8 @@ test('unlinking one agent removes only that agent link and leaves the source ski
 })
 
 /**
- * Phase-4 A1 (issue #114) — negative paths for the single unlink IPC. The
- * handler dispatches on `lstat` kind via ts-pattern (skills.ts:130-145):
+ * Negative paths for the single unlink IPC. The
+ * handler dispatches on `lstat` kind via ts-pattern:
  *
  *   - symlink                    → fs.unlink, success: true
  *   - directory (local skill)    → confirmed shell.trashItem, success: true
@@ -496,12 +496,11 @@ test('batch-unlinking removes the reviewed link slot, not a decoy whose name mat
 })
 
 /**
- * Phase-4 A2 (issue #114) — partial failure aggregation for the batch unlink.
+ * Partial failure aggregation for the batch unlink.
  *
- * The serial loop in `SKILLS_UNLINK_MANY_FROM_AGENT` (skills.ts:341-354) calls
- * `removeFromAgent` per item and pushes either an `'unlinked'` row or an
- * `'error'` row with the structured `{ message, code? }` shape. The contract
- * we're locking in:
+ * The serial loop in `SKILLS_UNLINK_MANY_FROM_AGENT` processes each reviewed
+ * path and pushes either an `'unlinked'` row or an `'error'` row with the
+ * structured `{ message, code? }` shape. The contract we're locking in:
  *
  *   1. Per-item failures DO NOT short-circuit the loop. The 4 healthy items
  *      still unlink even though index 2 is poisoned.
@@ -510,10 +509,8 @@ test('batch-unlinking removes the reviewed link slot, not a decoy whose name mat
  *      its toast/state per skill.
  *   3. The "directory at link path" branch refuses with a meaningful copy
  *      ("Cannot unlink a local skill...") rather than rm-rfing the dir.
- *      Single-unlink rm-rfs (skills.ts:138-141) but the BATCH path is
- *      explicitly non-destructive (skills.ts:85-89). A regression that
- *      copy-pasted the single-unlink dispatch into the batch loop would
- *      silently destroy local skills mid-batch.
+ *      A regression that copy-pasted the single-unlink dispatch into the
+ *      batch loop would silently destroy local skills mid-batch.
  *
  * Index 2 (middle) is poisoned so a regression that aborts the loop on first
  * failure leaves indexes 3-4 unprocessed and the test fails with a clear
@@ -673,7 +670,7 @@ test('removing all links from an agent is refused when its folder is a symlink a
 })
 
 /**
- * Phase-4 C1 + C2 (issue #114) — happy path for `removeAllFromAgent`.
+ * Happy path for `removeAllFromAgent`.
  *
  * The two refusal tests above (`unlink-agent.e2e.ts` Test 3, `regression.e2e.ts`
  * B1/B2) pin every IRON RULE branch, but they all short-circuit BEFORE any
@@ -684,10 +681,9 @@ test('removing all links from an agent is refused when its folder is a symlink a
  *
  * `delete.e2e.ts` and `bulk-delete.e2e.ts` test the IN-APP trash at
  * `<HOME>/.agents/.trash/` — that's `trashService.moveToTrash`, a different
- * code path. `removeAllFromAgent` calls `shell.trashItem` directly (skills.ts:209)
- * which routes to the OS Trash via NSWorkspace on macOS. The handler's contract
- * — "moves to OS trash so accidents can be restored from Finder" (skills.ts:208) —
- * is verifiable only by inspecting the user's actual `~/.Trash/`.
+ * code path. `removeAllFromAgent` calls `shell.trashItem` directly, which routes
+ * to the OS Trash via NSWorkspace on macOS. The handler's contract is verifiable
+ * only by inspecting the user's actual `~/.Trash/`.
  *
  * macOS `shell.trashItem` routing is uid-based (NSWorkspace), NOT HOME-env-based,
  * so the isolated HOME doesn't affect routing — the agent dir lands in the

--- a/scripts/generate-icons.js
+++ b/scripts/generate-icons.js
@@ -13,15 +13,12 @@ const OUTPUT_DIR = path.join(__dirname, '../resources')
 const ICONSET_DIR = path.join(OUTPUT_DIR, 'icon.iconset')
 
 async function generateIcons() {
-  // Create iconset directory
   if (!fs.existsSync(ICONSET_DIR)) {
     fs.mkdirSync(ICONSET_DIR, { recursive: true })
   }
 
-  // Read SVG
   const svgBuffer = fs.readFileSync(SVG_PATH)
 
-  // Generate PNGs for iconset
   for (const size of SIZES) {
     const filename =
       size === 1024 ? `icon_512x512@2x.png` : `icon_${size}x${size}.png`
@@ -42,7 +39,6 @@ async function generateIcons() {
     console.log(`Generated ${filename}`)
   }
 
-  // Also create main icon.png
   await sharp(svgBuffer)
     .resize(1024, 1024)
     .png()
@@ -59,7 +55,6 @@ async function generateIcons() {
     console.error('Failed to generate icns (requires macOS):', err.message)
   }
 
-  // Clean up iconset directory
   fs.rmSync(ICONSET_DIR, { recursive: true })
   console.log('Cleaned up iconset directory')
 }

--- a/src/main/ipc/ipc-schemas.ts
+++ b/src/main/ipc/ipc-schemas.ts
@@ -63,7 +63,7 @@ const skillNameString = z
  * Tombstone id format: `<unix_ms>-<skillName>-<rand8hex>`.
  * Regex blocks path separators in both skillName and rand8 segments so a
  * crafted id cannot escape `TRASH_DIR` when joined.
- * The trailing 8-hex group prevents same-ms entry collisions (reviewer iter-2 HIGH-4).
+ * The trailing 8-hex group prevents same-ms entry collisions.
  * @example "1729180800000-theme-generator-a1b2c3d4"
  */
 export const tombstoneIdSchema = z

--- a/src/main/ipc/skills.copyToAgents.integration.test.ts
+++ b/src/main/ipc/skills.copyToAgents.integration.test.ts
@@ -9,6 +9,7 @@ import {
   symlink,
   writeFile,
 } from 'node:fs/promises'
+import type * as NodeFs from 'node:fs/promises'
 import type * as NodeOs from 'node:os'
 import { tmpdir } from 'node:os'
 import { join, relative } from 'node:path'
@@ -66,6 +67,7 @@ describe('skills:copyToAgents handler', () => {
   afterEach(async () => {
     vi.doUnmock('os')
     vi.doUnmock('node:os')
+    vi.doUnmock('node:fs/promises')
     await rm(tempHome, { recursive: true, force: true })
   })
 
@@ -210,5 +212,55 @@ describe('skills:copyToAgents handler', () => {
     await expect(readlink(copiedLinkPath)).resolves.toBe(
       await realpath(targetPath),
     )
+  })
+
+  it('reports destination inspection errors without copying to that agent', async () => {
+    // Arrange
+    const skillName = 'task'
+    const sourcePath = join(tempHome, '.agents', 'skills', skillName)
+    const blockedDestPath = join(tempHome, '.cursor', 'skills', skillName)
+    await mkdir(sourcePath, { recursive: true })
+    await writeFile(join(sourcePath, 'SKILL.md'), '# Task\n')
+    vi.doMock('node:fs/promises', async () => {
+      const actual = await vi.importActual<typeof NodeFs>('node:fs/promises')
+      return {
+        ...actual,
+        lstat: async (path: string) => {
+          if (path === blockedDestPath) {
+            throw Object.assign(new Error('permission denied'), {
+              code: 'EACCES',
+            })
+          }
+          return actual.lstat(path)
+        },
+      }
+    })
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+    const copyToAgentsHandler = getRegisteredHandler('skills:copyToAgents')
+
+    // Act
+    const result = (await copyToAgentsHandler(
+      {},
+      {
+        skillName,
+        sourcePath,
+        targetAgentIds: ['cursor'],
+      },
+    )) as {
+      success: boolean
+      copied: number
+      failures: unknown[]
+    }
+
+    // Assert
+    expect(result).toEqual({
+      success: false,
+      copied: 0,
+      failures: [{ agentId: 'cursor', error: 'permission denied' }],
+    })
+    await expect(lstat(blockedDestPath)).rejects.toMatchObject({
+      code: 'ENOENT',
+    })
   })
 })

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -788,7 +788,6 @@ export function registerSkillsHandlers(): void {
         }
       }
 
-      // Count entries before deletion for reporting
       let removedCount = 0
       try {
         const entries = await fs.readdir(derivedAgentPath)
@@ -855,9 +854,8 @@ export function registerSkillsHandlers(): void {
   })
 
   /**
-   * Batch delete N skills. Runs serially (for...of await) per reviewer #21 so
-   * that per-item tombstone creation, agent symlink walks, and manifest writes
-   * don't race each other on the same filesystem.
+   * Batch delete N skills. Runs serially (for...of await) so per-item tombstone
+   * creation, agent symlink walks, and manifest writes don't race each other.
    *
    * Progress: emits \`skills:deleteProgress\` after each item when N >= 10 so the
    * SelectionToolbar can show "Deleting 3 of 12". Smaller batches skip the
@@ -1056,7 +1054,6 @@ export function registerSkillsHandlers(): void {
       }
 
       try {
-        // Ensure agent skills directory exists
         await fs.mkdir(agent.path, { recursive: true })
 
         // Atomic: attempt symlink directly, handle EEXIST
@@ -1161,7 +1158,6 @@ export function registerSkillsHandlers(): void {
       const destPath = join(agent.path, skillName)
 
       try {
-        // Ensure agent skills directory exists
         await fs.mkdir(agent.path, { recursive: true })
 
         // Check if something already exists at the destination
@@ -1169,9 +1165,7 @@ export function registerSkillsHandlers(): void {
           await fs.lstat(destPath)
           failures.push({ agentId, error: 'Already exists' })
           continue
-        } catch {
-          // Nothing exists, proceed
-        }
+        } catch {}
 
         if (isSymlink) {
           await fs.symlink(symlinkTarget, destPath)

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -1165,7 +1165,18 @@ export function registerSkillsHandlers(): void {
           await fs.lstat(destPath)
           failures.push({ agentId, error: 'Already exists' })
           continue
-        } catch {}
+        } catch (error) {
+          if (errorCode(error) !== 'ENOENT') {
+            failures.push({
+              agentId,
+              error: extractErrorMessage(
+                error,
+                'Cannot verify destination path',
+              ),
+            })
+            continue
+          }
+        }
 
         if (isSymlink) {
           await fs.symlink(symlinkTarget, destPath)

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -168,7 +168,7 @@ type DeleteIdentity =
 
 /**
  * Build a unique trash entry name from skillName + current clock + random suffix.
- * `rand8hex` prevents same-ms collisions on fast machines (reviewer iter-2 HIGH-4).
+ * `rand8hex` prevents same-ms collisions on fast machines.
  * @param skillName - Validated skill name (no path separators)
  * @returns Entry basename safe to use under TRASH_DIR
  * @example buildEntryName('theme-generator') // '1729180800000-theme-generator-a1b2c3d4'
@@ -1081,8 +1081,6 @@ async function removeSourceBackedAgentSymlinks(
 /**
  * Source-backed path of `moveToTrash`. Walks agent dirs, removes symlinks,
  * renames the source dir into the entry, writes a v2 source-backed manifest.
- * Same lifecycle as the original v0.13.x implementation, just gated on the
- * source-existed branch in the wrapper.
  */
 async function moveSourceBackedToTrash(
   skillName: SkillName,

--- a/src/main/utils/windowBackgroundBlur.ts
+++ b/src/main/utils/windowBackgroundBlur.ts
@@ -14,7 +14,6 @@ export const MAIN_WINDOW_OPAQUE_BACKGROUND = 'rgb(10, 15, 28)'
 
 /**
  * Fully transparent BrowserWindow backplate used when real window opacity is on.
- * Corelive BrainDump uses the same clear backplate before applying setOpacity.
  */
 export const MAIN_WINDOW_TRANSPARENT_BACKGROUND = '#00000000'
 
@@ -40,7 +39,7 @@ export function shouldUseNativeWindowBlur(blurRadius: number): boolean {
 /**
  * Convert the blur slider into the real Electron window opacity.
  * @param blurRadius - Normalized or raw blur radius.
- * @returns Whole-window opacity from opaque to Corelive-style transparent.
+ * @returns Whole-window opacity from opaque to transparent.
  * @example
  * getMainWindowOpacity(48) // => 0.45
  */

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -53,7 +53,6 @@ contextBridge.exposeInMainWorld('electron', {
       typedInvoke('skills:createSymlinks', options),
     copyToAgents: async (options: CopyToAgentsOptions) =>
       typedInvoke('skills:copyToAgents', options),
-    // Bulk delete + undo (Section E of the bulk-delete plan).
     // deleteSkills runs serially in main; batches of >=10 emit progress events.
     deleteSkills: async (options: DeleteSkillsOptions) =>
       typedInvoke('skills:deleteSkills', options),
@@ -155,7 +154,7 @@ contextBridge.exposeInMainWorld('electron', {
 
 // E2E-only escape hatch from the typed `electron.*` IPC contract above.
 //
-// Why this lives outside the contract: Phase-2 specs need to assert on raw
+// Why this lives outside the contract: E2E specs need to assert on raw
 // IPC traffic (e.g. "SKILLS_DELETE_PROGRESS fired exactly 10 times for the
 // bulk-delete batch at the threshold"). Routing those assertions through the
 // typed surface would force every channel to ship an `events()` accessor in

--- a/src/renderer/settings/sections/About.tsx
+++ b/src/renderer/settings/sections/About.tsx
@@ -45,7 +45,7 @@ function statusLabel(status: CheckStatus): string {
 /**
  * About pane.
  *
- * Real surfaces (v0.15.0):
+ * Real surfaces:
  *  - App version from `__APP_VERSION__` (Vite define injecting
  *    `package.json#version`).
  *  - "Check for Updates" calls the existing `update:check` IPC and

--- a/src/renderer/settings/sections/Keybindings.tsx
+++ b/src/renderer/settings/sections/Keybindings.tsx
@@ -5,7 +5,7 @@ import { KEYBINDINGS } from '@/shared/constants'
 import { SectionFrame } from './SectionFrame'
 
 /**
- * Keybindings pane — read-only list for v0.15.0.
+ * Keybindings pane — read-only list.
  *
  * The list is sourced from the canonical `KEYBINDINGS` constant in
  * `src/shared/constants.ts` so adding or renaming a menu accelerator

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -119,12 +119,10 @@ const App = React.memo(function App(): React.ReactElement {
 
   return (
     <TooltipProvider delayDuration={200}>
-      {/* Window glow effect - subtle inner shadow for depth */}
       <div
         data-testid="window-background-surface"
         className="window-background-surface flex h-screen text-foreground window-glow transition-[background-color]"
-        // Match Corelive BrainDump: renderer paints a solid surface, while
-        // BrowserWindow.setOpacity controls real desktop transparency.
+        // Renderer paints a solid surface while BrowserWindow.setOpacity controls real desktop transparency.
         style={{ backgroundColor: 'var(--background)' }}
       >
         <Sidebar />

--- a/src/renderer/src/components/UpdateToast.tsx
+++ b/src/renderer/src/components/UpdateToast.tsx
@@ -111,7 +111,6 @@ export const UpdateToast = React.memo(
           'animate-in slide-in-from-bottom-4 fade-in duration-300',
         )}
       >
-        {/* Header */}
         <div className="flex items-center justify-between p-3 border-b border-border">
           <div className="flex items-center gap-2">
             {headerIcon}
@@ -129,7 +128,6 @@ export const UpdateToast = React.memo(
           </Button>
         </div>
 
-        {/* Content */}
         <div className="p-3">
           <p className="text-sm text-muted-foreground">{bodyText}</p>
 
@@ -149,7 +147,6 @@ export const UpdateToast = React.memo(
             </div>
           )}
 
-          {/* Actions */}
           <div className="flex items-center justify-end gap-2 mt-3">
             {actions}
           </div>

--- a/src/renderer/src/components/dashboard/utils/gridConstants.ts
+++ b/src/renderer/src/components/dashboard/utils/gridConstants.ts
@@ -11,9 +11,9 @@
  * body — not enough for stat tiles (icon+number+label ≈ 72px). Bumping to 64
  * gives h=2 ≈ 100px body, fitting the stat tiles with breathing room, and keeps
  * h=3/h=4 generous for lists and cards. The Symlink Health widget is the
- * exception that needs h=3, not h=2: PR #185 added a "Scan issues" action row
- * below its label/bar/legend stack, so its `minSize.h` is 3 (see
- * widgets/sizes.ts) and a v3 → v4 migration clamps persisted layouts up.
+ * exception that needs h=3, not h=2: its "Scan issues" action row sits below
+ * the label/bar/legend stack, so `minSize.h` is 3 (see widgets/sizes.ts) and a
+ * v3 → v4 migration clamps persisted layouts up.
  */
 export const GRID_COLS = 6
 export const GRID_ROW_HEIGHT_PX = 64

--- a/src/renderer/src/components/dashboard/widgets/ActivityTimelineWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/ActivityTimelineWidget.tsx
@@ -86,10 +86,9 @@ const TimelineRow = React.memo(function TimelineRow({
  *
  * Today this surface only has one data source: the last sync execution
  * (`uiSlice.syncResult.details`). A proper timeline would need main-process
- * event tracking for add/remove/sync/rename — see `docs/activity-log.md`
- * (TODO). For now the widget shows the most recent sync's per-item actions
- * so the ecosystem hook exists and the widget isn't empty when
- * `ENABLE_DASHBOARD_EXPERIMENTAL` is on.
+ * event tracking for add/remove/sync/rename. For now the widget shows the
+ * most recent sync's per-item actions so the ecosystem hook exists and the
+ * widget isn't empty when `ENABLE_DASHBOARD_EXPERIMENTAL` is on.
  */
 export const ActivityTimelineWidget = React.memo(
   function ActivityTimelineWidget(): React.ReactElement {

--- a/src/renderer/src/components/dashboard/widgets/HealthWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/HealthWidget.tsx
@@ -126,8 +126,6 @@ export const HealthWidget = React.memo(
 
     return (
       <div className="h-full w-full flex flex-col gap-2 px-4 py-3">
-        {/* Percentage is the hero metric; the card title ("Symlink Health") already
-            names the widget, so the inline "HEALTH" label was redundant and removed. */}
         <span className="text-2xl font-semibold tabular-nums text-foreground">
           {percentLabel === null ? '—' : percentLabel}
         </span>

--- a/src/renderer/src/components/marketplace/InstallModal.tsx
+++ b/src/renderer/src/components/marketplace/InstallModal.tsx
@@ -87,7 +87,6 @@ export const InstallModal = React.memo(
           </DialogHeader>
 
           <div className="py-4">
-            {/* Agent selection */}
             <div>
               <h4 className="text-sm font-medium mb-3">Select Agents</h4>
               <div className="max-h-60 overflow-y-auto rounded-md border p-2 space-y-1">
@@ -109,7 +108,6 @@ export const InstallModal = React.memo(
               )}
             </div>
 
-            {/* Progress indicator */}
             {isInstalling && installProgress && (
               <div className="mt-4 p-3 bg-primary/10 rounded-md">
                 <div className="flex items-center gap-2">

--- a/src/renderer/src/components/marketplace/LeaderboardSkeleton.tsx
+++ b/src/renderer/src/components/marketplace/LeaderboardSkeleton.tsx
@@ -13,9 +13,7 @@ export const LeaderboardSkeleton = React.memo(
             key={i}
             className="rounded-lg bg-card p-4 flex items-center gap-4 h-19"
           >
-            {/* Rank square */}
             <div className="h-8 w-8 rounded bg-muted animate-pulse shrink-0" />
-            {/* Name + repo */}
             <div className="flex-1 space-y-2">
               <div
                 className="h-4 bg-muted animate-pulse rounded"
@@ -26,9 +24,7 @@ export const LeaderboardSkeleton = React.memo(
                 style={{ width: '30%' }}
               />
             </div>
-            {/* Install count */}
             <div className="h-4 w-12 bg-muted animate-pulse rounded shrink-0" />
-            {/* Button placeholder */}
             <div className="h-8 w-20 bg-muted animate-pulse rounded shrink-0" />
           </div>
         ))}

--- a/src/renderer/src/components/marketplace/MarketplaceDashboard.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceDashboard.tsx
@@ -38,7 +38,6 @@ export const MarketplaceDashboard = React.memo(
       <div className="flex-1 flex flex-col p-6 gap-6 overflow-auto">
         <h2 className="text-xl font-bold text-foreground">Marketplace</h2>
 
-        {/* Stats cards */}
         <div className="flex gap-4">
           <div className="flex-1 rounded-lg bg-muted border border-border p-4 flex flex-col gap-2">
             <span className="text-xs font-medium text-muted-foreground">
@@ -58,7 +57,6 @@ export const MarketplaceDashboard = React.memo(
           </div>
         </div>
 
-        {/* Trending section */}
         <div className="flex items-center gap-2">
           <TrendingUp className="h-4 w-4 text-primary" />
           <h3 className="text-base font-semibold text-foreground">Trending</h3>
@@ -104,7 +102,6 @@ export const MarketplaceDashboard = React.memo(
           </div>
         )}
 
-        {/* Browse prompt */}
         <div className="flex items-center justify-center py-4">
           <p className="text-[13px] text-muted-foreground flex items-center gap-1.5">
             <Star className="h-3.5 w-3.5" />

--- a/src/renderer/src/components/marketplace/MarketplaceSkillPreview.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceSkillPreview.tsx
@@ -85,7 +85,6 @@ export const MarketplaceSkillPreview = React.memo(
 
     return (
       <div className="flex-1 flex flex-col overflow-hidden">
-        {/* Back bar */}
         <div className="flex items-center justify-between px-3 py-2 shrink-0">
           <button
             type="button"
@@ -100,10 +99,8 @@ export const MarketplaceSkillPreview = React.memo(
           </span>
         </div>
 
-        {/* Separator */}
         <div className="h-px bg-border shrink-0" />
 
-        {/* Webview area */}
         <div className="flex-1 relative min-h-0">
           {isLoading && <WebviewSkeleton />}
           <webview
@@ -115,7 +112,6 @@ export const MarketplaceSkillPreview = React.memo(
           />
         </div>
 
-        {/* URL bar */}
         <div className="px-3 py-1.5 bg-background border-t border-border shrink-0">
           <span className="text-[11px] text-muted-foreground font-mono">
             {skill.url}
@@ -134,25 +130,19 @@ const WebviewSkeleton = React.memo(
   function WebviewSkeleton(): React.ReactElement {
     return (
       <div className="absolute inset-0 p-8 flex flex-col gap-5 bg-background">
-        {/* Title */}
         <div className="h-7 w-48 bg-muted animate-pulse rounded" />
-        {/* Subtitle */}
         <div className="h-4 w-36 bg-muted animate-pulse rounded" />
-        {/* Description lines */}
         <div className="flex flex-col gap-2">
           <div className="h-4 w-full bg-muted animate-pulse rounded" />
           <div className="h-4 w-4/5 bg-muted animate-pulse rounded" />
           <div className="h-4 w-3/5 bg-muted animate-pulse rounded" />
         </div>
-        {/* Stats row */}
         <div className="flex gap-6 pt-2">
           <div className="h-10 w-16 bg-muted animate-pulse rounded" />
           <div className="h-10 w-16 bg-muted animate-pulse rounded" />
           <div className="h-10 w-16 bg-muted animate-pulse rounded" />
         </div>
-        {/* Separator */}
         <div className="h-px bg-border" />
-        {/* README placeholder */}
         <div className="h-4 w-24 bg-muted animate-pulse rounded" />
         <div className="flex flex-col gap-2">
           <div className="h-4 w-full bg-muted animate-pulse rounded" />

--- a/src/renderer/src/components/marketplace/SkillRowMarketplace.tsx
+++ b/src/renderer/src/components/marketplace/SkillRowMarketplace.tsx
@@ -75,7 +75,6 @@ export const SkillRowMarketplace = React.memo(function SkillRowMarketplace({
         gridTemplateColumns: `minmax(0, 1fr) ${BOOKMARK_COLUMN_WIDTH_PX}px ${INSTALL_COUNT_COLUMN_WIDTH_PX}px ${ACTION_COLUMN_WIDTH_PX}px`,
       }}
     >
-      {/* Rank Badge + Skill Info — clickable preview area */}
       <button
         type="button"
         onClick={handleRowClick}
@@ -94,7 +93,6 @@ export const SkillRowMarketplace = React.memo(function SkillRowMarketplace({
         </div>
       </button>
 
-      {/* Bookmark Toggle */}
       <button
         type="button"
         aria-label={
@@ -115,7 +113,6 @@ export const SkillRowMarketplace = React.memo(function SkillRowMarketplace({
         />
       </button>
 
-      {/* Install Count */}
       <div className="flex items-center justify-end gap-1.5 text-muted-foreground shrink-0">
         <Download className="h-3.5 w-3.5 text-muted-foreground" />
         <span className="font-mono text-[13px] font-medium">
@@ -123,7 +120,6 @@ export const SkillRowMarketplace = React.memo(function SkillRowMarketplace({
         </span>
       </div>
 
-      {/* Action Button (or Installed badge) */}
       <div className="flex justify-end">
         {isInstalled ? (
           // Informational badge, intentionally non-interactive. Uninstall lives in

--- a/src/renderer/src/components/marketplace/SkillsMarketplace.tsx
+++ b/src/renderer/src/components/marketplace/SkillsMarketplace.tsx
@@ -80,16 +80,13 @@ export const SkillsMarketplace = React.memo(
       dispatch(loadLeaderboard(rankingFilter))
     }, [dispatch, rankingFilter])
 
-    /** Handle tab change: switch filter and load data */
     const handleFilterChange = useCallback((filter: RankingFilter): void => {
       setRankingFilter(filter)
     }, [])
 
     return (
       <div className="h-full flex flex-col">
-        {/* Header with Title and Search */}
         <div className="p-6 pb-4 space-y-4">
-          {/* Title */}
           <div>
             <h1 className="text-[28px] font-bold text-foreground">
               Skills Marketplace
@@ -99,42 +96,35 @@ export const SkillsMarketplace = React.memo(
             </p>
           </div>
 
-          {/* Ranking Tabs */}
           <RankingTabs
             value={rankingFilter}
             onChange={handleFilterChange}
             disabled={hasSearched}
           />
 
-          {/* Search */}
           <MarketplaceSearch />
         </div>
 
-        {/* Error display */}
         {error && (
           <div className="mx-6 mb-4 px-4 py-2 bg-destructive/10 border border-destructive/20 rounded-md">
             <p className="text-sm text-destructive">{error}</p>
           </div>
         )}
 
-        {/* Results area */}
         <div className="flex-1 overflow-y-auto px-6">
           <div
             className="pb-6 min-w-0"
             aria-busy={isLeaderboardLoading || isSearching}
             aria-live="polite"
           >
-            {/* === Search results (takes priority over leaderboard) === */}
             {hasSearched && (
               <>
-                {/* Loading state */}
                 {isSearching && (
                   <div className="flex items-center justify-center py-16">
                     <div className="text-muted-foreground">Searching...</div>
                   </div>
                 )}
 
-                {/* No results */}
                 {!isSearching && searchResults.length === 0 && (
                   <div className="flex flex-col items-center justify-center py-16 text-center">
                     <p className="text-muted-foreground">
@@ -146,7 +136,6 @@ export const SkillsMarketplace = React.memo(
                   </div>
                 )}
 
-                {/* Results list */}
                 {searchResults.length > 0 && (
                   <div className="flex flex-col gap-2">
                     <p className="text-sm text-muted-foreground mb-3">
@@ -167,13 +156,10 @@ export const SkillsMarketplace = React.memo(
               </>
             )}
 
-            {/* === Leaderboard (shown when no search is active) === */}
             {!hasSearched && (
               <>
-                {/* Skeleton loading */}
                 {isLeaderboardLoading && <LeaderboardSkeleton />}
 
-                {/* Network error with no cache */}
                 {isLeaderboardError && (
                   <div className="flex flex-col items-center justify-center py-16 text-center">
                     <WifiOff className="h-12 w-12 text-muted-foreground mb-4" />
@@ -186,10 +172,8 @@ export const SkillsMarketplace = React.memo(
                   </div>
                 )}
 
-                {/* Leaderboard data */}
                 {leaderboardSkills.length > 0 && (
                   <div className="flex flex-col gap-2">
-                    {/* Header: count + filter label (left) + updated timestamp (right) */}
                     <div className="flex items-center justify-between mb-3">
                       <p className="text-sm text-muted-foreground">
                         {leaderboardSkills.length} skill
@@ -213,7 +197,6 @@ export const SkillsMarketplace = React.memo(
                   </div>
                 )}
 
-                {/* Edge case: fetch succeeded but returned 0 skills */}
                 {!isLeaderboardLoading &&
                   !isLeaderboardError &&
                   leaderboardSkills.length === 0 &&
@@ -233,7 +216,6 @@ export const SkillsMarketplace = React.memo(
           </div>
         </div>
 
-        {/* Modals */}
         <InstallModal />
       </div>
     )

--- a/src/renderer/src/components/skills/SkillDetail.tsx
+++ b/src/renderer/src/components/skills/SkillDetail.tsx
@@ -68,7 +68,6 @@ export const SkillDetail = React.memo(function SkillDetail({
   return (
     // Fill DetailPanel's remaining height after its drag strip so tab scrollers are not clipped.
     <div className="flex min-h-0 flex-1 flex-col">
-      {/* Header with skill name */}
       <div className="p-4 border-b border-border">
         <h2 className="text-lg font-semibold truncate">{skill.name}</h2>
         {skill.description && (
@@ -78,7 +77,6 @@ export const SkillDetail = React.memo(function SkillDetail({
         )}
       </div>
 
-      {/* Tab buttons */}
       <div className="flex border-b border-border">
         <button
           type="button"

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -475,12 +475,6 @@ export const SkillItem = React.memo(function SkillItem({
     dispatch(selectSkill(isSelected ? null : skill))
   }, [dispatch, isSelected, skill])
 
-  // Partial-fail flash (local to the row). The parent (MainContent) decides
-  // which skills recently failed by subscribing to the thunk result and
-  // seeding a DOM-level data attribute or ref; for now, the flag is wired
-  // through a ref kept in sync with a sentinel attribute so Phase D (if any)
-  // can animate it without structural changes. Initialised off; the
-  // MainContent-level effect flips it on when a bulk op returns errors.
   const [didPartialFail, setDidPartialFail] = useState(false)
   const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   useUnmountEffect(() => {
@@ -534,12 +528,8 @@ export const SkillItem = React.memo(function SkillItem({
             !didPartialFail &&
               isInaccessibleSkill &&
               'border-l-2 border-l-amber-400/60',
-            // Orphan accent — surfaces dangling rows that the loosened
-            // selectFilteredSkills now lets through. Mutually exclusive with
-            // isLinked/isLocalSkill by definition (no source dir → no valid
-            // symlinks and no local copy could've kept it from being marked
-            // orphan), so the order below is purely for the partial-fail
-            // override.
+            // Orphan accent — mutually exclusive with linked/local rows by
+            // definition, so the order below is purely for the partial-fail override.
             !didPartialFail &&
               skill.isOrphan &&
               'border-l-2 border-l-amber-400/60',

--- a/src/renderer/src/components/skills/SkillsList.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillsList.browser.test.tsx
@@ -239,11 +239,10 @@ describe('SkillsList loading branch — scroll-preservation regression', () => {
   it('keeps the list mounted during background refetch (loading=true, items=[skill])', async () => {
     // Arrange
     // Background refetch after a mutation: Redux flips loading=true while
-    // items still contain the previous data. The fix at SkillsList.tsx:93
-    // (`if (loading && skills.length === 0)`) ensures the existing <List>
-    // stays mounted so react-window's internal scrollTop survives. If a
-    // future change reverts to `if (loading)` the list unmounts and the
-    // placeholder shows — this assertion catches that regression.
+    // items still contain the previous data. The `loading && skills.length === 0`
+    // guard ensures the existing <List> stays mounted so react-window's
+    // internal scrollTop survives. If a future change reverts to `if (loading)`
+    // the list unmounts and the placeholder shows — this assertion catches that regression.
     mockGetAll.mockReturnValue(new Promise(() => {}))
 
     // Act

--- a/src/renderer/src/components/skills/skillItemHelpers.test.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.test.ts
@@ -531,15 +531,7 @@ describe('getSkillItemVisibility', () => {
   })
 
   describe('orphan skill guard', () => {
-    // PR #131 (issue #71 PR-2) loosens the orphan gate on Delete and Unlink
-    // so users can sweep orphans surfaced by the new amber-border row UI.
-    // Add stays gated because there is no live source to point a new
-    // symlink at. The original #127 hide-everything stance is gone.
     it('shows global Delete for an orphan-only skill so the user can sweep the dangling row', () => {
-      // Source removed, broken symlinks across two agents, no real folders.
-      // Delete clears all dangling agent symlinks plus the now-empty source
-      // tombstone in one shot — the bulk version of the Cleanup-per-agent
-      // flow.
       // Arrange — orphan skill: broken symlinks on two agents, no live source.
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'broken', isLocal: false }),
@@ -582,9 +574,6 @@ describe('getSkillItemVisibility', () => {
     })
 
     it('keeps global Delete but still gates Add when a skill is explicitly marked orphan', () => {
-      // After the loosen, Delete is purely a global-view concern (`!selectedAgentId`).
-      // The explicit isOrphan override no longer suppresses it — the override
-      // only steers Add visibility now.
       // Arrange — valid symlink but the skill is force-flagged isOrphan: true.
       const symlinks = [
         makeSymlink({ agentId: 'cursor', status: 'valid', isLocal: false }),

--- a/src/renderer/src/components/skills/skillItemHelpers.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.ts
@@ -116,13 +116,10 @@ export function getSkillItemVisibility(
   return {
     // Delete is the primary cleanup action for orphans in global view —
     // sweeping the dangling row removes every agent-side symlink at once.
-    // Restored so users have an explicit way to act on what the loosened
-    // selectFilteredSkills now shows them.
     showDeleteButton: !selectedAgentId,
     // Orphan skills have no live source to symlink _to_, so the Add button
     // (which opens AddSymlinkModal / CopyToAgentsModal) would surface a flow
-    // that can only fail. Stays gated on `!isOrphan` even after the Delete
-    // and Unlink loosens.
+    // that can only fail.
     showAddButton:
       (!selectedAgentId || hasUsableSkillInSelectedAgent) &&
       !isOrphan &&

--- a/src/renderer/src/redux/migrations.test.ts
+++ b/src/renderer/src/redux/migrations.test.ts
@@ -501,8 +501,8 @@ describe('migrateState — v3 → v4 dashboard health min-size clamp', () => {
   }
 
   /**
-   * PR #185 added a "Scan issues" action row to the Symlink Health widget,
-   * which clipped against the card's bottom edge at the old h: 2. The fix grew
+   * The Symlink Health widget's "Scan issues" action row clipped against the
+   * card's bottom edge at the old h: 2. The fix grew
    * `WIDGET_REGISTRY['health'].minSize.h` to 3; this migration rewrites layouts
    * persisted on the old floor so react-grid-layout doesn't re-clamp (and shove
    * neighbors) on first render.

--- a/src/renderer/src/redux/migrations.ts
+++ b/src/renderer/src/redux/migrations.ts
@@ -42,9 +42,9 @@ export const V2_WIDGET_MIN_SIZES = {
 } as const satisfies Partial<Record<WidgetType, WidgetSize>>
 
 /**
- * v4 floor — the Symlink Health widget's `minSize.h` grew 2 → 3 (PR #185 added
- * a "Scan issues" action row that clipped against the card's bottom edge at
- * h=2). **Mirror** of `WIDGET_REGISTRY['health'].minSize`, kept here for the
+ * v4 floor — the Symlink Health widget's `minSize.h` grew 2 → 3 after its
+ * "Scan issues" action row clipped against the card's bottom edge at h=2.
+ * **Mirror** of `WIDGET_REGISTRY['health'].minSize`, kept here for the
  * same reason as {@link V2_WIDGET_MIN_SIZES} — this module must stay free of
  * the widget-component graph. Same contract: bump the registry, add the floor
  * here, AND ship a migration.
@@ -207,8 +207,8 @@ function migrateV2ToV3(state: MigratableState): void {
 
 /**
  * v3 → v4 migration for the dashboard slice. The Symlink Health widget's
- * `minSize.h` grew 2 → 3 so its "Scan issues" action row (added in PR #185)
- * stops clipping against the card's bottom edge. Layouts persisted at the old
+ * `minSize.h` grew 2 → 3 so its "Scan issues" action row stops clipping
+ * against the card's bottom edge. Layouts persisted at the old
  * `h: 2` are clamped up to the v4 floor; react-grid-layout's default vertical
  * compactor then reflows any widget the taller card now overlaps on first
  * render (and re-persists the result via `onLayoutChange`), so only the size

--- a/src/renderer/src/redux/selectors.test.ts
+++ b/src/renderer/src/redux/selectors.test.ts
@@ -286,8 +286,8 @@ describe('selectFilteredSkills', () => {
     // An orphan: source dir vanished, but cursor still has a dangling symlink
     // pointing at where the source used to live. The per-agent view must
     // surface this row so the right-click "Cleanup missing skills..." flow
-    // (PR #71) has something to act on. Hiding it would silently strand the
-    // orphan symlink in the agent dir.
+    // has something to act on. Hiding it would silently strand the orphan
+    // symlink in the agent dir.
     // Arrange
     const skill: Skill = {
       name: 'broken-skill',

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -373,7 +373,6 @@ export const AGENT_DEFINITIONS = [
     installDir: '.config/agents',
     scanDir: '.config/agents',
   },
-  // Additional agents synced through Skills CLI v1.5.1
   {
     id: 'bob',
     cliId: 'bob',
@@ -528,7 +527,6 @@ export const AGENT_DEFINITIONS = [
     installDir: '.agents',
     scanDir: '.warp',
   },
-  // Additional agents synced through Skills CLI v1.5.5
   {
     id: 'aider-desk',
     cliId: 'aider-desk',

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -27,8 +27,7 @@ export const WINDOW_BACKGROUND_BLUR_MAX_RADIUS = 48
 
 /**
  * Visual opacity range paired with the background blur slider.
- * `1` keeps the app surface fully opaque when blur is off; the minimum mirrors
- * Corelive BrainDump's real Electron window opacity so the desktop is visible.
+ * `1` keeps the app surface fully opaque when blur is off; the minimum keeps the desktop visible.
  */
 export const WINDOW_BACKGROUND_OPACITY_MAX = 1
 export const WINDOW_BACKGROUND_OPACITY_MIN = 0.45

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -925,7 +925,7 @@ export const tombstoneId = (value: string): TombstoneId => value as TombstoneId
  * @example { items: [{ skillName: 'task', skillPath: '/Users/me/.agents/skills/task', filesystemIdentity: { kind: 'directory', dev: 1, ino: 2, size: 96, ctimeMs: 1, mtimeMs: 1 } }] }
  */
 export interface DeleteSkillsOptions {
-  /** Skills to delete, in the order the user selected them (batch runs serially per reviewer #21). */
+  /** Skills to delete in the order the user selected them; batch runs serially. */
   items: Array<{
     skillName: SkillName
     skillPath: AbsolutePath
@@ -935,7 +935,7 @@ export interface DeleteSkillsOptions {
 
 /**
  * Per-item result from a batch delete. Discriminated on `outcome` so error items
- * never carry a phantom `tombstoneId` (reviewer CRITICAL-1).
+ * never carry a phantom `tombstoneId`.
  *
  * Three success-or-failure shapes:
  * - `deleted`: tombstoned (source-backed or local-only). Carries a `tombstoneId`

--- a/website/src/app/globals.css
+++ b/website/src/app/globals.css
@@ -46,7 +46,6 @@
   }
 }
 
-/* Custom animations */
 @keyframes float {
   0%,
   100% {
@@ -61,7 +60,6 @@
   animation: float 3s ease-in-out infinite;
 }
 
-/* Gradient text */
 .gradient-text {
   background: linear-gradient(135deg, #22d3ee 0%, #3b82f6 50%, #8b5cf6 100%);
   -webkit-background-clip: text;
@@ -69,7 +67,6 @@
   background-clip: text;
 }
 
-/* Glass effect */
 .glass {
   background: rgba(30, 41, 59, 0.7);
   backdrop-filter: blur(12px);

--- a/website/src/components/Download.tsx
+++ b/website/src/components/Download.tsx
@@ -7,7 +7,6 @@ export function Download() {
     <section className="py-20 lg:py-32">
       <div className="container mx-auto px-4">
         <div className="relative overflow-hidden rounded-2xl border border-border bg-card/30">
-          {/* Background decoration */}
           <div className="absolute -right-20 -top-20 size-64 rounded-full bg-primary/10 blur-3xl" />
           <div className="absolute -bottom-20 -left-20 size-64 rounded-full bg-accent/10 blur-3xl" />
 
@@ -22,7 +21,6 @@ export function Download() {
                 Macs.
               </p>
 
-              {/* Download buttons */}
               <div className="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
                 <a
                   href="https://github.com/laststance/skills-desktop/releases/download/v0.21.2/skills-desktop-0.21.2-arm64.dmg"
@@ -51,7 +49,6 @@ export function Download() {
                 </a>
               </div>
 
-              {/* Alternative download */}
               <div className="mt-8">
                 <a
                   href="https://github.com/laststance/skills-desktop/releases"
@@ -62,7 +59,6 @@ export function Download() {
                 </a>
               </div>
 
-              {/* System requirements */}
               <div className="mt-12 rounded-lg border border-border/50 bg-background/50 p-4">
                 <h3 className="mb-2 text-sm font-semibold">
                   System Requirements

--- a/website/src/components/Features.tsx
+++ b/website/src/components/Features.tsx
@@ -45,7 +45,6 @@ export function Features() {
   return (
     <section className="py-20 lg:py-32">
       <div className="container mx-auto px-4">
-        {/* Section header */}
         <div className="mb-16 text-center">
           <h2 className="mb-4 text-3xl font-semibold tracking-tight sm:text-4xl">
             Everything You Need to Manage Skills
@@ -56,7 +55,6 @@ export function Features() {
           </p>
         </div>
 
-        {/* Feature grid */}
         <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
           {features.map((feature) => (
             <div
@@ -72,7 +70,6 @@ export function Features() {
           ))}
         </div>
 
-        {/* Agent logos section */}
         <div className="mt-20">
           <p className="mb-8 text-center text-sm text-muted-foreground">
             Works with your favorite AI coding assistants

--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -5,30 +5,25 @@ import { Apple, Cpu } from 'lucide-react'
 export function Hero() {
   return (
     <section className="relative overflow-hidden py-20 lg:py-32">
-      {/* Background gradient */}
       <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-primary/5 via-transparent to-transparent" />
 
       <div className="container mx-auto px-4">
         <div className="flex flex-col items-center text-center">
-          {/* Badge */}
           <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-border bg-card/50 px-4 py-1.5 text-sm text-muted-foreground">
             <span className="size-2 rounded-full bg-primary animate-pulse" />
             Now available for macOS
           </div>
 
-          {/* Title */}
           <h1 className="mb-6 max-w-4xl text-4xl font-semibold tracking-tight sm:text-5xl lg:text-6xl">
             Manage Your AI Agent <span className="gradient-text">Skills</span>{' '}
             in One Place
           </h1>
 
-          {/* Subtitle */}
           <p className="mb-10 max-w-2xl text-lg text-muted-foreground lg:text-xl">
             Visualize installed Skills, check symlink status across 54 AI
             agents, and keep your development tools perfectly synchronized.
           </p>
 
-          {/* CTA Buttons */}
           <div className="flex flex-col gap-4 sm:flex-row">
             <a
               href="https://github.com/laststance/skills-desktop/releases/download/v0.21.2/skills-desktop-0.21.2-arm64.dmg"
@@ -64,7 +59,6 @@ export function Hero() {
             </a>
           </div>
 
-          {/* App Screenshot */}
           <div className="relative mt-16 w-full max-w-5xl">
             <div className="absolute -inset-4 rounded-2xl bg-gradient-to-r from-primary/20 via-accent/20 to-primary/20 blur-2xl" />
             <div className="glass relative overflow-hidden rounded-xl shadow-2xl">
@@ -77,9 +71,7 @@ export function Hero() {
                 </span>
               </div>
               <div className="aspect-[16/10] bg-background/50 p-4">
-                {/* Placeholder for actual screenshot */}
                 <div className="flex h-full gap-4">
-                  {/* Sidebar */}
                   <div className="w-60 rounded-lg bg-card/50 p-4">
                     <div className="mb-4 font-mono text-lg font-semibold text-primary">
                       Skills Desktop
@@ -96,7 +88,6 @@ export function Hero() {
                       </div>
                     </div>
                   </div>
-                  {/* Main content */}
                   <div className="flex-1 rounded-lg bg-card/30 p-4">
                     <div className="grid gap-4 sm:grid-cols-2">
                       {[


### PR DESCRIPTION
## Summary
- remove stale, redundant, or line-number-specific comments across the app, tests, scripts, and website
- keep useful safety and behavior rationale while trimming outdated reviewer/phase references
- refresh e2e diagnostic comments so they describe current behavior without stale helper names
- surface non-ENOENT destination inspection errors during copy-to-agent instead of treating them as missing paths

## Verification
- git diff --check
- ./node_modules/.bin/prettier --check e2e/spec/delete.e2e.ts e2e/spec/regression.e2e.ts e2e/spec/unlink-agent.e2e.ts src/main/services/trashService.ts src/main/utils/windowBackgroundBlur.ts src/shared/settings.ts src/main/ipc/skills.ts
- ./node_modules/.bin/vitest run src/main/ipc/skills.copyToAgents.integration.test.ts
- ./node_modules/.bin/eslint . --max-warnings 0
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/vitest run
- ./node_modules/.bin/fallow dead-code --fail-on-issues
- ./node_modules/.bin/fallow dupes --fail-on-issues
- ./node_modules/.bin/fallow health --complexity --fail-on-issues
- ./node_modules/.bin/storybook build

Note: pnpm validate currently stops before scripts on pnpm 11 build-approval state (ERR_PNPM_IGNORED_BUILDS), so the validate script components were run directly via local bins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ソース内コメント・ドキュメント表現を広範に整理・簡潔化しました（注釈差し替え・削除・表現統一）。

* **Tests**
  * 統合テストに説明整理と権限エラーケースの検証を追加しました（テストの明確化）。

* **ユーザー向けの変更なし**
  * 表示・動作・API契約に変更はなく、エンドユーザーの体験には影響ありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->