### PR TITLE
feat: route bookmark Skill Install through the shared Marketplace modal

### DIFF
--- a/src/renderer/src/components/layout/MainContent.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.browser.test.tsx
@@ -112,6 +112,11 @@ beforeEach(() => {
       clearOrphanSymlinks: mockClearOrphanSymlinks,
       unlinkManyFromAgent: mockUnlinkManyFromAgent,
     },
+    // MainContent now hosts useMarketplaceProgress(), whose mount effect
+    // subscribes to install progress — stub it so the effect's cleanup is valid.
+    skillsCli: {
+      onProgress: vi.fn(() => () => {}),
+    },
     shell: {
       openExternal: mockShellOpenExternal,
     },
@@ -375,6 +380,35 @@ describe('MainContent Installed search count display', () => {
   })
 })
 
+describe('MainContent hosts the shared InstallModal', () => {
+  it('opens the Install Skill dialog when a skill is selected for install (e.g. from a sidebar bookmark)', async () => {
+    // Arrange
+    // MainContent is the always-mounted host for <InstallModal/> (hoisted out of
+    // SkillsMarketplace, which Radix unmounts when the Marketplace tab is inactive).
+    // This test deliberately does NOT mount its own InstallModal, so it fails if
+    // MainContent stops rendering it — guarding the cross-tree path that sidebar
+    // bookmark installs depend on (BookmarkItem/BookmarkDetailModal unit tests
+    // mount their own sibling and cannot catch this regression).
+    const { screen, store } = await renderMainContent()
+    const { selectSkillForInstall } =
+      await import('@/renderer/src/redux/slices/marketplaceSlice')
+
+    // Act
+    // Exactly the payload BookmarkItem/BookmarkDetailModal dispatch from the sidebar.
+    store.dispatch(
+      selectSkillForInstall({
+        name: 'task',
+        repo: repositoryId('vercel-labs/skills'),
+      }),
+    )
+
+    // Assert
+    await expect
+      .element(screen.getByRole('dialog', { name: 'Install Skill' }))
+      .toBeInTheDocument()
+  })
+})
+
 describe('MainContent bulk-select toggle button', () => {
   it('labels the bulk toggle "Select" and unpressed before the user enters bulk mode', async () => {
     // Arrange
@@ -629,6 +663,45 @@ describe('MainContent keyboard shortcuts (Esc 2-step)', () => {
     } finally {
       document.body.removeChild(textInput)
     }
+  })
+
+  it('does not clear the selection or exit bulk mode when Escape closes an open install modal overlaying the Installed tab', async () => {
+    // Arrange
+    // The always-mounted InstallModal (hoisted onto MainContent so sidebar
+    // bookmark installs open it on any tab) can now overlay the Installed tab
+    // while bulk-select is active. Escape must close ONLY the modal; without the
+    // open-dialog guard in handleKey, the same Escape would also clear the
+    // selection — a double-fire that silently wipes the user's batch.
+    const { screen, store } = await renderMainContent()
+    const { enterBulkSelectMode } =
+      await import('@/renderer/src/redux/slices/uiSlice')
+    const { toggleSelection } =
+      await import('@/renderer/src/redux/slices/skillsSlice')
+    const { selectSkillForInstall } =
+      await import('@/renderer/src/redux/slices/marketplaceSlice')
+
+    store.dispatch(enterBulkSelectMode())
+    store.dispatch(toggleSelection('task' as SkillName))
+    await waitForBulkSelectReady(screen)
+
+    // Open the shared InstallModal (exactly the sidebar bookmark install path),
+    // then wait for the Radix dialog to mount with data-state="open".
+    store.dispatch(
+      selectSkillForInstall({
+        name: 'task',
+        repo: repositoryId('vercel-labs/skills'),
+      }),
+    )
+    await expect
+      .element(screen.getByRole('dialog', { name: 'Install Skill' }))
+      .toBeInTheDocument()
+
+    // Act
+    dispatchKey({ key: 'Escape' })
+
+    // Assert
+    expect(store.getState().skills.selectedSkillNames).toEqual(['task'])
+    expect(store.getState().ui.bulkSelectMode).toBe(true)
   })
 })
 

--- a/src/renderer/src/components/layout/MainContent.selectionToolbar.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.selectionToolbar.browser.test.tsx
@@ -158,6 +158,10 @@ describe('MainContent SelectionToolbar integration', () => {
         onDeleteProgress: mockOnDeleteProgress,
         unlinkManyFromAgent: mockUnlinkManyFromAgent,
       },
+      // MainContent now hosts useMarketplaceProgress(); stub its subscription.
+      skillsCli: {
+        onProgress: vi.fn(() => () => {}),
+      },
     })
   })
 

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -12,6 +12,7 @@ import { toast } from 'sonner'
 
 import { SymlinkCleanupDialog } from '@/renderer/src/components/dashboard/SymlinkCleanupDialog'
 import { SkillsMarketplace } from '@/renderer/src/components/marketplace'
