### PR TITLE
refactor: dedup error coercion + dead selector + bulk-pending matcher

### DIFF
--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -53,6 +53,20 @@ type AgentPathRemovalResult =
   | { success: false; error: string; code?: string }
 
 /**
+ * Normalize a caught error into the IPC error shape, preferring TrashError's own message/code over generic extraction, so TrashError-aware normalization lives in one place across the skills delete/clear catch blocks.
+ * @param error - The caught error (unknown type).
+ * @returns `{ message, code }` where code is undefined when none is available.
+ * @example describeError(new TrashError('busy', 'EBUSY')) // => { message: 'busy', code: 'EBUSY' }
+ */
+function describeError(error: unknown): { message: string; code?: string } {
+  return {
+    message:
+      error instanceof TrashError ? error.message : extractErrorMessage(error),
+    code: error instanceof TrashError ? error.code : errorCode(error),
+  }
+}
+
+/**
  * Require a renderer path to name the same derived main-process path.
  * @param rendererPath - Path supplied over IPC for backward-compatible callers
  * @param derivedPath - Path calculated from validated main-process state
@@ -449,9 +463,7 @@ async function clearReviewedBrokenSymlinkSlot(item: {
       outcome: 'unlinked',
     }
   } catch (error) {
-    const message =
-      error instanceof TrashError ? error.message : extractErrorMessage(error)
-    const code = error instanceof TrashError ? error.code : errorCode(error)
+    const { message, code } = describeError(error)
     return {
       agentId: item.agentId,
       skillName: item.linkName,
@@ -603,9 +615,7 @@ async function clearReviewedOrphanRecord(item: {
       cascadeAgents,
     }
   } catch (error) {
-    const message =
-      error instanceof TrashError ? error.message : extractErrorMessage(error)
-    const code = error instanceof TrashError ? error.code : errorCode(error)
+    const { message, code } = describeError(error)
     // Surface any partial cleanup so the summary mirrors disk state instead of
     // reporting zero removed when N-1 of N agents already unlinked.
     return {
@@ -889,12 +899,7 @@ export function registerSkillsHandlers(): void {
             cascadeAgents: moveResult.cascadeAgents,
           })
         } catch (error) {
-          const message =
-            error instanceof TrashError
-              ? error.message
-              : extractErrorMessage(error)
-          const code =
-            error instanceof TrashError ? error.code : errorCode(error)
+          const { message, code } = describeError(error)
           results.push({
             skillName,
             outcome: 'error',

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -389,6 +389,24 @@ async function moveDirectoryNoOverwrite(
   await fs.rm(source, { recursive: true, force: true })
 }
 
+/**
+ * Normalize a caught identity-validation error into a TrashError, reused by the staged-source and staged-local-copy revert paths so message/code shaping stays consistent.
+ * @param error - The caught error (already a TrashError, or an unknown fs/identity error).
+ * @param messagePrefix - Human prefix prepended when wrapping a non-TrashError.
+ * @returns The error unchanged when it is already a TrashError; otherwise a new TrashError(`${messagePrefix}: <message>`, <code>).
+ * @example
+ * coerceTrashError(new Error('boom'), 'Failed to validate staged source')
+ * // => TrashError('Failed to validate staged source: boom')
+ */
+function coerceTrashError(error: unknown, messagePrefix: string): TrashError {
+  return error instanceof TrashError
+    ? error
+    : new TrashError(
+        `${messagePrefix}: ${extractErrorMessage(error)}`,
+        errorCode(error),
+      )
+}
+
 interface SourceMoveFailure {
   error: TrashError
   preserveEntryDirForManualRecovery: boolean
@@ -420,24 +438,18 @@ async function moveSourceIntoTrashEntry(
       } catch {
         return {
           preserveEntryDirForManualRecovery: true,
-          error:
-            identityError instanceof TrashError
-              ? identityError
-              : new TrashError(
-                  `Failed to validate staged source: ${extractErrorMessage(identityError)}`,
-                  errorCode(identityError),
-                ),
+          error: coerceTrashError(
+            identityError,
+            'Failed to validate staged source',
+          ),
         }
       }
       return {
         preserveEntryDirForManualRecovery: false,
-        error:
-          identityError instanceof TrashError
-            ? identityError
-            : new TrashError(
-                `Failed to validate staged source: ${extractErrorMessage(identityError)}`,
-                errorCode(identityError),
-              ),
+        error: coerceTrashError(
+          identityError,
+          'Failed to validate staged source',
+        ),
       }
     }
     return null
