### PR TITLE
refactor(ui): refined button scale (44px → 32px, flat) + DESIGN.md

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -210,26 +210,46 @@ changing layout or meaning.
 
 ### Buttons
 
-| Type               | Visual height  | Hit target                          | Use                        |
-| ------------------ | -------------- | ----------------------------------- | -------------------------- |
-| Primary action     | 32-36px        | >= 36px                             | Install, sync, confirm     |
-| Secondary action   | 30-34px        | >= 36px                             | Cancel, alternate actions  |
-| Small dense action | 28-32px        | May use expanded invisible hit area | Row tools, filters         |
-| Icon-only          | 24-32px visual | >= 24x24px (WCAG 2.5.8 AA floor)    | Close, settings, row tools |
+The size scale lives once in `button.tsx` (cva `size` variants); this table
+mirrors it exactly. On a pointer-driven desktop the visual height **is** the hit
+target — there is no 44px touch inflation. Use a token below; never hard-code
+`h-11`/`min-h-11` (44px) on a visible button (see Target sizing for the one
+invisible-hit-area exception).
+
+| Variant   | Class        | Height | Use                                            |
+| --------- | ------------ | ------ | ---------------------------------------------- |
+| `xs`      | `h-6 px-2`   | 24px   | Inline / metadata-dense actions (AA floor)     |
+| `sm`      | `h-7 px-2.5` | 28px   | Row tools, toolbar buttons, filters            |
+| `default` | `h-8 px-3`   | 32px   | Primary and secondary actions (Install, sync)  |
+| `lg`      | `h-9 px-4`   | 36px   | Prominent / isolated hero CTAs                 |
+| `icon`    | `size-7`     | 28px   | Icon-only buttons (close, settings, row tools) |
+
+Base (all variants): `text-[13px]`, `rounded-md`, 16px glyphs (`[&_svg]:size-4`),
+`focus-visible:ring-1`.
 
 Rules:
 
-- If a button feels too tall, reduce the visual surface before reducing
+- **Filled buttons are flat** — no `shadow`/`shadow-sm` on default, secondary,
+  outline, or destructive. Convey state with surface + border + hover tint, not
+  drop shadow (see Depth and Elevation). "Chunky" = tall + heavily padded +
+  raised; the refined scale removes all three. Shadow is reserved for floating UI
+  (popovers, dialogs, toasts).
+- `default` (32px) is the baseline for text buttons. Reach for `lg` (36px) only
+  for an isolated hero CTA; use `sm` (28px) in dense toolbars and row tools.
+- Icon-only buttons are `icon` (28px) by default; drop to `size-6` (24px, the
+  WCAG 2.5.8 AA floor) only for genuinely dense rows. Never go below 24px.
+- If a button feels too tall, reduce the visual surface before reducing the
   accessible hit area.
-- Size icon buttons to context: `size="icon"` for comfortable standalone
-  controls, `size-6` (24px, WCAG 2.5.8 AA floor) for dense row tools.
-- Prefer lucide icons for tool buttons.
+- Prefer lucide icons for tool buttons; glyphs stay 14-16px, not scaled to the
+  button.
 - Avoid multiple primary buttons in one region.
-- Destructive buttons should be visually explicit and never rely on icon alone.
+- Destructive buttons must be visually explicit and never rely on icon alone.
 
 ### Inputs and Search
 
-- Height: 32-36px for standard fields.
+- Height: 32px (`h-8`) for standard fields; 36px (`h-9`) only for a prominent,
+  isolated field. Match the adjacent button scale so a field and its submit
+  button align to the same height.
 - Use border + muted background, not heavy inset shadows.
 - Placeholder text must stay lower contrast than real values.
 - Search should feel command-palette-adjacent: compact, keyboard-first,
@@ -237,6 +257,8 @@ Rules:
 
 ### Tabs and Segmented Controls
 
+- Tabs and segmented-control items are 32px (`min-h-8`, or ToggleGroup
+  `default`); use the `sm` size (28px) only inside an already-dense popover.
 - Tabs should be compact and stable.
 - Use underline, border, or subtle background to communicate selection.
 - Do not increase container height on hover or active state.
@@ -308,8 +330,18 @@ This is a pointer-driven desktop app (mouse and trackpad), so the mobile 44px
 finger-target minimum does not apply. The floor is WCAG 2.5.8 AA: 24x24 CSS px
 (`size-6`). Comfortable standalone controls can still be larger.
 
