### PR TITLE
feat: marketplace incremental search with debounced live results

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Electron desktop app (macOS) for visualizing Skills symlink status across AI age
 **version bump → notarized build → ZIP rename → GitHub release → website URL update → artifacts upload**
 
 **Forbidden:**
-- `/ship` MUST NOT bump `package.json` version. `/ship` is for code commits/PRs only. Version bumps are owned exclusively by `/electron-release`.
+- `/ship` MUST NOT bump `package.json` version. Version bumps are owned exclusively by `/electron-release`.
 - Manual `gh release create` outside `/electron-release` (skips notarization check, ZIP rename, website update — auto-update breaks)
 - Manual edit of `package.json` `"version"` field
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -254,6 +254,14 @@ Rules:
 - Placeholder text must stay lower contrast than real values.
 - Search should feel command-palette-adjacent: compact, keyboard-first,
   immediately scannable.
+- Reset native form chrome to the token palette. macOS Chromium renders the
+  `type="search"` clear control (`::-webkit-search-cancel-button`) in the system
+  accent (blue), which breaks the muted OKLCH surface. Prefer a palette-matched
+  affordance: recolor the pseudo-element via `appearance: none` + a masked SVG in
+  `--muted-foreground` (preserves one-click clear), or supply a custom clear
+  button. Top-tier tools (Linear, Raycast, Notion) never expose raw browser
+  chrome. The current native blue × is an accepted low-priority item — see Polish
+  Backlog Guidance.
 
 ### Tabs and Segmented Controls
 
@@ -285,6 +293,21 @@ Rules:
   - Reserve overlay space with padding so revealing a corner action never
     shifts the row's content (zero-layout-shift); align overlays to the title
     row, not the card's raw top edge.
+
+### Empty States
+
+- Empty-state prominence scales with severity. Match the treatment to whether
+  the empty is expected or a failure:
+  - Expected / transient empties (a search with no matches, a freshly filtered
+    list) stay to one quiet muted line. A zero-result search is a normal outcome
+    — typos, narrow queries — not an error, so it must not look like one.
+    (Spotlight, Linear, Raycast keep search misses understated.)
+  - Rare / terminal failures (network error, leaderboard unavailable) earn the
+    fuller icon + heading + description treatment, because they signal that
+    something actually broke and may need user action.
+- Never dress an expected empty as a failure: no `h-12` icon or `text-lg`
+  heading for a search miss. This is the operational reading of principle 5's
+  "no noisy empty states."
 
 ### Cards and Widgets
 
@@ -424,6 +447,13 @@ Likely app-safe improvements:
 - Add 120-180ms color/opacity transitions to selected rows and tabs.
 - Add 250-350ms width transitions to progress indicators only when they track
   real progress.
+- Recolor the native search clear control to the palette. Both the marketplace
+  and skills-tab search inputs use `type="search"`, so macOS Chromium paints the
+  `::-webkit-search-cancel-button` in system-accent blue. A single global rule
+  (`appearance: none` + masked SVG in `--muted-foreground` on the pseudo-element)
+  recolors both at once while preserving one-click clear; Electron's pinned
+  Chromium keeps the mask approach low-risk. Low priority — the blue × is the
+  only off-palette element in an otherwise clean search surface.
 
 ## Agent Prompt Guide
 

