### PR TITLE
feat(marketplace): copy, resize, and expand the skill preview (#197)

### DIFF
--- a/e2e/spec/marketplace-preview-expand.e2e.ts
+++ b/e2e/spec/marketplace-preview-expand.e2e.ts
@@ -1,0 +1,127 @@
+import type { Page } from '@playwright/test'
+
+import { test, expect } from '../fixtures/electron-app'
+import { dispatchAction, waitForInitialScan } from '../helpers/redux'
+
+/**
+ * A SkillSearchResult shape (rank/name/repo/url) seeded straight into the
+ * marketplace slice so the preview renders without hitting skills.sh. The
+ * <webview> guest page never loads over the network in CI — these specs assert
+ * the host-side contract (DOM node identity + focus + Escape), which is exactly
+ * what proves "expanding never re-parents/reloads the webview".
+ */
+const PREVIEW_SKILL = {
+  rank: 1,
+  name: 'find-skills',
+  repo: 'vercel-labs/skills',
+  url: 'https://skills.sh/vercel-labs/skills/find-skills',
+  installCount: 1,
+}
+
+/**
+ * Open the Marketplace preview for PREVIEW_SKILL by switching tabs and seeding
+ * the preview slice, then wait for the in-pane Expand affordance to render.
+ */
+async function openPreview(appWindow: Page) {
+  await appWindow.getByRole('tab', { name: 'Marketplace' }).click()
+  await dispatchAction(appWindow, {
+    type: 'marketplace/setPreviewSkill',
+    payload: PREVIEW_SKILL,
+  })
+  const expandButton = appWindow.getByRole('button', { name: 'Expand preview' })
+  await expect(expandButton).toBeVisible()
+  return expandButton
+}
+
+test('Marketplace preview expands into a focused overlay without re-parenting the webview', async ({
+  appWindow,
+}) => {
+  // Arrange — boot, open the preview, and tag the live <webview> node. The tag
+  // survives only if the node is never removed/re-inserted; a re-parent would
+  // remount it (dropping the marker) and reload the guest page (failing AC#5).
+  await waitForInitialScan(appWindow)
+  const expandButton = await openPreview(appWindow)
+
+  await appWindow.evaluate(() => {
+    const webview = document.querySelector<HTMLElement>('webview')
+    if (!webview) throw new Error('preview <webview> not rendered')
+    webview.dataset.e2eIdentity = 'preview-node-stable'
+    webview.dataset.loadStarts = '0'
+    webview.addEventListener('did-start-loading', () => {
+      const current = Number(webview.dataset.loadStarts ?? '0')
+      webview.dataset.loadStarts = String(current + 1)
+    })
+  })
+
+  // Reset the load-start counter right before toggling so only reloads caused
+  // by the expand/collapse round-trip are counted (not the initial mount load).
+  await appWindow.evaluate(() => {
+    const webview = document.querySelector<HTMLElement>('webview')
+    if (webview) webview.dataset.loadStarts = '0'
+  })
+
+  // Act — expand into the overlay.
+  await expandButton.click()
+
+  // Assert — the focused dialog is up and focus moved into it (to the close
+  // button), per modal a11y.
+  const dialog = appWindow.getByRole('dialog', { name: /find-skills preview/i })
+  await expect(dialog).toBeVisible()
+  const closeButton = appWindow.getByRole('button', {
+    name: 'Close expanded preview',
+  })
+  await expect(closeButton).toBeFocused()
+
+  // Act — collapse via Escape.
+  await appWindow.keyboard.press('Escape')
+
+  // Assert — overlay dismissed and focus restored to the expand trigger.
+  await expect(dialog).toBeHidden()
+  await expect(expandButton).toBeFocused()
+
+  // Assert — the SAME <webview> node survived the round-trip and no reload
+  // (did-start-loading) fired while toggling. This is the AC#5 guarantee.
+  const probe = await appWindow.evaluate(() => {
+    const webview = document.querySelector<HTMLElement>('webview')
+    return {
+      identity: webview?.dataset.e2eIdentity ?? null,
+      loadStarts: webview?.dataset.loadStarts ?? null,
+    }
+  })
+  expect(probe.identity).toBe('preview-node-stable')
+  expect(probe.loadStarts).toBe('0')
+})
+
+test('Marketplace preview overlay closes on backdrop click and via the close button', async ({
+  appWindow,
+}) => {
+  // Arrange.
+  await waitForInitialScan(appWindow)
+  const expandButton = await openPreview(appWindow)
+
+  // Act — expand, then click the scrim behind the overlay.
+  await expandButton.click()
+  const dialog = appWindow.getByRole('dialog', { name: /find-skills preview/i })
+  await expect(dialog).toBeVisible()
+  await appWindow.evaluate(() => {
+    const backdrop = document.querySelector<HTMLElement>(
+      '[aria-hidden="true"].fixed.inset-0',
+    )
+    if (!backdrop) throw new Error('overlay backdrop not rendered')
+    backdrop.click()
+  })
+
+  // Assert — backdrop click collapses; body scroll-lock is released.
+  await expect(dialog).toBeHidden()
+  expect(await appWindow.evaluate(() => document.body.style.overflow)).toBe('')
+
+  // Act — expand again and close via the explicit button.
+  await expandButton.click()
+  await expect(dialog).toBeVisible()
+  await appWindow
+    .getByRole('button', { name: 'Close expanded preview' })
+    .click()
+
+  // Assert.
+  await expect(dialog).toBeHidden()
+})

--- a/e2e/spec/marketplace-preview-expand.e2e.ts
+++ b/e2e/spec/marketplace-preview-expand.e2e.ts
@@ -95,25 +95,32 @@ test('Marketplace preview expands into a focused overlay without re-parenting th
 test('Marketplace preview overlay closes on backdrop click and via the close button', async ({
   appWindow,
 }) => {
-  // Arrange.
+  // Arrange — capture the pre-expand body overflow so the scroll-lock-release
+  // assertion compares against the real baseline, not a hardcoded '' that only
+  // happens to be correct in this environment (the hook restores the prior value).
   await waitForInitialScan(appWindow)
   const expandButton = await openPreview(appWindow)
+  const initialOverflow = await appWindow.evaluate(
+    () => document.body.style.overflow,
+  )
 
-  // Act — expand, then click the scrim behind the overlay.
+  // Act — expand, then click the scrim behind the overlay. Drive it through a
+  // real locator click (not evaluate()'s raw HTMLElement.click, which skips
+  // Playwright's actionability/hit-test). The scrim is inset-0 z-40 but the
+  // preview panel sits on top at inset-4 z-50, so click a point inside the
+  // exposed ~16px margin where the scrim is the genuine hit-test target.
   await expandButton.click()
   const dialog = appWindow.getByRole('dialog', { name: /find-skills preview/i })
   await expect(dialog).toBeVisible()
-  await appWindow.evaluate(() => {
-    const backdrop = document.querySelector<HTMLElement>(
-      '[aria-hidden="true"].fixed.inset-0',
-    )
-    if (!backdrop) throw new Error('overlay backdrop not rendered')
-    backdrop.click()
-  })
+  const backdrop = appWindow.locator('[aria-hidden="true"].fixed.inset-0')
+  await expect(backdrop).toBeVisible()
+  await backdrop.click({ position: { x: 5, y: 5 } })
 
-  // Assert — backdrop click collapses; body scroll-lock is released.
+  // Assert — backdrop click collapses; body scroll-lock is released to baseline.
   await expect(dialog).toBeHidden()
-  expect(await appWindow.evaluate(() => document.body.style.overflow)).toBe('')
+  expect(await appWindow.evaluate(() => document.body.style.overflow)).toBe(
+    initialOverflow,
+  )
 
   // Act — expand again and close via the explicit button.
   await expandButton.click()

--- a/src/renderer/src/components/marketplace/MarketplaceSkillPreview.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceSkillPreview.tsx
@@ -1,7 +1,10 @@
-import { ArrowLeft } from 'lucide-react'
+import { ArrowLeft, Check, Copy, Maximize2, X } from 'lucide-react'
 import React, { useRef, useState } from 'react'
 
+import { useCopyToClipboard } from '@/renderer/src/hooks/useCopyToClipboard'
 import { useCycleEffect } from '@/renderer/src/hooks/useCycleEffect'
+import { useFocusedOverlay } from '@/renderer/src/hooks/useFocusedOverlay'
+import { cn } from '@/renderer/src/lib/utils'
 import { useAppDispatch } from '@/renderer/src/redux/hooks'
 import { setPreviewSkill } from '@/renderer/src/redux/slices/marketplaceSlice'
 import { isAllowedSkillsUrl } from '@/shared/marketplaceUrlPolicy'
@@ -26,6 +29,17 @@ export const MarketplaceSkillPreview = React.memo(
     const dispatch = useAppDispatch()
     const webviewRef = useRef<Electron.WebviewTag>(null)
     const [isLoading, setIsLoading] = useState(true)
+    // The live URL the webview is showing (skill.url plus any in-allowlist
+    // in-page navigation), so the footer + copy reflect what the user sees.
+    const [currentUrl, setCurrentUrl] = useState(skill.url)
+    const { copied, copy } = useCopyToClipboard()
+    // Focused full-window overlay state + modal a11y. Keyed on skill.url so a
+    // new skill never inherits an open overlay (this component persists across
+    // skill switches). The <webview> node never moves — only its wrapper class
+    // flips — so expanding cannot reload the guest page (proven via e2e).
+    const { isExpanded, expand, collapse, closeButtonRef } = useFocusedOverlay(
+      skill.url,
+    )
 
     const handleBack = (): void => {
       dispatch(setPreviewSkill(null))
@@ -35,13 +49,26 @@ export const MarketplaceSkillPreview = React.memo(
     const isSrcAllowed = isAllowedSkillsUrl(skill.url)
 
     useCycleEffect(() => {
+      // Reset per-skill view state up front so switching skills (this component
+      // persists across switches) never carries over a stale URL. (Overlay
+      // expansion is reset by useFocusedOverlay's own resetKey effect.)
+      setIsLoading(true)
+      setCurrentUrl(skill.url)
+
       const wv = webviewRef.current
       if (!wv || !isSrcAllowed) return
 
-      setIsLoading(true)
-
       const handleLoaded = (): void => setIsLoading(false)
       const handleFailed = (): void => setIsLoading(false)
+
+      /** Mirror the live URL into the footer/copy, but only within the allowlist */
+      const handleDidNavigate = (
+        e: Electron.DidNavigateEvent | Electron.DidNavigateInPageEvent,
+      ): void => {
+        if (isAllowedSkillsUrl(e.url)) {
+          setCurrentUrl(e.url)
+        }
+      }
 
       /** Block in-page navigations to non-allowed origins */
       const handleNavigate = (e: Electron.WillNavigateEvent): void => {
@@ -57,11 +84,15 @@ export const MarketplaceSkillPreview = React.memo(
 
       wv.addEventListener('did-finish-load', handleLoaded)
       wv.addEventListener('did-fail-load', handleFailed)
+      wv.addEventListener('did-navigate', handleDidNavigate)
+      wv.addEventListener('did-navigate-in-page', handleDidNavigate)
       wv.addEventListener('will-navigate', handleNavigate)
       wv.addEventListener('new-window', handleNewWindow)
       return () => {
         wv.removeEventListener('did-finish-load', handleLoaded)
         wv.removeEventListener('did-fail-load', handleFailed)
+        wv.removeEventListener('did-navigate', handleDidNavigate)
+        wv.removeEventListener('did-navigate-in-page', handleDidNavigate)
         wv.removeEventListener('will-navigate', handleNavigate)
         wv.removeEventListener('new-window', handleNewWindow)
       }
@@ -85,7 +116,12 @@ export const MarketplaceSkillPreview = React.memo(
 
     return (
       <div className="flex-1 flex flex-col overflow-hidden">
-        <div className="flex items-center justify-between px-3 py-2 shrink-0">
+        {/* Header is inert while expanded so its Back/Expand controls leave the
+            tab order behind the focused overlay. */}
+        <div
+          className="flex items-center justify-between px-3 py-2 shrink-0"
+          inert={isExpanded}
+        >
           <button
             type="button"
             onClick={handleBack}
@@ -94,14 +130,49 @@ export const MarketplaceSkillPreview = React.memo(
             <ArrowLeft className="h-3.5 w-3.5" />
             Back to Dashboard
           </button>
-          <span className="text-xs text-muted-foreground font-medium">
-            {skill.name}
-          </span>
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-muted-foreground font-medium">
+              {skill.name}
+            </span>
+            <button
+              type="button"
+              onClick={expand}
+              aria-label="Expand preview"
+              className="flex items-center justify-center size-7 rounded text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+            >
+              <Maximize2 className="h-3.5 w-3.5" />
+            </button>
+          </div>
         </div>
 
         <div className="h-px bg-border shrink-0" />
 
-        <div className="flex-1 relative min-h-0">
+        {/* Scrim behind the focused overlay; click to collapse. Below the
+            webview host (z-40 < z-50) and below toasts so error toasts stay
+            visible while expanded. */}
+        {isExpanded && (
+          <div
+            className="fixed inset-0 z-40 bg-black/80 animate-in fade-in-0 duration-150"
+            onClick={collapse}
+            aria-hidden="true"
+          />
+        )}
+
+        {/* Stable webview host: rendered once, never re-parented. Only this
+            wrapper's className flips between the in-pane slot and the focused
+            full-window overlay — moving the <webview> node would detach its
+            guest WebContents and reload the page (losing scroll/page state). */}
+        <div
+          className={cn(
+            'min-h-0',
+            isExpanded
+              ? 'fixed inset-4 z-50 rounded-lg overflow-hidden border border-border shadow-2xl bg-background'
+              : 'relative flex-1',
+          )}
+          role={isExpanded ? 'dialog' : undefined}
+          aria-modal={isExpanded ? true : undefined}
+          aria-label={isExpanded ? `${skill.name} preview` : undefined}
+        >
           {isLoading && <WebviewSkeleton />}
           <webview
             ref={webviewRef}
@@ -110,12 +181,45 @@ export const MarketplaceSkillPreview = React.memo(
             className={`absolute inset-0 ${isLoading ? 'opacity-0' : 'opacity-100'} transition-opacity`}
             style={{ width: '100%', height: '100%' }}
           />
+          {isExpanded && (
+            <button
+              ref={closeButtonRef}
+              type="button"
+              onClick={collapse}
+              aria-label="Close expanded preview"
+              className="absolute top-2 right-2 z-10 flex items-center justify-center size-8 rounded-md bg-background/90 text-muted-foreground shadow-sm border border-border hover:text-foreground hover:bg-background transition-colors"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          )}
         </div>
 
-        <div className="px-3 py-1.5 bg-background border-t border-border shrink-0">
-          <span className="text-[11px] text-muted-foreground font-mono">
-            {skill.url}
+        {/* Footer carries the live URL + copy; inert while expanded so its copy
+            button is not tab-reachable behind the overlay. */}
+        <div
+          className="px-3 py-1.5 bg-background border-t border-border shrink-0 flex items-center gap-2"
+          inert={isExpanded}
+        >
+          <span
+            className="text-[11px] text-muted-foreground font-mono truncate flex-1 min-w-0"
+            title={currentUrl}
+          >
+            {currentUrl}
           </span>
+          <button
+            type="button"
+            onClick={() => {
+              void copy(currentUrl, 'preview URL')
+            }}
+            aria-label="Copy preview URL"
+            className="flex items-center justify-center size-6 rounded text-muted-foreground hover:text-foreground hover:bg-muted transition-colors shrink-0"
+          >
+            {copied ? (
+              <Check className="h-3.5 w-3.5 text-success" />
+            ) : (
+              <Copy className="h-3.5 w-3.5" />
+            )}
+          </button>
         </div>
       </div>
     )

--- a/src/renderer/src/components/skills/SkillDetail.tsx
+++ b/src/renderer/src/components/skills/SkillDetail.tsx
@@ -10,14 +10,12 @@ import { cn } from '@/renderer/src/lib/utils'
 import { useAppSelector } from '@/renderer/src/redux/hooks'
 import type { LocationViewModel } from '@/renderer/src/utils/getLocationViewModel'
 import { getLocationViewModel } from '@/renderer/src/utils/getLocationViewModel'
+import { COPIED_FEEDBACK_DURATION_MS } from '@/shared/constants'
 import type { Settings } from '@/shared/settings'
 import type { Skill, SymlinkInfo } from '@/shared/types'
 
 import { CodePreview } from './CodePreview'
 import { SourceLink } from './SourceLink'
-
-// Keep copied feedback visible long enough to be noticed without lingering.
-const COPIED_FEEDBACK_DURATION_MS = 1600
 
 interface SkillDetailProps {
   skill: Skill

--- a/src/renderer/src/hooks/useCopyToClipboard.browser.test.tsx
+++ b/src/renderer/src/hooks/useCopyToClipboard.browser.test.tsx
@@ -1,0 +1,118 @@
+import { memo, type ReactElement } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import { useCopyToClipboard } from './useCopyToClipboard'
+
+// `vi.hoisted` defines the toast spy so the hoisted `vi.mock('sonner')` factory
+// (lifted above imports at runtime) can reference it without a TDZ error.
+const { mockToastError } = vi.hoisted(() => ({ mockToastError: vi.fn() }))
+vi.mock('sonner', () => ({ toast: { error: mockToastError } }))
+
+const mockWriteText = vi.fn<(text: string) => Promise<void>>()
+let originalClipboardDescriptor: PropertyDescriptor | undefined
+
+/**
+ * Minimal host exposing the hook's `copied` flag as DOM text and wiring a
+ * button to `copy`, so the suite drives a real click and asserts observable
+ * feedback the way the marketplace footer renders it.
+ */
+const CopyHarness = memo(function CopyHarness(): ReactElement {
+  const { copied, copy } = useCopyToClipboard()
+  return (
+    <div>
+      <output data-testid="copy-state">{copied ? 'copied' : 'idle'}</output>
+      <button
+        type="button"
+        onClick={() => {
+          void copy('https://skills.sh/task', 'preview URL')
+        }}
+      >
+        Copy
+      </button>
+    </div>
+  )
+})
+
+beforeEach(() => {
+  mockToastError.mockReset()
+  mockWriteText.mockReset()
+  mockWriteText.mockResolvedValue(undefined)
+  // Swap navigator.clipboard for a spy (restored in afterEach).
+  originalClipboardDescriptor = Object.getOwnPropertyDescriptor(
+    navigator,
+    'clipboard',
+  )
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: { writeText: mockWriteText },
+  })
+})
+
+afterEach(() => {
+  if (originalClipboardDescriptor) {
+    Object.defineProperty(navigator, 'clipboard', originalClipboardDescriptor)
+  } else {
+    Reflect.deleteProperty(navigator, 'clipboard')
+  }
+  vi.restoreAllMocks()
+})
+
+describe('useCopyToClipboard', () => {
+  it('writes the given value to the clipboard', async () => {
+    // Arrange
+    const screen = await render(<CopyHarness />)
+
+    // Act
+    await screen.getByRole('button', { name: 'Copy' }).click()
+
+    // Assert
+    await vi.waitFor(() => {
+      expect(mockWriteText).toHaveBeenCalledWith('https://skills.sh/task')
+    })
+  })
+
+  it('lights the copied flag after a successful copy', async () => {
+    // Arrange
+    const screen = await render(<CopyHarness />)
+
+    // Act
+    await screen.getByRole('button', { name: 'Copy' }).click()
+
+    // Assert
+    await expect
+      .element(screen.getByTestId('copy-state'))
+      .toHaveTextContent('copied')
+  })
+
+  it('clears the copied flag after the feedback window elapses', async () => {
+    // Arrange
+    const screen = await render(<CopyHarness />)
+    await screen.getByRole('button', { name: 'Copy' }).click()
+    await expect
+      .element(screen.getByTestId('copy-state'))
+      .toHaveTextContent('copied')
+
+    // Act + Assert — the real 1600ms window expires and the flash resets.
+    await expect
+      .element(screen.getByTestId('copy-state'), { timeout: 2500 })
+      .toHaveTextContent('idle')
+  })
+
+  it('shows an error toast naming the failure label when the write rejects', async () => {
+    // Arrange
+    mockWriteText.mockRejectedValue(new Error('denied'))
+    const screen = await render(<CopyHarness />)
+
+    // Act
+    await screen.getByRole('button', { name: 'Copy' }).click()
+
+    // Assert — error toast fired and the flash never lit.
+    await vi.waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith('Failed to copy preview URL')
+    })
+    await expect
+      .element(screen.getByTestId('copy-state'))
+      .toHaveTextContent('idle')
+  })
+})

--- a/src/renderer/src/hooks/useCopyToClipboard.ts
+++ b/src/renderer/src/hooks/useCopyToClipboard.ts
@@ -1,0 +1,65 @@
+import { useCallback, useRef, useState } from 'react'
+import { toast } from 'sonner'
+
+import { useUnmountEffect } from '@/renderer/src/hooks/useUnmountEffect'
+import { COPIED_FEEDBACK_DURATION_MS } from '@/shared/constants'
+
+interface CopyToClipboardState {
+  /** True for COPIED_FEEDBACK_DURATION_MS after a successful copy, otherwise false. */
+  copied: boolean
+  /**
+   * Write `value` to the clipboard, flash `copied`, and toast on failure.
+   * @param value - The text to place on the clipboard.
+   * @param failureLabel - What to name in the error toast (e.g. "preview URL").
+   */
+  copy: (value: string, failureLabel: string) => Promise<void>
+}
+
+/**
+ * Single-value clipboard copy with a self-resetting "Copied" flash and an error
+ * toast — exists so any copy affordance (skill path, marketplace preview URL)
+ * shares one feedback contract instead of re-implementing the timeout dance;
+ * fires on a copy button click.
+ * @returns `copied` flag for button state and an async `copy(value, label)` action.
+ * @example
+ * const { copied, copy } = useCopyToClipboard()
+ * <button onClick={() => copy(url, 'preview URL')}>{copied ? 'Copied' : 'Copy'}</button>
+ */
+export function useCopyToClipboard(): CopyToClipboardState {
+  const [copied, setCopied] = useState(false)
+  const resetCopiedTimeoutRef = useRef<number | null>(null)
+
+  // Clear a pending reset timer if the component unmounts mid-flash.
+  useUnmountEffect(() => {
+    if (resetCopiedTimeoutRef.current !== null) {
+      window.clearTimeout(resetCopiedTimeoutRef.current)
+    }
+  })
+
+  const copy = useCallback(
+    async (value: string, failureLabel: string): Promise<void> => {
+      try {
+        if (!navigator.clipboard?.writeText) {
+          throw new Error('Clipboard API unavailable')
+        }
+        await navigator.clipboard.writeText(value)
+        setCopied(true)
+
+        // Reset the flash after a short confirmation window, replacing any
+        // in-flight timer so rapid re-copies extend rather than stack.
+        if (resetCopiedTimeoutRef.current !== null) {
+          window.clearTimeout(resetCopiedTimeoutRef.current)
+        }
+        resetCopiedTimeoutRef.current = window.setTimeout(() => {
+          setCopied(false)
+          resetCopiedTimeoutRef.current = null
+        }, COPIED_FEEDBACK_DURATION_MS)
+      } catch {
+        toast.error(`Failed to copy ${failureLabel}`)
+      }
+    },
+    [],
+  )
+
+  return { copied, copy }
+}

--- a/src/renderer/src/hooks/useFocusedOverlay.browser.test.tsx
+++ b/src/renderer/src/hooks/useFocusedOverlay.browser.test.tsx
@@ -1,0 +1,106 @@
+import { memo, type ReactElement } from 'react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import { useFocusedOverlay } from './useFocusedOverlay'
+
+/**
+ * Minimal host that surfaces the hook's state + actions as real DOM so the
+ * suite drives it the way a user would (click to open/close, press Escape)
+ * and asserts observable behavior rather than internal state.
+ */
+const OverlayHarness = memo(function OverlayHarness({
+  resetKey,
+}: {
+  resetKey: string
+}): ReactElement {
+  const { isExpanded, expand, collapse, closeButtonRef } =
+    useFocusedOverlay(resetKey)
+  return (
+    <div>
+      <output data-testid="overlay-state">
+        {isExpanded ? 'expanded' : 'collapsed'}
+      </output>
+      <button type="button" onClick={expand}>
+        Open overlay
+      </button>
+      <button type="button" ref={closeButtonRef} onClick={collapse}>
+        Close overlay
+      </button>
+    </div>
+  )
+})
+
+beforeEach(() => {
+  document.body.style.overflow = ''
+})
+
+afterEach(() => {
+  // Guard against a test that asserts mid-expand leaking the scroll-lock.
+  document.body.style.overflow = ''
+})
+
+describe('useFocusedOverlay', () => {
+  it('enters the overlay and locks body scroll when expanded', async () => {
+    // Arrange
+    const screen = await render(<OverlayHarness resetKey="skill-a" />)
+
+    // Act
+    await screen.getByRole('button', { name: 'Open overlay' }).click()
+
+    // Assert
+    await expect
+      .element(screen.getByTestId('overlay-state'))
+      .toHaveTextContent('expanded')
+    expect(document.body.style.overflow).toBe('hidden')
+  })
+
+  it('leaves the overlay and restores body scroll when collapsed', async () => {
+    // Arrange
+    const screen = await render(<OverlayHarness resetKey="skill-a" />)
+    await screen.getByRole('button', { name: 'Open overlay' }).click()
+
+    // Act
+    await screen.getByRole('button', { name: 'Close overlay' }).click()
+
+    // Assert
+    await expect
+      .element(screen.getByTestId('overlay-state'))
+      .toHaveTextContent('collapsed')
+    expect(document.body.style.overflow).toBe('')
+  })
+
+  it('collapses the overlay when the Escape key is pressed', async () => {
+    // Arrange
+    const screen = await render(<OverlayHarness resetKey="skill-a" />)
+    await screen.getByRole('button', { name: 'Open overlay' }).click()
+    await expect
+      .element(screen.getByTestId('overlay-state'))
+      .toHaveTextContent('expanded')
+
+    // Act — a global Escape keydown while expanded.
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+
+    // Assert
+    await expect
+      .element(screen.getByTestId('overlay-state'))
+      .toHaveTextContent('collapsed')
+  })
+
+  it('collapses an open overlay when the reset key changes (new subject)', async () => {
+    // Arrange
+    const screen = await render(<OverlayHarness resetKey="skill-a" />)
+    await screen.getByRole('button', { name: 'Open overlay' }).click()
+    await expect
+      .element(screen.getByTestId('overlay-state'))
+      .toHaveTextContent('expanded')
+
+    // Act — switch to a different subject (e.g. previewing another skill).
+    await screen.rerender(<OverlayHarness resetKey="skill-b" />)
+
+    // Assert
+    await expect
+      .element(screen.getByTestId('overlay-state'))
+      .toHaveTextContent('collapsed')
+  })
+})

--- a/src/renderer/src/hooks/useFocusedOverlay.ts
+++ b/src/renderer/src/hooks/useFocusedOverlay.ts
@@ -1,0 +1,72 @@
+import { useCallback, useRef, useState } from 'react'
+
+import { useCycleEffect } from '@/renderer/src/hooks/useCycleEffect'
+import { useUpdateEffect } from '@/renderer/src/hooks/useUpdateEffect'
+
+interface FocusedOverlayState {
+  /** True while the subject is lifted into the focused full-window overlay. */
+  isExpanded: boolean
+  /** Enter the overlay, remembering the current focus for later restoration. */
+  expand: () => void
+  /** Leave the overlay and restore focus to the element that triggered it. */
+  collapse: () => void
+  /** Wire to the overlay's close button; it receives focus when the overlay opens. */
+  closeButtonRef: React.RefObject<HTMLButtonElement | null>
+}
+
+/**
+ * Local view-state + modal a11y plumbing for an "expand this panel into a
+ * focused full-window overlay" affordance — owns the expanded flag and, while
+ * open, traps Escape to close, locks body scroll, moves focus to the close
+ * button, and restores focus to the trigger on close; auto-collapses when
+ * `resetKey` changes so a new subject never inherits an open overlay. Extracted
+ * so the host component (e.g. the marketplace preview) stays presentational.
+ * @param resetKey - Identity of the current subject; a change collapses the overlay.
+ * @returns Expanded flag, `expand`/`collapse` actions, and a `closeButtonRef`.
+ * @example
+ * const { isExpanded, expand, collapse, closeButtonRef } = useFocusedOverlay(skill.url)
+ */
+export function useFocusedOverlay(resetKey: string): FocusedOverlayState {
+  const [isExpanded, setIsExpanded] = useState(false)
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null)
+  // The element focused immediately before expanding, restored on collapse.
+  const triggerElementRef = useRef<HTMLElement | null>(null)
+
+  const expand = useCallback((): void => {
+    triggerElementRef.current =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null
+    setIsExpanded(true)
+  }, [])
+
+  const collapse = useCallback((): void => setIsExpanded(false), [])
+
+  // A new subject (e.g. switching previewed skill) must never open expanded.
+  useUpdateEffect(() => {
+    setIsExpanded(false)
+  }, [resetKey])
+
+  // While expanded: Escape-to-close, body scroll-lock, and focus into the
+  // overlay; the cleanup restores scroll + focus when collapsing or unmounting.
+  useCycleEffect(() => {
+    if (!isExpanded) return
+
+    const previousBodyOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    closeButtonRef.current?.focus()
+
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') setIsExpanded(false)
+    }
+    document.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      document.body.style.overflow = previousBodyOverflow
+      triggerElementRef.current?.focus()
+    }
+  }, [isExpanded])
+
+  return { isExpanded, expand, collapse, closeButtonRef }
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -817,6 +817,16 @@ export const MACOS_TRAFFIC_LIGHT_POSITION_PX = { x: 16, y: 16 } as const
 export const UNDO_WINDOW_MS = 15_000
 
 /**
+ * How long a "Copied" affordance stays lit after a successful clipboard write
+ * (ms). Shared by every copy-to-clipboard surface (skill Location-path rows,
+ * marketplace preview URL) so the confirmation flash has one duration and a new
+ * copy button can grep for the contract instead of re-picking a timeout.
+ * @example
+ * window.setTimeout(() => setCopied(false), COPIED_FEEDBACK_DURATION_MS)
+ */
+export const COPIED_FEEDBACK_DURATION_MS = 1600
+
+/**
  * Batch size at which bulk ops surface a live per-item progress counter in the
  * toolbar. Below this, the final `.fulfilled` toast is a better UX than a
  * flashing "k of n". Main-process `emitProgress` and renderer-side display


### PR DESCRIPTION
## Summary

Closes #197. Makes the Marketplace skill webview preview **copyable, resizable, and expandable**, satisfying all five acceptance criteria.

| AC | Behavior | How |
| --- | --- | --- |
| **#1** Copy current preview URL | Footer shows the live allowlisted `skills.sh` URL + one-click copy with a "Copied" flash | New `useCopyToClipboard` hook; URL mirrored from `did-navigate`/`did-navigate-in-page` (allowlist-guarded) |
| **#2** Independent scroll | Scrolling the preview never moves the surrounding detail page | `<webview>` is a separate `WebContents` inside an `overflow-hidden` host — inherent isolation |
| **#3** Drag to resize the preview area | Drag the panel divider to grow/shrink the preview | Existing `react-resizable-panels` `Separator` in `App.tsx` (verified it never reloads the webview) |
| **#4** Expand to a larger focused view + close back | Maximize button → full-window overlay; Escape / backdrop / × to close | New `useFocusedOverlay` hook (`role=dialog`, `aria-modal`, focus-to-close + restore, scroll-lock) |
| **#5** No page/scroll loss on expand | Guest page + scroll position survive expand→collapse | The `<webview>` node is rendered **once and never re-parented** — only its wrapper `className` flips |

## The core architectural constraint

An Electron `<webview>` guest `WebContents` is *attached to its embedder*. Moving the node in the DOM (re-parent, conditional-parent, portal) detaches and recreates it → the page **reloads**, losing scroll/page state (fails AC#5).

So the overlay is **hand-rolled, not a Radix Dialog**: the `<webview>` lives in one stable React position, and expanding only toggles its wrapper between the in-pane slot (`relative flex-1`) and the focused overlay (`fixed inset-4 z-50`). A node whose parent never changes cannot reload.

## Design tokens

The copy-confirm check uses the `--success` design token (`text-success`) — matching the marketplace installed badge — not a raw Tailwind green. Overlay motion (`duration-150`), elevation (`shadow-2xl` = Surface 4), and radius (`rounded-lg`) all follow DESIGN.md.

## Known limitation (intentional, scoped out)

Because the webview can't be portalled without reloading, the overlay `inert`s only the preview's own chrome (header/footer), **not** the app behind the backdrop. `aria-modal` still gives screen-reader containment; a sighted keyboard user can Tab to a landmark behind the 80%-opacity scrim, which merely navigates (no data loss). A full-app focus trap would require lifting overlay state into `App.tsx` and is out of scope for #197.

## Tests

- **Unit (browser lane):** `useCopyToClipboard` (4) + `useFocusedOverlay` (4) — clipboard write, self-resetting flash, error toast, scroll-lock, Escape, reset-key collapse.
- **e2e** `marketplace-preview-expand.e2e.ts` (2): proves webview **node identity** survives the round-trip, focus moves to close on open + restores to trigger on close, Escape/backdrop/× all dismiss, and **zero `did-start-loading`** fires across expand→collapse (the AC#5 guarantee).

## Verification

- `pnpm validate` (lint · test 1376 · typecheck · dead-code · dupes · health · storybook) ✅
- `pnpm test:e2e` — 55/55 ✅
- Live (playwright-cli / CDP): AC#2 host unmoved at guest `scrollY 600`; AC#3 separator drag grew the pane `563→713px` with **0 reloads**; guest scroll stayed `600` through resize + expand + collapse; copy wrote the canonical URL; success-token check renders `oklch(0.72 0.17 155)`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * マーケットプレイス プレビューの拡大/縮小UIを改善。拡大時に表示中のURLを正確に反映し、URLコピーが可能に
  * フルウィンドウのフォーカス付きオーバーレイ（展開/折畳）を追加し、スクロールロックやフォーカス復帰を適切に管理
  * コピー成功フィードバック表示を共通化（短時間の「Copied」表示）

* **Tests**
  * プレビューの拡大挙動を検証するE2Eテストを追加
  * クリップボードコピーとオーバーレイ挙動のブラウザテストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->