@@ -461,13 +473,10 @@ async function moveSourceIntoTrashEntry(
           await moveDirectoryNoOverwrite(siblingStagePath, sourcePath)
           return {
             preserveEntryDirForManualRecovery: false,
-            error:
-              identityError instanceof TrashError
-                ? identityError
-                : new TrashError(
-                    `Failed to validate staged source: ${extractErrorMessage(identityError)}`,
-                    errorCode(identityError),
-                  ),
+            error: coerceTrashError(
+              identityError,
+              'Failed to validate staged source',
+            ),
           }
         }
         await copyDirectoryNoOverwrite(siblingStagePath, entrySourceDir)
@@ -1314,13 +1323,10 @@ async function moveLocalOnlyToTrash(
                 kind: 'fatal' as const,
                 preserveEntryDir: false,
                 strandedAgentId: copy.agentId,
-                error:
-                  identityError instanceof TrashError
-                    ? identityError
-                    : new TrashError(
-                        `Failed to validate staged local copy (agent=${copy.agentId}): ${extractErrorMessage(identityError)}`,
-                        errorCode(identityError),
-                      ),
+                error: coerceTrashError(
+                  identityError,
+                  `Failed to validate staged local copy (agent=${copy.agentId})`,
+                ),
               }
             }
             await copyDirectoryNoOverwrite(siblingStagePath, stagedPath)
