### PR TITLE
Add CLI command toggle

### DIFF
--- a/.storybook/storybook-utils.tsx
+++ b/.storybook/storybook-utils.tsx
@@ -424,6 +424,34 @@ export function installStorybookElectronMock(): void {
     shell: {
       openExternal: async () => undefined,
     },
+    cliCommand: {
+      getStatus: async () => ({
+        status: 'not-installed',
+        commandName: 'skills-desktop',
+        commandPath: '/Users/story/.local/bin/skills-desktop',
+        message: 'Command is not installed.',
+      }),
+      install: async () => ({
+        ok: true,
+        status: {
+          status: 'installed',
+          commandName: 'skills-desktop',
+          commandPath: '/Users/story/.local/bin/skills-desktop',
+          message: 'Command is installed.',
+        },
+        message: 'Command installed at /Users/story/.local/bin/skills-desktop.',
+      }),
+      remove: async () => ({
+        ok: true,
+        status: {
+          status: 'not-installed',
+          commandName: 'skills-desktop',
+          commandPath: '/Users/story/.local/bin/skills-desktop',
+          message: 'Command is not installed.',
+        },
+        message: 'Command removed.',
+      }),
+    },
     skills: {
       getAll: async () => storySkills,
       unlinkFromAgent: async () => ({ success: true }),

--- a/src/main/ipc/cliCommand.integration.test.ts
+++ b/src/main/ipc/cliCommand.integration.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const handleMock = vi.fn()
+const getCliCommandStatusMock = vi.fn()
+const installCliCommandMock = vi.fn()
+const removeCliCommandMock = vi.fn()
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (...args: unknown[]) => handleMock(...args),
+  },
+}))
+
+vi.mock('../services/cliCommandService', () => ({
+  getCliCommandStatus: () => getCliCommandStatusMock(),
+  installCliCommand: () => installCliCommandMock(),
+  removeCliCommand: () => removeCliCommandMock(),
+}))
+
+/**
+ * Find a registered IPC handler by channel name so tests can invoke it directly.
+ * @param channel - IPC channel name captured from ipcMain.handle.
+ * @returns The registered handler function.
+ * @example getRegisteredHandler('cliCommand:getStatus')
+ */
+function getRegisteredHandler(
+  channel: string,
+): (event: unknown, ...args: unknown[]) => Promise<unknown> {
+  const registration = handleMock.mock.calls.find(([name]) => name === channel)
+  if (!registration) throw new Error(`No handler registered for ${channel}`)
+  return registration[1] as (
+    event: unknown,
+    ...args: unknown[]
+  ) => Promise<unknown>
+}
+
+describe('cliCommand IPC handlers', () => {
+  beforeEach(async () => {
+    vi.resetModules()
+    handleMock.mockReset()
+    getCliCommandStatusMock.mockReset()
+    installCliCommandMock.mockReset()
+    removeCliCommandMock.mockReset()
+    const { registerCliCommandHandlers } = await import('./cliCommand')
+    registerCliCommandHandlers()
+  })
+
+  it('returns command status through the no-arg status channel', async () => {
+    // Arrange
+    const expectedStatus = {
+      status: 'not-installed',
+      commandName: 'skills-desktop',
+      commandPath: '/Users/test/.local/bin/skills-desktop',
+      message: 'Command is not installed.',
+    }
+    getCliCommandStatusMock.mockResolvedValue(expectedStatus)
+    const handler = getRegisteredHandler('cliCommand:getStatus')
+
+    // Act
+    const result = await handler({})
+
+    // Assert
+    expect(result).toEqual(expectedStatus)
+    expect(getCliCommandStatusMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('installs the command through the no-arg install channel', async () => {
+    // Arrange
+    const expectedResult = {
+      ok: true,
+      status: {
+        status: 'installed',
+        commandName: 'skills-desktop',
+        commandPath: '/Users/test/.local/bin/skills-desktop',
+        message: 'Command is installed.',
+      },
+      message: 'Command installed.',
+    }
+    installCliCommandMock.mockResolvedValue(expectedResult)
+    const handler = getRegisteredHandler('cliCommand:install')
+
+    // Act
+    const result = await handler({})
+
+    // Assert
+    expect(result).toEqual(expectedResult)
+    expect(installCliCommandMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('removes the command through the no-arg remove channel', async () => {
+    // Arrange
+    const expectedResult = {
+      ok: true,
+      status: {
+        status: 'not-installed',
+        commandName: 'skills-desktop',
+        commandPath: '/Users/test/.local/bin/skills-desktop',
+        message: 'Command is not installed.',
+      },
+      message: 'Command removed.',
+    }
+    removeCliCommandMock.mockResolvedValue(expectedResult)
+    const handler = getRegisteredHandler('cliCommand:remove')
+
+    // Act
+    const result = await handler({})
+
+    // Assert
+    expect(result).toEqual(expectedResult)
+    expect(removeCliCommandMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/ipc/cliCommand.ts
+++ b/src/main/ipc/cliCommand.ts
@@ -1,0 +1,22 @@
+import { IPC_CHANNELS } from '@/shared/ipc-channels'
+
+import {
+  getCliCommandStatus,
+  installCliCommand,
+  removeCliCommand,
+} from '../services/cliCommandService'
+
+import { typedHandle } from './typedHandle'
+
+/**
+ * Registers Settings-facing handlers for managing the app-level CLI shim.
+ * @returns void after the three no-arg channels are attached to ipcMain.
+ * @example registerCliCommandHandlers()
+ */
+export function registerCliCommandHandlers(): void {
+  typedHandle(IPC_CHANNELS.CLI_COMMAND_GET_STATUS, async () =>
+    getCliCommandStatus(),
+  )
+  typedHandle(IPC_CHANNELS.CLI_COMMAND_INSTALL, async () => installCliCommand())
+  typedHandle(IPC_CHANNELS.CLI_COMMAND_REMOVE, async () => removeCliCommand())
+}

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -1,4 +1,5 @@
 import { registerAgentsHandlers } from './agents'
+import { registerCliCommandHandlers } from './cliCommand'
 import { registerFilesHandlers } from './files'
 import { registerFolderHandlers } from './folder'
 import { registerLeaderboardHandlers } from './leaderboard'
@@ -18,6 +19,7 @@ import { registerWindowHandlers } from './window'
 export function registerAllHandlers(): void {
   registerSkillsHandlers()
   registerSkillsCliHandlers()
+  registerCliCommandHandlers()
   registerLeaderboardHandlers()
   registerAgentsHandlers()
   registerSourceHandlers()

--- a/src/main/services/cliCommandService.test.ts
+++ b/src/main/services/cliCommandService.test.ts
@@ -1,0 +1,176 @@
+import { mkdtempSync, realpathSync } from 'node:fs'
+import {
+  lstat,
+  mkdir,
+  readFile,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from 'node:fs/promises'
+import type * as NodeOs from 'node:os'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest'
+
+const sharedHome = realpathSync(
+  mkdtempSync(join(tmpdir(), 'skills-cli-command-')),
+)
+const commandPath = join(sharedHome, '.local', 'bin', 'skills-desktop')
+
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof NodeOs>('node:os')
+  return {
+    ...actual,
+    homedir: () => sharedHome,
+  }
+})
+
+const servicePromise = (async () => import('./cliCommandService'))()
+
+describe('cliCommandService', () => {
+  afterEach(async () => {
+    await rm(join(sharedHome, '.local'), { recursive: true, force: true })
+  })
+
+  afterAll(async () => {
+    await rm(sharedHome, { recursive: true, force: true })
+  })
+
+  it('reports the command as not installed when ~/.local/bin/skills-desktop is missing', async () => {
+    // Arrange
+    const { getCliCommandStatus } = await servicePromise
+
+    // Act
+    const status = await getCliCommandStatus()
+
+    // Assert
+    expect(status).toEqual({
+      status: 'not-installed',
+      commandName: 'skills-desktop',
+      commandPath,
+      message: 'Command is not installed.',
+    })
+  })
+
+  it('installs an executable shim that opens the Skills Desktop bundle', async () => {
+    // Arrange
+    const { installCliCommand } = await servicePromise
+
+    // Act
+    const result = await installCliCommand()
+
+    // Assert
+    expect(result.ok).toBe(true)
+    expect(result.status.status).toBe('installed')
+    expect(result.message).toBe(`Command installed at ${commandPath}.`)
+    expect(await readFile(commandPath, 'utf-8')).toBe(`#!/bin/sh
+# >>> Skills Desktop CLI shim >>>
+# This file is managed by Skills Desktop from Settings.
+exec open -b "io.laststance.skills-desktop"
+# <<< Skills Desktop CLI shim <<<
+`)
+    expect((await stat(commandPath)).mode & 0o777).toBe(0o755)
+  })
+
+  it('refuses to overwrite an unmanaged file that already uses the command path', async () => {
+    // Arrange
+    const { installCliCommand } = await servicePromise
+    await mkdir(join(sharedHome, '.local', 'bin'), { recursive: true })
+    await writeFile(commandPath, '#!/bin/sh\necho unmanaged\n', 'utf-8')
+
+    // Act
+    const result = await installCliCommand()
+
+    // Assert
+    expect(result).toEqual({
+      ok: false,
+      status: {
+        status: 'blocked',
+        commandName: 'skills-desktop',
+        commandPath,
+        message: `${commandPath} is already occupied by an unmanaged file.`,
+      },
+      message: `${commandPath} is already occupied by an unmanaged file.`,
+    })
+    expect(await readFile(commandPath, 'utf-8')).toBe(
+      '#!/bin/sh\necho unmanaged\n',
+    )
+  })
+
+  it('refuses to remove a user-edited script that contains the managed markers', async () => {
+    // Arrange
+    const { removeCliCommand } = await servicePromise
+    const editedScript = `#!/bin/sh
+# >>> Skills Desktop CLI shim >>>
+# This file is managed by Skills Desktop from Settings.
+echo "custom logic"
+exec open -b "io.laststance.skills-desktop"
+# <<< Skills Desktop CLI shim <<<
+`
+    await mkdir(join(sharedHome, '.local', 'bin'), { recursive: true })
+    await writeFile(commandPath, editedScript, 'utf-8')
+
+    // Act
+    const result = await removeCliCommand()
+
+    // Assert
+    expect(result).toEqual({
+      ok: false,
+      status: {
+        status: 'blocked',
+        commandName: 'skills-desktop',
+        commandPath,
+        message: `${commandPath} is already occupied by an unmanaged file.`,
+      },
+      message: `${commandPath} is already occupied by an unmanaged file.`,
+    })
+    expect(await readFile(commandPath, 'utf-8')).toBe(editedScript)
+  })
+
+  it('removes the managed shim and leaves the command path missing afterward', async () => {
+    // Arrange
+    const { installCliCommand, removeCliCommand } = await servicePromise
+    await installCliCommand()
+
+    // Act
+    const result = await removeCliCommand()
+
+    // Assert
+    expect(result).toEqual({
+      ok: true,
+      status: {
+        status: 'not-installed',
+        commandName: 'skills-desktop',
+        commandPath,
+        message: 'Command is not installed.',
+      },
+      message: 'Command removed.',
+    })
+    await expect(lstat(commandPath)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('refuses to remove an unmanaged symlink that occupies the command path', async () => {
+    // Arrange
+    const { removeCliCommand } = await servicePromise
+    await mkdir(join(sharedHome, '.local', 'bin'), { recursive: true })
+    await symlink('/usr/bin/open', commandPath)
+
+    // Act
+    const result = await removeCliCommand()
+
+    // Assert
+    expect(result).toEqual({
+      ok: false,
+      status: {
+        status: 'blocked',
+        commandName: 'skills-desktop',
+        commandPath,
+        message: `${commandPath} is already occupied by an unmanaged symlink.`,
+      },
+      message: `${commandPath} is already occupied by an unmanaged symlink.`,
+    })
+    expect((await lstat(commandPath)).isSymbolicLink()).toBe(true)
+  })
+})

--- a/src/main/services/cliCommandService.ts
+++ b/src/main/services/cliCommandService.ts
@@ -1,0 +1,208 @@
+import { randomUUID } from 'node:crypto'
+import { promises as fs } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+import type {
+  AbsolutePath,
+  CliCommandOperationResult,
+  CliCommandStatus,
+} from '@/shared/types'
+
+import { errorCode } from '../utils/errorCode'
+import { extractErrorMessage } from '../utils/errors'
+
+const CLI_COMMAND_NAME = 'skills-desktop'
+const APP_BUNDLE_ID = 'io.laststance.skills-desktop'
+const MANAGED_SHIM_START = '# >>> Skills Desktop CLI shim >>>'
+const MANAGED_SHIM_END = '# <<< Skills Desktop CLI shim <<<'
+const EXECUTABLE_FILE_MODE = 0o755
+
+const CLI_COMMAND_DIR = join(homedir(), '.local', 'bin')
+const CLI_COMMAND_PATH: AbsolutePath = join(CLI_COMMAND_DIR, CLI_COMMAND_NAME)
+
+const SHIM_CONTENT = `#!/bin/sh
+${MANAGED_SHIM_START}
+# This file is managed by Skills Desktop from Settings.
+exec open -b "${APP_BUNDLE_ID}"
+${MANAGED_SHIM_END}
+`
+
+/**
+ * Checks whether a file is the exact app-managed CLI shim that Settings may safely remove.
+ * @param contents - Text read from the candidate command path.
+ * @returns True only when the file exactly matches the generated app shim.
+ * @example isManagedShim('# >>> Skills Desktop CLI shim >>>\nexec open -b "io.laststance.skills-desktop"\n# <<< Skills Desktop CLI shim <<<') // => true
+ */
+function isManagedShim(contents: string): boolean {
+  return contents === SHIM_CONTENT
+}
+
+/**
+ * Builds the shared status payload so IPC, tests, and Settings copy stay aligned.
+ * @param status - Current command installation discriminator.
+ * @param message - User-safe status explanation.
+ * @returns Full command status payload with path/name attached.
+ * @example buildStatus('not-installed', 'Command is not installed.')
+ */
+function buildStatus(
+  status: CliCommandStatus['status'],
+  message: string,
+): CliCommandStatus {
+  return {
+    status,
+    commandName: CLI_COMMAND_NAME,
+    commandPath: CLI_COMMAND_PATH,
+    message,
+  }
+}
+
+/**
+ * Reads ~/.local/bin/skills-desktop and classifies whether Settings can manage it.
+ * @returns Installed/missing/blocked status for the app-level command shim.
+ * @example await getCliCommandStatus()
+ */
+export async function getCliCommandStatus(): Promise<CliCommandStatus> {
+  try {
+    const entry = await fs.lstat(CLI_COMMAND_PATH)
+
+    // Symlinks may point anywhere, so never follow or manage them from Settings.
+    if (entry.isSymbolicLink()) {
+      return buildStatus(
+        'blocked',
+        `${CLI_COMMAND_PATH} is already occupied by an unmanaged symlink.`,
+      )
+    }
+
+    if (!entry.isFile()) {
+      return buildStatus(
+        'blocked',
+        `${CLI_COMMAND_PATH} is already occupied by another filesystem entry.`,
+      )
+    }
+
+    const contents = await fs.readFile(CLI_COMMAND_PATH, 'utf-8')
+    if (isManagedShim(contents)) {
+      return buildStatus('installed', 'Command is installed.')
+    }
+
+    return buildStatus(
+      'blocked',
+      `${CLI_COMMAND_PATH} is already occupied by an unmanaged file.`,
+    )
+  } catch (error) {
+    if (errorCode(error) === 'ENOENT') {
+      return buildStatus('not-installed', 'Command is not installed.')
+    }
+
+    return buildStatus(
+      'blocked',
+      `Could not inspect ${CLI_COMMAND_PATH}: ${extractErrorMessage(error)}`,
+    )
+  }
+}
+
+/**
+ * Installs the managed `skills-desktop` shim unless another command already owns the path.
+ * @returns Operation result with fresh status after the install attempt.
+ * @example await installCliCommand()
+ */
+export async function installCliCommand(): Promise<CliCommandOperationResult> {
+  const before = await getCliCommandStatus()
+  if (before.status === 'installed') {
+    return {
+      ok: true,
+      status: before,
+      message: 'Command is already installed.',
+    }
+  }
+
+  if (before.status === 'blocked') {
+    return {
+      ok: false,
+      status: before,
+      message: before.message,
+    }
+  }
+
+  await fs.mkdir(CLI_COMMAND_DIR, { recursive: true })
+  const temporaryPath = join(
+    CLI_COMMAND_DIR,
+    `.${CLI_COMMAND_NAME}.${randomUUID()}.tmp`,
+  )
+
+  try {
+    await fs.writeFile(temporaryPath, SHIM_CONTENT, {
+      encoding: 'utf-8',
+      mode: EXECUTABLE_FILE_MODE,
+      flag: 'wx',
+    })
+    await fs.chmod(temporaryPath, EXECUTABLE_FILE_MODE)
+    // Publish with link() instead of rename(): link fails when the final
+    // command path appears between status check and install, so we never
+    // overwrite an unmanaged command in a race.
+    await fs.link(temporaryPath, CLI_COMMAND_PATH)
+    await fs.rm(temporaryPath, { force: true })
+  } catch (error) {
+    await fs.rm(temporaryPath, { force: true })
+    const status = await getCliCommandStatus()
+    return {
+      ok: false,
+      status,
+      message: `Could not install command: ${extractErrorMessage(error)}`,
+    }
+  }
+
+  const status = await getCliCommandStatus()
+  return {
+    ok: status.status === 'installed',
+    status,
+    message:
+      status.status === 'installed'
+        ? `Command installed at ${CLI_COMMAND_PATH}.`
+        : status.message,
+  }
+}
+
+/**
+ * Removes only the managed `skills-desktop` shim and leaves unknown command paths untouched.
+ * @returns Operation result with fresh status after the remove attempt.
+ * @example await removeCliCommand()
+ */
+export async function removeCliCommand(): Promise<CliCommandOperationResult> {
+  const before = await getCliCommandStatus()
+  if (before.status === 'not-installed') {
+    return {
+      ok: true,
+      status: before,
+      message: 'Command is already removed.',
+    }
+  }
+
+  if (before.status === 'blocked') {
+    return {
+      ok: false,
+      status: before,
+      message: before.message,
+    }
+  }
+
+  try {
+    await fs.unlink(CLI_COMMAND_PATH)
+  } catch (error) {
+    const status = await getCliCommandStatus()
+    return {
+      ok: false,
+      status,
+      message: `Could not remove command: ${extractErrorMessage(error)}`,
+    }
+  }
+
+  const status = await getCliCommandStatus()
+  return {
+    ok: status.status === 'not-installed',
+    status,
+    message:
+      status.status === 'not-installed' ? 'Command removed.' : status.message,
+  }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -6,6 +6,8 @@ import type {
   AbsolutePath,
   ClearOrphanSymlinksOptions,
   ClearBrokenSymlinkSlotsOptions,
+  CliCommandOperationResult,
+  CliCommandStatus,
   CopyToAgentsOptions,
   CreateSymlinksOptions,
   DeleteProgressPayload,
@@ -39,6 +41,16 @@ contextBridge.exposeInMainWorld('electron', {
   shell: {
     openExternal: async (url: HttpUrl) =>
       typedInvoke('shell:openExternal', url),
+  },
+  // App CLI command API. Renderer asks main to inspect or mutate
+  // ~/.local/bin/skills-desktop because Context Isolation forbids direct fs.
+  cliCommand: {
+    getStatus: async (): Promise<CliCommandStatus> =>
+      typedInvoke('cliCommand:getStatus'),
+    install: async (): Promise<CliCommandOperationResult> =>
+      typedInvoke('cliCommand:install'),
+    remove: async (): Promise<CliCommandOperationResult> =>
+      typedInvoke('cliCommand:remove'),
   },
   // Skills API
   skills: {

--- a/src/renderer/settings/sections/General.browser.test.tsx
+++ b/src/renderer/settings/sections/General.browser.test.tsx
@@ -1,0 +1,167 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import { DEFAULT_SETTINGS } from '@/shared/settings'
+import type {
+  CliCommandOperationResult,
+  CliCommandStatus,
+} from '@/shared/types'
+
+const mockSettingsSet = vi.fn()
+const mockWindowGetMainBounds = vi.fn()
+const mockCliCommandGetStatus = vi.fn()
+const mockCliCommandInstall = vi.fn()
+const mockCliCommandRemove = vi.fn()
+
+const commandPath = '/Users/test/.local/bin/skills-desktop'
+
+const notInstalledStatus: CliCommandStatus = {
+  status: 'not-installed',
+  commandName: 'skills-desktop',
+  commandPath,
+  message: 'Command is not installed.',
+}
+
+const installedStatus: CliCommandStatus = {
+  status: 'installed',
+  commandName: 'skills-desktop',
+  commandPath,
+  message: 'Command is installed.',
+}
+
+const blockedStatus: CliCommandStatus = {
+  status: 'blocked',
+  commandName: 'skills-desktop',
+  commandPath,
+  message: `${commandPath} is already occupied by an unmanaged file.`,
+}
+
+beforeEach(() => {
+  mockSettingsSet.mockReset()
+  mockSettingsSet.mockResolvedValue(undefined)
+  mockWindowGetMainBounds.mockReset()
+  mockWindowGetMainBounds.mockResolvedValue({ width: 1200, height: 800 })
+  mockCliCommandGetStatus.mockReset()
+  mockCliCommandInstall.mockReset()
+  mockCliCommandRemove.mockReset()
+  vi.stubGlobal('electron', {
+    settings: { set: mockSettingsSet },
+    window: { getMainBounds: mockWindowGetMainBounds },
+    cliCommand: {
+      getStatus: mockCliCommandGetStatus,
+      install: mockCliCommandInstall,
+      remove: mockCliCommandRemove,
+    },
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+/**
+ * Build a minimal Redux store for the General settings pane.
+ * @returns Redux store with Settings defaults preloaded.
+ * @example const store = await createStore()
+ */
+async function createStore(): Promise<ReturnType<typeof configureStore>> {
+  const { default: settingsReducer } =
+    await import('@/renderer/src/redux/slices/settingsSlice')
+  return configureStore({
+    reducer: {
+      settings: settingsReducer,
+    },
+    preloadedState: {
+      settings: { ...DEFAULT_SETTINGS },
+    },
+  })
+}
+
+/**
+ * Render General with the provided CLI command status returned on mount.
+ * @param status - Initial command status returned by the preload mock.
+ * @returns The vitest-browser render screen.
+ * @example await renderGeneral(notInstalledStatus)
+ */
+async function renderGeneral(status: CliCommandStatus) {
+  mockCliCommandGetStatus.mockResolvedValueOnce(status)
+  const store = await createStore()
+  const { General } = await import('./General')
+  return render(
+    <Provider store={store}>
+      <General />
+    </Provider>,
+  )
+}
+
+describe('Settings → General command line command', () => {
+  it('installs the command and switches the action to removal', async () => {
+    // Arrange
+    const installResult: CliCommandOperationResult = {
+      ok: true,
+      status: installedStatus,
+      message: `Command installed at ${commandPath}.`,
+    }
+    mockCliCommandInstall.mockResolvedValueOnce(installResult)
+    const screen = await renderGeneral(notInstalledStatus)
+
+    // Act
+    const installButton = screen.getByRole('button', {
+      name: /Install command/i,
+    })
+    await expect.element(installButton).toBeEnabled()
+    await installButton.click()
+
+    // Assert
+    await expect.poll(() => mockCliCommandInstall.mock.calls.length).toBe(1)
+    await expect
+      .element(screen.getByRole('button', { name: /Remove command/i }))
+      .toBeVisible()
+    await expect
+      .element(screen.getByText(`Command installed at ${commandPath}.`))
+      .toBeVisible()
+  })
+
+  it('removes the command and switches the action back to installation', async () => {
+    // Arrange
+    const removeResult: CliCommandOperationResult = {
+      ok: true,
+      status: notInstalledStatus,
+      message: 'Command removed.',
+    }
+    mockCliCommandRemove.mockResolvedValueOnce(removeResult)
+    const screen = await renderGeneral(installedStatus)
+
+    // Act
+    const removeButton = screen.getByRole('button', {
+      name: /Remove command/i,
+    })
+    await expect.element(removeButton).toBeEnabled()
+    await removeButton.click()
+
+    // Assert
+    await expect.poll(() => mockCliCommandRemove.mock.calls.length).toBe(1)
+    await expect
+      .element(screen.getByRole('button', { name: /Install command/i }))
+      .toBeVisible()
+    await expect.element(screen.getByText('Command removed.')).toBeVisible()
+  })
+
+  it('disables mutation when another file already occupies the command path', async () => {
+    // Arrange
+    const screen = await renderGeneral(blockedStatus)
+
+    // Act
+    const installButton = screen.getByRole('button', {
+      name: /Install command/i,
+    })
+
+    // Assert
+    await expect.element(installButton).toBeDisabled()
+    await expect.element(screen.getByText(blockedStatus.message)).toBeVisible()
+    expect(mockCliCommandInstall).not.toHaveBeenCalled()
+    expect(mockCliCommandRemove).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/settings/sections/General.tsx
+++ b/src/renderer/settings/sections/General.tsx
@@ -1,4 +1,4 @@
-import { Files, Info } from 'lucide-react'
+import { Files, Info, Terminal, Trash2 } from 'lucide-react'
 import React, { useCallback, useState } from 'react'
 
 import { Button } from '@/renderer/src/components/ui/button'
@@ -12,6 +12,7 @@ import { useUpdateSettings } from '@/renderer/src/hooks/useUpdateSettings'
 import { useAppSelector } from '@/renderer/src/redux/hooks'
 import { TERMINAL_APP_IDS, TERMINAL_APP_UI_LABELS } from '@/shared/constants'
 import type { Settings } from '@/shared/settings'
+import type { CliCommandStatus } from '@/shared/types'
 
 import { SectionFrame, SectionRow } from './SectionFrame'
 
@@ -38,6 +39,81 @@ const DEFAULT_TAB_OPTIONS: ReadonlyArray<{
  */
 const CUSTOM_APP_NAME_MAX_LENGTH = 64
 
+interface CliCommandControlState {
+  status: CliCommandStatus | null
+  message: string | null
+  isBusy: boolean
+  install: () => void
+  remove: () => void
+}
+
+/**
+ * Owns the Settings-only state machine for inspecting/installing/removing the app CLI shim.
+ * @returns Current status, message, busy flag, and stable command actions.
+ * @example const cliCommand = useCliCommandControl()
+ */
+function useCliCommandControl(): CliCommandControlState {
+  const [status, setStatus] = useState<CliCommandStatus | null>(null)
+  const [message, setMessage] = useState<string | null>(null)
+  const [isBusy, setIsBusy] = useState<boolean>(false)
+
+  useInitialEffect(() => {
+    let cancelled = false
+
+    window.electron.cliCommand
+      .getStatus()
+      .then((nextStatus) => {
+        if (cancelled) return
+        setStatus(nextStatus)
+        setMessage(null)
+      })
+      .catch(() => {
+        if (cancelled) return
+        setMessage('Could not read command status.')
+      })
+
+    return () => {
+      cancelled = true
+    }
+  })
+
+  const install = useCallback((): void => {
+    setIsBusy(true)
+    setMessage(null)
+    void window.electron.cliCommand
+      .install()
+      .then((result) => {
+        setStatus(result.status)
+        setMessage(result.message)
+      })
+      .catch(() => {
+        setMessage('Could not install command.')
+      })
+      .finally(() => {
+        setIsBusy(false)
+      })
+  }, [])
+
+  const remove = useCallback((): void => {
+    setIsBusy(true)
+    setMessage(null)
+    void window.electron.cliCommand
+      .remove()
+      .then((result) => {
+        setStatus(result.status)
+        setMessage(result.message)
+      })
+      .catch(() => {
+        setMessage('Could not remove command.')
+      })
+      .finally(() => {
+        setIsBusy(false)
+      })
+  }, [])
+
+  return { status, message, isBusy, install, remove }
+}
+
 /**
  * General settings pane.
  *
@@ -61,6 +137,13 @@ const CUSTOM_APP_NAME_MAX_LENGTH = 64
 export const General = React.memo(function General(): React.ReactElement {
   const settings = useAppSelector((state) => state.settings)
   const updateSettings = useUpdateSettings()
+  const {
+    status: cliCommandStatus,
+    message: cliCommandMessage,
+    isBusy: isCliCommandBusy,
+    install: installCliCommand,
+    remove: removeCliCommand,
+  } = useCliCommandControl()
 
   // Local mirror of the custom name field so users can type without
   // committing on every keystroke. Initial value is whatever's in settings
@@ -183,6 +266,27 @@ export const General = React.memo(function General(): React.ReactElement {
 
   const persistedWindowSize = settings.windowSize
   const hasCustomWindowSize = persistedWindowSize !== undefined
+  const isCliCommandInstalled = cliCommandStatus?.status === 'installed'
+  const isCliCommandBlocked = cliCommandStatus?.status === 'blocked'
+  const isCliCommandUnknown = cliCommandStatus === null
+  const CliCommandButtonIcon = isCliCommandInstalled ? Trash2 : Terminal
+  const cliCommandButtonLabel = isCliCommandInstalled
+    ? 'Remove command'
+    : 'Install command'
+  const cliCommandStatusMessage =
+    cliCommandMessage ??
+    cliCommandStatus?.message ??
+    'Checking command status...'
+
+  const handleCliCommandClick = useCallback((): void => {
+    // Installed state maps the same row to removal; every other actionable
+    // state installs the managed shim.
+    if (isCliCommandInstalled) {
+      removeCliCommand()
+      return
+    }
+    installCliCommand()
+  }, [installCliCommand, isCliCommandInstalled, removeCliCommand])
 
   return (
     <SectionFrame
@@ -316,6 +420,45 @@ export const General = React.memo(function General(): React.ReactElement {
           <p className="text-xs text-muted-foreground">
             Takes effect the next time you launch the app.
           </p>
+        </div>
+      </SectionRow>
+
+      <SectionRow
+        label="Command line command"
+        description="Install a local command so Terminal can open Skills Desktop."
+      >
+        <div className="flex flex-col gap-2">
+          <p className="text-sm">
+            Run <code>skills-desktop</code> from your shell.
+          </p>
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant={isCliCommandInstalled ? 'destructive' : 'outline'}
+              size="sm"
+              onClick={handleCliCommandClick}
+              disabled={
+                isCliCommandBusy || isCliCommandUnknown || isCliCommandBlocked
+              }
+            >
+              <CliCommandButtonIcon className="h-3.5 w-3.5" />
+              {cliCommandButtonLabel}
+            </Button>
+            {isCliCommandBusy && (
+              <span className="text-xs text-muted-foreground">Working...</span>
+            )}
+          </div>
+          <p
+            className="text-xs text-muted-foreground"
+            aria-label="Command line command status"
+          >
+            {cliCommandStatusMessage}
+          </p>
+          {cliCommandStatus && (
+            <p className="text-xs text-muted-foreground">
+              Path: <code>{cliCommandStatus.commandPath}</code>
+            </p>
+          )}
         </div>
       </SectionRow>
     </SectionFrame>

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -12,12 +12,14 @@ import type {
   DeleteProgressPayload,
   DownloadProgress,
   FolderActionResult,
+  CliCommandOperationResult,
   PixelHeight,
   PixelWidth,
   RankingFilter,
   SkillSearchResult,
   InstallOptions,
   CliCommandResult,
+  CliCommandStatus,
   InstallProgress,
   UnlinkFromAgentOptions,
   UnlinkResult,
@@ -50,6 +52,11 @@ declare global {
     electron: {
       shell: {
         openExternal: (url: string) => Promise<void>
+      }
+      cliCommand: {
+        getStatus: () => Promise<CliCommandStatus>
+        install: () => Promise<CliCommandOperationResult>
+        remove: () => Promise<CliCommandOperationResult>
       }
       skills: {
         getAll: () => Promise<Skill[]>

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -46,6 +46,11 @@ export const IPC_CHANNELS = {
   // Shell (main-process-only APIs exposed via IPC)
   SHELL_OPEN_EXTERNAL: 'shell:openExternal',
 
+  // App CLI command (~/.local/bin/skills-desktop)
+  CLI_COMMAND_GET_STATUS: 'cliCommand:getStatus',
+  CLI_COMMAND_INSTALL: 'cliCommand:install',
+  CLI_COMMAND_REMOVE: 'cliCommand:remove',
+
   // Update
   UPDATE_DOWNLOAD: 'update:download',
   UPDATE_INSTALL: 'update:install',

--- a/src/shared/ipc-contract.test.ts
+++ b/src/shared/ipc-contract.test.ts
@@ -34,6 +34,9 @@ describe('IPC contract alignment', () => {
       [IPC_CHANNELS.UPDATE_INSTALL]: true,
       [IPC_CHANNELS.UPDATE_CHECK]: true,
       [IPC_CHANNELS.SHELL_OPEN_EXTERNAL]: true,
+      [IPC_CHANNELS.CLI_COMMAND_GET_STATUS]: true,
+      [IPC_CHANNELS.CLI_COMMAND_INSTALL]: true,
+      [IPC_CHANNELS.CLI_COMMAND_REMOVE]: true,
       [IPC_CHANNELS.SETTINGS_OPEN]: true,
       [IPC_CHANNELS.SETTINGS_GET]: true,
       [IPC_CHANNELS.SETTINGS_SET]: true,
@@ -51,7 +54,7 @@ describe('IPC contract alignment', () => {
     // The `satisfies` clause above is a structural guard; this length check is
     // the trip-wire that forces a human PR diff when a channel is added.
     // Assert
-    expect(invokeChannelKeys).toHaveLength(32)
+    expect(invokeChannelKeys).toHaveLength(35)
   })
 
   it('forces a review by tripping when a push-event channel is added or removed', () => {

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -8,7 +8,9 @@ import type {
   ClearOrphanSymlinksResult,
   ClearBrokenSymlinkSlotsOptions,
   ClearBrokenSymlinkSlotsResult,
+  CliCommandOperationResult,
   CliCommandResult,
+  CliCommandStatus,
   CopyToAgentsOptions,
   CopyToAgentsResult,
   CreateSymlinksOptions,
@@ -128,6 +130,9 @@ export interface IpcInvokeContract {
   'update:install': { args: []; result: void }
   'update:check': { args: []; result: void }
   'shell:openExternal': { args: [HttpUrl]; result: void }
+  'cliCommand:getStatus': { args: []; result: CliCommandStatus }
+  'cliCommand:install': { args: []; result: CliCommandOperationResult }
+  'cliCommand:remove': { args: []; result: CliCommandOperationResult }
   'settings:open': { args: []; result: void }
   'settings:get': { args: []; result: Settings }
   'settings:set': { args: [SettingsPatch]; result: Settings }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -717,6 +717,42 @@ export interface CliCommandResult {
 }
 
 /**
+ * Installation state of the app-level `skills-desktop` command in ~/.local/bin.
+ * @example 'not-installed'
+ * @example 'installed'
+ * @example 'blocked'
+ */
+export type CliCommandStatusKind = 'not-installed' | 'installed' | 'blocked'
+
+/**
+ * Status payload for the app-level command line shim.
+ * @example { status: 'installed', commandName: 'skills-desktop', commandPath: '/Users/me/.local/bin/skills-desktop', message: 'Command is installed.' }
+ */
+export interface CliCommandStatus {
+  /** Whether the command is absent, safely managed, or blocked by another entry. */
+  status: CliCommandStatusKind
+  /** Command users type in a terminal. @example "skills-desktop" */
+  commandName: string
+  /** Absolute path where the shim is expected. @example "/Users/me/.local/bin/skills-desktop" */
+  commandPath: AbsolutePath
+  /** User-safe explanation for status text in Settings. */
+  message: string
+}
+
+/**
+ * Result returned after installing or removing the app-level CLI command.
+ * @example { ok: true, status: { status: 'installed', commandName: 'skills-desktop', commandPath: '/Users/me/.local/bin/skills-desktop', message: 'Command is installed.' }, message: 'Command installed.' }
+ */
+export interface CliCommandOperationResult {
+  /** true only when the requested install/remove completed or was already satisfied. */
+  ok: boolean
+  /** Fresh command status after the operation attempt. */
+  status: CliCommandStatus
+  /** User-safe operation outcome. */
+  message: string
+}
+
+/**
  * Streamed progress event emitted while the skills CLI runs an install.
  * Pushed over IPC on the `skills:cli:progress` channel.
  * @example { phase: 'cloning', message: 'Fetching vercel-labs/skills...' }


### PR DESCRIPTION
## Summary
- add a main-process CLI command service for managing ~/.local/bin/skills-desktop
- expose typed IPC/preload APIs and Settings → General install/remove UI
- add service, IPC, and browser tests for installed, missing, and blocked states

## Safety
- writes only a marker-managed shim that opens/focuses the app bundle
- refuses unmanaged files, directories, and symlinks
- removes only the exact generated shim content

## Verification
- pnpm exec vitest run src/main/services/cliCommandService.test.ts
- pnpm validate
- pnpm test:e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **新機能**
  * 設定画面に CLI コマンドの管理セクションを追加しました。コマンドのインストール状態確認、インストール、削除の操作が可能になります。

* **テスト**
  * 新機能のテストスイートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->