### PR TITLE
chore: sync skills CLI agent definitions to 1.5.10

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ PRs are ready to ship only when `validate` and e2e both pass in that order.
 | Skill     | `~/.agents/skills/`  | Directory with SKILL.md                                        |
 | Agent     | `~/.<agent>/skills/` | AI agents (count = `AGENT_DEFINITIONS.length` in `src/shared/constants.ts`) |
 | Symlink   | Agent→Skill          | `valid` / `broken` / `inaccessible` / `missing`                  |
-| Universal | `~/.agents/skills/`  | 13 agents share this source dir (see `UNIVERSAL_AGENT_IDS` in `src/shared/constants.ts`) |
+| Universal | `~/.agents/skills/`  | 16 agents share this source dir (see `UNIVERSAL_AGENT_IDS` in `src/shared/constants.ts`) |
 
 ### Skills CLI
 

--- a/e2e/spec/bulk-copy.e2e.ts
+++ b/e2e/spec/bulk-copy.e2e.ts
@@ -54,11 +54,11 @@ function preStageSourceSkills(isolatedHome: string, names: string[]): void {
 /**
  * Pick `count` distinct-path agents that can serve as bulk-copy targets.
  *
- * Excludes the universal source dir itself — the 13 universal agents share
+ * Excludes the universal source dir itself — the 16 universal agents share
  * `~/.agents/skills`, so copying a source skill "into" one of them resolves to
  * `<sourceDir>/<skill>` (the source) and the handler reports `Already exists`
  * (skills.ts:1158-1166). Dedups by path so IRON-RULE shared scan dirs (amp /
- * kimi-cli / replit) cannot let one tick write into another target's space. No
+ * replit) cannot let one tick write into another target's space. No
  * `exists` filter: the handler `mkdir -p`s the destination (skills.ts:1161), so
  * a not-installed agent is still a valid, faithful target.
  *

--- a/e2e/spec/copy.e2e.ts
+++ b/e2e/spec/copy.e2e.ts
@@ -359,7 +359,7 @@ test('copying to one occupied and one free agent skips the occupied one and stil
   // to AGENT_DEFINITIONS by name; the contract being verified is the
   // collision *policy*, not the survival of any particular agent in the
   // catalog. Filtering on `seenPaths` also sidesteps the IRON RULE shared
-  // scanDirs (amp / kimi-cli / replit on .config/agents/skills) — picking
+  // scanDirs (amp / replit on .config/agents/skills) — picking
   // two agents that share a path would let the second mkdirSync see the
   // first's collision and break the asymmetric setup.
   const agentSelection = await getStoreState(appWindow, (state) => {

--- a/e2e/spec/marketplace-install-regression.e2e.ts
+++ b/e2e/spec/marketplace-install-regression.e2e.ts
@@ -162,14 +162,14 @@ test('Marketplace Install works when Electron starts with sparse macOS GUI PATH'
     await dialog.getByRole('button', { name: 'Install', exact: true }).click()
 
     // Assert — the fake npx ran with the pinned CLI version (SKILLS_CLI_VERSION
-    // is '1.5.5' in src/shared/constants.ts; hardcoded here so this test pins
+    // is '1.5.10' in src/shared/constants.ts; hardcoded here so this test pins
     // the literal command rather than computing the expectation from the same
     // constant the production command builds from) and the installed badge shows.
     await expect
       .poll(() => existsSync(markerPath), { timeout: 10_000 })
       .toBe(true)
     expect(readFileSync(markerPath, 'utf-8')).toContain(
-      'skills@1.5.5 add vercel-labs/skills',
+      'skills@1.5.10 add vercel-labs/skills',
     )
     await expect(
       appWindow.getByRole('img', { name: /find-skills is installed/i }),

--- a/e2e/spec/regression.e2e.ts
+++ b/e2e/spec/regression.e2e.ts
@@ -107,7 +107,7 @@ function filesystemIdentityForPath(path: string): E2EFilesystemIdentity {
  *    scanner reads each agent's own home dir, not the universal source.
  *
  * 3. IRON RULE multi-agent path collision — `SHARED_AGENT_PATHS` adds any
- *    `agent.path` shared by ≥2 agent definitions (amp/kimi-cli/replit all
+ *    `agent.path` shared by ≥2 agent definitions (amp/replit both
  *    resolve to `.config/agents/skills`). `isSharedAgentPath` stage 1 catches
  *    this without realpath, distinct from the symlink-alias path covered in
  *    `unlink-agent.e2e.ts` Test 3 (stages 2/3).
@@ -352,7 +352,7 @@ test('refuses to delete every skill from a directory shared by multiple agents (
   isolatedHome,
 }) => {
   // Arrange — pre-stage the shared scanDir as a real directory with a sentinel
-  // entry. amp, kimi-cli, replit all resolve to this path, so SHARED_AGENT_PATHS
+  // entry. amp, replit both resolve to this path, so SHARED_AGENT_PATHS
   // includes it via the multi-agent collision pass in main/constants.ts.
   // No symlinking required: stage 1 (`SHARED_AGENT_PATHS.has(resolved)`) of
   // `isSharedAgentPath` short-circuits before any realpath fallback runs.

--- a/src/main/constants.test.ts
+++ b/src/main/constants.test.ts
@@ -84,7 +84,7 @@ describe('SHARED_AGENT_PATHS', () => {
     expect(isGuarded).toBe(true)
   })
 
-  it('guards ~/.config/agents/skills so deleting amp or kimi-cli cannot wipe the dir they share', () => {
+  it('guards ~/.config/agents/skills so deleting amp or replit cannot wipe the dir they share', () => {
     // Arrange
     const sharedConfigPath = join(homedir(), '.config', 'agents', 'skills')
 
@@ -112,21 +112,36 @@ describe('SHARED_AGENT_PATHS', () => {
     expect(codexIsGuarded).toBe(false)
   })
 
-  it('guards the path that amp and kimi-cli both point at so neither delete destroys the other’s skills', () => {
-    // amp and kimi-cli are the two agents whose scanDir resolves to the
+  it('guards the path that amp and replit both point at so neither delete destroys the other’s skills', () => {
+    // amp and replit are the two agents whose scanDir resolves to the
     // same ~/.config/agents/skills directory; both must be guarded so a
     // delete on either cannot wipe the directory shared with the other.
+    // (Kimi left this shared dir in CLI 1.5.10 — see the dedicated-dir test.)
     // Arrange
     const amp = AGENTS.find((a) => a.id === 'amp')!
-    const kimiCli = AGENTS.find((a) => a.id === 'kimi-cli')!
+    const replit = AGENTS.find((a) => a.id === 'replit')!
 
     // Act
     const ampIsGuarded = SHARED_AGENT_PATHS.has(amp.path)
-    const kimiCliIsGuarded = SHARED_AGENT_PATHS.has(kimiCli.path)
+    const replitIsGuarded = SHARED_AGENT_PATHS.has(replit.path)
 
     // Assert
     expect(ampIsGuarded).toBe(true)
-    expect(kimiCliIsGuarded).toBe(true)
+    expect(replitIsGuarded).toBe(true)
+  })
+
+  it('lets Kimi (migrated to its own .kimi dir in CLI 1.5.10) be deleted without tripping the shared-path guard', () => {
+    // Kimi moved off the shared ~/.config/agents/skills dir to its own
+    // ~/.kimi/skills (scanDir '.kimi'), so its dedicated path is no longer
+    // shared and a delete on Kimi cannot wipe another agent's skills.
+    // Arrange
+    const kimiCli = AGENTS.find((a) => a.id === 'kimi-cli')!
+
+    // Act
+    const kimiCliIsGuarded = SHARED_AGENT_PATHS.has(kimiCli.path)
+
+    // Assert
+    expect(kimiCliIsGuarded).toBe(false)
   })
 })
 

--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -28,7 +28,7 @@ export const AGENTS = AGENT_DEFINITIONS.map((agent) => ({
  * Paths where a "delete everything under this agent" op would destroy data
  * that belongs to more than just that agent — either the Universal source
  * itself, or a directory that multiple agent rows point at on disk
- * (e.g. `~/.config/agents/skills`, shared by amp/kimi-cli/replit).
+ * (e.g. `~/.config/agents/skills`, shared by amp/replit).
  *
  * Mental model: each agent has its OWN dedicated skills dir (`AGENTS.path`,
  * derived from `scanDir`) AND additionally reads from the universal source

--- a/src/renderer/src/components/skills/SkillDetail.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillDetail.browser.test.tsx
@@ -30,7 +30,7 @@ const OVERFLOW_AGENT_ROWS = [
   { id: 'opencode', name: 'OpenCode' },
   { id: 'github-copilot', name: 'GitHub Copilot' },
   { id: 'cline', name: 'Cline' },
-  { id: 'windsurf', name: 'Windsurf' },
+  { id: 'windsurf', name: 'Devin Desktop' },
   { id: 'junie', name: 'Junie' },
   { id: 'antigravity', name: 'Antigravity' },
   { id: 'kiro-cli', name: 'Kiro CLI' },

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -56,7 +56,6 @@ describe('AGENT_DEFINITIONS', () => {
     const cline = AGENT_DEFINITIONS.find((a) => a.id === 'cline')
     const warp = AGENT_DEFINITIONS.find((a) => a.id === 'warp')
     const amp = AGENT_DEFINITIONS.find((a) => a.id === 'amp')
-    const kimiCli = AGENT_DEFINITIONS.find((a) => a.id === 'kimi-cli')
     const opencode = AGENT_DEFINITIONS.find((a) => a.id === 'opencode')
     const deepAgents = AGENT_DEFINITIONS.find((a) => a.id === 'deepagents')
     const replit = AGENT_DEFINITIONS.find((a) => a.id === 'replit')
@@ -65,21 +64,24 @@ describe('AGENT_DEFINITIONS', () => {
     expect(cline?.installDir).toBe('.agents')
     expect(warp?.installDir).toBe('.agents')
     expect(amp?.installDir).toBe('.config/agents')
-    expect(kimiCli?.installDir).toBe('.config/agents')
     expect(opencode?.installDir).toBe('.config/opencode')
     expect(deepAgents?.installDir).toBe('.deepagents/agent')
     expect(replit?.installDir).toBe('.config/agents')
   })
 
-  // Regression guard for the v0.13.0 cascade. Cline, Warp, and Dexto's
-  // installDir points at the universal source; without a divergent
-  // scanDir, the scanner would surface every source skill as their
-  // "local skills".
-  it('does not surface the whole universal source as Cline, Warp, or Dexto local skills', () => {
+  // Regression guard for the v0.13.0 cascade. Every agent whose installDir
+  // points at the universal source (~/.agents/skills) must declare a
+  // divergent scanDir; otherwise the scanner surfaces every source skill as
+  // that agent's "local skills". Kimi (migrated in CLI 1.5.10), Loaf, and Zed
+  // joined Cline/Warp/Dexto in this universal-source group.
+  it('does not surface the whole universal source as Cline, Warp, Dexto, Kimi, Loaf, or Zed local skills', () => {
     // Arrange / Act
     const cline = AGENT_DEFINITIONS.find((a) => a.id === 'cline')
     const warp = AGENT_DEFINITIONS.find((a) => a.id === 'warp')
     const dexto = AGENT_DEFINITIONS.find((a) => a.id === 'dexto')
+    const kimiCli = AGENT_DEFINITIONS.find((a) => a.id === 'kimi-cli')
+    const loaf = AGENT_DEFINITIONS.find((a) => a.id === 'loaf')
+    const zed = AGENT_DEFINITIONS.find((a) => a.id === 'zed')
 
     // Assert
     expect(cline?.installDir).toBe('.agents')
@@ -88,6 +90,12 @@ describe('AGENT_DEFINITIONS', () => {
     expect(warp?.scanDir).toBe('.warp')
     expect(dexto?.installDir).toBe('.agents')
     expect(dexto?.scanDir).toBe('.dexto')
+    expect(kimiCli?.installDir).toBe('.agents')
+    expect(kimiCli?.scanDir).toBe('.kimi')
+    expect(loaf?.installDir).toBe('.agents')
+    expect(loaf?.scanDir).toBe('.loaf')
+    expect(zed?.installDir).toBe('.agents')
+    expect(zed?.scanDir).toBe('.zed')
   })
 
   it('exposes every community agent added in CLI v1.5.5', () => {
@@ -105,6 +113,38 @@ describe('AGENT_DEFINITIONS', () => {
     expect(ids).toContain('rovodev')
     expect(ids).toContain('tabnine-cli')
   })
+
+  it('exposes every community agent added in CLI v1.5.10', () => {
+    // Act
+    const ids = AGENT_DEFINITIONS.map((a) => a.id)
+    // Assert
+    expect(ids).toContain('antigravity-cli')
+    expect(ids).toContain('astrbot')
+    expect(ids).toContain('autohand-code')
+    expect(ids).toContain('inference-sh')
+    expect(ids).toContain('jazz')
+    expect(ids).toContain('lingma')
+    expect(ids).toContain('loaf')
+    expect(ids).toContain('moxby')
+    expect(ids).toContain('ona')
+    expect(ids).toContain('qoder-cn')
+    expect(ids).toContain('reasonix')
+    expect(ids).toContain('terramind')
+    expect(ids).toContain('tinycloud')
+    expect(ids).toContain('zed')
+  })
+
+  it('maps Kimi internal id to the renamed kimi-code-cli CLI flag (1.5.10 rename)', () => {
+    // The CLI renamed the --agent value to 'kimi-code-cli' and moved it to the
+    // universal source. Internal id stays 'kimi-cli' so persisted Redux state
+    // survives; only the cliId tracks upstream.
+    // Arrange / Act
+    const kimiCli = AGENT_DEFINITIONS.find((a) => a.id === 'kimi-cli')
+    // Assert
+    expect(kimiCli?.cliId).toBe('kimi-code-cli')
+    expect(kimiCli?.installDir).toBe('.agents')
+    expect(kimiCli?.scanDir).toBe('.kimi')
+  })
 })
 
 describe('UNIVERSAL_AGENT_IDS', () => {
@@ -117,10 +157,11 @@ describe('UNIVERSAL_AGENT_IDS', () => {
     }
   })
 
-  it('treats the 13 shared-source agents as Universal and excludes Replit', () => {
+  it('treats the 16 shared-source agents as Universal and excludes Replit', () => {
     // Arrange / Act / Assert
     expect(UNIVERSAL_AGENT_IDS).toContain('amp')
     expect(UNIVERSAL_AGENT_IDS).toContain('antigravity')
+    expect(UNIVERSAL_AGENT_IDS).toContain('antigravity-cli')
     expect(UNIVERSAL_AGENT_IDS).toContain('cline')
     expect(UNIVERSAL_AGENT_IDS).toContain('codex')
     expect(UNIVERSAL_AGENT_IDS).toContain('cursor')
@@ -130,8 +171,10 @@ describe('UNIVERSAL_AGENT_IDS', () => {
     expect(UNIVERSAL_AGENT_IDS).toContain('gemini-cli')
     expect(UNIVERSAL_AGENT_IDS).toContain('github-copilot')
     expect(UNIVERSAL_AGENT_IDS).toContain('kimi-cli')
+    expect(UNIVERSAL_AGENT_IDS).toContain('loaf')
     expect(UNIVERSAL_AGENT_IDS).toContain('opencode')
     expect(UNIVERSAL_AGENT_IDS).toContain('warp')
+    expect(UNIVERSAL_AGENT_IDS).toContain('zed')
     expect(UNIVERSAL_AGENT_IDS).not.toContain('replit')
   })
 })

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -290,9 +290,13 @@ export const AGENT_DEFINITIONS = [
     scanDir: '.config/goose',
   },
   {
+    // Display renamed to Devin Desktop (Windsurf rebrand, Cognition 2026-06-02).
+    // id/cliId/dirs stay 'windsurf': upstream CLI has NOT renamed the agent and
+    // the ~/.codeium/windsurf path is still live during the transition (the app
+    // observes both ~/.devin and ~/.windsurf coexisting on disk).
     id: 'windsurf',
     cliId: 'windsurf',
-    name: 'Windsurf',
+    name: 'Devin Desktop',
     installDir: '.codeium/windsurf',
     scanDir: '.codeium/windsurf',
   },
@@ -367,11 +371,15 @@ export const AGENT_DEFINITIONS = [
     scanDir: '.adal',
   },
   {
+    // id≠cliId: upstream (CLI 1.5.10) renamed the --agent value to
+    // 'kimi-code-cli' and moved its globalSkillsDir to the universal source
+    // (~/.agents/skills). Internal `id` stays 'kimi-cli' to preserve persisted
+    // Redux state; scanDir diverges to '.kimi' per the v0.13.0 universal guard.
     id: 'kimi-cli',
-    cliId: 'kimi-cli',
+    cliId: 'kimi-code-cli',
     name: 'Kimi Code CLI',
-    installDir: '.config/agents',
-    scanDir: '.config/agents',
+    installDir: '.agents',
+    scanDir: '.kimi',
   },
   {
     id: 'bob',
@@ -597,6 +605,109 @@ export const AGENT_DEFINITIONS = [
     installDir: '.tabnine/agent',
     scanDir: '.tabnine/agent',
   },
+  // Community agents added in skills CLI v1.5.10 (synced 2026-06-05).
+  {
+    id: 'antigravity-cli',
+    cliId: 'antigravity-cli',
+    name: 'Antigravity CLI',
+    installDir: '.gemini/antigravity-cli',
+    scanDir: '.gemini/antigravity-cli',
+  },
+  {
+    id: 'astrbot',
+    cliId: 'astrbot',
+    name: 'AstrBot',
+    installDir: '.astrbot/data',
+    scanDir: '.astrbot/data',
+  },
+  {
+    id: 'autohand-code',
+    cliId: 'autohand-code',
+    name: 'Autohand Code CLI',
+    installDir: '.autohand',
+    scanDir: '.autohand',
+  },
+  {
+    id: 'inference-sh',
+    cliId: 'inference-sh',
+    name: 'inference.sh',
+    installDir: '.inferencesh',
+    scanDir: '.inferencesh',
+  },
+  {
+    id: 'jazz',
+    cliId: 'jazz',
+    name: 'Jazz',
+    installDir: '.jazz',
+    scanDir: '.jazz',
+  },
+  {
+    id: 'lingma',
+    cliId: 'lingma',
+    name: 'Lingma',
+    installDir: '.lingma',
+    scanDir: '.lingma',
+  },
+  {
+    // Universal-source agent: installs to ~/.agents/skills; scanDir diverges
+    // to '.loaf' per the v0.13.0 guard so the scanner reads its own home dir.
+    id: 'loaf',
+    cliId: 'loaf',
+    name: 'Loaf',
+    installDir: '.agents',
+    scanDir: '.loaf',
+  },
+  {
+    id: 'moxby',
+    cliId: 'moxby',
+    name: 'Moxby',
+    installDir: '.moxby',
+    scanDir: '.moxby',
+  },
+  {
+    id: 'ona',
+    cliId: 'ona',
+    name: 'Ona',
+    installDir: '.ona',
+    scanDir: '.ona',
+  },
+  {
+    id: 'qoder-cn',
+    cliId: 'qoder-cn',
+    name: 'Qoder CN',
+    installDir: '.qoder-cn',
+    scanDir: '.qoder-cn',
+  },
+  {
+    id: 'reasonix',
+    cliId: 'reasonix',
+    name: 'Reasonix',
+    installDir: '.reasonix',
+    scanDir: '.reasonix',
+  },
+  {
+    id: 'terramind',
+    cliId: 'terramind',
+    name: 'Terramind',
+    installDir: '.terramind',
+    scanDir: '.terramind',
+  },
+  {
+    id: 'tinycloud',
+    cliId: 'tinycloud',
+    name: 'Tinycloud',
+    installDir: '.tinycloud',
+    scanDir: '.tinycloud',
+  },
+  {
+    // Universal-source agent: installs to ~/.agents/skills; scanDir diverges
+    // to '.zed' per the v0.13.0 guard so the scanner reads its own home dir.
+    id: 'zed',
+    cliId: 'zed',
+    name: 'Zed',
+    installDir: '.agents',
+    scanDir: '.zed',
+  },
 ] as const
 
 /**
@@ -688,11 +799,13 @@ export const RELEASE_NOTES_LAST_SEEN_VERSION_KEY =
  * Source: https://github.com/vercel-labs/skills/blob/main/src/agents.ts
  *
  * @example
- * UNIVERSAL_AGENT_IDS // => ['amp', 'codex', 'gemini-cli', 'github-copilot', 'kimi-cli', 'opencode']
+ * // Universal agents read ~/.agents/skills directly, so no per-agent symlink is made:
+ * UNIVERSAL_AGENT_IDS.includes('zed') // => true
  */
 export const UNIVERSAL_AGENT_IDS = [
   'amp',
   'antigravity',
+  'antigravity-cli',
   'cline',
   'codex',
   'cursor',
@@ -702,8 +815,10 @@ export const UNIVERSAL_AGENT_IDS = [
   'gemini-cli',
   'github-copilot',
   'kimi-cli',
+  'loaf',
   'opencode',
   'warp',
+  'zed',
 ] as const satisfies readonly AgentId[]
 
 /**
@@ -792,7 +907,7 @@ export const TERMINAL_APP_UI_LABELS: Record<
  * @example
  * spawn('npx', [`skills@${SKILLS_CLI_VERSION}`, 'find', 'react'])
  */
-export const SKILLS_CLI_VERSION = '1.5.5'
+export const SKILLS_CLI_VERSION = '1.5.10'
 
 /**
  * Canonical hostname for skills marketplace pages used by renderer/main


### PR DESCRIPTION
## Summary

Sync `AGENT_DEFINITIONS` to **vercel-labs/skills v1.5.10** (was 1.5.5), triggered by the Windsurf → Devin Desktop rebrand (Cognition, 2026-06-02).

## Changes

- **+14 community agents**: antigravity-cli, astrbot, autohand-code, inference.sh, jazz, lingma, loaf, moxby, ona, qoder-cn, reasonix, terramind, tinycloud, zed
- **kimi migration (triple fix)**: `cliId` `kimi-cli`→`kimi-code-cli`, `installDir` `.config/agents`→`.agents`, `scanDir`→`.kimi`. Internal `id` kept as `kimi-cli` to preserve persisted Redux state.
- **Windsurf → Devin Desktop (display name only)**: upstream CLI is **not** renamed (`--agent windsurf` stays) and `.codeium/windsurf` is still live during the `.devin`/`.windsurf` transition, so only `name` changes. Touching `id`/`cliId`/dirs would break existing users' symlink detection.
- **UNIVERSAL_AGENT_IDS 13 → 16** (+antigravity-cli, loaf, zed)
- **SKILLS_CLI_VERSION 1.5.5 → 1.5.10**

## Why no app re-architecture

The app's CLI dependency surface is `find` + `add` only (`skillsCliService`); remove/sync/run/prompt go through the app's own IPC. New upstream commands and discovery improvements (well-known v2, nested catalog) come free with the version bump — no new concepts require app changes.

## Test evidence

- `pnpm validate` → **1376 tests pass** (105 files)
- `pnpm test:e2e` → **55 tests pass** (incl. the `skills@1.5.10` marketplace install version tripwire)

## Notes

- Does **not** bump `package.json` version — the release pipeline (`/electron-release`) owns that. `SKILLS_CLI_VERSION` is a separate CLI-dependency constant.
- The unrelated `.gitignore` `+.gbrain-source` change was intentionally left unstaged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  - 複数のコミュニティエージェント（Astrbot、Loaf、Zedなど14エージェント以上）への新規対応

* **改善**
  - Windsurfの表示名をDevin Desktopに更新
  - Skills CLIバージョンをv1.5.10に同期
  - ユニバーサルスキル共有機能の対応範囲を拡張

<!-- end of auto-generated comment: release notes by coderabbit.ai -->