@@ -1481,11 +1487,7 @@ async function moveLocalOnlyToTrash(
  */
 export async function evict(id: TombstoneId): Promise<void> {
   const entryDir = join(TRASH_DIR, id)
-  const timer = evictTimers.get(id)
-  if (timer) {
-    clearTimeout(timer)
-    evictTimers.delete(id)
-  }
+  cancelEvictTimer(id)
   try {
     await fs.rm(entryDir, { recursive: true, force: true })
   } catch (error) {

--- a/src/renderer/src/redux/selectors.test.ts
+++ b/src/renderer/src/redux/selectors.test.ts
@@ -22,7 +22,6 @@ import {
   selectFilteredSkills,
   selectFilteredSkillCount,
   selectHiddenSelectedCount,
-  selectInFlightDeleteNamesSet,
   selectRepoFacetOptions,
   selectSelectedCount,
   selectSelectedSkillNamesSet,
@@ -1278,37 +1277,6 @@ describe('selectVisibleIneligibleSelectedCount', () => {
 
     // Act & Assert
     expect(selectVisibleIneligibleSelectedCount(state as never)).toBe(1)
-  })
-})
-
-describe('selectInFlightDeleteNamesSet', () => {
-  it('exposes in-flight delete names as a Set for fast membership checks', () => {
-    // Arrange
-    const state = buildState({
-      inFlightDeleteNames: ['a', 'b', 'c'],
-    })
-
-    // Act
-    const result = selectInFlightDeleteNamesSet(state as never)
-
-    // Assert
-    expect(result.has('a')).toBe(true)
-    expect(result.has('z')).toBe(false)
-    expect(result.size).toBe(3)
-  })
-
-  it('returns the same Set reference on repeat reads so consumers do not re-render needlessly', () => {
-    // Arrange
-    const state = buildState({
-      inFlightDeleteNames: ['a'],
-    })
-
-    // Act
-    const result1 = selectInFlightDeleteNamesSet(state as never)
-    const result2 = selectInFlightDeleteNamesSet(state as never)
-
-    // Assert
-    expect(result1).toBe(result2)
   })
 })
 

--- a/src/renderer/src/redux/selectors.ts
+++ b/src/renderer/src/redux/selectors.ts
@@ -601,21 +601,6 @@ export const selectVisibleIneligibleSelectedCount = createSelector(
   },
 )
 
-/**
- * Memoized Set wrapper around `inFlightDeleteNames` so SkillItem's O(1)
- * `.has(name)` lookup does not trigger a Set-rebuild on every row render.
- * Without this, every row would create a fresh Set — the rebuild is cheap per
- * call but pathological across virtualized rows during a large batch.
- * @returns ReadonlySet<SkillName>
- * @example
- * const inFlight = useAppSelector(selectInFlightDeleteNamesSet)
- * const isFading = inFlight.has(skill.name)
- */
-export const selectInFlightDeleteNamesSet = createSelector(
-  [selectInFlightDeleteNames],
-  (names): ReadonlySet<SkillName> => new Set(names),
-)
-
 // Shared empty Set sentinel — returned by `selectAnyInFlightRemovalSet` when
 // no bulk delete is in flight, avoiding an allocation on every idle render.
 const EMPTY_SKILL_NAME_SET: ReadonlySet<SkillName> = new Set()

--- a/src/renderer/src/redux/slices/uiSlice.ts
+++ b/src/renderer/src/redux/slices/uiSlice.ts
@@ -1,5 +1,5 @@
 import type { PayloadAction } from '@reduxjs/toolkit'
-import { createSlice, createAsyncThunk } from '@reduxjs/toolkit'
+import { createSlice, createAsyncThunk, isAnyOf } from '@reduxjs/toolkit'
 import { match } from 'ts-pattern'
 
 import type { RootState } from '@/renderer/src/redux/store'
@@ -572,31 +572,6 @@ const uiSlice = createSlice({
         state.syncResult = null
         state.error = action.error.message ?? 'Sync failed'
       })
-      // ── Bulk delete/unlink: clear stale undo toast atomically ──────────
-      // A new bulk operation supersedes any in-flight undo affordance. The
-      // fresh fulfilled outcome will dispatch `setUndoToast` from MainContent.
-      .addCase(deleteSelectedSkills.pending, (state) => {
-        state.undoToast = null
-        state.bulkConfirm = null
-        // Bulk op committed — leaving mode ON would strand a checkbox column
-        // over a fresh post-delete list the user is now observing for result.
-        state.bulkSelectMode = false
-      })
-      .addCase(clearSelectedOrphanSymlinks.pending, (state) => {
-        state.undoToast = null
-        state.bulkConfirm = null
-        state.bulkSelectMode = false
-      })
-      .addCase(clearSelectedBrokenSymlinkSlots.pending, (state) => {
-        state.undoToast = null
-        state.bulkConfirm = null
-        state.bulkSelectMode = false
-      })
-      .addCase(unlinkSelectedFromAgent.pending, (state) => {
-        state.undoToast = null
-        state.bulkConfirm = null
-        state.bulkSelectMode = false
-      })
       // ── Prune stale repo filter ids when the skill inventory reloads ─────
       // After a refetch (delete, sync, manual refresh) a previously-ticked repo
       // may no longer back any skill. Drop those ids from `selectedSources` so
@@ -614,6 +589,24 @@ const uiSlice = createSlice({
           survivingSources.has(id),
         )
       })
+      // ── Bulk delete/unlink: clear stale undo toast atomically ──────────
+      // A new bulk operation supersedes any in-flight undo affordance. The
+      // fresh fulfilled outcome will dispatch `setUndoToast` from MainContent.
+      .addMatcher(
+        isAnyOf(
+          deleteSelectedSkills.pending,
+          clearSelectedOrphanSymlinks.pending,
+          clearSelectedBrokenSymlinkSlots.pending,
+          unlinkSelectedFromAgent.pending,
+        ),
+        (state) => {
+          state.undoToast = null
+          state.bulkConfirm = null
+          // Bulk op committed — leaving mode ON would strand a checkbox column
+          // over a fresh post-delete list the user is now observing for result.
+          state.bulkSelectMode = false
+        },
+      )
   },
 })
 

--- a/src/renderer/src/utils/summarizeBulkCopyResult.ts
+++ b/src/renderer/src/utils/summarizeBulkCopyResult.ts
@@ -1,3 +1,4 @@
+import { pluralize } from '@/renderer/src/utils/pluralize'
 import type { BulkCopyToAgentsResult } from '@/shared/types'
 
 /** Sonner toast severity for a bulk copy outcome. */
@@ -47,7 +48,7 @@ export function summarizeBulkCopyResult(
   }
 
   const skillCount = perSkill.length
