### PR TITLE
fix: close UX gaps across app surfaces

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -297,6 +297,12 @@ Rules:
 - Tabs should be compact and stable.
 - Use underline, border, or subtle background to communicate selection.
 - Do not increase container height on hover or active state.
+- A segmented control sits left-aligned under its own label, sized to its
+  content — it does not stretch full-width or center in the row. Stretching reads
+  as a primary tab bar; a secondary setting toggle should stay a compact,
+  left-anchored affordance. Apply `justify-start` to the ToggleGroup whenever its
+  parent is a full-width flex column. (macOS System Settings, Linear preference
+  toggles.)
 - Keep Radix roles in mind when testing: some toggle groups expose `radio`.
 
 ### Lists and Rows
@@ -335,6 +341,24 @@ Rules:
 - Never dress an expected empty as a failure: no `h-12` icon or `text-lg`
   heading for a search miss. This is the operational reading of principle 5's
   "no noisy empty states."
+
+### Loading and Skeletons
+
+- A fixed-shape skeleton — not a single "Loading…" text line — is the default
+  first-load placeholder for any list or panel whose populated layout is known.
+  Mirror the populated layout (same row count, same chip / text / trailing
+  structure) so the panel does not reflow when real data lands. (Linear, GitHub,
+  Vercel load lists this way.)
+- A skeleton is silent to assistive tech: the visible "Loading…" text it
+  replaces was announced; pulsing bars are not. So the skeleton container MUST
+  carry `role="status"` plus a descriptive `aria-label` (e.g. "Loading trending
+  skills"), and the inner placeholder rows are `aria-hidden`. Swapping announced
+  text for a bare skeleton is an accessibility regression, not a neutral visual
+  change.
+- A panel that renders a skeleton must actually request its data. A skeleton with
+  no fetch behind it is a permanent broken-looking spinner; own the fetch on
+  mount (guarded by a cache TTL) wherever the populated state is the intended
+  resting state.
 
 ### Cards and Widgets
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -66,14 +66,30 @@ The app uses OKLCH CSS variables, driven by `THEME_PRESETS` in
 
 Status colors must remain semantically stable:
 
-| Status               | Color                   |
-| -------------------- | ----------------------- |
-| Valid / linked       | `--success` fixed green |
-| Broken               | Amber                   |
-| Missing              | `--muted-foreground`    |
-| Orphan / destructive | `--destructive`         |
-| Local skill type     | Emerald                 |
-| G-Stack skill type   | `--gstack`              |
+| Status                | Color                    |
+| --------------------- | ------------------------ |
+| Valid / linked        | `--success` fixed green  |
+| Broken / inaccessible | Amber (see amber shades) |
+| Missing               | `--muted-foreground`     |
+| Orphan / destructive  | `--destructive`          |
+| Local skill type      | Emerald                  |
+| G-Stack skill type    | `--gstack`               |
+
+Amber shades — Tailwind ships several amber steps; pin them by role so the
+"needs review" hue stays consistent and reviews don't churn:
+
+| Role                                                       | Class                     |
+| ---------------------------------------------------------- | ------------------------- |
+| Broken / inaccessible / needs-review status text + icons   | `text-amber-400`          |
+| Warning-dialog icon glyphs, bookmark / star, stat emphasis | `text-amber-500`          |
+| Amber tint backgrounds (badges, status chips, fills)       | `bg-amber-500/{10,15,20}` |
+
+`text-amber-400` is the app-wide needs-review hue (`SymlinkStatus`, `badge`
+broken variant, `HealthWidget`); `text-amber-500` is the slightly stronger amber
+for warning affordances and the bookmark accent. Tint backgrounds always use the
+`amber-500` base at low alpha regardless of which text shade sits on them. The
+lone exception is `text-amber-300` for badge text on a denser amber tint, where
+the lighter step is needed for contrast.
 
 Rules:
 
@@ -350,11 +366,20 @@ Rules:
   structure) so the panel does not reflow when real data lands. (Linear, GitHub,
   Vercel load lists this way.)
 - A skeleton is silent to assistive tech: the visible "Loading…" text it
