### PR TITLE
feat: per-skill deletion protection

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -95,6 +95,7 @@ Rules:
 
 - Do not make status colors follow user theme hue.
 - Pair color with text, icon, position, or count; do not rely on color alone.
+- **Amber semantic cap** — amber carries exactly two meanings: broken/inaccessible status (`text-amber-400`) and the bookmark accent (`text-amber-500`). A third semantic (e.g. a lock/protection state) must use a different hue — `text-foreground` is the safe default. Adding a third amber role degrades both existing meanings.
 - Keep backgrounds low-chroma and accents high-chroma.
 - In neutral themes, linked state must never collapse to gray.
 - Avoid single-hue UIs. Theme presets can tint the app, but surfaces should
@@ -443,12 +444,30 @@ Rules:
   gradient borders.
 - Widget headers should stay compact and stable, typically 32-36px.
 
+### Toggleable Protection Controls
+
+Row-level toggleable controls (lock/protection, bookmark) that exist to guard or save state use a three-level opacity progression:
+
+- **Rest (off):** `opacity-40` always-visible — non-destructive value-add actions remain discoverable at rest per the visibility-asymmetry rule. Hover-only discovery is below the quality bar set by top-tier apps.
+- **Hover (off):** `opacity-70` — mid-state gives the interaction hint before commit.
+- **Active (on):** `opacity-100` + semantic color (`text-foreground` for protection, `text-amber-500` for bookmark) — the engaged state must be unambiguous.
+
+Always pair with a tooltip: `"Protected — cannot be deleted"` (on) / `"Click to protect"` (off). Lock semantics are not self-evident in operational UI.
+
 ### Dialogs, Popovers, and Toasts
 
 - Dialogs should be narrow, task-specific, and action-oriented.
 - Popovers should be visually above panels through shadow and border.
 - Toasts should stay compact, readable, and not shift as timers update.
 - Use motion only for entrance/exit and progress continuity.
+
+### Bulk Destructive Dialogs with Skipped Items
+
+When a bulk destructive action will silently skip a subset of selected items (protected, ineligible, stale), surface the skip count as secondary muted copy _before_ the action description:
+
+- Append as a separate sentence in `text-muted-foreground` style: _"N protected skills will be skipped."_ Singular/plural both required.
+- If **all** selected items are skipped (e.g. all locked), disable the primary CTA and replace the description with an inline message: _"All selected skills are protected and cannot be deleted."_ Do not open a confirm dialog when the guaranteed outcome is no-op — that is noise (see Linear pattern: inline state, no modal).
+- Never silently skip without surfacing a count. Silent skips erode user trust in bulk operations.
 
 ### Badges and Status Chips
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -1183,3 +1183,29 @@ Deferred items captured during planning. Pick up when scope and bandwidth allow.
 - Surface a "Sticky filter" preference toggle in Settings
 
 **Why deferred:** Reset behavior was a deliberate UX choice for the original 3-option filter; changing it now needs a usage-based justification rather than speculation.
+
+## Skill deletion protection follow-ups (2026-06-16)
+
+### P2. Skill rename silently drops its lock
+
+**Context:** `addProtection` / `removeProtection` store skill names. If a skill is renamed (source directory renamed on disk), the locked name is orphaned — the renamed skill appears unlocked. This is identical behavior to bookmarks, which have the same limitation.
+
+**Fix direction:** On skill rename, migrate the old name to the new name in `protect.items`. Requires a rename event in the scan result or a diffing pass after each fetch.
+
+**Why deferred:** Skill rename is rare and the failure is silent-unlock (not silent-delete). The user discovers it naturally on their next interaction with the row. Same accepted trade-off as bookmarks.
+
+### P3. isLocal auto-protect
+
+**Context:** Skills with `isLocal: true` (agent-unique, not in the universal `~/.agents/skills/` dir) are at higher risk of accidental deletion. The plan considered auto-protecting them, but user chose manual lock only for this release.
+
+**Fix direction:** After gathering usage data on the manual lock feature, consider showing a "Protect automatically?" nudge for `isLocal` skills on first lock of any skill.
+
+**Why deferred:** User explicitly chose "manual lock only" — deferred until there is evidence of demand.
+
+### P3. Protection state persistence failure in private browsing
+
+**Context:** `redux-persist` writes to `localStorage`. Private/incognito mode and certain browser-based Electron sandboxes can silently cap or reject localStorage writes. Protected skills would be lost on app restart.
+
+**Fix direction:** Detect localStorage write failure in `redux-persist`'s storage adapter and show a one-time warning: "Skill lock list could not be saved — it will be lost when the app closes."
+
+**Why deferred:** Electron with a real user profile almost always has a working localStorage. Private mode is not a primary Electron use case.

