### PR TITLE
feat(installed): add search count display setting

### DIFF
--- a/e2e/spec/installed-search-count.e2e.ts
+++ b/e2e/spec/installed-search-count.e2e.ts
@@ -1,106 +1,107 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
 import type { Page } from '@playwright/test'
 
-import { repositoryId, type AbsolutePath, type Skill } from '@/shared/types'
-
 import { test, expect } from '../fixtures/electron-app'
-import { readSettingsFile } from '../helpers/settings-file'
+import { readSettingsFile, writeSettingsFile } from '../helpers/settings-file'
 
 const SEARCH_COUNT_SKILLS = [
-  makeSourceSkill('alpha-count-e2e', 'laststance/skills'),
-  makeSourceSkill('beta-count-e2e', 'laststance/skills'),
-  makeSourceSkill('gamma-count-e2e', 'pbakaus/impeccable'),
+  { name: 'alpha-count-e2e', source: 'laststance/skills' },
+  { name: 'beta-count-e2e', source: 'laststance/skills' },
+  { name: 'gamma-count-e2e', source: 'pbakaus/impeccable' },
 ]
 
+type SearchCountDisplaySetting = 'tab' | 'inline'
+type IsolatedHomeUse = (home: string) => Promise<void>
+
 /**
- * Create a minimal source skill row for the Installed count E2E fixture.
- * @param name - Display name that the Installed search field matches.
- * @param source - Repository id used by the repo include filter.
- * @returns Serializable skill object accepted by the renderer Redux slice.
+ * Write one source skill folder that the real scanner will count after app launch.
+ * @param home - Isolated E2E HOME used by the Electron fixture.
+ * @param skillName - Folder name and SKILL.md title for the staged skill.
+ * @returns void after the source skill exists on disk.
  * @example
- * makeSourceSkill('alpha-count-e2e', 'laststance/skills')
+ * stageSourceSkill('/tmp/home', 'alpha-count-e2e')
  */
