### PR TITLE
test(e2e): add deterministic offline update-detection smoke

### DIFF
--- a/e2e/constants.ts
+++ b/e2e/constants.ts
@@ -71,3 +71,22 @@ export const OFFLINE_STDERR_PATTERNS = [
 
 /** File the global-setup writes for fixtures to discover the snapshot HOME. */
 export const SNAPSHOT_INFO_FILE = '.snapshot/info.json'
+
+/**
+ * Version advertised by the fake `latest-mac.yml` feed in the update-detection
+ * spec. Deliberately far higher than any real release so it always compares as
+ * newer than `UPDATE_DETECTION_CURRENT_VERSION`.
+ */
+export const UPDATE_DETECTION_ADVERTISED_VERSION = '99.0.0'
+
+/**
+ * Baseline version the update-detection spec assigns to `autoUpdater.currentVersion`
+ * so the advertised feed version compares as an available update.
+ */
+export const UPDATE_DETECTION_CURRENT_VERSION = '0.0.1'
+
+/**
+ * Loopback host the update-detection feed server binds to. `127.0.0.1` (not
+ * `localhost`) avoids DNS/IPv6 resolution flakiness in CI.
+ */
+export const UPDATE_DETECTION_FEED_HOST = '127.0.0.1'

--- a/e2e/spec/update-detection.e2e.ts
+++ b/e2e/spec/update-detection.e2e.ts
@@ -109,22 +109,24 @@ test('surfaces an available update when the release feed advertises a newer vers
   const { server, feedUrl } = await startUpdateFeed()
   const repoRoot = resolve(__dirname, '..', '..')
   const mainEntry = resolve(repoRoot, 'out', 'main', 'index.mjs')
-
-  const electronApp = await _electron.launch({
-    args: [mainEntry],
-    env: {
-      ...process.env,
-      HOME: isolatedHome,
-      E2E_USERDATA_DIR: resolve(isolatedHome, 'userData'),
-      E2E_BACKGROUND_LAUNCH: '1',
-      // Drives the test-only updater seam at the localhost feed. NOT setting
-      // E2E_DISABLE_UPDATE: this spec WANTS the updater active.
-      E2E_UPDATE_FEED_URL: feedUrl,
-      E2E_UPDATE_CURRENT_VERSION: UPDATE_DETECTION_CURRENT_VERSION,
-    },
-  })
+  // Declared before the try so the finally can clean up even if launch throws.
+  let electronApp: Awaited<ReturnType<typeof _electron.launch>> | null = null
 
   try {
+    electronApp = await _electron.launch({
+      args: [mainEntry],
+      env: {
+        ...process.env,
+        HOME: isolatedHome,
+        E2E_USERDATA_DIR: resolve(isolatedHome, 'userData'),
+        E2E_BACKGROUND_LAUNCH: '1',
+        // Drives the test-only updater seam at the localhost feed. NOT setting
+        // E2E_DISABLE_UPDATE: this spec WANTS the updater active.
+        E2E_UPDATE_FEED_URL: feedUrl,
+        E2E_UPDATE_CURRENT_VERSION: UPDATE_DETECTION_CURRENT_VERSION,
+      },
+    })
+
     // Act — wait for the renderer to mount, then let the detection result land
     // in Redux. The main process fires one check immediately, but that can race
     // the renderer's IPC subscription (webContents.send does not buffer for a
@@ -184,8 +186,12 @@ test('surfaces an available update when the release feed advertises a newer vers
       'the available version should match the version advertised by the feed',
     ).toBe(UPDATE_DETECTION_ADVERTISED_VERSION)
   } finally {
-    await electronApp.close()
-    await stopUpdateFeed(server)
-    destroyIsolatedHome(isolatedHome)
+    // Independent, resilient cleanup: one failing step must not skip the
+    // others, and a launch failure leaves electronApp null (nothing to close).
+    await Promise.allSettled([
+      electronApp ? electronApp.close() : Promise.resolve(),
+      stopUpdateFeed(server),
+      Promise.resolve().then(() => destroyIsolatedHome(isolatedHome)),
+    ])
   }
 })