+import { InstallModal } from '@/renderer/src/components/marketplace/InstallModal'
 import { CleanupAgentDialog } from '@/renderer/src/components/sidebar/CleanupAgentDialog'
 import { SyncConfirmDialog } from '@/renderer/src/components/sidebar/SyncConfirmDialog'
 import { SyncConflictDialog } from '@/renderer/src/components/sidebar/SyncConflictDialog'
@@ -63,6 +64,7 @@ import {
 } from '@/renderer/src/components/ui/tabs'
 import { useCycleEffect } from '@/renderer/src/hooks/useCycleEffect'
 import { useInitialEffect } from '@/renderer/src/hooks/useInitialEffect'
+import { useMarketplaceProgress } from '@/renderer/src/hooks/useMarketplaceProgress'
 import { useRenderEffect } from '@/renderer/src/hooks/useRenderEffect'
 import { cn } from '@/renderer/src/lib/utils'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
@@ -353,6 +355,10 @@ function appendDeleteRescanSummary(
 export const MainContent = React.memo(
   function MainContent(): React.ReactElement {
     const dispatch = useAppDispatch()
+    // Subscribe to install progress here (always-mounted host) rather than in
+    // SkillsMarketplace — the marketplace tab unmounts when "installed" is
+    // active, but bookmark installs fire from the always-visible sidebar.
+    useMarketplaceProgress()
     const selectedAgentId = useAppSelector((state) => state.ui.selectedAgentId)
     const sortOrder = useAppSelector((state) => state.ui.sortOrder)
     const skillTypeFilter = useAppSelector((state) => state.ui.skillTypeFilter)
@@ -441,6 +447,20 @@ export const MainContent = React.memo(
       const handleKey = (event: KeyboardEvent): void => {
         if (isEditableTarget(document.activeElement)) return
         if (!bulkSelectModeRef.current) return
+
+        // An open Radix dialog/alertdialog (e.g. the now always-mounted
+        // InstallModal — hoisted onto MainContent so sidebar-bookmark installs
+        // open it on any tab, including Installed) overlays this tab and owns
+        // Escape/Cmd+A while open. Bail so the modal, not the bulk-select
+        // handler, consumes the key: otherwise one Escape both closes the dialog
+        // AND clears the selection (a double-fire), and Cmd+A select-all leaks
+        // behind the modal.
+        if (
+          document.querySelector(
+            '[role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"]',
+          )
+        )
+          return
 
         // Cmd/Ctrl+A: select all visible
         if (
@@ -1304,6 +1324,12 @@ export const MainContent = React.memo(
           </TabsContent>
         </Tabs>
 
+        {/*
+          Shared install dialog — mounted here (always-rendered sibling of the
+          tabs) so BOTH marketplace rows and sidebar bookmarks open the exact
+          same agent-target picker. Redux-driven via marketplace.selectedSkill.
+        */}
+        <InstallModal />
         <UnlinkDialog />
         <AddSymlinkModal />
         <CopyToAgentsModal />

--- a/src/renderer/src/components/marketplace/SkillsMarketplace.tsx
+++ b/src/renderer/src/components/marketplace/SkillsMarketplace.tsx
@@ -2,12 +2,10 @@ import { Package, WifiOff } from 'lucide-react'
 import React, { useCallback, useMemo, useState } from 'react'
 
 import { useCycleEffect } from '@/renderer/src/hooks/useCycleEffect'
-import { useMarketplaceProgress } from '@/renderer/src/hooks/useMarketplaceProgress'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import { loadLeaderboard } from '@/renderer/src/redux/slices/marketplaceSlice'
 import type { RankingFilter } from '@/shared/types'
 
-import { InstallModal } from './InstallModal'
 import { LeaderboardSkeleton } from './LeaderboardSkeleton'
 import { MarketplaceSearch } from './MarketplaceSearch'
 import { RankingTabs } from './RankingTabs'
@@ -45,9 +43,6 @@ function formatUpdatedAgo(timestamp: number): string {
  */
 export const SkillsMarketplace = React.memo(
   function SkillsMarketplace(): React.ReactElement {
-    // Subscribe to installation progress events
-    useMarketplaceProgress()
-
     const dispatch = useAppDispatch()
     const [rankingFilter, setRankingFilter] =
       useState<RankingFilter>('all-time')
@@ -219,8 +214,6 @@ export const SkillsMarketplace = React.memo(
             )}
           </div>
         </div>
-
-        <InstallModal />
       </div>
     )
   },

--- a/src/renderer/src/components/sidebar/BookmarkDetailModal.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/BookmarkDetailModal.browser.test.tsx
@@ -1,0 +1,113 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import type { BookmarkForDetail } from '@/renderer/src/redux/slices/uiSlice'
+import { repositoryId } from '@/shared/types'
+
+/**
+ * Build a not-yet-installed bookmark fixture so the detail modal shows its
+ * Install button (its repo is non-empty, so the install path is reachable).
+ * @param overrides - Fields that differ from the default fixture.
+ * @returns Complete BookmarkForDetail accepted by uiSlice.
+ * @example makeBookmark({ name: 'lint' })
+ */
+function makeBookmark(
+  overrides: Partial<BookmarkForDetail> = {},
+): BookmarkForDetail {
+  return {
+    name: 'task',
+    repo: repositoryId('vercel-labs/skills'),
+    url: 'https://skills.sh/task',
+    bookmarkedAt: '2026-04-01T08:00:00.000Z',
+    isInstalled: false,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.stubGlobal('electron', {
+    skillsCli: {
+      search: vi.fn(),
+      install: vi.fn(),
+      cancel: vi.fn(),
+      onProgress: vi.fn(() => () => {}),
+    },
+    skills: {
+      getAll: vi.fn().mockResolvedValue([]),
+      onDeleteProgress: vi.fn(() => () => {}),
+    },
+    agents: { getAll: vi.fn().mockResolvedValue([]) },
+    marketplace: { leaderboard: vi.fn().mockResolvedValue([]) },
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+/**
+ * Build the reducer store shared by BookmarkDetailModal and the InstallModal it
+ * hands off to.
+ * @returns Redux store with ui, marketplace, agents, and skills slices.
+ */
+async function createStore() {
+  const [
+    { default: uiReducer },
+    { default: marketplaceReducer },
+    { default: agentsReducer },
+    { default: skillsReducer },
+  ] = await Promise.all([
+    import('@/renderer/src/redux/slices/uiSlice'),
+    import('@/renderer/src/redux/slices/marketplaceSlice'),
+    import('@/renderer/src/redux/slices/agentsSlice'),
+    import('@/renderer/src/redux/slices/skillsSlice'),
+  ])
+
+  return configureStore({
+    reducer: {
+      ui: uiReducer,
+      marketplace: marketplaceReducer,
+      agents: agentsReducer,
+      skills: skillsReducer,
+    },
+  })
+}
+
+describe('BookmarkDetailModal install', () => {
+  it('closes the detail modal and opens the shared Install Skill modal seeded with the bookmark', async () => {
+    // Arrange
+    const store = await createStore()
+    const { BookmarkDetailModal } = await import('./BookmarkDetailModal')
+    const { InstallModal } =
+      await import('@/renderer/src/components/marketplace/InstallModal')
+    const { setSelectedBookmarkForDetail } =
+      await import('@/renderer/src/redux/slices/uiSlice')
+    const screen = await render(
+      <Provider store={store}>
+        <BookmarkDetailModal />
+        <InstallModal />
+      </Provider>,
+    )
+    store.dispatch(setSelectedBookmarkForDetail(makeBookmark()))
+    await expect
+      .element(screen.getByRole('button', { name: 'Remove Bookmark' }))
+      .toBeInTheDocument()
+
+    // Act
+    await screen.getByRole('button', { name: 'Install' }).click()
+
+    // Assert
+    await expect
+      .element(screen.getByRole('dialog', { name: 'Install Skill' }))
+      .toBeInTheDocument()
+    await expect
+      .poll(() => store.getState().ui.selectedBookmarkForDetail)
+      .toBeNull()
+    expect(store.getState().marketplace.selectedSkill).toEqual({
+      name: 'task',
+      repo: 'vercel-labs/skills',
+    })
+  })
+})

--- a/src/renderer/src/components/sidebar/BookmarkDetailModal.tsx
+++ b/src/renderer/src/components/sidebar/BookmarkDetailModal.tsx
@@ -1,5 +1,5 @@
-import { Check, ExternalLink, Loader2 } from 'lucide-react'
-import React, { useCallback, useRef, useState } from 'react'
+import { Check, ExternalLink } from 'lucide-react'
+import React, { useCallback } from 'react'
 
 import { Button } from '@/renderer/src/components/ui/button'
 import {
@@ -12,8 +12,7 @@ import {
 import { Separator } from '@/renderer/src/components/ui/separator'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import { removeBookmark } from '@/renderer/src/redux/slices/bookmarkSlice'
-import { installSkill } from '@/renderer/src/redux/slices/marketplaceSlice'
-import { fetchSkills } from '@/renderer/src/redux/slices/skillsSlice'
+import { selectSkillForInstall } from '@/renderer/src/redux/slices/marketplaceSlice'
 import {
   clearSelectedBookmarkForDetail,
   selectSelectedBookmarkForDetail,
@@ -29,50 +28,21 @@ export const BookmarkDetailModal = React.memo(
   function BookmarkDetailModal(): React.ReactElement | null {
     const dispatch = useAppDispatch()
     const bookmark = useAppSelector(selectSelectedBookmarkForDetail)
-    const [isInstalling, setIsInstalling] = useState(false)
-    const [installSuccess, setInstallSuccess] = useState(false)
-    const [installError, setInstallError] = useState<string | null>(null)
-    // Generation counter: invalidates in-flight installs when modal closes/reopens
-    const installGenRef = useRef(0)
 
     const handleClose = useCallback((): void => {
-      installGenRef.current++
       dispatch(clearSelectedBookmarkForDetail())
-      setIsInstalling(false)
-      setInstallSuccess(false)
-      setInstallError(null)
     }, [dispatch])
 
-    const handleInstall = useCallback(async (): Promise<void> => {
+    // Hand off to the shared InstallModal (the exact marketplace install path):
+    // close this detail dialog, then open the agent-target picker seeded with
+    // this bookmark. No local install state — InstallModal owns progress/errors
+    // and refreshes the skill list, so the sidebar's Installed badge updates.
+    const handleInstall = useCallback((): void => {
       if (!bookmark || !bookmark.repo) return
-      const gen = ++installGenRef.current
-      setIsInstalling(true)
-      setInstallError(null)
-      try {
-        const success = await dispatch(
-          installSkill({
-            repo: bookmark.repo,
-            global: true,
-            agents: [],
-            skills: [bookmark.name],
-          }),
-        ).unwrap()
-        if (gen !== installGenRef.current) return
-        if (success) {
-          setInstallSuccess(true)
-          dispatch(fetchSkills())
-        } else {
-          setInstallError('Installation did not complete successfully')
-        }
-      } catch (err) {
-        if (gen !== installGenRef.current) return
-        const message = (err as { message?: string })?.message ?? String(err)
-        setInstallError(message)
-      } finally {
-        if (gen === installGenRef.current) {
-          setIsInstalling(false)
-        }
-      }
+      dispatch(
+        selectSkillForInstall({ name: bookmark.name, repo: bookmark.repo }),
+      )
+      dispatch(clearSelectedBookmarkForDetail())
     }, [bookmark, dispatch])
 
     const handleRemoveBookmark = useCallback((): void => {
@@ -88,7 +58,7 @@ export const BookmarkDetailModal = React.memo(
       [handleClose],
     )
 
-    const isInstalled = bookmark?.isInstalled || installSuccess
+    const isInstalled = bookmark?.isInstalled ?? false
 
     return (
       <Dialog open={bookmark !== null} onOpenChange={handleOpenChange}>
@@ -136,12 +106,7 @@ export const BookmarkDetailModal = React.memo(
                     Installed
                   </span>
                 ) : bookmark.repo ? (
-                  <Button onClick={handleInstall} disabled={isInstalling}>
-                    {isInstalling && (
-                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                    )}
-                    {isInstalling ? 'Installing...' : 'Install'}
-                  </Button>
+                  <Button onClick={handleInstall}>Install</Button>
                 ) : (
                   <span className="text-sm text-muted-foreground">
                     Not installed
@@ -151,12 +116,6 @@ export const BookmarkDetailModal = React.memo(
                   Remove Bookmark
                 </Button>
               </div>
-
-              {installError && (
-                <p className="text-sm text-amber-500">
-                  Install failed: {installError}
-                </p>
-              )}
             </>
           )}
         </DialogContent>

--- a/src/renderer/src/components/sidebar/BookmarkItem.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/BookmarkItem.browser.test.tsx
@@ -1,0 +1,134 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
+import type { BookmarkForDetail } from '@/renderer/src/redux/slices/uiSlice'
+import { repositoryId } from '@/shared/types'
+
+/**
+ * Build a not-yet-installed sidebar bookmark fixture (so the Install affordance
+ * renders rather than the "Installed" check).
+ * @param overrides - Fields that differ from the default fixture.
+ * @returns Complete BookmarkForDetail accepted by BookmarkItem.
+ * @example makeBookmark({ name: 'lint' })
+ */
+function makeBookmark(
+  overrides: Partial<BookmarkForDetail> = {},
+): BookmarkForDetail {
+  return {
+    name: 'task',
+    repo: repositoryId('vercel-labs/skills'),
+    url: 'https://skills.sh/task',
+    bookmarkedAt: '2026-04-01T08:00:00.000Z',
+    isInstalled: false,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  // InstallModal reads only Redux state on mount, but stub the IPC bridge so any
+  // incidental window.electron access never throws in the Chromium lane.
+  vi.stubGlobal('electron', {
+    skillsCli: {
+      search: vi.fn(),
+      install: vi.fn(),
+      cancel: vi.fn(),
+      onProgress: vi.fn(() => () => {}),
+    },
+    skills: {
+      getAll: vi.fn().mockResolvedValue([]),
+      onDeleteProgress: vi.fn(() => () => {}),
+    },
+    agents: { getAll: vi.fn().mockResolvedValue([]) },
+    marketplace: { leaderboard: vi.fn().mockResolvedValue([]) },
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+/**
+ * Build the reducer store shared by BookmarkItem and the hoisted InstallModal.
+ * @returns Redux store with marketplace, agents, and skills slices.
+ */
+async function createStore() {
+  const [
+    { default: marketplaceReducer },
+    { default: agentsReducer },
+    { default: skillsReducer },
+  ] = await Promise.all([
+    import('@/renderer/src/redux/slices/marketplaceSlice'),
+    import('@/renderer/src/redux/slices/agentsSlice'),
+    import('@/renderer/src/redux/slices/skillsSlice'),
+  ])
+
+  return configureStore({
+    reducer: {
+      marketplace: marketplaceReducer,
+      agents: agentsReducer,
+      skills: skillsReducer,
+    },
+  })
+}
+
+describe('BookmarkItem install', () => {
+  it('opens the shared Install Skill modal seeded with the bookmark', async () => {
+    // Arrange
+    const store = await createStore()
+    const { BookmarkItem } = await import('./BookmarkItem')
+    const { InstallModal } =
+      await import('@/renderer/src/components/marketplace/InstallModal')
+    const bookmark = makeBookmark()
+    const screen = await render(
+      <Provider store={store}>
+        <TooltipProvider>
+          <BookmarkItem bookmark={bookmark} />
+          <InstallModal />
+        </TooltipProvider>
+      </Provider>,
+    )
+
+    // Act
+    await screen.getByRole('button', { name: 'Install task' }).click()
+
+    // Assert
+    await expect
+      .element(screen.getByRole('dialog', { name: 'Install Skill' }))
+      .toBeInTheDocument()
+    expect(store.getState().marketplace.selectedSkill).toEqual({
+      name: 'task',
+      repo: 'vercel-labs/skills',
+    })
+  })
+
+  it('does not open the install modal for a bookmark with no source repo', async () => {
+    // Arrange
+    const store = await createStore()
+    const { BookmarkItem } = await import('./BookmarkItem')
+    const { InstallModal } =
+      await import('@/renderer/src/components/marketplace/InstallModal')
+    // A repo-less bookmark still shows the Install affordance, but the empty-repo
+    // guard must make the click a no-op (there is nothing to install from).
+    const localBookmark = makeBookmark({ repo: '' })
+    const screen = await render(
+      <Provider store={store}>
+        <TooltipProvider>
+          <BookmarkItem bookmark={localBookmark} />
+          <InstallModal />
+        </TooltipProvider>
+      </Provider>,
+    )
+
+    // Act
+    await screen.getByRole('button', { name: 'Install task' }).click()
+
+    // Assert
+    expect(store.getState().marketplace.selectedSkill).toBeNull()
+    expect(
+      screen.getByRole('dialog', { name: 'Install Skill' }).query(),
+    ).toBeNull()
+  })
+})

--- a/src/renderer/src/components/sidebar/BookmarkItem.tsx
+++ b/src/renderer/src/components/sidebar/BookmarkItem.tsx
@@ -7,9 +7,9 @@ import {
   TooltipTrigger,
 } from '@/renderer/src/components/ui/tooltip'
 import { cn } from '@/renderer/src/lib/utils'
-import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
+import { useAppDispatch } from '@/renderer/src/redux/hooks'
 import { removeBookmark } from '@/renderer/src/redux/slices/bookmarkSlice'
-import { installSkill } from '@/renderer/src/redux/slices/marketplaceSlice'
+import { selectSkillForInstall } from '@/renderer/src/redux/slices/marketplaceSlice'
 import type { BookmarkForDetail } from '@/renderer/src/redux/slices/uiSlice'
 import { setSelectedBookmarkForDetail } from '@/renderer/src/redux/slices/uiSlice'
 
@@ -28,20 +28,15 @@ export const BookmarkItem = React.memo(function BookmarkItem({
   bookmark,
 }: BookmarkItemProps): React.ReactElement {
   const dispatch = useAppDispatch()
-  const isInstalling = useAppSelector(
-    (state) => state.marketplace.status === 'installing',
-  )
 
+  // Open the shared InstallModal (the exact marketplace install path) seeded
+  // with this bookmark, instead of firing a hardcoded universal-only install.
+  // stopPropagation keeps the row's own click (open detail modal) from firing.
   const handleInstall = (e: React.MouseEvent): void => {
     e.stopPropagation()
     if (!bookmark.repo) return
     dispatch(
-      installSkill({
-        repo: bookmark.repo,
-        global: true,
-        agents: [],
-        skills: [bookmark.name],
-      }),
+      selectSkillForInstall({ name: bookmark.name, repo: bookmark.repo }),
     )
   }
 
@@ -110,7 +105,6 @@ export const BookmarkItem = React.memo(function BookmarkItem({
             aria-label={`Install ${bookmark.name}`}
             className="shrink-0 flex size-6 items-center justify-center rounded-md text-primary opacity-0 transition-[opacity,background-color,color] hover:bg-primary/10 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             onClick={handleInstall}
-            disabled={isInstalling}
           >
             <Download className="h-3.5 w-3.5" />
           </button>

--- a/src/renderer/src/redux/slices/marketplaceSlice.ts
+++ b/src/renderer/src/redux/slices/marketplaceSlice.ts
@@ -6,6 +6,7 @@ import type {
   RankingFilter,
   SearchQuery,
   SkillSearchResult,
+  InstallIntent,
   InstallOptions,
   InstallProgress,
   MarketplaceStatus,
@@ -30,8 +31,8 @@ interface MarketplaceState {
   searchQuery: SearchQuery
   /** Results from the most recent `skills find` call. */
   searchResults: SkillSearchResult[]
-  /** Skill chosen in the install modal. */
-  selectedSkill: SkillSearchResult | null
+  /** Skill chosen in the install modal — name + repo only (see InstallIntent). */
+  selectedSkill: InstallIntent | null
   /** Skill selected for right-pane webview preview (separate from install modal). */
   previewSkill: SkillSearchResult | null
   /** Live progress for an in-flight install, or null when idle. */
@@ -133,7 +134,7 @@ const marketplaceSlice = createSlice({
     },
     selectSkillForInstall: (
       state,
-      action: PayloadAction<SkillSearchResult | null>,
+      action: PayloadAction<InstallIntent | null>,
     ) => {
       state.selectedSkill = action.payload
     },

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -663,6 +663,17 @@ export interface SkillSearchResult {
 }
 
 /**
+ * Minimal identity the install modal needs to drive an install: just the skill
+ * name and its source repo. Exists so every install entry point (marketplace
+ * rows AND sidebar bookmarks) can open the one shared `InstallModal` without
+ * fabricating the leaderboard-only fields (`rank`, `url`, `installCount`) that
+ * a bookmark has no business inventing. Set as `marketplace.selectedSkill` via
+ * `selectSkillForInstall`; read by `InstallModal`.
+ * @example { name: 'task', repo: 'vercel-labs/skills' }
+ */
+export type InstallIntent = Pick<SkillSearchResult, 'name' | 'repo'>
+
+/**
  * A skill bookmarked for later reinstall.
  * Stored in Redux and persisted to localStorage.
  * @example


### PR DESCRIPTION
## What

Routes the sidebar **bookmark Install** action through the exact same path as a Marketplace install: it now opens the shared `<InstallModal/>` (agent-target picker → `installSkill` thunk → skills CLI) instead of firing a hardcoded universal-only install. Phase 2 of the marathon: "ブックマークのSkill InstallをMarketplaceでのインストールと全く同じ方法に変更".

## Why

Before, a bookmark install was a separate, lesser code path (universal-only, no agent picker, no progress/error surface). Users got inconsistent behavior depending on where they clicked Install. Now both entry points converge on one well-tested install flow.

## How

- `BookmarkItem` / `BookmarkDetailModal` dispatch `selectSkillForInstall({ name, repo })` (the same payload the Marketplace row dispatches) instead of a bespoke install thunk.
- `<InstallModal/>` is **hoisted out of `SkillsMarketplace`** (which Radix unmounts when the Marketplace tab is inactive) up to the always-mounted `MainContent`, so a sidebar bookmark can open it on any tab — including Installed.
- `marketplaceSlice` / `types.ts`: small typing additions for the shared install intent.

## Review (this session, on this exact commit)

`/review` Fix-First + Codex adversarial (structured, diff > 200 lines) ran on `16795e4`:

- **F1 (MEDIUM) — FIXED:** Hoisting InstallModal let its Escape/Cmd+A leak into the Installed-tab bulk-select handler (one Escape would both close the modal *and* clear the batch — a double-fire). Added an open-dialog guard in `MainContent` `handleKey` + a regression test.
- **F2 (MEDIUM) — DEFERRED (follow-up):** `InstallModal` has no in-modal error surface, so an install failing off the Marketplace tab closes silently. `InstallModal.tsx` is **unchanged by this PR** (reused verbatim = the spec, 全く同じ方法); the only correct fix mutates `marketplaceSlice`'s status/error which is shared with search — a separate feature with cross-feature blast radius. Pre-existing; does not block merge.

## Test plan

- `pnpm validate` → EXIT=0 (1498 tests, lint/typecheck/dead-code/dupes/health/storybook all green)
- `pnpm test:e2e` → 58/58 passed
- New tests: BookmarkItem install (happy-path + empty-repo no-op), BookmarkDetailModal install handoff, MainContent shared-InstallModal cross-tree regression guard, MainContent Escape-with-open-dialog guard.

Version stays `0.23.0` — `/electron-release` owns versioning (project rule).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * スキルのインストール処理を統一し、マーケットプレイスとブックマークから同一のインストールダイアログを使用するよう改善しました。
  * インストール機能の管理を中央集約化し、操作フローをシンプル化しました。

* **Tests**
  * インストール機能に関する統合テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->