--- a/src/renderer/src/components/layout/MainContent.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.browser.test.tsx
@@ -196,6 +196,8 @@ async function createStore() {
     await import('@/renderer/src/redux/slices/marketplaceSlice')
   const { default: settingsReducer } =
     await import('@/renderer/src/redux/slices/settingsSlice')
+  const { default: protectReducer } =
+    await import('@/renderer/src/redux/slices/protectSlice')
   return configureStore({
     reducer: {
       ui: uiReducer,
@@ -204,6 +206,7 @@ async function createStore() {
       bookmarks: bookmarksReducer,
       marketplace: marketplaceReducer,
       settings: settingsReducer,
+      protect: protectReducer,
     },
     preloadedState: {
       settings: { ...DEFAULT_SETTINGS },

--- a/src/renderer/src/components/layout/MainContent.selectionToolbar.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.selectionToolbar.browser.test.tsx
@@ -108,6 +108,7 @@ async function renderMainContentWithToolbar() {
     { default: bookmarksReducer },
     { default: marketplaceReducer },
     { default: settingsReducer },
+    { default: protectReducer },
     { MainContent },
   ] = await Promise.all([
     import('@/renderer/src/redux/slices/uiSlice'),
@@ -116,6 +117,7 @@ async function renderMainContentWithToolbar() {
     import('@/renderer/src/redux/slices/bookmarkSlice'),
     import('@/renderer/src/redux/slices/marketplaceSlice'),
     import('@/renderer/src/redux/slices/settingsSlice'),
+    import('@/renderer/src/redux/slices/protectSlice'),
     import('./MainContent'),
   ])
   const store = configureStore({
@@ -126,6 +128,7 @@ async function renderMainContentWithToolbar() {
       bookmarks: bookmarksReducer,
       marketplace: marketplaceReducer,
       settings: settingsReducer,
+      protect: protectReducer,
     },
     preloadedState: {
       settings: { ...DEFAULT_SETTINGS },

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -78,6 +78,7 @@ import {
 } from '@/renderer/src/redux/selectors'
 import type { SourceFilterRow } from '@/renderer/src/redux/selectors'
 import { setPreviewSkill } from '@/renderer/src/redux/slices/marketplaceSlice'
+import { selectProtectedNamesSet } from '@/renderer/src/redux/slices/protectSlice'
 import {
   clearSelection,
   clearSelectedOrphanSymlinks,
@@ -278,7 +279,22 @@ function getBulkDeleteTargetSummary(
     orphanRecords: bulkConfirm.orphanRecords,
     staleDeleteErrors: bulkConfirm.staleDeleteErrors,
     orphanErrors: bulkConfirm.orphanErrors,
+    protectedErrors: bulkConfirm.protectedErrors,
   }
+}
+
+/**
+ * Extract the protected-skill count from a nullable bulk-delete summary.
+ * Module-scope keeps the `??` branch out of MainContent's complexity budget.
+ * @param summary - Partitioned delete targets, or null when no delete is pending.
+ * @returns Count of protected skills that will be skipped in this batch.
+ * @example
+ * getProtectedSkippedCount(null) // => 0
+ */
+function getProtectedSkippedCount(
+  summary: PartitionedGlobalDeleteTargets | null,
+): number {
+  return summary?.protectedErrors.length ?? 0
 }
 
 /**
@@ -311,6 +327,7 @@ function isBulkDeleteConfirmPrimaryDisabled(
   summary: PartitionedGlobalDeleteTargets | null,
 ): boolean {
   if (bulkConfirm?.kind !== 'delete' || summary === null) return false
+  // Disable when nothing can actually be deleted (all protected, all stale, or empty).
   return (
     summary.deleteTargets.length === 0 && summary.orphanRecords.length === 0
   )
@@ -398,6 +415,7 @@ export const MainContent = React.memo(
     const excludedSkillTypeFilters = useAppSelector(
       selectExcludedSkillTypeFilters,
     )
+    const protectedNamesSet = useAppSelector(selectProtectedNamesSet)
 
     const installedSearchCountText =
       formatInstalledSearchCount(filteredSkillCount)
@@ -701,8 +719,17 @@ export const MainContent = React.memo(
         )
         return
       }
-      const { deleteTargets, orphanRecords, staleDeleteErrors, orphanErrors } =
-        partitionGlobalDeleteTargets(skills, selectedVisibleNames)
+      const {
+        deleteTargets,
+        orphanRecords,
+        staleDeleteErrors,
+        orphanErrors,
+        protectedErrors,
+      } = partitionGlobalDeleteTargets(
+        skills,
+        selectedVisibleNames,
+        protectedNamesSet,
+      )
       dispatch(
         setBulkConfirm({
           kind: 'delete',
@@ -714,10 +741,12 @@ export const MainContent = React.memo(
           orphanRecords,
           staleDeleteErrors,
           orphanErrors,
+          protectedErrors,
         }),
       )
     }, [
       dispatch,
+      protectedNamesSet,
       selectedAgentId,
       selectedAgent?.name,
       selectedVisibleNames,
@@ -867,6 +896,10 @@ export const MainContent = React.memo(
           staleDeleteErrors,
           orphanErrors,
         } = confirm
+        // protectedErrors are intentional skips — exclude from deleteItems so
+        // formatCascadeSummary and reconcileMixedDeleteSelection treat them as
+        // successes, not failures. The confirm dialog already surfaced the skip
+        // count via protectedCount before the user clicked confirm.
         const deleteItems: BulkDeleteItemResult[] = [
           ...staleDeleteErrors,
           ...orphanErrors,
@@ -1412,6 +1445,9 @@ export const MainContent = React.memo(
                         bulkDeleteTargetSummary?.staleDeleteErrors.length ?? 0,
                       orphanRescanCount:
                         bulkDeleteTargetSummary?.orphanErrors.length ?? 0,
+                      protectedCount: getProtectedSkippedCount(
+                        bulkDeleteTargetSummary,
+                      ),
                       sourceSummary: bulkConfirm.sourceSummary,
                     })
                   : `This removes the symlinks in ${bulkConfirm?.agentName ?? 'this agent'}. The underlying skill files stay in your source directory.`}

--- a/src/renderer/src/components/skills/SkillItem.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillItem.browser.test.tsx
@@ -75,12 +75,15 @@ async function createStore() {
     await import('@/renderer/src/redux/slices/agentsSlice')
   const { default: bookmarkReducer } =
     await import('@/renderer/src/redux/slices/bookmarkSlice')
+  const { default: protectReducer } =
+    await import('@/renderer/src/redux/slices/protectSlice')
   return configureStore({
     reducer: {
       ui: uiReducer,
       skills: skillsReducer,
       agents: agentsReducer,
       bookmarks: bookmarkReducer,
+      protect: protectReducer,
     },
   })
 }
@@ -435,6 +438,7 @@ describe('SkillItem delete button', () => {
       orphanRecords: [],
       staleDeleteErrors: [],
       orphanErrors: [],
+      protectedErrors: [],
     })
   })
 
@@ -465,6 +469,7 @@ describe('SkillItem delete button', () => {
       orphanRecords: [],
       staleDeleteErrors: [],
       orphanErrors: [],
+      protectedErrors: [],
     })
   })
 
@@ -1096,5 +1101,77 @@ describe('SkillItem partial-failure flash', () => {
     await expect
       .poll(() => cardRoot?.className.includes('border-l-red-500/70'))
       .toBe(false)
+  })
+})
+
+describe('SkillItem protection', () => {
+  it('shows a "Lock {name}" button when the skill is not protected', async () => {
+    // Arrange — default store has protect.items=[], so the skill is unlocked.
+    const { screen } = await renderSkillItem(
+      makeSkill({ name: 'task' as SkillName }),
+    )
+
+    // Act
+    // (no interaction — assert the lock affordance label matches the unlocked state)
+
+    // Assert — LockOpen icon with "Lock task" label indicates protection is off.
+    await expect
+      .element(screen.getByRole('button', { name: /^Lock task$/i }))
+      .toBeInTheDocument()
+  })
+
+  it('shows an "Unlock {name}" button when the skill is protected', async () => {
+    // Arrange — dispatch addProtection before rendering so ProtectButton
+    // receives isProtected=true and renders the Lock icon.
+    const { screen, store } = await renderSkillItem(
+      makeSkill({ name: 'task' as SkillName }),
+    )
+    const { addProtection } =
+      await import('@/renderer/src/redux/slices/protectSlice')
+
+    // Act
+    store.dispatch(addProtection('task' as SkillName))
+
+    // Assert — Lock icon + "Unlock task" label confirms the protected visual state.
+    await expect
+      .element(screen.getByRole('button', { name: /^Unlock task$/i }))
+      .toBeInTheDocument()
+  })
+
+  it('hides the delete button when the skill is locked', async () => {
+    // Arrange
+    const { screen, store } = await renderSkillItem(
+      makeSkill({ name: 'task' as SkillName }),
+    )
+    const { addProtection } =
+      await import('@/renderer/src/redux/slices/protectSlice')
+
+    // Act — lock the skill; protection gates showDeleteButton to false.
+    store.dispatch(addProtection('task' as SkillName))
+
+    // Assert — delete button must be absent; clicking it with protection on
+    // would mean the fat-finger guard is broken. Use async assertion so React
+    // has time to re-render after the store dispatch.
+    await expect
+      .element(screen.getByRole('button', { name: /^Delete task$/i }))
+      .not.toBeInTheDocument()
+  })
+
+  it('restores the delete button when the skill is unlocked', async () => {
+    // Arrange — start locked, then unlock.
+    const { screen, store } = await renderSkillItem(
+      makeSkill({ name: 'task' as SkillName }),
+    )
+    const { addProtection, removeProtection } =
+      await import('@/renderer/src/redux/slices/protectSlice')
+    store.dispatch(addProtection('task' as SkillName))
+
+    // Act
+    store.dispatch(removeProtection('task' as SkillName))
+
+    // Assert — delete button reappears after unlocking.
+    await expect
+      .element(screen.getByRole('button', { name: /^Delete task$/i }))
+      .toBeInTheDocument()
   })
 })

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -485,7 +485,7 @@ export const SkillItem = React.memo(function SkillItem({
       [skill.name],
       // Pass the real protection state so business logic enforces the guard
       // even if the UI gate (showDeleteButton) is weakened in future refactors.
-      isProtected ? new Set([skill.name as string]) : new Set<string>(),
+      new Set<SkillName>(isProtected ? [skill.name] : []),
     )
     dispatch(
       setBulkConfirm({

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -5,6 +5,8 @@ import {
   ExternalLink,
   FolderDot,
   Link2,
+  Lock,
+  LockOpen,
   Plus,
   X,
 } from 'lucide-react'
@@ -39,6 +41,11 @@ import {
   removeBookmark,
   selectIsBookmarked,
 } from '@/renderer/src/redux/slices/bookmarkSlice'
+import {
+  addProtection,
+  removeProtection,
+  selectIsProtected,
+} from '@/renderer/src/redux/slices/protectSlice'
 import {
   selectRange,
   selectSelectionAnchor,
@@ -79,6 +86,76 @@ declare global {
     'skills:bulkItemFailed': CustomEvent<{ skillName: SkillName }>
   }
 }
+
+interface ProtectButtonProps {
+  skillName: SkillName
+  /** Whether the bookmark button is visible (affects horizontal positioning). */
+  showBookmark: boolean
+  /** Whether an X button (unlink or delete) is visible (affects positioning). */
+  hasXButton: boolean
+}
+
+/**
+ * Lock / unlock toggle shown on every skill row. Manages its own Redux state
+ * so the parent SkillItem only needs `isProtected` for the delete-button gate.
+ * @param props - Skill name, bookmark visibility, and X-button visibility for positioning.
+ * @returns Tooltip-wrapped lock icon button that dispatches protect actions.
+ * @example
+ * <ProtectButton skillName="task" showBookmark={true} hasXButton={false} />
+ */
+const ProtectButton = React.memo(function ProtectButton({
+  skillName,
+  showBookmark,
+  hasXButton,
+}: ProtectButtonProps): React.ReactElement {
+  const dispatch = useAppDispatch()
+  const isProtected = useAppSelector((state) =>
+    selectIsProtected(state, skillName),
+  )
+
+  const handleToggle = (e: React.MouseEvent): void => {
+    e.stopPropagation()
+    dispatch(
+      isProtected ? removeProtection(skillName) : addProtection(skillName),
+    )
+  }
+
+  const rightClass =
+    showBookmark && hasXButton
+      ? 'right-22'
+      : hasXButton || showBookmark
+        ? 'right-11'
+        : 'right-0'
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onClick={handleToggle}
+          aria-label={isProtected ? `Unlock ${skillName}` : `Lock ${skillName}`}
+          data-testid={`skill-protect-${skillName}`}
+          className={cn(
+            'absolute top-1.5 min-h-11 min-w-11 flex items-center justify-center rounded-md z-10 transition-opacity focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+            rightClass,
+            isProtected
+              ? 'text-foreground'
+              : 'text-muted-foreground opacity-40 hover:opacity-70 focus-visible:opacity-100',
+          )}
+        >
+          {isProtected ? (
+            <Lock className="h-3.5 w-3.5" />
+          ) : (
+            <LockOpen className="h-3.5 w-3.5" />
+          )}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="left">
+        {isProtected ? 'Protected — cannot be deleted' : 'Click to protect'}
+      </TooltipContent>
+    </Tooltip>
+  )
+})
 
 interface SkillItemProps {
   skill: Skill
@@ -318,6 +395,9 @@ export const SkillItem = React.memo(function SkillItem({
   const isBookmarked = useAppSelector((state) =>
     selectIsBookmarked(state, skill.name),
   )
+  const isProtected = useAppSelector((state) =>
+    selectIsProtected(state, skill.name),
+  )
   const showBookmark = canBookmarkSkill(skill)
 
   const selectedNamesSet = useAppSelector(selectSelectedSkillNamesSet)
@@ -337,7 +417,7 @@ export const SkillItem = React.memo(function SkillItem({
     showAddButton,
     showUnlinkButton,
     showCopyButton,
-    showDeleteButton,
+    showDeleteButton: showDeleteButtonBase,
     isLinked,
     isLocalSkill,
     isInaccessibleSkill,
@@ -345,6 +425,9 @@ export const SkillItem = React.memo(function SkillItem({
     selectedLocalSkillInfo,
     showGStackBadge,
   } = getSkillItemVisibility(selectedAgentId, skill)
+  // Protected skills hide the delete button. Unlink is intentionally NOT gated —
+  // unlinking from a single agent is reversible and should not require unlocking.
+  const showDeleteButton = showDeleteButtonBase && !isProtected
   const isBulkSelectable = canBulkSelectRenderedSkill(
     selectedAgentId,
     visibleNames,
@@ -391,8 +474,15 @@ export const SkillItem = React.memo(function SkillItem({
    */
   const handleDeleteClick = (e: React.MouseEvent): void => {
     e.stopPropagation()
-    const { deleteTargets, orphanRecords, staleDeleteErrors, orphanErrors } =
-      partitionGlobalDeleteTargets([skill], [skill.name])
+    const {
+      deleteTargets,
+      orphanRecords,
+      staleDeleteErrors,
+      orphanErrors,
+      protectedErrors,
+      // Empty set is intentional — the delete button is hidden for protected skills
+      // (showDeleteButton gates on !isProtected), so this handler never fires for them.
+    } = partitionGlobalDeleteTargets([skill], [skill.name], new Set())
     dispatch(
       setBulkConfirm({
         kind: 'delete',
@@ -405,6 +495,7 @@ export const SkillItem = React.memo(function SkillItem({
         orphanRecords,
         staleDeleteErrors,
         orphanErrors,
+        protectedErrors,
       }),
     )
   }
@@ -603,6 +694,14 @@ export const SkillItem = React.memo(function SkillItem({
             </Tooltip>
           )}
 
+          {/* Lock toggle — always shown (protection is not source-gated).
+              Position adjusts based on which other overlay buttons are present. */}
+          <ProtectButton
+            skillName={skill.name}
+            showBookmark={showBookmark}
+            hasXButton={showUnlinkButton || showDeleteButtonBase}
+          />
+
           {/* Bookmark toggle — only for skills with repo source.
               Positioned to the left of the X button with a 44×44 hit area. */}
           {showBookmark && (
@@ -650,6 +749,7 @@ export const SkillItem = React.memo(function SkillItem({
               // under them on hover. Bookmark + X stack to 88px, so that case
               // needs pr-24 (96px), not the single-button pr-14 (56px).
               getCardContentPaddingClass({
+                showProtect: true,
                 showBookmark,
                 showUnlinkButton,
                 showDeleteButton,

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -480,9 +480,13 @@ export const SkillItem = React.memo(function SkillItem({
       staleDeleteErrors,
       orphanErrors,
       protectedErrors,
-      // Empty set is intentional — the delete button is hidden for protected skills
-      // (showDeleteButton gates on !isProtected), so this handler never fires for them.
-    } = partitionGlobalDeleteTargets([skill], [skill.name], new Set())
+    } = partitionGlobalDeleteTargets(
+      [skill],
+      [skill.name],
+      // Pass the real protection state so business logic enforces the guard
+      // even if the UI gate (showDeleteButton) is weakened in future refactors.
+      isProtected ? new Set([skill.name as string]) : new Set<string>(),
+    )
     dispatch(
       setBulkConfirm({
         kind: 'delete',
@@ -752,7 +756,9 @@ export const SkillItem = React.memo(function SkillItem({
                 showProtect: true,
                 showBookmark,
                 showUnlinkButton,
-                showDeleteButton,
+                // Use the pre-gate value: ProtectButton position is computed from
+                // showDeleteButtonBase, so padding must match that slot count.
+                showDeleteButton: showDeleteButtonBase,
               }),
             )}
           >

--- a/src/renderer/src/components/skills/SkillsList.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillsList.browser.test.tsx
@@ -64,6 +64,8 @@ async function createStore(
     await import('@/renderer/src/redux/slices/agentsSlice')
   const { default: bookmarkReducer } =
     await import('@/renderer/src/redux/slices/bookmarkSlice')
+  const { default: protectReducer } =
+    await import('@/renderer/src/redux/slices/protectSlice')
 
   // Build a complete SkillsState that satisfies the slice's typing while
   // letting tests override only the two fields that matter for the render
@@ -76,6 +78,7 @@ async function createStore(
       skills: skillsReducer,
       agents: agentsReducer,
       bookmarks: bookmarkReducer,
+      protect: protectReducer,
     },
     preloadedState: {
       skills: {

--- a/src/renderer/src/components/skills/bulkDeleteCopy.test.ts
+++ b/src/renderer/src/components/skills/bulkDeleteCopy.test.ts
@@ -260,4 +260,63 @@ describe('renderBulkDeleteDescription', () => {
     // Assert
     expect(description).toBe(BASE_PLURAL)
   })
+
+  it('appends a singular "protected skill will be skipped" sentence when one skill is locked', () => {
+    // Arrange / Act
+    const description = renderBulkDeleteDescription({
+      totalCount: 3,
+      protectedCount: 1,
+      sourceSummary: null,
+    })
+
+    // Assert — "skill" singular, not "skills"
+    expect(description).toBe(
+      `${BASE_PLURAL} 1 protected skill will be skipped.`,
+    )
+  })
+
+  it('appends a plural "protected skills will be skipped" sentence when multiple skills are locked', () => {
+    // Arrange / Act
+    const description = renderBulkDeleteDescription({
+      totalCount: 5,
+      protectedCount: 2,
+      sourceSummary: null,
+    })
+
+    // Assert — "skills" plural
+    expect(description).toBe(
+      `${BASE_PLURAL} 2 protected skills will be skipped.`,
+    )
+  })
+
+  it('omits the protected-skills sentence when protectedCount is zero', () => {
+    // Arrange / Act
+    const description = renderBulkDeleteDescription({
+      totalCount: 3,
+      protectedCount: 0,
+      sourceSummary: null,
+    })
+
+    // Assert — zero protected skills → no extra sentence
+    expect(description).toBe(BASE_PLURAL)
+  })
+
+  it('returns the all-protected message when every selected skill is locked and nothing will be deleted', () => {
+    // Arrange — trashCount=0 and all other counts=0 means the confirm button is
+    // disabled, but the dialog description must still explain why.
+    const description = renderBulkDeleteDescription({
+      totalCount: 2,
+      trashCount: 0,
+      orphanCleanupCount: 0,
+      staleDeleteCount: 0,
+      orphanRescanCount: 0,
+      protectedCount: 2,
+      sourceSummary: null,
+    })
+
+    // Assert — early guard replaces the "moves to trash" copy entirely
+    expect(description).toBe(
+      'All selected skills are protected and cannot be deleted.',
+    )
+  })
 })

--- a/src/renderer/src/components/skills/bulkDeleteCopy.tsx
+++ b/src/renderer/src/components/skills/bulkDeleteCopy.tsx
@@ -49,6 +49,7 @@ export const renderBulkDeleteDescription = ({
   orphanCleanupCount = 0,
   staleDeleteCount = 0,
   orphanRescanCount = 0,
+  protectedCount = 0,
   sourceSummary,
 }: {
   totalCount: number
@@ -56,8 +57,22 @@ export const renderBulkDeleteDescription = ({
   orphanCleanupCount?: number
   staleDeleteCount?: number
   orphanRescanCount?: number
+  /** Skills the user has locked; they will be silently skipped by the delete. */
+  protectedCount?: number
   sourceSummary: SourceFilterSummary | null
 }): React.ReactNode => {
+  // All selected skills are protected and nothing will be moved — the confirm
+  // button is disabled, but the dialog description must still be accurate.
+  if (
+    protectedCount > 0 &&
+    trashCount === 0 &&
+    orphanCleanupCount === 0 &&
+    staleDeleteCount === 0 &&
+    orphanRescanCount === 0
+  ) {
+    return 'All selected skills are protected and cannot be deleted.'
+  }
+
   const hasBaseTrashCopy =
     orphanCleanupCount === 0 &&
     orphanRescanCount === 0 &&
@@ -106,6 +121,11 @@ export const renderBulkDeleteDescription = ({
     .exhaustive()
 
   const scopeSentences: string[] = []
+  if (protectedCount > 0) {
+    scopeSentences.push(
+      `${protectedCount} protected ${pluralize(protectedCount, 'skill')} will be skipped.`,
+    )
+  }
   if (staleDeleteCount > 0) {
     scopeSentences.push(
       `${staleDeleteCount} selected ${pluralize(staleDeleteCount, 'skill')} ${pluralize(staleDeleteCount, 'needs', 'need')} a rescan before delete because the reviewed filesystem identity is missing.`,

--- a/src/renderer/src/components/skills/reviewedDestructiveTargets.test.ts
+++ b/src/renderer/src/components/skills/reviewedDestructiveTargets.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
-import type { AbsolutePath, AgentId, Skill, SymlinkInfo } from '@/shared/types'
+import type {
+  AbsolutePath,
+  AgentId,
+  FilesystemEntryIdentity,
+  Skill,
+  SymlinkInfo,
+} from '@/shared/types'
 
 import {
   buildAgentUnlinkTargets,
@@ -128,6 +134,129 @@ describe('buildAgentUnlinkTargets', () => {
     // Assert
     expect(result.targets).toEqual([])
     expect(result.staleNames).toEqual(['vanished'])
+  })
+})
+
+describe('partitionGlobalDeleteTargets — protected names', () => {
+  it('routes a protected skill to protectedErrors and excludes it from delete targets', () => {
+    // Arrange — a normal source skill selected for deletion, but locked by the user.
+    const sourceSkill: Skill = {
+      name: 'task',
+      description: 'desc',
+      path: '/Users/me/.agents/skills/task' as AbsolutePath,
+      symlinkCount: 0,
+      symlinks: [],
+      isSource: true,
+      isOrphan: false,
+    }
+
+    // Act
+    const result = partitionGlobalDeleteTargets(
+      [sourceSkill],
+      ['task'],
+      new Set(['task']),
+    )
+
+    // Assert — protected skill is in protectedErrors, not deleteTargets
+    expect(result.protectedErrors).toEqual([
+      {
+        skillName: 'task',
+        outcome: 'error',
+        error: {
+          code: 'EPROTECTED',
+          message: 'Skill is protected. Unlock it before deleting.',
+        },
+      },
+    ])
+    expect(result.deleteTargets).toEqual([])
+    expect(result.orphanRecords).toEqual([])
+    expect(result.staleDeleteErrors).toEqual([])
+    expect(result.orphanErrors).toEqual([])
+  })
+
+  it('routes a protected orphan skill to protectedErrors and bypasses the orphan cleanup path', () => {
+    // Arrange — an orphan skill (isOrphan=true) that the user has locked.
+    // The orphan check runs after the protected check, so a locked orphan
+    // must never reach orphan-cleanup records.
+    const orphanSkill: Skill = {
+      name: 'abandoned',
+      description: 'desc',
+      path: '/Users/me/.agents/skills/abandoned' as AbsolutePath,
+      symlinkCount: 0,
+      symlinks: [
+        {
+          agentId: 'codex' as AgentId,
+          agentName: 'Codex',
+          status: 'broken',
+          linkPath: '/Users/me/.codex/skills/abandoned' as AbsolutePath,
+          targetPath: '/Users/me/.agents/skills/abandoned' as AbsolutePath,
+          isLocal: false,
+        },
+      ],
+      isSource: true,
+      isOrphan: true,
+    }
+
+    // Act
+    const result = partitionGlobalDeleteTargets(
+      [orphanSkill],
+      ['abandoned'],
+      new Set(['abandoned']),
+    )
+
+    // Assert — protection intercepts before orphan path
+    expect(result.protectedErrors).toHaveLength(1)
+    expect(result.protectedErrors[0].skillName).toBe('abandoned')
+    expect(result.orphanRecords).toEqual([])
+    expect(result.orphanErrors).toEqual([])
+  })
+
+  it('only routes the locked skill to protectedErrors when deleting a mixed batch', () => {
+    // Arrange — two skills selected; only one is locked. The unlocked skill must
+    // have filesystemIdentity so partitionGlobalDeleteTargets routes it to
+    // deleteTargets rather than staleDeleteErrors.
+    const identity: FilesystemEntryIdentity = {
+      kind: 'directory',
+      dev: 1,
+      ino: 2,
+      size: 96,
+      ctimeMs: 3,
+      mtimeMs: 4,
+    }
+    const skills: Skill[] = [
+      {
+        name: 'locked',
+        description: 'desc',
+        path: '/Users/me/.agents/skills/locked' as AbsolutePath,
+        symlinkCount: 0,
+        symlinks: [],
+        isSource: true,
+        isOrphan: false,
+      },
+      {
+        name: 'unlocked',
+        description: 'desc',
+        path: '/Users/me/.agents/skills/unlocked' as AbsolutePath,
+        filesystemIdentity: identity,
+        symlinkCount: 0,
+        symlinks: [],
+        isSource: true,
+        isOrphan: false,
+      },
+    ]
+
+    // Act
+    const result = partitionGlobalDeleteTargets(
+      skills,
+      ['locked', 'unlocked'],
+      new Set(['locked']),
+    )
+
+    // Assert — only the locked skill is skipped; unlocked proceeds to deleteTargets
+    expect(result.protectedErrors).toHaveLength(1)
+    expect(result.protectedErrors[0].skillName).toBe('locked')
+    expect(result.deleteTargets).toHaveLength(1)
+    expect(result.deleteTargets[0].skillName).toBe('unlocked')
   })
 })
 

--- a/src/renderer/src/components/skills/reviewedDestructiveTargets.ts
+++ b/src/renderer/src/components/skills/reviewedDestructiveTargets.ts
@@ -20,6 +20,8 @@ export interface PartitionedGlobalDeleteTargets {
   orphanRecords: ReviewedOrphanCleanupRecord[]
   staleDeleteErrors: BulkDeleteItemResult[]
   orphanErrors: BulkDeleteItemResult[]
+  /** Skills skipped because the user has locked them — silently excluded from delete/orphan paths. */
+  protectedErrors: BulkDeleteItemResult[]
 }
 
 export interface AgentUnlinkTargets {
@@ -49,22 +51,40 @@ function isReviewedOrphanCleanupSlot(
 
 /**
  * Split reviewed global delete rows into source/local deletes and orphan cleanup.
+ * Protected names (locked by the user) are intercepted first and returned in
+ * `protectedErrors` — they never reach the delete or orphan paths.
  * @param skills - Skill rows exactly visible when the confirmation opened.
  * @param skillNames - Display names selected for deletion.
- * @returns Reviewed targets plus stale/preflight errors.
- * @example partitionGlobalDeleteTargets(skills, ['task'])
+ * @param protectedNames - Skill names the user has locked (from protectSlice).
+ * @returns Reviewed targets plus stale/preflight errors and skipped protected entries.
+ * @example partitionGlobalDeleteTargets(skills, ['task'], new Set(['task']))
  */
 export function partitionGlobalDeleteTargets(
   skills: readonly Skill[],
   skillNames: readonly Skill['name'][],
+  protectedNames: ReadonlySet<Skill['name']> = new Set(),
 ): PartitionedGlobalDeleteTargets {
   const skillsByName = new Map(skills.map((skill) => [skill.name, skill]))
   const deleteTargets: DeleteSelectedSkillTarget[] = []
   const orphanRecords: ReviewedOrphanCleanupRecord[] = []
   const staleDeleteErrors: BulkDeleteItemResult[] = []
   const orphanErrors: BulkDeleteItemResult[] = []
+  const protectedErrors: BulkDeleteItemResult[] = []
 
   for (const skillName of skillNames) {
+    // Protected check runs first — a locked skill is never deleted regardless of orphan status.
+    if (protectedNames.has(skillName)) {
+      protectedErrors.push({
+        skillName,
+        outcome: 'error',
+        error: {
+          message: 'Skill is protected. Unlock it before deleting.',
+          code: 'EPROTECTED',
+        },
+      })
+      continue
+    }
+
     const skill = skillsByName.get(skillName)
     if (!skill?.isOrphan) {
       if (skill?.filesystemIdentity) {
@@ -110,7 +130,13 @@ export function partitionGlobalDeleteTargets(
     })
   }
 
-  return { deleteTargets, orphanRecords, staleDeleteErrors, orphanErrors }
+  return {
+    deleteTargets,
+    orphanRecords,
+    staleDeleteErrors,
+    orphanErrors,
+    protectedErrors,
+  }
 }
 
 /**

--- a/src/renderer/src/components/skills/skillItemHelpers.test.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.test.ts
@@ -700,6 +700,7 @@ describe('getCardContentPaddingClass', () => {
     // exact state from the reported hover bug where "+ Add" slid under the
     // bookmark.
     const flags = {
+      showProtect: false,
       showBookmark: true,
       showUnlinkButton: false,
       showDeleteButton: true,
@@ -715,6 +716,7 @@ describe('getCardContentPaddingClass', () => {
   it('reserves the wide gutter when a bookmark stacks with the unlink button in agent view', () => {
     // Arrange — agent view, valid symlink: bookmark + unlink X also stack to 88px.
     const flags = {
+      showProtect: false,
       showBookmark: true,
       showUnlinkButton: true,
       showDeleteButton: false,
@@ -731,6 +733,7 @@ describe('getCardContentPaddingClass', () => {
     // Arrange — bookmarkable skill whose agent row is broken: no X button, so
     // the bookmark sits alone at right-0 (one 44px overlay).
     const flags = {
+      showProtect: false,
       showBookmark: true,
       showUnlinkButton: false,
       showDeleteButton: false,
@@ -746,6 +749,7 @@ describe('getCardContentPaddingClass', () => {
   it('reserves a single-button gutter when only an X button shows (non-bookmarkable skill)', () => {
     // Arrange — local skill (no repo source → not bookmarkable) with an unlink X.
     const flags = {
+      showProtect: false,
       showBookmark: false,
       showUnlinkButton: true,
       showDeleteButton: false,
@@ -761,6 +765,7 @@ describe('getCardContentPaddingClass', () => {
   it('uses normal padding when no overlay buttons render', () => {
     // Arrange — no bookmark, no X (e.g. orphan row in agent view).
     const flags = {
+      showProtect: false,
       showBookmark: false,
       showUnlinkButton: false,
       showDeleteButton: false,
@@ -771,5 +776,88 @@ describe('getCardContentPaddingClass', () => {
 
     // Assert — falls back to the default p-4 right padding.
     expect(paddingClass).toBe('pr-4')
+  })
+
+  it('reserves the widest gutter when the lock, bookmark, and delete buttons all show (three-button stack)', () => {
+    // Arrange — protected skill with a bookmark and a delete button: the production
+    // case where ProtectButton sits at right-22 and the stack reaches 132px.
+    const flags = {
+      showProtect: true,
+      showBookmark: true,
+      showUnlinkButton: false,
+      showDeleteButton: true,
+    }
+
+    // Act
+    const paddingClass = getCardContentPaddingClass(flags)
+
+    // Assert — pr-36 (144px) clears the full three-button 132px stack.
+    expect(paddingClass).toBe('pr-36')
+  })
+
+  it('reserves the widest gutter when lock, bookmark, and unlink all show', () => {
+    // Arrange — agent-view skill with lock + bookmark + unlink X.
+    const flags = {
+      showProtect: true,
+      showBookmark: true,
+      showUnlinkButton: true,
+      showDeleteButton: false,
+    }
+
+    // Act
+    const paddingClass = getCardContentPaddingClass(flags)
+
+    // Assert
+    expect(paddingClass).toBe('pr-36')
+  })
+
+  it('reserves the two-button gutter when lock and bookmark show without an X', () => {
+    // Arrange — bookmarked source skill that has no X (e.g. broken agent row in
+    // install view but the user has locked it): lock + bookmark = two-button stack.
+    const flags = {
+      showProtect: true,
+      showBookmark: true,
+      showUnlinkButton: false,
+      showDeleteButton: false,
+    }
+
+    // Act
+    const paddingClass = getCardContentPaddingClass(flags)
+
+    // Assert — pr-24 (96px) clears the 88px two-button stack.
+    expect(paddingClass).toBe('pr-24')
+  })
+
+  it('reserves the two-button gutter when lock and an X show without a bookmark', () => {
+    // Arrange — non-bookmarkable skill (no source) with lock + delete X.
+    const flags = {
+      showProtect: true,
+      showBookmark: false,
+      showUnlinkButton: false,
+      showDeleteButton: true,
+    }
+
+    // Act
+    const paddingClass = getCardContentPaddingClass(flags)
+
+    // Assert
+    expect(paddingClass).toBe('pr-24')
+  })
+
+  it('reserves a single-button gutter when only the lock button shows', () => {
+    // Arrange — locked skill whose delete button is hidden (protected) and has
+    // no bookmark: lock sits alone at right-0.
+    const flags = {
+      showProtect: true,
+      showBookmark: false,
+      showUnlinkButton: false,
+      showDeleteButton: false,
+    }
+
+    // Act
+    const paddingClass = getCardContentPaddingClass(flags)
+
+    // Assert — pr-14 (56px) clears a single 44px button.
+    expect(paddingClass).toBe('pr-14')
   })
 })

--- a/src/renderer/src/components/skills/skillItemHelpers.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.ts
@@ -116,6 +116,7 @@ export function getSkillItemVisibility(
   return {
     // Delete is the primary cleanup action for orphans in global view —
     // sweeping the dangling row removes every agent-side symlink at once.
+    // Protected skills hide the delete button entirely; unlock before deleting.
     showDeleteButton: !selectedAgentId,
     // Orphan skills have no live source to symlink _to_, so the Add button
     // (which opens AddSymlinkModal / CopyToAgentsModal) would surface a flow
@@ -151,33 +152,43 @@ export function getSkillItemVisibility(
 /**
  * Tailwind right-padding class for a SkillItem card body.
  *
- * Exists because the action buttons (bookmark + X) are `absolute`-positioned
+ * Exists because the action buttons (lock + bookmark + X) are `absolute`-positioned
  * overlays out of the content flow, so the body needs a manual right gutter to
  * keep its always-visible title-row controls (the "+ Add" button) from sliding
- * under those overlays on hover. The bookmark + X form an 88px stack
- * (bookmark at `right-11` = 44px wide, X at `right-0` = 44px wide), so a single
- * `pr-14` (56px) reserve only clears one button — two need `pr-24` (96px).
+ * under those overlays on hover.
+ *
+ * Button positions (each 44px wide):
+ * - X (delete/unlink): right-0
+ * - bookmark: right-11 when X shows, else right-0
+ * - lock: right-22 when both X and bookmark show, else adjusts left
  *
  * @param flags - Which overlay buttons render (from `getSkillItemVisibility` + `canBookmarkSkill`)
  * @returns
- * - `'pr-24'` (96px): bookmark AND an X button both show → clear the 88px stack
- * - `'pr-14'` (56px): exactly one of bookmark / X shows → clear one 44px button
+ * - `'pr-36'` (144px): lock AND bookmark AND an X button all show → clear the 132px stack
+ * - `'pr-24'` (96px): two of the three overlay slots occupied
+ * - `'pr-14'` (56px): exactly one overlay slot occupied
  * - `'pr-4'` (16px): no overlay buttons → normal card padding
  * @example
- * getCardContentPaddingClass({ showBookmark: true, showUnlinkButton: false, showDeleteButton: true }) // => 'pr-24'
- * getCardContentPaddingClass({ showBookmark: true, showUnlinkButton: false, showDeleteButton: false }) // => 'pr-14'
- * getCardContentPaddingClass({ showBookmark: false, showUnlinkButton: false, showDeleteButton: false }) // => 'pr-4'
+ * getCardContentPaddingClass({ showProtect: true, showBookmark: true, showUnlinkButton: false, showDeleteButton: true }) // => 'pr-36'
+ * getCardContentPaddingClass({ showProtect: false, showBookmark: true, showUnlinkButton: false, showDeleteButton: true }) // => 'pr-24'
+ * getCardContentPaddingClass({ showProtect: false, showBookmark: true, showUnlinkButton: false, showDeleteButton: false }) // => 'pr-14'
+ * getCardContentPaddingClass({ showProtect: false, showBookmark: false, showUnlinkButton: false, showDeleteButton: false }) // => 'pr-4'
  */
 export function getCardContentPaddingClass(flags: {
+  showProtect: boolean
   showBookmark: boolean
   showUnlinkButton: boolean
   showDeleteButton: boolean
-}): 'pr-24' | 'pr-14' | 'pr-4' {
-  const { showBookmark, showUnlinkButton, showDeleteButton } = flags
+}): 'pr-36' | 'pr-24' | 'pr-14' | 'pr-4' {
+  const { showProtect, showBookmark, showUnlinkButton, showDeleteButton } =
+    flags
   const hasXButton = showUnlinkButton || showDeleteButton
-  // Two stacked 44px buttons span 88px; only pr-24 (96px) leaves a gap.
-  if (showBookmark && hasXButton) return 'pr-24'
-  // Either button alone is a single 44px overlay; pr-14 (56px) clears it.
-  if (showBookmark || hasXButton) return 'pr-14'
+  // Count occupied overlay slots to compute the total stack width.
+  const overlayCount = [showProtect, showBookmark, hasXButton].filter(
+    Boolean,
+  ).length
+  if (overlayCount >= 3) return 'pr-36'
+  if (overlayCount === 2) return 'pr-24'
+  if (overlayCount === 1) return 'pr-14'
   return 'pr-4'
 }

--- a/src/renderer/src/redux/migrations.ts
+++ b/src/renderer/src/redux/migrations.ts
@@ -24,6 +24,8 @@ import type { ThemeState } from './slices/themeSlice'
 export interface MigratableState {
   theme?: ThemeState
   dashboard?: unknown
+  /** New in v4+: protect slice starts from initialState on first load, no migration needed. */
+  protect?: unknown
 }
 
 /**

--- a/src/renderer/src/redux/slices/protectSlice.test.ts
+++ b/src/renderer/src/redux/slices/protectSlice.test.ts
@@ -1,0 +1,130 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { describe, expect, it } from 'vitest'
+
+import type { RootState } from '@/renderer/src/redux/store'
+import type { SkillName } from '@/shared/types'
+
+async function createTestStore() {
+  const { default: protectReducer } = await import('./protectSlice')
+  return configureStore({ reducer: { protect: protectReducer } })
+}
+
+describe('protectSlice', () => {
+  it('starts with an empty protected list', async () => {
+    // Arrange
+    const store = await createTestStore()
+
+    // Act
+    const items = store.getState().protect.items
+
+    // Assert
+    expect(items).toEqual([])
+  })
+
+  it('locking a skill adds its name to the protected list', async () => {
+    // Arrange
+    const { addProtection } = await import('./protectSlice')
+    const store = await createTestStore()
+
+    // Act
+    store.dispatch(addProtection('task' as SkillName))
+
+    // Assert
+    expect(store.getState().protect.items).toEqual(['task'])
+  })
+
+  it('locking the same skill twice keeps only one entry', async () => {
+    // Arrange
+    const { addProtection } = await import('./protectSlice')
+    const store = await createTestStore()
+
+    // Act
+    store.dispatch(addProtection('task' as SkillName))
+    store.dispatch(addProtection('task' as SkillName))
+
+    // Assert
+    expect(store.getState().protect.items).toHaveLength(1)
+  })
+
+  it('locks two distinct skills as separate entries', async () => {
+    // Arrange
+    const { addProtection } = await import('./protectSlice')
+    const store = await createTestStore()
+
+    // Act
+    store.dispatch(addProtection('task' as SkillName))
+    store.dispatch(addProtection('browse' as SkillName))
+
+    // Assert
+    expect(store.getState().protect.items).toHaveLength(2)
+  })
+
+  it('unlocking a skill removes only that skill and leaves the rest protected', async () => {
+    // Arrange
+    const { addProtection, removeProtection } = await import('./protectSlice')
+    const store = await createTestStore()
+    store.dispatch(addProtection('task' as SkillName))
+    store.dispatch(addProtection('browse' as SkillName))
+
+    // Act
+    store.dispatch(removeProtection('task' as SkillName))
+
+    // Assert
+    const items = store.getState().protect.items
+    expect(items).toHaveLength(1)
+    expect(items[0]).toBe('browse')
+  })
+
+  it('leaves the list unchanged when unlocking a name that was never locked', async () => {
+    // Arrange
+    const { addProtection, removeProtection } = await import('./protectSlice')
+    const store = await createTestStore()
+    store.dispatch(addProtection('task' as SkillName))
+
+    // Act
+    store.dispatch(removeProtection('nonexistent' as SkillName))
+
+    // Assert
+    expect(store.getState().protect.items).toHaveLength(1)
+  })
+
+  it('reports a skill as protected only when it is in the protected list', async () => {
+    // Arrange
+    const { addProtection, selectIsProtected } = await import('./protectSlice')
+    const store = await createTestStore()
+    store.dispatch(addProtection('task' as SkillName))
+
+    // Act
+    const isTaskProtected = selectIsProtected(
+      store.getState() as unknown as RootState,
+      'task' as SkillName,
+    )
+    const isOtherProtected = selectIsProtected(
+      store.getState() as unknown as RootState,
+      'other' as SkillName,
+    )
+
+    // Assert
+    expect(isTaskProtected).toBe(true)
+    expect(isOtherProtected).toBe(false)
+  })
+
+  it('selectProtectedNamesSet returns a Set containing all locked skill names', async () => {
+    // Arrange
+    const { addProtection, selectProtectedNamesSet } =
+      await import('./protectSlice')
+    const store = await createTestStore()
+    store.dispatch(addProtection('task' as SkillName))
+    store.dispatch(addProtection('browse' as SkillName))
+
+    // Act
+    const set = selectProtectedNamesSet(
+      store.getState() as unknown as RootState,
+    )
+
+    // Assert
+    expect(set.has('task' as SkillName)).toBe(true)
+    expect(set.has('browse' as SkillName)).toBe(true)
+    expect(set.has('other' as SkillName)).toBe(false)
+  })
+})

--- a/src/renderer/src/redux/slices/protectSlice.ts
+++ b/src/renderer/src/redux/slices/protectSlice.ts
@@ -1,0 +1,84 @@
+import type { PayloadAction } from '@reduxjs/toolkit'
+import { createSelector, createSlice } from '@reduxjs/toolkit'
+
+import type { RootState } from '@/renderer/src/redux/store'
+import type { SkillName } from '@/shared/types'
+
+/**
+ * Redux state for the per-skill protection feature.
+ * Persisted to localStorage via redux-persist so locked skills survive app restarts.
+ * Protection is a fat-finger guard only — it lives in the renderer and can be bypassed
+ * by clearing app data. Do not treat it as a security control.
+ */
+interface ProtectState {
+  /** Skill names that the user has locked (insertion order, no duplicates). */
+  items: SkillName[]
+}
+
+const initialState: ProtectState = {
+  items: [],
+}
+
+const protectSlice = createSlice({
+  name: 'protect',
+  initialState,
+  reducers: {
+    /**
+     * Lock a skill by name. Ignores duplicates.
+     * @param action.payload - Skill name to protect
+     * @example
+     * dispatch(addProtection('task'))
+     */
+    addProtection: (state, action: PayloadAction<SkillName>) => {
+      if (!state.items.includes(action.payload)) {
+        state.items.push(action.payload)
+      }
+    },
+    /**
+     * Unlock a skill by name.
+     * @param action.payload - Skill name to unprotect
+     * @example
+     * dispatch(removeProtection('task'))
+     */
+    removeProtection: (state, action: PayloadAction<SkillName>) => {
+      state.items = state.items.filter((name) => name !== action.payload)
+    },
+  },
+})
+
+export const { addProtection, removeProtection } = protectSlice.actions
+
+/** Redux state shape required by protect selectors (slice tests use a minimal store). */
+type ProtectSelectorState = Pick<RootState, 'protect'>
+
+/**
+ * Select all protected skill names (internal — used by createSelector below).
+ * @returns SkillName[]
+ */
+const selectProtectedItems = (state: ProtectSelectorState): SkillName[] =>
+  state.protect.items
+
+/**
+ * Memoized Set of protected skill names. Built once per `items` reference
+ * and shared across all callers — O(items) build cost amortized across the
+ * full list render, not paid per row. Use this in components that need the
+ * whole set (e.g. MainContent bulk-delete partition) to avoid a useMemo.
+ */
+export const selectProtectedNamesSet = createSelector(
+  [selectProtectedItems],
+  (items) => new Set(items) as ReadonlySet<SkillName>,
+)
+
+/**
+ * Check if a skill is protected by name.
+ * @param name - Skill name to check
+ * @returns boolean
+ * @example
+ * const isProtected = useAppSelector((state) => selectIsProtected(state, 'task'))
+ */
+export const selectIsProtected = (
+  state: ProtectSelectorState,
+  name: SkillName,
+): boolean => selectProtectedNamesSet(state).has(name)
+
+export default protectSlice.reducer

--- a/src/renderer/src/redux/slices/uiSlice.test.ts
+++ b/src/renderer/src/redux/slices/uiSlice.test.ts
@@ -1070,6 +1070,7 @@ describe('uiSlice atomic-clear contract on context switch', () => {
         orphanRecords: [],
         staleDeleteErrors: [],
         orphanErrors: [],
+        protectedErrors: [],
       }),
     )
   }
@@ -1587,6 +1588,7 @@ describe('uiSlice bulk confirm dialog', () => {
         orphanRecords: [],
         staleDeleteErrors: [],
         orphanErrors: [],
+        protectedErrors: [],
       }),
     )
     expect(store.getState().ui.bulkConfirm).not.toBeNull()
@@ -1820,6 +1822,7 @@ describe('uiSlice selectors read the live ui state', () => {
         orphanRecords: [],
         staleDeleteErrors: [],
         orphanErrors: [],
+        protectedErrors: [],
       }),
     )
     store.dispatch(enterBulkSelectMode())

--- a/src/renderer/src/redux/slices/uiSlice.ts
+++ b/src/renderer/src/redux/slices/uiSlice.ts
@@ -132,6 +132,8 @@ export type BulkConfirmState =
       staleDeleteErrors: BulkDeleteItemResult[]
       /** Stale orphan preflight errors captured when the dialog opened. */
       orphanErrors: BulkDeleteItemResult[]
+      /** Protected skills skipped by the user's lock — will not be deleted. */
+      protectedErrors: BulkDeleteItemResult[]
     })
   | (BulkConfirmBase & {
       kind: 'unlink'

--- a/src/renderer/src/redux/store.test.ts
+++ b/src/renderer/src/redux/store.test.ts
@@ -270,6 +270,7 @@ describe('store wiring (singleton assembly)', () => {
       'bookmarks',
       'dashboard',
       'marketplace',
+      'protect',
       'settings',
       'skills',
       'theme',

--- a/src/renderer/src/redux/store.ts
+++ b/src/renderer/src/redux/store.ts
@@ -10,6 +10,7 @@ import agentsReducer from './slices/agentsSlice'
 import bookmarkReducer from './slices/bookmarkSlice'
 import dashboardReducer from './slices/dashboardSlice'
 import marketplaceReducer from './slices/marketplaceSlice'
+import protectReducer from './slices/protectSlice'
 import settingsReducer from './slices/settingsSlice'
 import skillsReducer from './slices/skillsSlice'
 import themeReducer from './slices/themeSlice'
@@ -22,6 +23,7 @@ const rootReducer = combineReducers({
   skills: skillsReducer,
   agents: agentsReducer,
   bookmarks: bookmarkReducer,
+  protect: protectReducer,
   ui: uiReducer,
   update: updateReducer,
   marketplace: marketplaceReducer,
@@ -43,7 +45,7 @@ const { middleware: storageMiddleware, reducer } =
   createStorageMiddleware<RootReducerState>({
     rootReducer,
     key: PERSIST_STORAGE_KEY,
-    slices: ['theme', 'bookmarks', 'dashboard'],
+    slices: ['theme', 'bookmarks', 'protect', 'dashboard'],
     version: PERSIST_STATE_VERSION,
     migrate: migrateState,
   })


### PR DESCRIPTION
## Summary

Adds per-skill deletion protection so users can lock individual skills against accidental deletion. Protected skills are excluded from both single-item and bulk delete flows at every layer — Redux state, business logic, and UI.

## Changes

**State (`protectSlice`)**
- New Redux slice with `SkillName[]` state persisted via `redux-persist`
- Selectors: `selectProtectedNamesSet` (memoized `ReadonlySet`), `selectIsProtected`
- Redux migration initializes `protect: []` for existing persisted states

**Business logic (`partitionGlobalDeleteTargets`)**
- New optional `protectedNames` param (defaults to empty set)
- Protected skills short-circuit before orphan/stale path resolution into a `protectedErrors` bucket with `code: 'EPROTECTED'`

**UI**
- `ProtectButton` extracted from `SkillItem`: Lock/LockOpen icons with `aria-label="Lock {name}"` / `"Unlock {name}"` and tooltip
- Delete button suppressed for locked skills; layout position keyed on `showDeleteButtonBase` so locking never shifts adjacent controls
- `getCardContentPaddingClass` updated to `pr-36` for 3-overlay rows (lock + bookmark + X)
- Bulk delete dialog: early exit with dedicated copy when all selected are protected; otherwise appends "N protected skills will be skipped."
- `MainContent.tsx` excludes `protectedErrors` from `deleteItems` so protected rows never flash red or enter retry selection

**Docs**
- `DESIGN.md`: amber semantic cap rule, toggleable protection control states (opacity-40/70/100), tooltip requirement for toggleable controls
- `TODOS.md`: P2/P3 follow-up items

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 新機能
* スキルの保護機能を追加：各スキル行に Lock/Unlock ボタンを表示し、保護中は削除をできないようにしました  
* 一括削除では、保護されたスキルは自動的にスキップされます  
* ロック状態は再起動後も保持されます  

## 変更・改善
* 一括削除の説明文に「保護スキップ件数」を反映し、全件保護時は CTA を無効化して理由を表示します  
* 保護状態のツールチップ文言と状態遷移表示（Rest/Hover/Active）を調整しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->