-  const skillWord = skillCount === 1 ? 'skill' : 'skills'
+  const skillWord = pluralize(skillCount, 'skill')
   const totalCopied = perSkill.reduce((sum, outcome) => sum + outcome.copied, 0)
   const failureLines = perSkill.flatMap((outcome) =>
     outcome.failures.map(
@@ -68,7 +69,7 @@ export function summarizeBulkCopyResult(
 
   // Some targets rejected (e.g. destination already exists) — partial success.
   if (failureCount > 0) {
-    const copyWord = failureCount === 1 ? 'copy' : 'copies'
+    const copyWord = pluralize(failureCount, 'copy', 'copies')
     const fullySucceeded = perSkill.filter(
       (outcome) => outcome.failures.length === 0,
     ).length
@@ -82,7 +83,7 @@ export function summarizeBulkCopyResult(
   // Every selected skill copied to every chosen agent. Use the authoritative
   // ticked-agent count for the title rather than inferring it from a skill's
   // `copied`, so the wording can't drift if the IPC contract ever changes.
-  const agentWord = targetAgentCount === 1 ? 'agent' : 'agents'
+  const agentWord = pluralize(targetAgentCount, 'agent')
   return {
     tone: 'success',
     title: `Copied ${skillCount} ${skillWord} to ${targetAgentCount} ${agentWord}`,


### PR DESCRIPTION
## Summary

`/simplify` whole-codebase pass — **behavior-preserving** dedup + dead-code removal. No public API, no test expectations, no user-visible behavior changed.

6 edits across 6 files, **net −46 lines** (75 insertions / 121 deletions).

## Changes

| # | File | What | Why |
|---|------|------|-----|
| 1 | `src/main/services/trashService.ts` | Extract `coerceTrashError(error, prefix)` helper; replace 4 identical `error instanceof TrashError ? … : new TrashError(…)` ternaries | DRY the staged-source / staged-local-copy revert error shaping |
| 2 | `src/main/services/trashService.ts` | Reuse hoisted `cancelEvictTimer(id)` in `evict()` instead of inline `get/clearTimeout/delete` | Single timer-cancel path |
| 3 | `src/main/ipc/skills.ts` | Extract `describeError(error)` → `{ message, code? }`; replace 3 catch-block `const message=…; const code=…` pairs | DRY error→IPC-payload shaping; downstream `error: code ? {message,code} : {message}` untouched |
| 4 | `src/renderer/src/redux/selectors.ts` | Delete dead `selectInFlightDeleteNamesSet` selector (0 consumers; `selectAnyInFlightRemovalSet` is the live one) | Remove dead code |
| 5 | `src/renderer/src/redux/slices/uiSlice.ts` | Collapse 4 byte-identical `.pending` `addCase` blocks into one `addMatcher(isAnyOf(…))` | Dedup bulk-action pending reset (RTK: matcher placed after all addCase) |
| 6 | `src/renderer/src/utils/summarizeBulkCopyResult.ts` | Use existing `pluralize()` for 3 inline `count===1 ? … : …` ternaries | Reuse existing util |

## Behavior preservation

- `coerceTrashError` preserves laziness — non-`TrashError` path builds the prefix string eagerly, but `copy.agentId` is a plain branded-string field (side-effect-free).
- `isAnyOf(…)` matches only the 4 exact bulk action types; those thunks have no other `addCase` in the slice → no double-run. Matcher body sets the identical 3 fields (`undoToast=null; bulkConfirm=null; bulkSelectMode=false`).
- Dead selector had zero consumers; its 2 tests removed (2118 → 2116).
- `pluralize.ts` is pre-existing on `main`; variable names unchanged so downstream templates are byte-identical.

## Verification

- `pnpm validate` ✅ — lint / **2116 vitest** / typecheck / dead-code / dupes / health / storybook
- `pnpm test:e2e` ✅ — **58/58**
- `/review` ✅ — scope clean, 0 critical, adversarial behavior-change hunt → APPROVE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * エラーハンドリングロジックを共通化し、削除操作全体での一貫性を向上
  * バルク操作時の状態管理を最適化
  * セレクタロジックを整理し、パフォーマンスを改善

* **Tests**
  * 不要なテストケースを削除

<!-- end of auto-generated comment: release notes by coderabbit.ai -->