### PR TITLE
refactor(types): colorful-type annotation-only hardening across 34 files

### DIFF
--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -641,10 +641,7 @@ export function registerSkillsHandlers(): void {
         return { success: false, error: 'Agent not found' }
       }
 
-      const derivedLinkPath = assertAgentSlotPath(
-        linkPath,
-        agent.path as AbsolutePath,
-      )
+      const derivedLinkPath = assertAgentSlotPath(linkPath, agent.path)
 
       // Allow agent dirs (for local skills) AND SOURCE_DIR (for symlinked skills).
       // validatePath calls realpathSync, which follows the symlink to its source
@@ -739,7 +736,7 @@ export function registerSkillsHandlers(): void {
 
       const derivedAgentPath = assertDerivedPathMatch(
         agentPath,
-        agent.path as AbsolutePath,
+        agent.path,
         'agent path',
       )
 

--- a/src/main/services/agentScanner.ts
+++ b/src/main/services/agentScanner.ts
@@ -2,7 +2,7 @@ import { access, lstat, readdir } from 'fs/promises'
 import { join } from 'path'
 
 import { AGENTS } from '@/main/constants'
-import type { Agent } from '@/shared/types'
+import type { AbsolutePath, Agent, SkillCount } from '@/shared/types'
 
 import { filesystemIdentityFromStats } from './filesystemIdentity'
 import { checkSymlinkStatus } from './symlinkChecker'
@@ -73,7 +73,7 @@ export async function scanAgents(): Promise<Agent[]> {
  * @param agentPath - Path to agent's skills directory
  * @returns true if directory exists
  */
-async function checkAgentExists(agentPath: string): Promise<boolean> {
+async function checkAgentExists(agentPath: AbsolutePath): Promise<boolean> {
   try {
     await access(agentPath)
     return true
@@ -90,7 +90,7 @@ async function checkAgentExists(agentPath: string): Promise<boolean> {
  * countAgentSkills('/Users/.claude/skills')
  * // => 3 (only symlinks pointing to existing targets)
  */
-async function countAgentSkills(agentPath: string): Promise<number> {
+async function countAgentSkills(agentPath: AbsolutePath): Promise<SkillCount> {
   try {
     const entries = await readdir(agentPath, { withFileTypes: true })
     const symlinks = entries.filter((e) => e.isSymbolicLink())
@@ -118,7 +118,7 @@ async function countAgentSkills(agentPath: string): Promise<number> {
  * countLocalSkills('/Users/.claude/skills')
  * // => 1 (folders with SKILL.md, not symlinks)
  */
-async function countLocalSkills(agentPath: string): Promise<number> {
+async function countLocalSkills(agentPath: AbsolutePath): Promise<SkillCount> {
   try {
     const entries = await readdir(agentPath, { withFileTypes: true })
     // Get directories that are NOT symlinks and don't start with '.'

--- a/src/main/services/fileReader.ts
+++ b/src/main/services/fileReader.ts
@@ -13,6 +13,8 @@ import {
 } from '@/shared/fileTypes'
 import type { FilePreviewKind } from '@/shared/fileTypes'
 import type {
+  AbsolutePath,
+  PosixRelativePath,
   SkillBinaryContent,
   SkillFile,
   SkillFileContent,
@@ -39,7 +41,9 @@ import type {
  * //   { name: 'logo.png',   relativePath: 'assets/logo.png', previewable: 'image', ... },
  * // ]
  */
-export async function listSkillFiles(skillPath: string): Promise<SkillFile[]> {
+export async function listSkillFiles(
+  skillPath: AbsolutePath,
+): Promise<SkillFile[]> {
   let collected: SkillFile[]
   try {
     collected = await walk(skillPath, skillPath, 0)
@@ -54,23 +58,23 @@ export async function listSkillFiles(skillPath: string): Promise<SkillFile[]> {
 }
 
 async function walk(
-  rootPath: string,
-  dirPath: string,
+  rootPath: AbsolutePath,
+  dirPath: AbsolutePath,
   depth: number,
 ): Promise<SkillFile[]> {
   if (depth > MAX_TREE_DEPTH) return []
 
   let entries: Dirent[]
   try {
-    entries = (await readdir(dirPath, { withFileTypes: true })) as Dirent[]
+    entries = await readdir(dirPath, { withFileTypes: true })
   } catch {
     return []
   }
 
-  const subDirs: string[] = []
+  const subDirs: AbsolutePath[] = []
   const previewableFiles: Array<{
     entry: Dirent
-    fullPath: string
+    fullPath: AbsolutePath
     kind: 'text' | 'image'
   }> = []
 
@@ -116,9 +120,9 @@ async function walk(
 }
 
 async function buildFileEntry(
-  rootPath: string,
+  rootPath: AbsolutePath,
   entry: Dirent,
-  fullPath: string,
+  fullPath: AbsolutePath,
   kind: 'text' | 'image',
 ): Promise<SkillFile | null> {
   let size = 0
@@ -148,7 +152,10 @@ async function buildFileEntry(
  * separator to split on regardless of host OS.
  * @example toPosixRelative('/a/b', '/a/b/lib/x.py') // => 'lib/x.py'
  */
-function toPosixRelative(root: string, full: string): string {
+function toPosixRelative(
+  root: AbsolutePath,
+  full: AbsolutePath,
+): PosixRelativePath {
   const rel = full.slice(root.length).replace(/^[/\\]+/, '')
   return rel.split(/[/\\]+/).join('/')
 }
@@ -164,7 +171,7 @@ function toPosixRelative(root: string, full: string): string {
  * // => { name: 'SKILL.md', content: '...', extension: '.md', lineCount: 42 }
  */
 export async function readSkillFile(
-  filePath: string,
+  filePath: AbsolutePath,
 ): Promise<SkillFileContent | null> {
   try {
     const size = (await stat(filePath)).size
@@ -194,7 +201,7 @@ export async function readSkillFile(
  * // => { name: 'logo.png', dataUrl: 'data:image/png;base64,...', mimeType: 'image/png', size: 2048 }
  */
 export async function readBinaryFile(
-  filePath: string,
+  filePath: AbsolutePath,
 ): Promise<SkillBinaryContent | null> {
   try {
     const size = (await stat(filePath)).size

--- a/src/main/services/leaderboardService.ts
+++ b/src/main/services/leaderboardService.ts
@@ -1,6 +1,10 @@
 import { REPO_PATTERN, SKILL_NAME_PATTERN } from '@/main/utils/skillIdentifiers'
 import { repositoryId } from '@/shared/types'
-import type { RankingFilter, SkillSearchResult } from '@/shared/types'
+import type {
+  InstallCount,
+  RankingFilter,
+  SkillSearchResult,
+} from '@/shared/types'
 
 /** Maps ranking filter to skills.sh URL */
 const LEADERBOARD_URLS: Record<RankingFilter, string> = {
@@ -28,7 +32,7 @@ const MAX_RESULTS = 50
  * parseFormattedCount('927')    // => 927
  * parseFormattedCount('12.3K')  // => 12300
  */
-export function parseFormattedCount(text: string): number {
+export function parseFormattedCount(text: string): InstallCount {
   const trimmed = text.trim().replace(/,/g, '')
   const match = trimmed.match(/^(\d+(?:\.\d+)?)\s*([KMB])?$/i)
   if (!match) return 0

--- a/src/main/services/metadataParser.ts
+++ b/src/main/services/metadataParser.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'fs/promises'
 import { join, basename } from 'path'
 
-import type { SkillMetadata } from '@/shared/types'
+import type { AbsolutePath, SkillMetadata } from '@/shared/types'
 
 /**
  * Parse SKILL.md frontmatter to extract metadata
@@ -12,7 +12,7 @@ import type { SkillMetadata } from '@/shared/types'
  * // => { name: 'theme-generator', description: 'Generate color themes...' }
  */
 export async function parseSkillMetadata(
-  skillPath: string,
+  skillPath: AbsolutePath,
 ): Promise<SkillMetadata> {
   const skillMdPath = join(skillPath, 'SKILL.md')
   const dirName = basename(skillPath) || 'Unknown'

--- a/src/main/services/pathValidation.ts
+++ b/src/main/services/pathValidation.ts
@@ -2,6 +2,7 @@ import { realpathSync } from 'node:fs'
 import { isAbsolute, relative, resolve } from 'node:path'
 
 import { AGENTS, SOURCE_DIR } from '@/main/constants'
+import type { AbsolutePath } from '@/shared/types'
 
 /**
  * Validate that a file path is within an allowed base directory.
@@ -24,9 +25,9 @@ import { AGENTS, SOURCE_DIR } from '@/main/constants'
  * // => throws Error('Path traversal attempt detected')
  */
 export function validatePath(
-  requestedPath: string,
-  allowedBases: string[],
-): string {
+  requestedPath: AbsolutePath,
+  allowedBases: AbsolutePath[],
+): AbsolutePath {
   const normalized = resolve(requestedPath)
 
   // Two-mode comparison: if the request path exists we canonicalize both
@@ -70,6 +71,6 @@ export function validatePath(
  * getAllowedBases()
  * // => ['/Users/x/.agents/skills', '/Users/x/.claude/skills', '/Users/x/.cursor/skills', ...]
  */
-export function getAllowedBases(): string[] {
+export function getAllowedBases(): AbsolutePath[] {
   return [...new Set([SOURCE_DIR, ...AGENTS.map((a) => a.path)])]
 }

--- a/src/main/services/skillScanner.ts
+++ b/src/main/services/skillScanner.ts
@@ -8,6 +8,7 @@ import { formatBytes } from '@/shared/fileTypes'
 import { repositoryId } from '@/shared/types'
 import type {
   AbsolutePath,
+  FileSizeBytes,
   HttpUrl,
   RepositoryId,
   Skill,
@@ -62,11 +63,17 @@ type AgentDefinition = (typeof AGENTS)[number]
 /** Partial slot update used only while merging scanner observations into a grouped skill record. */
 type SymlinkInfoPatch = Partial<SymlinkInfo>
 
+/** One observed agent-side symlink entry from a status scan, grouped later by skill name into `Skill` records. */
 interface AgentSymlinkStatusHit {
+  /** Agent definition the symlink was found under. */
   agent: AgentDefinition
+  /** Link/directory name observed in the agent's skills dir. */
   name: SkillName
+  /** Absolute path to the symlink inside the agent's skills dir. */
   linkPath: AbsolutePath
+  /** Symlink state resolved for this entry (valid, broken, inaccessible, or missing). */
   status: SymlinkStatus
+  /** Resolved symlink target when readable; omitted when no target could be read. */
   targetPath?: AbsolutePath
 }
 
@@ -620,7 +627,9 @@ export async function getSourceStats(): Promise<SourceStats> {
  * @param dirPath - Directory path
  * @returns Total size in bytes
  */
-async function calculateDirectorySize(dirPath: string): Promise<number> {
+async function calculateDirectorySize(
+  dirPath: AbsolutePath,
+): Promise<FileSizeBytes> {
   let total = 0
 
   try {

--- a/src/main/services/skillValidation.ts
+++ b/src/main/services/skillValidation.ts
@@ -1,6 +1,8 @@
 import { stat } from 'fs/promises'
 import { join } from 'path'
 
+import type { AbsolutePath } from '@/shared/types'
+
 /**
  * Check if a directory is a valid skill directory (contains SKILL.md as a regular file).
  * Uses stat().isFile() instead of access() to verify the entry is actually a file,
@@ -10,7 +12,7 @@ import { join } from 'path'
  * @example
  * await isValidSkillDir('/path/to/my-skill') // true if SKILL.md is a file
  */
-export async function isValidSkillDir(dirPath: string): Promise<boolean> {
+export async function isValidSkillDir(dirPath: AbsolutePath): Promise<boolean> {
   try {
     const stats = await stat(join(dirPath, 'SKILL.md'))
     return stats.isFile()

--- a/src/main/services/skillsCliService.ts
+++ b/src/main/services/skillsCliService.ts
@@ -14,6 +14,8 @@ import type {
   InstallOptions,
   CliCommandResult,
   InstallProgress,
+  ProgressPercent,
+  SearchQuery,
 } from '@/shared/types'
 
 /**
@@ -127,7 +129,7 @@ class SkillsCliService extends EventEmitter {
    * search('react')
    * // => [{ rank: 1, name: 'vercel-react-best-practices', repo: 'vercel-labs/agent-skills', url: '...' }]
    */
-  async search(query: string): Promise<SkillSearchResult[]> {
+  async search(query: SearchQuery): Promise<SkillSearchResult[]> {
     const result = await this.execCli(['find', query])
     if (!result.success) {
       return []
@@ -357,9 +359,9 @@ class SkillsCliService extends EventEmitter {
   private emitProgress(
     phase: InstallProgress['phase'],
     message: string,
-    percent?: number,
+    percent?: ProgressPercent,
   ): void {
-    this.emit('progress', { phase, message, percent } as InstallProgress)
+    this.emit('progress', { phase, message, percent })
   }
 }
 

--- a/src/main/services/symlinkChecker.ts
+++ b/src/main/services/symlinkChecker.ts
@@ -9,6 +9,7 @@ import type {
   AbsolutePath,
   FilesystemEntryIdentity,
   SkillName,
+  SymlinkCount,
   SymlinkInfo,
   SymlinkStatus,
 } from '@/shared/types'
@@ -35,7 +36,9 @@ interface LinkOrLocalResult {
  * // => { status: 'valid', isLocal: false } (symlink)
  * // => { status: 'valid', isLocal: true } (real folder)
  */
-async function checkLinkOrLocal(path: string): Promise<LinkOrLocalResult> {
+async function checkLinkOrLocal(
+  path: AbsolutePath,
+): Promise<LinkOrLocalResult> {
   try {
     const stats = await lstat(path)
 
@@ -239,7 +242,7 @@ export async function readSymlinkTargetIfPresent(
  * // => '/home/me/.agents/skills/foo' when `.config` points into dotfiles
  */
 export async function resolveRawSymlinkTarget(
-  linkPath: string,
+  linkPath: AbsolutePath,
   target: string,
 ): Promise<AbsolutePath> {
   if (isAbsolute(target)) {
@@ -279,6 +282,6 @@ async function resolveSymlinkTarget(
  * countValidSymlinks([{ status: 'valid' }, { status: 'missing' }])
  * // => 1
  */
-export function countValidSymlinks(symlinks: SymlinkInfo[]): number {
+export function countValidSymlinks(symlinks: SymlinkInfo[]): SymlinkCount {
   return symlinks.filter((s) => s.status === 'valid').length
 }

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -19,6 +19,7 @@ import type {
   FilesystemEntryIdentity,
   RestoreDeletedSkillResult,
   SkillName,
+  SymlinkCount,
   TombstoneId,
   UnixTimestampMs,
 } from '@/shared/types'
@@ -74,8 +75,8 @@ const evictTimers = new Map<TombstoneId, NodeJS.Timeout>()
  * @example await copyDirectoryNoOverwrite('/trash/source', '/Users/me/.agents/skills/task')
  */
 async function copyDirectoryNoOverwrite(
-  source: string,
-  destination: string,
+  source: AbsolutePath,
+  destination: AbsolutePath,
 ): Promise<void> {
   await fs.cp(source, destination, {
     recursive: true,
@@ -93,8 +94,8 @@ async function copyDirectoryNoOverwrite(
  * @example await restorePathNoOverwrite('/agent/task.cleanup-id', '/agent/task')
  */
 async function restorePathNoOverwrite(
-  movedPath: string,
-  destination: string,
+  movedPath: AbsolutePath,
+  destination: AbsolutePath,
 ): Promise<void> {
   const stats = await fs.lstat(movedPath)
 
@@ -293,7 +294,7 @@ async function assertReviewedSkillDirectory(
 function buildSiblingStagePath(
   reviewedPath: AbsolutePath,
   label: string,
-): string {
+): AbsolutePath {
   const suffix = randomBytes(RAND_SUFFIX_BYTES).toString('hex')
   return join(
     dirname(reviewedPath),
@@ -333,7 +334,7 @@ async function assertStagedReviewedDirectory(
  * @example await markManualRecoveryEntry(entryDir, 'source rollback failed')
  */
 async function markManualRecoveryEntry(
-  entryDir: string,
+  entryDir: AbsolutePath,
   reason: string,
 ): Promise<void> {
   const markerPath = join(entryDir, MANUAL_RECOVERY_MARKER)
@@ -355,7 +356,9 @@ async function markManualRecoveryEntry(
  * @returns true when the marker exists or cannot be checked safely.
  * @example await hasManualRecoveryMarker('/Users/me/.agents/.trash/...')
  */
-async function hasManualRecoveryMarker(entryDir: string): Promise<boolean> {
+async function hasManualRecoveryMarker(
+  entryDir: AbsolutePath,
+): Promise<boolean> {
   try {
     await fs.access(join(entryDir, MANUAL_RECOVERY_MARKER))
     return true
@@ -379,8 +382,8 @@ async function hasManualRecoveryMarker(entryDir: string): Promise<boolean> {
  * @example await moveDirectoryNoOverwrite('/tmp/staged', '/Users/me/.claude/skills/task')
  */
 async function moveDirectoryNoOverwrite(
-  source: string,
-  destination: string,
+  source: AbsolutePath,
+  destination: AbsolutePath,
 ): Promise<void> {
   await copyDirectoryNoOverwrite(source, destination)
   await fs.rm(source, { recursive: true, force: true })
@@ -400,7 +403,7 @@ interface SourceMoveFailure {
  */
 async function moveSourceIntoTrashEntry(
   sourcePath: AbsolutePath,
-  entrySourceDir: string,
+  entrySourceDir: AbsolutePath,
   reviewedIdentity: FilesystemEntryIdentity,
 ): Promise<SourceMoveFailure | null> {
   try {
@@ -555,7 +558,7 @@ async function rollbackRemovedSymlinks(
  * @returns The copies whose restore failed (empty array means full success)
  */
 async function rollbackMovedLocalCopies(
-  entryDir: string,
+  entryDir: AbsolutePath,
   copies: RecordedLocalCopy[],
 ): Promise<RecordedLocalCopy[]> {
   const unrestoredCopies: RecordedLocalCopy[] = []
@@ -586,7 +589,7 @@ export type MoveToTrashResult = {
   kind: 'tombstoned'
   tombstoneId: TombstoneId
   cascadeAgents: AgentId[]
-  symlinksRemoved: number
+  symlinksRemoved: SymlinkCount
 }
 
 /**
@@ -1582,7 +1585,7 @@ export async function restore(
  */
 async function restoreSourceBacked(
   id: TombstoneId,
-  entryDir: string,
+  entryDir: AbsolutePath,
   manifest: Extract<z.infer<typeof manifestSchema>, { kind: 'source-backed' }>,
 ): Promise<RestoreDeletedSkillResult> {
   const entrySourceDir = join(entryDir, 'source')
@@ -1717,7 +1720,7 @@ async function restoreSourceBacked(
  */
 async function restoreLocalOnly(
   id: TombstoneId,
-  entryDir: string,
+  entryDir: AbsolutePath,
   manifest: Extract<z.infer<typeof manifestSchema>, { kind: 'local-only' }>,
 ): Promise<RestoreDeletedSkillResult> {
   let symlinksRestored = 0
@@ -1809,7 +1812,7 @@ function cancelEvictTimer(id: TombstoneId): void {
  */
 async function finalizeRestore(
   id: TombstoneId,
-  entryDir: string,
+  entryDir: AbsolutePath,
 ): Promise<void> {
   cancelEvictTimer(id)
   await fs.rm(entryDir, { recursive: true, force: true })

--- a/src/main/utils/clampSizeToWorkArea.ts
+++ b/src/main/utils/clampSizeToWorkArea.ts
@@ -1,3 +1,5 @@
+import type { PixelHeight, PixelWidth } from '@/shared/types'
+
 /**
  * Clamp a desired window size to a display's usable work area.
  *
@@ -23,9 +25,9 @@
  * // => { width: 1000, height: 700 }
  */
 export function clampSizeToWorkArea(
-  desired: { width: number; height: number },
-  workArea: { width: number; height: number },
-): { width: number; height: number } {
+  desired: { width: PixelWidth; height: PixelHeight },
+  workArea: { width: PixelWidth; height: PixelHeight },
+): { width: PixelWidth; height: PixelHeight } {
   return {
     width: Math.min(desired.width, workArea.width),
     height: Math.min(desired.height, workArea.height),

--- a/src/renderer/src/components/dashboard/types.ts
+++ b/src/renderer/src/components/dashboard/types.ts
@@ -10,8 +10,9 @@ import type { Brand } from '@/shared/types'
 // ============================================================================
 
 /**
- * All widget types recognized by the dashboard.
- * Experimental widgets are hidden behind `experimental: true` in the registry.
+ * @description All widget types recognized by the dashboard. Experimental
+ * widgets are hidden behind `experimental: true` in the registry.
+ * @example "stats"
  */
 export type WidgetType =
   | 'stats'
@@ -82,21 +83,32 @@ export type GridRowSpan = number
  * { id: 'w_abc', type: 'stats', x: 0, y: 0, w: 6, h: 2 }
  */
 export interface WidgetInstance {
+  /** Unique instance id (distinct from the page id and the widget type). */
   id: WidgetInstanceId
+  /** Which registered widget this instance renders. */
   type: WidgetType
+  /** Zero-based grid column where the widget begins. */
   x: GridColumnStart
+  /** Zero-based grid row where the widget begins. */
   y: GridRowStart
+  /** Width in grid columns. */
   w: GridColumnSpan
+  /** Height in grid rows. */
   h: GridRowSpan
 }
 
 /**
  * A dashboard page holding up to ~4 widgets. When the user adds a widget and
  * no empty grid cell fits, a new page is created automatically.
+ * @example
+ * { id: 'p_abc', name: 'Overview', widgets: [{ id: 'w_abc', type: 'stats', x: 0, y: 0, w: 6, h: 2 }] }
  */
 export interface DashboardPage {
+  /** Unique id for this page (tab). */
   id: DashboardPageId
+  /** Human-readable tab name shown in the page strip. */
   name: DashboardPageName
+  /** Widgets placed on this page, each with its own grid placement. */
   widgets: WidgetInstance[]
 }
 
@@ -109,18 +121,25 @@ export interface DashboardPage {
 // ============================================================================
 
 /**
- * Grid size bounds for a widget, in 6-col cells.
+ * @description Grid size bounds for a widget, in 6-col cells. Used for both
+ * `defaultSize` and `minSize` in a WidgetDefinition.
  */
 export interface WidgetSize {
+  /** Width in grid columns. */
   w: GridColumnSpan
+  /** Height in grid rows. */
   h: GridRowSpan
 }
 
 /**
- * Static description of a widget type — label, icon, default/min size, and
- * the component that renders its body inside the WidgetShell frame.
+ * @description Static description of a widget type — label, icon, default/min
+ * size, and the component that renders its body inside the WidgetShell frame.
+ * One entry per WidgetType lives in `widgets/registry.ts`.
+ * @example
+ * { type: 'stats', label: 'Skill Stats', description: 'Totals at a glance', icon: BarChart3, defaultSize: { w: 6, h: 2 }, minSize: { w: 3, h: 2 }, Component: StatsWidget }
  */
 export interface WidgetDefinition {
+  /** Which widget type this definition describes. */
   type: WidgetType
   /** Short label shown in WidgetPicker and in the widget's title bar. */
   label: string

--- a/src/renderer/src/components/dashboard/widgets/AgentHeatmapWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/AgentHeatmapWidget.tsx
@@ -3,7 +3,14 @@ import React, { useMemo } from 'react'
 import { useAppSelector } from '@/renderer/src/redux/hooks'
 import { selectAgentItems } from '@/renderer/src/redux/slices/agentsSlice'
 import { selectSkillsItems } from '@/renderer/src/redux/slices/skillsSlice'
-import type { Agent, Skill, SymlinkInfo, SymlinkStatus } from '@/shared/types'
+import type {
+  Agent,
+  AgentName,
+  Skill,
+  SkillName,
+  SymlinkInfo,
+  SymlinkStatus,
+} from '@/shared/types'
 
 // ----------------------------------------------------------------------------
 // Tunables
@@ -59,7 +66,7 @@ function buildSymlinkIndex(skills: readonly Skill[]): Map<string, SymlinkInfo> {
  * @example abbreviateAgentName("Cursor")      // => "CU" (first two chars, uppercased)
  * @example abbreviateAgentName("Codex")       // => "CO"
  */
-function abbreviateAgentName(name: string): string {
+function abbreviateAgentName(name: AgentName): string {
   const parts = name.trim().split(/\s+/)
   if (parts.length >= 2) {
     return `${parts[0][0] ?? ''}${parts[1][0] ?? ''}`.toUpperCase()
@@ -75,8 +82,8 @@ function abbreviateAgentName(name: string): string {
 // ----------------------------------------------------------------------------
 
 interface HeatmapCellProps {
-  skillName: string
-  agentName: string
+  skillName: SkillName
+  agentName: AgentName
   link: SymlinkInfo | undefined
 }
 
@@ -109,7 +116,7 @@ const HeatmapCell = React.memo(function HeatmapCell({
 // ----------------------------------------------------------------------------
 
 interface HeatmapRowProps {
-  skillName: string
+  skillName: SkillName
   agents: readonly Agent[]
   symlinkIndex: Map<string, SymlinkInfo>
 }

--- a/src/renderer/src/components/dashboard/widgets/CoverageWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/CoverageWidget.tsx
@@ -5,7 +5,7 @@ import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import { selectAgentItems } from '@/renderer/src/redux/slices/agentsSlice'
 import { selectSkillsItems } from '@/renderer/src/redux/slices/skillsSlice'
 import { selectAgent } from '@/renderer/src/redux/slices/uiSlice'
-import type { Agent, AgentId } from '@/shared/types'
+import type { Agent, AgentId, SkillCount } from '@/shared/types'
 
 // ----------------------------------------------------------------------------
 // Pure helpers
@@ -14,11 +14,11 @@ import type { Agent, AgentId } from '@/shared/types'
 interface CoverageRow {
   agent: Agent
   /** Total = symlinked + local — what shows up in that agent's skills dir. */
-  total: number
+  total: SkillCount
   /** Symlinked-from-source count (already on `agent.skillCount`). */
-  linked: number
+  linked: SkillCount
   /** Locally-created skills in that agent's directory. */
-  local: number
+  local: SkillCount
   /** `total / totalSkillsInSource` as 0..1, clamped to 1. */
   ratio: number
 }
@@ -37,7 +37,7 @@ interface CoverageRow {
  */
 function buildCoverageRows(
   agents: readonly Agent[],
-  totalSourceSkills: number,
+  totalSourceSkills: SkillCount,
 ): CoverageRow[] {
   return agents.map((agent) => {
     const total = agent.skillCount + agent.localSkillCount

--- a/src/renderer/src/components/dashboard/widgets/HealthWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/HealthWidget.tsx
@@ -6,17 +6,17 @@ import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import { selectSkillsItems } from '@/renderer/src/redux/slices/skillsSlice'
 import { openSymlinkCleanupDialog } from '@/renderer/src/redux/slices/uiSlice'
 import { pluralize } from '@/renderer/src/utils/pluralize'
-import type { Skill } from '@/shared/types'
+import type { Skill, SymlinkCount } from '@/shared/types'
 
 // ----------------------------------------------------------------------------
 // Pure helpers
 // ----------------------------------------------------------------------------
 
 interface HealthTotals {
-  valid: number
-  broken: number
-  inaccessible: number
-  missing: number
+  valid: SymlinkCount
+  broken: SymlinkCount
+  inaccessible: SymlinkCount
+  missing: SymlinkCount
 }
 
 /**
@@ -66,9 +66,9 @@ function healthPercentLabel(totals: HealthTotals): string | null {
 // ----------------------------------------------------------------------------
 
 interface HealthBarProps {
-  valid: number
-  cleanupIssues: number
-  manualReview: number
+  valid: SymlinkCount
+  cleanupIssues: SymlinkCount
+  manualReview: SymlinkCount
 }
 
 const HealthBar = React.memo(function HealthBar({

--- a/src/renderer/src/components/dashboard/widgets/StatsWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/StatsWidget.tsx
@@ -4,6 +4,7 @@ import React, { useMemo } from 'react'
 import { useAppSelector } from '@/renderer/src/redux/hooks'
 import { selectAgentItems } from '@/renderer/src/redux/slices/agentsSlice'
 import { selectSkillsItems } from '@/renderer/src/redux/slices/skillsSlice'
+import type { AgentCount, SkillCount } from '@/shared/types'
 
 // ----------------------------------------------------------------------------
 // Pure helpers — derived outside the component so they're trivially testable
@@ -18,7 +19,7 @@ import { selectSkillsItems } from '@/renderer/src/redux/slices/skillsSlice'
  */
 function countLinkedSkills(
   items: ReadonlyArray<{ symlinkCount: number }>,
-): number {
+): SkillCount {
   return items.filter((skill) => skill.symlinkCount > 0).length
 }
 
@@ -29,7 +30,9 @@ function countLinkedSkills(
  * @returns active agent count
  * @example countActiveAgents([{exists: true}, {exists: false}]) // => 1
  */
-function countActiveAgents(items: ReadonlyArray<{ exists: boolean }>): number {
+function countActiveAgents(
+  items: ReadonlyArray<{ exists: boolean }>,
+): AgentCount {
   return items.filter((agent) => agent.exists).length
 }
 

--- a/src/renderer/src/components/sidebar/AgentItem.tsx
+++ b/src/renderer/src/components/sidebar/AgentItem.tsx
@@ -25,7 +25,7 @@ import {
   setCleanupAgentTarget,
 } from '@/renderer/src/redux/slices/uiSlice'
 import { AGENT_DEFINITIONS } from '@/shared/constants'
-import type { Agent, AgentId } from '@/shared/types'
+import type { Agent, AgentId, SkillCount } from '@/shared/types'
 
 interface AgentItemProps {
   agent: Agent
@@ -44,7 +44,10 @@ interface AgentItemProps {
  * buildSkillCountText(3, 1) // => "3 linked, 1 local"
  * buildSkillCountText(0, 2) // => "2 local"
  */
-function buildSkillCountText(linked: number, local: number): string | null {
+function buildSkillCountText(
+  linked: SkillCount,
+  local: SkillCount,
+): string | null {
   const parts: string[] = []
   if (linked > 0) parts.push(`${linked} linked`)
   if (local > 0) parts.push(`${local} local`)

--- a/src/renderer/src/components/skills/CodePreview.tsx
+++ b/src/renderer/src/components/skills/CodePreview.tsx
@@ -2,12 +2,13 @@ import * as TabsPrimitive from '@radix-ui/react-tabs'
 import React, { useCallback } from 'react'
 
 import { useCodePreview } from '@/renderer/src/hooks/useCodePreview'
+import type { AbsolutePath } from '@/shared/types'
 
 import { FileContent } from './FileContent'
 import { FileTabs } from './FileTabs'
 
 interface CodePreviewProps {
-  skillPath: string
+  skillPath: AbsolutePath
 }
 
 /**

--- a/src/renderer/src/components/skills/SkillDetail.tsx
+++ b/src/renderer/src/components/skills/SkillDetail.tsx
@@ -12,7 +12,12 @@ import type { LocationViewModel } from '@/renderer/src/utils/getLocationViewMode
 import { getLocationViewModel } from '@/renderer/src/utils/getLocationViewModel'
 import { COPIED_FEEDBACK_DURATION_MS } from '@/shared/constants'
 import type { Settings } from '@/shared/settings'
-import type { Skill, SymlinkInfo } from '@/shared/types'
+import type {
+  AbsolutePath,
+  Skill,
+  SymlinkCount,
+  SymlinkInfo,
+} from '@/shared/types'
 
 import { CodePreview } from './CodePreview'
 import { SourceLink } from './SourceLink'
@@ -161,15 +166,15 @@ const OrphanNotice = React.memo(function OrphanNotice(): React.ReactElement {
 interface InfoViewProps {
   skill: Skill
   filteredSymlinks: SymlinkInfo[]
-  validCount: number
-  brokenCount: number
-  inaccessibleCount: number
+  validCount: SymlinkCount
+  brokenCount: SymlinkCount
+  inaccessibleCount: SymlinkCount
   location: LocationViewModel
 }
 
 interface LocationPathClipboardState {
-  copiedPath: string | null
-  copyPath: (path: string, label: string) => Promise<void>
+  copiedPath: AbsolutePath | null
+  copyPath: (path: AbsolutePath, label: string) => Promise<void>
 }
 
 /**
@@ -179,7 +184,7 @@ interface LocationPathClipboardState {
  * const { copiedPath, copyPath } = useLocationPathClipboard()
  */
 function useLocationPathClipboard(): LocationPathClipboardState {
-  const [copiedPath, setCopiedPath] = React.useState<string | null>(null)
+  const [copiedPath, setCopiedPath] = React.useState<AbsolutePath | null>(null)
   const resetCopiedPathTimeoutRef = React.useRef<number | null>(null)
 
   // react-doctor-disable-next-line react-doctor/exhaustive-deps -- mount-once cleanup that intentionally reads the LATEST resetCopiedPathTimeoutRef.current at unmount to clear a pending timer; capturing it earlier would leak the timer.
@@ -192,7 +197,7 @@ function useLocationPathClipboard(): LocationPathClipboardState {
   }, [])
 
   const copyPath = React.useCallback(
-    async (path: string, label: string): Promise<void> => {
+    async (path: AbsolutePath, label: string): Promise<void> => {
       try {
         if (!navigator.clipboard?.writeText) {
           throw new Error('Clipboard API unavailable')
@@ -298,9 +303,9 @@ const InfoView = React.memo(function InfoView({
 
 interface LocationPathRowProps {
   label: string
-  path: string
+  path: AbsolutePath
   isCopied: boolean
-  onCopy: (path: string, label: string) => Promise<void>
+  onCopy: (path: AbsolutePath, label: string) => Promise<void>
 }
 
 /**

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -54,7 +54,13 @@ import {
 } from '@/renderer/src/redux/slices/uiSlice'
 import { BULK_ITEM_FAILED_EVENT } from '@/renderer/src/utils/bulkOpVisuals'
 import { GSTACK_REPOSITORY_URL } from '@/shared/constants'
-import type { Skill, SkillName, SymlinkInfo } from '@/shared/types'
+import type { AgentId, AgentName } from '@/shared/constants'
+import type {
+  Skill,
+  SkillName,
+  SymlinkCount,
+  SymlinkInfo,
+} from '@/shared/types'
 
 import { canBookmarkSkill, skillToBookmarkData } from './bookmarkHelpers'
 import { computeRangeSelection } from './bulkDeleteHelpers'
@@ -79,12 +85,12 @@ interface SkillItemProps {
 }
 
 interface SymlinkStatusBuckets {
-  validCount: number
-  brokenCount: number
-  inaccessibleCount: number
-  validAgentNames: string[]
-  brokenAgentNames: string[]
-  inaccessibleAgentNames: string[]
+  validCount: SymlinkCount
+  brokenCount: SymlinkCount
+  inaccessibleCount: SymlinkCount
+  validAgentNames: AgentName[]
+  brokenAgentNames: AgentName[]
+  inaccessibleAgentNames: AgentName[]
 }
 
 /** How long the partial-failure red edge persists (ms). */
@@ -135,7 +141,7 @@ function getSymlinkStatusBuckets(
  * canBulkSelectRenderedSkill(null, [], 'task') // => true
  */
 function canBulkSelectRenderedSkill(
-  selectedAgentId: string | null,
+  selectedAgentId: AgentId | null,
   visibleNames: readonly SkillName[],
   skillName: SkillName,
 ): boolean {

--- a/src/renderer/src/components/skills/UnlinkDialog.tsx
+++ b/src/renderer/src/components/skills/UnlinkDialog.tsx
@@ -9,7 +9,7 @@ import {
   unlinkSkillFromAgent,
 } from '@/renderer/src/redux/slices/skillsSlice'
 import { refreshAllData } from '@/renderer/src/redux/thunks'
-import type { SymlinkInfo } from '@/shared/types'
+import type { SkillName, SymlinkInfo } from '@/shared/types'
 
 /**
  * Three exhaustive states the dialog has to cover:
@@ -38,7 +38,7 @@ interface UnlinkCopy {
 /** Pure mapper from symlink shape → strings shown in the dialog and toast. */
 function getUnlinkCopy(
   variant: UnlinkVariant,
-  skillName: string,
+  skillName: SkillName,
   agentName: string,
 ): UnlinkCopy {
   return match(variant)

--- a/src/renderer/src/components/skills/bulkDeleteHelpers.ts
+++ b/src/renderer/src/components/skills/bulkDeleteHelpers.ts
@@ -7,7 +7,9 @@ import type {
   BulkDeleteResult,
   BulkUnlinkItemResult,
   BulkUnlinkResult,
+  SkillCount,
   SkillName,
+  SymlinkCount,
 } from '@/shared/types'
 
 /**
@@ -28,9 +30,9 @@ export interface ToolbarStateInput {
   view: ToolbarView
   agentId: AgentId | null
   /** Number of items currently ticked (not intersected with visible). */
-  count: number
+  count: SkillCount
   /** Number of items currently ticked AND visible. */
-  visibleCount: number
+  visibleCount: SkillCount
   /**
    * Human-readable agent name (e.g. "Cursor"). When provided in agent view,
    * it is embedded directly into the primary label and aria label ("Unlink
@@ -157,7 +159,9 @@ export const getToolbarState = ({
  *   { skillName: 'b', outcome: 'error', symlinksRemoved: 1, cascadeAgents: ['claude-code'], error: { message: 'EACCES', code: 'EACCES' } },
  * ] }) // => 3
  */
-export const countOrphanSymlinksRemoved = (result: BulkDeleteResult): number =>
+export const countOrphanSymlinksRemoved = (
+  result: BulkDeleteResult,
+): SymlinkCount =>
   result.items.reduce((total, item) => {
     if (item.outcome === 'orphan-cleared') return total + item.symlinksRemoved
     if (item.outcome === 'error' && item.cascadeAgents) {

--- a/src/renderer/src/components/status/StatusBadge.tsx
+++ b/src/renderer/src/components/status/StatusBadge.tsx
@@ -7,13 +7,14 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/renderer/src/components/ui/tooltip'
-import type { SymlinkStatus } from '@/shared/types'
+import type { AgentName } from '@/shared/constants'
+import type { SymlinkCount, SymlinkStatus } from '@/shared/types'
 
 interface StatusBadgeProps {
   status: SymlinkStatus
-  count?: number
+  count?: SymlinkCount
   /** Agent names to display in tooltip (e.g. ["Claude", "Cursor"]) */
-  agentNames?: string[]
+  agentNames?: AgentName[]
 }
 
 const STATUS_CONFIG = {

--- a/src/renderer/src/redux/selectors.ts
+++ b/src/renderer/src/redux/selectors.ts
@@ -8,6 +8,7 @@ import type {
   AgentId,
   RepositoryId,
   Skill,
+  SkillCount,
   SkillName,
   SymlinkInfo,
 } from '@/shared/types'
@@ -34,7 +35,7 @@ import type {
 
 interface RepoFacetOption {
   source: RepositoryId
-  count: number
+  count: SkillCount
 }
 
 /**
@@ -281,7 +282,7 @@ export const selectRepoFacetOptions = createSelector(
 
 export interface SourceFilterRow {
   source: RepositoryId
-  count: number
+  count: SkillCount
   /** True when this repo is in `selectedSources` (drives the checkbox tick). */
   checked: boolean
 }
@@ -312,7 +313,7 @@ interface SourceFilterViewModel {
   triggerAriaLabel: string
   isSelectAllDisabled: boolean
   hasNoRepositories: boolean
-  localHiddenCount: number
+  localHiddenCount: SkillCount
 }
 
 /**

--- a/src/renderer/src/redux/slices/dashboardSlice.ts
+++ b/src/renderer/src/redux/slices/dashboardSlice.ts
@@ -36,6 +36,7 @@ import type { RootState } from '@/renderer/src/redux/store'
 // survives removing + re-adding the widget.
 // ============================================================================
 
+/** Redux state for the dashboard canvas: the persisted page arrangement, the active page, edit-mode toggle, and one-time onboarding flags. */
 interface DashboardState {
   pages: DashboardPage[]
   currentPageId: DashboardPageId | null

--- a/src/renderer/src/redux/slices/skillsSlice.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.ts
@@ -896,4 +896,4 @@ export const selectBulkCopyModalOpen = (state: RootState): boolean =>
   state.skills.bulkCopyModalOpen
 export const selectBulkProgress = (
   state: RootState,
-): { current: number; total: number } | null => state.skills.bulkProgress
+): DeleteProgressPayload | null => state.skills.bulkProgress

--- a/src/renderer/src/redux/slices/skillsSlice.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.ts
@@ -11,6 +11,7 @@ import type {
   ClearOrphanSymlinksResult,
   ClearBrokenSymlinkSlotsOptions,
   ClearBrokenSymlinkSlotsResult,
+  DeleteProgressPayload,
   FilesystemEntryIdentity,
   RestoreDeletedSkillResult,
   Skill,
@@ -74,7 +75,7 @@ interface SkillsState {
   /** true while the BulkCopyToAgentsModal (global-view multi-skill copy) is open. */
   bulkCopyModalOpen: boolean
   /** Progress counter emitted by main for batches with total >= 10. */
-  bulkProgress: { current: number; total: number } | null
+  bulkProgress: DeleteProgressPayload | null
 }
 
 const initialState: SkillsState = {
@@ -121,12 +122,20 @@ function reconcileByLiveNames(
   return names.filter((name) => liveNames.has(name))
 }
 
+/**
+ * Reviewed bulk-delete row identity: the display name plus the exact source
+ * path and filesystem identity main revalidates before deleting the source.
+ */
 export type DeleteSelectedSkillTarget = {
   skillName: SkillName
   skillPath: AbsolutePath
   filesystemIdentity: FilesystemEntryIdentity
 }
 
+/**
+ * Reviewed bulk-unlink row identity: the display name plus the exact agent link
+ * path and its symlink target captured when the confirm dialog opened.
+ */
 export type UnlinkSelectedSkillTarget = {
   skillName: SkillName
   linkPath: AbsolutePath
@@ -630,7 +639,7 @@ const skillsSlice = createSlice({
      */
     setBulkProgress: (
       state,
-      action: PayloadAction<{ current: number; total: number } | null>,
+      action: PayloadAction<DeleteProgressPayload | null>,
     ) => {
       state.bulkProgress = action.payload
     },

--- a/src/renderer/src/redux/slices/uiSlice.ts
+++ b/src/renderer/src/redux/slices/uiSlice.ts
@@ -12,6 +12,7 @@ import type {
   IsoTimestamp,
   RepositoryId,
   SearchQuery,
+  SkillCount,
   SkillName,
   SourceStats,
   SyncExecuteOptions,
@@ -37,14 +38,21 @@ import {
 /** Bookmark with install status, used for the detail modal */
 export type BookmarkForDetail = BookmarkedSkill & { isInstalled: boolean }
 
+/** Sort direction for the skill-name sort (A→Z vs Z→A). */
 export type SortOrder = 'asc' | 'desc'
+/** Positive skill-type include mode for the agent-view list filter. */
 export type SkillTypeFilter =
   | 'all'
   | 'symlinked'
   | 'local'
   | 'gstack'
   | 'orphan'
+/** SkillTypeFilter minus `'all'` — the type modes that can be subtracted as excludes. */
 export type ExcludableSkillTypeFilter = Exclude<SkillTypeFilter, 'all'>
+/**
+ * Which top-level main-content tab is active.
+ * @example 'installed'
+ */
 export type ActiveTab = 'installed' | 'marketplace'
 /**
  * Which field the search box matches against.
@@ -86,7 +94,7 @@ interface UndoToastState {
  */
 export interface SourceFilterSummary {
   repositoryIds: RepositoryId[]
-  localHiddenCount: number
+  localHiddenCount: SkillCount
 }
 
 /**
@@ -107,6 +115,10 @@ interface BulkConfirmBase {
   sourceSummary: SourceFilterSummary | null
 }
 
+/**
+ * Discriminated bulk-confirm payload: the delete variant carries reviewed
+ * source/orphan targets, the unlink variant carries the target agent + links.
+ */
 export type BulkConfirmState =
   | (BulkConfirmBase & {
       kind: 'delete'
@@ -129,6 +141,7 @@ export type BulkConfirmState =
       unlinkTargets: UnlinkSelectedSkillTarget[]
     })
 
+/** Redux state for global UI surface coordination: tabs, filters, search, sync, and bulk/cleanup dialogs. */
 interface UiState {
   /** Active main content tab */
   activeTab: ActiveTab

--- a/src/renderer/src/redux/slices/updateSlice.ts
+++ b/src/renderer/src/redux/slices/updateSlice.ts
@@ -3,6 +3,7 @@ import { createSlice } from '@reduxjs/toolkit'
 
 import type {
   DownloadProgress,
+  ProgressPercent,
   SemanticVersion,
   UpdateInfo,
   UpdateStatus,
@@ -20,7 +21,7 @@ interface UpdateState {
   /** Markdown release notes attached to `version`, if provided by the publisher. */
   releaseNotes: string | null
   /** Download progress percentage (0–100). */
-  progress: number
+  progress: ProgressPercent
   /** Human-readable error from the last failed update step. */
   error: string | null
   /** true once the user has clicked "later" — suppresses the banner until next app start. */

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -790,6 +790,7 @@ export type ThemePresetName = keyof typeof THEME_PRESETS
 /**
  * Agent IDs used in app state and IPC.
  * Derived from AGENT_DEFINITIONS to stay in sync with skills CLI.
+ * @example "claude-code"
  */
 export type AgentId = (typeof AGENT_DEFINITIONS)[number]['id']
 
@@ -822,6 +823,7 @@ export const AGENT_IDS = _AGENT_IDS as unknown as readonly [
 /**
  * Agent display names shown in UI.
  * Derived from AGENT_DEFINITIONS to avoid manual union maintenance.
+ * @example "Claude Code"
  */
 export type AgentName = (typeof AGENT_DEFINITIONS)[number]['name']
 

--- a/src/shared/fileTypes.ts
+++ b/src/shared/fileTypes.ts
@@ -115,6 +115,7 @@ export const MAX_TREE_DEPTH = 4
  * - `text`: render the raw UTF-8 body in a <pre> block
  * - `image`: fetch as base64 via files:readBinary, render in an <img>
  * - `binary`: show a "binary file — cannot preview" placeholder
+ * @example 'text'
  */
 export type FilePreviewKind = 'text' | 'image' | 'binary'
 

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -172,5 +172,7 @@ export interface IpcEventContract {
   'settings:changed': Settings
 }
 
+/** Union of every request/response IPC invoke channel name in {@link IpcInvokeContract}. */
 export type IpcInvokeChannel = keyof IpcInvokeContract
+/** Union of every one-way (main → renderer) IPC event channel name in {@link IpcEventContract}. */
 export type IpcEventChannel = keyof IpcEventContract

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -212,6 +212,16 @@ export const SettingsSchema = z.object({
  * `app.getPath('userData')/settings.json`. Renderers cache this in
  * Redux but never write directly — see `src/main/services/settings.ts`
  * and the `settings:get` / `settings:set` IPC handlers.
+ * @example
+ * {
+ *   defaultSkillTab: 'files',
+ *   preferredTerminal: 'iterm',
+ *   windowSize: { width: 1280, height: 800 },
+ *   windowBackgroundBlurRadius: 24,
+ *   installedSearchCountDisplay: 'tab',
+ *   hiddenAgentIds: ['claude-code'],
+ *   autoDownloadUpdates: false,
+ * }
  */
 export type Settings = z.infer<typeof SettingsSchema>
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -185,11 +185,14 @@ export type BatchItemIndex = number
 export type BatchItemCount = number
 
 /**
- * A non-negative count of agent symlinks. Used in two senses, both of which
- * count valid symlinks (broken/missing entries are excluded by callers):
+ * A non-negative count of agent symlink records. Used in three senses:
  * - Sync operation outcomes — `SyncExecuteResult.{created,replaced,skipped}`
- *   and `SyncPreviewResult.{toCreate,alreadySynced}`
- * - "Agents linked to this skill" — `Skill.symlinkCount`
+ *   and `SyncPreviewResult.{toCreate,alreadySynced}` — count valid symlinks
+ *   only (broken/missing excluded by those callers).
+ * - "Agents linked to this skill" — `Skill.symlinkCount` — valid links only.
+ * - Health tallies — the Symlink Health widget counts symlink records by
+ *   status, so every status bucket (valid/broken/inaccessible/missing) is a
+ *   `SymlinkCount`.
  * Distinguishes "number of symlinks" from other counts (skill counts,
  * install counts) at sync IPC boundaries and skill-list rendering.
  * @example 12
@@ -775,7 +778,7 @@ export interface InstallProgress {
   /** Human-readable status line surfaced in the UI. */
   message: string
   /** Overall completion percentage (0–100) when the stage can report one. */
-  percent?: number
+  percent?: ProgressPercent
 }
 
 /**
@@ -916,7 +919,7 @@ export interface RemoveAllFromAgentResult {
   /** true if the folder was emptied successfully. */
   success: boolean
   /** Number of entries (symlinks and local folders) removed. @example 5 */
-  removedCount: number
+  removedCount: SkillCount
   /** Failure reason when `success` is false. */
   error?: string
 }


### PR DESCRIPTION
## What

`/colorful-type` refactor (Phase 7 of the type-safety marathon): replace colorless
primitives (`string` / `number`) at domain boundaries with named domain type aliases
and enrich domain types with JSDoc `@example`, across **34 files**. Also removes
now-redundant `as` casts that the new annotations make unnecessary.

**Annotation-only. Zero runtime behavior change.**

## Why

Colorless primitives at IPC and service boundaries hide intent — a `string` could be
a skill name, an absolute path, or a search query; a `number` could be a skill count,
a symlink count, or a pixel dimension. Naming them (`SkillName`, `AbsolutePath`,
`SkillCount`, `SymlinkCount`, `PixelWidth`, `ProgressPercent`, …) makes call sites
self-documenting and lets the type checker catch category errors. The aliases already
existed in `src/shared/types.ts`; this PR applies them where primitives were still in use.

## How (design rules followed)

- Plain aliases only swapped where the underlying type is identical (`SkillName = string`,
  `SkillCount = number`) — pure annotation, no cast, no runtime change.
- **Never** added an `as` cast to force a narrowing. Union-literal narrowings
  (`AgentId`/`AgentName`) were left as primitives where the value didn't already
  originate as the union type (7 such sites correctly skipped).
- 3 genuinely-redundant `as` casts removed (`agent.path as AbsolutePath`,
  `readdir(...) as Dirent[]`, `{ … } as InstallProgress`) — all compile-time-only.
- Branded types (`RepositoryId` / `SemanticVersion` / `TombstoneId`) untouched — no
  new branded values produced outside their factories.

## Review

Six independent reviews (typescript-pro, adversarial runtime-hunt, maintainability,
testing, Codex adversarial, Codex structured) converged on **5 P2/P3 domain-annotation
refinements** — all fixed in this PR:

- `RemoveAllFromAgentResult.removedCount`: `SymlinkCount` → `SkillCount` (counts
  symlinks **and** local folders; 3 models + the field's own JSDoc agreed `SymlinkCount`
  was the wrong alias).
- `clampSizeToWorkArea` return type → `{ width: PixelWidth; height: PixelHeight }`
  (params were already annotated; return was left bare).
- `SkillDetail` `onCopy` first param → `AbsolutePath` (matched its sibling `copyPath`).
- `trashService` `entryDir` ×2 → `AbsolutePath` (matched 6 sibling params).
- `SymlinkCount` JSDoc clarified to document the health-tally usage (3rd sense)
  alongside the two sync senses.

**No runtime change found by any reviewer.** Empirically confirmed: esbuild
type-stripping produces byte-identical emitted JS for all 34 files (base vs HEAD).

## Verification

- `npx tsc --noEmit` — clean (incl. `e2e/tsconfig.json`)
- `pnpm validate` — lint / 2118 vitest / typecheck / dead-code / dupes / health / storybook all green
- `pnpm test:e2e` — green
- WidgetPicker.browser.test flake did not recur

## Version

No `package.json` version bump — releases are owned exclusively by `/electron-release`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * パス、スキル数/リンク数、進捗（完了率）などの値の扱いを、より厳密な型に統一しました。表示や削除・復元などの動作ロジックは変わっていません。

* **Documentation**
  * JSDocの説明や `settings.json` の具体例、型の意味が分かる補足を追加しました。API利用時の理解がしやすくなりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->