--- a/src/renderer/src/components/marketplace/MarketplaceSearch.browser.test.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceSearch.browser.test.tsx
@@ -1,0 +1,126 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import { SEARCH_DEBOUNCE_MS } from '@/shared/constants'
+import { repositoryId } from '@/shared/types'
+import type { SkillSearchResult } from '@/shared/types'
+
+// The unit tests cover the debounce primitive and the reducer's latest-wins
+// guard in isolation. This file is the only place the *composed* incremental
+// search runs end to end: a real keystroke → handleChange → debounced run →
+// runSearch's commit+dispatch → the IPC `search` call → results in the store.
+// It guards the wiring the lint-forced callback pivot moved into the component,
+// which nothing else exercises.
+
+const mockSearch = vi.fn()
+
+beforeEach(() => {
+  // Fresh mock state per test, then re-point `window.electron.skillsCli.search`
+  // at it. Stub `electron` (not `window`) so the browser lane keeps its real
+  // window/DOM — `window.electron` resolves to this on `globalThis`.
+  vi.resetAllMocks()
+  vi.stubGlobal('electron', {
+    skillsCli: {
+      search: mockSearch,
+      install: vi.fn(),
+      cancel: vi.fn(),
+      onProgress: vi.fn(() => () => {}),
+    },
+    // MarketplaceSearch never dispatches loadLeaderboard, but stubbing keeps the
+    // test resilient if a future render path pulls the thunk in transitively.
+    marketplace: {
+      leaderboard: vi.fn(async () => []),
+    },
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+const sampleResult: SkillSearchResult = {
+  rank: 1,
+  name: 'task',
+  repo: repositoryId('vercel-labs/skill-task'),
+  url: 'https://skills.sh/vercel-labs/skill-task',
+}
+
+/**
+ * Render MarketplaceSearch over a marketplace-only store. Dynamic imports run
+ * after `beforeEach` installs the `electron` stub, so the IPC bridge is in
+ * place before the component module evaluates.
+ */
+async function renderSearch() {
+  const { default: marketplaceReducer } =
+    await import('@/renderer/src/redux/slices/marketplaceSlice')
+  const store = configureStore({
+    reducer: { marketplace: marketplaceReducer },
+  })
+  const { MarketplaceSearch } = await import('./MarketplaceSearch')
+  const screen = await render(
+    <Provider store={store}>
+      <MarketplaceSearch />
+    </Provider>,
+  )
+  const input = screen.getByRole('searchbox', {
+    name: 'Search marketplace skills',
+  })
+  return { screen, store, input }
+}
+
+describe('MarketplaceSearch — incremental search', () => {
+  it('fires a single remote search for the final query after a burst of typing', async () => {
+    // Arrange
+    mockSearch.mockResolvedValue([sampleResult])
+    const { store, input } = await renderSearch()
+
+    // Act — a fast burst: each keystroke restarts the debounce window.
+    await input.fill('r')
+    await input.fill('re')
+    await input.fill('react')
+
+    // Assert — exactly one remote call lands, for the final query, not one per
+    // keystroke (that would be three calls).
+    await expect.poll(() => mockSearch.mock.calls.length).toBe(1)
+    expect(mockSearch).toHaveBeenCalledWith('react')
+
+    // Assert — the settled query is committed and its results fill the panel.
+    expect(store.getState().marketplace.searchQuery).toBe('react')
+    await expect
+      .poll(() => store.getState().marketplace.searchResults)
+      .toEqual([sampleResult])
+  })
+
+  it('wipes the results and returns to the leaderboard when the box is cleared', async () => {
+    // Arrange — run one search to completion so there is state to clear.
+    mockSearch.mockResolvedValue([sampleResult])
+    const { store, input } = await renderSearch()
+    await input.fill('react')
+    await expect
+      .poll(() => store.getState().marketplace.searchResults)
+      .toEqual([sampleResult])
+
+    // Act — empty the box.
+    await input.fill('')
+
+    // Assert — results cleared, query reset, panel back to its idle state.
+    await expect.poll(() => store.getState().marketplace.status).toBe('idle')
+    expect(store.getState().marketplace.searchResults).toEqual([])
+    expect(store.getState().marketplace.searchQuery).toBe('')
+  })
+
+  it('cancels the pending remote search when the box is cleared before it fires', async () => {
+    // Arrange — search never gets to run; the clear should pre-empt it.
+    const { input } = await renderSearch()
+
+    // Act — type, then clear within the same quiet window.
+    await input.fill('react')
+    await input.fill('')
+
+    // Assert — well past the debounce window, no remote call ever happened.
+    await new Promise((resolve) => setTimeout(resolve, SEARCH_DEBOUNCE_MS * 2))
+    expect(mockSearch).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/marketplace/MarketplaceSearch.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceSearch.tsx
@@ -1,81 +1,81 @@
 import { Search, Loader2 } from 'lucide-react'
 import React, { useCallback, useState } from 'react'
 
-import { Button } from '@/renderer/src/components/ui/button'
 import { Input } from '@/renderer/src/components/ui/input'
+import { useDebouncedCallback } from '@/renderer/src/hooks/useDebouncedCallback'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import {
   searchSkills,
   setMarketplaceSearchQuery,
   clearSearchResults,
 } from '@/renderer/src/redux/slices/marketplaceSlice'
+import { SEARCH_DEBOUNCE_MS } from '@/shared/constants'
 
 /**
- * Search box for finding skills in the marketplace
+ * Incremental search box for the marketplace. Searches as the user types: each
+ * keystroke updates a local value instantly and fires a debounced remote
+ * `skills find` call, and committing the query flips the panel from leaderboard
+ * to results. Deliberately button-less — incremental search means there is
+ * nothing to click, matching the skills-tab `SearchBox` and DESIGN.md "Polish
+ * by subtraction first".
  */
 export const MarketplaceSearch = React.memo(
   function MarketplaceSearch(): React.ReactElement {
     const dispatch = useAppDispatch()
     const { searchQuery, status } = useAppSelector((state) => state.marketplace)
+    // Local value drives the input for instant typing feedback; the debounced
+    // callback drives the actual (expensive, IPC-bound) remote search.
     const [localQuery, setLocalQuery] = useState(searchQuery)
     const isSearching = status === 'searching'
 
-    const handleSearch = useCallback((): void => {
-      if (localQuery.trim()) {
-        dispatch(setMarketplaceSearchQuery(localQuery.trim()))
-        dispatch(searchSkills(localQuery.trim()))
-      }
-    }, [dispatch, localQuery])
+    // Fire the remote search for a settled query. Committing the query to Redux
+    // (setMarketplaceSearchQuery) and dispatching the search together keeps the
+    // view switch (hasSearched) and the 'searching' status atomic, so the
+    // results pane never flashes "no results" while the user is mid-type.
+    const runSearch = useCallback(
+      (query: string): void => {
+        const trimmedQuery = query.trim()
+        if (trimmedQuery === '') return
+        dispatch(setMarketplaceSearchQuery(trimmedQuery))
+        dispatch(searchSkills(trimmedQuery))
+      },
+      [dispatch],
+    )
+    const debouncedSearch = useDebouncedCallback(runSearch, SEARCH_DEBOUNCE_MS)
 
-    /** Clear search input and return to leaderboard */
     const handleChange = useCallback(
       (e: React.ChangeEvent<HTMLInputElement>): void => {
         const value = e.target.value
         setLocalQuery(value)
-        // When input is cleared (native X button or manual), reset search state
-        if (value === '') {
+        if (value.trim() === '') {
+          // Clearing the box snaps back to the leaderboard immediately and
+          // cancels the search that was about to fire for the prior keystrokes.
+          debouncedSearch.cancel()
           dispatch(clearSearchResults())
+        } else {
+          debouncedSearch.run(value)
         }
       },
-      [dispatch],
-    )
-
-    const handleKeyDown = useCallback(
-      (e: React.KeyboardEvent): void => {
-        if (e.key === 'Enter') {
-          handleSearch()
-        }
-      },
-      [handleSearch],
+      [dispatch, debouncedSearch],
     )
 
     return (
-      <div className="flex gap-2">
-        <div className="relative flex-1">
+      <div className="relative">
+        {/* Left icon morphs to a spinner while a search is in flight — conveys
+            loading without a separate control or layout shift. */}
+        {isSearching ? (
+          <Loader2 className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 animate-spin text-muted-foreground" />
+        ) : (
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-          <Input
-            type="search"
-            placeholder="Search skills (e.g., react, vercel, nextjs)..."
-            value={localQuery}
-            onChange={handleChange}
-            onKeyDown={handleKeyDown}
-            className="pl-10 bg-background h-8"
-            disabled={isSearching}
-          />
-        </div>
-        <Button
-          onClick={handleSearch}
-          disabled={isSearching || !localQuery.trim()}
-        >
-          {isSearching ? (
-            <>
-              <Loader2 className="h-4 w-4 animate-spin" />
-              Searching...
-            </>
-          ) : (
-            'Search'
-          )}
-        </Button>
+        )}
+        <Input
+          type="search"
+          placeholder="Search skills (e.g., react, vercel, nextjs)..."
+          value={localQuery}
+          onChange={handleChange}
+          className="pl-10 bg-background h-8"
+          aria-label="Search marketplace skills"
+        />
       </div>
     )
   },

--- a/src/renderer/src/components/marketplace/SkillsMarketplace.tsx
+++ b/src/renderer/src/components/marketplace/SkillsMarketplace.tsx
@@ -119,7 +119,11 @@ export const SkillsMarketplace = React.memo(
           >
             {hasSearched && (
               <>
-                {isSearching && (
+                {/* First-search spinner only. While re-searching with results
+                    already on screen, keep them visible (the search box icon
+                    spins instead) so incremental typing never blanks the list —
+                    same "keep stale during refresh" intent as the leaderboard. */}
+                {isSearching && searchResults.length === 0 && (
                   <div className="flex items-center justify-center py-16">
                     <div className="text-muted-foreground">Searching...</div>
                   </div>

--- a/src/renderer/src/hooks/useDebouncedCallback.browser.test.tsx
+++ b/src/renderer/src/hooks/useDebouncedCallback.browser.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest'
+import { renderHook } from 'vitest-browser-react'
+
+import { useDebouncedCallback } from './useDebouncedCallback'
+
+// Real timers + `vi.waitFor` polling: deterministic without the React-flush
+// fragility of fake timers under vitest browser mode. The "not called yet"
+// checks run synchronously right after `run()` — a real setTimeout cannot fire
+// within that microtask gap, so they are not racy.
+const DELAY_MS = 50
+
+describe('useDebouncedCallback', () => {
+  it('runs only the final call in a burst, and only after the quiet period', async () => {
+    // Arrange
+    const callback = vi.fn()
+    const { result } = await renderHook(() =>
+      useDebouncedCallback(callback, DELAY_MS),
+    )
+
+    // Act — three rapid calls; each restarts the timer.
+    result.current.run('r')
+    result.current.run('re')
+    result.current.run('react')
+
+    // Assert — nothing fires synchronously.
+    expect(callback).not.toHaveBeenCalled()
+
+    // Assert — after the quiet period only the final call runs, exactly once.
+    await vi.waitFor(() => expect(callback).toHaveBeenCalledTimes(1))
+    expect(callback).toHaveBeenCalledWith('react')
+  })
+
+  it('cancel() drops a scheduled call so it never runs', async () => {
+    // Arrange
+    const callback = vi.fn()
+    const { result } = await renderHook(() =>
+      useDebouncedCallback(callback, DELAY_MS),
+    )
+
+    // Act — schedule, then immediately cancel before the quiet period elapses.
+    result.current.run('react')
+    result.current.cancel()
+
+    // Assert — well past the delay, the callback still never fired.
+    await new Promise((resolve) => setTimeout(resolve, DELAY_MS * 3))
+    expect(callback).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/hooks/useDebouncedCallback.ts
+++ b/src/renderer/src/hooks/useDebouncedCallback.ts
@@ -1,0 +1,52 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react'
+
+/**
+ * Returns a stable debounced wrapper around `callback`. Calling `run(...)`
+ * (re)starts a timer; only the final `run` within a `delayMs` quiet window
+ * actually fires. Exists so an event handler can trigger an expensive action —
+ * e.g. a remote search — directly as the user types, without one call per
+ * keystroke and without a value-watching effect. `cancel()` drops any pending
+ * call (e.g. when the search box is cleared); the timer is also cleared on
+ * unmount. Pass a stable `callback` (wrap in `useCallback`) so a scheduled run
+ * never fires a stale closure. Used by `MarketplaceSearch` for incremental search.
+ *
+ * @param callback - The function to debounce; receives `run`'s arguments.
+ * @param delayMs - Quiet period, in ms, before a scheduled call fires.
+ * @returns
+ * - `run(...args)`: schedule `callback(...args)` after the quiet period
+ * - `cancel()`: drop any scheduled-but-unfired call
+ * @example
+ * const search = useDebouncedCallback((q: string) => dispatch(searchSkills(q)), 300)
+ * onChange={(e) => search.run(e.target.value)}
+ */
+export function useDebouncedCallback<TArgs extends readonly unknown[]>(
+  callback: (...args: TArgs) => void,
+  delayMs: number,
+): { run: (...args: TArgs) => void; cancel: () => void } {
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const cancel = useCallback((): void => {
+    if (timeoutRef.current !== null) {
+      clearTimeout(timeoutRef.current)
+      timeoutRef.current = null
+    }
+  }, [])
+
+  const run = useCallback(
+    (...args: TArgs): void => {
+      // Restart the quiet window on every call, so only the last one in a burst
+      // survives to fire.
+      cancel()
+      timeoutRef.current = setTimeout(() => {
+        timeoutRef.current = null
+        callback(...args)
+      }, delayMs)
+    },
+    [callback, delayMs, cancel],
+  )
+
+  // Drop any pending call when the consumer unmounts.
+  useEffect(() => cancel, [cancel])
+
+  return useMemo(() => ({ run, cancel }), [run, cancel])
+}

--- a/src/renderer/src/redux/slices/marketplaceSlice.test.ts
+++ b/src/renderer/src/redux/slices/marketplaceSlice.test.ts
@@ -111,10 +111,11 @@ describe('marketplaceSlice', () => {
 
   it('dismisses a surfaced error banner and lets the user search again', async () => {
     // Arrange — drive the panel into the error state via a failing search
-    const { clearError } = await import('./marketplaceSlice')
+    const { clearError, searchSkills, setMarketplaceSearchQuery } =
+      await import('./marketplaceSlice')
     const store = await createTestStore()
     mockSearch.mockRejectedValue(new Error('fail'))
-    const { searchSkills } = await import('./marketplaceSlice')
+    store.dispatch(setMarketplaceSearchQuery('test'))
     await store.dispatch(searchSkills('test'))
     expect(store.getState().marketplace.status).toBe('error')
 
@@ -151,9 +152,11 @@ describe('marketplaceSlice', () => {
       }),
     )
     const store = await createTestStore()
-    const { searchSkills } = await import('./marketplaceSlice')
+    const { searchSkills, setMarketplaceSearchQuery } =
+      await import('./marketplaceSlice')
 
     // Act
+    store.dispatch(setMarketplaceSearchQuery('react'))
     const promise = store.dispatch(searchSkills('react'))
 
     // Assert
@@ -167,9 +170,12 @@ describe('marketplaceSlice', () => {
     // Arrange
     mockSearch.mockResolvedValue([sampleResult])
     const store = await createTestStore()
-    const { searchSkills } = await import('./marketplaceSlice')
+    const { searchSkills, setMarketplaceSearchQuery } =
+      await import('./marketplaceSlice')
 
-    // Act
+    // Act — the box holds the query before its results land (the real flow:
+    // MarketplaceSearch commits the query, then dispatches the search).
+    store.dispatch(setMarketplaceSearchQuery('task'))
     await store.dispatch(searchSkills('task'))
 
     // Assert
@@ -183,14 +189,162 @@ describe('marketplaceSlice', () => {
     // Arrange
     mockSearch.mockRejectedValue(new Error('API timeout'))
     const store = await createTestStore()
-    const { searchSkills } = await import('./marketplaceSlice')
+    const { searchSkills, setMarketplaceSearchQuery } =
+      await import('./marketplaceSlice')
 
     // Act
+    store.dispatch(setMarketplaceSearchQuery('test'))
     await store.dispatch(searchSkills('test'))
 
     // Assert
     expect(store.getState().marketplace.status).toBe('error')
     expect(store.getState().marketplace.error).toBe('API timeout')
+  })
+
+  it('keeps the latest query results when an earlier search resolves out of order', async () => {
+    // Arrange — two searches in flight. "rea" is dispatched first but its
+    // response is made to land AFTER "react" resolves, simulating an
+    // out-of-order IPC reply (the CLI runs searches concurrently).
+    let resolveRea!: (value: SkillSearchResult[]) => void
+    let resolveReact!: (value: SkillSearchResult[]) => void
+    const reaResult: SkillSearchResult = { ...sampleResult, name: 'rea-hit' }
+    const reactResult: SkillSearchResult = {
+      ...sampleResult,
+      name: 'react-hit',
+    }
+    mockSearch
+      .mockReturnValueOnce(
+        new Promise<SkillSearchResult[]>((r) => {
+          resolveRea = r
+        }),
+      )
+      .mockReturnValueOnce(
+        new Promise<SkillSearchResult[]>((r) => {
+          resolveReact = r
+        }),
+      )
+    const store = await createTestStore()
+    const { searchSkills, setMarketplaceSearchQuery } =
+      await import('./marketplaceSlice')
+
+    // Act — fire "rea", then "react" (the box now holds "react"). Resolve
+    // "react" first, then let the stale "rea" response arrive afterwards.
+    store.dispatch(setMarketplaceSearchQuery('rea'))
+    const reaSearch = store.dispatch(searchSkills('rea'))
+    store.dispatch(setMarketplaceSearchQuery('react'))
+    const reactSearch = store.dispatch(searchSkills('react'))
+    resolveReact([reactResult])
+    await reactSearch
+    resolveRea([reaResult])
+    await reaSearch
+
+    // Assert — the box shows "react", so only its results survive; the late
+    // "rea" reply is dropped instead of overwriting them.
+    const state = store.getState().marketplace
+    expect(state.searchResults).toEqual([reactResult])
+    expect(state.status).toBe('idle')
+  })
+
+  it('ignores a stale search failure once the query has moved on', async () => {
+    // Arrange — "rea" will reject, "react" will succeed; "react" resolves
+    // first, then the superseded "rea" rejection lands.
+    let rejectRea!: (reason: Error) => void
+    let resolveReact!: (value: SkillSearchResult[]) => void
+    mockSearch
+      .mockReturnValueOnce(
+        new Promise<SkillSearchResult[]>((_resolve, reject) => {
+          rejectRea = reject
+        }),
+      )
+      .mockReturnValueOnce(
+        new Promise<SkillSearchResult[]>((r) => {
+          resolveReact = r
+        }),
+      )
+    const store = await createTestStore()
+    const { searchSkills, setMarketplaceSearchQuery } =
+      await import('./marketplaceSlice')
+
+    // Act
+    store.dispatch(setMarketplaceSearchQuery('rea'))
+    const reaSearch = store.dispatch(searchSkills('rea'))
+    store.dispatch(setMarketplaceSearchQuery('react'))
+    const reactSearch = store.dispatch(searchSkills('react'))
+    resolveReact([sampleResult])
+    await reactSearch
+    rejectRea(new Error('rea timed out'))
+    await reaSearch
+
+    // Assert — the superseded failure must not raise an error banner over the
+    // "react" results the user is actually looking at.
+    const state = store.getState().marketplace
+    expect(state.error).toBeNull()
+    expect(state.status).toBe('idle')
+    expect(state.searchResults).toEqual([sampleResult])
+  })
+
+  it('discards a search response that lands after the box is cleared', async () => {
+    // Arrange — a search is still in flight when the user empties the box.
+    let resolveSearch!: (value: SkillSearchResult[]) => void
+    mockSearch.mockReturnValue(
+      new Promise<SkillSearchResult[]>((r) => {
+        resolveSearch = r
+      }),
+    )
+    const store = await createTestStore()
+    const { searchSkills, setMarketplaceSearchQuery, clearSearchResults } =
+      await import('./marketplaceSlice')
+
+    // Act — fire "react", clear the box, then let the response arrive.
+    store.dispatch(setMarketplaceSearchQuery('react'))
+    const search = store.dispatch(searchSkills('react'))
+    store.dispatch(clearSearchResults())
+    resolveSearch([sampleResult])
+    await search
+
+    // Assert — the emptied box stays on the leaderboard; the late response
+    // does not repopulate stale results behind it.
+    const state = store.getState().marketplace
+    expect(state.searchQuery).toBe('')
+    expect(state.searchResults).toEqual([])
+    expect(state.status).toBe('idle')
+  })
+
+  it('returns the panel to idle when the box is cleared mid-search', async () => {
+    // Arrange — keep a search pending so the panel sits in 'searching'.
+    mockSearch.mockReturnValue(new Promise<SkillSearchResult[]>(() => {}))
+    const store = await createTestStore()
+    const { searchSkills, setMarketplaceSearchQuery, clearSearchResults } =
+      await import('./marketplaceSlice')
+    store.dispatch(setMarketplaceSearchQuery('react'))
+    store.dispatch(searchSkills('react'))
+    expect(store.getState().marketplace.status).toBe('searching')
+
+    // Act
+    store.dispatch(clearSearchResults())
+
+    // Assert — the input spinner must not outlive the emptied box.
+    expect(store.getState().marketplace.status).toBe('idle')
+  })
+
+  it('clears a stranded error banner when the box is emptied after a failed search', async () => {
+    // Arrange — a search fails, leaving the destructive error banner on screen.
+    // The banner renders on `error` (not `status`), so emptying the box must
+    // wipe `error` too or the red banner outlives the query over the leaderboard.
+    mockSearch.mockRejectedValue(new Error('skills CLI offline'))
+    const store = await createTestStore()
+    const { searchSkills, setMarketplaceSearchQuery, clearSearchResults } =
+      await import('./marketplaceSlice')
+    store.dispatch(setMarketplaceSearchQuery('react'))
+    await store.dispatch(searchSkills('react'))
+    expect(store.getState().marketplace.error).toBe('skills CLI offline')
+
+    // Act — empty the box.
+    store.dispatch(clearSearchResults())
+
+    // Assert — no error string survives to render a banner over the leaderboard.
+    expect(store.getState().marketplace.error).toBeNull()
+    expect(store.getState().marketplace.status).toBe('idle')
   })
 
   // --- installSkill thunk ---

--- a/src/renderer/src/redux/slices/marketplaceSlice.ts
+++ b/src/renderer/src/redux/slices/marketplaceSlice.ts
@@ -161,6 +161,12 @@ const marketplaceSlice = createSlice({
     clearSearchResults: (state) => {
       state.searchResults = []
       state.searchQuery = ''
+      // Emptying the box returns to the leaderboard, so reset BOTH halves of the
+      // status/error pair: the input spinner keys off `status`, but the error
+      // banner renders on `error` itself — clearing only one leaves the last
+      // query's spinner or red banner stranded over the leaderboard.
+      state.status = 'idle'
+      state.error = null
     },
   },
   extraReducers: (builder) => {
@@ -171,10 +177,20 @@ const marketplaceSlice = createSlice({
         state.error = null
       })
       .addCase(searchSkills.fulfilled, (state, action) => {
+        // Latest-wins guard. Incremental search fires a new `skills find` on
+        // every debounced keystroke, and the CLI runs them concurrently — we
+        // never abort, because cancel() kills *every* child (the latest search
+        // and any install too). So an earlier "rea" response can resolve after
+        // "react"; drop any whose query no longer matches the box. `meta.arg`
+        // is the query that was searched; `searchQuery` is what's committed now.
+        if (action.meta.arg !== state.searchQuery) return
         state.status = 'idle'
         state.searchResults = action.payload
       })
       .addCase(searchSkills.rejected, (state, action) => {
+        // Same guard: a superseded query's failure must not raise an error
+        // banner over the results the user is actually looking at.
+        if (action.meta.arg !== state.searchQuery) return
         state.status = 'error'
         state.error = action.error.message || 'Search failed'
       })

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -942,6 +942,18 @@ export const UNDO_WINDOW_MS = 15_000
 export const COPIED_FEEDBACK_DURATION_MS = 1600
 
 /**
+ * Quiet period (ms) the marketplace search box waits after the last keystroke
+ * before firing a remote `skills find` call. Exists because search runs as the
+ * user types (incremental search) and each call spawns an `npx skills` child —
+ * debouncing collapses a burst of keystrokes into one request. Consumed by
+ * `useDebouncedCallback` inside `MarketplaceSearch`; tuned to feel instant while
+ * sparing the CLI from per-character churn.
+ * @example
+ * const search = useDebouncedCallback(runSearch, SEARCH_DEBOUNCE_MS)
+ */
+export const SEARCH_DEBOUNCE_MS = 300
+
+/**
  * Batch size at which bulk ops surface a live per-item progress counter in the
  * toolbar. Below this, the final `.fulfilled` toast is a better UX than a
  * flashing "k of n". Main-process `emitProgress` and renderer-side display


### PR DESCRIPTION
## What

Button-less incremental search for the Marketplace tab. Each keystroke fires a debounced `skills find`; results stream into the panel with no submit button.

## Changes
- **useDebouncedCallback** hook (`{ run, cancel }`) — debounces the callback, fired from `onChange`, per the repo's no-effect lint rules
- **MarketplaceSearch** — incremental search; Search↔Loader2 icon morph; clearing the box returns to the leaderboard
- **marketplaceSlice** — latest-wins guard drops out-of-order concurrent CLI responses; `clearSearchResults` now resets both `status` **and** `error` so a failed query's banner can't outlive the box
- **SkillsMarketplace** — no-flash refine (keeps prior results visible while re-searching)
- `SEARCH_DEBOUNCE_MS` = 300ms

## Tests
- slice: latest-wins (out-of-order resolve, stale failure), clear-mid-search, stranded-error-banner regression
- debounce primitive: final-call-only burst, cancel drops pending
- composed browser test: single search after a burst, clear→leaderboard, cancel-on-clear
- `pnpm validate` green (lint / 1421 tests / typecheck / dead-code)

Also folds in two small doc commits from the same session (CLAUDE.md `/ship` framing, DESIGN.md empty-state + form-chrome rules).

Note: no version bump — releases are owned by `/electron-release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * マーケットプレイス検索がリアルタイム検索に対応しました。検索ボタンやEnterキーを押さずに、入力中に自動的に検索結果が更新されるようになります。

* **Bug Fixes**
  * 検索中のスピナー表示と検索結果の状態管理を改善し、意図しない重複表示を防ぎました。

* **Documentation**
  * 検索入力フィールドのUI設計指針を追加し、空状態の表示ルールを明確化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->