-- Standalone icon buttons: 24x24px (`size-6`) meets the AA floor; size up toward
-  32px when the control is primary or isolated.
+- Standalone icon buttons are 28px (`size-7`, the `icon` variant) by default.
+  `size-6` (24px) is the AA floor, reserved for genuinely dense rows; only an
+  isolated hero icon control sizes up toward 32px (`size-8`).
+- A **visible, always-on control sets real layout** — its box, and any space
+  reserved for it (e.g. a fixed list column like `BOOKMARK_COLUMN_WIDTH_PX`),
+  follows the button scale above. Never reserve 44px around a 16px glyph; that is
+  wasted width on a pointer-driven app, and width is scarce in the center list.
+- An **invisible or conditional hit area carries no resting box and no layout
+  cost**, so it MAY exceed the scale. An `opacity-0 group-hover` corner action or
+  a bulk-select checkbox wrapper can keep a 44px (`min-h-11 min-w-11`) target:
+  the glyph stays small, nothing reads as chunky, and the larger target is pure
+  ergonomics. This is the ONLY sanctioned use of 44px on a control.
 - Dense row controls may show a smaller glyph inside a 24px-or-larger target. An
   invisible `after:-inset-*` halo can extend the comfortable click area, but
   never over a row that is itself clickable: `opacity-0` controls stay
@@ -379,10 +411,14 @@ When making small visual refinements, prefer this order:
 
 Likely app-safe improvements:
 
-- Compact default buttons from 36px toward 32-34px where the surrounding target
-  remains comfortable.
-- Keep standalone icon buttons at a comfortable hit area (24px AA floor, larger
-  when isolated), but use a smaller visible glyph and subtle hover background.
+- The refined button scale (xs 24 / sm 28 / default 32 / lg 36 / icon 28) is now
+  codified in `button.tsx` and the Buttons table above; new surfaces inherit it.
+  Remaining drift work is catching stray `h-11`/`min-h-11` on visible buttons —
+  the only place 44px belongs is an invisible/conditional hit area (Target
+  sizing).
+- Keep standalone icon buttons at the 28px (`size-7`) default — 24px (`size-6`)
+  AA floor for dense rows — with a smaller visible glyph and subtle hover
+  background.
 - Reduce ordinary card shadow intensity; reserve stronger shadows for toasts,
   dropdowns, and dialogs.
 - Add 120-180ms color/opacity transitions to selected rows and tabs.

