### PR TITLE
chore: sync skills CLI agent definitions to 1.5.11

### DIFF
--- a/.claude/skills/skills-cli-sync/SKILL.md
+++ b/.claude/skills/skills-cli-sync/SKILL.md
@@ -149,6 +149,25 @@ Do not bump `package.json` `version` — releases are owned solely by
 
 ## Latest run (example — point-in-time, NOT part of the procedure)
 
+**2026-06-14 · v1.5.10 → v1.5.11** (version-only bump)
+
+- **No agent-list change:** `src/agents.ts` is byte-identical between v1.5.10
+  and v1.5.11 (`diff` clean), so `AGENT_DEFINITIONS`, `UNIVERSAL_AGENT_IDS`, and
+  every doc agent-count stayed put. Drift gate confirmed: upstream `name:` set
+  (71) minus app `cliId` set (68) = exactly the 3 standing exclusions below;
+  zero app orphans.
+- **Edits:** bumped `SKILLS_CLI_VERSION` 1.5.10 → 1.5.11; bumped the e2e pin
+  (`marketplace-install-regression.e2e.ts` literal `skills@1.5.11 add …` +
+  comment); bumped the CLAUDE.md Domain-Concepts pinned-version cell.
+- **Unchanged history kept verbatim:** the "CLI 1.5.10" / "added in v1.5.10"
+  comments in `constants.ts` and the `*.test.ts` files are accurate history of
+  _when_ kimi migrated / agents landed — not bumped.
+- **Excluded at this version** (still valid, agents.ts unchanged): `promptscript`
+  (`globalSkillsDir: undefined`), `universal` (`showInUniversalList: false`),
+  `zenflow` (dir collides with zencoder's `~/.zencoder/skills`).
+- Gates: `reconcile-agents.mjs` clean, prettier clean, `pnpm validate` +
+  `pnpm test:e2e` green.
+
 **2026-06-05 · v1.5.5 → v1.5.10** (PR #204, commit `41b455e`)
 
 - **+14 community agents:** antigravity-cli, astrbot, autohand-code,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ PRs are ready to ship only when `validate` and e2e both pass in that order.
 | Repository     | https://github.com/vercel-labs/skills (paths below are inside that repo)                       |
 | CLI agent list | `src/agents.ts`                                                                                |
 | CLI types      | `src/types.ts`                                                                                 |
-| Pinned version | `SKILLS_CLI_VERSION` in `src/shared/constants.ts` (currently `1.5.10`) — bump when re-syncing `AGENT_DEFINITIONS` against the upstream skills CLI |
+| Pinned version | `SKILLS_CLI_VERSION` in `src/shared/constants.ts` (currently `1.5.11`) — bump when re-syncing `AGENT_DEFINITIONS` against the upstream skills CLI |
 
 `AGENT_DEFINITIONS` in `src/shared/constants.ts` mirrors the CLI's agent
 list. Each entry: `id` (app state), `cliId` (`--agent` flag), `name`

--- a/e2e/spec/marketplace-install-regression.e2e.ts
+++ b/e2e/spec/marketplace-install-regression.e2e.ts
@@ -162,14 +162,14 @@ test('Marketplace Install works when Electron starts with sparse macOS GUI PATH'
     await dialog.getByRole('button', { name: 'Install', exact: true }).click()
 
     // Assert — the fake npx ran with the pinned CLI version (SKILLS_CLI_VERSION
-    // is '1.5.10' in src/shared/constants.ts; hardcoded here so this test pins
+    // is '1.5.11' in src/shared/constants.ts; hardcoded here so this test pins
     // the literal command rather than computing the expectation from the same
     // constant the production command builds from) and the installed badge shows.
     await expect
       .poll(() => existsSync(markerPath), { timeout: 10_000 })
       .toBe(true)
     expect(readFileSync(markerPath, 'utf-8')).toContain(
-      'skills@1.5.10 add vercel-labs/skills',
+      'skills@1.5.11 add vercel-labs/skills',
     )
     await expect(
       appWindow.getByRole('img', { name: /find-skills is installed/i }),

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -976,7 +976,7 @@ export const TERMINAL_APP_UI_LABELS: Record<
  * @example
  * spawn('npx', [`skills@${SKILLS_CLI_VERSION}`, 'find', 'react'])
  */
-export const SKILLS_CLI_VERSION = '1.5.10'
+export const SKILLS_CLI_VERSION = '1.5.11'
 
 /**
  * Canonical hostname for skills marketplace pages used by renderer/main


### PR DESCRIPTION
## Summary

Sync the pinned upstream `vercel-labs/skills` CLI version to **1.5.11** (released 2026-06-11). This is a **version-only bump** — `src/agents.ts` is byte-identical between v1.5.10 and v1.5.11 (`diff` clean), so the agent model is untouched.

## Drift gate (clean)

| Check | Result |
| --- | --- |
| `reconcile-agents.mjs` | ✅ 68 agents match on `(cliId, detection-path)`, no drift |
| upstream `name:` set (71) − app `cliId` set (68) | exactly the 3 standing exclusions, zero app orphans |
| Exclusions still valid | `promptscript` (`globalSkillsDir: undefined`), `universal` (`showInUniversalList: false`), `zenflow` (dir collides with zencoder's `~/.zencoder/skills`) |

## Changes

- Bump `SKILLS_CLI_VERSION` `1.5.10` → `1.5.11` (`src/shared/constants.ts`).
- Bump the e2e pin in `marketplace-install-regression.e2e.ts` (literal `skills@1.5.11 add …` assertion + its comment) so it tracks the constant the production spawn templates from.
- Bump the `CLAUDE.md` Domain-Concepts pinned-version cell.
- Document the run in the `/skills-cli-sync` skill's "Latest run" section.
- Historical `CLI 1.5.10` comments in `constants.ts` and `*.test.ts` are **kept** — accurate history of when kimi migrated / community agents landed.

## Verification

- `reconcile-agents.mjs` clean, `prettier --check` clean.
- `pnpm validate` green (2118 tests).
- `pnpm test:e2e` green (58 tests), including the bumped `marketplace-install-regression` asserting `skills@1.5.11`.
- `npx skills@1.5.11` resolves — npm has 1.5.11.

No `package.json` version bump (releases owned solely by `/electron-release`; app stays 0.23.0).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Skills CLI バージョンを 1.5.11 にアップデートしました。
  * 関連するテストとドキュメントを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->