--- a/e2e/spec/update-detection.e2e.ts
+++ b/e2e/spec/update-detection.e2e.ts
@@ -1,0 +1,191 @@
+import { createServer, type Server } from 'node:http'
+import { type AddressInfo } from 'node:net'
+import { resolve } from 'node:path'
+
+import { test, expect, _electron } from '@playwright/test'
+
+import {
+  UPDATE_DETECTION_ADVERTISED_VERSION,
+  UPDATE_DETECTION_CURRENT_VERSION,
+  UPDATE_DETECTION_FEED_HOST,
+} from '../constants'
+import {
+  createIsolatedHome,
+  destroyIsolatedHome,
+} from '../fixtures/isolated-home'
+
+/**
+ * Channel file name electron-updater GETs on macOS (channel "latest" + the
+ * darwin "-mac" suffix + ".yml"). The fake feed server matches any request
+ * whose pathname ends with this, ignoring the no-cache query string that
+ * electron-updater appends.
+ */
+const MAC_CHANNEL_FILE = 'latest-mac.yml'
+
+/**
+ * Minimal valid `latest-mac.yml` advertising a version far higher than any real
+ * release. Only `version` gates the availability decision; `files`/`sha512`/`size`
+ * are download-time fields and are never validated during detection (the spec
+ * disables auto-download, so the artifact is never fetched). The advertised
+ * version is interpolated from the shared constant so the feed and the final
+ * assertion can never drift.
+ */
+const LATEST_MAC_YML = `version: ${UPDATE_DETECTION_ADVERTISED_VERSION}
+files:
+  - url: skills-desktop-${UPDATE_DETECTION_ADVERTISED_VERSION}-arm64-mac.zip
+    sha512: AdummyBase64Sha512ForTestOnlyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+    size: 12345678
+path: skills-desktop-${UPDATE_DETECTION_ADVERTISED_VERSION}-arm64-mac.zip
+sha512: AdummyBase64Sha512ForTestOnlyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+releaseDate: '2026-06-13T00:00:00.000Z'
+`
+
+/**
+ * Shape of the `update` Redux slice the spec polls. Narrowed inline (the
+ * canonical slice type lives in the renderer bundle, which the spec does not
+ * import) — only the two fields the assertion reads are declared.
+ */
+interface UpdateSliceState {
+  status: string
+  version: string | null
+}
+
+/**
+ * Start a localhost generic update feed that serves the fake `latest-mac.yml`
+ * on an EPHEMERAL port (the repo has documented port-sticking pain, so the port
+ * is never hardcoded). Any path that is not the channel file returns 404 so a
+ * stray artifact request fails loudly rather than silently succeeding.
+ *
+ * @returns The listening server plus its `http://127.0.0.1:<port>` base URL.
+ * @example
+ * const { server, feedUrl } = await startUpdateFeed()
+ * // GET `${feedUrl}/latest-mac.yml` -> the yml; everything else -> 404
+ */
+async function startUpdateFeed(): Promise<{ server: Server; feedUrl: string }> {
+  const server = createServer((request, response) => {
+    // Match on pathname only: electron-updater appends a `?noCache=...` query,
+    // so an exact `req.url === '/latest-mac.yml'` comparison would 404.
+    const requestUrl = new URL(
+      request.url ?? '/',
+      `http://${UPDATE_DETECTION_FEED_HOST}`,
+    )
+    if (requestUrl.pathname.endsWith(MAC_CHANNEL_FILE)) {
+      response.writeHead(200, { 'Content-Type': 'text/yaml' })
+      response.end(LATEST_MAC_YML)
+      return
+    }
+    // Detection-only: the artifact zip must never be requested. A 404 here keeps
+    // the test honest if a download is ever accidentally triggered.
+    response.writeHead(404)
+    response.end()
+  })
+
+  await new Promise<void>((resolveListen) => {
+    server.listen(0, UPDATE_DETECTION_FEED_HOST, resolveListen)
+  })
+
+  // listen(0) assigns a free port; AddressInfo carries it once listening.
+  const { port } = server.address() as AddressInfo
+  return {
+    server,
+    feedUrl: `http://${UPDATE_DETECTION_FEED_HOST}:${port}`,
+  }
+}
+
+/** Close the feed server, resolving once the socket is fully released. */
+async function stopUpdateFeed(server: Server): Promise<void> {
+  await new Promise<void>((resolveClose, rejectClose) => {
+    server.close((closeError) => {
+      if (closeError) rejectClose(closeError)
+      else resolveClose()
+    })
+  })
+}
+
+test('surfaces an available update when the release feed advertises a newer version', async () => {
+  // Arrange — bring up a localhost feed advertising a high version and an
+  // isolated HOME so the real userData/HOME is never touched.
+  const isolatedHome = createIsolatedHome()
+  const { server, feedUrl } = await startUpdateFeed()
+  const repoRoot = resolve(__dirname, '..', '..')
+  const mainEntry = resolve(repoRoot, 'out', 'main', 'index.mjs')
+
+  const electronApp = await _electron.launch({
+    args: [mainEntry],
+    env: {
+      ...process.env,
+      HOME: isolatedHome,
+      E2E_USERDATA_DIR: resolve(isolatedHome, 'userData'),
+      E2E_BACKGROUND_LAUNCH: '1',
+      // Drives the test-only updater seam at the localhost feed. NOT setting
+      // E2E_DISABLE_UPDATE: this spec WANTS the updater active.
+      E2E_UPDATE_FEED_URL: feedUrl,
+      E2E_UPDATE_CURRENT_VERSION: UPDATE_DETECTION_CURRENT_VERSION,
+    },
+  })
+
+  try {
+    // Act — wait for the renderer to mount, then let the detection result land
+    // in Redux. The main process fires one check immediately, but that can race
+    // the renderer's IPC subscription (webContents.send does not buffer for a
+    // not-yet-attached listener). Re-triggering a fresh check each poll tick
+    // self-heals a dropped first event; the 500ms interval guarantees each tick
+    // is a completed (non-deduped) check.
+    const appWindow = await electronApp.firstWindow()
+    await appWindow.waitForLoadState('domcontentloaded')
+
+    try {
+      await appWindow.waitForFunction(
+        () => {
+          const reduxState = window.__store__?.getState() as
+            | { update?: { status?: string } }
+            | undefined
+          if (reduxState?.update?.status === 'available') return true
+          // Nudge a fresh check; by now the renderer is subscribed so the
+          // re-emitted update-available reaches Redux. The `update` channel is
+          // not declared on the shared e2e `electron` surface, so it is typed
+          // via a local intersection cast — the call exists at runtime because
+          // the preload exposes `window.electron.update.check` unconditionally.
+          void (
+            window.electron as typeof window.electron & {
+              update: { check: () => Promise<unknown> }
+            }
+          ).update.check()
+          return false
+        },
+        undefined,
+        { timeout: 15_000, polling: 500 },
+      )
+    } catch (timeoutError) {
+      // Surface the final slice state so a real failure is legible instead of a
+      // bare timeout: status:'error' + message => feed/config issue; stuck
+      // 'idle' => the IPC event never landed.
+      const finalUpdate = await appWindow.evaluate(
+        () => (window.__store__?.getState() as { update?: unknown })?.update,
+      )
+      throw new Error(
+        `update never reached "available"; final state=${JSON.stringify(
+          finalUpdate,
+        )} (${String(timeoutError)})`,
+      )
+    }
+
+    // Assert — the slice reflects the version the feed advertised.
+    const finalUpdate = await appWindow.evaluate(
+      () =>
+        (window.__store__?.getState() as { update: UpdateSliceState }).update,
+    )
+    expect(
+      finalUpdate.status,
+      'detecting a newer feed version should move the update slice to "available"',
+    ).toBe('available')
+    expect(
+      finalUpdate.version,
+      'the available version should match the version advertised by the feed',
+    ).toBe(UPDATE_DETECTION_ADVERTISED_VERSION)
+  } finally {
+    await electronApp.close()
+    await stopUpdateFeed(server)
+    destroyIsolatedHome(isolatedHome)
+  }
+})

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -17,7 +17,7 @@ import { getMainWindow, setMainWindow } from './services/mainWindowState'
 import { getSettings, loadSettings } from './services/settings'
 import { createOrFocusSettingsWindow } from './services/settingsWindow'
 import { startupCleanup as runTrashStartupCleanup } from './services/trashService'