-  replaces was announced; pulsing bars are not. So the skeleton container MUST
-  carry `role="status"` plus a descriptive `aria-label` (e.g. "Loading trending
-  skills"), and the inner placeholder rows are `aria-hidden`. Swapping announced
-  text for a bare skeleton is an accessibility regression, not a neutral visual
-  change.
+  replaces was announced; pulsing bars are not. How to restore the announcement
+  depends on whether the skeleton is a **primary loading surface** or a
+  **decorative one in a dense grid**:
+  - **Primary loading surface** — a main panel or list the user is actively
+    waiting on (e.g. the Trending panel). The skeleton container MUST carry
+    `role="status"` plus a descriptive `aria-label` (e.g. "Loading trending
+    skills"), and the inner placeholder rows are `aria-hidden`. Swapping
+    announced text for a bare skeleton here is an accessibility regression.
+  - **Decorative skeleton in a dense widget grid** — many small widgets loading
+    at once (e.g. `dashboard/widgets/*Skeleton`). It MAY instead be fully
+    `aria-hidden`, because announcing each of N silhouettes would fire a burst of
+    competing "Loading…" messages; the surrounding region's own status copy
+    covers the wait. Pick one mode — never put `role="status"` and `aria-hidden`
+    on the same element (they contradict).
 - A panel that renders a skeleton must actually request its data. A skeleton with
   no fetch behind it is a permanent broken-looking spinner; own the fetch on
   mount (guarded by a cache TTL) wherever the populated state is the intended
@@ -397,6 +422,25 @@ Baseline:
 - Icon-only controls need `aria-label`.
 - Use native controls before custom roles.
 - Do not remove focus outlines without a visible replacement.
+
+Focus indicators:
+
+The shared `button.tsx` is the source of truth — every variant ships
+`focus-visible:ring-1 ring-ring` (see Buttons). Use it for any standard button so
+the focus treatment is inherited, not re-invented. For focusable elements that
+genuinely can't use it (clickable rows, footer links, hand-rolled icon buttons):
+
+- Always pair `focus-visible:outline-none` with a visible `focus-visible:ring-*
+ring-ring`, and always use `focus-visible`, never bare `focus` — bare `focus`
+  also fires on pointer click, flashing a ring at mouse users.
+- Ring width tracks prominence, not a rigid tier: compact in-surface controls may
+  match `button.tsx`'s `ring-1`; standalone hand-rolled controls commonly use
+  `ring-2` (e.g. `BookmarkItem`, the sidebar gear). Both are fine as long as the
+  ring reads clearly against `--ring`. Do not treat a single width as mandatory.
+- Full-width or edge-adjacent controls add `focus-visible:ring-inset` so the ring
+  renders inside the control instead of clipping against a container border —
+  full-width rows (`AgentItem`), the footer `skills.sh` link, and underline-style
+  tabs all use the inset ring.
 
 Target sizing:
 

--- a/src/renderer/settings/sections/Appearance.tsx
+++ b/src/renderer/settings/sections/Appearance.tsx
@@ -73,7 +73,7 @@ const BackgroundBlurRangeInput = React.memo(function BackgroundBlurRangeInput({
       value={value}
       onChange={handleInputChange}
       aria-label={label}
-      className="h-2 min-w-0 flex-1 accent-primary"
+      className="h-2 min-w-0 flex-1 accent-primary rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
     />
   )
 })
@@ -171,6 +171,7 @@ export const Appearance = React.memo(function Appearance(): React.ReactElement {
           type="single"
           variant="outline"
           size="sm"
+          className="justify-start"
           value={installedSearchCountDisplay}
           onValueChange={handleSearchCountDisplayChange}
           aria-label={INSTALLED_SEARCH_COUNT_DISPLAY_LABEL}

--- a/src/renderer/settings/sections/General.tsx
+++ b/src/renderer/settings/sections/General.tsx
@@ -301,6 +301,7 @@ export const General = React.memo(function General(): React.ReactElement {
           type="single"
           variant="outline"
           size="sm"
+          className="justify-start"
           value={settings.defaultSkillTab}
           onValueChange={handleDefaultTabChange}
           aria-label="Default tab when opening a skill"

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -1,4 +1,5 @@
 import {
+  AlertTriangle,
   ArrowDownAZ,
   ArrowUpAZ,
   CheckSquare,
@@ -278,6 +279,23 @@ function getBulkDeleteTargetSummary(
     staleDeleteErrors: bulkConfirm.staleDeleteErrors,
     orphanErrors: bulkConfirm.orphanErrors,
   }
+}
+
+/**
+ * Pick the bulk-confirm dialog's warning-icon tint: red for the irreversible
+ * delete, amber for the lighter unlink. Module-scope (taking the whole state,
+ * so the call site needs no optional chain) keeps this branch out of
+ * MainContent's complexity budget.
+ * @param bulkConfirm - Pending bulk confirm dialog state, or null when closed.
+ * @returns Tailwind text-color class for the AlertTriangle glyph.
+ * @example
+ * bulkConfirmIconColorClass({ kind: 'delete', ... }) // => 'text-destructive'
+ * bulkConfirmIconColorClass({ kind: 'unlink', ... }) // => 'text-amber-500'
+ */
+function bulkConfirmIconColorClass(
+  bulkConfirm: BulkConfirmState | null,
+): string {
+  return bulkConfirm?.kind === 'delete' ? 'text-destructive' : 'text-amber-500'
 }
 
 /**
@@ -1371,11 +1389,16 @@ export const MainContent = React.memo(
         >
           <DialogContent className="max-w-md">
             <DialogHeader>
-              <DialogTitle>
-                {bulkConfirm?.kind === 'delete'
-                  ? `Delete ${bulkConfirm.skillNames.length} ${pluralize(bulkConfirm.skillNames.length, 'skill')}?`
-                  : `Unlink ${bulkConfirm?.skillNames.length ?? 0} ${pluralize(bulkConfirm?.skillNames.length ?? 0, 'skill')} from ${bulkConfirm?.agentName ?? 'agent'}?`}
-              </DialogTitle>
+              <div className="flex items-center gap-2">
+                <AlertTriangle
+                  className={`h-5 w-5 ${bulkConfirmIconColorClass(bulkConfirm)}`}
+                />
+                <DialogTitle>
+                  {bulkConfirm?.kind === 'delete'
+                    ? `Delete ${bulkConfirm.skillNames.length} ${pluralize(bulkConfirm.skillNames.length, 'skill')}?`
+                    : `Unlink ${bulkConfirm?.skillNames.length ?? 0} ${pluralize(bulkConfirm?.skillNames.length ?? 0, 'skill')} from ${bulkConfirm?.agentName ?? 'agent'}?`}
+                </DialogTitle>
+              </div>
               <DialogDescription>
                 {bulkConfirm?.kind === 'delete'
                   ? renderBulkDeleteDescription({

--- a/src/renderer/src/components/marketplace/MarketplaceDashboard.browser.test.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceDashboard.browser.test.tsx
@@ -1,6 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { Provider } from 'react-redux'
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import type { RootState } from '@/renderer/src/redux/store'
@@ -20,7 +20,30 @@ import type {
 // is active with no skill previewed. It reads three slices (installed count,
 // bookmark count, trending leaderboard cache) and lets the user pick a trending
 // row for preview. This file guards: the trending-row click → previewSkill
-// selection, and the loading vs settled-empty trending placeholders.
+// selection, the loading/error/settled-empty trending placeholders, and the
+// mount fetch that populates the panel.
+
+// The dashboard dispatches `loadLeaderboard('trending')` on mount, whose thunk
+// reads `window.electron.marketplace.leaderboard`. Browser-mode tests replace
+// the preload bridge, so the IPC surface is stubbed. The default is a
+// never-resolving promise: it lets each test pin the leaderboard state it seeded
+// without a late `fulfilled` action racing in and overwriting the rendered
+// branch (the fresh-cache TTL guard already blocks the fetch for seeded tests).
+const mockLeaderboard = vi.fn()
+
+beforeEach(() => {
+  mockLeaderboard.mockReset()
+  mockLeaderboard.mockReturnValue(new Promise<SkillSearchResult[]>(() => {}))
+  vi.stubGlobal('electron', {
+    marketplace: {
+      leaderboard: mockLeaderboard,
+    },
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 /**
  * Build a `SkillSearchResult` fixture so each test varies only the field it
@@ -58,8 +81,10 @@ function makeLeaderboardData(
 
 /**
  * Render MarketplaceDashboard over the real marketplace + skills + bookmark
- * reducers, seeded with `preloadedState`. The dashboard has no mount thunk, so
- * the seeded state is rendered verbatim with no async settling.
+ * reducers, seeded with `preloadedState`. The dashboard fires a mount fetch, but
+ * the stubbed IPC defaults to a never-resolving promise so seeded state renders
+ * without a late `fulfilled` overwriting it; fresh seeded entries also short-
+ * circuit the thunk via its cache-TTL guard.
  * @param preloadedState - Partial marketplace + skills + bookmarks state to seed
  */
 async function renderDashboard(preloadedState: {
@@ -170,16 +195,31 @@ describe('MarketplaceDashboard — trending preview selection', () => {
 })
 
 describe('MarketplaceDashboard — trending placeholders', () => {
-  it('shows a loading placeholder while the trending leaderboard has not loaded yet', async () => {
+  it('requests the trending leaderboard on mount so the panel populates itself', async () => {
+    // Arrange — an unseeded trending slot means the cache-TTL guard cannot
+    // short-circuit, so the mount thunk must reach the IPC bridge.
+    // Act
+    await renderDashboard({ marketplace: { leaderboard: {} } })
+
+    // Assert — the dashboard owns its own trending fetch (it is not piggy-backing
+    // on SkillsMarketplace's default 'all-time' request), keyed to the trending
+    // filter so the skeleton resolves without the user opening the ranking tab.
+    await expect
+      .poll(() => mockLeaderboard.mock.calls.length)
+      .toBeGreaterThan(0)
+    expect(mockLeaderboard).toHaveBeenCalledWith({ filter: 'trending' })
+  })
+
+  it('shows a loading skeleton, announced to screen readers, while the trending leaderboard has not loaded yet', async () => {
     // Arrange — no trending cache entry means trendingData is undefined, which
     // the dashboard treats as still loading.
     const { screen } = await renderDashboard({
       marketplace: { leaderboard: {} },
     })
 
-    // Act + Assert
+    // Act + Assert — pulsing rows expose an accessible loading status
     await expect
-      .element(screen.getByText('Loading trending skills...'))
+      .element(screen.getByRole('status', { name: 'Loading trending skills' }))
       .toBeInTheDocument()
   })
 
@@ -201,6 +241,31 @@ describe('MarketplaceDashboard — trending placeholders', () => {
     // Act + Assert
     await expect
       .element(screen.getByText('No trending skills available'))
+      .toBeInTheDocument()
+  })
+
+  it('shows an offline notice when the trending fetch failed and nothing is cached', async () => {
+    // Arrange — an errored trending entry with zero cached skills is the
+    // failure state, distinct from both loading and a settled-empty list. The
+    // mount thunk re-fetches errored filters (errors bypass the TTL gate), so
+    // the IPC mock must reject for state to settle back on the error branch
+    // instead of getting stuck on the in-flight skeleton.
+    mockLeaderboard.mockRejectedValue(new Error('network down'))
+    const { screen } = await renderDashboard({
+      marketplace: {
+        leaderboard: {
+          trending: makeLeaderboardData({
+            skills: [],
+            status: 'error',
+            error: 'network down',
+          }),
+        },
+      },
+    })
+
+    // Act + Assert
+    await expect
+      .element(screen.getByText('Trending unavailable'))
       .toBeInTheDocument()
   })
 })

--- a/src/renderer/src/components/marketplace/MarketplaceDashboard.browser.test.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceDashboard.browser.test.tsx
@@ -204,9 +204,10 @@ describe('MarketplaceDashboard — trending placeholders', () => {
     // Assert — the dashboard owns its own trending fetch (it is not piggy-backing
     // on SkillsMarketplace's default 'all-time' request), keyed to the trending
     // filter so the skeleton resolves without the user opening the ranking tab.
-    await expect
-      .poll(() => mockLeaderboard.mock.calls.length)
-      .toBeGreaterThan(0)
+    // Exactly one IPC call: the thunk's in-flight guard dedupes StrictMode's
+    // double-mount (the first dispatch sets status:'loading' synchronously, so
+    // the second dispatch's `condition` short-circuits before reaching IPC).
+    await expect.poll(() => mockLeaderboard.mock.calls.length).toBe(1)
     expect(mockLeaderboard).toHaveBeenCalledWith({ filter: 'trending' })
   })
 
@@ -242,6 +243,9 @@ describe('MarketplaceDashboard — trending placeholders', () => {
     await expect
       .element(screen.getByText('No trending skills available'))
       .toBeInTheDocument()
+    // …and the fresh (idle, just-fetched) cache entry short-circuits the mount
+    // thunk via its TTL guard, so no redundant IPC refetch fires.
+    expect(mockLeaderboard).not.toHaveBeenCalled()
   })
 
   it('shows an offline notice when the trending fetch failed and nothing is cached', async () => {

--- a/src/renderer/src/components/marketplace/MarketplaceDashboard.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceDashboard.tsx
@@ -1,10 +1,17 @@
-import { Download, Star, TrendingUp } from 'lucide-react'
+import { Download, Star, TrendingUp, WifiOff } from 'lucide-react'
 import React from 'react'
+import { match } from 'ts-pattern'
 
+import { useCycleEffect } from '@/renderer/src/hooks/useCycleEffect'
 import { formatInstallCount } from '@/renderer/src/lib/utils'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
-import { setPreviewSkill } from '@/renderer/src/redux/slices/marketplaceSlice'
+import {
+  loadLeaderboard,
+  setPreviewSkill,
+} from '@/renderer/src/redux/slices/marketplaceSlice'
 import type { SkillSearchResult } from '@/shared/types'
+
+import { resolveTrendingView } from './marketplaceDashboardHelpers'
 
 const TRENDING_PREVIEW_LIMIT = 5
 
@@ -27,8 +34,19 @@ export const MarketplaceDashboard = React.memo(
       () => trendingData?.skills?.slice(0, TRENDING_PREVIEW_LIMIT) ?? [],
       [trendingData],
     )
-    const isTrendingLoading =
-      trendingData === undefined || trendingData.status === 'loading'
+    const trendingView = resolveTrendingView(
+      trendingSkills.length,
+      trendingData?.status,
+    )
+
+    // Own the Trending fetch on mount: the only other dispatch site
+    // (SkillsMarketplace) requests the user-selected ranking filter, which
+    // defaults to 'all-time', so without this the Trending panel's skeleton
+    // would never resolve. The thunk's in-flight + cache-TTL guards dedupe the
+    // double-mount and skip refetching data that is still fresh.
+    useCycleEffect(() => {
+      dispatch(loadLeaderboard('trending'))
+    }, [dispatch])
 
     const handleSkillClick = (skill: SkillSearchResult): void => {
       dispatch(setPreviewSkill(skill))
@@ -43,7 +61,7 @@ export const MarketplaceDashboard = React.memo(
             <span className="text-xs font-medium text-muted-foreground">
               Installed Skills
             </span>
-            <span className="text-3xl font-bold text-primary">
+            <span className="text-2xl font-semibold tabular-nums text-primary">
               {installedCount}
             </span>
           </div>
@@ -51,7 +69,7 @@ export const MarketplaceDashboard = React.memo(
             <span className="text-xs font-medium text-muted-foreground">
               Bookmarked
             </span>
-            <span className="text-3xl font-bold text-amber-500">
+            <span className="text-2xl font-semibold tabular-nums text-amber-500">
               {bookmarkedCount}
             </span>
           </div>
@@ -65,42 +83,45 @@ export const MarketplaceDashboard = React.memo(
           </span>
         </div>
 
-        {trendingSkills.length > 0 ? (
-          <div className="flex flex-col gap-2">
-            {trendingSkills.map((skill) => (
-              <button
-                key={skill.name}
-                type="button"
-                onClick={() => handleSkillClick(skill)}
-                className="flex items-center gap-3 p-3 rounded-lg bg-background border border-border hover:border-primary/50 transition-colors text-left"
-              >
-                <div className="flex items-center justify-center w-7 h-7 shrink-0 rounded-md bg-muted font-mono text-[13px] font-semibold text-primary">
-                  {skill.rank}
-                </div>
-                <div className="flex-1 min-w-0 flex flex-col gap-0.5">
-                  <span className="text-sm font-semibold text-foreground truncate">
-                    {skill.name}
-                  </span>
-                  <span className="font-mono text-xs text-muted-foreground truncate">
-                    {skill.repo}
-                  </span>
-                </div>
-                <div className="flex items-center gap-1 text-muted-foreground shrink-0">
-                  <Download className="h-3 w-3" />
-                  <span className="font-mono text-xs font-medium">
-                    {formatInstallCount(skill.installCount)}
-                  </span>
-                </div>
-              </button>
-            ))}
-          </div>
-        ) : (
-          <div className="flex items-center justify-center py-8 text-sm text-muted-foreground">
-            {isTrendingLoading
-              ? 'Loading trending skills...'
-              : 'No trending skills available'}
-          </div>
-        )}
+        {match(trendingView)
+          .with('populated', () => (
+            <div className="flex flex-col gap-2">
+              {trendingSkills.map((skill) => (
+                <button
+                  key={skill.name}
+                  type="button"
+                  onClick={() => handleSkillClick(skill)}
+                  className="flex items-center gap-3 p-3 rounded-lg bg-background border border-border hover:border-primary/50 transition-colors text-left"
+                >
+                  <div className="flex items-center justify-center w-7 h-7 shrink-0 rounded-md bg-muted font-mono text-[13px] font-semibold text-primary">
+                    {skill.rank}
+                  </div>
+                  <div className="flex-1 min-w-0 flex flex-col gap-0.5">
+                    <span className="text-sm font-semibold text-foreground truncate">
+                      {skill.name}
+                    </span>
+                    <span className="font-mono text-xs text-muted-foreground truncate">
+                      {skill.repo}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-1 text-muted-foreground shrink-0">
+                    <Download className="h-3 w-3" />
+                    <span className="font-mono text-xs font-medium">
+                      {formatInstallCount(skill.installCount)}
+                    </span>
+                  </div>
+                </button>
+              ))}
+            </div>
+          ))
+          .with('loading', () => <TrendingSkeleton />)
+          .with('error', () => <TrendingError />)
+          .with('empty', () => (
+            <div className="flex items-center justify-center py-8 text-sm text-muted-foreground">
+              No trending skills available
+            </div>
+          ))
+          .exhaustive()}
 
         <div className="flex items-center justify-center py-4">
           <p className="text-[13px] text-muted-foreground flex items-center gap-1.5">
@@ -112,3 +133,57 @@ export const MarketplaceDashboard = React.memo(
     )
   },
 )
+
+/**
+ * Fixed five-row placeholder shown while the first Trending fetch is in flight.
+ * Mirrors the populated row layout (rank chip, two text lines, a trailing
+ * count) so the panel does not reflow when real data lands — a single "Loading…"
+ * text line would collapse to one row and make the list jump. Row count is
+ * fixed to `TRENDING_PREVIEW_LIMIT` to match the eventual populated height.
+ */
+const TrendingSkeleton = React.memo(
+  function TrendingSkeleton(): React.ReactElement {
+    return (
+      // role="status" + aria-label keeps the loading state announced to screen
+      // readers now that the visible "Loading…" text has become silent pulse bars.
+      <div
+        className="flex flex-col gap-2"
+        role="status"
+        aria-label="Loading trending skills"
+      >
+        {Array.from({ length: TRENDING_PREVIEW_LIMIT }, (_, index) => (
+          <div
+            key={`trending-skeleton-${index}`}
+            aria-hidden
+            className="flex items-center gap-3 p-3 rounded-lg bg-background border border-border"
+          >
+            <div className="w-7 h-7 rounded-md bg-muted animate-pulse shrink-0" />
+            <div className="flex-1 min-w-0 flex flex-col gap-0.5">
+              <div className="h-4 w-[40%] rounded bg-muted animate-pulse" />
+              <div className="h-3 w-[30%] rounded bg-muted animate-pulse" />
+            </div>
+            <div className="h-3 w-10 rounded bg-muted animate-pulse shrink-0" />
+          </div>
+        ))}
+      </div>
+    )
+  },
+)
+
+/**
+ * Offline notice shown when the Trending fetch failed and no cached data exists
+ * to fall back on. A network failure is a rare, actionable state, so it earns a
+ * fuller icon+heading+hint treatment — vs. the single quiet line used for a
+ * genuinely empty leaderboard — per DESIGN.md's empty-state severity scale.
+ */
+const TrendingError = React.memo(function TrendingError(): React.ReactElement {
+  return (
+    <div className="flex flex-col items-center justify-center py-8 text-center gap-1">
+      <WifiOff className="h-6 w-6 text-muted-foreground mb-1" />
+      <p className="text-sm font-medium text-foreground">
+        Trending unavailable
+      </p>
+      <p className="text-xs text-muted-foreground">Check your connection</p>
+    </div>
+  )
+})

--- a/src/renderer/src/components/marketplace/MarketplaceDetailPanel.browser.test.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceDetailPanel.browser.test.tsx
@@ -144,7 +144,7 @@ describe('MarketplaceDetailPanel routing', () => {
   })
 })
 
-describe('MarketplaceDashboard empty state', () => {
+describe('MarketplaceDashboard trending placeholders', () => {
   it('shows a loading skeleton, announced to screen readers, before trending skills have been fetched', async () => {
     // Arrange
     const store = await createStore()

--- a/src/renderer/src/components/marketplace/MarketplaceDetailPanel.browser.test.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceDetailPanel.browser.test.tsx
@@ -1,11 +1,34 @@
 import { configureStore } from '@reduxjs/toolkit'
 import type { ReactElement } from 'react'
 import { Provider } from 'react-redux'
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import type { SkillName, SkillSearchResult } from '@/shared/types'
 import { repositoryId } from '@/shared/types'
+
+// MarketplaceDashboard (rendered by MarketplaceDetailPanel when nothing is
+// previewed) dispatches `loadLeaderboard('trending')` on mount, whose thunk
+// reads `window.electron.marketplace.leaderboard`. Browser-mode tests replace
+// the preload bridge, so the IPC surface is stubbed. The default never-resolving
+// promise lets each test pin the state it dispatched without a late `fulfilled`
+// racing in; the error test overrides it with a rejection so the re-fetch
+// (errors bypass the cache-TTL gate) settles back on the error branch.
+const mockLeaderboard = vi.fn()
+
+beforeEach(() => {
+  mockLeaderboard.mockReset()
+  mockLeaderboard.mockReturnValue(new Promise<SkillSearchResult[]>(() => {}))
+  vi.stubGlobal('electron', {
+    marketplace: {
+      leaderboard: mockLeaderboard,
+    },
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 /**
  * Build a minimal `SkillSearchResult` fixture and let callers override only
@@ -122,7 +145,7 @@ describe('MarketplaceDetailPanel routing', () => {
 })
 
 describe('MarketplaceDashboard empty state', () => {
-  it('shows a loading message before trending skills have been fetched', async () => {
+  it('shows a loading skeleton, announced to screen readers, before trending skills have been fetched', async () => {
     // Arrange
     const store = await createStore()
     const { MarketplaceDashboard } = await import('./MarketplaceDashboard')
@@ -130,9 +153,9 @@ describe('MarketplaceDashboard empty state', () => {
     // Act
     const screen = await renderWithStore(<MarketplaceDashboard />, store)
 
-    // Assert
+    // Assert — the pulsing placeholder carries an accessible loading status
     await expect
-      .element(screen.getByText('Loading trending skills...'))
+      .element(screen.getByRole('status', { name: 'Loading trending skills' }))
       .toBeInTheDocument()
   })
 
@@ -156,6 +179,32 @@ describe('MarketplaceDashboard empty state', () => {
     // Assert
     await expect
       .element(screen.getByText('No trending skills available'))
+      .toBeInTheDocument()
+  })
+
+  it('shows an offline notice when the trending fetch fails with nothing cached', async () => {
+    // Arrange — seed the failed state, then make the mount re-fetch fail too so
+    // the panel settles back on the error branch (errors bypass the TTL gate,
+    // so the dashboard re-requests trending on mount).
+    mockLeaderboard.mockRejectedValue(new Error('network down'))
+    const store = await createStore()
+    const { loadLeaderboard } =
+      await import('@/renderer/src/redux/slices/marketplaceSlice')
+    const { MarketplaceDashboard } = await import('./MarketplaceDashboard')
+    store.dispatch(
+      loadLeaderboard.rejected(
+        new Error('network down'),
+        'test-request',
+        'trending',
+      ),
+    )
+
+    // Act
+    const screen = await renderWithStore(<MarketplaceDashboard />, store)
+
+    // Assert — a failed load surfaces a recoverable offline notice, not a blank list
+    await expect
+      .element(screen.getByText('Trending unavailable'))
       .toBeInTheDocument()
   })
 })

--- a/src/renderer/src/components/marketplace/SkillsMarketplace.tsx
+++ b/src/renderer/src/components/marketplace/SkillsMarketplace.tsx
@@ -82,14 +82,9 @@ export const SkillsMarketplace = React.memo(
     return (
       <div className="h-full flex flex-col">
         <div className="p-6 pb-4 space-y-4">
-          <div>
-            <h1 className="text-[28px] font-bold text-foreground">
-              Skills Marketplace
-            </h1>
-            <p className="text-sm text-muted-foreground mt-1">
-              Browse, search and install skills from skills.sh
-            </p>
-          </div>
+          <h1 className="text-lg font-semibold text-foreground">
+            Skills Marketplace
+          </h1>
 
           <RankingTabs
             value={rankingFilter}

--- a/src/renderer/src/components/marketplace/marketplaceDashboardHelpers.test.ts
+++ b/src/renderer/src/components/marketplace/marketplaceDashboardHelpers.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveTrendingView } from '@/renderer/src/components/marketplace/marketplaceDashboardHelpers'
+
+describe('resolveTrendingView', () => {
+  it('shows the leaderboard rows whenever cached skills exist', () => {
+    // Arrange / Act — five skills cached, fetch idle
+    const view = resolveTrendingView(5, 'idle')
+
+    // Assert
+    expect(view).toBe('populated')
+  })
+
+  it('keeps showing cached rows during a background refresh instead of blanking to a skeleton', () => {
+    // Arrange / Act — stale cache present while a refresh is in flight
+    const view = resolveTrendingView(5, 'loading')
+
+    // Assert — stale-while-revalidate: populated wins over loading
+    expect(view).toBe('populated')
+  })
+
+  it('keeps showing cached rows even after a refresh fails', () => {
+    // Arrange / Act — stale cache present but the latest fetch errored
+    const view = resolveTrendingView(3, 'error')
+
+    // Assert — populated wins over error so a failed refresh never blanks the list
+    expect(view).toBe('populated')
+  })
+
+  it('shows the loading skeleton before any fetch has started', () => {
+    // Arrange / Act — tab never visited yet (status undefined), no skills
+    const view = resolveTrendingView(0, undefined)
+
+    // Assert
+    expect(view).toBe('loading')
+  })
+
+  it('shows the loading skeleton while the first fetch is in flight', () => {
+    // Arrange / Act — fetch pending, nothing cached yet
+    const view = resolveTrendingView(0, 'loading')
+
+    // Assert
+    expect(view).toBe('loading')
+  })
+
+  it('shows the offline error notice when the fetch fails with nothing cached', () => {
+    // Arrange / Act — fetch failed and there is no stale data to fall back on
+    const view = resolveTrendingView(0, 'error')
+
+    // Assert
+    expect(view).toBe('error')
+  })
+
+  it('shows the genuine empty state when the fetch succeeds with zero skills', () => {
+    // Arrange / Act — fetch settled successfully but the leaderboard is empty
+    const view = resolveTrendingView(0, 'idle')
+
+    // Assert
+    expect(view).toBe('empty')
+  })
+})

--- a/src/renderer/src/components/marketplace/marketplaceDashboardHelpers.ts
+++ b/src/renderer/src/components/marketplace/marketplaceDashboardHelpers.ts
@@ -1,0 +1,43 @@
+import type { LeaderboardStatus } from '@/shared/types'
+
+/** The four mutually-exclusive visual states the dashboard's Trending panel renders. */
+export type TrendingView = 'populated' | 'loading' | 'error' | 'empty'
+
+/**
+ * Decide which Trending panel state the marketplace dashboard renders from the
+ * cached skill count and fetch status. Extracted as a pure function so the
+ * four-way visual branch is unit-testable without React Testing Library (per
+ * the src/renderer `.coderabbit.yaml` guideline) and stays exhaustive.
+ *
+ * Precedence is stale-while-revalidate: any cached skills win first (so a
+ * background refresh never blanks the list), then an in-flight/never-started
+ * fetch shows the skeleton, then a failed fetch shows the offline notice, and
+ * only a successful-but-empty result is treated as a genuine empty.
+ *
+ * @param trendingSkillCount - Number of trending skills available to render.
+ * @param status - Cache fetch status for the trending filter, or `undefined` when never fetched.
+ * @returns
+ * - `'populated'` when at least one skill is present
+ * - `'loading'` when no skills yet and the fetch is in flight (or never started)
+ * - `'error'` when no skills and the last fetch failed
+ * - `'empty'` when the fetch succeeded with zero skills
+ * @example
+ * resolveTrendingView(5, 'idle')    // => 'populated'
+ * resolveTrendingView(0, undefined) // => 'loading'
+ * resolveTrendingView(0, 'loading') // => 'loading'
+ * resolveTrendingView(0, 'error')   // => 'error'
+ * resolveTrendingView(0, 'idle')    // => 'empty'
+ */
+export function resolveTrendingView(
+  trendingSkillCount: number,
+  status: LeaderboardStatus | undefined,
+): TrendingView {
+  // Stale cache (even mid-refresh or after a failed refresh) always renders.
+  if (trendingSkillCount > 0) return 'populated'
+  // No data yet and a fetch is pending (or has never run) → skeleton, not "empty".
+  if (status === undefined || status === 'loading') return 'loading'
+  // Fetch finished but failed, with nothing cached to fall back on.
+  if (status === 'error') return 'error'
+  // Fetch succeeded with zero results — a true empty leaderboard.
+  return 'empty'
+}

--- a/src/renderer/src/components/marketplace/marketplaceDashboardHelpers.ts
+++ b/src/renderer/src/components/marketplace/marketplaceDashboardHelpers.ts
@@ -4,16 +4,9 @@ import type { LeaderboardStatus } from '@/shared/types'
 export type TrendingView = 'populated' | 'loading' | 'error' | 'empty'
 
 /**
- * Decide which Trending panel state the marketplace dashboard renders from the
- * cached skill count and fetch status. Extracted as a pure function so the
- * four-way visual branch is unit-testable without React Testing Library (per
- * the src/renderer `.coderabbit.yaml` guideline) and stays exhaustive.
- *
- * Precedence is stale-while-revalidate: any cached skills win first (so a
- * background refresh never blanks the list), then an in-flight/never-started
- * fetch shows the skeleton, then a failed fetch shows the offline notice, and
- * only a successful-but-empty result is treated as a genuine empty.
- *
+ * Pick the dashboard Trending panel's visual state from cached count + fetch
+ * status, stale-while-revalidate: cached skills win, then in-flight → skeleton,
+ * then failure → offline notice, then a successful-but-empty result → empty.
  * @param trendingSkillCount - Number of trending skills available to render.
  * @param status - Cache fetch status for the trending filter, or `undefined` when never fetched.
  * @returns

--- a/src/renderer/src/components/sidebar/AgentItem.tsx
+++ b/src/renderer/src/components/sidebar/AgentItem.tsx
@@ -159,7 +159,7 @@ export const AgentItem = React.memo(function AgentItem({
               type="button"
               aria-label={`Filter skills by ${agent.name}${skillCountText ? ` (${skillCountText})` : ''}`}
               className={cn(
-                'flex w-full items-center gap-2 min-h-11 py-1.5 px-2 rounded-md transition-colors border-l-4 border-l-transparent text-left',
+                'flex w-full items-center gap-2 min-h-11 py-1.5 px-2 rounded-md transition-colors border-l-4 border-l-transparent text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset',
                 agent.exists && 'cursor-pointer hover:bg-muted/50',
                 isSelected && 'border-l-primary bg-primary/10',
               )}

--- a/src/renderer/src/components/sidebar/SidebarFooter.tsx
+++ b/src/renderer/src/components/sidebar/SidebarFooter.tsx
@@ -36,7 +36,7 @@ export const SidebarFooter = React.memo(
         <button
           type="button"
           onClick={handleSkillsLinkClick}
-          className="flex flex-1 items-center justify-center gap-1.5 rounded-sm text-xs font-medium font-mono text-muted-foreground hover:text-primary transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="flex flex-1 items-center justify-center gap-1.5 rounded-sm text-xs font-medium font-mono text-muted-foreground hover:text-primary transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
         >
           <span>skills.sh</span>
           <ExternalLink className="h-3 w-3" />

--- a/src/renderer/src/components/sidebar/SidebarFooter.tsx
+++ b/src/renderer/src/components/sidebar/SidebarFooter.tsx
@@ -36,7 +36,7 @@ export const SidebarFooter = React.memo(
         <button
           type="button"
           onClick={handleSkillsLinkClick}
-          className="flex flex-1 items-center justify-center gap-1.5 text-xs font-medium font-mono text-muted-foreground hover:text-primary transition-colors"
+          className="flex flex-1 items-center justify-center gap-1.5 rounded-sm text-xs font-medium font-mono text-muted-foreground hover:text-primary transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           <span>skills.sh</span>
           <ExternalLink className="h-3 w-3" />
@@ -47,7 +47,7 @@ export const SidebarFooter = React.memo(
               type="button"
               aria-label="Open settings"
               onClick={handleSettingsClick}
-              className="no-drag inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
+              className="no-drag inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
               <Settings className="h-3.5 w-3.5" />
             </button>

--- a/src/renderer/src/components/skills/CodePreview.tsx
+++ b/src/renderer/src/components/skills/CodePreview.tsx
@@ -43,7 +43,7 @@ export const CodePreview = React.memo(function CodePreview({
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-48 text-muted-foreground text-sm">
+      <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
         Loading files...
       </div>
     )
@@ -51,7 +51,7 @@ export const CodePreview = React.memo(function CodePreview({
 
   if (files.length === 0) {
     return (
-      <div className="flex items-center justify-center h-48 text-muted-foreground text-sm">
+      <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
         No preview files found
       </div>
     )

--- a/src/renderer/src/components/skills/SkillDetail.tsx
+++ b/src/renderer/src/components/skills/SkillDetail.tsx
@@ -86,7 +86,7 @@ export const SkillDetail = React.memo(function SkillDetail({
           aria-pressed={activeTab === 'files'}
           onClick={() => handleTabChange('files')}
           className={cn(
-            'px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors',
+            'px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset',
             activeTab === 'files'
               ? 'text-primary border-primary'
               : 'text-muted-foreground border-transparent hover:text-foreground',
@@ -99,7 +99,7 @@ export const SkillDetail = React.memo(function SkillDetail({
           aria-pressed={activeTab === 'info'}
           onClick={() => handleTabChange('info')}
           className={cn(
-            'px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors',
+            'px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset',
             activeTab === 'info'
               ? 'text-primary border-primary'
               : 'text-muted-foreground border-transparent hover:text-foreground',
@@ -242,15 +242,38 @@ const InfoView = React.memo(function InfoView({
       <div className="flex gap-4 text-sm mb-4">
         <div>
           <span className="text-muted-foreground">Valid:</span>
-          <span className="ml-1 text-success">{validCount}</span>
+          <span
+            className={cn(
+              'ml-1',
+              validCount > 0 ? 'text-success' : 'text-muted-foreground',
+            )}
+          >
+            {validCount}
+          </span>
         </div>
         <div>
           <span className="text-muted-foreground">Broken:</span>
-          <span className="ml-1 text-amber-400">{brokenCount}</span>
+          <span
+            className={cn(
+              'ml-1',
+              brokenCount > 0 ? 'text-amber-400' : 'text-muted-foreground',
+            )}
+          >
+            {brokenCount}
+          </span>
         </div>
         <div>
           <span className="text-muted-foreground">Inaccessible:</span>
-          <span className="ml-1 text-amber-400">{inaccessibleCount}</span>
+          <span
+            className={cn(
+              'ml-1',
+              inaccessibleCount > 0
+                ? 'text-amber-400'
+                : 'text-muted-foreground',
+            )}
+          >
+            {inaccessibleCount}
+          </span>
         </div>
       </div>
 

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -569,7 +569,7 @@ export const SkillItem = React.memo(function SkillItem({
                       ? `Delete ${skill.name} from ${selectedAgentName}`
                       : `Unlink ${skill.name} from ${selectedAgentName}`
                   }
-                  className="absolute top-1.5 right-0 min-h-11 min-w-11 flex items-center justify-center rounded-md hover:bg-destructive/10 text-muted-foreground hover:text-destructive z-10 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
+                  className="absolute top-1.5 right-0 min-h-11 min-w-11 flex items-center justify-center rounded-md hover:bg-destructive/10 text-muted-foreground hover:text-destructive z-10 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                 >
                   <X className="h-3.5 w-3.5" />
                 </button>
@@ -594,7 +594,7 @@ export const SkillItem = React.memo(function SkillItem({
                   onClick={handleDeleteClick}
                   aria-label={`Delete ${skill.name}`}
                   data-testid={`skill-delete-${skill.name}`}
-                  className="absolute top-1.5 right-0 min-h-11 min-w-11 flex items-center justify-center rounded-md hover:bg-destructive/10 text-muted-foreground hover:text-destructive z-10 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
+                  className="absolute top-1.5 right-0 min-h-11 min-w-11 flex items-center justify-center rounded-md hover:bg-destructive/10 text-muted-foreground hover:text-destructive z-10 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                 >
                   <X className="h-3.5 w-3.5" />
                 </button>
@@ -617,7 +617,7 @@ export const SkillItem = React.memo(function SkillItem({
                       : `Bookmark ${skill.name}`
                   }
                   className={cn(
-                    'absolute top-1.5 min-h-11 min-w-11 flex items-center justify-center rounded-md z-10 transition-opacity',
+                    'absolute top-1.5 min-h-11 min-w-11 flex items-center justify-center rounded-md z-10 transition-opacity focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
                     // Right-align: slide the bookmark left of the X when an
                     // X button (unlink in agent view, delete in global view)
                     // shares the top-right corner.

--- a/src/renderer/src/components/skills/SourceLink.tsx
+++ b/src/renderer/src/components/skills/SourceLink.tsx
@@ -82,7 +82,7 @@ export const SourceLink = React.memo(function SourceLink({
             type="button"
             onClick={handleFilterClick}
             aria-label={`Filter skills by repository ${source}`}
-            className="text-sm text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+            className="text-sm text-muted-foreground hover:text-foreground transition-colors cursor-pointer rounded-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
           >
             {source}
           </button>
@@ -92,7 +92,7 @@ export const SourceLink = React.memo(function SourceLink({
             rel="noreferrer"
             onClick={handleExternalClick}
             aria-label={`Open ${source} on GitHub`}
-            className="text-muted-foreground hover:text-foreground transition-colors inline-flex items-center"
+            className="text-muted-foreground hover:text-foreground transition-colors inline-flex items-center rounded-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
           >
             <ExternalLink className="h-3 w-3" />
           </a>

--- a/src/renderer/src/components/theme/ThemeSelector.tsx
+++ b/src/renderer/src/components/theme/ThemeSelector.tsx
@@ -278,16 +278,16 @@ export const ThemeSelector = React.memo(function ThemeSelector(): ReactElement {
                 key={name}
                 type="button"
                 onClick={() => dispatch(setTheme(name))}
-                className="min-h-8 min-w-8 flex items-center justify-center"
+                className="min-h-8 min-w-8 flex items-center justify-center rounded-md hover:bg-muted transition-colors"
                 title={config.label}
                 aria-label={`Select ${config.label} theme`}
                 aria-pressed={isSelected}
               >
                 <span
                   className={cn(
-                    'h-6 w-6 rounded-full transition-transform hover:scale-110 block',
+                    'h-6 w-6 rounded-full block',
                     isSelected &&
-                      'ring-2 ring-white ring-offset-2 ring-offset-background',
+                      'ring-2 ring-foreground ring-offset-2 ring-offset-background',
                   )}
                   style={{
                     backgroundColor: `oklch(${SWATCH_LIGHTNESS} ${config.chroma} ${config.hue})`,
@@ -332,9 +332,9 @@ export const ThemeSelector = React.memo(function ThemeSelector(): ReactElement {
               >
                 <span
                   className={cn(
-                    'h-6 w-6 rounded-full transition-transform hover:scale-110 block',
+                    'h-6 w-6 rounded-full block',
                     isSelected &&
-                      'ring-2 ring-white ring-offset-2 ring-offset-background',
+                      'ring-2 ring-foreground ring-offset-2 ring-offset-background',
                   )}
                   style={{
                     backgroundColor: `oklch(${SWATCH_LIGHTNESS} ${family.chroma} ${family.hue})`,

--- a/src/renderer/src/components/ui/card.tsx
+++ b/src/renderer/src/components/ui/card.tsx
@@ -11,7 +11,7 @@ const Card = React.memo(function Card({
     <div
       ref={ref}
       className={cn(
-        'rounded-xl border border-border bg-card text-card-foreground shadow',
+        'rounded-lg border border-border bg-card text-card-foreground',
         className,
       )}
       {...props}

--- a/src/renderer/src/components/ui/dialog.tsx
+++ b/src/renderer/src/components/ui/dialog.tsx
@@ -56,7 +56,7 @@ const DialogContent = React.memo(function DialogContent({
       >
         {children}
         {hideCloseButton ? null : (
-          <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground min-h-7 min-w-7 flex items-center justify-center">
+          <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground min-h-7 min-w-7 flex items-center justify-center">
             <X className="h-4 w-4" />
             <span className="sr-only">Close</span>
           </DialogPrimitive.Close>


### PR DESCRIPTION
## Summary

Phase 10 of the UX hardening pass. Closes a batch of UX gaps surfaced by a whole-app `/ux-gap-detector` sweep, then a `/review` polish pass on top.

**Marketplace — Trending panel self-loads (9ebcb3a)**
- `MarketplaceDashboard` now owns its own `loadLeaderboard('trending')` fetch on mount, so the Trending panel populates without the user opening the ranking tab. Previously the only dispatch site requested the user-selected filter (default `all-time`), so the Trending skeleton could hang forever.
- Added a fixed-shape loading skeleton (`role="status"`, announced) and an offline error state (`WifiOff` + recoverable copy), with a pure `resolveTrendingView(count, status)` helper driving a `ts-pattern` exhaustive match over populated / loading / error / empty. Stale-while-revalidate: cached skills always render, even mid-refresh.

**Cross-app UX polish (9ebcb3a)**
- Settings (Appearance/General), `MainContent` bulk-confirm, `SkillDetail`, `ThemeSelector`, `AgentItem`, `CodePreview`, `SourceLink`, `SkillItem`, and `card`/`dialog` primitives: focus-ring, labeling, and layout consistency fixes.

**Review polish (683423a)**
- `SidebarFooter`: full-width skills.sh link gets `focus-visible:ring-inset` so the ring renders inside the control instead of clipping the footer border (matches `AgentItem`).
- Tests strengthened: mount fetch asserted to fire exactly once (locks the thunk in-flight guard deduping StrictMode's double-mount); settled-empty case asserts the fresh TTL cache short-circuits the mount thunk; `MarketplaceDetailPanel` describe renamed to match the loading/empty/error cases it exercises.
- `resolveTrendingView` JSDoc compressed to the house 1-line rule.
- `DESIGN.md`: added a Focus Indicators rule, pinned amber shades by role (`amber-400` status text/icons vs `amber-500` warning glyphs + bookmark), and split the skeleton a11y rule into primary (`role="status"`) vs dense-grid decorative (`aria-hidden`) surfaces.

## Test Coverage
- New unit coverage: `marketplaceDashboardHelpers.test.ts` (resolveTrendingView, all 4 states).
- New browser coverage: trending preview selection, loading/empty/error placeholders, mount-fetch dedup, TTL short-circuit (across `MarketplaceDashboard.browser.test.tsx` + `MarketplaceDetailPanel.browser.test.tsx`).
- `pnpm validate`: 2130 tests passing (168 files), lint + typecheck + dead-code + dupes + health + storybook build all green.
- `pnpm test:e2e`: 58 Electron e2e passing.
- Strengthened assertions verified flake-free across 3 consecutive isolated runs.

## Pre-Landing Review
Full `/review` review-army (Testing, Maintainability, Performance, Design + Claude adversarial + Codex adversarial + Codex structured): **zero critical**, 13 informational. All informational findings either fixed (this branch's 683423a) or deferred with rationale (DialogIconHeader reuse — MainContent sits at the complexity ceiling; whole-slice selector narrowing — negligible re-render delta).

## Design Review
Frontend changed. Findings folded into `DESIGN.md` as living rules (Focus Indicators, amber shade roles, primary-vs-decorative skeleton a11y) per the project's design-review principle that DESIGN.md is refined, not just obeyed.

## Adversarial Review
Claude adversarial: NO FINDINGS (refuted all attack vectors; ran the browser suite 12x, 12/12 green). Codex adversarial: NO FINDINGS. Codex structured (≥200-line diff): NO FINDINGS.

## Plan Completion
Phase 10 of the autonomous marathon (`/ux-gap-detector` whole-app sweep + UX fixes). Complete. Version intentionally held at 0.23.0 — release is owned by `/electron-release` (Phase 13).

## TODOS
No TODO items completed in this PR (the deferred backlog is symlink-cleanup work, unrelated to this UX pass).

## Test plan
- [x] `pnpm validate` — 2130 tests, 0 failures
- [x] `pnpm test:e2e` — 58 tests, 0 failures
- [x] Strengthened browser assertions — 3/3 isolated runs green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **改善**
  * アクセシビリティの向上：フォーカスインジケータの統一的な実装とARIA対応の強化
  * UIスタイルの調整：カード、ボタン、トグルコンポーネントのスタイル統一
  * マーケットプレイス：トレンド表示の読み込み状態とエラーハンドリング機能を追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->