### PR TITLE
feat(skills): bulk-copy selected skills to agents

### DIFF
--- a/e2e/spec/bulk-copy.e2e.ts
+++ b/e2e/spec/bulk-copy.e2e.ts
@@ -22,7 +22,7 @@ interface TargetAgent {
  * scanner derives skill identity from `name:` when present and otherwise falls
  * back to the folder basename (see bulk-delete.e2e.ts `preStageDummySkills`,
  * whose `# ${name}` skills are identified by basename). The bulk-copy modal
- * selects skills by basename via `selectSelectedSkillObjects`, so the heading
+ * selects skills by basename via `selectSelectedVisibleSkillObjects`, so the heading
  * form keeps identity == basename while still giving each skill distinct bytes
  * to assert the *right* source landed at each destination.
  *
@@ -100,7 +100,7 @@ async function pickDistinctTargetAgents(
 /**
  * Read which staged skills the renderer store now knows about by name. Used as
  * a boundary assertion after `refreshSkillsState`: if the scanner ever names a
- * staged skill differently from its basename, `selectSelectedSkillObjects`
+ * staged skill differently from its basename, `selectSelectedVisibleSkillObjects`
  * resolves to `[]`, the modal's Copy button stays disabled, and the UI click
  * would time out with an opaque failure. Asserting presence up front converts
  * that into a clear "staged skill missing from store" at the setup boundary.
@@ -145,7 +145,7 @@ test('the bulk Copy-to-Agents modal copies every selected skill into every ticke
   isolatedHome,
 }) => {
   // Arrange — stage two fresh source skills, then make the renderer aware of
-  // them so the modal's `selectSelectedSkillObjects` can resolve their paths.
+  // them so the modal's `selectSelectedVisibleSkillObjects` can resolve their paths.
   const sourceDir = join(isolatedHome, '.agents', 'skills')
   const skillNames = ['bulk-copy-alpha', 'bulk-copy-beta']
   preStageSourceSkills(isolatedHome, skillNames)

--- a/e2e/spec/bulk-copy.e2e.ts
+++ b/e2e/spec/bulk-copy.e2e.ts
@@ -1,0 +1,305 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { test, expect } from '../fixtures/electron-app'
+import {
+  dispatchAction,
+  getStoreState,
+  refreshSkillsState,
+  waitForInitialScan,
+} from '../helpers/redux'
+
+interface TargetAgent {
+  id: string
+  name: string
+  path: string
+}
+
+/**
+ * Build the SKILL.md body for a staged source skill.
+ *
+ * Deliberately a markdown `#` heading, NOT a `name:` frontmatter key: the
+ * scanner derives skill identity from `name:` when present and otherwise falls
+ * back to the folder basename (see bulk-delete.e2e.ts `preStageDummySkills`,
+ * whose `# ${name}` skills are identified by basename). The bulk-copy modal
+ * selects skills by basename via `selectSelectedSkillObjects`, so the heading
+ * form keeps identity == basename while still giving each skill distinct bytes
+ * to assert the *right* source landed at each destination.
+ *
+ * @param name - Skill folder basename, doubling as its scanned identity.
+ * @returns SKILL.md contents unique to that skill.
+ * @example sourceMarkerFor('bulk-copy-alpha') // => "# bulk-copy-alpha\n\nFixture…\n"
+ */
+function sourceMarkerFor(name: string): string {
+  return `# ${name}\n\nFixture source skill for the bulk-copy E2E spec.\n`
+}
+
+/**
+ * Pre-stage source-backed skills under the isolated HOME's universal source dir
+ * (`~/.agents/skills/<name>`), each with a basename-identified SKILL.md.
+ *
+ * @param isolatedHome - E2E fixture HOME.
+ * @param names - Skill basenames to create, in order.
+ * @example preStageSourceSkills(home, ['bulk-copy-alpha', 'bulk-copy-beta'])
+ */
+function preStageSourceSkills(isolatedHome: string, names: string[]): void {
+  const sourceDir = join(isolatedHome, '.agents', 'skills')
+  for (const name of names) {
+    const skillDir = join(sourceDir, name)
+    mkdirSync(skillDir, { recursive: true })
+    writeFileSync(join(skillDir, 'SKILL.md'), sourceMarkerFor(name))
+  }
+}
+
+/**
+ * Pick `count` distinct-path agents that can serve as bulk-copy targets.
+ *
+ * Excludes the universal source dir itself — the 13 universal agents share
+ * `~/.agents/skills`, so copying a source skill "into" one of them resolves to
+ * `<sourceDir>/<skill>` (the source) and the handler reports `Already exists`
+ * (skills.ts:1158-1166). Dedups by path so IRON-RULE shared scan dirs (amp /
+ * kimi-cli / replit) cannot let one tick write into another target's space. No
+ * `exists` filter: the handler `mkdir -p`s the destination (skills.ts:1161), so
+ * a not-installed agent is still a valid, faithful target.
+ *
+ * @param page - Playwright page bound to the renderer store.
+ * @param sourceDir - Absolute universal source dir to exclude.
+ * @param count - Number of distinct-path agents to return.
+ * @returns Up to `count` agents with their id, display name, and scan path.
+ */
+async function pickDistinctTargetAgents(
+  page: Parameters<typeof getStoreState>[0],
+  sourceDir: string,
+  count: number,
+): Promise<TargetAgent[]> {
+  return getStoreState(
+    page,
+    (state, params) => {
+      const root = state as {
+        agents: { items: Array<{ id: string; name: string; path: string }> }
+      }
+      const { sourceDirLiteral, countLiteral } = params as {
+        sourceDirLiteral: string
+        countLiteral: number
+      }
+      const seenPaths = new Set<string>()
+      const picked: Array<{ id: string; name: string; path: string }> = []
+      for (const agent of root.agents.items) {
+        if (agent.path === sourceDirLiteral) continue
+        if (seenPaths.has(agent.path)) continue
+        seenPaths.add(agent.path)
+        picked.push({ id: agent.id, name: agent.name, path: agent.path })
+        if (picked.length === countLiteral) break
+      }
+      return picked
+    },
+    { sourceDirLiteral: sourceDir, countLiteral: count },
+  )
+}
+
+/**
+ * Read which staged skills the renderer store now knows about by name. Used as
+ * a boundary assertion after `refreshSkillsState`: if the scanner ever names a
+ * staged skill differently from its basename, `selectSelectedSkillObjects`
+ * resolves to `[]`, the modal's Copy button stays disabled, and the UI click
+ * would time out with an opaque failure. Asserting presence up front converts
+ * that into a clear "staged skill missing from store" at the setup boundary.
+ *
+ * @param page - Playwright page bound to the renderer store.
+ * @param names - Expected staged skill basenames.
+ * @returns The subset of `names` present in `state.skills.items`.
+ */
+async function getPresentSkillNames(
+  page: Parameters<typeof getStoreState>[0],
+  names: string[],
+): Promise<string[]> {
+  return getStoreState(
+    page,
+    (state, expectedNames) => {
+      const root = state as { skills: { items: Array<{ name: string }> } }
+      const present = new Set(root.skills.items.map((skill) => skill.name))
+      return (expectedNames as string[]).filter((name) => present.has(name))
+    },
+    names,
+  )
+}
+
+/**
+ * Bulk copy (issue #198) — fan the `copyToAgents` IPC out across the whole list
+ * selection so every selected skill lands in every ticked agent.
+ *
+ * These specs are UI-driven on purpose. The single-skill IPC contract (symlink
+ * vs directory branch, realpath round-trip, per-target `Already exists`) is
+ * already locked by copy.e2e.ts; a `createAsyncThunk` cannot be dispatched from
+ * `page.evaluate` anyway. What #198 ADDS — and what only an E2E can prove — is
+ * (1) the multi-skill fan-out and (2) the SelectionToolbar → modal → thunk →
+ * IPC → filesystem wiring. So we drive the real click path and assert on the
+ * filesystem (deterministic) rather than the toast (timing-sensitive).
+ *
+ * Each test pre-stages its own source skills, so no azure-* snapshot dependency
+ * and no offline skip is needed.
+ */
+
+test('the bulk Copy-to-Agents modal copies every selected skill into every ticked agent', async ({
+  appWindow,
+  isolatedHome,
+}) => {
+  // Arrange — stage two fresh source skills, then make the renderer aware of
+  // them so the modal's `selectSelectedSkillObjects` can resolve their paths.
+  const sourceDir = join(isolatedHome, '.agents', 'skills')
+  const skillNames = ['bulk-copy-alpha', 'bulk-copy-beta']
+  preStageSourceSkills(isolatedHome, skillNames)
+
+  await waitForInitialScan(appWindow)
+  await refreshSkillsState(appWindow)
+
+  // Boundary assertion — both staged skills must be in the store by basename,
+  // else the selection resolves to [] and the Copy button never enables.
+  expect(await getPresentSkillNames(appWindow, skillNames)).toEqual(skillNames)
+
+  const targetAgents = await pickDistinctTargetAgents(appWindow, sourceDir, 2)
+  expect(
+    targetAgents,
+    'expected two distinct-path target agents outside the universal source dir',
+  ).toHaveLength(2)
+
+  // Pre-condition the destinations are empty so the post-click existence checks
+  // genuinely prove the click chain reached `fs.cp`, not a stale snapshot.
+  for (const agent of targetAgents) {
+    for (const skillName of skillNames) {
+      expect(existsSync(join(agent.path, skillName))).toBe(false)
+    }
+  }
+
+  // Act — enter bulk-select mode and tick both skills (global view is the
+  // default; the "Copy to..." button renders only there). enterBulkSelectMode
+  // first so selectAll is the last selection-affecting dispatch.
+  await dispatchAction(appWindow, { type: 'ui/enterBulkSelectMode' })
+  await dispatchAction(appWindow, {
+    type: 'skills/selectAll',
+    payload: skillNames,
+  })
+
+  // Open the modal from the toolbar's non-destructive bulk-copy button.
+  await appWindow
+    .getByRole('button', { name: 'Copy selected skills to agents' })
+    .click()
+
+  const dialog = appWindow.getByRole('dialog')
+  await dialog
+    .getByRole('heading', { name: 'Copy to Agents' })
+    .waitFor({ state: 'visible', timeout: 5_000 })
+
+  // Tick both target agents (checkbox aria-label is the agent display name).
+  // Scope to the dialog: bulk mode also renders per-row skill checkboxes.
+  for (const agent of targetAgents) {
+    await dialog.getByRole('checkbox', { name: agent.name }).check()
+  }
+
+  // Primary button label is "Copy 2 skills to 2 agent(s)".
+  await dialog
+    .getByRole('button', { name: /^Copy 2 skills to 2 agent\(s\)$/ })
+    .click()
+
+  // Assert — the thunk awaits each skill's copyToAgents serially, fanning to the
+  // ticked agents in order; the last serial write is the second skill into the
+  // second agent. Poll that one, then read all four destinations synchronously.
+  const lastWritten = join(targetAgents[1].path, skillNames[1], 'SKILL.md')
+  await expect
+    .poll(() => existsSync(lastWritten), { timeout: 10_000 })
+    .toBe(true)
+
+  // Every selected skill landed in every ticked agent, with the right bytes.
+  for (const agent of targetAgents) {
+    for (const skillName of skillNames) {
+      const copiedSkillMd = join(agent.path, skillName, 'SKILL.md')
+      expect(
+        existsSync(copiedSkillMd),
+        `expected ${skillName} copied into ${agent.id}`,
+      ).toBe(true)
+      expect(readFileSync(copiedSkillMd, 'utf-8')).toBe(
+        sourceMarkerFor(skillName),
+      )
+    }
+  }
+})
+
+test('a bulk copy keeps copying the rest when one skill already exists in one agent', async ({
+  appWindow,
+  isolatedHome,
+}) => {
+  // Arrange — two source skills and two distinct-path target agents.
+  const sourceDir = join(isolatedHome, '.agents', 'skills')
+  const skillNames = ['bulk-partial-alpha', 'bulk-partial-beta']
+  const [alphaName, betaName] = skillNames
+  preStageSourceSkills(isolatedHome, skillNames)
+
+  await waitForInitialScan(appWindow)
+  await refreshSkillsState(appWindow)
+
+  expect(await getPresentSkillNames(appWindow, skillNames)).toEqual(skillNames)
+
+  const targetAgents = await pickDistinctTargetAgents(appWindow, sourceDir, 2)
+  expect(targetAgents).toHaveLength(2)
+  const [occupiedAgent, freeAgent] = targetAgents
+
+  // Pre-occupy ONLY alpha in the first agent with a sentinel. The handler's
+  // `lstat(destPath)` will report `Already exists` for alpha→occupied while
+  // every other (skill, agent) pair stays free — the asymmetric setup the
+  // no-abort contract is proven against.
+  const sentinelDir = join(occupiedAgent.path, alphaName)
+  mkdirSync(sentinelDir, { recursive: true })
+  const sentinelContent = `# pre-existing\nDO NOT OVERWRITE — collision sentinel.\n`
+  writeFileSync(join(sentinelDir, 'SKILL.md'), sentinelContent)
+
+  // Act — select both skills, open the modal, tick both agents, copy.
+  await dispatchAction(appWindow, { type: 'ui/enterBulkSelectMode' })
+  await dispatchAction(appWindow, {
+    type: 'skills/selectAll',
+    payload: skillNames,
+  })
+
+  await appWindow
+    .getByRole('button', { name: 'Copy selected skills to agents' })
+    .click()
+
+  const dialog = appWindow.getByRole('dialog')
+  await dialog
+    .getByRole('heading', { name: 'Copy to Agents' })
+    .waitFor({ state: 'visible', timeout: 5_000 })
+
+  for (const agent of targetAgents) {
+    await dialog.getByRole('checkbox', { name: agent.name }).check()
+  }
+
+  await dialog
+    .getByRole('button', { name: /^Copy 2 skills to 2 agent\(s\)$/ })
+    .click()
+
+  // Assert — last serial write is beta→free; poll it, then read the matrix.
+  const lastWritten = join(freeAgent.path, betaName, 'SKILL.md')
+  await expect
+    .poll(() => existsSync(lastWritten), { timeout: 10_000 })
+    .toBe(true)
+
+  // 1) Collision did NOT overwrite — the sentinel survives byte-for-byte. A
+  //    regression that swapped `lstat` for `cp -f` shows up here as a mismatch.
+  expect(readFileSync(join(sentinelDir, 'SKILL.md'), 'utf-8')).toBe(
+    sentinelContent,
+  )
+
+  // 2) Per-skill no-abort — beta still reached the occupied agent even though
+  //    alpha→occupied failed earlier in the same batch.
+  const betaInOccupied = join(occupiedAgent.path, betaName, 'SKILL.md')
+  expect(existsSync(betaInOccupied)).toBe(true)
+  expect(readFileSync(betaInOccupied, 'utf-8')).toBe(sourceMarkerFor(betaName))
+
+  // 3) Per-agent no-abort — alpha still reached the free agent even though
+  //    alpha→occupied failed.
+  const alphaInFree = join(freeAgent.path, alphaName, 'SKILL.md')
+  expect(existsSync(alphaInFree)).toBe(true)
+  expect(readFileSync(alphaInFree, 'utf-8')).toBe(sourceMarkerFor(alphaName))
+
+  // 4) The free agent received both skills.
+  expect(readFileSync(lastWritten, 'utf-8')).toBe(sourceMarkerFor(betaName))
+})

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -17,6 +17,7 @@ import { SyncConfirmDialog } from '@/renderer/src/components/sidebar/SyncConfirm
 import { SyncConflictDialog } from '@/renderer/src/components/sidebar/SyncConflictDialog'
 import { SyncResultDialog } from '@/renderer/src/components/sidebar/SyncResultDialog'
 import { AddSymlinkModal } from '@/renderer/src/components/skills/AddSymlinkModal'
+import { BulkCopyToAgentsModal } from '@/renderer/src/components/skills/BulkCopyToAgentsModal'
 import { renderBulkDeleteDescription } from '@/renderer/src/components/skills/bulkDeleteCopy'
 import {
   formatCascadeSummary,
@@ -80,6 +81,7 @@ import {
   selectAll,
   selectSelectedSkillNames,
   selectSkillsItems,
+  setBulkCopyModalOpen,
   setBulkProgress,
   undoLastBulkDelete,
   unlinkSelectedFromAgent,
@@ -518,6 +520,11 @@ export const MainContent = React.memo(
      * the "no window.confirm in renderer" review rule) without leaking the
      * thunk wiring into Redux state.
      */
+    /** Open the bulk copy-to-agents modal for the current global-view selection. */
+    const handleCopyAction = useCallback((): void => {
+      dispatch(setBulkCopyModalOpen(true))
+    }, [dispatch])
+
     const handlePrimaryAction = useCallback((): void => {
       if (selectedVisibleNames.length === 0) return
       // Snapshot the active repo-filter scope so the confirm dialog can state
@@ -1183,6 +1190,7 @@ export const MainContent = React.memo(
             {/* Renders only when at least one skill is ticked. */}
             <SelectionToolbar
               onPrimaryAction={handlePrimaryAction}
+              onCopyAction={handleCopyAction}
               agentDisplayName={selectedAgent?.name}
             />
 
@@ -1202,6 +1210,7 @@ export const MainContent = React.memo(
         <UnlinkDialog />
         <AddSymlinkModal />
         <CopyToAgentsModal />
+        <BulkCopyToAgentsModal />
         <SyncConfirmDialog />
         <SyncConflictDialog />
         <SyncResultDialog />

--- a/src/renderer/src/components/skills/BulkCopyToAgentsModal.tsx
+++ b/src/renderer/src/components/skills/BulkCopyToAgentsModal.tsx
@@ -12,7 +12,7 @@ import {
   DialogTitle,
 } from '@/renderer/src/components/ui/dialog'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
-import { selectSelectedSkillObjects } from '@/renderer/src/redux/selectors'
+import { selectSelectedVisibleSkillObjects } from '@/renderer/src/redux/selectors'
 import {
   bulkCopyToAgents,
   selectBulkCopying,
@@ -30,7 +30,7 @@ import { AgentSelectionOption } from './AgentSelectionOption'
  * Modal for copying every currently-selected skill to a chosen set of agents.
  *
  * The bulk analogue of `CopyToAgentsModal`: instead of one `skillToCopy`, it
- * reads the whole list selection (`selectSelectedSkillObjects`) and fans the
+ * reads the visible list selection (`selectSelectedVisibleSkillObjects`) and fans the
  * `copyToAgents` IPC out across it via the `bulkCopyToAgents` thunk. Global
  * view only — each skill's source is its own `skill.path` (mirrors the
  * AddSymlinkModal "copy files" path). Non-destructive, so the selection is left
@@ -45,7 +45,7 @@ export const BulkCopyToAgentsModal = React.memo(
   function BulkCopyToAgentsModal(): React.ReactElement {
     const dispatch = useAppDispatch()
     const open = useAppSelector(selectBulkCopyModalOpen)
-    const selectedSkills = useAppSelector(selectSelectedSkillObjects)
+    const selectedSkills = useAppSelector(selectSelectedVisibleSkillObjects)
     const { items: agents } = useAppSelector((state) => state.agents)
     const bulkCopying = useAppSelector(selectBulkCopying)
 
@@ -82,6 +82,11 @@ export const BulkCopyToAgentsModal = React.memo(
     )
 
     const handleCopy = useCallback(async (): Promise<void> => {
+      // Re-entrancy guard: the button is disabled while `bulkCopying`, but a
+      // fast double-click can fire two handlers before React re-renders the
+      // disabled state. Bail here so a single click never dispatches twice and
+      // races itself in main (lstat-then-write would see its own half-write).
+      if (bulkCopying) return
       if (selectedSkills.length === 0 || checkedAgentIds.length === 0) return
       const items = selectedSkills.map((skill) => ({
         skillName: skill.name,
@@ -91,7 +96,10 @@ export const BulkCopyToAgentsModal = React.memo(
         bulkCopyToAgents({ items, agentIds: checkedAgentIds }),
       )
       if (bulkCopyToAgents.fulfilled.match(result)) {
-        const content = summarizeBulkCopyResult(result.payload.perSkill)
+        const content = summarizeBulkCopyResult(
+          result.payload.perSkill,
+          checkedAgentIds.length,
+        )
         toast[content.tone](content.title, { description: content.description })
       } else {
         toast.error('Failed to copy skills', {
@@ -104,7 +112,7 @@ export const BulkCopyToAgentsModal = React.memo(
       // Selection is preserved (non-destructive); only the local checks reset.
       setCheckedAgentIds([])
       dispatch(setBulkCopyModalOpen(false))
-    }, [dispatch, selectedSkills, checkedAgentIds])
+    }, [dispatch, selectedSkills, checkedAgentIds, bulkCopying])
 
     const skillCount = selectedSkills.length
     const skillWord = skillCount === 1 ? 'skill' : 'skills'

--- a/src/renderer/src/components/skills/BulkCopyToAgentsModal.tsx
+++ b/src/renderer/src/components/skills/BulkCopyToAgentsModal.tsx
@@ -1,0 +1,164 @@
+import { Copy, Loader2 } from 'lucide-react'
+import React, { useCallback, useMemo, useState } from 'react'
+import { toast } from 'sonner'
+
+import { Button } from '@/renderer/src/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/renderer/src/components/ui/dialog'
+import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
+import { selectSelectedSkillObjects } from '@/renderer/src/redux/selectors'
+import {
+  bulkCopyToAgents,
+  selectBulkCopying,
+  selectBulkCopyModalOpen,
+  setBulkCopyModalOpen,
+} from '@/renderer/src/redux/slices/skillsSlice'
+import { refreshAllData } from '@/renderer/src/redux/thunks'
+import { summarizeBulkCopyResult } from '@/renderer/src/utils/summarizeBulkCopyResult'
+import type { AgentId } from '@/shared/types'
+
+import { getTargetAgentsForSelection } from './agentSelectionHelpers'
+import { AgentSelectionOption } from './AgentSelectionOption'
+
+/**
+ * Modal for copying every currently-selected skill to a chosen set of agents.
+ *
+ * The bulk analogue of `CopyToAgentsModal`: instead of one `skillToCopy`, it
+ * reads the whole list selection (`selectSelectedSkillObjects`) and fans the
+ * `copyToAgents` IPC out across it via the `bulkCopyToAgents` thunk. Global
+ * view only — each skill's source is its own `skill.path` (mirrors the
+ * AddSymlinkModal "copy files" path). Non-destructive, so the selection is left
+ * intact after a successful copy. Open state lives in Redux
+ * (`bulkCopyModalOpen`) like the sibling modals; the checked target agents are
+ * local because they are ephemeral to one modal session.
+ *
+ * @example
+ * <BulkCopyToAgentsModal />
+ */
+export const BulkCopyToAgentsModal = React.memo(
+  function BulkCopyToAgentsModal(): React.ReactElement {
+    const dispatch = useAppDispatch()
+    const open = useAppSelector(selectBulkCopyModalOpen)
+    const selectedSkills = useAppSelector(selectSelectedSkillObjects)
+    const { items: agents } = useAppSelector((state) => state.agents)
+    const bulkCopying = useAppSelector(selectBulkCopying)
+
+    // Checked target agents — ephemeral to this modal session, so local state.
+    const [checkedAgentIds, setCheckedAgentIds] = useState<AgentId[]>([])
+
+    // Global view copies to any agent; the source skill has no "self" to exclude.
+    const targetAgents = useMemo(
+      () => getTargetAgentsForSelection(agents, { excludeAgentId: null }),
+      [agents],
+    )
+
+    const handleAgentToggle = useCallback((agentId: AgentId): void => {
+      setCheckedAgentIds((current) =>
+        current.includes(agentId)
+          ? current.filter((id) => id !== agentId)
+          : [...current, agentId],
+      )
+    }, [])
+
+    // Dismiss path (Cancel / Esc / overlay). Blocked mid-copy so a half-finished
+    // batch is never abandoned; resets checks so the next open starts clean.
+    const handleDismiss = useCallback((): void => {
+      if (bulkCopying) return
+      setCheckedAgentIds([])
+      dispatch(setBulkCopyModalOpen(false))
+    }, [bulkCopying, dispatch])
+
+    const handleDialogOpenChange = useCallback(
+      (next: boolean): void => {
+        if (!next) handleDismiss()
+      },
+      [handleDismiss],
+    )
+
+    const handleCopy = useCallback(async (): Promise<void> => {
+      if (selectedSkills.length === 0 || checkedAgentIds.length === 0) return
+      const items = selectedSkills.map((skill) => ({
+        skillName: skill.name,
+        sourcePath: skill.path,
+      }))
+      const result = await dispatch(
+        bulkCopyToAgents({ items, agentIds: checkedAgentIds }),
+      )
+      if (bulkCopyToAgents.fulfilled.match(result)) {
+        const content = summarizeBulkCopyResult(result.payload.perSkill)
+        toast[content.tone](content.title, { description: content.description })
+      } else {
+        toast.error('Failed to copy skills', {
+          description: result.error?.message || 'An unexpected error occurred',
+        })
+      }
+      // refreshAllData on success pulls the new symlinks; on failure it clears
+      // any stale skills error so the list does not stay stuck on the error view.
+      refreshAllData(dispatch)
+      // Selection is preserved (non-destructive); only the local checks reset.
+      setCheckedAgentIds([])
+      dispatch(setBulkCopyModalOpen(false))
+    }, [dispatch, selectedSkills, checkedAgentIds])
+
+    const skillCount = selectedSkills.length
+    const skillWord = skillCount === 1 ? 'skill' : 'skills'
+    const canCopy = skillCount > 0 && checkedAgentIds.length > 0 && !bulkCopying
+
+    return (
+      <Dialog open={open} onOpenChange={handleDialogOpenChange}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Copy className="h-4 w-4" />
+              Copy to Agents
+            </DialogTitle>
+            <DialogDescription>
+              Copy{' '}
+              <strong>
+                {skillCount} selected {skillWord}
+              </strong>{' '}
+              to the chosen agents. The originals are left untouched.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="max-h-64 overflow-y-auto space-y-2 py-2">
+            {targetAgents.map((agent) => (
+              <AgentSelectionOption
+                key={agent.id}
+                agentId={agent.id}
+                checkboxId={`bulk-copy-agent-${agent.id}`}
+                name={agent.name}
+                checked={checkedAgentIds.includes(agent.id)}
+                disabled={bulkCopying}
+                hoverClassName="hover:bg-accent transition-colors"
+                onToggle={handleAgentToggle}
+              />
+            ))}
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={handleDismiss}
+              disabled={bulkCopying}
+            >
+              Cancel
+            </Button>
+            <Button onClick={handleCopy} disabled={!canCopy}>
+              {bulkCopying && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
+              {bulkCopying
+                ? 'Copying...'
+                : `Copy ${skillCount} ${skillWord} to ${checkedAgentIds.length} agent(s)`}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    )
+  },
+)

--- a/src/renderer/src/components/skills/SelectionToolbar.tsx
+++ b/src/renderer/src/components/skills/SelectionToolbar.tsx
@@ -116,8 +116,10 @@ export const SelectionToolbar = React.memo(function SelectionToolbar({
   return (
     <div
       // Sticky below the search/filter row; matches the border styling of
-      // MainContent's neighbouring bars for visual continuity.
-      className="px-4 py-2 border-b border-border bg-primary/5 flex items-center gap-3 flex-wrap"
+      // MainContent's neighbouring bars for visual continuity. `gap-y-2` gives
+      // the action cluster breathing room on the rare second row at narrow
+      // widths; `gap-x-3` keeps the count↔cluster horizontal rhythm.
+      className="px-4 py-2 border-b border-border bg-primary/5 flex items-center gap-x-3 gap-y-2 flex-wrap"
       // `role="group"` rather than `role="toolbar"`: the WAI-ARIA toolbar
       // pattern requires roving-tabindex arrow-key navigation between its
       // children, which we do not implement. `group` keeps the labelled
@@ -164,65 +166,71 @@ export const SelectionToolbar = React.memo(function SelectionToolbar({
         </span>
       )}
 
-      <div className="flex-1" />
-
-      <Button
-        variant="ghost"
-        size="sm"
-        onClick={handleSelectAllVisible}
-        disabled={isBusy}
-        className="shrink-0"
-      >
-        Select all visible
-      </Button>
-
-      <Button
-        variant="ghost"
-        size="sm"
-        onClick={handleClear}
-        disabled={isBusy}
-        className="shrink-0"
-      >
-        <X className="h-3 w-3 mr-1" />
-        Clear
-      </Button>
-
-      {/* Non-destructive bulk copy — global view only. The outline variant +
-          Copy icon visually separates it from the destructive Delete (AC#4). */}
-      {selectedAgentId === null && onCopyAction && (
+      {/* Action cluster — kept as one `ml-auto` right-aligned group so that
+          when the count + buttons exceed the panel width the whole cluster
+          wraps to a second row as a cohesive, right-aligned block, rather than
+          the toolbar's own flex-wrap orphaning the trailing primary button on a
+          lone left-aligned row. Also absorbs agent-view's long "Unlink from
+          {agent}" label without disturbing the count on the left. */}
+      <div className="ml-auto flex items-center gap-2 flex-wrap justify-end">
         <Button
-          variant="outline"
+          variant="ghost"
           size="sm"
-          onClick={onCopyAction}
+          onClick={handleSelectAllVisible}
           disabled={isBusy}
-          aria-label="Copy selected skills to agents"
           className="shrink-0"
         >
-          <Copy className="h-4 w-4" />
-          Copy to...
+          Select all visible
         </Button>
-      )}
 
-      <Button
-        variant={toolbarState.isDestructive ? 'destructive' : 'default'}
-        size="sm"
-        onClick={onPrimaryAction}
-        disabled={toolbarState.isPrimaryDisabled || isBusy}
-        aria-label={toolbarState.primaryAriaLabel}
-        className={cn(
-          'shrink-0 gap-1.5',
-          toolbarState.isDestructive && 'font-medium',
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={handleClear}
+          disabled={isBusy}
+          className="shrink-0"
+        >
+          <X className="h-3 w-3 mr-1" />
+          Clear
+        </Button>
+
+        {/* Non-destructive bulk copy — global view only. The outline variant +
+            Copy icon visually separates it from the destructive Delete (AC#4). */}
+        {selectedAgentId === null && onCopyAction && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onCopyAction}
+            disabled={isBusy}
+            aria-label="Copy selected skills to agents"
+            className="shrink-0"
+          >
+            <Copy className="h-4 w-4" />
+            Copy to...
+          </Button>
         )}
-      >
-        {isBusy ? (
-          <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" />
-        ) : toolbarState.isDestructive ? (
-          <Trash2 className="h-4 w-4" />
-        ) : (
-          <Unlink className="h-4 w-4" />
-        )}
-        {toolbarState.primaryLabel}
-      </Button>
+
+        <Button
+          variant={toolbarState.isDestructive ? 'destructive' : 'default'}
+          size="sm"
+          onClick={onPrimaryAction}
+          disabled={toolbarState.isPrimaryDisabled || isBusy}
+          aria-label={toolbarState.primaryAriaLabel}
+          className={cn(
+            'shrink-0 gap-1.5',
+            toolbarState.isDestructive && 'font-medium',
+          )}
+        >
+          {isBusy ? (
+            <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" />
+          ) : toolbarState.isDestructive ? (
+            <Trash2 className="h-4 w-4" />
+          ) : (
+            <Unlink className="h-4 w-4" />
+          )}
+          {toolbarState.primaryLabel}
+        </Button>
+      </div>
     </div>
   )
 })

--- a/src/renderer/src/components/skills/SelectionToolbar.tsx
+++ b/src/renderer/src/components/skills/SelectionToolbar.tsx
@@ -1,4 +1,4 @@
-import { Loader2, Trash2, Unlink, X } from 'lucide-react'
+import { Copy, Loader2, Trash2, Unlink, X } from 'lucide-react'
 import React, { useCallback } from 'react'
 
 import { Button } from '@/renderer/src/components/ui/button'
@@ -14,6 +14,7 @@ import {
 import {
   clearSelection,
   selectAll,
+  selectBulkCopying,
   selectBulkDeleting,
   selectBulkProgress,
   selectBulkUnlinking,
@@ -38,6 +39,12 @@ interface SelectionToolbarProps {
    * Undefined when in global view.
    */
   agentDisplayName?: string
+  /**
+   * Callback fired when the non-destructive "Copy to…" action is clicked.
+   * MainContent opens the BulkCopyToAgentsModal. Only rendered in global view
+   * (selectedAgentId === null); omit it to hide the button.
+   */
+  onCopyAction?: () => void
 }
 
 /**
@@ -60,6 +67,7 @@ interface SelectionToolbarProps {
 export const SelectionToolbar = React.memo(function SelectionToolbar({
   onPrimaryAction,
   agentDisplayName,
+  onCopyAction,
 }: SelectionToolbarProps): React.ReactElement | null {
   const dispatch = useAppDispatch()
 
@@ -74,6 +82,7 @@ export const SelectionToolbar = React.memo(function SelectionToolbar({
   const bulkSelectMode = useAppSelector(selectBulkSelectMode)
   const bulkDeleting = useAppSelector(selectBulkDeleting)
   const bulkUnlinking = useAppSelector(selectBulkUnlinking)
+  const bulkCopying = useAppSelector(selectBulkCopying)
   const bulkProgress = useAppSelector(selectBulkProgress)
 
   const handleSelectAllVisible = useCallback((): void => {
@@ -99,7 +108,7 @@ export const SelectionToolbar = React.memo(function SelectionToolbar({
     visibleCount: visibleSelectedCount,
     agentDisplayName,
   })
-  const isBusy = bulkDeleting || bulkUnlinking
+  const isBusy = bulkDeleting || bulkUnlinking || bulkCopying
 
   const showProgress =
     bulkProgress !== null && bulkProgress.total >= BULK_PROGRESS_THRESHOLD
@@ -177,6 +186,22 @@ export const SelectionToolbar = React.memo(function SelectionToolbar({
         <X className="h-3 w-3 mr-1" />
         Clear
       </Button>
+
+      {/* Non-destructive bulk copy — global view only. The outline variant +
+          Copy icon visually separates it from the destructive Delete (AC#4). */}
+      {selectedAgentId === null && onCopyAction && (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onCopyAction}
+          disabled={isBusy}
+          aria-label="Copy selected skills to agents"
+          className="shrink-0"
+        >
+          <Copy className="h-4 w-4" />
+          Copy to...
+        </Button>
+      )}
 
       <Button
         variant={toolbarState.isDestructive ? 'destructive' : 'default'}

--- a/src/renderer/src/components/skills/SkillsList.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillsList.browser.test.tsx
@@ -97,6 +97,8 @@ async function createStore(
         inFlightUnlinkNames: [],
         bulkDeleting: false,
         bulkUnlinking: false,
+        bulkCopying: false,
+        bulkCopyModalOpen: false,
         bulkProgress: null,
       },
     },

--- a/src/renderer/src/redux/selectors.test.ts
+++ b/src/renderer/src/redux/selectors.test.ts
@@ -24,6 +24,7 @@ import {
   selectRepoFacetOptions,
   selectSelectedCount,
   selectSelectedSkillNamesSet,
+  selectSelectedSkillObjects,
   selectSelectedVisibleCount,
   selectSelectedVisibleNames,
   selectSourceFilterViewModel,
@@ -67,6 +68,8 @@ function buildState(overrides: {
       inFlightUnlinkNames: overrides.inFlightUnlinkNames ?? [],
       bulkDeleting: false,
       bulkUnlinking: false,
+      bulkCopying: false,
+      bulkCopyModalOpen: false,
       bulkProgress: null,
     },
     ui: {
@@ -1302,6 +1305,43 @@ describe('selectSelectedSkillNamesSet', () => {
 
     // Assert
     expect(result1).toBe(result2)
+  })
+})
+
+describe('selectSelectedSkillObjects', () => {
+  it('resolves the ticked names to their full skill objects so the bulk-copy modal can read each path', () => {
+    // Arrange — three live skills, two of them ticked
+    const skills = [
+      makeSkill('alpha', 'claude-code'),
+      makeSkill('beta', 'claude-code'),
+      makeSkill('gamma', 'claude-code'),
+    ]
+    const state = buildState({
+      skills,
+      selectedSkillNames: ['gamma', 'alpha'],
+    })
+
+    // Act
+    const result = selectSelectedSkillObjects(state as never)
+
+    // Assert — kept in items order (alpha, gamma), each a full Skill with a path
+    expect(result.map((skill) => skill.name)).toEqual(['alpha', 'gamma'])
+    expect(result[0].path).toBe('/home/user/.agents/skills/alpha')
+  })
+
+  it('drops ticked names whose skill is gone so a stale selection cannot copy a phantom', () => {
+    // Arrange — "ghost" was ticked then removed by a background refresh
+    const skills = [makeSkill('alpha', 'claude-code')]
+    const state = buildState({
+      skills,
+      selectedSkillNames: ['alpha', 'ghost'],
+    })
+
+    // Act
+    const result = selectSelectedSkillObjects(state as never)
+
+    // Assert
+    expect(result.map((skill) => skill.name)).toEqual(['alpha'])
   })
 })
 

--- a/src/renderer/src/redux/selectors.test.ts
+++ b/src/renderer/src/redux/selectors.test.ts
@@ -24,7 +24,7 @@ import {
   selectRepoFacetOptions,
   selectSelectedCount,
   selectSelectedSkillNamesSet,
-  selectSelectedSkillObjects,
+  selectSelectedVisibleSkillObjects,
   selectSelectedVisibleCount,
   selectSelectedVisibleNames,
   selectSourceFilterViewModel,
@@ -1308,9 +1308,9 @@ describe('selectSelectedSkillNamesSet', () => {
   })
 })
 
-describe('selectSelectedSkillObjects', () => {
+describe('selectSelectedVisibleSkillObjects', () => {
   it('resolves the ticked names to their full skill objects so the bulk-copy modal can read each path', () => {
-    // Arrange — three live skills, two of them ticked
+    // Arrange — three live skills, two of them ticked, no filter active
     const skills = [
       makeSkill('alpha', 'claude-code'),
       makeSkill('beta', 'claude-code'),
@@ -1322,7 +1322,7 @@ describe('selectSelectedSkillObjects', () => {
     })
 
     // Act
-    const result = selectSelectedSkillObjects(state as never)
+    const result = selectSelectedVisibleSkillObjects(state as never)
 
     // Assert — kept in items order (alpha, gamma), each a full Skill with a path
     expect(result.map((skill) => skill.name)).toEqual(['alpha', 'gamma'])
@@ -1338,9 +1338,29 @@ describe('selectSelectedSkillObjects', () => {
     })
 
     // Act
-    const result = selectSelectedSkillObjects(state as never)
+    const result = selectSelectedVisibleSkillObjects(state as never)
 
     // Assert
+    expect(result.map((skill) => skill.name)).toEqual(['alpha'])
+  })
+
+  it('excludes ticked skills hidden by the active filter so bulk copy honors the "will not be affected" promise', () => {
+    // Arrange — alpha and beta both ticked, but a search query hides beta
+    const skills = [
+      makeSkill('alpha', 'claude-code'),
+      makeSkill('beta', 'claude-code'),
+    ]
+    const state = buildState({
+      skills,
+      selectedSkillNames: ['alpha', 'beta'],
+      searchQuery: 'alpha',
+    })
+
+    // Act
+    const result = selectSelectedVisibleSkillObjects(state as never)
+
+    // Assert — only the visible-and-ticked skill survives; hidden beta is dropped,
+    // matching the bulk delete/unlink behavior the toolbar badge advertises
     expect(result.map((skill) => skill.name)).toEqual(['alpha'])
   })
 })

--- a/src/renderer/src/redux/selectors.ts
+++ b/src/renderer/src/redux/selectors.ts
@@ -637,3 +637,16 @@ export const selectSelectedSkillNamesSet = createSelector(
   [selectSelectedSkillNames],
   (names): ReadonlySet<SkillName> => new Set(names),
 )
+
+/**
+ * The full `Skill` objects for the currently ticked names. Resolves
+ * `selectedSkillNames` against `state.skills.items`, dropping any name with no
+ * live skill (e.g. removed by a concurrent refresh). Feeds the bulk copy modal,
+ * which needs each skill's `path` as the copy source.
+ * @returns Skill[] in `items` order
+ */
+export const selectSelectedSkillObjects = createSelector(
+  [selectSkillsItems, selectSelectedSkillNamesSet],
+  (items, selectedNames): Skill[] =>
+    items.filter((skill) => selectedNames.has(skill.name)),
+)

--- a/src/renderer/src/redux/selectors.ts
+++ b/src/renderer/src/redux/selectors.ts
@@ -639,14 +639,19 @@ export const selectSelectedSkillNamesSet = createSelector(
 )
 
 /**
- * The full `Skill` objects for the currently ticked names. Resolves
- * `selectedSkillNames` against `state.skills.items`, dropping any name with no
- * live skill (e.g. removed by a concurrent refresh). Feeds the bulk copy modal,
- * which needs each skill's `path` as the copy source.
- * @returns Skill[] in `items` order
+ * The full `Skill` objects for the ticked names that are ALSO currently visible
+ * (pass the active search/repo filter). Mirrors `selectSelectedVisibleNames`
+ * used by bulk delete/unlink, so bulk copy honors the toolbar's "+K hidden by
+ * filter — will not be affected" promise instead of silently copying hidden
+ * selections. Any ticked name with no live skill (removed by a concurrent
+ * refresh) is dropped too. Feeds the bulk copy modal, which needs each skill's
+ * `path` as the copy source.
+ * @returns Skill[] in `items` order, restricted to the visible-and-selected set
  */
-export const selectSelectedSkillObjects = createSelector(
-  [selectSkillsItems, selectSelectedSkillNamesSet],
-  (items, selectedNames): Skill[] =>
-    items.filter((skill) => selectedNames.has(skill.name)),
+export const selectSelectedVisibleSkillObjects = createSelector(
+  [selectSkillsItems, selectSelectedVisibleNames],
+  (items, visibleSelectedNames): Skill[] => {
+    const visibleSelectedSet = new Set(visibleSelectedNames)
+    return items.filter((skill) => visibleSelectedSet.has(skill.name))
+  },
 )

--- a/src/renderer/src/redux/slices/skillsSlice.test.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.test.ts
@@ -684,6 +684,32 @@ describe('skillsSlice bulkCopyToAgents thunk', () => {
     expect(inFlight).toBe(true)
     expect(store.getState().skills.bulkCopying).toBe(false)
   })
+
+  it('leaves the list selection intact after copying so the same rows can be copied elsewhere', async () => {
+    // Arrange — two skills ticked; copy is non-destructive
+    mockCopyToAgents.mockResolvedValue({
+      success: true,
+      copied: 1,
+      failures: [],
+    })
+    const store = await createTestStore()
+    const { bulkCopyToAgents, selectAll } = await import('./skillsSlice')
+    store.dispatch(selectAll(['alpha' as SkillName, 'beta' as SkillName]))
+
+    // Act
+    await store.dispatch(
+      bulkCopyToAgents({
+        items: [item('alpha'), item('beta')],
+        agentIds: ['codex' as AgentId],
+      }),
+    )
+
+    // Assert — selection survives (unlike deleteSelectedSkills, which clears it)
+    expect(store.getState().skills.selectedSkillNames).toEqual([
+      'alpha',
+      'beta',
+    ])
+  })
 })
 
 describe('skillsSlice bulk selection reducers (v2.4)', () => {

--- a/src/renderer/src/redux/slices/skillsSlice.test.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.test.ts
@@ -710,6 +710,36 @@ describe('skillsSlice bulkCopyToAgents thunk', () => {
       'beta',
     ])
   })
+
+  it('cancels a dispatch while another bulk copy is already in flight (single-flight guard)', async () => {
+    // Arrange — simulate an in-flight batch by putting the slice in its pending
+    // state, exactly as a real first dispatch would (bulkCopying = true).
+    const store = await createTestStore()
+    const { bulkCopyToAgents } = await import('./skillsSlice')
+    store.dispatch(
+      bulkCopyToAgents.pending('inflight-request-id', {
+        items: [item('alpha')],
+        agentIds: ['codex' as AgentId],
+      }),
+    )
+    expect(store.getState().skills.bulkCopying).toBe(true)
+
+    // Act — a second concurrent dispatch must be cancelled by the thunk's
+    // `condition` before its payload creator (the IPC fan-out) ever runs.
+    const result = await store.dispatch(
+      bulkCopyToAgents({
+        items: [item('beta')],
+        agentIds: ['codex' as AgentId],
+      }),
+    )
+
+    // Assert — rejected via `condition`, and the copy IPC was never invoked
+    expect(bulkCopyToAgents.rejected.match(result)).toBe(true)
+    if (bulkCopyToAgents.rejected.match(result)) {
+      expect(result.meta.condition).toBe(true)
+    }
+    expect(mockCopyToAgents).not.toHaveBeenCalled()
+  })
 })
 
 describe('skillsSlice bulk selection reducers (v2.4)', () => {

--- a/src/renderer/src/redux/slices/skillsSlice.test.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.test.ts
@@ -11,6 +11,7 @@ import type {
   FilesystemEntryIdentity,
   RestoreDeletedSkillResult,
   Skill,
+  SkillName,
   SymlinkInfo,
   TombstoneId,
 } from '@/shared/types'
@@ -546,6 +547,142 @@ describe('skillsSlice', () => {
 
     // Assert
     expect(store.getState().skills.error).toBe('Failed to copy to any agent')
+  })
+})
+
+describe('skillsSlice bulkCopyToAgents thunk', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const item = (
+    name: string,
+  ): { skillName: SkillName; sourcePath: AbsolutePath } => ({
+    skillName: name as SkillName,
+    sourcePath: `/Users/me/.agents/skills/${name}` as AbsolutePath,
+  })
+
+  it('copies every selected skill to the chosen agents and returns one outcome per skill', async () => {
+    // Arrange
+    mockCopyToAgents.mockResolvedValue({
+      success: true,
+      copied: 2,
+      failures: [],
+    })
+    const store = await createTestStore()
+    const { bulkCopyToAgents } = await import('./skillsSlice')
+
+    // Act
+    const result = await store.dispatch(
+      bulkCopyToAgents({
+        items: [item('alpha'), item('beta')],
+        agentIds: ['codex' as AgentId, 'cursor' as AgentId],
+      }),
+    )
+
+    // Assert
+    expect(mockCopyToAgents).toHaveBeenCalledTimes(2)
+    expect(bulkCopyToAgents.fulfilled.match(result)).toBe(true)
+    if (bulkCopyToAgents.fulfilled.match(result)) {
+      expect(result.payload.perSkill).toEqual([
+        { skillName: 'alpha', copied: 2, failures: [] },
+        { skillName: 'beta', copied: 2, failures: [] },
+      ])
+    }
+    expect(store.getState().skills.bulkCopying).toBe(false)
+  })
+
+  it('keeps copying the rest of the batch when one skill fails on an occupied target', async () => {
+    // Arrange — alpha is clean; beta already exists on codex
+    mockCopyToAgents
+      .mockResolvedValueOnce({ success: true, copied: 1, failures: [] })
+      .mockResolvedValueOnce({
+        success: false,
+        copied: 0,
+        failures: [{ agentId: 'codex', error: 'Already exists' }],
+      })
+    const store = await createTestStore()
+    const { bulkCopyToAgents } = await import('./skillsSlice')
+
+    // Act
+    const result = await store.dispatch(
+      bulkCopyToAgents({
+        items: [item('alpha'), item('beta')],
+        agentIds: ['codex' as AgentId],
+      }),
+    )
+
+    // Assert — both attempted (no abort), beta's per-target failure recorded
+    expect(mockCopyToAgents).toHaveBeenCalledTimes(2)
+    if (bulkCopyToAgents.fulfilled.match(result)) {
+      expect(result.payload.perSkill[0]).toEqual({
+        skillName: 'alpha',
+        copied: 1,
+        failures: [],
+      })
+      expect(result.payload.perSkill[1]).toEqual({
+        skillName: 'beta',
+        copied: 0,
+        failures: [{ agentId: 'codex', error: 'Already exists' }],
+      })
+    }
+  })
+
+  it('records a per-target failure when the copy IPC rejects, without aborting the batch', async () => {
+    // Arrange — alpha's IPC throws (e.g. source path validation), beta succeeds
+    mockCopyToAgents
+      .mockRejectedValueOnce(new Error('Invalid source path'))
+      .mockResolvedValueOnce({ success: true, copied: 1, failures: [] })
+    const store = await createTestStore()
+    const { bulkCopyToAgents } = await import('./skillsSlice')
+
+    // Act
+    const result = await store.dispatch(
+      bulkCopyToAgents({
+        items: [item('alpha'), item('beta')],
+        agentIds: ['codex' as AgentId],
+      }),
+    )
+
+    // Assert — alpha rejected → recorded as a failure; beta still copied
+    expect(mockCopyToAgents).toHaveBeenCalledTimes(2)
+    if (bulkCopyToAgents.fulfilled.match(result)) {
+      expect(result.payload.perSkill[0]).toEqual({
+        skillName: 'alpha',
+        copied: 0,
+        failures: [{ agentId: 'codex', error: 'Invalid source path' }],
+      })
+      expect(result.payload.perSkill[1]).toEqual({
+        skillName: 'beta',
+        copied: 1,
+        failures: [],
+      })
+    }
+  })
+
+  it('sets bulkCopying true while in flight and false once settled', async () => {
+    // Arrange
+    mockCopyToAgents.mockResolvedValue({
+      success: true,
+      copied: 1,
+      failures: [],
+    })
+    const store = await createTestStore()
+    const { bulkCopyToAgents } = await import('./skillsSlice')
+
+    // Act — read the flag before awaiting the dispatch
+    const pending = store.dispatch(
+      bulkCopyToAgents({
+        items: [item('alpha')],
+        agentIds: ['codex' as AgentId],
+      }),
+    )
+    const inFlight = store.getState().skills.bulkCopying
+    await pending
+
+    // Assert
+    expect(inFlight).toBe(true)
+    expect(store.getState().skills.bulkCopying).toBe(false)
   })
 })
 

--- a/src/renderer/src/redux/slices/skillsSlice.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.ts
@@ -320,38 +320,57 @@ export const bulkCopyToAgents = createAsyncThunk<
   {
     items: Array<{ skillName: SkillName; sourcePath: AbsolutePath }>
     agentIds: AgentId[]
-  }
->('skills/bulkCopyToAgents', async ({ items, agentIds }) => {
-  const perSkill: BulkCopyToAgentsResult['perSkill'] = []
-  // Serial fan-out: one IPC round-trip per skill. Each iteration is isolated so
-  // a rejected copy (e.g. source path failed validation) fails only that skill.
-  for (const item of items) {
-    try {
-      const result = await window.electron.skills.copyToAgents({
-        skillName: item.skillName,
-        sourcePath: item.sourcePath,
-        targetAgentIds: agentIds,
-      })
-      perSkill.push({
-        skillName: item.skillName,
-        copied: result.copied,
-        failures: result.failures,
-      })
-    } catch (error) {
-      // IPC rejected outright → record every target as failed for this skill
-      // and keep going; the aggregate surfaces it as a partial failure.
-      perSkill.push({
-        skillName: item.skillName,
-        copied: 0,
-        failures: agentIds.map((agentId) => ({
-          agentId,
-          error: error instanceof Error ? error.message : 'Copy failed',
-        })),
-      })
+  },
+  // The condition only reads `state.skills.bulkCopying`, so depend on exactly
+  // that slice (indexed from RootState) rather than the whole store. This keeps
+  // the thunk dispatchable from both the app store and the skills-only test
+  // store, and documents the thunk's true state surface.
+  { state: Pick<RootState, 'skills'> }
+>(
+  'skills/bulkCopyToAgents',
+  async ({ items, agentIds }) => {
+    const perSkill: BulkCopyToAgentsResult['perSkill'] = []
+    // Serial fan-out: one IPC round-trip per skill. Each iteration is isolated so
+    // a rejected copy (e.g. source path failed validation) fails only that skill.
+    for (const item of items) {
+      try {
+        const result = await window.electron.skills.copyToAgents({
+          skillName: item.skillName,
+          sourcePath: item.sourcePath,
+          targetAgentIds: agentIds,
+        })
+        perSkill.push({
+          skillName: item.skillName,
+          copied: result.copied,
+          failures: result.failures,
+        })
+      } catch (error) {
+        // IPC rejected outright → record every target as failed for this skill
+        // and keep going; the aggregate surfaces it as a partial failure.
+        perSkill.push({
+          skillName: item.skillName,
+          copied: 0,
+          failures: agentIds.map((agentId) => ({
+            agentId,
+            error: error instanceof Error ? error.message : 'Copy failed',
+          })),
+        })
+      }
     }
-  }
-  return { perSkill }
-})
+    return { perSkill }
+  },
+  {
+    // Dispatch-level single-flight guard: the modal's disabled button and early
+    // return both read a render-stale `bulkCopying`, so a same-frame double click
+    // (or any programmatic re-dispatch) could slip a second batch through before
+    // React re-renders. `bulkCopying` flips true synchronously in this thunk's
+    // `pending` reducer, so cancelling when it is already set makes the re-entrant
+    // dispatch a no-op — the only race-free point to enforce single-flight.
+    condition: (_arg, { getState }) => {
+      if (getState().skills.bulkCopying) return false
+    },
+  },
+)
 
 /**
  * Delete every selected skill in a single batch. Serial execution happens in

--- a/src/renderer/src/redux/slices/skillsSlice.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.ts
@@ -5,6 +5,7 @@ import type { RootState } from '@/renderer/src/redux/store'
 import type {
   AbsolutePath,
   AgentId,
+  BulkCopyToAgentsResult,
   BulkDeleteResult,
   BulkUnlinkResult,
   ClearOrphanSymlinksResult,
@@ -68,6 +69,10 @@ interface SkillsState {
   bulkDeleting: boolean
   /** true while a batch unlink thunk is between .pending and settled. */
   bulkUnlinking: boolean
+  /** true while a batch copy-to-agents thunk is between .pending and settled. */
+  bulkCopying: boolean
+  /** true while the BulkCopyToAgentsModal (global-view multi-skill copy) is open. */
+  bulkCopyModalOpen: boolean
   /** Progress counter emitted by main for batches with total >= 10. */
   bulkProgress: { current: number; total: number } | null
 }
@@ -91,6 +96,8 @@ const initialState: SkillsState = {
   inFlightUnlinkNames: [],
   bulkDeleting: false,
   bulkUnlinking: false,
+  bulkCopying: false,
+  bulkCopyModalOpen: false,
   bulkProgress: null,
 }
 
@@ -294,6 +301,59 @@ export const copyToAgents = createAsyncThunk(
 )
 
 /**
+ * Copy every selected skill to the chosen target agents in one batch.
+ *
+ * Renderer-side fan-out: loops the RAW `copyToAgents` IPC once per selected
+ * skill — NOT the single `copyToAgents` thunk, which throws when a skill copies
+ * to zero agents and would abort the whole batch. Each skill's per-agent result
+ * is collected even when some targets fail ("Already exists", broken source),
+ * so one bad skill never blocks the rest. Non-destructive: the source skills are
+ * never modified or removed, so the list selection survives the operation.
+ * @param params.items - selected skills as `{ skillName, sourcePath }`; sourcePath = `skill.path` in global view
+ * @param params.agentIds - target agents every selected skill is copied into
+ * @returns BulkCopyToAgentsResult — one PerSkillCopyOutcome per item, in dispatch order
+ * @example
+ * await dispatch(bulkCopyToAgents({ items: [{ skillName: 'a', sourcePath: '/Users/me/.agents/skills/a' }], agentIds: ['codex'] }))
+ */
+export const bulkCopyToAgents = createAsyncThunk<
+  BulkCopyToAgentsResult,
+  {
+    items: Array<{ skillName: SkillName; sourcePath: AbsolutePath }>
+    agentIds: AgentId[]
+  }
+>('skills/bulkCopyToAgents', async ({ items, agentIds }) => {
+  const perSkill: BulkCopyToAgentsResult['perSkill'] = []
+  // Serial fan-out: one IPC round-trip per skill. Each iteration is isolated so
+  // a rejected copy (e.g. source path failed validation) fails only that skill.
+  for (const item of items) {
+    try {
+      const result = await window.electron.skills.copyToAgents({
+        skillName: item.skillName,
+        sourcePath: item.sourcePath,
+        targetAgentIds: agentIds,
+      })
+      perSkill.push({
+        skillName: item.skillName,
+        copied: result.copied,
+        failures: result.failures,
+      })
+    } catch (error) {
+      // IPC rejected outright → record every target as failed for this skill
+      // and keep going; the aggregate surfaces it as a partial failure.
+      perSkill.push({
+        skillName: item.skillName,
+        copied: 0,
+        failures: agentIds.map((agentId) => ({
+          agentId,
+          error: error instanceof Error ? error.message : 'Copy failed',
+        })),
+      })
+    }
+  }
+  return { perSkill }
+})
+
+/**
  * Delete every selected skill in a single batch. Serial execution happens in
  * main; the renderer receives a `BulkDeleteResult` with a per-item outcome.
  *
@@ -470,6 +530,14 @@ const skillsSlice = createSlice({
       state.selectedCopyAgentIds = []
     },
     /**
+     * Open/close the BulkCopyToAgentsModal (global-view multi-skill copy).
+     * The toolbar's "Copy to…" opens it; the modal dispatches false on
+     * dismiss/Cancel/completion. List selection is untouched (non-destructive).
+     */
+    setBulkCopyModalOpen: (state, action: PayloadAction<boolean>) => {
+      state.bulkCopyModalOpen = action.payload
+    },
+    /**
      * Toggle one target agent in the AddSymlinkModal selection.
      */
     toggleAddAgentSelection: (state, action: PayloadAction<AgentId>) => {
@@ -602,6 +670,21 @@ const skillsSlice = createSlice({
       .addCase(copyToAgents.rejected, (state, action) => {
         state.copying = false
         state.error = action.error.message ?? 'Failed to copy skill'
+      })
+      // Bulk copy to agents (renderer fan-out over the copyToAgents IPC)
+      .addCase(bulkCopyToAgents.pending, (state) => {
+        state.bulkCopying = true
+        state.error = null
+      })
+      .addCase(bulkCopyToAgents.fulfilled, (state) => {
+        // Selection is intentionally preserved: copy is non-destructive, so the
+        // user can keep the same rows ticked to copy elsewhere. The modal closes
+        // itself and refreshAllData repopulates the list.
+        state.bulkCopying = false
+      })
+      .addCase(bulkCopyToAgents.rejected, (state, action) => {
+        state.bulkCopying = false
+        state.error = action.error.message ?? 'Failed to copy skills'
       })
       .addCase(deleteSelectedSkills.pending, (state, action) => {
         state.inFlightDeleteNames = reconcileByLiveNames(
@@ -754,6 +837,7 @@ export const {
   selectAll,
   clearSelection,
   setBulkProgress,
+  setBulkCopyModalOpen,
 } = skillsSlice.actions
 export default skillsSlice.reducer
 
@@ -776,6 +860,10 @@ export const selectBulkDeleting = (state: RootState): boolean =>
   state.skills.bulkDeleting
 export const selectBulkUnlinking = (state: RootState): boolean =>
   state.skills.bulkUnlinking
+export const selectBulkCopying = (state: RootState): boolean =>
+  state.skills.bulkCopying
+export const selectBulkCopyModalOpen = (state: RootState): boolean =>
+  state.skills.bulkCopyModalOpen
 export const selectBulkProgress = (
   state: RootState,
 ): { current: number; total: number } | null => state.skills.bulkProgress

--- a/src/renderer/src/utils/summarizeBulkCopyResult.test.ts
+++ b/src/renderer/src/utils/summarizeBulkCopyResult.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+
+import type { PerSkillCopyOutcome } from '@/shared/types'
+
+import { summarizeBulkCopyResult } from './summarizeBulkCopyResult'
+
+describe('summarizeBulkCopyResult', () => {
+  it('reports success and lists the copied skills when every target succeeds', () => {
+    // Arrange
+    const perSkill: PerSkillCopyOutcome[] = [
+      { skillName: 'alpha', copied: 2, failures: [] },
+      { skillName: 'beta', copied: 2, failures: [] },
+    ]
+
+    // Act
+    const content = summarizeBulkCopyResult(perSkill)
+
+    // Assert
+    expect(content).toEqual({
+      tone: 'success',
+      title: 'Copied 2 skills to 2 agents',
+      description: 'alpha, beta',
+    })
+  })
+
+  it('uses singular wording for one skill copied to one agent', () => {
+    // Arrange
+    const perSkill: PerSkillCopyOutcome[] = [
+      { skillName: 'alpha', copied: 1, failures: [] },
+    ]
+
+    // Act
+    const content = summarizeBulkCopyResult(perSkill)
+
+    // Assert
+    expect(content).toEqual({
+      tone: 'success',
+      title: 'Copied 1 skill to 1 agent',
+      description: 'alpha',
+    })
+  })
+
+  it('warns and lists the per-target failures when some copies fail', () => {
+    // Arrange
+    const perSkill: PerSkillCopyOutcome[] = [
+      { skillName: 'alpha', copied: 1, failures: [] },
+      {
+        skillName: 'beta',
+        copied: 0,
+        failures: [{ agentId: 'codex', error: 'Already exists' }],
+      },
+    ]
+
+    // Act
+    const content = summarizeBulkCopyResult(perSkill)
+
+    // Assert
+    expect(content).toEqual({
+      tone: 'warning',
+      title: 'Copied 1 of 2 skills, 1 copy failed',
+      description: 'beta → codex: Already exists',
+    })
+  })
+
+  it('reports a hard error when nothing was copied to any agent', () => {
+    // Arrange
+    const perSkill: PerSkillCopyOutcome[] = [
+      {
+        skillName: 'alpha',
+        copied: 0,
+        failures: [{ agentId: 'codex', error: 'Already exists' }],
+      },
+    ]
+
+    // Act
+    const content = summarizeBulkCopyResult(perSkill)
+
+    // Assert
+    expect(content).toEqual({
+      tone: 'error',
+      title: 'Failed to copy 1 skill',
+      description: 'alpha → codex: Already exists',
+    })
+  })
+
+  it('returns an error for an empty result instead of a misleading success', () => {
+    // Arrange
+    const perSkill: PerSkillCopyOutcome[] = []
+
+    // Act
+    const content = summarizeBulkCopyResult(perSkill)
+
+    // Assert
+    expect(content).toEqual({
+      tone: 'error',
+      title: 'Nothing to copy',
+      description: 'No skills were selected.',
+    })
+  })
+})

--- a/src/renderer/src/utils/summarizeBulkCopyResult.test.ts
+++ b/src/renderer/src/utils/summarizeBulkCopyResult.test.ts
@@ -6,14 +6,14 @@ import { summarizeBulkCopyResult } from './summarizeBulkCopyResult'
 
 describe('summarizeBulkCopyResult', () => {
   it('reports success and lists the copied skills when every target succeeds', () => {
-    // Arrange
+    // Arrange — two skills, each copied to both ticked agents
     const perSkill: PerSkillCopyOutcome[] = [
       { skillName: 'alpha', copied: 2, failures: [] },
       { skillName: 'beta', copied: 2, failures: [] },
     ]
 
     // Act
-    const content = summarizeBulkCopyResult(perSkill)
+    const content = summarizeBulkCopyResult(perSkill, 2)
 
     // Assert
     expect(content).toEqual({
@@ -24,13 +24,13 @@ describe('summarizeBulkCopyResult', () => {
   })
 
   it('uses singular wording for one skill copied to one agent', () => {
-    // Arrange
+    // Arrange — one skill, one ticked agent
     const perSkill: PerSkillCopyOutcome[] = [
       { skillName: 'alpha', copied: 1, failures: [] },
     ]
 
     // Act
-    const content = summarizeBulkCopyResult(perSkill)
+    const content = summarizeBulkCopyResult(perSkill, 1)
 
     // Assert
     expect(content).toEqual({
@@ -41,7 +41,7 @@ describe('summarizeBulkCopyResult', () => {
   })
 
   it('warns and lists the per-target failures when some copies fail', () => {
-    // Arrange
+    // Arrange — alpha lands on the one agent, beta collides on it
     const perSkill: PerSkillCopyOutcome[] = [
       { skillName: 'alpha', copied: 1, failures: [] },
       {
@@ -52,7 +52,7 @@ describe('summarizeBulkCopyResult', () => {
     ]
 
     // Act
-    const content = summarizeBulkCopyResult(perSkill)
+    const content = summarizeBulkCopyResult(perSkill, 1)
 
     // Assert
     expect(content).toEqual({
@@ -62,8 +62,34 @@ describe('summarizeBulkCopyResult', () => {
     })
   })
 
+  it('uses plural "copies" wording when several targets fail but some still copy', () => {
+    // Arrange — alpha fully copies to both agents, beta collides on both
+    const perSkill: PerSkillCopyOutcome[] = [
+      { skillName: 'alpha', copied: 2, failures: [] },
+      {
+        skillName: 'beta',
+        copied: 0,
+        failures: [
+          { agentId: 'codex', error: 'Already exists' },
+          { agentId: 'cursor', error: 'Already exists' },
+        ],
+      },
+    ]
+
+    // Act
+    const content = summarizeBulkCopyResult(perSkill, 2)
+
+    // Assert
+    expect(content).toEqual({
+      tone: 'warning',
+      title: 'Copied 1 of 2 skills, 2 copies failed',
+      description:
+        'beta → codex: Already exists, beta → cursor: Already exists',
+    })
+  })
+
   it('reports a hard error when nothing was copied to any agent', () => {
-    // Arrange
+    // Arrange — the one skill collides on its one target
     const perSkill: PerSkillCopyOutcome[] = [
       {
         skillName: 'alpha',
@@ -73,7 +99,7 @@ describe('summarizeBulkCopyResult', () => {
     ]
 
     // Act
-    const content = summarizeBulkCopyResult(perSkill)
+    const content = summarizeBulkCopyResult(perSkill, 1)
 
     // Assert
     expect(content).toEqual({
@@ -83,12 +109,56 @@ describe('summarizeBulkCopyResult', () => {
     })
   })
 
+  it('reports a hard error listing every failure when nothing copies across multiple skills', () => {
+    // Arrange — both skills collide on the same single target
+    const perSkill: PerSkillCopyOutcome[] = [
+      {
+        skillName: 'alpha',
+        copied: 0,
+        failures: [{ agentId: 'codex', error: 'Already exists' }],
+      },
+      {
+        skillName: 'beta',
+        copied: 0,
+        failures: [{ agentId: 'codex', error: 'Already exists' }],
+      },
+    ]
+
+    // Act
+    const content = summarizeBulkCopyResult(perSkill, 1)
+
+    // Assert
+    expect(content).toEqual({
+      tone: 'error',
+      title: 'Failed to copy 2 skills',
+      description:
+        'alpha → codex: Already exists, beta → codex: Already exists',
+    })
+  })
+
+  it('falls back to a generic error when nothing copied and no failures were reported', () => {
+    // Arrange — defensive path: a skill came back copied:0 with no failure rows
+    const perSkill: PerSkillCopyOutcome[] = [
+      { skillName: 'alpha', copied: 0, failures: [] },
+    ]
+
+    // Act
+    const content = summarizeBulkCopyResult(perSkill, 0)
+
+    // Assert
+    expect(content).toEqual({
+      tone: 'error',
+      title: 'Failed to copy 1 skill',
+      description: 'An unexpected error occurred',
+    })
+  })
+
   it('returns an error for an empty result instead of a misleading success', () => {
-    // Arrange
+    // Arrange — no skills selected
     const perSkill: PerSkillCopyOutcome[] = []
 
     // Act
-    const content = summarizeBulkCopyResult(perSkill)
+    const content = summarizeBulkCopyResult(perSkill, 2)
 
     // Assert
     expect(content).toEqual({

--- a/src/renderer/src/utils/summarizeBulkCopyResult.ts
+++ b/src/renderer/src/utils/summarizeBulkCopyResult.ts
@@ -19,19 +19,23 @@ export interface BulkCopyToastContent {
  * fulfilment.
  *
  * @param perSkill - one outcome per selected skill (`BulkCopyToAgentsResult.perSkill`)
+ * @param targetAgentCount - how many agents the user ticked; the authoritative
+ *   denominator for the success title, sourced from the modal's checked agents
+ *   rather than inferred from any single skill's `copied`
  * @returns
  * - every target copied → `success`, lists the copied skill names so each is recognizable later
  * - nothing copied at all → `error`, lists the failures
  * - mixed → `warning`, reports the fully-copied count and the per-target failures
  * @example
- * summarizeBulkCopyResult([{ skillName: 'a', copied: 2, failures: [] }])
+ * summarizeBulkCopyResult([{ skillName: 'a', copied: 2, failures: [] }], 2)
  * // => { tone: 'success', title: 'Copied 1 skill to 2 agents', description: 'a' }
  * @example
- * summarizeBulkCopyResult([{ skillName: 'a', copied: 1, failures: [{ agentId: 'codex', error: 'Already exists' }] }])
+ * summarizeBulkCopyResult([{ skillName: 'a', copied: 1, failures: [{ agentId: 'codex', error: 'Already exists' }] }], 2)
  * // => { tone: 'warning', title: 'Copied 0 of 1 skill, 1 copy failed', description: 'a → codex: Already exists' }
  */
 export function summarizeBulkCopyResult(
   perSkill: BulkCopyToAgentsResult['perSkill'],
+  targetAgentCount: number,
 ): BulkCopyToastContent {
   // Defensive: callers guard against this, but never fabricate a "success".
   if (perSkill.length === 0) {
@@ -75,13 +79,13 @@ export function summarizeBulkCopyResult(
     }
   }
 
-  // Every selected skill copied to every chosen agent. With zero failures each
-  // skill targeted the same agents, so any outcome's `copied` is the agent count.
-  const agentsPerSkill = perSkill[0].copied
-  const agentWord = agentsPerSkill === 1 ? 'agent' : 'agents'
+  // Every selected skill copied to every chosen agent. Use the authoritative
+  // ticked-agent count for the title rather than inferring it from a skill's
+  // `copied`, so the wording can't drift if the IPC contract ever changes.
+  const agentWord = targetAgentCount === 1 ? 'agent' : 'agents'
   return {
     tone: 'success',
-    title: `Copied ${skillCount} ${skillWord} to ${agentsPerSkill} ${agentWord}`,
+    title: `Copied ${skillCount} ${skillWord} to ${targetAgentCount} ${agentWord}`,
     description: perSkill.map((outcome) => outcome.skillName).join(', '),
   }
 }

--- a/src/renderer/src/utils/summarizeBulkCopyResult.ts
+++ b/src/renderer/src/utils/summarizeBulkCopyResult.ts
@@ -1,0 +1,87 @@
+import type { BulkCopyToAgentsResult } from '@/shared/types'
+
+/** Sonner toast severity for a bulk copy outcome. */
+export type BulkCopyToastTone = 'success' | 'warning' | 'error'
+
+/** Title + description + severity for the single toast shown after a bulk copy. */
+export interface BulkCopyToastContent {
+  tone: BulkCopyToastTone
+  title: string
+  description: string
+}
+
+/**
+ * Collapse a bulk copy-to-agents result into ONE user-facing toast.
+ *
+ * Exists so `BulkCopyToAgentsModal` fires a single toast (not one per skill)
+ * after the renderer fan-out completes, and so the success / partial / failure
+ * wording stays unit-testable in isolation. Triggered on `bulkCopyToAgents`
+ * fulfilment.
+ *
+ * @param perSkill - one outcome per selected skill (`BulkCopyToAgentsResult.perSkill`)
+ * @returns
+ * - every target copied → `success`, lists the copied skill names so each is recognizable later
+ * - nothing copied at all → `error`, lists the failures
+ * - mixed → `warning`, reports the fully-copied count and the per-target failures
+ * @example
+ * summarizeBulkCopyResult([{ skillName: 'a', copied: 2, failures: [] }])
+ * // => { tone: 'success', title: 'Copied 1 skill to 2 agents', description: 'a' }
+ * @example
+ * summarizeBulkCopyResult([{ skillName: 'a', copied: 1, failures: [{ agentId: 'codex', error: 'Already exists' }] }])
+ * // => { tone: 'warning', title: 'Copied 0 of 1 skill, 1 copy failed', description: 'a → codex: Already exists' }
+ */
+export function summarizeBulkCopyResult(
+  perSkill: BulkCopyToAgentsResult['perSkill'],
+): BulkCopyToastContent {
+  // Defensive: callers guard against this, but never fabricate a "success".
+  if (perSkill.length === 0) {
+    return {
+      tone: 'error',
+      title: 'Nothing to copy',
+      description: 'No skills were selected.',
+    }
+  }
+
+  const skillCount = perSkill.length
+  const skillWord = skillCount === 1 ? 'skill' : 'skills'
+  const totalCopied = perSkill.reduce((sum, outcome) => sum + outcome.copied, 0)
+  const failureLines = perSkill.flatMap((outcome) =>
+    outcome.failures.map(
+      (failure) =>
+        `${outcome.skillName} → ${failure.agentId}: ${failure.error}`,
+    ),
+  )
+  const failureCount = failureLines.length
+
+  // Nothing landed anywhere — surface as a hard failure.
+  if (totalCopied === 0) {
+    return {
+      tone: 'error',
+      title: `Failed to copy ${skillCount} ${skillWord}`,
+      description: failureLines.join(', ') || 'An unexpected error occurred',
+    }
+  }
+
+  // Some targets rejected (e.g. destination already exists) — partial success.
+  if (failureCount > 0) {
+    const copyWord = failureCount === 1 ? 'copy' : 'copies'
+    const fullySucceeded = perSkill.filter(
+      (outcome) => outcome.failures.length === 0,
+    ).length
+    return {
+      tone: 'warning',
+      title: `Copied ${fullySucceeded} of ${skillCount} ${skillWord}, ${failureCount} ${copyWord} failed`,
+      description: failureLines.join(', '),
+    }
+  }
+
+  // Every selected skill copied to every chosen agent. With zero failures each
+  // skill targeted the same agents, so any outcome's `copied` is the agent count.
+  const agentsPerSkill = perSkill[0].copied
+  const agentWord = agentsPerSkill === 1 ? 'agent' : 'agents'
+  return {
+    tone: 'success',
+    title: `Copied ${skillCount} ${skillWord} to ${agentsPerSkill} ${agentWord}`,
+    description: perSkill.map((outcome) => outcome.skillName).join(', '),
+  }
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1201,6 +1201,32 @@ export interface CopyToAgentsResult {
 }
 
 /**
+ * One selected skill's outcome inside a {@link BulkCopyToAgentsResult}.
+ * Mirrors a single `copyToAgents` IPC result, tagged with the skill it came from.
+ * @example { skillName: 'my-skill', copied: 2, failures: [] }
+ */
+export interface PerSkillCopyOutcome {
+  /** The skill that was copied. */
+  skillName: SkillName
+  /** Number of target agents this skill was successfully copied to. @example 2 */
+  copied: AgentCount
+  /** Per-agent failures for THIS skill (e.g. destination already exists). */
+  failures: CopyToAgentsResult['failures']
+}
+
+/**
+ * Aggregate result of a bulk copy-to-agents run. The renderer fans the
+ * `copyToAgents` IPC out once per selected skill and collects every outcome —
+ * even when some skills or targets fail — so the batch never aborts on a single
+ * bad skill. Summarised for the user by `summarizeBulkCopyResult`.
+ * @example { perSkill: [{ skillName: 'a', copied: 1, failures: [] }] }
+ */
+export interface BulkCopyToAgentsResult {
+  /** One outcome per selected skill, in dispatch order. */
+  perSkill: PerSkillCopyOutcome[]
+}
+
+/**
  * A sync conflict: a real folder already exists at the path where the skill
  * symlink would be created. Surfaced to the user for create-vs-replace choice.
  * @example


### PR DESCRIPTION
## Summary

Adds **bulk copy** to the skills list: in global (all-skills) view, enter bulk-select
mode, tick several skills, and copy them all into a chosen set of agents in one
action. This is the non-destructive sibling of the existing bulk **delete**/**unlink**
and of the single-skill **Copy to Agents** modal.

- New global-view toolbar action **"Copy to…"** (outline + Copy icon), visually
  separated from the destructive **Delete** (`SelectionToolbar`).
- New **`BulkCopyToAgentsModal`** — mirrors the single-skill `CopyToAgentsModal`
  scaffold (narrow dialog, agent checklist, live count), fanning the existing
  `copyToAgents` IPC across every selected skill via a new `bulkCopyToAgents`
  thunk.
- A result is summarized into one success / warning / error toast
  (`summarizeBulkCopyResult`), listing per-skill→agent outcomes.

Closes #198.

## ⚠️ Scope note: what "copy" means here

The issue's optional *example* ("paste the result into a note or message") implies a
**clipboard** copy. Per maintainer direction, **"copy" here means a physical /
symlink copy to agents via `copyToAgents`** — i.e. install the selected skills into
the chosen agents — **superseding the issue's clipboard example**. This satisfies the
binding acceptance criteria (esp. "the copied result includes enough information for
each selected skill to be recognized later": the full skill directory lands in each
agent), and matches the established single-skill "Copy to Agents" flow.

## Acceptance criteria

| AC | How it's met |
| --- | --- |
| Select multiple + copy in one action | Bulk-select → "Copy to…" → modal → `bulkCopyToAgents` fans out |
| Result recognizable later | Full skill dir (SKILL.md + contents) copied into each agent |
| Shows success/failure | `summarizeBulkCopyResult` → success / warning / error toast w/ per-target detail |
| Distinguishable from delete | Outline + Copy icon "Copy to…", separated from the red Trash Delete |
| Non-destructive (originals kept) | `copyToAgents` never touches the source; selection is preserved after copy |

## Review findings addressed (in-PR)

From `/review` (own pass + 3 specialist subagents + a cross-model adversarial pass):

- **Visible-selection safety (HIGH):** bulk copy now operates on the *visible*
  selection (`selectSelectedVisibleSkillObjects` → `selectSelectedVisibleNames`),
  mirroring bulk delete/unlink, so the toolbar's "+K hidden by filter — will not be
  affected" promise holds. Hidden/filtered ticks are no longer copied.
- **Double-submit (HIGH):** `handleCopy` guards against a re-entrant dispatch while
  `bulkCopying`, so a fast double-click can't race two batches in main.
- **Summary decoupling:** `summarizeBulkCopyResult` takes an authoritative
  `targetAgentCount` instead of inferring it from `perSkill[0].copied`.
- **Tests:** added the hidden-by-filter exclusion (selector), selection-survives-copy
  (slice), and the previously-untested summarizer branches.

From `/design-review` (live-app audit vs. DESIGN.md + Linear/Notion bar):

- **Toolbar wrap regression (fixed):** adding the 4th action button made the
  selection toolbar overflow the middle column at common widths (~540px, reachable
  at a 1400px window with the Inspector open), orphaning the destructive Delete on a
  lone left-aligned second row. The action buttons are now one `ml-auto … justify-end`
  cluster that wraps as a cohesive right-aligned block (verified at 520px: primary
  sits 16px from the right edge, not the left).

## Deferred (intentionally out of scope — noted, not fixed here)

- **Shared-path agent dedup** — pre-existing in the single-skill copy / universal-agent
  model, not introduced here.
- **Stale in-flight count cosmetics** — the selector's drop-stale behavior is correct
  and reconciles on refresh.
- **"Copied 0 of 1 skill" partial wording** — a defensible, tested choice; success-path
  accuracy is covered by the `targetAgentCount` fix.

## Testing / gates

- `pnpm validate` ✅ (lint + typecheck + 1367 unit tests + dead-code).
- e2e ✅ — full suite (53) green before the toolbar polish; bulk-copy + bulk-delete
  re-verified after it. New `bulk-copy.e2e.ts`: happy path (every selected skill →
  every ticked agent) + partial-failure (one skill pre-occupied in one agent, the
  rest still copy).
- `/design-review` ✅ — modal + button DESIGN.md-compliant; one wrap regression found
  and fixed.
- `/qa-electron` ✅ — driven on the live app against the real home: real success copy
  (toast "Copied 2 skills to 1 agent", physical copy, sources untouched), real error
  path (all-"Already exists" → "Failed to copy 2 skills", zero footprint), Fix A's
  visible-eligible restriction confirmed on real data, focus-trapped dialog + Esc
  dismiss, 0 console errors. QA-created files were cleaned up (no residue).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 選択ツールバーの「Copy to...」から複数スキルを複数エージェントへ一括コピーできるモーダルを追加。コピー中は操作が無効化され、処理完了後に一覧を更新します。
  * コピー結果を要約してトースト表示（成功／部分失敗／全失敗）する通知を追加。選択はコピー後も保持されます。

* **テスト**
  * バルクコピーのE2Eとユニットテスト群を追加し、実動作と通知の振る舞いを検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->