-import { initAutoUpdater } from './updater'
+import { initAutoUpdater, initAutoUpdaterForE2E } from './updater'
 import { attachExternalLinkHandler } from './utils/attachExternalLinkHandler'
 import { clampSizeToWorkArea } from './utils/clampSizeToWorkArea'
 import { isE2EBackgroundLaunch } from './utils/e2eEnv'
@@ -326,10 +326,25 @@ app.whenReady().then(async () => {
   createMenu()
   createWindow()
 
-  // Initialize auto updater in production.
-  // E2E_DISABLE_UPDATE=1 lets Playwright tests run against a packaged-shaped
-  // build without the updater hitting the network or showing toasts.
-  if (app.isPackaged && process.env['E2E_DISABLE_UPDATE'] !== '1') {
+  // Initialize the auto updater.
+  //
+  // First branch: a TEST-ONLY seam. `E2E_UPDATE_FEED_URL` is injected only by
+  // the Electron update-detection e2e spec to point the updater at a localhost
+  // feed for a deterministic, offline detection check. It is NEVER set in
+  // production, so this branch is dead code in shipped builds. `app.isPackaged`
+  // is deliberately NOT required here because the e2e build runs unpacked.
+  //
+  // Else branch: preserves the EXACT original packaged gate — the updater runs
+  // only in a packaged build, and E2E_DISABLE_UPDATE=1 lets the other Playwright
+  // specs launch a packaged-shaped build without the updater hitting the network
+  // or showing toasts.
+  const e2eUpdateFeedUrl = process.env['E2E_UPDATE_FEED_URL']
+  if (e2eUpdateFeedUrl) {
+    initAutoUpdaterForE2E({
+      feedUrl: e2eUpdateFeedUrl,
+      currentVersion: process.env['E2E_UPDATE_CURRENT_VERSION'],
+    })
+  } else if (app.isPackaged && process.env['E2E_DISABLE_UPDATE'] !== '1') {
     initAutoUpdater()
   }
 

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -2,13 +2,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 /**
  * Mutable stand-in for the electron-updater singleton. `applyUpdaterPreferences`
- * writes the config values onto it; the tests read them back. `autoInstallOnAppQuit`
- * starts `true` to mirror electron-updater's real default so the consent-pin
- * assertion below is meaningful.
+ * and `initAutoUpdaterForE2E` write config values onto it; the tests read them
+ * back. `autoInstallOnAppQuit` starts `true` to mirror electron-updater's real
+ * default so the consent-pin assertion is meaningful. `checkForUpdates` resolves
+ * because `initAutoUpdaterForE2E` chains `.catch()` onto its result.
  */
 const mockAutoUpdater = vi.hoisted(() => ({
   autoDownload: false,
   autoInstallOnAppQuit: true,
+  forceDevUpdateConfig: false,
+  currentVersion: '1.0.0',
+  on: vi.fn(),
+  setFeedURL: vi.fn(),
+  checkForUpdates: vi.fn().mockResolvedValue(undefined),
 }))
 
 vi.mock('electron-updater', () => ({
@@ -23,7 +29,7 @@ vi.mock('electron', () => ({
   BrowserWindow: { getAllWindows: vi.fn(() => []) },
 }))
 
-import { applyUpdaterPreferences } from './updater'
+import { applyUpdaterPreferences, initAutoUpdaterForE2E } from './updater'
 
 describe('applyUpdaterPreferences', () => {
   beforeEach(() => {
@@ -64,5 +70,67 @@ describe('applyUpdaterPreferences', () => {
 
     // Assert
     expect(mockAutoUpdater.autoInstallOnAppQuit).toBe(false)
+  })
+})
+
+describe('initAutoUpdaterForE2E', () => {
+  beforeEach(() => {
+    // Reset every field the seam touches so state does not leak between cases.
+    mockAutoUpdater.autoDownload = false
+    mockAutoUpdater.forceDevUpdateConfig = false
+    mockAutoUpdater.currentVersion = '1.0.0'
+    mockAutoUpdater.on.mockClear()
+    mockAutoUpdater.setFeedURL.mockClear()
+    mockAutoUpdater.checkForUpdates.mockClear()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('forces dev update config so a check can run against the unpacked e2e build', () => {
+    // Arrange + Act
+    initAutoUpdaterForE2E({ feedUrl: 'http://127.0.0.1:54321' })
+
+    // Assert
+    expect(mockAutoUpdater.forceDevUpdateConfig).toBe(true)
+  })
+
+  it('disables auto-download so the dummy artifact is never fetched during detection', () => {
+    // Arrange + Act
+    initAutoUpdaterForE2E({ feedUrl: 'http://127.0.0.1:54321' })
+
+    // Assert
+    expect(mockAutoUpdater.autoDownload).toBe(false)
+  })
+
+  it('lowers currentVersion to the passed baseline so a higher feed version compares as available', () => {
+    // Arrange + Act
+    initAutoUpdaterForE2E({
+      feedUrl: 'http://127.0.0.1:54321',
+      currentVersion: '0.0.1',
+    })
+
+    // Assert
+    expect(mockAutoUpdater.currentVersion).toBe('0.0.1')
+  })
+
+  it('points the updater at the localhost generic feed', () => {
+    // Arrange + Act
+    initAutoUpdaterForE2E({ feedUrl: 'http://127.0.0.1:54321' })
+
+    // Assert
+    expect(mockAutoUpdater.setFeedURL).toHaveBeenCalledWith({
+      provider: 'generic',
+      url: 'http://127.0.0.1:54321',
+    })
+  })
+
+  it('triggers an update check immediately so detection runs without the boot delay', () => {
+    // Arrange + Act
+    initAutoUpdaterForE2E({ feedUrl: 'http://127.0.0.1:54321' })
+
+    // Assert
+    expect(mockAutoUpdater.checkForUpdates).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -128,6 +128,30 @@ interface E2EUpdaterOptions {
 }
 
 /**
+ * Guard the test-only update feed URL to a localhost loopback http origin —
+ * `E2E_UPDATE_FEED_URL` flows straight into `setFeedURL`, so this stops the
+ * offline-E2E seam from ever being pointed at a real network host (which would
+ * also bypass the production `app.isPackaged` gate). Throws on any non-loopback
+ * or non-http URL; called first in {@link initAutoUpdaterForE2E}.
+ * @param feedUrl - Candidate feed base URL injected by the e2e harness.
+ * @returns void — returns only for a loopback http URL; throws otherwise.
+ * @example
+ * assertLoopbackFeedUrl('http://127.0.0.1:54321') // ok
+ * assertLoopbackFeedUrl('https://example.com')    // throws
+ */
+function assertLoopbackFeedUrl(feedUrl: string): void {
+  const parsedFeedUrl = new URL(feedUrl)
+  // WHATWG URL keeps IPv6 hosts bracketed (e.g. "[::1]"); strip the brackets so
+  // the bare-address comparison matches a real IPv6 loopback feed URL too.
+  const hostname = parsedFeedUrl.hostname.replace(/^\[|\]$/g, '')
+  const isLoopbackHost =
+    hostname === '127.0.0.1' || hostname === 'localhost' || hostname === '::1'
+  if (parsedFeedUrl.protocol !== 'http:' || !isLoopbackHost) {
+    throw new Error(`E2E update feed must use a loopback http URL: ${feedUrl}`)
+  }
+}
+
+/**
  * TEST-ONLY seam that drives a deterministic, OFFLINE update-DETECTION check
  * against a localhost generic feed. Reached only from `src/main/index.ts` when
  * the `E2E_UPDATE_FEED_URL` env var is set, which the Electron e2e spec
@@ -144,6 +168,10 @@ interface E2EUpdaterOptions {
  * // -> GET http://127.0.0.1:54321/latest-mac.yml, then broadcasts UPDATE_AVAILABLE for the higher feed version
  */
 export function initAutoUpdaterForE2E(options: E2EUpdaterOptions): void {
+  // Defense-in-depth: this seam takes its URL straight from an env var, so
+  // refuse anything but a localhost loopback http feed before wiring it in.
+  assertLoopbackFeedUrl(options.feedUrl)
+
   // Allow an update CHECK in the UNPACKED e2e build. Without this,
   // isUpdaterActive() short-circuits (app.isPackaged === false) and
   // checkForUpdates() logs "Skip checkForUpdates because application is not

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -8,6 +8,13 @@ import { broadcastTypedEvent as broadcastEvent } from './ipc/typedSend'
 import { getSettings } from './services/settings'
 
 /**
+ * Delay before the boot-time update check fires, giving the renderer time to
+ * mount and subscribe to the `update:*` IPC channels before the first
+ * `update-available`/`update-not-available` event is broadcast.
+ */
+const UPDATE_CHECK_DELAY_MS = 3000
+
+/**
  * Push the user's persisted update preference onto the live
  * `electron-updater` singleton. Called once at init (so the boot-time
  * update check honors the saved value) and again from the `settings:set`
@@ -33,14 +40,16 @@ export function applyUpdaterPreferences(
 }
 
 /**
- * Initialize auto updater with IPC-based UI notifications
- * Replaces native dialogs with in-app toast notifications
+ * Register the `electron-updater` lifecycle handlers that forward each phase
+ * to the renderer as a typed IPC broadcast. Extracted so both the production
+ * `initAutoUpdater` and the test-only `initAutoUpdaterForE2E` share one
+ * source of truth for the event-to-IPC mapping (no behavior drift between
+ * the two entry points).
+ * @example
+ * registerUpdaterEventHandlers()
+ * // autoUpdater now broadcasts UPDATE_CHECKING / UPDATE_AVAILABLE / etc. over IPC
  */
-export function initAutoUpdater(): void {
-  // Seed the updater from the persisted user preference. The default keeps
-  // autoDownload off, preserving the manual confirm-via-UI flow.
-  applyUpdaterPreferences(getSettings())
-
+function registerUpdaterEventHandlers(): void {
   autoUpdater.on('checking-for-update', () => {
     console.log('Checking for updates...')
     broadcastEvent(IPC_CHANNELS.UPDATE_CHECKING)
@@ -83,13 +92,92 @@ export function initAutoUpdater(): void {
         typeof info.releaseNotes === 'string' ? info.releaseNotes : undefined,
     })
   })
+}
+
+/**
+ * Initialize auto updater with IPC-based UI notifications
+ * Replaces native dialogs with in-app toast notifications
+ */
+export function initAutoUpdater(): void {
+  // Seed the updater from the persisted user preference. The default keeps
+  // autoDownload off, preserving the manual confirm-via-UI flow.
+  applyUpdaterPreferences(getSettings())
+
+  registerUpdaterEventHandlers()
 
   // Check for updates after a short delay
   setTimeout(() => {
     autoUpdater.checkForUpdates().catch((err) => {
       console.error('Failed to check for updates:', err)
     })
-  }, 3000)
+  }, UPDATE_CHECK_DELAY_MS)
+}
+
+/**
+ * Options for {@link initAutoUpdaterForE2E}.
+ */
+interface E2EUpdaterOptions {
+  /** Localhost generic feed base URL; macOS GETs `<feedUrl>/latest-mac.yml`. */
+  feedUrl: string
+  /**
+   * Baseline version the feed is compared against. Set LOW (e.g. "0.0.1") so a
+   * higher advertised feed version compares as available. Omit to keep the
+   * real `app.version`.
+   */
+  currentVersion?: string
+}
+
+/**
+ * TEST-ONLY seam that drives a deterministic, OFFLINE update-DETECTION check
+ * against a localhost generic feed. Reached only from `src/main/index.ts` when
+ * the `E2E_UPDATE_FEED_URL` env var is set, which the Electron e2e spec
+ * (`e2e/spec/update-detection.e2e.ts`) injects; it is NEVER set in production,
+ * so this function is dead code in shipped builds. It forces dev-mode update
+ * config (so a check runs in the unpacked build), disables auto-download (the
+ * dummy artifact is never fetched), optionally lowers `currentVersion` so the
+ * feed compares as newer, points the feed at localhost, registers the shared
+ * IPC handlers, and triggers the check immediately (no boot delay).
+ * @param options - {@link E2EUpdaterOptions}: `feedUrl` (required localhost URL) and optional `currentVersion`.
+ * @example
+ * // Driven by the e2e harness, never in production:
+ * initAutoUpdaterForE2E({ feedUrl: 'http://127.0.0.1:54321', currentVersion: '0.0.1' })
+ * // -> GET http://127.0.0.1:54321/latest-mac.yml, then broadcasts UPDATE_AVAILABLE for the higher feed version
+ */
+export function initAutoUpdaterForE2E(options: E2EUpdaterOptions): void {
+  // Allow an update CHECK in the UNPACKED e2e build. Without this,
+  // isUpdaterActive() short-circuits (app.isPackaged === false) and
+  // checkForUpdates() logs "Skip checkForUpdates because application is not
+  // packed and dev update config is not forced" and does nothing.
+  autoUpdater.forceDevUpdateConfig = true
+
+  // Detection-only: never fetch the dummy artifact. With autoDownload=false the
+  // availability check stops after the version comparison (downloadPromise is null).
+  autoUpdater.autoDownload = false
+
+  // Force the comparison baseline LOW so the higher feed version compares as
+  // newer. `currentVersion` is declared `readonly currentVersion: SemVer` in
+  // electron-updater's .d.ts, but at runtime it is a plain writable instance
+  // field, and the comparison path uses semver gt/eq which accept a string —
+  // so a plain string works (e.g. gt('99.0.0','0.0.1') === true). The cast is
+  // REQUIRED to assign past the readonly type; importing `semver` to build a
+  // SemVer is not viable (transitive-only dep, ESM main process has no require).
+  if (options.currentVersion !== undefined) {
+    ;(autoUpdater as unknown as { currentVersion: string }).currentVersion =
+      options.currentVersion
+  }
+
+  // Point at the localhost generic feed. On macOS this GETs <feedUrl>/latest-mac.yml.
+  // Calling setFeedURL before checkForUpdates also short-circuits the on-disk
+  // dev-app-update.yml lookup, keeping the test fully offline.
+  autoUpdater.setFeedURL({ provider: 'generic', url: options.feedUrl })
+
+  registerUpdaterEventHandlers()
+
+  // Trigger detection immediately (no boot delay): fetch + parse + compare the
+  // yml, then broadcast UPDATE_AVAILABLE. No artifact download.
+  autoUpdater.checkForUpdates().catch((err) => {
+    console.error('Failed to check for updates (E2E):', err)
+  })
 }
 
 /**


### PR DESCRIPTION
## Why
`v0.23.0` release closeout could confirm the public `latest-mac.yml` + asset URLs, but **live old-version update detection timed out** (`net::ERR_TIMED_OUT`) from a temp-launched app. This adds a **deterministic, offline** smoke so update detection is provable without depending on GitHub/Electron net.

## What
A new Electron e2e spec — `e2e/spec/update-detection.e2e.ts` — proves an app at `currentVersion 0.0.1` observes a feed advertising `99.0.0` as available, end-to-end through the real `electron-updater` → IPC → Redux chain.

### Determinism / offline / safety (by construction)
- **Localhost feed only:** an ephemeral-port (`listen(0)`) http server serves a controlled `latest-mac.yml` (v99.0.0). `provider: 'generic'`, never the GitHub provider.
- **Detection-only:** `autoDownload = false` → the dummy artifact is never fetched; **`downloadUpdate`/`quitAndInstall` are never called.**
- **Isolated:** runs under a tempdir HOME; never touches the real `HOME`, `userData`, or `/Applications`.
- **Production-dead seam:** `initAutoUpdaterForE2E` is reached only when `E2E_UPDATE_FEED_URL` is set (injected by the spec, never in production). The production gate `app.isPackaged && E2E_DISABLE_UPDATE !== '1'` is preserved **byte-for-byte** in the else-branch.

### Production changes (minimal seam + tidy refactor)
- `src/main/updater.ts`: extracted the 6 `autoUpdater.on(...)` handlers into a private `registerUpdaterEventHandlers()` (verbatim, no behavior change) shared by both entry points; `3000` → `UPDATE_CHECK_DELAY_MS`; added the test-only `initAutoUpdaterForE2E({ feedUrl, currentVersion? })`.
- `src/main/index.ts`: env-gated `E2E_UPDATE_FEED_URL` branch; original packaged gate preserved.
- `src/main/updater.test.ts`: 5 new behavior-named unit tests for the seam.

## Verification (run locally on this branch's content)
- `pnpm exec vitest run src/main/updater.test.ts` → **8/8 passed**
- `npx tsc -p e2e/tsconfig.json --noEmit` → clean
- `pnpm typecheck` → clean
- `eslint` on all 5 files → clean
- `pnpm build:e2e && playwright test e2e/spec/update-detection.e2e.ts` → **1 passed** (offline, ~0.9s)

## Known design note
The spec re-triggers `update.check()` every 500ms inside the wait poll — this is the load-bearing delivery path (the main-process immediate emit can race the renderer's IPC subscription, which doesn't buffer). It routes through the existing `update:check` IPC with `autoDownload=false`, so it stays safe. Flagged for reviewer awareness rather than hidden.

## Satisfies the standing TODO
"deterministic auto-update detection smoke that does not depend on Electron net reaching GitHub" — simulated availability from older→newer against a controlled local endpoint, proving old observes newer, leaving real HOME/app data/`/Applications` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * テスト用のローカル更新フィードを使ったアップデート検知のテストモードを追加。テスト環境での更新検出動作を即時確認可能にしました。
* **Tests**
  * 更新検知のエンドツーエンドテストを追加し、検出・通知の安定性を検証するシナリオを導入しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->