-function makeSourceSkill(name: string, source: string): Skill {
-  return {
-    name,
-    description: `${name} description`,
-    path: `/tmp/skills-desktop-e2e/${name}` as AbsolutePath,
-    filesystemIdentity: {
-      kind: 'directory',
-      dev: 101,
-      ino: name.length,
-      size: 96,
-      ctimeMs: 1,
-      mtimeMs: 2,
-    },
-    symlinkCount: 0,
-    symlinks: [],
-    isSource: true,
-    isOrphan: false,
-    source: repositoryId(source),
-    sourceUrl: `https://github.com/${source}.git`,
-  }
+function stageSourceSkill(home: string, skillName: string): void {
+  const sourcePath = join(home, '.agents', 'skills', skillName)
+  mkdirSync(sourcePath, { recursive: true })
+  writeFileSync(
+    join(sourcePath, 'SKILL.md'),
+    `---\nname: ${skillName}\ndescription: ${skillName} description\n---\n# ${skillName}\n`,
+    'utf8',
+  )
 }
 
 /**
- * Wait for the E2E Redux bridge before dispatching synthetic scan data.
- * @param page - Electron renderer page under test.
- * @returns Promise that resolves once `window.__store__` is available.
+ * Write the skills CLI lockfile so the real scanner exposes deterministic repo facets.
+ * @param home - Isolated E2E HOME used by the Electron fixture.
+ * @returns void after `.skill-lock.json` maps each staged skill to its repo.
  * @example
- * await waitForExposedStore(appWindow)
+ * stageSkillLock('/tmp/home')
  */
-async function waitForExposedStore(page: Page): Promise<void> {
-  await page.waitForFunction(() => Boolean(window.__store__ ?? window.__store))
-}
-
-/**
- * Replace scanner output with a fixed Installed inventory and reset filters.
- * @param page - Electron renderer page under test.
- * @returns Promise that resolves once Redux has the deterministic fixture.
- * @example
- * await seedInstalledCountFixture(appWindow)
- */
-async function seedInstalledCountFixture(page: Page): Promise<void> {
-  await waitForExposedStore(page)
-  await page.evaluate((skills) => {
-    const store = window.__store__ ?? window.__store
-    if (!store) throw new Error('window.__store__ is not exposed')
-
-    store.dispatch({
-      type: 'ui/setActiveTab',
-      payload: 'installed',
-    })
-    store.dispatch({
-      type: 'ui/selectAgent',
-      payload: null,
-    })
-    store.dispatch({
-      type: 'ui/setSkillTypeFilter',
-      payload: 'all',
-    })
-    store.dispatch({
-      type: 'ui/clearExcludedSkillTypeFilters',
-    })
-    store.dispatch({
-      type: 'ui/setSearchScope',
-      payload: 'name',
-    })
-    store.dispatch({
-      type: 'ui/setSearchQuery',
-      payload: '',
-    })
-    store.dispatch({
-      type: 'ui/setSelectedSources',
-      payload: [],
-    })
-    store.dispatch({
-      type: 'skills/fetchAll/fulfilled',
-      payload: skills,
-      meta: {
-        requestId: 'e2e-installed-search-count',
-        requestStatus: 'fulfilled',
+function stageSkillLock(home: string): void {
+  const lockPath = join(home, '.agents', '.skill-lock.json')
+  const skills = Object.fromEntries(
+    SEARCH_COUNT_SKILLS.map((skill) => [
+      skill.name,
+      {
+        source: skill.source,
+        sourceType: 'github',
+        sourceUrl: `https://github.com/${skill.source}.git`,
       },
-    })
-  }, SEARCH_COUNT_SKILLS)
+    ]),
+  )
+
+  writeFileSync(lockPath, JSON.stringify({ skills }, null, 2), 'utf8')
+}
+
+/**
+ * Stage the complete Installed-count HOME before Electron starts scanning.
+ * @param home - Isolated E2E HOME used by the Electron fixture.
+ * @returns void after source skills and repo metadata are on disk.
+ * @example
+ * stageInstalledCountHome('/tmp/home')
+ */
+function stageInstalledCountHome(home: string): void {
+  mkdirSync(join(home, '.agents', 'skills'), { recursive: true })
+  for (const skill of SEARCH_COUNT_SKILLS) {
+    stageSourceSkill(home, skill.name)
+  }
+  stageSkillLock(home)
+}
+
+/**
+ * Provide an isolated HOME with only the three Installed-count skills staged.
+ * @param use - Playwright fixture continuation that launches Electron after setup.
+ * @param display - Optional persisted count placement to write before launch.
+ * @returns Promise that resolves after the fixture HOME is cleaned up.
+ * @example
+ * await useInstalledCountHome(use, 'inline')
+ */
+async function useInstalledCountHome(
+  use: IsolatedHomeUse,
+  display?: SearchCountDisplaySetting,
+): Promise<void> {
+  const home = realpathSync.native(
+    mkdtempSync(join(tmpdir(), 'skills-desktop-e2e-search-count-')),
+  )
+  try {
+    stageInstalledCountHome(home)
+    if (display) {
+      writeSettingsFile(home, { installedSearchCountDisplay: display })
+    }
+    await use(home)
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
 }
 
 /**
@@ -129,100 +130,106 @@ async function applyInstalledFilters(
   }, filters)
 }
 
-test('Installed tab badge tracks the current visible count and Marketplace stays count-free', async ({
-  appWindow,
-}) => {
-  // Arrange
-  await seedInstalledCountFixture(appWindow)
-
-  // Assert
-  await expect(
-    appWindow.getByRole('tab', {
-      name: /^Installed, 3 skills visible$/,
-    }),
-  ).toBeVisible()
-  await expect(
-    appWindow.getByRole('tab', { name: /^Marketplace$/ }),
-  ).toBeVisible()
-
-  // Act
-  await applyInstalledFilters(appWindow, {
-    query: 'alpha-count',
-    sources: [],
-  })
-
-  // Assert
-  await expect(
-    appWindow.getByRole('tab', {
-      name: /^Installed, 1 skill visible$/,
-    }),
-  ).toBeVisible()
-
-  // Act
-  await applyInstalledFilters(appWindow, {
-    query: '',
-    sources: ['pbakaus/impeccable'],
-  })
-
-  // Assert
-  await expect(
-    appWindow.getByRole('tab', {
-      name: /^Installed, 1 skill visible$/,
-    }),
-  ).toBeVisible()
-
-  // Act
-  await applyInstalledFilters(appWindow, {
-    query: 'missing-count-e2e',
-    sources: [],
-  })
-
-  // Assert
-  await expect(
-    appWindow.getByRole('tab', {
-      name: /^Installed, 0 skills visible$/,
-    }),
-  ).toBeVisible()
-  await expect(
-    appWindow.getByRole('tab', { name: /^Marketplace$/ }),
-  ).toBeVisible()
+const installedCountTest = test.extend<{ isolatedHome: string }>({
+  // eslint-disable-next-line no-empty-pattern
+  isolatedHome: async ({}, use) => {
+    await useInstalledCountHome(use)
+  },
 })
 
-test('persisted inline mode moves the count into the toolbar and removes the tab badge', async ({
-  appWindow,
-  isolatedHome,
-}) => {
-  // Arrange
-  await seedInstalledCountFixture(appWindow)
+const inlineInstalledCountTest = test.extend<{ isolatedHome: string }>({
+  // eslint-disable-next-line no-empty-pattern
+  isolatedHome: async ({}, use) => {
+    await useInstalledCountHome(use, 'inline')
+  },
+})
 
-  // Act
-  await appWindow.evaluate(async () => {
-    await window.electron.settings.set({
-      installedSearchCountDisplay: 'inline',
+installedCountTest(
+  'Installed tab badge tracks the current visible count and Marketplace stays count-free',
+  async ({ appWindow }) => {
+    // Arrange / Assert
+    await expect(
+      appWindow.getByRole('tab', {
+        name: /^Installed, 3 skills visible$/,
+      }),
+    ).toBeVisible()
+    await expect(
+      appWindow.getByRole('tab', { name: /^Marketplace$/ }),
+    ).toBeVisible()
+
+    // Act
+    await applyInstalledFilters(appWindow, {
+      query: 'alpha-count',
+      sources: [],
     })
-  })
 
-  // Assert
-  await appWindow.waitForFunction(() => {
-    const store = window.__store__ ?? window.__store
-    if (!store) return false
-    const state = store.getState() as {
-      settings?: { installedSearchCountDisplay?: string }
-    }
-    return state.settings?.installedSearchCountDisplay === 'inline'
-  })
-  await expect(
-    appWindow.getByRole('tab', { name: /^Installed$/ }),
-  ).toBeVisible()
-  await expect(
-    appWindow.getByRole('tab', {
-      name: /^Installed, 3 skills visible$/,
-    }),
-  ).toHaveCount(0)
-  await expect(appWindow.getByText(/^3 skills$/)).toBeVisible()
+    // Assert
+    await expect(
+      appWindow.getByRole('tab', {
+        name: /^Installed, 1 skill visible$/,
+      }),
+    ).toBeVisible()
 
-  const persisted = readSettingsFile(isolatedHome) as {
-    installedSearchCountDisplay?: string
-  } | null
-  expect(persisted?.installedSearchCountDisplay).toBe('inline')
-})
+    // Act
+    await applyInstalledFilters(appWindow, {
+      query: '',
+      sources: ['pbakaus/impeccable'],
+    })
+
+    // Assert
+    await expect(
+      appWindow.getByRole('tab', {
+        name: /^Installed, 1 skill visible$/,
+      }),
+    ).toBeVisible()
+
+    // Act
+    await applyInstalledFilters(appWindow, {
+      query: 'missing-count-e2e',
+      sources: [],
+    })
+
+    // Assert
+    await expect(
+      appWindow.getByRole('tab', {
+        name: /^Installed, 0 skills visible$/,
+      }),
+    ).toBeVisible()
+    await expect(
+      appWindow.getByRole('tab', { name: /^Marketplace$/ }),
+    ).toBeVisible()
+  },
+)
+
+inlineInstalledCountTest(
+  'persisted inline mode moves the count into the toolbar and removes the tab badge',
+  async ({ appWindow, isolatedHome }) => {
+    // Arrange / Assert
+    await appWindow.waitForFunction(() => {
+      const store = window.__store__ ?? window.__store
+      if (!store) return false
+      const state = store.getState() as {
+        settings?: { installedSearchCountDisplay?: string }
+      }
+      return state.settings?.installedSearchCountDisplay === 'inline'
+    })
+    await expect(
+      appWindow.getByRole('tab', { name: /^Installed$/ }),
+    ).toBeVisible()
+    await expect(
+      appWindow.getByRole('tab', {
+        name: /^Installed, 3 skills visible$/,
+      }),
+    ).toHaveCount(0)
+    await expect(
+      appWindow
+        .locator('[aria-live="polite"]')
+        .filter({ hasText: /^3 skills$/ }),
+    ).toBeVisible()
+
+    const persisted = readSettingsFile(isolatedHome) as {
+      installedSearchCountDisplay?: string
+    } | null
+    expect(persisted?.installedSearchCountDisplay).toBe('inline')
+  },
+)

--- a/e2e/spec/installed-search-count.e2e.ts
+++ b/e2e/spec/installed-search-count.e2e.ts
@@ -1,0 +1,228 @@
+import type { Page } from '@playwright/test'
+
+import { repositoryId, type AbsolutePath, type Skill } from '@/shared/types'
+
+import { test, expect } from '../fixtures/electron-app'
+import { readSettingsFile } from '../helpers/settings-file'
+
+const SEARCH_COUNT_SKILLS = [
+  makeSourceSkill('alpha-count-e2e', 'laststance/skills'),
+  makeSourceSkill('beta-count-e2e', 'laststance/skills'),
+  makeSourceSkill('gamma-count-e2e', 'pbakaus/impeccable'),
+]
+
+/**
+ * Create a minimal source skill row for the Installed count E2E fixture.
+ * @param name - Display name that the Installed search field matches.
+ * @param source - Repository id used by the repo include filter.
+ * @returns Serializable skill object accepted by the renderer Redux slice.
+ * @example
+ * makeSourceSkill('alpha-count-e2e', 'laststance/skills')
+ */
+function makeSourceSkill(name: string, source: string): Skill {
+  return {
+    name,
+    description: `${name} description`,
+    path: `/tmp/skills-desktop-e2e/${name}` as AbsolutePath,
+    filesystemIdentity: {
+      kind: 'directory',
+      dev: 101,
+      ino: name.length,
+      size: 96,
+      ctimeMs: 1,
+      mtimeMs: 2,
+    },
+    symlinkCount: 0,
+    symlinks: [],
+    isSource: true,
+    isOrphan: false,
+    source: repositoryId(source),
+    sourceUrl: `https://github.com/${source}.git`,
+  }
+}
+
+/**
+ * Wait for the E2E Redux bridge before dispatching synthetic scan data.
+ * @param page - Electron renderer page under test.
+ * @returns Promise that resolves once `window.__store__` is available.
+ * @example
+ * await waitForExposedStore(appWindow)
+ */
+async function waitForExposedStore(page: Page): Promise<void> {
+  await page.waitForFunction(() => Boolean(window.__store__ ?? window.__store))
+}
+
+/**
+ * Replace scanner output with a fixed Installed inventory and reset filters.
+ * @param page - Electron renderer page under test.
+ * @returns Promise that resolves once Redux has the deterministic fixture.
+ * @example
+ * await seedInstalledCountFixture(appWindow)
+ */
+async function seedInstalledCountFixture(page: Page): Promise<void> {
+  await waitForExposedStore(page)
+  await page.evaluate((skills) => {
+    const store = window.__store__ ?? window.__store
+    if (!store) throw new Error('window.__store__ is not exposed')
+
+    store.dispatch({
+      type: 'ui/setActiveTab',
+      payload: 'installed',
+    })
+    store.dispatch({
+      type: 'ui/selectAgent',
+      payload: null,
+    })
+    store.dispatch({
+      type: 'ui/setSkillTypeFilter',
+      payload: 'all',
+    })
+    store.dispatch({
+      type: 'ui/clearExcludedSkillTypeFilters',
+    })
+    store.dispatch({
+      type: 'ui/setSearchScope',
+      payload: 'name',
+    })
+    store.dispatch({
+      type: 'ui/setSearchQuery',
+      payload: '',
+    })
+    store.dispatch({
+      type: 'ui/setSelectedSources',
+      payload: [],
+    })
+    store.dispatch({
+      type: 'skills/fetchAll/fulfilled',
+      payload: skills,
+      meta: {
+        requestId: 'e2e-installed-search-count',
+        requestStatus: 'fulfilled',
+      },
+    })
+  }, SEARCH_COUNT_SKILLS)
+}
+
+/**
+ * Dispatch Installed search and repo filters in one renderer transaction.
+ * @param page - Electron renderer page under test.
+ * @param filters - Search query and selected repository ids to apply.
+ * @returns Promise that resolves once Redux has the requested filter state.
+ * @example
+ * await applyInstalledFilters(appWindow, { query: 'missing', sources: [] })
+ */
+async function applyInstalledFilters(
+  page: Page,
+  filters: { query: string; sources: string[] },
+): Promise<void> {
+  await page.evaluate(({ query, sources }) => {
+    const store = window.__store__ ?? window.__store
+    if (!store) throw new Error('window.__store__ is not exposed')
+    store.dispatch({
+      type: 'ui/setSearchQuery',
+      payload: query,
+    })
+    store.dispatch({
+      type: 'ui/setSelectedSources',
+      payload: sources,
+    })
+  }, filters)
+}
+
+test('Installed tab badge tracks the current visible count and Marketplace stays count-free', async ({
+  appWindow,
+}) => {
+  // Arrange
+  await seedInstalledCountFixture(appWindow)
+
+  // Assert
+  await expect(
+    appWindow.getByRole('tab', {
+      name: /^Installed, 3 skills visible$/,
+    }),
+  ).toBeVisible()
+  await expect(
+    appWindow.getByRole('tab', { name: /^Marketplace$/ }),
+  ).toBeVisible()
+
+  // Act
+  await applyInstalledFilters(appWindow, {
+    query: 'alpha-count',
+    sources: [],
+  })
+
+  // Assert
+  await expect(
+    appWindow.getByRole('tab', {
+      name: /^Installed, 1 skill visible$/,
+    }),
+  ).toBeVisible()
+
+  // Act
+  await applyInstalledFilters(appWindow, {
+    query: '',
+    sources: ['pbakaus/impeccable'],
+  })
+
+  // Assert
+  await expect(
+    appWindow.getByRole('tab', {
+      name: /^Installed, 1 skill visible$/,
+    }),
+  ).toBeVisible()
+
+  // Act
+  await applyInstalledFilters(appWindow, {
+    query: 'missing-count-e2e',
+    sources: [],
+  })
+
+  // Assert
+  await expect(
+    appWindow.getByRole('tab', {
+      name: /^Installed, 0 skills visible$/,
+    }),
+  ).toBeVisible()
+  await expect(
+    appWindow.getByRole('tab', { name: /^Marketplace$/ }),
+  ).toBeVisible()
+})
+
+test('persisted inline mode moves the count into the toolbar and removes the tab badge', async ({
+  appWindow,
+  isolatedHome,
+}) => {
+  // Arrange
+  await seedInstalledCountFixture(appWindow)
+
+  // Act
+  await appWindow.evaluate(async () => {
+    await window.electron.settings.set({
+      installedSearchCountDisplay: 'inline',
+    })
+  })
+
+  // Assert
+  await appWindow.waitForFunction(() => {
+    const store = window.__store__ ?? window.__store
+    if (!store) return false
+    const state = store.getState() as {
+      settings?: { installedSearchCountDisplay?: string }
+    }
+    return state.settings?.installedSearchCountDisplay === 'inline'
+  })
+  await expect(
+    appWindow.getByRole('tab', { name: /^Installed$/ }),
+  ).toBeVisible()
+  await expect(
+    appWindow.getByRole('tab', {
+      name: /^Installed, 3 skills visible$/,
+    }),
+  ).toHaveCount(0)
+  await expect(appWindow.getByText(/^3 skills$/)).toBeVisible()
+
+  const persisted = readSettingsFile(isolatedHome) as {
+    installedSearchCountDisplay?: string
+  } | null
+  expect(persisted?.installedSearchCountDisplay).toBe('inline')
+})

--- a/e2e/spec/installed-search-count.e2e.ts
+++ b/e2e/spec/installed-search-count.e2e.ts
@@ -10,6 +10,8 @@ import { join } from 'node:path'
 
 import type { Page } from '@playwright/test'
 
+import type { Settings } from '@/shared/settings'
+
 import { test, expect } from '../fixtures/electron-app'
 import { readSettingsFile, writeSettingsFile } from '../helpers/settings-file'
 
@@ -19,7 +21,7 @@ const SEARCH_COUNT_SKILLS = [
   { name: 'gamma-count-e2e', source: 'pbakaus/impeccable' },
 ]
 
-type SearchCountDisplaySetting = 'tab' | 'inline'
+type SearchCountDisplaySetting = Settings['installedSearchCountDisplay']
 type IsolatedHomeUse = (home: string) => Promise<void>
 
 /**
@@ -117,7 +119,7 @@ async function applyInstalledFilters(
   filters: { query: string; sources: string[] },
 ): Promise<void> {
   await page.evaluate(({ query, sources }) => {
-    const store = window.__store__ ?? window.__store
+    const store = window.__store__
     if (!store) throw new Error('window.__store__ is not exposed')
     store.dispatch({
       type: 'ui/setSearchQuery',
@@ -206,7 +208,7 @@ inlineInstalledCountTest(
   async ({ appWindow, isolatedHome }) => {
     // Arrange / Assert
     await appWindow.waitForFunction(() => {
-      const store = window.__store__ ?? window.__store
+      const store = window.__store__
       if (!store) return false
       const state = store.getState() as {
         settings?: { installedSearchCountDisplay?: string }

--- a/src/main/ipc/ipc-schemas.test.ts
+++ b/src/main/ipc/ipc-schemas.test.ts
@@ -535,11 +535,29 @@ describe('settings:set lockstep with SettingsSchema', () => {
     expect(schema.safeParse([{ autoDownloadUpdates: true }]).success).toBe(true)
   })
 
+  it('lets the user persist the Installed search count display placement', () => {
+    // Arrange / Act / Assert
+    expect(
+      schema.safeParse([{ installedSearchCountDisplay: 'inline' }]).success,
+    ).toBe(true)
+    expect(
+      schema.safeParse([{ installedSearchCountDisplay: 'tab' }]).success,
+    ).toBe(true)
+  })
+
   it('blocks a non-boolean auto-download toggle from reaching disk', () => {
     // Arrange / Act / Assert
     expect(schema.safeParse([{ autoDownloadUpdates: 'yes' }]).success).toBe(
       false,
     )
+  })
+
+  it('blocks an unknown Installed search count display placement from reaching disk', () => {
+    // Arrange / Act / Assert
+    expect(
+      schema.safeParse([{ installedSearchCountDisplay: 'marketplace' }])
+        .success,
+    ).toBe(false)
   })
 
   it('blocks an unknown terminal preset from reaching disk', () => {
@@ -628,6 +646,14 @@ describe('settings:set lockstep with SettingsSchema', () => {
 
     // Assert
     expect('autoDownloadUpdates' in parsed[0]).toBe(false)
+  })
+
+  it('does not wipe a persisted Installed search count placement when an unrelated setting is saved', () => {
+    // Arrange / Act
+    const parsed = schema.parse([{ defaultSkillTab: 'info' }]) as [object]
+
+    // Assert
+    expect('installedSearchCountDisplay' in parsed[0]).toBe(false)
   })
 
   it('lets the user persist an explicit hiddenAgentIds list', () => {

--- a/src/main/ipc/ipc-schemas.ts
+++ b/src/main/ipc/ipc-schemas.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { AGENT_IDS, TERMINAL_APP_IDS } from '@/shared/constants'
 import type { IpcInvokeChannel } from '@/shared/ipc-contract'
 import {
+  INSTALLED_SEARCH_COUNT_DISPLAY_OPTIONS,
   SettingsSchema,
   WINDOW_BACKGROUND_BLUR_RADIUS_SCHEMA,
 } from '@/shared/settings'
@@ -360,6 +361,11 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
         // unrelated partial settings writes do not reset blur to zero.
         windowBackgroundBlurRadius:
           WINDOW_BACKGROUND_BLUR_RADIUS_SCHEMA.optional(),
+        // Search-count display preference. Keep this as a non-defaulting enum
+        // so unrelated partial settings writes do not reset the user's choice.
+        installedSearchCountDisplay: z
+          .enum(INSTALLED_SEARCH_COUNT_DISPLAY_OPTIONS)
+          .optional(),
         // Strict z.enum here — renderers should only ever emit valid ids.
         // Intentionally NOT chained off `SettingsSchema.shape.hiddenAgentIds`:
         // that field carries a `.default([])` for forgiving disk reads, and

--- a/src/main/services/settings.test.ts
+++ b/src/main/services/settings.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 
-import type { Settings } from '@/shared/settings'
+import { DEFAULT_SETTINGS, type Settings } from '@/shared/settings'
 
 import { areSettingsEqual } from './settings'
 
@@ -13,13 +13,7 @@ import { areSettingsEqual } from './settings'
  * the saved dimensions are identical.
  */
 describe('areSettingsEqual', () => {
-  const baseSettings: Settings = {
-    defaultSkillTab: 'files',
-    preferredTerminal: 'terminal',
-    windowBackgroundBlurRadius: 0,
-    hiddenAgentIds: [],
-    autoDownloadUpdates: false,
-  }
+  const baseSettings: Settings = DEFAULT_SETTINGS
 
   it('treats two settings with identical primitive fields as unchanged so no redundant save fires', () => {
     // Arrange

--- a/src/renderer/settings/sections/Appearance.browser.test.tsx
+++ b/src/renderer/settings/sections/Appearance.browser.test.tsx
@@ -41,6 +41,30 @@ async function createStore(
 }
 
 describe('Settings → Appearance', () => {
+  it('persists Toolbar text when the Installed search count display is changed', async () => {
+    // Arrange
+    const store = await createStore()
+    const { Appearance } = await import('./Appearance')
+    const screen = await render(
+      <Provider store={store}>
+        <Appearance />
+      </Provider>,
+    )
+
+    // Act
+    await screen.getByRole('radio', { name: /Toolbar text/i }).click()
+
+    // Assert
+    await expect.poll(() => mockSettingsSet.mock.calls.length).toBe(1)
+    expect(mockSettingsSet).toHaveBeenCalledWith({
+      installedSearchCountDisplay: 'inline',
+    })
+    const settingsState = store.getState() as {
+      settings: typeof DEFAULT_SETTINGS
+    }
+    expect(settingsState.settings.installedSearchCountDisplay).toBe('inline')
+  })
+
   it('persists the new window blur radius when the opacity slider moves', async () => {
     // Arrange
     const store = await createStore()

--- a/src/renderer/settings/sections/Appearance.tsx
+++ b/src/renderer/settings/sections/Appearance.tsx
@@ -12,6 +12,7 @@ import { useAppSelector } from '@/renderer/src/redux/hooks'
 import {
   DEFAULT_SETTINGS,
   getWindowBackgroundOpacity,
+  INSTALLED_SEARCH_COUNT_DISPLAY_OPTIONS as INSTALLED_SEARCH_COUNT_DISPLAY_VALUES,
   WINDOW_BACKGROUND_BLUR_MAX_RADIUS,
   WINDOW_BACKGROUND_BLUR_MIN_RADIUS,
 } from '@/shared/settings'
@@ -21,13 +22,18 @@ import { SectionFrame, SectionRow } from './SectionFrame'
 
 const BACKGROUND_BLUR_LABEL = 'Opacity / Blur'
 const INSTALLED_SEARCH_COUNT_DISPLAY_LABEL = 'Installed search count'
-const INSTALLED_SEARCH_COUNT_DISPLAY_OPTIONS: ReadonlyArray<{
-  value: Settings['installedSearchCountDisplay']
-  label: string
-}> = [
-  { value: 'tab', label: 'Tab badge' },
-  { value: 'inline', label: 'Toolbar text' },
-]
+const INSTALLED_SEARCH_COUNT_DISPLAY_LABELS: Record<
+  Settings['installedSearchCountDisplay'],
+  string
+> = {
+  tab: 'Tab badge',
+  inline: 'Toolbar text',
+}
+const INSTALLED_SEARCH_COUNT_DISPLAY_OPTIONS =
+  INSTALLED_SEARCH_COUNT_DISPLAY_VALUES.map((value) => ({
+    value,
+    label: INSTALLED_SEARCH_COUNT_DISPLAY_LABELS[value],
+  }))
 
 interface BackgroundBlurRangeInputProps {
   value: number

--- a/src/renderer/settings/sections/Appearance.tsx
+++ b/src/renderer/settings/sections/Appearance.tsx
@@ -1,6 +1,10 @@
 import React from 'react'
 
 import { Button } from '@/renderer/src/components/ui/button'
+import {
+  ToggleGroup,
+  ToggleGroupItem,
+} from '@/renderer/src/components/ui/toggle-group'
 import { useUnmountEffect } from '@/renderer/src/hooks/useUnmountEffect'
 import { useUpdateEffect } from '@/renderer/src/hooks/useUpdateEffect'
 import { useUpdateSettings } from '@/renderer/src/hooks/useUpdateSettings'
@@ -11,10 +15,19 @@ import {
   WINDOW_BACKGROUND_BLUR_MAX_RADIUS,
   WINDOW_BACKGROUND_BLUR_MIN_RADIUS,
 } from '@/shared/settings'
+import type { Settings } from '@/shared/settings'
 
 import { SectionFrame, SectionRow } from './SectionFrame'
 
 const BACKGROUND_BLUR_LABEL = 'Opacity / Blur'
+const INSTALLED_SEARCH_COUNT_DISPLAY_LABEL = 'Installed search count'
+const INSTALLED_SEARCH_COUNT_DISPLAY_OPTIONS: ReadonlyArray<{
+  value: Settings['installedSearchCountDisplay']
+  label: string
+}> = [
+  { value: 'tab', label: 'Tab badge' },
+  { value: 'inline', label: 'Toolbar text' },
+]
 
 interface BackgroundBlurRangeInputProps {
   value: number
@@ -70,6 +83,9 @@ export const Appearance = React.memo(function Appearance(): React.ReactElement {
   const windowBackgroundBlurRadius = useAppSelector(
     (state) => state.settings.windowBackgroundBlurRadius,
   )
+  const installedSearchCountDisplay = useAppSelector(
+    (state) => state.settings.installedSearchCountDisplay,
+  )
   const updateSettings = useUpdateSettings()
   const [blurRadiusDraft, setBlurRadiusDraft] = React.useState<number>(
     windowBackgroundBlurRadius,
@@ -109,6 +125,14 @@ export const Appearance = React.memo(function Appearance(): React.ReactElement {
     })
   }, [clearPersistTimer, updateSettings])
 
+  const handleSearchCountDisplayChange = React.useCallback(
+    (nextValue: string): void => {
+      if (nextValue !== 'tab' && nextValue !== 'inline') return
+      updateSettings({ installedSearchCountDisplay: nextValue })
+    },
+    [updateSettings],
+  )
+
   useUpdateEffect(() => {
     clearPersistTimer()
     setBlurRadiusDraft(windowBackgroundBlurRadius)
@@ -133,6 +157,26 @@ export const Appearance = React.memo(function Appearance(): React.ReactElement {
       title="Appearance"
       description="Visual options for the main window."
     >
+      <SectionRow
+        label={INSTALLED_SEARCH_COUNT_DISPLAY_LABEL}
+        description="Choose where the current Installed result count appears."
+      >
+        <ToggleGroup
+          type="single"
+          variant="outline"
+          size="sm"
+          value={installedSearchCountDisplay}
+          onValueChange={handleSearchCountDisplayChange}
+          aria-label={INSTALLED_SEARCH_COUNT_DISPLAY_LABEL}
+        >
+          {INSTALLED_SEARCH_COUNT_DISPLAY_OPTIONS.map((option) => (
+            <ToggleGroupItem key={option.value} value={option.value}>
+              {option.label}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
+      </SectionRow>
+
       <SectionRow
         label={BACKGROUND_BLUR_LABEL}
         description="Surface opacity and background blur for the main window."

--- a/src/renderer/src/components/layout/MainContent.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.browser.test.tsx
@@ -5,6 +5,7 @@ import { render } from 'vitest-browser-react'
 
 import { partitionGlobalDeleteTargets } from '@/renderer/src/components/skills/reviewedDestructiveTargets'
 import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
+import { DEFAULT_SETTINGS } from '@/shared/settings'
 import type {
   AgentId,
   BulkDeleteResult,
@@ -138,6 +139,8 @@ async function createStore() {
     await import('@/renderer/src/redux/slices/bookmarkSlice')
   const { default: marketplaceReducer } =
     await import('@/renderer/src/redux/slices/marketplaceSlice')
+  const { default: settingsReducer } =
+    await import('@/renderer/src/redux/slices/settingsSlice')
   return configureStore({
     reducer: {
       ui: uiReducer,
@@ -145,6 +148,10 @@ async function createStore() {
       agents: agentsReducer,
       bookmarks: bookmarksReducer,
       marketplace: marketplaceReducer,
+      settings: settingsReducer,
+    },
+    preloadedState: {
+      settings: { ...DEFAULT_SETTINGS },
     },
   })
 }
@@ -244,6 +251,129 @@ function makeAgentLocalSkill(name: string, agentId: AgentId): Skill {
     isOrphan: false,
   }
 }
+
+describe('MainContent Installed search count display', () => {
+  it('shows the current visible count in the Installed tab by default and keeps Marketplace count-free', async () => {
+    // Arrange
+    const { screen, store } = await renderMainContent()
+    const { fetchSkills } =
+      await import('@/renderer/src/redux/slices/skillsSlice')
+    store.dispatch(
+      fetchSkills.fulfilled(
+        [
+          makeSourceSkill('alpha', 'laststance/skills'),
+          makeSourceSkill('beta', 'laststance/skills'),
+          makeSourceSkill('gamma', 'pbakaus/impeccable'),
+        ],
+        'req-id',
+      ),
+    )
+
+    // Assert
+    await expect
+      .element(
+        screen.getByRole('tab', {
+          name: /Installed, 3 skills visible/i,
+        }),
+      )
+      .toBeInTheDocument()
+    await expect
+      .element(screen.getByRole('tab', { name: /^Marketplace$/ }))
+      .toBeInTheDocument()
+  })
+
+  it('updates the Installed tab count when search and repo filters change visible skills', async () => {
+    // Arrange
+    const { screen, store } = await renderMainContent()
+    const { fetchSkills } =
+      await import('@/renderer/src/redux/slices/skillsSlice')
+    const { setSearchQuery, setSelectedSources } =
+      await import('@/renderer/src/redux/slices/uiSlice')
+    store.dispatch(
+      fetchSkills.fulfilled(
+        [
+          makeSourceSkill('alpha', 'laststance/skills'),
+          makeSourceSkill('beta', 'laststance/skills'),
+          makeSourceSkill('gamma', 'pbakaus/impeccable'),
+        ],
+        'req-id',
+      ),
+    )
+
+    // Act
+    store.dispatch(setSearchQuery('alpha'))
+
+    // Assert
+    await expect
+      .element(
+        screen.getByRole('tab', {
+          name: /Installed, 1 skill visible/i,
+        }),
+      )
+      .toBeInTheDocument()
+
+    // Act
+    store.dispatch(setSearchQuery(''))
+    store.dispatch(setSelectedSources([repositoryId('pbakaus/impeccable')]))
+
+    // Assert
+    await expect
+      .element(
+        screen.getByRole('tab', {
+          name: /Installed, 1 skill visible/i,
+        }),
+      )
+      .toBeInTheDocument()
+
+    // Act
+    store.dispatch(setSearchQuery('missing'))
+
+    // Assert
+    await expect
+      .element(
+        screen.getByRole('tab', {
+          name: /Installed, 0 skills visible/i,
+        }),
+      )
+      .toBeInTheDocument()
+  })
+
+  it('moves the current visible count into the toolbar when the inline setting is selected', async () => {
+    // Arrange
+    const { screen, store } = await renderMainContent()
+    const { fetchSkills } =
+      await import('@/renderer/src/redux/slices/skillsSlice')
+    const { setSettings } =
+      await import('@/renderer/src/redux/slices/settingsSlice')
+    store.dispatch(
+      fetchSkills.fulfilled(
+        [
+          makeSourceSkill('alpha', 'laststance/skills'),
+          makeSourceSkill('beta', 'laststance/skills'),
+          makeSourceSkill('gamma', 'pbakaus/impeccable'),
+        ],
+        'req-id',
+      ),
+    )
+
+    // Act
+    store.dispatch(
+      setSettings({
+        ...DEFAULT_SETTINGS,
+        installedSearchCountDisplay: 'inline',
+      }),
+    )
+
+    // Assert
+    await expect.element(screen.getByText(/^3 skills$/)).toBeInTheDocument()
+    await expect
+      .element(screen.getByRole('tab', { name: /^Installed$/ }))
+      .toBeInTheDocument()
+    expect(
+      screen.getByRole('tab', { name: /Installed, 3 skills visible/i }).query(),
+    ).toBeNull()
+  })
+})
 
 describe('MainContent bulk-select toggle button', () => {
   it('labels the bulk toggle "Select" and unpressed before the user enters bulk mode', async () => {

--- a/src/renderer/src/components/layout/MainContent.selectionToolbar.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.selectionToolbar.browser.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
+import { DEFAULT_SETTINGS } from '@/shared/settings'
 import type { Agent, Skill, SkillName, SymlinkInfo } from '@/shared/types'
 
 const mockUnlinkManyFromAgent = vi.fn()
@@ -106,6 +107,7 @@ async function renderMainContentWithToolbar() {
     { default: agentsReducer },
     { default: bookmarksReducer },
     { default: marketplaceReducer },
+    { default: settingsReducer },
     { MainContent },
   ] = await Promise.all([
     import('@/renderer/src/redux/slices/uiSlice'),
@@ -113,6 +115,7 @@ async function renderMainContentWithToolbar() {
     import('@/renderer/src/redux/slices/agentsSlice'),
     import('@/renderer/src/redux/slices/bookmarkSlice'),
     import('@/renderer/src/redux/slices/marketplaceSlice'),
+    import('@/renderer/src/redux/slices/settingsSlice'),
     import('./MainContent'),
   ])
   const store = configureStore({
@@ -122,6 +125,10 @@ async function renderMainContentWithToolbar() {
       agents: agentsReducer,
       bookmarks: bookmarksReducer,
       marketplace: marketplaceReducer,
+      settings: settingsReducer,
+    },
+    preloadedState: {
+      settings: { ...DEFAULT_SETTINGS },
     },
   })
   const screen = await render(

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -68,6 +68,7 @@ import { cn } from '@/renderer/src/lib/utils'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import {
   selectBulkSelectableVisibleSkillNames,
+  selectFilteredSkillCount,
   selectRepoFacetOptions,
   selectSelectedVisibleNames,
   selectSourceFilterViewModel,
@@ -123,6 +124,7 @@ import {
   UNDO_WINDOW_MS,
 } from '@/shared/constants'
 import { FEATURE_FLAGS } from '@/shared/featureFlags'
+import type { Settings } from '@/shared/settings'
 import type {
   BulkDeleteItemResult,
   IsoTimestamp,
@@ -174,6 +176,87 @@ function getUnavailableExcludeReason(
 }
 
 const SKILLS_SH_URL = 'https://skills.sh'
+
+/**
+ * Formats the Installed visible count for tab and toolbar UI in MainContent.
+ * @param count - Current `selectFilteredSkills.length` after all Installed filters.
+ * @returns Short count label with singular/plural skill copy.
+ * @example
+ * formatInstalledSearchCount(1) // => "1 skill"
+ * formatInstalledSearchCount(24) // => "24 skills"
+ */
+function formatInstalledSearchCount(count: number): string {
+  return `${count} ${pluralize(count, 'skill')}`
+}
+
+interface InstalledTabLabelProps {
+  count: number
+  countText: string
+  display: Settings['installedSearchCountDisplay']
+}
+
+/**
+ * Installed tab label with the optional current visible-count badge.
+ * @param props - Count text and placement setting read by MainContent.
+ * @returns TabsTrigger for the Installed tab.
+ * @example
+ * <InstalledTabLabel count={24} countText="24 skills" display="tab" />
+ */
+const InstalledTabLabel = React.memo(function InstalledTabLabel({
+  count,
+  countText,
+  display,
+}: InstalledTabLabelProps): React.ReactElement {
+  const shouldShowCount = display === 'tab'
+  const accessibleText = `${countText} visible`
+
+  return (
+    <TabsTrigger
+      value="installed"
+      className="group flex-1 gap-2"
+      aria-label={shouldShowCount ? `Installed, ${accessibleText}` : undefined}
+    >
+      Installed
+      {shouldShowCount && (
+        <span
+          aria-hidden="true"
+          className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-muted px-1.5 text-[11px] font-semibold tabular-nums text-muted-foreground transition-colors group-data-[state=active]:bg-primary/10 group-data-[state=active]:text-primary"
+        >
+          {count}
+        </span>
+      )}
+    </TabsTrigger>
+  )
+})
+
+interface InstalledInlineCountProps {
+  countText: string
+  display: Settings['installedSearchCountDisplay']
+}
+
+/**
+ * Search toolbar count used when the user prefers inline Installed counts.
+ * @param props - Count text and placement setting read by MainContent.
+ * @returns Muted toolbar count, or null when tab-badge mode is active.
+ * @example
+ * <InstalledInlineCount countText="24 skills" display="inline" />
+ */
+const InstalledInlineCount = React.memo(function InstalledInlineCount({
+  countText,
+  display,
+}: InstalledInlineCountProps): React.ReactElement | null {
+  if (display !== 'inline') return null
+
+  return (
+    <p
+      className="min-w-20 shrink-0 whitespace-nowrap text-xs tabular-nums text-muted-foreground"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      {countText}
+    </p>
+  )
+})
 
 /**
  * Build bulk-delete targets only for delete confirms so MainContent stays branch-light.
@@ -283,9 +366,16 @@ export const MainContent = React.memo(
     const bulkSelectMode = useAppSelector(selectBulkSelectMode)
     const sourceFilter = useAppSelector(selectSourceFilterViewModel)
     const repoFacetOptions = useAppSelector(selectRepoFacetOptions)
+    const filteredSkillCount = useAppSelector(selectFilteredSkillCount)
+    const installedSearchCountDisplay = useAppSelector(
+      (state) => state.settings.installedSearchCountDisplay,
+    )
     const excludedSkillTypeFilters = useAppSelector(
       selectExcludedSkillTypeFilters,
     )
+
+    const installedSearchCountText =
+      formatInstalledSearchCount(filteredSkillCount)
 
     const selectedAgent = agents.find((a) => a.id === selectedAgentId)
     const bulkDeleteTargetSummary = useMemo(() => {
@@ -890,9 +980,11 @@ export const MainContent = React.memo(
         >
           <div className="p-4 border-b border-border">
             <TabsList className="w-full">
-              <TabsTrigger value="installed" className="flex-1">
-                Installed
-              </TabsTrigger>
+              <InstalledTabLabel
+                count={filteredSkillCount}
+                countText={installedSearchCountText}
+                display={installedSearchCountDisplay}
+              />
               {FEATURE_FLAGS.ENABLE_MARKETPLACE_UI ? (
                 <TabsTrigger value="marketplace" className="flex-1">
                   Marketplace
@@ -918,6 +1010,11 @@ export const MainContent = React.memo(
               <div className="min-w-64 flex-[1_1_20rem]">
                 <SearchBox />
               </div>
+
+              <InstalledInlineCount
+                countText={installedSearchCountText}
+                display={installedSearchCountDisplay}
+              />
 
               {/* Sort toggle: A→Z ⟷ Z→A */}
               <Button

--- a/src/renderer/src/redux/selectors.ts
+++ b/src/renderer/src/redux/selectors.ts
@@ -230,6 +230,17 @@ export const selectFilteredSkills = createSelector(
 )
 
 /**
+ * Count visible Installed rows after every active Installed filter has run.
+ * @returns Number of rows currently rendered by `SkillsList`.
+ * @example
+ * const count = useAppSelector(selectFilteredSkillCount) // => 24
+ */
+export const selectFilteredSkillCount = createSelector(
+  [selectFilteredSkills],
+  (filteredSkills): number => filteredSkills.length,
+)
+
+/**
  * Exact repo choices for the Installed toolbar. It shares the agent/type gates
  * with `selectFilteredSkills`, but intentionally ignores the active source
  * include filter and text query so users can recover from an over-narrowed

--- a/src/shared/settings.test.ts
+++ b/src/shared/settings.test.ts
@@ -110,6 +110,29 @@ describe('SettingsSchema', () => {
     expect(parsed.autoDownloadUpdates).toBe(false)
   })
 
+  it('defaults the Installed search count display to the tab badge', () => {
+    // Arrange / Act
+    const parsed = SettingsSchema.parse({})
+    // Assert
+    expect(parsed.installedSearchCountDisplay).toBe('tab')
+  })
+
+  it('persists moving the Installed search count into the toolbar', () => {
+    // Arrange / Act
+    const parsed = SettingsSchema.parse({
+      installedSearchCountDisplay: 'inline',
+    })
+    // Assert
+    expect(parsed.installedSearchCountDisplay).toBe('inline')
+  })
+
+  it('rejects an unknown Installed search count display placement', () => {
+    // Arrange / Act / Assert
+    expect(() =>
+      SettingsSchema.parse({ installedSearchCountDisplay: 'marketplace' }),
+    ).toThrow()
+  })
+
   it('persists opting into background downloads', () => {
     // Arrange / Act
     const parsed = SettingsSchema.parse({

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -33,6 +33,12 @@ export const WINDOW_BACKGROUND_OPACITY_MAX = 1
 export const WINDOW_BACKGROUND_OPACITY_MIN = 0.45
 
 /**
+ * Allowed placements for the Installed view's current result count.
+ * Exported so disk schema and strict IPC schema share the same value set.
+ */
+export const INSTALLED_SEARCH_COUNT_DISPLAY_OPTIONS = ['tab', 'inline'] as const
+
+/**
  * Clamp a persisted blur radius before it touches Electron or CSS surfaces.
  * @param blurRadius - User setting from `settings.json` or IPC.
  * @returns Whole-pixel radius inside the app-supported range.
@@ -162,6 +168,9 @@ const HIDDEN_AGENT_IDS_SCHEMA = z
  * - `windowBackgroundBlurRadius`: Electron 42 `View#setBackgroundBlur`
  *   radius for the main window. `0` disables the translucent surface and
  *   restores the opaque app background.
+ * - `installedSearchCountDisplay`: where the Installed view shows the
+ *   current visible result count. `'tab'` is the default compact badge;
+ *   `'inline'` moves the count into the search toolbar.
  * - `hiddenAgentIds`: agents the user has chosen to hide from the
  *   sidebar's installed list. Pure visibility toggle — the agent's
  *   skills folder, symlinks, and Marketplace presence are unaffected.
@@ -178,7 +187,7 @@ const HIDDEN_AGENT_IDS_SCHEMA = z
  * so unknown keys are rejected at the IPC boundary (defense in depth).
  *
  * @example
- * SettingsSchema.parse({}) // { defaultSkillTab: 'files', preferredTerminal: 'terminal', windowBackgroundBlurRadius: 0, hiddenAgentIds: [], autoDownloadUpdates: false }
+ * SettingsSchema.parse({}) // { defaultSkillTab: 'files', preferredTerminal: 'terminal', windowBackgroundBlurRadius: 0, installedSearchCountDisplay: 'tab', hiddenAgentIds: [], autoDownloadUpdates: false }
  */
 export const SettingsSchema = z.object({
   defaultSkillTab: z.enum(['files', 'info']).default('files'),
@@ -188,6 +197,9 @@ export const SettingsSchema = z.object({
   windowBackgroundBlurRadius: WINDOW_BACKGROUND_BLUR_RADIUS_SCHEMA.default(
     WINDOW_BACKGROUND_BLUR_MIN_RADIUS,
   ),
+  installedSearchCountDisplay: z
+    .enum(INSTALLED_SEARCH_COUNT_DISPLAY_OPTIONS)
+    .default('tab'),
   hiddenAgentIds: HIDDEN_AGENT_IDS_SCHEMA,
   // Legacy auto-download preference. Defaults to false so the manual
   // confirm-via-UI download flow is preserved unless a persisted opt-in
@@ -219,6 +231,7 @@ export const DEFAULT_SETTINGS: Settings = {
   defaultSkillTab: 'files',
   preferredTerminal: 'terminal',
   windowBackgroundBlurRadius: WINDOW_BACKGROUND_BLUR_MIN_RADIUS,
+  installedSearchCountDisplay: 'tab',
   hiddenAgentIds: [],
   autoDownloadUpdates: false,
 }


### PR DESCRIPTION
## Summary
- Add an Installed search count display setting with `tab` as the default and `inline` as an alternate placement.
- Show the current visible Installed count from the filtered skill list while keeping Marketplace count-free.
- Add Settings → Appearance controls, IPC/schema validation, browser tests, and deterministic Electron E2E coverage.

## Verification
- `pnpm test:e2e e2e/spec/installed-search-count.e2e.ts`
- `pnpm exec eslint e2e/spec/installed-search-count.e2e.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm validate`
- `pnpm test:e2e`

## QA
- Manual Electron QA completed for tab badge, inline toolbar, filtered zero state, filter updates, Marketplace count-free behavior, and persistence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Appearance設定でInstalled検索結果数の表示位置を「タブ内バッジ」または「インライン（ツールバー）」から切替可能に。メイン画面と検索欄で選択に応じて表示が切り替わります。

* **テスト**
  * 表示切替・永続化・可視性（件数0/1/3など）を検証する単体/統合/E2Eテストを追加しました。

* **設定**
  * 表示設定の既定値は「タブ」になっています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->