--- a/src/renderer/src/components/dashboard/DashboardEditToolbar.tsx
+++ b/src/renderer/src/components/dashboard/DashboardEditToolbar.tsx
@@ -72,7 +72,7 @@ export const DashboardEditToolbar = React.memo(
                 variant="ghost"
                 size="sm"
                 onClick={handleOpenPicker}
-                className="min-h-11 gap-1.5 text-xs"
+                className="gap-1.5 text-xs"
               >
                 <Plus className="h-3.5 w-3.5" />
                 Widget
@@ -81,7 +81,7 @@ export const DashboardEditToolbar = React.memo(
                 variant="ghost"
                 size="sm"
                 onClick={handleAddPage}
-                className="min-h-11 gap-1.5 text-xs"
+                className="gap-1.5 text-xs"
               >
                 <LayoutGrid className="h-3.5 w-3.5" />
                 Page
@@ -90,7 +90,7 @@ export const DashboardEditToolbar = React.memo(
                 variant="ghost"
                 size="sm"
                 onClick={handleResetLayout}
-                className="min-h-11 gap-1.5 text-xs text-muted-foreground"
+                className="gap-1.5 text-xs text-muted-foreground"
               >
                 <RotateCcw className="h-3.5 w-3.5" />
                 Reset
@@ -102,7 +102,7 @@ export const DashboardEditToolbar = React.memo(
             size="sm"
             onClick={handleToggleEditMode}
             aria-pressed={isEditMode}
-            className="min-h-11 gap-1.5 text-xs"
+            className="gap-1.5 text-xs"
           >
             {isEditMode ? (
               <>

--- a/src/renderer/src/components/dashboard/DashboardPageTabs.tsx
+++ b/src/renderer/src/components/dashboard/DashboardPageTabs.tsx
@@ -135,7 +135,7 @@ export const DashboardPageTabs = React.memo(
             aria-label="Add page"
             title="Add page"
             className="
-              min-h-11 min-w-11 inline-flex items-center justify-center
+              min-h-7 min-w-7 inline-flex items-center justify-center
               rounded-md text-muted-foreground hover:text-foreground hover:bg-accent
               transition-colors focus-visible:outline-none
               focus-visible:ring-2 focus-visible:ring-ring
@@ -243,7 +243,7 @@ const PageTab = React.memo(function PageTab({
         }}
         aria-label={`Rename page ${page.name}`}
         className="
-          min-h-11 min-w-30 px-3 text-xs font-medium
+          min-h-8 min-w-30 px-3 text-xs font-medium
           rounded-md bg-background border border-input
           outline-none focus:ring-2 focus:ring-ring
         "
@@ -259,7 +259,7 @@ const PageTab = React.memo(function PageTab({
         aria-selected={isActive}
         onClick={handleSelect}
         className={cn(
-          'min-h-11 px-3 text-xs font-medium rounded-md transition-colors whitespace-nowrap',
+          'min-h-8 px-3 text-xs font-medium rounded-md transition-colors whitespace-nowrap',
           isActive
             ? 'bg-primary/10 text-primary'
             : 'text-muted-foreground hover:text-foreground hover:bg-accent',
@@ -274,7 +274,7 @@ const PageTab = React.memo(function PageTab({
               type="button"
               aria-label={`Options for ${page.name}`}
               className="
-                min-h-11 min-w-7 ml-0.5 inline-flex items-center justify-center
+                min-h-7 min-w-7 ml-0.5 inline-flex items-center justify-center
                 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent
                 transition-colors focus-visible:outline-none
                 focus-visible:ring-2 focus-visible:ring-ring

--- a/src/renderer/src/components/dashboard/WidgetShell.tsx
+++ b/src/renderer/src/components/dashboard/WidgetShell.tsx
@@ -27,7 +27,7 @@ interface WidgetShellProps {
  *
  * Responsibilities:
  *  - Title bar with icon + label (the draggable handle in edit mode).
- *  - Remove button (visible only in edit mode, 44×44 hit area per HIG).
+ *  - Remove button (visible only in edit mode, 28×28 hit area — pointer-driven, no 44px touch inflation).
  *  - Body slot where the widget's `Component` renders.
  *  - In preview mode (`isPreview`), edit chrome is suppressed so the picker
  *    shows exactly what the widget looks like at rest on the canvas.

--- a/src/renderer/src/components/dashboard/WidgetShell.tsx
+++ b/src/renderer/src/components/dashboard/WidgetShell.tsx
@@ -85,7 +85,7 @@ export const WidgetShell = React.memo(function WidgetShell({
             onClick={handleRemove}
             onMouseDown={(event) => event.stopPropagation()}
             aria-label={`Remove ${definition.label} widget`}
-            className="ml-auto min-h-11 min-w-11 -my-2.5 -mr-3 flex items-center justify-center rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors"
+            className="ml-auto min-h-7 min-w-7 -my-2.5 -mr-3 flex items-center justify-center rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors"
           >
             <X className="h-3.5 w-3.5" />
           </button>

--- a/src/renderer/src/components/dashboard/widgets/QuickActionsWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/QuickActionsWidget.tsx
@@ -40,7 +40,7 @@ const ActionTile = React.memo(function ActionTile({
       disabled={isBusy}
       aria-label={label}
       className="
-        group flex-1 min-w-0 min-h-11 flex items-center gap-2 px-3 py-2
+        group flex-1 min-w-0 flex items-center gap-2 px-3 py-2
         rounded-md border border-border/60 bg-background/30 text-left
         hover:bg-muted hover:border-border
         disabled:opacity-60 disabled:cursor-not-allowed

--- a/src/renderer/src/components/dashboard/widgets/WelcomeWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/WelcomeWidget.tsx
@@ -56,7 +56,7 @@ export const WelcomeWidget = React.memo(function WelcomeWidget({
           onClick={handleDismiss}
           aria-label="Remove welcome widget"
           className="
-            min-h-11 min-w-11 shrink-0
+            min-h-7 min-w-7 shrink-0
             inline-flex items-center justify-center rounded-md
             text-muted-foreground hover:text-foreground hover:bg-muted
             transition-colors focus-visible:outline-none
@@ -95,7 +95,7 @@ export const WelcomeWidget = React.memo(function WelcomeWidget({
           onClick={handleDismiss}
           aria-label="Dismiss welcome"
           className="
-            min-h-11 min-w-11 shrink-0
+            min-h-7 min-w-7 shrink-0
             inline-flex items-center justify-center rounded-md
             text-muted-foreground hover:text-foreground hover:bg-muted
             transition-colors focus-visible:outline-none
@@ -114,7 +114,7 @@ export const WelcomeWidget = React.memo(function WelcomeWidget({
             bg-primary text-primary-foreground text-xs font-semibold
             hover:bg-primary/90 transition-colors focus-visible:outline-none
             focus-visible:ring-2 focus-visible:ring-ring
-            min-h-11
+            min-h-8
           "
         >
           <Store className="h-3.5 w-3.5" aria-hidden="true" />

--- a/src/renderer/src/components/layout/DetailPanel.tsx
+++ b/src/renderer/src/components/layout/DetailPanel.tsx
@@ -27,7 +27,7 @@ export const DetailPanel = React.memo(
             <button
               type="button"
               onClick={() => dispatch(selectSkill(null))}
-              className="no-drag min-h-7 min-w-7 flex items-center justify-center rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+              className="no-drag min-h-7 min-w-7 flex items-center justify-center rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
               aria-label="Close detail panel"
             >
               <X size={14} />

--- a/src/renderer/src/components/layout/DetailPanel.tsx
+++ b/src/renderer/src/components/layout/DetailPanel.tsx
@@ -27,7 +27,7 @@ export const DetailPanel = React.memo(
             <button
               type="button"
               onClick={() => dispatch(selectSkill(null))}
-              className="no-drag min-h-11 min-w-11 flex items-center justify-center rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+              className="no-drag min-h-7 min-w-7 flex items-center justify-center rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
               aria-label="Close detail panel"
             >
               <X size={14} />

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -922,7 +922,7 @@ export const MainContent = React.memo(
                     : 'Sorted Z to A, click to reverse'
                 }
                 onClick={handleToggleSortOrder}
-                className="shrink-0 text-muted-foreground hover:text-foreground min-h-11 min-w-11"
+                className="shrink-0 text-muted-foreground hover:text-foreground"
               >
                 {sortOrder === 'asc' ? (
                   <ArrowDownAZ className="h-4 w-4" />
@@ -942,7 +942,7 @@ export const MainContent = React.memo(
                     size="sm"
                     aria-label={sourceFilter.triggerAriaLabel}
                     className={cn(
-                      'shrink-0 gap-1.5 min-h-11 max-w-44',
+                      'shrink-0 gap-1.5 max-w-44',
                       sourceFilter.selectedSources.length > 0
                         ? 'text-primary'
                         : 'text-muted-foreground hover:text-foreground',
@@ -1005,7 +1005,7 @@ export const MainContent = React.memo(
                 }
                 onClick={handleToggleBulkSelectMode}
                 className={cn(
-                  'shrink-0 gap-1.5 min-h-11',
+                  'shrink-0 gap-1.5',
                   bulkSelectMode
                     ? 'text-primary'
                     : 'text-muted-foreground hover:text-foreground',
@@ -1032,7 +1032,7 @@ export const MainContent = React.memo(
                           : `Skill type filter: ${selectedSkillTypeLabel}, excluding ${excludedSkillTypeFilters.length} types`
                       }
                       className={cn(
-                        'shrink-0 gap-1.5 min-h-11 max-w-48',
+                        'shrink-0 gap-1.5 max-w-48',
                         skillTypeFilter !== 'all' ||
                           excludedSkillTypeFilters.length > 0
                           ? 'text-primary'

--- a/src/renderer/src/components/marketplace/MarketplaceDashboard.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceDashboard.tsx
@@ -72,7 +72,7 @@ export const MarketplaceDashboard = React.memo(
                 key={skill.name}
                 type="button"
                 onClick={() => handleSkillClick(skill)}
-                className="flex items-center gap-3 p-3 rounded-lg bg-background border border-border hover:border-primary/50 transition-colors text-left min-h-11"
+                className="flex items-center gap-3 p-3 rounded-lg bg-background border border-border hover:border-primary/50 transition-colors text-left"
               >
                 <div className="flex items-center justify-center w-7 h-7 shrink-0 rounded-md bg-muted font-mono text-[13px] font-semibold text-primary">
                   {skill.rank}

--- a/src/renderer/src/components/marketplace/MarketplaceSearch.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceSearch.tsx
@@ -59,12 +59,11 @@ export const MarketplaceSearch = React.memo(
             value={localQuery}
             onChange={handleChange}
             onKeyDown={handleKeyDown}
-            className="pl-10 bg-background h-11"
+            className="pl-10 bg-background h-8"
             disabled={isSearching}
           />
         </div>
         <Button
-          className="h-11"
           onClick={handleSearch}
           disabled={isSearching || !localQuery.trim()}
         >

--- a/src/renderer/src/components/marketplace/MarketplaceSkillPreview.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceSkillPreview.tsx
@@ -75,7 +75,7 @@ export const MarketplaceSkillPreview = React.memo(
           <button
             type="button"
             onClick={handleBack}
-            className="text-primary underline min-h-11"
+            className="text-primary underline"
           >
             Back to Dashboard
           </button>
@@ -89,7 +89,7 @@ export const MarketplaceSkillPreview = React.memo(
           <button
             type="button"
             onClick={handleBack}
-            className="flex items-center gap-1.5 px-2 py-1.5 rounded text-xs text-muted-foreground hover:text-foreground transition-colors min-h-11"
+            className="flex items-center gap-1.5 px-2 py-1.5 rounded text-xs text-muted-foreground hover:text-foreground transition-colors min-h-8"
           >
             <ArrowLeft className="h-3.5 w-3.5" />
             Back to Dashboard

--- a/src/renderer/src/components/marketplace/RankingTabs.tsx
+++ b/src/renderer/src/components/marketplace/RankingTabs.tsx
@@ -60,7 +60,7 @@ export const RankingTabs = React.memo(function RankingTabs({
           onClick={() => onChange(tab.id)}
           disabled={disabled}
           className={cn(
-            'px-4 py-2 rounded-md text-[13px] font-medium transition-colors min-h-11 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+            'px-3 py-1.5 rounded-md text-[13px] font-medium transition-colors min-h-8 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
             value === tab.id
               ? 'bg-card text-primary'
               : 'text-muted-foreground hover:text-foreground hover:bg-card/50',

--- a/src/renderer/src/components/marketplace/SkillRowMarketplace.tsx
+++ b/src/renderer/src/components/marketplace/SkillRowMarketplace.tsx
@@ -24,8 +24,10 @@ interface SkillRowMarketplaceProps {
 // (VL-001 / #171): at the ~1400px default window the 3-pane layout leaves the
 // list only ~510px, so every pixel reserved here is one the skill name — the
 // primary identifier a user scans to decide what to install — loses. Bookmark
-// stays 44px to preserve the 44×44 touch target (DESIGN.md target sizing).
-const BOOKMARK_COLUMN_WIDTH_PX = 44
+// column is 28px (size-7) — the refined glyph-button hit-area around the 16px
+// star glyph (DESIGN.md button scale). Pointer-precise on desktop; the old 44px
+// was a mobile touch reflex that wasted ~16px of the width-precious name column.
+const BOOKMARK_COLUMN_WIDTH_PX = 28
 const INSTALL_COUNT_COLUMN_WIDTH_PX = 80
 const ACTION_COLUMN_WIDTH_PX = 128
 
@@ -100,7 +102,7 @@ export const SkillRowMarketplace = React.memo(function SkillRowMarketplace({
             ? `Remove ${skill.name} from bookmarks`
             : `Bookmark ${skill.name}`
         }
-        className="min-h-11 min-w-11 flex items-center justify-center transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded-md"
+        className="min-h-7 min-w-7 flex items-center justify-center transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded-md"
         onClick={handleToggleBookmark}
       >
         <Star
@@ -146,7 +148,7 @@ export const SkillRowMarketplace = React.memo(function SkillRowMarketplace({
             onClick={handleInstall}
             disabled={isOperating}
             className={cn(
-              'flex items-center gap-1.5 px-4 py-2 rounded-md min-h-11',
+              'flex items-center gap-1.5 px-3 py-1.5 rounded-md min-h-8',
               'bg-primary text-primary-foreground text-[13px] font-semibold',
               'hover:bg-primary/90 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
               'disabled:opacity-50 disabled:cursor-not-allowed',

--- a/src/renderer/src/components/sidebar/BookmarkDetailModal.tsx
+++ b/src/renderer/src/components/sidebar/BookmarkDetailModal.tsx
@@ -136,11 +136,7 @@ export const BookmarkDetailModal = React.memo(
                     Installed
                   </span>
                 ) : bookmark.repo ? (
-                  <Button
-                    onClick={handleInstall}
-                    disabled={isInstalling}
-                    className="h-11"
-                  >
+                  <Button onClick={handleInstall} disabled={isInstalling}>
                     {isInstalling && (
                       <Loader2 className="h-4 w-4 mr-2 animate-spin" />
                     )}
@@ -151,11 +147,7 @@ export const BookmarkDetailModal = React.memo(
                     Not installed
                   </span>
                 )}
-                <Button
-                  variant="ghost"
-                  onClick={handleRemoveBookmark}
-                  className="h-11"
-                >
+                <Button variant="ghost" onClick={handleRemoveBookmark}>
                   Remove Bookmark
                 </Button>
               </div>

--- a/src/renderer/src/components/sidebar/SourceCard.tsx
+++ b/src/renderer/src/components/sidebar/SourceCard.tsx
@@ -178,7 +178,7 @@ export const SourceCard = React.memo(function SourceCard(): React.ReactElement {
               <Button
                 variant="ghost"
                 size="sm"
-                className="min-h-11 px-2 text-xs font-medium gap-1"
+                className="px-2 text-xs font-medium gap-1"
                 onClick={handleSyncClick}
                 disabled={isSyncing}
               >
@@ -194,7 +194,6 @@ export const SourceCard = React.memo(function SourceCard(): React.ReactElement {
               <Button
                 variant="ghost"
                 size="icon"
-                className="h-11 w-11"
                 aria-label={
                   isRefreshing
                     ? 'Refreshing skills and agent status'
@@ -214,7 +213,6 @@ export const SourceCard = React.memo(function SourceCard(): React.ReactElement {
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="h-11 w-11"
                   aria-label="Source folder actions"
                   disabled={!sourceStats}
                   onClick={handleKebabClick}

--- a/src/renderer/src/components/skills/SelectionToolbar.tsx
+++ b/src/renderer/src/components/skills/SelectionToolbar.tsx
@@ -162,7 +162,7 @@ export const SelectionToolbar = React.memo(function SelectionToolbar({
         size="sm"
         onClick={handleSelectAllVisible}
         disabled={isBusy}
-        className="shrink-0 min-h-11"
+        className="shrink-0"
       >
         Select all visible
       </Button>
@@ -172,7 +172,7 @@ export const SelectionToolbar = React.memo(function SelectionToolbar({
         size="sm"
         onClick={handleClear}
         disabled={isBusy}
-        className="shrink-0 min-h-11"
+        className="shrink-0"
       >
         <X className="h-3 w-3 mr-1" />
         Clear
@@ -185,7 +185,7 @@ export const SelectionToolbar = React.memo(function SelectionToolbar({
         disabled={toolbarState.isPrimaryDisabled || isBusy}
         aria-label={toolbarState.primaryAriaLabel}
         className={cn(
-          'shrink-0 min-h-11 gap-1.5',
+          'shrink-0 gap-1.5',
           toolbarState.isDestructive && 'font-medium',
         )}
       >

--- a/src/renderer/src/components/theme/ThemeSelector.tsx
+++ b/src/renderer/src/components/theme/ThemeSelector.tsx
@@ -203,7 +203,6 @@ export const ThemeSelector = React.memo(function ThemeSelector(): ReactElement {
         <Button
           variant="ghost"
           size="icon"
-          className="h-11 w-11"
           aria-label="Theme and color options"
         >
           <Palette className="h-4 w-4" />
@@ -278,7 +277,7 @@ export const ThemeSelector = React.memo(function ThemeSelector(): ReactElement {
                 key={name}
                 type="button"
                 onClick={() => dispatch(setTheme(name))}
-                className="min-h-11 min-w-11 flex items-center justify-center"
+                className="min-h-8 min-w-8 flex items-center justify-center"
                 title={config.label}
                 aria-label={`Select ${config.label} theme`}
                 aria-pressed={isSelected}
@@ -327,7 +326,7 @@ export const ThemeSelector = React.memo(function ThemeSelector(): ReactElement {
                 title={family.label}
                 aria-label={`Select ${family.label} theme`}
                 aria-pressed={isSelected}
-                className="flex-1 flex flex-col items-center gap-1 py-1.5 rounded-md hover:bg-muted transition-colors min-h-11"
+                className="flex-1 flex flex-col items-center gap-1 py-1.5 rounded-md hover:bg-muted transition-colors"
               >
                 <span
                   className={cn(

--- a/src/renderer/src/components/ui/button.tsx
+++ b/src/renderer/src/components/ui/button.tsx
@@ -5,29 +5,31 @@ import * as React from 'react'
 import { cn } from '@/renderer/src/lib/utils'
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  'inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-md text-[13px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
     variants: {
       variant: {
-        default:
-          'bg-primary text-primary-foreground shadow hover:bg-primary/90',
+        // Filled variants are flat — border + tonal surface, no drop-shadow.
+        // Shadow is reserved for floating UI (popovers, dialogs, toasts).
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
         destructive:
-          'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90',
+          'bg-destructive text-destructive-foreground hover:bg-destructive/90',
         outline:
-          'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground',
+          'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
         secondary:
-          'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
+          'bg-secondary text-secondary-foreground hover:bg-secondary/80',
         ghost: 'hover:bg-accent hover:text-accent-foreground',
         link: 'text-primary underline-offset-4 hover:underline',
       },
+      // Refined desktop scale (DESIGN.md Buttons). This is a pointer-driven app,
+      // so the visual height IS the hit target — no 44px touch inflation needed.
       size: {
-        default: 'h-9 px-4 py-2',
-        sm: 'h-8 rounded-md px-3 text-xs',
-        lg: 'h-10 rounded-md px-8',
-        // Apple HIG: interactive targets must be ≥44×44pt for reliable tap/click.
-        // `icon` variant is used for icon-only buttons where no surrounding label
-        // expands the hit area — so it must carry the full 44px itself.
-        icon: 'h-11 w-11',
+        default: 'h-8 px-3', // 32px — Linear/Raycast density, 13px label from base
+        xs: 'h-6 px-2 text-xs', // 24px — dense chips, inline actions
+        sm: 'h-7 px-2.5 text-xs', // 28px — toolbar / filter buttons
+        lg: 'h-9 px-4 text-sm', // 36px — primary CTAs
+        // Standalone icon button. Dense row tools use size-6 (24px WCAG 2.5.8 AA floor).
+        icon: 'size-7', // 28px, 16px glyph
       },
     },
     defaultVariants: {

--- a/src/renderer/src/components/ui/button.tsx
+++ b/src/renderer/src/components/ui/button.tsx
@@ -25,9 +25,9 @@ const buttonVariants = cva(
       // so the visual height IS the hit target — no 44px touch inflation needed.
       size: {
         default: 'h-8 px-3', // 32px — Linear/Raycast density, 13px label from base
-        xs: 'h-6 px-2 text-xs', // 24px — dense chips, inline actions
-        sm: 'h-7 px-2.5 text-xs', // 28px — toolbar / filter buttons
-        lg: 'h-9 px-4 text-sm', // 36px — primary CTAs
+        xs: 'h-6 px-2', // 24px — dense chips, inline actions
+        sm: 'h-7 px-2.5', // 28px — toolbar / filter buttons
+        lg: 'h-9 px-4', // 36px — primary CTAs
         // Standalone icon button. Dense row tools use size-6 (24px WCAG 2.5.8 AA floor).
         icon: 'size-7', // 28px, 16px glyph
       },

--- a/src/renderer/src/components/ui/dialog.tsx
+++ b/src/renderer/src/components/ui/dialog.tsx
@@ -56,7 +56,7 @@ const DialogContent = React.memo(function DialogContent({
       >
         {children}
         {hideCloseButton ? null : (
-          <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground min-h-11 min-w-11 flex items-center justify-center">
+          <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground min-h-7 min-w-7 flex items-center justify-center">
             <X className="h-4 w-4" />
             <span className="sr-only">Close</span>
           </DialogPrimitive.Close>

--- a/src/renderer/src/components/ui/toggle-group.tsx
+++ b/src/renderer/src/components/ui/toggle-group.tsx
@@ -12,10 +12,10 @@ import { cn } from '@/renderer/src/lib/utils'
  * be dead code.
  *
  * Tuning notes:
- * - Default size is `h-11` (44px) so it clears the Apple HIG / WCAG 2.2 AA
- *   tap-target floor without callers having to remember to bump `size`. The
- *   `sm` variant intentionally stays at 32px — it's a "compact" opt-in for
- *   inspector toolbars where the user has explicitly chosen density.
+ * - Refined desktop scale parallels `button.tsx`: default `h-8` (32px),
+ *   `sm` (28px), `lg` (36px). This is a pointer-driven app, so the visual
+ *   height is the hit target — no 44px touch inflation. Glyph-only items
+ *   still clear the 24px WCAG 2.5.8 AA floor via `min-w`.
  * - Focus ring is `ring-2 ring-offset-2`. Single-pixel rings disappear into
  *   the input border on `outline` variants when the theme preset has low
  *   chroma (neutral-light); the offset gives the ring its own breathing room
@@ -26,7 +26,7 @@ import { cn } from '@/renderer/src/lib/utils'
  *   width change) so there is no layout shift when toggling.
  */
 const toggleVariants = cva(
-  'inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium transition-colors hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+  'inline-flex items-center justify-center gap-2 rounded-md text-[13px] font-medium transition-colors hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
   {
     variants: {
       variant: {
@@ -35,9 +35,9 @@ const toggleVariants = cva(
           'border border-input bg-transparent shadow-sm hover:bg-accent hover:text-accent-foreground data-[state=on]:border-primary',
       },
       size: {
-        default: 'h-11 px-3 min-w-11',
-        sm: 'h-8 px-1.5 min-w-8',
-        lg: 'h-12 px-3.5 min-w-12',
+        default: 'h-8 px-3 min-w-8',
+        sm: 'h-7 px-1.5 min-w-7',
+        lg: 'h-9 px-3.5 min-w-9',
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Why

All buttons were unified at 44px — chunky (tall + heavily padded + raised drop-shadow) and not stylish. This app is **pointer-driven** (macOS Electron, no touch), so the 44px finger-target minimum never applied: the visual height *is* the hit target.

Root cause was **code↔doc drift**: `DESIGN.md` already prescribed 28–36px buttons (the 44px rule was abolished in #173), but ~20 files still hard-coded `h-11`/`min-h-11` (44px). This PR migrates the running app to a refined scale **and** rewrites `DESIGN.md` to mirror the implementation literally so the two can't drift again.

## The refined scale (`button.tsx` cva — flat, no drop-shadow)

| variant | class | px | use |
| --- | --- | --- | --- |
| `xs` | `h-6 px-2` | 24 | inline / metadata-dense (AA floor) |
| `sm` | `h-7 px-2.5` | 28 | toolbar / row tools / filters |
| `default` | `h-8 px-3` | **32** | primary & secondary actions |
| `lg` | `h-9 px-4` | 36 | isolated hero CTAs |
| `icon` | `size-7` | 28 | icon-only buttons |

Base: `text-[13px]`, `rounded-md`, 16px glyphs, `focus-visible:ring-1`. Filled variants flattened — elevation now comes from surface + border + hover tint, not drop-shadow (shadow reserved for floating UI).

## What changed

- **Foundation** (`button.tsx`, `toggle-group.tsx`): new size scale + flat variants.
- **19 visible surfaces migrated** off 44px: marketplace (search, ranking tabs, install button, bookmark column), dashboard (page tabs, widget close, quick-action tiles, welcome), sidebar (source card, bookmark modal), theme menu (palette button, swatch grid), dialog/detail-panel close.
- **Icon/glyph buttons unified at 28px** (`size-7`); 24px (`size-6`) is the AA floor for dense rows only.
- **Bookmark column 44 → 28px** (`BOOKMARK_COLUMN_WIDTH_PX`), reclaiming ~16px for the width-precious skill-name column (VL-001 / #171).
- **`DESIGN.md`**: button table mirrors the cva literally; adds the flat-button rule and the previously-missing icon/glyph hit-area rule (the absence of which let 44px proliferate); aligns Inputs/Tabs heights.

## Deliberately KEPT at 44px (not chunky — no resting box, no layout cost)

Invisible/conditional hit areas, documented as the one sanctioned 44px use in `DESIGN.md` → Target sizing:

- `SkillItem` `opacity-0 group-hover` corner actions (×3) + bulk-select checkbox wrapper
- `AgentItem` row-density height (separate density concept, untouched)

## Verification

- `pnpm validate`: typecheck ✅ / lint ✅ / dead-code ✅ (no issues) / **test 1351 passed** / storybook build ✅
- `pnpm test:e2e`: **51 passed** (1.1m) ✅
- Live QA (playwright-cli on the running app) across 3 surfaces — dashboard, marketplace, theme menu — confirmed the de-chunk with no layout breakage. Selected-swatch ring renders cleanly in the tightened grid; bookmark star not cramped (gap-4 provides breathing room).

## Notes

- **No version bump** — releases are owned exclusively by `/electron-release` per `CLAUDE.md`. This PR is code + docs only.
- CSS-class-only change (heights/padding/shadow); no logic, API, IPC, or data touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * ボタンとUIコントロールのサイズ体系を再定義し、全体的にコンパクト化（多くの固定44px指定を削除/縮小）。
  * 各画面（ダッシュボード、マーケットプレイス、サイドバー、モーダル等）のボタン・アイコンの最低寸法を調整し見た目を統一。
  * アイコンボタンの既定を28pxに、24pxは密集行向けのAAフロア、32pxは孤立ヒーロー用途に限定。

* **Documentation**
  * デザインガイドラインを更新し、新しいボタンスケールとアクセシビリティ運用ルールを明記。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->