### PR TITLE
fix(dashboard): page-name collisions, preset comment, styled delete confirm

### DIFF
--- a/src/renderer/src/components/dashboard/DashboardPageTabs.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/DashboardPageTabs.browser.test.tsx
@@ -408,24 +408,46 @@ describe('DashboardPageTabs', () => {
       .toBe('Overview')
   })
 
-  it('deletes the page after the confirm prompt is accepted', async () => {
+  it('deletes the page after the destructive confirm dialog is accepted', async () => {
     // Arrange: two pages in edit mode so the delete item is offered.
     const overview = makePage('Overview')
     const discovery = makePage('Discovery')
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
     const { screen, store } = await renderTabs({
       pages: [overview, discovery],
       currentPageId: overview.id,
       isEditMode: true,
     })
 
-    // Act: open the first tab's menu and choose Delete (confirm returns true).
+    // Act: open the first tab's menu, choose Delete, then confirm in the dialog.
     await screen.getByRole('button', { name: 'Options for Overview' }).click()
     await screen.getByRole('menuitem', { name: 'Delete' }).click()
+    await screen.getByRole('button', { name: 'Delete' }).click()
 
-    // Assert: the user was warned and the page was removed from the store.
-    expect(confirmSpy).toHaveBeenCalledOnce()
+    // Assert: the page was removed from the store, leaving only Discovery.
     await expect.poll(() => store.getState().dashboard.pages.length).toBe(1)
     expect(store.getState().dashboard.pages[0]?.name).toBe('Discovery')
+  })
+
+  it('keeps the page when the destructive confirm dialog is cancelled', async () => {
+    // Arrange: two pages in edit mode so the delete item is offered.
+    const overview = makePage('Overview')
+    const discovery = makePage('Discovery')
+    const { screen, store } = await renderTabs({
+      pages: [overview, discovery],
+      currentPageId: overview.id,
+      isEditMode: true,
+    })
+
+    // Act: open the menu, choose Delete, then dismiss the dialog with Cancel.
+    await screen.getByRole('button', { name: 'Options for Overview' }).click()
+    await screen.getByRole('menuitem', { name: 'Delete' }).click()
+    await screen.getByRole('button', { name: 'Cancel' }).click()
+
+    // Assert: both pages survive — cancelling is non-destructive.
+    await expect.poll(() => store.getState().dashboard.pages.length).toBe(2)
+    expect(store.getState().dashboard.pages.map((page) => page.name)).toEqual([
+      'Overview',
+      'Discovery',
+    ])
   })
 })

--- a/src/renderer/src/components/dashboard/DashboardPageTabs.tsx
+++ b/src/renderer/src/components/dashboard/DashboardPageTabs.tsx
@@ -2,6 +2,7 @@ import { MoreHorizontal, Pencil, Plus, Trash2 } from 'lucide-react'
 import React, { useCallback, useRef, useState } from 'react'
 import { match } from 'ts-pattern'
 
