### PR TITLE
feat: adjustable preview font sizes + code theme in Settings

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -145,6 +145,44 @@ Rules:
 - Use mono only for technical values, file paths, code, and exact commands.
 - Prefer sentence case for UI labels.
 
+### Preview typography (user-adjustable)
+
+The skill file preview has **two independent font-size anchors**, both surfaced
+as sliders in Settings → Appearance and persisted via `settings.json`:
+
+| Setting              | Governs                                                   | Default | Range   |
+| -------------------- | --------------------------------------------------------- | ------- | ------- |
+| `markdownFontSizePx` | The Markdown **Reading** view (`.markdown-reading-prose`) | 14px    | 12-22px |
+| `codeFontSizePx`     | The Shiki **code** pane and the plain-text code fallback  | 13px    | 11-20px |
+
+Anchoring rules — keep these straight, they are a common source of bugs:
+
+- **The two anchors do not cross.** `codeFontSizePx` sizes the syntax-highlighted
+  code pane only. `markdownFontSizePx` sizes the rendered Markdown. A fenced code
+  block (` ``` `) **inside** a Markdown document scales with
+  `markdownFontSizePx` (it is Markdown content), _not_ with `codeFontSizePx`.
+- **Child sizes are `em`-relative to their anchor**, set with `text-[Nem]` (h1
+  `1.714em`, h2 `1.429em`, h3 `1.143em`, block code `0.857em`, inline `0.85em`).
+  The anchor is applied as an inline `style={{ fontSize }}` so the whole subtree
+  scales from one number. Verify em-ratios in the **running app** — Tailwind
+  arbitrary-value classes like `text-[1.714em]` do not JIT-generate in the
+  vitest browser env, so computed-style assertions on them are false negatives;
+  test the anchor wiring via inline-style assertions instead.
+- **Code line-height is font-relative** (`min-height: 1.5em; line-height: 1.5`
+  on `.skill-code-preview .line`), not a fixed px. This is required so lines
+  grow with the font; the trade-off is ≈0.5px shorter per line at the 13px
+  default than the old fixed 20px — imperceptible, and the correct call over
+  breaking scalability.
+
+### Code theme
+
+`codeThemeId` selects one of five curated Shiki light/dark theme **pairs**
+(`github` default, `vs`, `vitesse`, `one`, `catppuccin`); the active half is
+chosen by the app's light/dark mode via Shiki's dual-theme `defaultColor: false`
+output. Theme changes re-render the preview live across windows through the
+`settings:changed` broadcast. Curated pairs are the only surface — do not expose
+raw single-theme selection; a pair guarantees both light and dark legibility.
+
 ## Spacing and Layout
 
 The base grid is 4px. Keep spacing small but breathable.

--- a/src/main/ipc/ipc-schemas.test.ts
+++ b/src/main/ipc/ipc-schemas.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  CODE_FONT_SIZE_MAX_PX,
+  CODE_FONT_SIZE_MIN_PX,
+  MARKDOWN_FONT_SIZE_MAX_PX,
+  MARKDOWN_FONT_SIZE_MIN_PX,
   WINDOW_BACKGROUND_BLUR_MAX_RADIUS,
   WINDOW_BACKGROUND_BLUR_MIN_RADIUS,
 } from '@/shared/settings'
@@ -530,6 +534,21 @@ describe('settings:set lockstep with SettingsSchema', () => {
     )
   })
 
+  it('lets the user persist a Markdown reading font size within bounds', () => {
+    // Arrange / Act / Assert
+    expect(schema.safeParse([{ markdownFontSizePx: 18 }]).success).toBe(true)
+  })
+
+  it('lets the user persist a code preview font size within bounds', () => {
+    // Arrange / Act / Assert
+    expect(schema.safeParse([{ codeFontSizePx: 16 }]).success).toBe(true)
+  })
+
+  it('lets the user persist a curated code theme id', () => {
+    // Arrange / Act / Assert
+    expect(schema.safeParse([{ codeThemeId: 'catppuccin' }]).success).toBe(true)
+  })
+
   it('lets the user persist the auto-download updates toggle', () => {
     // Arrange / Act / Assert
     expect(schema.safeParse([{ autoDownloadUpdates: true }]).success).toBe(true)
@@ -600,6 +619,39 @@ describe('settings:set lockstep with SettingsSchema', () => {
     ).toBe(false)
   })
 
+  it('blocks an out-of-range or fractional Markdown reading font size', () => {
+    // Act / Assert — below the allowed minimum is rejected.
+    expect(
+      schema.safeParse([{ markdownFontSizePx: MARKDOWN_FONT_SIZE_MIN_PX - 1 }])
+        .success,
+    ).toBe(false)
+    // Act / Assert — a fractional size is rejected.
+    expect(schema.safeParse([{ markdownFontSizePx: 14.5 }]).success).toBe(false)
+    // Act / Assert — above the allowed maximum is rejected.
+    expect(
+      schema.safeParse([{ markdownFontSizePx: MARKDOWN_FONT_SIZE_MAX_PX + 1 }])
+        .success,
+    ).toBe(false)
+  })
+
+  it('blocks an out-of-range or fractional code preview font size', () => {
+    // Act / Assert — below the allowed minimum is rejected.
+    expect(
+      schema.safeParse([{ codeFontSizePx: CODE_FONT_SIZE_MIN_PX - 1 }]).success,
+    ).toBe(false)
+    // Act / Assert — a fractional size is rejected.
+    expect(schema.safeParse([{ codeFontSizePx: 13.5 }]).success).toBe(false)
+    // Act / Assert — above the allowed maximum is rejected.
+    expect(
+      schema.safeParse([{ codeFontSizePx: CODE_FONT_SIZE_MAX_PX + 1 }]).success,
+    ).toBe(false)
+  })
+
+  it('blocks an unknown code theme id from reaching disk', () => {
+    // Arrange / Act / Assert
+    expect(schema.safeParse([{ codeThemeId: 'dracula' }]).success).toBe(false)
+  })
+
   it('blocks an unknown extra settings key (.strict()) from a compromised renderer', () => {
     // Arrange / Act / Assert
     expect(
@@ -631,6 +683,38 @@ describe('settings:set lockstep with SettingsSchema', () => {
 
     // Assert
     expect('windowBackgroundBlurRadius' in parsed[0]).toBe(false)
+  })
+
+  it('does not wipe a persisted Markdown reading font size when an unrelated setting is saved', () => {
+    // Arrange
+    // Same wipe-on-every-write guard as blur: the IPC schema declares the
+    // size as a bare `.optional()` off the shared non-defaulting font schema
+    // rather than chaining `.optional()` over the disk schema's
+    // `.default(14)`. If it re-inherited the default, every unrelated
+    // settings:set would parse to `{ markdownFontSizePx: 14 }` and reset a
+    // user's chosen reading size.
+
+    // Act
+    const parsed = schema.parse([{ defaultSkillTab: 'info' }]) as [object]
+
+    // Assert
+    expect('markdownFontSizePx' in parsed[0]).toBe(false)
+  })
+
+  it('does not wipe a persisted code preview font size when an unrelated setting is saved', () => {
+    // Arrange / Act
+    const parsed = schema.parse([{ defaultSkillTab: 'info' }]) as [object]
+
+    // Assert
+    expect('codeFontSizePx' in parsed[0]).toBe(false)
+  })
+
+  it('does not wipe a persisted code theme choice when an unrelated setting is saved', () => {
+    // Arrange / Act
+    const parsed = schema.parse([{ defaultSkillTab: 'info' }]) as [object]
+
+    // Assert
+    expect('codeThemeId' in parsed[0]).toBe(false)
   })
 
   it('does not wipe a persisted auto-download opt-in when an unrelated setting is saved', () => {

--- a/src/main/ipc/ipc-schemas.ts
+++ b/src/main/ipc/ipc-schemas.ts
@@ -1,9 +1,11 @@
 import { z } from 'zod'
 
-import { AGENT_IDS, TERMINAL_APP_IDS } from '@/shared/constants'
+import { AGENT_IDS, CODE_THEME_IDS, TERMINAL_APP_IDS } from '@/shared/constants'
 import type { IpcInvokeChannel } from '@/shared/ipc-contract'
 import {
+  CODE_FONT_SIZE_SCHEMA,
   INSTALLED_SEARCH_COUNT_DISPLAY_OPTIONS,
+  MARKDOWN_FONT_SIZE_SCHEMA,
   SettingsSchema,
   WINDOW_BACKGROUND_BLUR_RADIUS_SCHEMA,
 } from '@/shared/settings'
@@ -357,6 +359,13 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
       // unrelated partial settings writes do not reset blur to zero.
       windowBackgroundBlurRadius:
         WINDOW_BACKGROUND_BLUR_RADIUS_SCHEMA.optional(),
+      // Preview font sizes + code theme. Shared non-defaulting schemas, kept
+      // `.optional()` (not chained off a defaulted SettingsSchema field) so an
+      // unrelated partial settings:set never materializes a default and
+      // clobbers the user's persisted font size / theme.
+      markdownFontSizePx: MARKDOWN_FONT_SIZE_SCHEMA.optional(),
+      codeFontSizePx: CODE_FONT_SIZE_SCHEMA.optional(),
+      codeThemeId: z.enum(CODE_THEME_IDS).optional(),
       // Search-count display preference. Keep this as a non-defaulting enum
       // so unrelated partial settings writes do not reset the user's choice.
       installedSearchCountDisplay: z

--- a/src/main/services/settings.test.ts
+++ b/src/main/services/settings.test.ts
@@ -297,11 +297,15 @@ describe('settings persistence', () => {
       // Act
       const loaded = await loadSettings()
 
-      // Assert
+      // Assert — the three preview-typography fields are absent from this
+      // legacy on-disk file, so the schema backfills their defaults.
       expect(loaded).toEqual({
         defaultSkillTab: 'info',
         preferredTerminal: 'terminal',
         windowBackgroundBlurRadius: 0,
+        markdownFontSizePx: 14,
+        codeFontSizePx: 13,
+        codeThemeId: 'github',
         installedSearchCountDisplay: 'tab',
         hiddenAgentIds: ['cursor'],
         autoDownloadUpdates: true,

--- a/src/renderer/settings/sections/Appearance.browser.test.tsx
+++ b/src/renderer/settings/sections/Appearance.browser.test.tsx
@@ -3,7 +3,7 @@ import { Provider } from 'react-redux'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
-import { DEFAULT_SETTINGS } from '@/shared/settings'
+import { DEFAULT_SETTINGS, type Settings } from '@/shared/settings'
 
 const mockSettingsSet = vi.fn()
 
@@ -22,11 +22,13 @@ afterEach(() => {
 
 /**
  * Build a small settings-only store for the Appearance pane.
- * @param windowBackgroundBlurRadius - Initial Electron blur radius.
+ * @param overrides - Settings fields that differ from DEFAULT_SETTINGS.
  * @returns Redux store with settings preloaded.
+ * @example
+ * await createStore({ windowBackgroundBlurRadius: 24, markdownFontSizePx: 18 })
  */
 async function createStore(
-  windowBackgroundBlurRadius: number = 0,
+  overrides: Partial<Settings> = {},
 ): Promise<ReturnType<typeof configureStore>> {
   const { default: settingsReducer } =
     await import('@/renderer/src/redux/slices/settingsSlice')
@@ -35,7 +37,7 @@ async function createStore(
       settings: settingsReducer,
     },
     preloadedState: {
-      settings: { ...DEFAULT_SETTINGS, windowBackgroundBlurRadius },
+      settings: { ...DEFAULT_SETTINGS, ...overrides },
     },
   })
 }
@@ -87,9 +89,30 @@ describe('Settings → Appearance', () => {
     })
   })
 
+  it('announces the opacity slider value to assistive tech as readable text, not the raw radius', async () => {
+    // Arrange
+    const store = await createStore()
+    const { Appearance } = await import('./Appearance')
+    const screen = await render(
+      <Provider store={store}>
+        <Appearance />
+      </Provider>,
+    )
+    const slider = screen.getByRole('slider', { name: /Opacity/i })
+
+    // Assert — at the opaque default a screen reader hears 'Opaque', not '0'
+    await expect.element(slider).toHaveAttribute('aria-valuetext', 'Opaque')
+
+    // Act
+    await slider.fill('24')
+
+    // Assert — after the drag it hears the same badge the eye sees, not '24'
+    await expect.element(slider).toHaveAttribute('aria-valuetext', '72% / 24px')
+  })
+
   it('restores the opaque default window when Reset to default is pressed', async () => {
     // Arrange
-    const store = await createStore(24)
+    const store = await createStore({ windowBackgroundBlurRadius: 24 })
     const { Appearance } = await import('./Appearance')
     const screen = await render(
       <Provider store={store}>
@@ -98,8 +121,10 @@ describe('Settings → Appearance', () => {
     )
     await expect.element(screen.getByText('72% / 24px')).toBeVisible()
 
-    // Act
-    await screen.getByRole('button', { name: /Reset to default/i }).click()
+    // Act — the per-row aria-label disambiguates the three reset buttons.
+    await screen
+      .getByRole('button', { name: /Reset to default: Opacity/i })
+      .click()
 
     // Assert
     await expect.element(screen.getByText('Opaque')).toBeVisible()
@@ -108,13 +133,102 @@ describe('Settings → Appearance', () => {
       windowBackgroundBlurRadius: 0,
     })
     expect(
-      screen.getByRole('button', { name: /Reset to default/i }).element(),
+      screen
+        .getByRole('button', { name: /Reset to default: Opacity/i })
+        .element(),
+    ).toBeDisabled()
+  })
+
+  it('persists the chosen reading font size when the Reading font size slider moves', async () => {
+    // Arrange
+    const store = await createStore()
+    const { Appearance } = await import('./Appearance')
+    const screen = await render(
+      <Provider store={store}>
+        <Appearance />
+      </Provider>,
+    )
+
+    // Act
+    const slider = screen.getByRole('slider', { name: /Reading font size/i })
+    await slider.fill('18')
+
+    // Assert
+    await expect.element(screen.getByText('18px')).toBeVisible()
+    await expect.poll(() => mockSettingsSet.mock.calls.length).toBe(1)
+    expect(mockSettingsSet).toHaveBeenCalledWith({ markdownFontSizePx: 18 })
+  })
+
+  it('persists the chosen code font size when the Code font size slider moves', async () => {
+    // Arrange
+    const store = await createStore()
+    const { Appearance } = await import('./Appearance')
+    const screen = await render(
+      <Provider store={store}>
+        <Appearance />
+      </Provider>,
+    )
+
+    // Act
+    const slider = screen.getByRole('slider', { name: /Code font size/i })
+    await slider.fill('16')
+
+    // Assert
+    await expect.element(screen.getByText('16px')).toBeVisible()
+    await expect.poll(() => mockSettingsSet.mock.calls.length).toBe(1)
+    expect(mockSettingsSet).toHaveBeenCalledWith({ codeFontSizePx: 16 })
+  })
+
+  it('persists the chosen code theme when a new theme is selected', async () => {
+    // Arrange
+    const store = await createStore()
+    const { Appearance } = await import('./Appearance')
+    const screen = await render(
+      <Provider store={store}>
+        <Appearance />
+      </Provider>,
+    )
+
+    // Act
+    await screen
+      .getByRole('combobox', { name: /Code theme/i })
+      .selectOptions('Vitesse')
+
+    // Assert
+    await expect.poll(() => mockSettingsSet.mock.calls.length).toBe(1)
+    expect(mockSettingsSet).toHaveBeenCalledWith({ codeThemeId: 'vitesse' })
+  })
+
+  it('restores the default reading font size when its Reset to default is pressed', async () => {
+    // Arrange
+    const store = await createStore({ markdownFontSizePx: 18 })
+    const { Appearance } = await import('./Appearance')
+    const screen = await render(
+      <Provider store={store}>
+        <Appearance />
+      </Provider>,
+    )
+    await expect.element(screen.getByText('18px')).toBeVisible()
+
+    // Act
+    await screen
+      .getByRole('button', { name: /Reset to default: Reading font size/i })
+      .click()
+
+    // Assert
+    await expect.element(screen.getByText('14px')).toBeVisible()
+    await expect.poll(() => mockSettingsSet.mock.calls.length).toBe(1)
+    expect(mockSettingsSet).toHaveBeenCalledWith({ markdownFontSizePx: 14 })
+    expect(
+      screen
+        .getByRole('button', { name: /Reset to default: Reading font size/i })
+        .element(),
     ).toBeDisabled()
   })
 
   it('does not persist a slider drag that an incoming settings broadcast overrides', async () => {
     // Arrange
-    const store = await createStore(12)
+    const store = await createStore({ windowBackgroundBlurRadius: 12 })
     const { setSettings } =
       await import('@/renderer/src/redux/slices/settingsSlice')
     const { Appearance } = await import('./Appearance')

--- a/src/renderer/settings/sections/Appearance.tsx
+++ b/src/renderer/settings/sections/Appearance.tsx
@@ -1,18 +1,29 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 
 import { Button } from '@/renderer/src/components/ui/button'
 import {
   ToggleGroup,
   ToggleGroupItem,
 } from '@/renderer/src/components/ui/toggle-group'
-import { useUnmountEffect } from '@/renderer/src/hooks/useUnmountEffect'
-import { useUpdateEffect } from '@/renderer/src/hooks/useUpdateEffect'
+import { useDraftRangeSetting } from '@/renderer/src/hooks/useDraftRangeSetting'
 import { useUpdateSettings } from '@/renderer/src/hooks/useUpdateSettings'
 import { useAppSelector } from '@/renderer/src/redux/hooks'
 import {
+  CODE_THEME_DEFINITIONS,
+  CODE_THEME_IDS,
+  SETTINGS_RANGE_DEBOUNCE_MS,
+} from '@/shared/constants'
+import type { CodeThemeId } from '@/shared/constants'
+import {
+  CODE_FONT_SIZE_DEFAULT_PX,
+  CODE_FONT_SIZE_MAX_PX,
+  CODE_FONT_SIZE_MIN_PX,
   DEFAULT_SETTINGS,
   getWindowBackgroundOpacity,
   INSTALLED_SEARCH_COUNT_DISPLAY_OPTIONS as INSTALLED_SEARCH_COUNT_DISPLAY_VALUES,
+  MARKDOWN_FONT_SIZE_DEFAULT_PX,
+  MARKDOWN_FONT_SIZE_MAX_PX,
+  MARKDOWN_FONT_SIZE_MIN_PX,
   WINDOW_BACKGROUND_BLUR_MAX_RADIUS,
   WINDOW_BACKGROUND_BLUR_MIN_RADIUS,
 } from '@/shared/settings'
@@ -21,6 +32,9 @@ import type { Settings } from '@/shared/settings'
 import { SectionFrame, SectionRow } from './SectionFrame'
 
 const BACKGROUND_BLUR_LABEL = 'Opacity / Blur'
+const MARKDOWN_FONT_SIZE_LABEL = 'Reading font size'
+const CODE_FONT_SIZE_LABEL = 'Code font size'
+const CODE_THEME_LABEL = 'Code theme'
 const INSTALLED_SEARCH_COUNT_DISPLAY_LABEL = 'Installed search count'
 const INSTALLED_SEARCH_COUNT_DISPLAY_LABELS: Record<
   Settings['installedSearchCountDisplay'],
@@ -35,103 +49,238 @@ const INSTALLED_SEARCH_COUNT_DISPLAY_OPTIONS =
     label: INSTALLED_SEARCH_COUNT_DISPLAY_LABELS[value],
   }))
 
-interface BackgroundBlurRangeInputProps {
-  value: number
-  label: string
-  onBlurRadiusChange: (value: number) => void
+/**
+ * Format the blur slider's value badge: fully opaque reads "Opaque", otherwise
+ * the surface opacity percent plus the blur radius in px.
+ * @param blurRadius - Current draft blur radius.
+ * @returns Display string for the value badge.
+ * @example
+ * formatBlurValue(0)  // => 'Opaque'
+ * formatBlurValue(24) // => '72% / 24px'
+ */
+function formatBlurValue(blurRadius: number): string {
+  if (blurRadius === WINDOW_BACKGROUND_BLUR_MIN_RADIUS) return 'Opaque'
+  const opacityPercent = Math.round(
+    getWindowBackgroundOpacity(blurRadius) * 100,
+  )
+  return `${opacityPercent}% / ${blurRadius}px`
 }
 
 /**
- * Native range control for the Electron background blur setting.
- * @param value - Current persisted blur radius in CSS pixels.
- * @param label - Accessible label that matches the visible setting row.
- * @param onBlurRadiusChange - Emits a numeric radius after input changes.
+ * Format a font-size slider's value badge.
+ * @param fontSizePx - Current draft font size.
+ * @returns Pixel-suffixed display string.
+ * @example
+ * formatPxValue(14) // => '14px'
+ */
+function formatPxValue(fontSizePx: number): string {
+  return `${fontSizePx}px`
+}
+
+interface SettingRangeInputProps {
+  value: number
+  min: number
+  max: number
+  label: string
+  valueText: string
+  onValueChange: (value: number) => void
+}
+
+/**
+ * Native range control shared by the appearance sliders (blur, font sizes).
+ * @param value - Current draft value.
+ * @param min - Slider lower bound.
+ * @param max - Slider upper bound.
+ * @param label - Accessible label matching the visible setting row.
+ * @param valueText - Human-readable value announced to screen readers (e.g. 'Opaque', '14px') so AT speaks the visible badge instead of the raw integer.
+ * @param onValueChange - Emits the parsed integer after each input change.
  * @returns Slider input sized to fit the Settings row.
  * @example
- * <BackgroundBlurRangeInput value={24} label="Opacity / Blur" onBlurRadiusChange={setRadius} />
+ * <SettingRangeInput value={14} min={12} max={22} label="Reading font size" valueText="14px" onValueChange={setSize} />
  */
-const BackgroundBlurRangeInput = React.memo(function BackgroundBlurRangeInput({
+const SettingRangeInput = React.memo(function SettingRangeInput({
   value,
+  min,
+  max,
   label,
-  onBlurRadiusChange,
-}: BackgroundBlurRangeInputProps): React.ReactElement {
+  valueText,
+  onValueChange,
+}: SettingRangeInputProps): React.ReactElement {
   const handleInputChange = (
     event: React.ChangeEvent<HTMLInputElement>,
   ): void => {
     // Native range input emits strings; Zod validates the final integer at IPC.
-    const nextRadius = parseInt(event.currentTarget.value, 10)
-    if (Number.isNaN(nextRadius)) return
-    onBlurRadiusChange(nextRadius)
+    const nextValue = parseInt(event.currentTarget.value, 10)
+    if (Number.isNaN(nextValue)) return
+    onValueChange(nextValue)
   }
 
   return (
     <input
       type="range"
-      min={WINDOW_BACKGROUND_BLUR_MIN_RADIUS}
-      max={WINDOW_BACKGROUND_BLUR_MAX_RADIUS}
+      min={min}
+      max={max}
       step={1}
       value={value}
       onChange={handleInputChange}
       aria-label={label}
+      aria-valuetext={valueText}
       className="h-2 min-w-0 flex-1 accent-primary rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
     />
   )
 })
 
+interface RangeSettingControlProps {
+  label: string
+  min: number
+  max: number
+  draft: number
+  isDefault: boolean
+  formatValue: (value: number) => string
+  onValueChange: (value: number) => void
+  onReset: () => void
+}
+
 /**
- * Appearance pane for visual controls backed by persisted Settings.
- *
- * The first real control is the Electron 42 background blur radius. The same
- * slider also lowers the app-surface opacity, so users see an immediate
- * opacity/blur change instead of a fixed 85% backplate.
+ * Slider + live value badge + "Reset to default" row, shared by every
+ * appearance range setting so the three sliders stay visually identical.
+ * @param label - Accessible/visible control label.
+ * @param min - Slider lower bound.
+ * @param max - Slider upper bound.
+ * @param draft - Current draft value driving slider + badge.
+ * @param isDefault - Disables Reset when the draft already equals the default.
+ * @param formatValue - Renders the value badge text.
+ * @param onValueChange - Slider change handler.
+ * @param onReset - Reset-to-default handler.
+ * @returns The composed control column.
+ * @example
+ * <RangeSettingControl label="Code font size" min={11} max={20} draft={13} isDefault formatValue={formatPxValue} onValueChange={fn} onReset={fn} />
+ */
+const RangeSettingControl = React.memo(function RangeSettingControl({
+  label,
+  min,
+  max,
+  draft,
+  isDefault,
+  formatValue,
+  onValueChange,
+  onReset,
+}: RangeSettingControlProps): React.ReactElement {
+  return (
+    <div className="flex max-w-md flex-col gap-2">
+      <div className="flex items-center gap-3">
+        <SettingRangeInput
+          value={draft}
+          min={min}
+          max={max}
+          label={label}
+          valueText={formatValue(draft)}
+          onValueChange={onValueChange}
+        />
+        <span className="w-20 whitespace-nowrap text-right text-sm tabular-nums text-muted-foreground">
+          {formatValue(draft)}
+        </span>
+      </div>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={onReset}
+        disabled={isDefault}
+        className="w-fit"
+        aria-label={`Reset to default: ${label}`}
+      >
+        Reset to default
+      </Button>
+    </div>
+  )
+})
+
+interface CodeThemeSelectProps {
+  value: CodeThemeId
+  onValueChange: (value: CodeThemeId) => void
+}
+
+/**
+ * Native picker for the curated Shiki code-preview theme. Native `<select>`
+ * (matching General's terminal picker) keeps all five named themes compact
+ * without overflowing the row the way a five-item segmented control would.
+ * @param value - Currently selected theme id.
+ * @param onValueChange - Emits the chosen theme id.
+ * @returns Theme select control.
+ * @example
+ * <CodeThemeSelect value="github" onValueChange={setTheme} />
+ */
+const CodeThemeSelect = React.memo(function CodeThemeSelect({
+  value,
+  onValueChange,
+}: CodeThemeSelectProps): React.ReactElement {
+  const handleChange = (event: React.ChangeEvent<HTMLSelectElement>): void => {
+    // `find` narrows the readonly tuple to CodeThemeId without an `as` cast;
+    // the IPC schema (`z.enum(CODE_THEME_IDS)`) is the real trust boundary.
+    const next = CODE_THEME_IDS.find((id) => id === event.target.value)
+    if (!next) return
+    onValueChange(next)
+  }
+
+  return (
+    <select
+      className="h-9 min-w-56 rounded-md border border-input bg-background px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring"
+      value={value}
+      onChange={handleChange}
+      aria-label={CODE_THEME_LABEL}
+    >
+      {CODE_THEME_DEFINITIONS.map((theme) => (
+        <option key={theme.id} value={theme.id}>
+          {theme.label}
+        </option>
+      ))}
+    </select>
+  )
+})
+
+/**
+ * Appearance pane for visual controls backed by persisted Settings: the
+ * Electron background blur (which also drives app-surface opacity), the file
+ * preview typography (Markdown reading size, code size, code theme), and where
+ * the Installed result count is shown.
  */
 export const Appearance = React.memo(function Appearance(): React.ReactElement {
   const windowBackgroundBlurRadius = useAppSelector(
     (state) => state.settings.windowBackgroundBlurRadius,
   )
+  const markdownFontSizePx = useAppSelector(
+    (state) => state.settings.markdownFontSizePx,
+  )
+  const codeFontSizePx = useAppSelector(
+    (state) => state.settings.codeFontSizePx,
+  )
+  const codeThemeId = useAppSelector((state) => state.settings.codeThemeId)
   const installedSearchCountDisplay = useAppSelector(
     (state) => state.settings.installedSearchCountDisplay,
   )
   const updateSettings = useUpdateSettings()
-  const [blurRadiusDraft, setBlurRadiusDraft] = React.useState<number>(
+
+  const blur = useDraftRangeSetting(
     windowBackgroundBlurRadius,
+    DEFAULT_SETTINGS.windowBackgroundBlurRadius,
+    (radius) => updateSettings({ windowBackgroundBlurRadius: radius }),
+    SETTINGS_RANGE_DEBOUNCE_MS,
   )
-  const persistTimerRef = React.useRef<number | null>(null)
-
-  const clearPersistTimer = React.useCallback((): void => {
-    if (persistTimerRef.current === null) return
-    window.clearTimeout(persistTimerRef.current)
-    persistTimerRef.current = null
-  }, [])
-
-  const persistBlurRadius = React.useCallback(
-    (nextRadius: number): void => {
-      clearPersistTimer()
-      persistTimerRef.current = window.setTimeout(() => {
-        updateSettings({ windowBackgroundBlurRadius: nextRadius })
-        persistTimerRef.current = null
-      }, 120)
-    },
-    [clearPersistTimer, updateSettings],
+  const markdownFont = useDraftRangeSetting(
+    markdownFontSizePx,
+    MARKDOWN_FONT_SIZE_DEFAULT_PX,
+    (fontSizePx) => updateSettings({ markdownFontSizePx: fontSizePx }),
+    SETTINGS_RANGE_DEBOUNCE_MS,
+  )
+  const codeFont = useDraftRangeSetting(
+    codeFontSizePx,
+    CODE_FONT_SIZE_DEFAULT_PX,
+    (fontSizePx) => updateSettings({ codeFontSizePx: fontSizePx }),
+    SETTINGS_RANGE_DEBOUNCE_MS,
   )
 
-  const handleBlurRadiusChange = React.useCallback(
-    (nextRadius: number): void => {
-      setBlurRadiusDraft(nextRadius)
-      persistBlurRadius(nextRadius)
-    },
-    [persistBlurRadius],
-  )
-
-  const handleResetBlurRadius = React.useCallback((): void => {
-    clearPersistTimer()
-    setBlurRadiusDraft(DEFAULT_SETTINGS.windowBackgroundBlurRadius)
-    updateSettings({
-      windowBackgroundBlurRadius: DEFAULT_SETTINGS.windowBackgroundBlurRadius,
-    })
-  }, [clearPersistTimer, updateSettings])
-
-  const handleSearchCountDisplayChange = React.useCallback(
+  const handleSearchCountDisplayChange = useCallback(
     (nextValue: string): void => {
       if (nextValue !== 'tab' && nextValue !== 'inline') return
       updateSettings({ installedSearchCountDisplay: nextValue })
@@ -139,24 +288,12 @@ export const Appearance = React.memo(function Appearance(): React.ReactElement {
     [updateSettings],
   )
 
-  useUpdateEffect(() => {
-    clearPersistTimer()
-    setBlurRadiusDraft(windowBackgroundBlurRadius)
-  }, [windowBackgroundBlurRadius, clearPersistTimer])
-
-  useUnmountEffect(() => {
-    clearPersistTimer()
-  })
-
-  const backgroundOpacityPercent = Math.round(
-    getWindowBackgroundOpacity(blurRadiusDraft) * 100,
+  const handleCodeThemeChange = useCallback(
+    (nextThemeId: CodeThemeId): void => {
+      updateSettings({ codeThemeId: nextThemeId })
+    },
+    [updateSettings],
   )
-  const blurRadiusLabel =
-    blurRadiusDraft === WINDOW_BACKGROUND_BLUR_MIN_RADIUS
-      ? 'Opaque'
-      : `${backgroundOpacityPercent}% / ${blurRadiusDraft}px`
-  const isDefaultBlurRadius =
-    blurRadiusDraft === DEFAULT_SETTINGS.windowBackgroundBlurRadius
 
   return (
     <SectionFrame
@@ -188,28 +325,58 @@ export const Appearance = React.memo(function Appearance(): React.ReactElement {
         label={BACKGROUND_BLUR_LABEL}
         description="Surface opacity and background blur for the main window."
       >
-        <div className="flex max-w-md flex-col gap-2">
-          <div className="flex items-center gap-3">
-            <BackgroundBlurRangeInput
-              value={blurRadiusDraft}
-              label={BACKGROUND_BLUR_LABEL}
-              onBlurRadiusChange={handleBlurRadiusChange}
-            />
-            <span className="w-20 whitespace-nowrap text-right text-sm tabular-nums text-muted-foreground">
-              {blurRadiusLabel}
-            </span>
-          </div>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={handleResetBlurRadius}
-            disabled={isDefaultBlurRadius}
-            className="w-fit"
-          >
-            Reset to default
-          </Button>
-        </div>
+        <RangeSettingControl
+          label={BACKGROUND_BLUR_LABEL}
+          min={WINDOW_BACKGROUND_BLUR_MIN_RADIUS}
+          max={WINDOW_BACKGROUND_BLUR_MAX_RADIUS}
+          draft={blur.draft}
+          isDefault={blur.isDefault}
+          formatValue={formatBlurValue}
+          onValueChange={blur.change}
+          onReset={blur.reset}
+        />
+      </SectionRow>
+
+      <SectionRow
+        label={MARKDOWN_FONT_SIZE_LABEL}
+        description="Body text size for the Markdown reading view; headings and code scale with it."
+      >
+        <RangeSettingControl
+          label={MARKDOWN_FONT_SIZE_LABEL}
+          min={MARKDOWN_FONT_SIZE_MIN_PX}
+          max={MARKDOWN_FONT_SIZE_MAX_PX}
+          draft={markdownFont.draft}
+          isDefault={markdownFont.isDefault}
+          formatValue={formatPxValue}
+          onValueChange={markdownFont.change}
+          onReset={markdownFont.reset}
+        />
+      </SectionRow>
+
+      <SectionRow
+        label={CODE_FONT_SIZE_LABEL}
+        description="Font size for the syntax-highlighted code preview."
+      >
+        <RangeSettingControl
+          label={CODE_FONT_SIZE_LABEL}
+          min={CODE_FONT_SIZE_MIN_PX}
+          max={CODE_FONT_SIZE_MAX_PX}
+          draft={codeFont.draft}
+          isDefault={codeFont.isDefault}
+          formatValue={formatPxValue}
+          onValueChange={codeFont.change}
+          onReset={codeFont.reset}
+        />
+      </SectionRow>
+
+      <SectionRow
+        label={CODE_THEME_LABEL}
+        description="Syntax highlighting theme for the code preview (light/dark matches the app)."
+      >
+        <CodeThemeSelect
+          value={codeThemeId}
+          onValueChange={handleCodeThemeChange}
+        />
       </SectionRow>
     </SectionFrame>
   )

--- a/src/renderer/src/components/skills/CodePreview.browser.test.tsx
+++ b/src/renderer/src/components/skills/CodePreview.browser.test.tsx
@@ -1,7 +1,10 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import type { PreviewContent } from '@/renderer/src/hooks/useCodePreview'
+import { DEFAULT_SETTINGS, type Settings } from '@/shared/settings'
 import type { AbsolutePath, SkillFile } from '@/shared/types'
 import '@/renderer/src/styles/globals.css'
 
@@ -59,6 +62,30 @@ function makeHookReturn(overrides: {
   }
 }
 
+/**
+ * Render CodePreview inside a settings-preloaded Redux Provider. CodePreview
+ * reads the preview-typography settings via `useAppSelector`, so every render
+ * needs a store; `overrides` preloads non-default appearance values.
+ * @param overrides - Settings fields that differ from DEFAULT_SETTINGS.
+ * @returns The vitest-browser-react render result.
+ * @example
+ * await renderCodePreview({ codeFontSizePx: 16 })
+ */
+async function renderCodePreview(overrides: Partial<Settings> = {}) {
+  const { default: settingsReducer } =
+    await import('@/renderer/src/redux/slices/settingsSlice')
+  const store = configureStore({
+    reducer: { settings: settingsReducer },
+    preloadedState: { settings: { ...DEFAULT_SETTINGS, ...overrides } },
+  })
+  const { CodePreview } = await import('./CodePreview')
+  return render(
+    <Provider store={store}>
+      <CodePreview skillPath={SKILL_PATH} />
+    </Provider>,
+  )
+}
+
 describe('CodePreview', () => {
   beforeEach(() => {
     mockUseCodePreview.mockReset()
@@ -67,10 +94,9 @@ describe('CodePreview', () => {
   it('shows a loading placeholder while the file list is still being fetched', async () => {
     // Arrange
     mockUseCodePreview.mockReturnValue(makeHookReturn({ loading: true }))
-    const { CodePreview } = await import('./CodePreview')
 
     // Act
-    const screen = await render(<CodePreview skillPath={SKILL_PATH} />)
+    const screen = await renderCodePreview()
 
     // Assert
     await expect
@@ -83,10 +109,9 @@ describe('CodePreview', () => {
     mockUseCodePreview.mockReturnValue(
       makeHookReturn({ loading: false, files: [] }),
     )
-    const { CodePreview } = await import('./CodePreview')
 
     // Act
-    const screen = await render(<CodePreview skillPath={SKILL_PATH} />)
+    const screen = await renderCodePreview()
 
     // Assert
     await expect
@@ -109,10 +134,9 @@ describe('CodePreview', () => {
         content: { kind: 'empty' },
       }),
     )
-    const { CodePreview } = await import('./CodePreview')
 
     // Act
-    const screen = await render(<CodePreview skillPath={SKILL_PATH} />)
+    const screen = await renderCodePreview()
 
     // Assert
     await expect
@@ -140,13 +164,51 @@ describe('CodePreview', () => {
         setActiveFile: setActiveFileSpy,
       }),
     )
-    const { CodePreview } = await import('./CodePreview')
-    const screen = await render(<CodePreview skillPath={SKILL_PATH} />)
+    const screen = await renderCodePreview()
 
     // Act
     await screen.getByRole('tab', { name: /README\.md/ }).click()
 
     // Assert
     expect(setActiveFileSpy).toHaveBeenCalledWith(readmeFile.path)
+  })
+
+  it('renders the code preview at the user-configured code font size from settings', async () => {
+    // Arrange — the Redux→props seam: a non-default codeFontSizePx persisted in
+    // settings must flow through CodePreview into FileContent's code root.
+    const skillFile = makeFile()
+    mockUseCodePreview.mockReturnValue(
+      makeHookReturn({
+        files: [skillFile],
+        activeFile: skillFile.path,
+        content: {
+          kind: 'text',
+          data: {
+            name: 'SKILL.md',
+            content: 'const answer = 42\n',
+            extension: '.md',
+            lineCount: 1,
+          },
+        },
+      }),
+    )
+
+    // Act
+    const screen = await renderCodePreview({ codeFontSizePx: 16 })
+
+    // Assert — the code scroll root (Shiki div or plain-text fallback table)
+    // carries the configured 16px inline font size.
+    const scrollPane = screen.container.querySelector(
+      '[data-file-preview-scroll]',
+    )
+    expect(scrollPane).toBeInstanceOf(HTMLElement)
+    await expect
+      .poll(() =>
+        (scrollPane as HTMLElement).firstElementChild instanceof HTMLElement
+          ? ((scrollPane as HTMLElement).firstElementChild as HTMLElement).style
+              .fontSize
+          : null,
+      )
+      .toBe('16px')
   })
 })

--- a/src/renderer/src/components/skills/CodePreview.tsx
+++ b/src/renderer/src/components/skills/CodePreview.tsx
@@ -2,6 +2,7 @@ import * as TabsPrimitive from '@radix-ui/react-tabs'
 import React, { useCallback } from 'react'
 
 import { useCodePreview } from '@/renderer/src/hooks/useCodePreview'
+import { useAppSelector } from '@/renderer/src/redux/hooks'
 import type { AbsolutePath } from '@/shared/types'
 
 import { FileContent } from './FileContent'
@@ -32,6 +33,15 @@ export const CodePreview = React.memo(function CodePreview({
 }: CodePreviewProps): React.ReactElement {
   const { files, activeFile, setActiveFile, content, loading } =
     useCodePreview(skillPath)
+  // Preview typography is user-configurable in Settings → Appearance; this is
+  // the single Redux read that feeds the otherwise-presentational FileContent.
+  const markdownFontSizePx = useAppSelector(
+    (state) => state.settings.markdownFontSizePx,
+  )
+  const codeFontSizePx = useAppSelector(
+    (state) => state.settings.codeFontSizePx,
+  )
+  const codeThemeId = useAppSelector((state) => state.settings.codeThemeId)
 
   const handleValueChange = useCallback(
     (next: string) => {
@@ -68,7 +78,12 @@ export const CodePreview = React.memo(function CodePreview({
         value={activeFile ?? ''}
         className="flex-1 flex flex-col min-h-0 focus-visible:outline-none"
       >
-        <FileContent content={content} />
+        <FileContent
+          content={content}
+          markdownFontSizePx={markdownFontSizePx}
+          codeFontSizePx={codeFontSizePx}
+          codeThemeId={codeThemeId}
+        />
       </TabsPrimitive.Content>
     </TabsPrimitive.Root>
   )

--- a/src/renderer/src/components/skills/FileContent.browser.test.tsx
+++ b/src/renderer/src/components/skills/FileContent.browser.test.tsx
@@ -440,3 +440,52 @@ describe('FileContent Reading Mode element styling', () => {
     expect(headerCell?.closest('table')).toBeInstanceOf(HTMLTableElement)
   })
 })
+
+describe('FileContent preview typography scaling', () => {
+  it('renders the Markdown reading view at the configured body font size', async () => {
+    // Arrange
+    const { FileContent } = await import('./FileContent')
+    const screen = await render(
+      <FileContent
+        content={makeTextContent({ content: '# Title\n\nBody text' })}
+        markdownFontSizePx={18}
+      />,
+    )
+
+    // Act
+    await screen.getByRole('radio', { name: /Show rendered Markdown/i }).click()
+
+    // Assert — the reading article is the scale anchor: its inline font size
+    // matches the configured body size exactly.
+    const article = screen.container.querySelector('.markdown-reading-prose')
+    expect(article).toBeInstanceOf(HTMLElement)
+    expect((article as HTMLElement).style.fontSize).toBe('18px')
+  })
+
+  it('renders the code view at the configured code font size', async () => {
+    // Arrange — default mode is code, so the syntax-highlighted view shows
+    // first; its scroll root carries the configured inline font size whether
+    // Shiki has resolved (div) or the plain-text fallback (table) is showing.
+    const { FileContent } = await import('./FileContent')
+    const screen = await render(
+      <FileContent
+        content={makeTextContent({ content: 'const answer = 42\n' })}
+        codeFontSizePx={16}
+      />,
+    )
+
+    // Act
+    const scrollPane = screen.container.querySelector(
+      '[data-file-preview-scroll]',
+    )
+    expect(scrollPane).toBeInstanceOf(HTMLElement)
+
+    // Assert
+    await expect
+      .poll(() => {
+        const root = (scrollPane as HTMLElement).firstElementChild
+        return root instanceof HTMLElement ? root.style.fontSize : null
+      })
+      .toBe('16px')
+  })
+})

--- a/src/renderer/src/components/skills/FileContent.codeTheme.browser.test.tsx
+++ b/src/renderer/src/components/skills/FileContent.codeTheme.browser.test.tsx
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import type { PreviewContent } from '@/renderer/src/hooks/useCodePreview'
+import '@/renderer/src/styles/globals.css'
+
+// Mock the Shiki shorthand so this file can assert which theme pair FileContent
+// actually hands the highlighter — the one seam (props -> resolveCodeTheme ->
+// codeToHtml) that real-Shiki render tests can't observe, since Shiki colours
+// aren't assertable in the browser env. vi.hoisted keeps the spy reference safe
+// across vi.mock hoisting. Isolated in its own file because vi.mock is
+// file-scoped: the sibling FileContent tests need the real transformer output
+// (line numbers), which a mocked codeToHtml would strip.
+const { mockCodeToHtml } = vi.hoisted(() => ({ mockCodeToHtml: vi.fn() }))
+
+vi.mock('./shikiPreview', () => ({ codeToHtml: mockCodeToHtml }))
+
+/**
+ * Build a code-file text preview payload off the IPC layer.
+ * @param content - Raw source rendered in the default code view.
+ * @returns PreviewContent for FileContent's `text` branch.
+ * @example
+ * makeCodeContent('const x = 1\n')
+ */
+function makeCodeContent(content: string): PreviewContent {
+  return {
+    kind: 'text',
+    data: {
+      name: 'example.ts',
+      content,
+      extension: '.ts',
+      lineCount: content.split('\n').length,
+    },
+  }
+}
+
+describe('FileContent code theme', () => {
+  beforeEach(() => {
+    mockCodeToHtml.mockReset()
+    mockCodeToHtml.mockResolvedValue(
+      '<pre class="shiki"><code><span class="line">code</span></code></pre>',
+    )
+  })
+
+  it('highlights the code preview using the user-selected theme pair', async () => {
+    // Arrange
+    const { FileContent } = await import('./FileContent')
+
+    // Act — the code view is the default mode, so SyntaxHighlightedCode runs
+    // immediately with the non-default 'vitesse' theme.
+    await render(
+      <FileContent
+        content={makeCodeContent('const answer = 42\n')}
+        codeThemeId="vitesse"
+      />,
+    )
+
+    // Assert — the chosen id is resolved to its light/dark pair and forwarded to
+    // Shiki, so picking 'vitesse' in Settings actually recolours the preview.
+    await expect.poll(() => mockCodeToHtml.mock.calls.length).toBeGreaterThan(0)
+    expect(mockCodeToHtml).toHaveBeenCalledWith(
+      'const answer = 42\n',
+      expect.objectContaining({
+        themes: { dark: 'vitesse-dark', light: 'vitesse-light' },
+      }),
+    )
+  })
+})

--- a/src/renderer/src/components/skills/FileContent.tsx
+++ b/src/renderer/src/components/skills/FileContent.tsx
@@ -11,14 +11,27 @@ import {
 import type { PreviewContent } from '@/renderer/src/hooks/useCodePreview'
 import { useCycleEffect } from '@/renderer/src/hooks/useCycleEffect'
 import { cn } from '@/renderer/src/lib/utils'
+import { DEFAULT_CODE_THEME_ID } from '@/shared/constants'
+import type { CodeThemeId } from '@/shared/constants'
 import { formatBytes } from '@/shared/fileTypes'
+import {
+  CODE_FONT_SIZE_DEFAULT_PX,
+  MARKDOWN_FONT_SIZE_DEFAULT_PX,
+} from '@/shared/settings'
 import type { FileName, FileSizeBytes, SkillFileContent } from '@/shared/types'
 
+import { resolveCodeTheme } from './codeThemeHelpers'
 import { isMarkdownPreview, languageForPreview } from './filePreviewLanguage'
 import { codeToHtml } from './shikiPreview'
 
 interface FileContentProps {
   content: PreviewContent
+  /** Markdown reading-mode body font size (CSS px). */
+  markdownFontSizePx?: number
+  /** Shiki code preview font size (CSS px). */
+  codeFontSizePx?: number
+  /** Curated Shiki theme id for the code preview. */
+  codeThemeId?: CodeThemeId
 }
 
 type TextPreviewMode = 'code' | 'reading'
@@ -35,6 +48,9 @@ type TextPreviewMode = 'code' | 'reading'
  */
 export const FileContent = React.memo(function FileContent({
   content,
+  markdownFontSizePx = MARKDOWN_FONT_SIZE_DEFAULT_PX,
+  codeFontSizePx = CODE_FONT_SIZE_DEFAULT_PX,
+  codeThemeId = DEFAULT_CODE_THEME_ID,
 }: FileContentProps): React.ReactElement {
   // Exhaustive over PreviewContent: a future variant added to the union (e.g.
   // a `pdf` preview) fails compilation here instead of silently falling
@@ -53,12 +69,22 @@ export const FileContent = React.memo(function FileContent({
         />
       </div>
     ))
-    .with({ kind: 'text' }, ({ data }) => <TextPreview file={data} />)
+    .with({ kind: 'text' }, ({ data }) => (
+      <TextPreview
+        file={data}
+        markdownFontSizePx={markdownFontSizePx}
+        codeFontSizePx={codeFontSizePx}
+        codeThemeId={codeThemeId}
+      />
+    ))
     .exhaustive()
 })
 
 interface TextPreviewProps {
   file: SkillFileContent
+  markdownFontSizePx: number
+  codeFontSizePx: number
+  codeThemeId: CodeThemeId
 }
 
 /**
@@ -70,6 +96,9 @@ interface TextPreviewProps {
  */
 const TextPreview = React.memo(function TextPreview({
   file,
+  markdownFontSizePx,
+  codeFontSizePx,
+  codeThemeId,
 }: TextPreviewProps): React.ReactElement {
   const isMarkdown = isMarkdownPreview(file)
   const fileIdentity = `${file.name}:${file.extension}`
@@ -118,11 +147,16 @@ const TextPreview = React.memo(function TextPreview({
       )}
 
       {isMarkdown && mode === 'reading' ? (
-        <MarkdownReadingPreview content={file.content} />
+        <MarkdownReadingPreview
+          content={file.content}
+          fontSizePx={markdownFontSizePx}
+        />
       ) : (
         <SyntaxHighlightedCode
           content={file.content}
           language={languageForPreview(file)}
+          fontSizePx={codeFontSizePx}
+          codeThemeId={codeThemeId}
         />
       )}
     </div>
@@ -132,20 +166,26 @@ const TextPreview = React.memo(function TextPreview({
 interface SyntaxHighlightedCodeProps {
   content: string
   language: string
+  fontSizePx: number
+  codeThemeId: CodeThemeId
 }
 
 /**
  * Highlight code asynchronously with Shiki.
  * @param content - Raw file text.
  * @param language - Shiki language identifier.
+ * @param fontSizePx - Code font size; line metrics scale with it via em CSS.
+ * @param codeThemeId - Curated Shiki theme id resolved to a light/dark pair.
  * @returns Scrollable highlighted source with a bottom spacer after the final
  * line so the last row is reachable and not pinned to the pane edge.
  * @example
- * <SyntaxHighlightedCode content="const x = 1" language="typescript" />
+ * <SyntaxHighlightedCode content="const x = 1" language="typescript" fontSizePx={13} codeThemeId="github" />
  */
 const SyntaxHighlightedCode = React.memo(function SyntaxHighlightedCode({
   content,
   language,
+  fontSizePx,
+  codeThemeId,
 }: SyntaxHighlightedCodeProps): React.ReactElement {
   const [highlightedHtml, setHighlightedHtml] = useState<string | null>(null)
   const plainTextLines = useMemo(() => content.split('\n'), [content])
@@ -153,14 +193,17 @@ const SyntaxHighlightedCode = React.memo(function SyntaxHighlightedCode({
   useCycleEffect(() => {
     let cancelled = false
     setHighlightedHtml(null)
+    // Resolve inside the effect so a theme change re-runs highlighting; the
+    // light/dark keys feed the --shiki-light / --shiki-dark CSS var bridge.
+    const codeTheme = resolveCodeTheme(codeThemeId)
 
     async function highlight(): Promise<void> {
       try {
         const html = await codeToHtml(content, {
           lang: language,
           themes: {
-            dark: 'github-dark',
-            light: 'github-light',
+            dark: codeTheme.dark,
+            light: codeTheme.light,
           },
           defaultColor: false,
           transformers: [
@@ -191,7 +234,8 @@ const SyntaxHighlightedCode = React.memo(function SyntaxHighlightedCode({
     return () => {
       cancelled = true
     }
-  }, [content, language])
+    // codeThemeId is a dep so switching themes re-highlights with the new pair.
+  }, [content, language, codeThemeId])
 
   return (
     <div
@@ -200,14 +244,17 @@ const SyntaxHighlightedCode = React.memo(function SyntaxHighlightedCode({
     >
       {highlightedHtml ? (
         <div
-          className="skill-code-preview min-w-max text-[13px] font-mono leading-5"
+          // Font size is inline so the slider scales it; `.line` line-height in
+          // globals.css is unitless, so rows scale with the font.
+          style={{ fontSize: `${fontSizePx}px` }}
+          className="skill-code-preview min-w-max font-mono"
           // Shiki escapes the source text before returning HTML; this injects
           // only the highlighter's `<pre><code><span>` structure and styles.
           // react-doctor-disable-next-line react-doctor/no-danger -- highlightedHtml is Shiki output; Shiki HTML-escapes the source text and emits only its own <pre><code><span> markup, so there is no attacker-controlled HTML path here.
           dangerouslySetInnerHTML={{ __html: highlightedHtml }}
         />
       ) : (
-        <PlainTextCode lines={plainTextLines} />
+        <PlainTextCode lines={plainTextLines} fontSizePx={fontSizePx} />
       )}
       <div className="h-8" data-file-preview-bottom-spacer aria-hidden />
     </div>
@@ -216,28 +263,34 @@ const SyntaxHighlightedCode = React.memo(function SyntaxHighlightedCode({
 
 interface PlainTextCodeProps {
   lines: string[]
+  fontSizePx: number
 }
 
 /**
  * Immediate plain-text fallback shown while Shiki loads or when highlighting
  * fails for an unknown grammar.
  * @param lines - Raw content split on newline boundaries.
+ * @param fontSizePx - Code font size; unitless line-height keeps rows scaling.
  * @returns Line-numbered plain text table.
  * @example
- * <PlainTextCode lines={['first', 'second']} />
+ * <PlainTextCode lines={['first', 'second']} fontSizePx={13} />
  */
 const PlainTextCode = React.memo(function PlainTextCode({
   lines,
+  fontSizePx,
 }: PlainTextCodeProps): React.ReactElement {
   return (
-    <table className="w-full min-w-max text-[13px] font-mono leading-5">
+    <table
+      style={{ fontSize: `${fontSizePx}px` }}
+      className="w-full min-w-max font-mono leading-[1.5]"
+    >
       <tbody>
         {lines.map((line, idx) => (
           <tr key={idx} className="hover:bg-foreground/5">
-            <td className="sticky left-0 z-10 h-5 w-12 bg-muted px-2 py-0 text-right text-muted-foreground select-none border-r border-border/50 align-top">
+            <td className="sticky left-0 z-10 w-12 bg-muted px-2 py-0 text-right text-muted-foreground select-none border-r border-border/50 align-top">
               {idx + 1}
             </td>
-            <td className="h-5 px-3 py-0 whitespace-pre text-foreground">
+            <td className="px-3 py-0 whitespace-pre text-foreground">
               {line || ' '}
             </td>
           </tr>
@@ -249,17 +302,20 @@ const PlainTextCode = React.memo(function PlainTextCode({
 
 interface MarkdownReadingPreviewProps {
   content: string
+  fontSizePx: number
 }
 
 /**
  * Render Markdown documents in a readable inspector view.
  * @param content - Markdown source.
+ * @param fontSizePx - Body font size; headings/code/tables scale via em.
  * @returns Scrollable article with GitHub Flavored Markdown features enabled.
  * @example
- * <MarkdownReadingPreview content="# Title\n\n- [x] done" />
+ * <MarkdownReadingPreview content="# Title\n\n- [x] done" fontSizePx={14} />
  */
 const MarkdownReadingPreview = React.memo(function MarkdownReadingPreview({
   content,
+  fontSizePx,
 }: MarkdownReadingPreviewProps): React.ReactElement {
   const readableContent = useMemo(
     () => stripMarkdownFrontmatter(content),
@@ -272,7 +328,13 @@ const MarkdownReadingPreview = React.memo(function MarkdownReadingPreview({
       className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden bg-background"
       data-markdown-reading-scroll
     >
-      <article className="markdown-reading-prose min-w-0 max-w-full overflow-x-hidden break-words px-7 py-6 pb-10 text-sm leading-7 text-foreground">
+      {/* Inline font size is the scale anchor: child sizes are em (heading,
+          code, table), so the whole document scales from this one value.
+          `leading-loose` (2.0) matches the prior `leading-7` (28px ÷ 14px). */}
+      <article
+        style={{ fontSize: `${fontSizePx}px` }}
+        className="markdown-reading-prose min-w-0 max-w-full overflow-x-hidden break-words px-7 py-6 pb-10 leading-loose text-foreground"
+      >
         <ReactMarkdown
           remarkPlugins={remarkPlugins}
           components={markdownComponents}
@@ -398,7 +460,9 @@ const markdownComponents: Components = {
         <code
           {...domProps}
           className={cn(
-            'block max-w-full overflow-x-hidden rounded-md border border-border bg-muted px-3 py-2 font-mono text-xs leading-6 text-foreground',
+            // em sizes (text-xs≈0.857em, leading-6≈2) so block code scales
+            // with the Markdown body font instead of staying a fixed 12px.
+            'block max-w-full overflow-x-hidden rounded-md border border-border bg-muted px-3 py-2 font-mono text-[0.857em] leading-[2] text-foreground',
             className,
           )}
         >
@@ -426,7 +490,8 @@ const markdownComponents: Components = {
       <h1
         {...domProps}
         className={cn(
-          'mb-4 mt-0 border-b border-border pb-3 text-2xl font-semibold leading-tight',
+          // text-2xl (24px) as em (24÷14) so headings scale with the body font.
+          'mb-4 mt-0 border-b border-border pb-3 text-[1.714em] font-semibold leading-tight',
           className,
         )}
       >
@@ -441,7 +506,8 @@ const markdownComponents: Components = {
       <h2
         {...domProps}
         className={cn(
-          'mb-3 mt-7 border-b border-border/70 pb-2 text-xl font-semibold leading-tight',
+          // text-xl (20px) as em (20÷14) so headings scale with the body font.
+          'mb-3 mt-7 border-b border-border/70 pb-2 text-[1.429em] font-semibold leading-tight',
           className,
         )}
       >
@@ -455,7 +521,12 @@ const markdownComponents: Components = {
     return (
       <h3
         {...domProps}
-        className={cn('mb-2 mt-6 text-base font-semibold', className)}
+        className={cn(
+          // text-base (16px) as em (16÷14); leading-normal restores the line
+          // height that the named text-base utility used to supply.
+          'mb-2 mt-6 text-[1.143em] font-semibold leading-normal',
+          className,
+        )}
       >
         {children}
       </h3>
@@ -508,7 +579,9 @@ const markdownComponents: Components = {
         <table
           {...domProps}
           className={cn(
-            'w-full table-fixed border-collapse text-left text-sm',
+            // No explicit size: the table inherits the article's em font so it
+            // scales with the Markdown body (was a fixed text-sm/14px).
+            'w-full table-fixed border-collapse text-left',
             className,
           )}
         >

--- a/src/renderer/src/components/skills/codeThemeHelpers.test.ts
+++ b/src/renderer/src/components/skills/codeThemeHelpers.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveCodeTheme } from './codeThemeHelpers'
+
+/**
+ * Unit tests for `resolveCodeTheme` — the forgiving bridge from a persisted
+ * `codeThemeId` to the Shiki `{ light, dark }` pair the code preview renders.
+ * The resolver is the safety net for a `settings.json` carrying a theme id
+ * that a future build removed: it must degrade to the default instead of
+ * breaking the preview.
+ */
+describe('resolveCodeTheme', () => {
+  it('maps each curated theme id to its Shiki light/dark pair', () => {
+    // Arrange / Act / Assert — every curated id resolves to its named pair.
+    expect(resolveCodeTheme('github')).toEqual({
+      light: 'github-light',
+      dark: 'github-dark',
+    })
+    expect(resolveCodeTheme('vs')).toEqual({
+      light: 'light-plus',
+      dark: 'dark-plus',
+    })
+    expect(resolveCodeTheme('vitesse')).toEqual({
+      light: 'vitesse-light',
+      dark: 'vitesse-dark',
+    })
+    expect(resolveCodeTheme('one')).toEqual({
+      light: 'one-light',
+      dark: 'one-dark-pro',
+    })
+    expect(resolveCodeTheme('catppuccin')).toEqual({
+      light: 'catppuccin-latte',
+      dark: 'catppuccin-mocha',
+    })
+  })
+
+  it('resolves the Visual Studio id whose Shiki theme names differ from the id', () => {
+    // Regression guard for the one pair where id ('vs') ≠ Shiki theme names
+    // ('light-plus' / 'dark-plus'): an accidental id===theme assumption would
+    // silently break only this entry.
+    // Arrange / Act
+    const resolved = resolveCodeTheme('vs')
+    // Assert
+    expect(resolved.light).toBe('light-plus')
+    expect(resolved.dark).toBe('dark-plus')
+  })
+
+  it('falls back to the default GitHub pair for an unknown (stale) theme id', () => {
+    // A settings.json left over from a build that has since removed a theme
+    // must not break the preview — it degrades to the default pair.
+    // Arrange / Act
+    const resolved = resolveCodeTheme('a-theme-that-was-removed')
+    // Assert
+    expect(resolved).toEqual({ light: 'github-light', dark: 'github-dark' })
+  })
+})

--- a/src/renderer/src/components/skills/codeThemeHelpers.ts
+++ b/src/renderer/src/components/skills/codeThemeHelpers.ts
@@ -1,0 +1,52 @@
+import {
+  CODE_THEME_DEFINITIONS,
+  DEFAULT_CODE_THEME_ID,
+} from '@/shared/constants'
+
+/**
+ * A Shiki light/dark theme pair, shaped exactly as `codeToHtml`'s `themes`
+ * option expects (keys stay `light` / `dark` — the CSS-var bridge in
+ * `globals.css` reads `--shiki-light` / `--shiki-dark` derived from them).
+ */
+export interface ResolvedCodeTheme {
+  light: string
+  dark: string
+}
+
+/**
+ * The default pair, resolved once. A module-scope guard mirrors the
+ * `AGENT_IDS` pattern: `DEFAULT_CODE_THEME_ID` is a member of
+ * `CODE_THEME_DEFINITIONS` by construction, so the throw is unreachable at
+ * runtime and only a future refactor that drops the default would trip it.
+ */
+const foundDefaultCodeThemeDefinition = CODE_THEME_DEFINITIONS.find(
+  (theme) => theme.id === DEFAULT_CODE_THEME_ID,
+)
+if (!foundDefaultCodeThemeDefinition) {
+  /* v8 ignore next 2 -- defensive: DEFAULT_CODE_THEME_ID is always a CODE_THEME_DEFINITIONS member; only a refactor could empty it */
+  throw new Error('DEFAULT_CODE_THEME_ID must exist in CODE_THEME_DEFINITIONS')
+}
+// Bind the post-throw narrowed value so the type carries into `resolveCodeTheme`
+// (a function body does not inherit module-scope control-flow narrowing).
+const DEFAULT_CODE_THEME_DEFINITION = foundDefaultCodeThemeDefinition
+
+/**
+ * Map a persisted `codeThemeId` to its Shiki `{ light, dark }` pair, falling
+ * back to the default for an unknown id. Accepts a bare `string` (not the
+ * `CodeThemeId` union) on purpose: it is a forgiving resolver for a value read
+ * from `settings.json`, so a stale id left over from a removed theme degrades
+ * to the default instead of breaking the preview.
+ * @param codeThemeId - Persisted theme id from settings (possibly stale).
+ * @returns
+ * - The matching pair when `codeThemeId` is a known theme
+ * - The default (GitHub) pair when it is unknown
+ * @example
+ * resolveCodeTheme('vitesse') // => { light: 'vitesse-light', dark: 'vitesse-dark' }
+ * resolveCodeTheme('removed') // => { light: 'github-light', dark: 'github-dark' }
+ */
+export function resolveCodeTheme(codeThemeId: string): ResolvedCodeTheme {
+  const definition =
+    CODE_THEME_DEFINITIONS.find((theme) => theme.id === codeThemeId) ??
+    DEFAULT_CODE_THEME_DEFINITION
+  return { light: definition.light, dark: definition.dark }
+}

--- a/src/renderer/src/components/skills/shikiPreview.test.ts
+++ b/src/renderer/src/components/skills/shikiPreview.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { CODE_THEME_DEFINITIONS } from '@/shared/constants'
+
 /**
  * The focused Shiki bundle in `shikiPreview.ts` registers each grammar as a
  * lazy `() => import('shiki/langs/<lang>.mjs')` loader and wires up a singleton
@@ -98,12 +100,29 @@ vi.mock('shiki/langs/xml.mjs', () => stubLangModule('xml'))
 vi.mock('shiki/langs/yaml.mjs', () => stubLangModule('yaml'))
 vi.mock('shiki/langs/zsh.mjs', () => stubLangModule('zsh'))
 
-vi.mock('shiki/themes/github-dark.mjs', () => ({
-  default: { name: 'github-dark' },
-}))
-vi.mock('shiki/themes/github-light.mjs', () => ({
-  default: { name: 'github-light' },
-}))
+// Each Shiki theme module the SUT lazily imports is stubbed with the same
+// `{ default: { name } }` shape, so driving a loader proves the registered key
+// is wired to the matching theme module (not a mismatched one).
+const stubThemeModule = (themeName: string): { default: { name: string } } => ({
+  default: { name: themeName },
+})
+
+vi.mock('shiki/themes/github-dark.mjs', () => stubThemeModule('github-dark'))
+vi.mock('shiki/themes/github-light.mjs', () => stubThemeModule('github-light'))
+vi.mock('shiki/themes/light-plus.mjs', () => stubThemeModule('light-plus'))
+vi.mock('shiki/themes/dark-plus.mjs', () => stubThemeModule('dark-plus'))
+vi.mock('shiki/themes/vitesse-light.mjs', () =>
+  stubThemeModule('vitesse-light'),
+)
+vi.mock('shiki/themes/vitesse-dark.mjs', () => stubThemeModule('vitesse-dark'))
+vi.mock('shiki/themes/one-light.mjs', () => stubThemeModule('one-light'))
+vi.mock('shiki/themes/one-dark-pro.mjs', () => stubThemeModule('one-dark-pro'))
+vi.mock('shiki/themes/catppuccin-latte.mjs', () =>
+  stubThemeModule('catppuccin-latte'),
+)
+vi.mock('shiki/themes/catppuccin-mocha.mjs', () =>
+  stubThemeModule('catppuccin-mocha'),
+)
 
 describe('shikiPreview bundle', () => {
   beforeEach(() => {
@@ -200,23 +219,41 @@ describe('shikiPreview bundle', () => {
     }
   })
 
-  it('offers the github-dark and github-light themes for the preview pane', async () => {
-    // Arrange
+  it('bundles exactly the light/dark themes every curated pair needs, each wired to its own module', async () => {
+    // Arrange — the bundled theme set must be EXACTLY the union of every
+    // curated pair's light + dark names. Derived from CODE_THEME_DEFINITIONS
+    // (the source of truth) on purpose: this is the drift guard that fails when
+    // a pair is added to CODE_THEME_DEFINITIONS but its loaders are not added to
+    // shikiPreview.ts (or vice versa) — hard-coding the names would defeat it.
+    const expectedThemeNames = CODE_THEME_DEFINITIONS.flatMap((pair) => [
+      pair.light,
+      pair.dark,
+    ])
     await import('./shikiPreview')
     const capturedConfig = shikiCoreMocks.capturedBundleConfig.value
     expect(capturedConfig).not.toBeNull()
 
-    // Act — invoke both theme loaders to run their dynamic imports.
-    const darkTheme = await capturedConfig!.themes['github-dark']()
-    const lightTheme = await capturedConfig!.themes['github-light']()
+    // Assert — the registered theme keys are exactly that derived set.
+    expect(Object.keys(capturedConfig!.themes).sort()).toEqual(
+      [...expectedThemeNames].sort(),
+    )
 
-    // Assert
-    expect(Object.keys(capturedConfig!.themes).sort()).toEqual([
-      'github-dark',
-      'github-light',
-    ])
-    expect(darkTheme).toEqual({ default: { name: 'github-dark' } })
-    expect(lightTheme).toEqual({ default: { name: 'github-light' } })
+    // Act — drive every theme loader so its dynamic import runs, keeping the
+    // registered key paired with the module it resolves to.
+    const loadedThemesByName = await Promise.all(
+      expectedThemeNames.map(async (themeName) => ({
+        themeName,
+        themeModule: await capturedConfig!.themes[themeName](),
+      })),
+    )
+
+    // Assert — every registered key resolves to the theme module whose name
+    // matches it, so a mis-wired loader (e.g. 'one-dark-pro' pointing at
+    // one-light.mjs) is caught even though the total theme count stays 10.
+    expect(loadedThemesByName).toHaveLength(10)
+    for (const { themeName, themeModule } of loadedThemesByName) {
+      expect(themeModule).toEqual({ default: { name: themeName } })
+    }
   })
 
   it('highlights offline using the WASM-free JavaScript regex engine', async () => {

--- a/src/renderer/src/components/skills/shikiPreview.ts
+++ b/src/renderer/src/components/skills/shikiPreview.ts
@@ -45,9 +45,21 @@ const createPreviewHighlighter = createBundledHighlighter({
     yaml: async () => import('shiki/langs/yaml.mjs'),
     zsh: async () => import('shiki/langs/zsh.mjs'),
   },
+  // Static `import('shiki/themes/<name>.mjs')` literals (not a template-literal
+  // glob) so the bundler tree-shakes to exactly these themes — the curated
+  // light/dark pairs in `CODE_THEME_DEFINITIONS`. A renderer drift-guard test
+  // asserts every pair there is bundled here.
   themes: {
     'github-dark': async () => import('shiki/themes/github-dark.mjs'),
     'github-light': async () => import('shiki/themes/github-light.mjs'),
+    'light-plus': async () => import('shiki/themes/light-plus.mjs'),
+    'dark-plus': async () => import('shiki/themes/dark-plus.mjs'),
+    'vitesse-light': async () => import('shiki/themes/vitesse-light.mjs'),
+    'vitesse-dark': async () => import('shiki/themes/vitesse-dark.mjs'),
+    'one-light': async () => import('shiki/themes/one-light.mjs'),
+    'one-dark-pro': async () => import('shiki/themes/one-dark-pro.mjs'),
+    'catppuccin-latte': async () => import('shiki/themes/catppuccin-latte.mjs'),
+    'catppuccin-mocha': async () => import('shiki/themes/catppuccin-mocha.mjs'),
   },
   // JavaScript regex avoids shipping the Oniguruma WASM runtime for this
   // read-only preview pane while keeping highlighting deterministic offline.

--- a/src/renderer/src/hooks/useDraftRangeSetting.ts
+++ b/src/renderer/src/hooks/useDraftRangeSetting.ts
@@ -1,0 +1,76 @@
+import { useCallback, useRef, useState } from 'react'
+
+import { useDebouncedCallback } from './useDebouncedCallback'
+import { useUpdateEffect } from './useUpdateEffect'
+
+/**
+ * Local draft + debounced persist for one numeric range setting.
+ */
+interface UseDraftRangeSettingResult {
+  /** Current draft value, updated instantly on each change for a responsive slider. */
+  draft: number
+  /** True when the draft equals the setting's default (e.g. to disable Reset). */
+  isDefault: boolean
+  /** Update the draft now and schedule a debounced persist. */
+  change: (next: number) => void
+  /** Cancel any pending persist, snap the draft to the default, persist immediately. */
+  reset: () => void
+}
+
+/**
+ * Drive a Settings range slider: the draft updates instantly so the slider
+ * feels live, while `commit` is debounced so a drag's burst of ticks collapses
+ * into a single persist. An external settings broadcast (or any `value` change)
+ * cancels a pending persist and re-syncs the draft, so a drag that the main
+ * process overrides never writes back. Backs the appearance sliders (blur,
+ * markdown/code font size).
+ *
+ * @param value - The persisted value from Redux (source of truth).
+ * @param defaultValue - The setting's default, used by `reset` and `isDefault`.
+ * @param commit - Persists a value (e.g. `(px) => updateSettings({ codeFontSizePx: px })`). May be an inline closure; the latest is always used.
+ * @param delayMs - Debounce quiet period before `commit` fires.
+ * @returns `{ draft, isDefault, change, reset }`.
+ * @example
+ * const font = useDraftRangeSetting(codeFontSizePx, 13, (px) => updateSettings({ codeFontSizePx: px }), 120)
+ * <input type="range" value={font.draft} onChange={(e) => font.change(Number(e.target.value))} />
+ */
+export function useDraftRangeSetting(
+  value: number,
+  defaultValue: number,
+  commit: (next: number) => void,
+  delayMs: number,
+): UseDraftRangeSettingResult {
+  const [draft, setDraft] = useState<number>(value)
+
+  // Hold the latest commit so `change`/`reset` stay referentially stable even
+  // when the consumer passes an inline closure (keeps the memo slider stable).
+  const commitRef = useRef(commit)
+  commitRef.current = commit
+  const persist = useCallback((next: number): void => {
+    commitRef.current(next)
+  }, [])
+  const debouncedPersist = useDebouncedCallback(persist, delayMs)
+
+  const change = useCallback(
+    (next: number): void => {
+      setDraft(next)
+      debouncedPersist.run(next)
+    },
+    [debouncedPersist],
+  )
+
+  const reset = useCallback((): void => {
+    debouncedPersist.cancel()
+    setDraft(defaultValue)
+    persist(defaultValue)
+  }, [debouncedPersist, defaultValue, persist])
+
+  // A broadcast (or any value change) wins over a pending local drag: drop the
+  // scheduled persist and mirror the new source-of-truth value.
+  useUpdateEffect(() => {
+    debouncedPersist.cancel()
+    setDraft(value)
+  }, [value, debouncedPersist])
+
+  return { draft, isDefault: draft === defaultValue, change, reset }
+}

--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -301,12 +301,13 @@
     white-space: normal;
   }
 
-  /* GitHub source panes use a compact 20px row rhythm, which keeps long skill
-   * files scannable without making blank lines look oversized. */
+  /* Compact GitHub-style row rhythm. Metrics are font-relative (em min-height
+   * + unitless line-height) so the rows scale when the user changes the code
+   * preview font size in Settings; blank lines still hold a full row. */
   .skill-code-preview .line {
     display: block;
-    min-height: 1.25rem;
-    line-height: 1.25rem;
+    min-height: 1.5em;
+    line-height: 1.5;
     padding-right: 0.75rem;
     white-space: pre;
   }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1147,6 +1147,10 @@ export const DEFAULT_CODE_THEME_ID: CodeThemeId = 'github'
  * z.enum(CODE_THEME_IDS).safeParse('vitesse').success // => true
  */
 const _CODE_THEME_IDS = CODE_THEME_DEFINITIONS.map((theme) => theme.id)
+if (_CODE_THEME_IDS.length === 0) {
+  /* v8 ignore next -- defensive: CODE_THEME_DEFINITIONS is a non-empty const array literal, so no runtime input can empty it; only a future refactor would trip this */
+  throw new Error('CODE_THEME_DEFINITIONS must not be empty')
+}
 export const CODE_THEME_IDS = _CODE_THEME_IDS as unknown as readonly [
   CodeThemeId,
   ...CodeThemeId[],

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1025,6 +1025,17 @@ export const COPIED_FEEDBACK_DURATION_MS = 1600
 export const SEARCH_DEBOUNCE_MS = 300
 
 /**
+ * Quiet period (ms) a Settings range slider waits after the last drag tick
+ * before persisting via the `settings:set` IPC. Collapses a drag's burst of
+ * input events into one disk write while the local draft updates instantly.
+ * Consumed by `useDraftRangeSetting` for the appearance sliders (blur,
+ * markdown/code font size).
+ * @example
+ * useDraftRangeSetting(value, def, commit, SETTINGS_RANGE_DEBOUNCE_MS)
+ */
+export const SETTINGS_RANGE_DEBOUNCE_MS = 120
+
+/**
  * Batch size at which bulk ops surface a live per-item progress counter in the
  * toolbar. Below this, the final `.fulfilled` toast is a better UX than a
  * flashing "k of n". Main-process `emitProgress` and renderer-side display
@@ -1071,6 +1082,75 @@ export const REPOSITORY_FACET_LABEL_MAX_CHARS = 28
  * <Button style={{ minHeight: MIN_TOUCH_TARGET_PX }}>Clear</Button>
  */
 export const MIN_TOUCH_TARGET_PX = 44
+
+/**
+ * Curated Shiki light/dark theme pairs offered in Settings → Appearance for the
+ * file/code preview pane. `light` / `dark` are the exact Shiki bundled-theme
+ * module names (`shiki/themes/<name>.mjs`) — they MUST stay in lockstep with
+ * the static imports in `shikiPreview.ts` (a renderer-only drift-guard test
+ * asserts every name here is bundled). `id` is the value persisted in
+ * `settings.json` (`codeThemeId`); `label` is the picker display string.
+ *
+ * Each pair is symmetrical (one light + one dark) so the preview recolors
+ * correctly whether the app is in light or dark mode — the same `themes:
+ * { light, dark }` object Shiki's `codeToHtml` consumes.
+ * @example
+ * CODE_THEME_DEFINITIONS.find((t) => t.id === 'one') // => { id:'one', label:'One', light:'one-light', dark:'one-dark-pro' }
+ */
+export const CODE_THEME_DEFINITIONS = [
+  { id: 'github', label: 'GitHub', light: 'github-light', dark: 'github-dark' },
+  {
+    id: 'vs',
+    label: 'Visual Studio',
+    light: 'light-plus',
+    dark: 'dark-plus',
+  },
+  {
+    id: 'vitesse',
+    label: 'Vitesse',
+    light: 'vitesse-light',
+    dark: 'vitesse-dark',
+  },
+  { id: 'one', label: 'One', light: 'one-light', dark: 'one-dark-pro' },
+  {
+    id: 'catppuccin',
+    label: 'Catppuccin',
+    light: 'catppuccin-latte',
+    dark: 'catppuccin-mocha',
+  },
+] as const satisfies readonly {
+  id: string
+  label: string
+  light: string
+  dark: string
+}[]
+
+/**
+ * Persisted code-theme identifier. Derived from CODE_THEME_DEFINITIONS so the
+ * Settings schema enum, the picker, and the resolver share one source of truth.
+ * @example "github"
+ */
+export type CodeThemeId = (typeof CODE_THEME_DEFINITIONS)[number]['id']
+
+/**
+ * Default code-theme id. GitHub matches the preview pane's prior hard-coded
+ * `github-light` / `github-dark` pair, so existing installs render unchanged.
+ */
+export const DEFAULT_CODE_THEME_ID: CodeThemeId = 'github'
+
+/**
+ * Runtime non-empty tuple of every CodeThemeId for `z.enum`, derived from
+ * CODE_THEME_DEFINITIONS so the two stay in lockstep automatically. Mirrors the
+ * `AGENT_IDS` cast pattern — `.map()` returns `CodeThemeId[]`, which the type
+ * system cannot narrow to the non-empty tuple `z.enum` requires.
+ * @example
+ * z.enum(CODE_THEME_IDS).safeParse('vitesse').success // => true
+ */
+const _CODE_THEME_IDS = CODE_THEME_DEFINITIONS.map((theme) => theme.id)
+export const CODE_THEME_IDS = _CODE_THEME_IDS as unknown as readonly [
+  CodeThemeId,
+  ...CodeThemeId[],
+]
 
 /**
  * Keyboard shortcuts surfaced read-only in the Settings window's

--- a/src/shared/settings.test.ts
+++ b/src/shared/settings.test.ts
@@ -2,8 +2,12 @@ import { describe, it, expect } from 'vitest'
 
 import { AGENT_DEFINITIONS } from './constants'
 import {
+  CODE_FONT_SIZE_MAX_PX,
+  CODE_FONT_SIZE_MIN_PX,
   DEFAULT_SETTINGS,
   getWindowBackgroundOpacity,
+  MARKDOWN_FONT_SIZE_MAX_PX,
+  MARKDOWN_FONT_SIZE_MIN_PX,
   normalizeWindowBackgroundBlurRadius,
   SettingsSchema,
   WINDOW_BACKGROUND_BLUR_MAX_RADIUS,
@@ -231,6 +235,99 @@ describe('SettingsSchema', () => {
     expect(() =>
       SettingsSchema.parse({ windowBackgroundBlurRadius: 12.5 }),
     ).toThrow()
+  })
+
+  it('defaults the Markdown reading font size to the prior 14px preview base', () => {
+    // Arrange / Act
+    const parsed = SettingsSchema.parse({})
+    // Assert
+    expect(parsed.markdownFontSizePx).toBe(14)
+  })
+
+  it('accepts a Markdown reading font size at the bounded min and max', () => {
+    // Arrange / Act
+    const atMin = SettingsSchema.parse({
+      markdownFontSizePx: MARKDOWN_FONT_SIZE_MIN_PX,
+    })
+    const atMax = SettingsSchema.parse({
+      markdownFontSizePx: MARKDOWN_FONT_SIZE_MAX_PX,
+    })
+    // Assert
+    expect(atMin.markdownFontSizePx).toBe(12)
+    expect(atMax.markdownFontSizePx).toBe(22)
+  })
+
+  it('rejects a Markdown reading font size outside the bounded range', () => {
+    // Arrange / Act / Assert
+    expect(() =>
+      SettingsSchema.parse({
+        markdownFontSizePx: MARKDOWN_FONT_SIZE_MIN_PX - 1,
+      }),
+    ).toThrow()
+    expect(() =>
+      SettingsSchema.parse({
+        markdownFontSizePx: MARKDOWN_FONT_SIZE_MAX_PX + 1,
+      }),
+    ).toThrow()
+  })
+
+  it('rejects a non-integer Markdown reading font size', () => {
+    // Arrange / Act / Assert
+    expect(() => SettingsSchema.parse({ markdownFontSizePx: 14.5 })).toThrow()
+  })
+
+  it('defaults the code preview font size to the prior 13px preview base', () => {
+    // Arrange / Act
+    const parsed = SettingsSchema.parse({})
+    // Assert
+    expect(parsed.codeFontSizePx).toBe(13)
+  })
+
+  it('accepts a code preview font size at the bounded min and max', () => {
+    // Arrange / Act
+    const atMin = SettingsSchema.parse({
+      codeFontSizePx: CODE_FONT_SIZE_MIN_PX,
+    })
+    const atMax = SettingsSchema.parse({
+      codeFontSizePx: CODE_FONT_SIZE_MAX_PX,
+    })
+    // Assert
+    expect(atMin.codeFontSizePx).toBe(11)
+    expect(atMax.codeFontSizePx).toBe(20)
+  })
+
+  it('rejects a code preview font size outside the bounded range', () => {
+    // Arrange / Act / Assert
+    expect(() =>
+      SettingsSchema.parse({ codeFontSizePx: CODE_FONT_SIZE_MIN_PX - 1 }),
+    ).toThrow()
+    expect(() =>
+      SettingsSchema.parse({ codeFontSizePx: CODE_FONT_SIZE_MAX_PX + 1 }),
+    ).toThrow()
+  })
+
+  it('rejects a non-integer code preview font size', () => {
+    // Arrange / Act / Assert
+    expect(() => SettingsSchema.parse({ codeFontSizePx: 13.5 })).toThrow()
+  })
+
+  it('defaults the code theme to the GitHub pair on a fresh parse', () => {
+    // Arrange / Act
+    const parsed = SettingsSchema.parse({})
+    // Assert
+    expect(parsed.codeThemeId).toBe('github')
+  })
+
+  it('persists choosing a curated code theme', () => {
+    // Arrange / Act
+    const parsed = SettingsSchema.parse({ codeThemeId: 'vitesse' })
+    // Assert
+    expect(parsed.codeThemeId).toBe('vitesse')
+  })
+
+  it('rejects an unknown code theme id', () => {
+    // Arrange / Act / Assert
+    expect(() => SettingsSchema.parse({ codeThemeId: 'dracula' })).toThrow()
   })
 
   it('hides no agents by default on a fresh parse', () => {

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -1,6 +1,11 @@
 import { z } from 'zod'
 
-import { AGENT_IDS, TERMINAL_APP_IDS } from './constants'
+import {
+  AGENT_IDS,
+  CODE_THEME_IDS,
+  DEFAULT_CODE_THEME_ID,
+  TERMINAL_APP_IDS,
+} from './constants'
 import type { AgentId } from './types'
 
 /**
@@ -31,6 +36,26 @@ export const WINDOW_BACKGROUND_BLUR_MAX_RADIUS = 48
  */
 export const WINDOW_BACKGROUND_OPACITY_MAX = 1
 export const WINDOW_BACKGROUND_OPACITY_MIN = 0.45
+
+/**
+ * Bounds for the Markdown reading-mode body font size (CSS px). The default
+ * matches the preview's prior `text-sm` (14px) base so existing installs render
+ * identically; the range keeps a hand-edited settings file from requesting an
+ * unreadably small or oversized body. Markdown-embedded code fences scale with
+ * this size (they are `react-markdown`, not the Shiki preview pane).
+ */
+export const MARKDOWN_FONT_SIZE_MIN_PX = 12
+export const MARKDOWN_FONT_SIZE_MAX_PX = 22
+export const MARKDOWN_FONT_SIZE_DEFAULT_PX = 14
+
+/**
+ * Bounds for the syntax-highlighted code preview font size (CSS px). The
+ * default matches the preview pane's prior `text-[13px]` so existing installs
+ * render identically. Governs the dedicated Shiki preview pane only.
+ */
+export const CODE_FONT_SIZE_MIN_PX = 11
+export const CODE_FONT_SIZE_MAX_PX = 20
+export const CODE_FONT_SIZE_DEFAULT_PX = 13
 
 /**
  * Allowed placements for the Installed view's current result count.
@@ -87,6 +112,22 @@ export const WINDOW_BACKGROUND_BLUR_RADIUS_SCHEMA = z
   .int()
   .min(WINDOW_BACKGROUND_BLUR_MIN_RADIUS)
   .max(WINDOW_BACKGROUND_BLUR_MAX_RADIUS)
+
+/**
+ * Non-defaulting preview font-size schemas shared by disk and IPC boundaries.
+ * `SettingsSchema` adds the persisted default; the IPC schema keeps them
+ * optional so an unrelated partial write does not reset the user's font size.
+ */
+export const MARKDOWN_FONT_SIZE_SCHEMA = z
+  .number()
+  .int()
+  .min(MARKDOWN_FONT_SIZE_MIN_PX)
+  .max(MARKDOWN_FONT_SIZE_MAX_PX)
+export const CODE_FONT_SIZE_SCHEMA = z
+  .number()
+  .int()
+  .min(CODE_FONT_SIZE_MIN_PX)
+  .max(CODE_FONT_SIZE_MAX_PX)
 
 /**
  * Persisted startup window size. `undefined` means "no preference —
@@ -168,6 +209,13 @@ const HIDDEN_AGENT_IDS_SCHEMA = z
  * - `windowBackgroundBlurRadius`: Electron 42 `View#setBackgroundBlur`
  *   radius for the main window. `0` disables the translucent surface and
  *   restores the opaque app background.
+ * - `markdownFontSizePx`: body font size (CSS px) for the file preview's
+ *   Markdown reading mode. Heading/code sizes scale proportionally (em).
+ * - `codeFontSizePx`: font size (CSS px) for the Shiki syntax-highlighted
+ *   code preview pane.
+ * - `codeThemeId`: which curated Shiki light/dark theme pair the code
+ *   preview uses (see `CODE_THEME_DEFINITIONS`). The pane always picks the
+ *   light or dark variant to match the app theme.
  * - `installedSearchCountDisplay`: where the Installed view shows the
  *   current visible result count. `'tab'` is the default compact badge;
  *   `'inline'` moves the count into the search toolbar.
@@ -187,7 +235,7 @@ const HIDDEN_AGENT_IDS_SCHEMA = z
  * so unknown keys are rejected at the IPC boundary (defense in depth).
  *
  * @example
- * SettingsSchema.parse({}) // { defaultSkillTab: 'files', preferredTerminal: 'terminal', windowBackgroundBlurRadius: 0, installedSearchCountDisplay: 'tab', hiddenAgentIds: [], autoDownloadUpdates: false }
+ * SettingsSchema.parse({}) // { defaultSkillTab: 'files', preferredTerminal: 'terminal', windowBackgroundBlurRadius: 0, markdownFontSizePx: 14, codeFontSizePx: 13, codeThemeId: 'github', installedSearchCountDisplay: 'tab', hiddenAgentIds: [], autoDownloadUpdates: false }
  */
 export const SettingsSchema = z.object({
   defaultSkillTab: z.enum(['files', 'info']).default('files'),
@@ -197,6 +245,11 @@ export const SettingsSchema = z.object({
   windowBackgroundBlurRadius: WINDOW_BACKGROUND_BLUR_RADIUS_SCHEMA.default(
     WINDOW_BACKGROUND_BLUR_MIN_RADIUS,
   ),
+  markdownFontSizePx: MARKDOWN_FONT_SIZE_SCHEMA.default(
+    MARKDOWN_FONT_SIZE_DEFAULT_PX,
+  ),
+  codeFontSizePx: CODE_FONT_SIZE_SCHEMA.default(CODE_FONT_SIZE_DEFAULT_PX),
+  codeThemeId: z.enum(CODE_THEME_IDS).default(DEFAULT_CODE_THEME_ID),
   installedSearchCountDisplay: z
     .enum(INSTALLED_SEARCH_COUNT_DISPLAY_OPTIONS)
     .default('tab'),
@@ -218,6 +271,9 @@ export const SettingsSchema = z.object({
  *   preferredTerminal: 'iterm',
  *   windowSize: { width: 1280, height: 800 },
  *   windowBackgroundBlurRadius: 24,
+ *   markdownFontSizePx: 14,
+ *   codeFontSizePx: 13,
+ *   codeThemeId: 'github',
  *   installedSearchCountDisplay: 'tab',
  *   hiddenAgentIds: ['claude-code'],
  *   autoDownloadUpdates: false,
@@ -241,6 +297,9 @@ export const DEFAULT_SETTINGS: Settings = {
   defaultSkillTab: 'files',
   preferredTerminal: 'terminal',
   windowBackgroundBlurRadius: WINDOW_BACKGROUND_BLUR_MIN_RADIUS,
+  markdownFontSizePx: MARKDOWN_FONT_SIZE_DEFAULT_PX,
+  codeFontSizePx: CODE_FONT_SIZE_DEFAULT_PX,
+  codeThemeId: DEFAULT_CODE_THEME_ID,
   installedSearchCountDisplay: 'tab',
   hiddenAgentIds: [],
   autoDownloadUpdates: false,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -47,6 +47,14 @@ const shikiPreviewDeps = [
   'shiki/langs/zsh.mjs',
   'shiki/themes/github-dark.mjs',
   'shiki/themes/github-light.mjs',
+  'shiki/themes/light-plus.mjs',
+  'shiki/themes/dark-plus.mjs',
+  'shiki/themes/vitesse-light.mjs',
+  'shiki/themes/vitesse-dark.mjs',
+  'shiki/themes/one-light.mjs',
+  'shiki/themes/one-dark-pro.mjs',
+  'shiki/themes/catppuccin-latte.mjs',
+  'shiki/themes/catppuccin-mocha.mjs',
 ] as const
 
 export default defineConfig({


### PR DESCRIPTION
## What

Adds three user-adjustable preview-appearance settings, surfaced in **Settings → Appearance**:

- **Reading font size** (`markdownFontSizePx`, 12–22px, default 14) — body size for the Markdown reading view; headings and fenced code scale with it.
- **Code font size** (`codeFontSizePx`, 11–20px, default 13) — the syntax-highlighted code preview.
- **Code theme** (`codeThemeId`, default `github`) — one of 5 curated Shiki light/dark pairs: GitHub, Visual Studio, Vitesse, One, Catppuccin.

## How

**Two-anchor typography.** The Markdown reading view anchors to `markdownFontSizePx` (inline `font-size` on `.markdown-reading-prose`), with child sizes expressed in `em` so headings/code scale proportionally. The code pane anchors independently to `codeFontSizePx`. The anchors don't cross; fenced code *inside* Markdown scales with the Markdown anchor. `.line` metrics in `globals.css` are now font-relative so rows grow with the slider.

**Curated code themes.** `shikiPreview.ts` statically bundles exactly the 10 theme `.mjs` for the 5 pairs (tree-shake-friendly literals; a drift-guard test asserts 10). `resolveCodeTheme()` maps a possibly-stale `codeThemeId` to its `{light, dark}` pair, falling back to the default. `FileContent` highlights with dual-theme `codeToHtml(..., { defaultColor: false })` and re-highlights on theme change.

**Settings plumbing.** `SettingsSchema` and the `settings:set` IPC tuple widen in lockstep; IPC fields use bare `.optional()` off the shared non-defaulting field schemas so a partial `set` never clobbers sibling defaults. Cross-window live updates ride the existing `settings:changed` broadcast → all windows re-render.

**Controls.** Two font-size sliders + a native code-theme `<select>`, all driven by `useDraftRangeSetting` (local draft + debounced persist via `useDebouncedCallback`, no direct `useEffect`). Sliders expose `aria-valuetext` so assistive tech announces the readable badge ("Opaque", "14px") instead of the raw integer.

## Tests

DAMP/AAA across the stack: schema bounds + defaults + partial-set safety (`settings.test.ts`, `ipc-schemas.test.ts`), theme resolver + bundle drift-guard (`codeThemeHelpers.test.ts`, `shikiPreview.test.ts`), preview typography scaling + theme-seam wiring (`FileContent*.browser.test.tsx`, `CodePreview.browser.test.tsx`), and the Appearance controls incl. the new aria-valuetext spec (`Appearance.browser.test.tsx`).

`pnpm validate` ✅ (2162 unit tests) · `pnpm test:e2e` ✅ (58 e2e).

## Design review

Verified live in the running app: code font scales 13→20px, markdown font scales 14→20px with correct production em-ratios (h1 34.28px, h2 28.58px at 20px), and the code theme switches cross-window via the Settings window. DESIGN.md gains the two-anchor model + curated-pairs rule as binding visual source-of-truth.

## Follow-up

- #221 — theme-only code switch flashes colored→plain→colored (FOUC); confined to a backgrounded main window, deferred to a focused video-verified PR.

> Version intentionally unchanged (stays 0.23.0) — releases + version bumps are owned exclusively by `/electron-release`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* スキルファイルプレビューの「Markdown本文フォントサイズ」「コードフォントサイズ」をスライダーで個別調整可能に。
* コードプレビューのテーマ（ライト/ダークのペアを含む）をキュレーション済みの選択肢から変更可能に。
* 調整内容は永続化され、次回起動後も保持されます（リセットも反映）。

## Bug Fixes
* 設定の許容範囲・小数の扱い・テーマIDの妥当性を強化し、無効値を反映しないように。

## Documentation
* プレビュー用タイポグラフィ設定の設計ドキュメントを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->