+import { DestructiveConfirmDialog } from '@/renderer/src/components/shared/DestructiveConfirmDialog'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -184,6 +185,8 @@ const PageTab = React.memo(function PageTab({
   const renameInputRef = useRef<HTMLInputElement>(null)
   // react-doctor-disable-next-line react-doctor/no-derived-useState -- intentional edit buffer: draftName starts from page.name then diverges during inline rename, and is re-synced when rename mode opens (useCycleEffect below).
   const [draftName, setDraftName] = useState(page.name)
+  // Controls the styled destructive-confirm dialog for page deletion.
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
 
   // Reset the draft to the latest canonical name each time rename mode opens.
   // Using rAF defers focus until after the input is mounted in the DOM.
@@ -214,17 +217,23 @@ const PageTab = React.memo(function PageTab({
     onFinishRename()
   }
 
-  const handleDelete = useCallback((): void => {
-    // The reducer already protects the last page, but the trigger is hidden
-    // in that case anyway — keep the guard for defensive symmetry.
+  // Open the styled confirm dialog instead of a native window.confirm so the
+  // destructive flow matches the app's design system. The reducer already
+  // protects the last page, but the trigger is hidden in that case anyway —
+  // keep the guard for defensive symmetry.
+  const handleRequestDelete = useCallback((): void => {
     if (!canDelete) return
-    const userConfirmed = window.confirm(
-      `Delete page "${page.name}"? All widgets on this page will be removed.`,
-    )
-    if (userConfirmed) {
-      dispatch(removePage(page.id))
-    }
-  }, [canDelete, dispatch, page.id, page.name])
+    setIsDeleteDialogOpen(true)
+  }, [canDelete])
+
+  const handleConfirmDelete = useCallback((): void => {
+    dispatch(removePage(page.id))
+    setIsDeleteDialogOpen(false)
+  }, [dispatch, page.id])
+
+  const handleCancelDelete = useCallback((): void => {
+    setIsDeleteDialogOpen(false)
+  }, [])
 
   if (isRenaming) {
     return (
@@ -294,7 +303,7 @@ const PageTab = React.memo(function PageTab({
               <>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
-                  onClick={handleDelete}
+                  onClick={handleRequestDelete}
                   className="text-destructive focus:text-destructive"
                 >
                   <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
@@ -305,6 +314,21 @@ const PageTab = React.memo(function PageTab({
           </DropdownMenuContent>
         </DropdownMenu>
       )}
+      <DestructiveConfirmDialog
+        open={isDeleteDialogOpen}
+        onClose={handleCancelDelete}
+        onConfirm={handleConfirmDelete}
+        loading={false}
+        title="Delete page"
+        description={
+          <>
+            Delete page <strong>{page.name}</strong>? All widgets on this page
+            will be removed. This action cannot be undone.
+          </>
+        }
+        confirmLabel="Delete"
+        loadingLabel="Deleting..."
+      />
     </div>
   )
 })

--- a/src/renderer/src/components/dashboard/utils/nextPageName.test.ts
+++ b/src/renderer/src/components/dashboard/utils/nextPageName.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+
+import type { DashboardPage } from '@/renderer/src/components/dashboard/types'
+
+import { newDashboardPageId } from './ids'
+import { nextPageName } from './nextPageName'
+
+/**
+ * Build a widget-free page with a real branded id and the given name. Only the
+ * name participates in collision detection, so widgets stay empty.
+ * @param name - the page's display name
+ * @returns a minimal DashboardPage usable as input to nextPageName
+ * @example makePage('Overview').name // => "Overview"
+ */
+function makePage(name: string): DashboardPage {
+  return {
+    id: newDashboardPageId(),
+    name,
+    widgets: [],
+  }
+}
+
+describe('nextPageName', () => {
+  it('numbers the first overflow page after the four named preset pages', () => {
+    // Arrange: the default preset — four pages, none named "Page N".
+    const pages = [
+      makePage('Overview'),
+      makePage('Discovery'),
+      makePage('Actions'),
+      makePage('Personal'),
+    ]
+
+    // Act
+    const name = nextPageName(pages)
+
+    // Assert: count is 4, so the familiar next number is "Page 5".
+    expect(name).toBe('Page 5')
+  })
+
+  it('skips a still-present "Page N" so a deleted middle page cannot be duplicated', () => {
+    // Arrange: "Page 5" was deleted earlier, leaving "Page 6" behind.
+    const pages = [
+      makePage('Overview'),
+      makePage('Discovery'),
+      makePage('Actions'),
+      makePage('Personal'),
+      makePage('Page 6'),
+    ]
+
+    // Act
+    const name = nextPageName(pages)
+
+    // Assert: count+1 is "Page 6", which is taken, so it bumps to "Page 7".
+    expect(name).toBe('Page 7')
+  })
+
+  it('mints "Page 1" when there are no pages', () => {
+    // Arrange: an empty dashboard (defensive — the UI keeps at least one page).
+    const pages: DashboardPage[] = []
+
+    // Act
+    const name = nextPageName(pages)
+
+    // Assert: count is 0, so the first mintable name is "Page 1".
+    expect(name).toBe('Page 1')
+  })
+
+  it('bumps past several consecutive taken numbers', () => {
+    // Arrange: two pages occupy the slots that count+1 would otherwise land on.
+    const pages = [makePage('Page 2'), makePage('Page 3')]
+
+    // Act
+    const name = nextPageName(pages)
+
+    // Assert: count+1 = 3 ("Page 3" taken) → bumps to the free "Page 4".
+    expect(name).toBe('Page 4')
+  })
+})

--- a/src/renderer/src/components/dashboard/utils/nextPageName.ts
+++ b/src/renderer/src/components/dashboard/utils/nextPageName.ts
@@ -1,0 +1,33 @@
+import type {
+  DashboardPage,
+  DashboardPageName,
+} from '@/renderer/src/components/dashboard/types'
+
+/**
+ * Compute a collision-free default page name of the form `Page N`. Exists
+ * because both `addPage` and `addWidget`'s overflow path mint default names,
+ * and a naive `Page <count+1>` can repeat a name after a middle page is
+ * deleted (ids stay unique, but two tabs would then read identically). Starts
+ * from the historical `Page <count+1>` and bumps the suffix until it is free.
+ *
+ * @param pages - the dashboard's current pages
+ * @returns a `Page N` name guaranteed not to equal any `pages[i].name`
+ * @example
+ * // 4 preset pages (Overview/Discovery/Actions/Personal), none named "Page N"
+ * nextPageName(presetPages) // => "Page 5"
+ * @example
+ * // Overview, Discovery, Actions, Personal, "Page 6"  ("Page 5" was deleted)
+ * nextPageName(pages) // => "Page 7"  (skips the still-present "Page 6")
+ */
+export function nextPageName(
+  pages: readonly DashboardPage[],
+): DashboardPageName {
+  const existingNames = new Set(pages.map((page) => page.name))
+  // Preserve the familiar "next number" starting point, then step past any
+  // suffix that a surviving page already occupies so the result is unique.
+  let suffix = pages.length + 1
+  while (existingNames.has(`Page ${suffix}`)) {
+    suffix += 1
+  }
+  return `Page ${suffix}`
+}

--- a/src/renderer/src/components/dashboard/utils/widgetPresets.ts
+++ b/src/renderer/src/components/dashboard/utils/widgetPresets.ts
@@ -17,8 +17,12 @@ import { newDashboardPageId, newWidgetInstanceId } from './ids'
 // ----------------------------------------------------------------------------
 // Shown on first launch. Four pages mirror the "information architecture" of
 // the app: Overview (at-a-glance state) → Discovery (marketplace) → Actions
-// (things to do) → Personal (your saved work). Each page holds 3–4 widgets,
-// staying under MAX_WIDGETS_PER_PAGE so the user can add one without overflow.
+// (things to do) → Personal (your saved work). Overview ships full — four
+// widgets, equal to MAX_WIDGETS_PER_PAGE (one is the dismissable Welcome card);
+// the other pages hold one or two. Adding a widget to a page that is already
+// full is non-destructive: `addWidget` drops the new widget onto a
+// freshly-created page and navigates there. Once Welcome is dismissed, Overview
+// falls to three widgets and accepts an in-place add.
 // ============================================================================
 
 /** Specification for a page-to-be-built — layout is laid out by hand per preset. */

--- a/src/renderer/src/redux/slices/dashboardSlice.test.ts
+++ b/src/renderer/src/redux/slices/dashboardSlice.test.ts
@@ -378,6 +378,37 @@ describe('dashboardSlice', () => {
       expect(state.currentPageId).toBe(lastPage.id)
     })
 
+    it('does not reuse a page name after a middle auto-named page is deleted', async () => {
+      // Arrange: seed 4 named pages, then auto-add "Page 5" and "Page 6".
+      const { addPage, removePage, seedDefaultsIfEmpty } =
+        await import('./dashboardSlice')
+      const store = await createTestStore()
+      store.dispatch(seedDefaultsIfEmpty())
+      store.dispatch(addPage()) // => "Page 5"
+      store.dispatch(addPage()) // => "Page 6"
+      const pageFive = store
+        .getState()
+        .dashboard.pages.find((page) => page.name === 'Page 5')
+      if (!pageFive) throw new Error('expected an auto-named "Page 5"')
+
+      // Act: delete the middle "Page 5", then auto-add another page.
+      store.dispatch(removePage(pageFive.id))
+      store.dispatch(addPage())
+
+      // Assert: the new page skips the still-present "Page 6" and becomes
+      // "Page 7", so no two tabs ever share a name.
+      const names = store.getState().dashboard.pages.map((page) => page.name)
+      expect(names).toEqual([
+        'Overview',
+        'Discovery',
+        'Actions',
+        'Personal',
+        'Page 6',
+        'Page 7',
+      ])
+      expect(new Set(names).size).toBe(names.length)
+    })
+
     it('renames a page to the new title', async () => {
       // Arrange
       const { renamePage, seedDefaultsIfEmpty } =

--- a/src/renderer/src/redux/slices/dashboardSlice.ts
+++ b/src/renderer/src/redux/slices/dashboardSlice.ts
@@ -18,6 +18,7 @@ import {
   newDashboardPageId,
   newWidgetInstanceId,
 } from '@/renderer/src/components/dashboard/utils/ids'
+import { nextPageName } from '@/renderer/src/components/dashboard/utils/nextPageName'
 import { buildDefaultDashboardPages } from '@/renderer/src/components/dashboard/utils/widgetPresets'
 import { WIDGET_SIZES } from '@/renderer/src/components/dashboard/widgets/sizes'
 import type { RootState } from '@/renderer/src/redux/store'
@@ -173,7 +174,7 @@ const dashboardSlice = createSlice({
       // Overflow: create a new page and drop the widget at the origin.
       const overflowPage: DashboardPage = {
         id: newDashboardPageId(),
-        name: `Page ${state.pages.length + 1}`,
+        name: nextPageName(state.pages),
         widgets: [newWidget],
       }
       state.pages.push(overflowPage)
@@ -215,7 +216,7 @@ const dashboardSlice = createSlice({
     ) => {
       const newPage: DashboardPage = {
         id: newDashboardPageId(),
-        name: action.payload?.name ?? `Page ${state.pages.length + 1}`,
+        name: action.payload?.name ?? nextPageName(state.pages),
         widgets: [],
       }
       state.pages.push(newPage)


### PR DESCRIPTION
## Summary

Three fixes from a focused bug investigation of the **Widget (dashboard) feature** (logic / edge-case / state-management / IPC sweep). No high or medium severity logic bugs were found — the feature is well-built — so this PR lands the two real low-severity issues plus the design-system cleanup that surfaced.

## Changes

1. **`fix`: collision-free dashboard page names** — `addPage` and `addWidget`'s overflow path both minted default names with `Page ${pages.length + 1}`. Deleting a middle auto-named page and then adding another could produce two tabs both reading `Page N` (ids stay unique; the labels collided). New `nextPageName` util starts from the familiar `count + 1` and bumps past any suffix a surviving page still holds.
   - `utils/nextPageName.ts` (+ unit tests), wired into `dashboardSlice` `addWidget` overflow + `addPage`.
2. **`docs`: accurate `widgetPresets` overflow comment** — the comment promised "add one without overflow", but Overview ships at `MAX_WIDGETS_PER_PAGE` (4, incl. the dismissable Welcome card), so a fresh user's first add overflows. Comment now documents the real contract: overflow is **non-destructive** (`addWidget` creates and navigates to a new page), and the in-place add only holds once Welcome is dismissed. No behavior change.
3. **`refactor`: styled `DestructiveConfirmDialog` for page deletion** — page delete used a native `window.confirm`, clashing with the app's design system (every other destructive flow uses `DestructiveConfirmDialog`). Swapped to the shared dialog, driven by local open state.

## Investigated but deliberately NOT changed (not bugs)

- **Preview side-effects** (Trending/What's-New fetch the leaderboard on picker preview): benign — `loadLeaderboard`'s condition gate dedupes in-flight requests and respects a 30-min TTL. Documented tradeoff.
- **Global ⌘E / ⌘1-9 shortcuts**: `DashboardCanvas` is conditionally rendered, so the listener unmounts when you leave the dashboard — no app-wide capture.
- **rename Escape→onBlur**: modern React does not fire `onBlur` on unmount, so Escape cannot commit.

## Test evidence

- `pnpm validate` — **2227 passed** (lint / test / typecheck / fallow dead-code all green)
- `pnpm test:e2e` — **60 passed**
- New tests: `nextPageName.test.ts` (4, all branches incl. empty + multi-bump), `dashboardSlice` no-duplicate regression (1), `DashboardPageTabs` delete-dialog accept + cancel (2).

## Notes

- **No version bump** — `package.json` version is owned exclusively by `/electron-release` per project policy; this PR intentionally does not touch it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ページ削除時の確認ダイアログを改善し、より安全な削除フローを実装
  * ダッシュボードページの自動命名を改善し、ページ削除後の新規作成時に重複を回避

* **Tests**
  * 削除ダイアログの動作検証テストを追加
  * ページ名自動生成ロジックのテストスイートを新規追加
  * ページ管理機能のテストケースを拡充

* **Documentation**
  * ダッシュボードプリセットのコメント説明を更新

<!-- end of auto-generated comment: release notes by coderabbit.ai -->