### PR TITLE
Fix protected skill removal in agent view

### DIFF
--- a/src/renderer/src/components/layout/MainContent.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.browser.test.tsx
@@ -2554,6 +2554,67 @@ describe('MainContent toolbar primary action guards', () => {
     expect(store.getState().ui.bulkConfirm).toBeNull()
   })
 
+  it('does nothing when only protected rows are selected in agent view', async () => {
+    // Arrange — the row is visible and selected, but protection excludes it from
+    // agent-view bulk unlink candidates before the confirm dialog can open.
+    mockSelectionToolbarState.enabled = true
+    const { screen, store } = await renderMainContent()
+    const { fetchAgents } =
+      await import('@/renderer/src/redux/slices/agentsSlice')
+    const { enterBulkSelectMode, selectAgent } =
+      await import('@/renderer/src/redux/slices/uiSlice')
+    const { fetchSkills, toggleSelection } =
+      await import('@/renderer/src/redux/slices/skillsSlice')
+    const { addProtection } =
+      await import('@/renderer/src/redux/slices/protectSlice')
+    const skillName = 'protected-link' as SkillName
+    const protectedSkill: Skill = {
+      name: skillName,
+      description: '',
+      path: '/home/user/.agents/skills/protected-link' as never,
+      filesystemIdentity: directoryIdentity,
+      symlinkCount: 1,
+      symlinks: [
+        {
+          agentId: 'cursor' as AgentId,
+          agentName: 'Cursor' as never,
+          linkPath: '/home/user/.cursor/skills/protected-link' as never,
+          targetPath: '/home/user/.agents/skills/protected-link' as never,
+          status: 'valid',
+          isLocal: false,
+        },
+      ],
+      isSource: true,
+      isOrphan: false,
+    }
+    store.dispatch(
+      fetchAgents.fulfilled(
+        [
+          {
+            id: 'cursor' as AgentId,
+            name: 'Cursor' as never,
+            path: '/home/user/.cursor/skills' as never,
+            exists: true,
+            skillCount: 1,
+            localSkillCount: 0,
+          },
+        ],
+        'req-agent',
+      ),
+    )
+    store.dispatch(selectAgent('cursor' as AgentId))
+    store.dispatch(fetchSkills.fulfilled([protectedSkill], 'req-protected'))
+    store.dispatch(enterBulkSelectMode())
+    store.dispatch(toggleSelection(skillName))
+    store.dispatch(addProtection(skillName))
+
+    // Act
+    await screen.getByRole('button', { name: 'Open bulk confirm' }).click()
+
+    // Assert
+    expect(store.getState().ui.bulkConfirm).toBeNull()
+  })
+
   it('blocks unlink and prompts a rescan when the selected agent slot went stale', async () => {
     // Arrange — a cursor row is selectable (status valid) yet its slot lost the
     // reviewed targetPath, so buildAgentUnlinkTargets reports it stale.

--- a/src/renderer/src/components/skills/BulkCopyToAgentsModal.browser.test.tsx
+++ b/src/renderer/src/components/skills/BulkCopyToAgentsModal.browser.test.tsx
@@ -143,6 +143,8 @@ async function renderModal(options: {
     await import('@/renderer/src/redux/slices/agentsSlice')
   const { default: uiReducer } =
     await import('@/renderer/src/redux/slices/uiSlice')
+  const { default: protectReducer } =
+    await import('@/renderer/src/redux/slices/protectSlice')
   const { BulkCopyToAgentsModal } = await import('./BulkCopyToAgentsModal')
 
   const store = configureStore({
@@ -150,6 +152,7 @@ async function renderModal(options: {
       skills: skillsReducer,
       agents: agentsReducer,
       ui: uiReducer,
+      protect: protectReducer,
     },
   })
 

--- a/src/renderer/src/components/skills/SelectionToolbar.browser.test.tsx
+++ b/src/renderer/src/components/skills/SelectionToolbar.browser.test.tsx
@@ -66,12 +66,15 @@ async function renderToolbar(options: {
     selectAgent,
     setSearchQuery,
   } = await import('@/renderer/src/redux/slices/uiSlice')
+  const { default: protectReducer } =
+    await import('@/renderer/src/redux/slices/protectSlice')
   const { SelectionToolbar } = await import('./SelectionToolbar')
 
   const store = configureStore({
     reducer: {
       skills: skillsReducer,
       ui: uiReducer,
+      protect: protectReducer,
     },
   })
 

--- a/src/renderer/src/components/skills/SkillItem.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillItem.browser.test.tsx
@@ -1174,4 +1174,112 @@ describe('SkillItem protection', () => {
       .element(screen.getByRole('button', { name: /^Delete task$/i }))
       .toBeInTheDocument()
   })
+
+  it('hides the agent-view unlink button when the skill is locked', async () => {
+    // Arrange
+    const linkedSkill = makeSkill({
+      name: 'task' as SkillName,
+      symlinks: [
+        {
+          agentId: 'cursor',
+          agentName: 'Cursor',
+          status: 'valid',
+          linkPath: '/home/user/.cursor/skills/task' as SymlinkInfo['linkPath'],
+          targetPath:
+            '/home/user/.agents/skills/task' as SymlinkInfo['targetPath'],
+          isLocal: false,
+        },
+      ],
+    })
+    const { screen, store } = await renderSkillItem(linkedSkill)
+    const { selectAgent } = await import('@/renderer/src/redux/slices/uiSlice')
+    const { addProtection } =
+      await import('@/renderer/src/redux/slices/protectSlice')
+
+    // Act
+    store.dispatch(selectAgent('cursor'))
+    store.dispatch(addProtection('task' as SkillName))
+
+    // Assert
+    await expect
+      .element(screen.getByRole('button', { name: /^Unlock task$/i }))
+      .toBeInTheDocument()
+    await expect
+      .poll(() =>
+        screen
+          .getByRole('button', { name: /^Unlink task from agent$/i })
+          .query(),
+      )
+      .toBeNull()
+  })
+
+  it('hides the agent-view local delete button when the skill is locked', async () => {
+    // Arrange
+    const localSkill = makeSkill({
+      name: 'task' as SkillName,
+      symlinks: [
+        {
+          agentId: 'cursor',
+          agentName: 'Cursor',
+          status: 'valid',
+          linkPath: '/home/user/.cursor/skills/task' as SymlinkInfo['linkPath'],
+          isLocal: true,
+        },
+      ],
+    })
+    const { screen, store } = await renderSkillItem(localSkill)
+    const { selectAgent } = await import('@/renderer/src/redux/slices/uiSlice')
+    const { addProtection } =
+      await import('@/renderer/src/redux/slices/protectSlice')
+
+    // Act
+    store.dispatch(selectAgent('cursor'))
+    store.dispatch(addProtection('task' as SkillName))
+
+    // Assert
+    await expect
+      .element(screen.getByRole('button', { name: /^Unlock task$/i }))
+      .toBeInTheDocument()
+    await expect
+      .poll(() =>
+        screen
+          .getByRole('button', { name: /^Delete task from agent$/i })
+          .query(),
+      )
+      .toBeNull()
+  })
+
+  it('restores the agent-view unlink button when the skill is unlocked', async () => {
+    // Arrange
+    const linkedSkill = makeSkill({
+      name: 'task' as SkillName,
+      symlinks: [
+        {
+          agentId: 'cursor',
+          agentName: 'Cursor',
+          status: 'valid',
+          linkPath: '/home/user/.cursor/skills/task' as SymlinkInfo['linkPath'],
+          targetPath:
+            '/home/user/.agents/skills/task' as SymlinkInfo['targetPath'],
+          isLocal: false,
+        },
+      ],
+    })
+    const { screen, store } = await renderSkillItem(linkedSkill)
+    const { selectAgent } = await import('@/renderer/src/redux/slices/uiSlice')
+    const { addProtection, removeProtection } =
+      await import('@/renderer/src/redux/slices/protectSlice')
+    store.dispatch(selectAgent('cursor'))
+    store.dispatch(addProtection('task' as SkillName))
+
+    // Act
+    store.dispatch(removeProtection('task' as SkillName))
+
+    // Assert
+    await expect
+      .element(
+        screen.getByRole('button', { name: /^Unlink task from agent$/i }),
+      )
+      .toBeInTheDocument()
+  })
 })

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -151,7 +151,9 @@ const ProtectButton = React.memo(function ProtectButton({
         </button>
       </TooltipTrigger>
       <TooltipContent side="left">
-        {isProtected ? 'Protected — cannot be deleted' : 'Click to protect'}
+        {isProtected
+          ? 'Protected — cannot be deleted or removed'
+          : 'Click to protect'}
       </TooltipContent>
     </Tooltip>
   )
@@ -415,7 +417,7 @@ export const SkillItem = React.memo(function SkillItem({
 
   const {
     showAddButton,
-    showUnlinkButton,
+    showUnlinkButton: showUnlinkButtonBase,
     showCopyButton,
     showDeleteButton: showDeleteButtonBase,
     isLinked,
@@ -425,9 +427,10 @@ export const SkillItem = React.memo(function SkillItem({
     selectedLocalSkillInfo,
     showGStackBadge,
   } = getSkillItemVisibility(selectedAgentId, skill)
-  // Protected skills hide the delete button. Unlink is intentionally NOT gated —
-  // unlinking from a single agent is reversible and should not require unlocking.
+  // Protected skills hide every destructive X action, including agent-view
+  // unlink/delete, so the lock copy matches the actual behavior.
   const showDeleteButton = showDeleteButtonBase && !isProtected
+  const showUnlinkButton = showUnlinkButtonBase && !isProtected
   const isBulkSelectable = canBulkSelectRenderedSkill(
     selectedAgentId,
     visibleNames,
@@ -447,6 +450,9 @@ export const SkillItem = React.memo(function SkillItem({
   // threshold is floored just below 100 rather than chased. See vitest.config.ts.
   const handleUnlinkClick = (e: React.MouseEvent): void => {
     e.stopPropagation()
+    // Protection is enforced here too so future UI refactors cannot stage a
+    // locked skill for removal by accidentally showing the button.
+    if (isProtected) return
     const targetSymlink = selectedAgentSymlink ?? selectedLocalSkillInfo
     if (targetSymlink) {
       dispatch(setSkillToUnlink({ skill, symlink: targetSymlink }))
@@ -703,7 +709,7 @@ export const SkillItem = React.memo(function SkillItem({
           <ProtectButton
             skillName={skill.name}
             showBookmark={showBookmark}
-            hasXButton={showUnlinkButton || showDeleteButtonBase}
+            hasXButton={showUnlinkButtonBase || showDeleteButtonBase}
           />
 
           {/* Bookmark toggle — only for skills with repo source.
@@ -755,7 +761,7 @@ export const SkillItem = React.memo(function SkillItem({
               getCardContentPaddingClass({
                 showProtect: true,
                 showBookmark,
-                showUnlinkButton,
+                showUnlinkButton: showUnlinkButtonBase,
                 // Use the pre-gate value: ProtectButton position is computed from
                 // showDeleteButtonBase, so padding must match that slot count.
                 showDeleteButton: showDeleteButtonBase,

--- a/src/renderer/src/redux/selectors.test.ts
+++ b/src/renderer/src/redux/selectors.test.ts
@@ -47,6 +47,7 @@ function buildState(overrides: {
   selectedSkillNames?: SkillName[]
   inFlightDeleteNames?: SkillName[]
   inFlightUnlinkNames?: SkillName[]
+  protectedSkillNames?: SkillName[]
 }) {
   return {
     skills: {
@@ -123,6 +124,9 @@ function buildState(overrides: {
     },
     bookmarks: {
       items: overrides.bookmarks ?? [],
+    },
+    protect: {
+      items: overrides.protectedSkillNames ?? [],
     },
   }
 }
@@ -1138,6 +1142,45 @@ describe('selectBulkSelectableVisibleSkillNames', () => {
     expect(selectBulkSelectableVisibleSkillNames(state as never)).toEqual([
       'valid-symlink',
     ])
+  })
+
+  it('excludes protected valid agent rows from bulk unlink names', () => {
+    // Arrange
+    const protectedSkill = makeSkill('protected-skill', 'cursor')
+    const availableSkill = makeSkill('available-skill', 'cursor')
+    const state = buildState({
+      skills: [protectedSkill, availableSkill],
+      selectedAgentId: 'cursor',
+      protectedSkillNames: ['protected-skill' as SkillName],
+    })
+
+    // Act
+    const visibleNames = selectVisibleSkillNames(state as never)
+    const bulkSelectableNames = selectBulkSelectableVisibleSkillNames(
+      state as never,
+    )
+
+    // Assert
+    expect(visibleNames).toEqual(['available-skill', 'protected-skill'])
+    expect(bulkSelectableNames).toEqual(['available-skill'])
+  })
+
+  it('keeps protected rows selectable in global delete view so the confirm dialog can report the skip', () => {
+    // Arrange
+    const protectedSkill = makeSkill('protected-skill', 'cursor')
+    const state = buildState({
+      skills: [protectedSkill],
+      selectedAgentId: null,
+      protectedSkillNames: ['protected-skill' as SkillName],
+    })
+
+    // Act
+    const bulkSelectableNames = selectBulkSelectableVisibleSkillNames(
+      state as never,
+    )
+
+    // Assert
+    expect(bulkSelectableNames).toEqual(['protected-skill'])
   })
 })
 

--- a/src/renderer/src/redux/selectors.ts
+++ b/src/renderer/src/redux/selectors.ts
@@ -14,6 +14,7 @@ import type {
 } from '@/shared/types'
 
 import { selectBookmarkItems } from './slices/bookmarkSlice'
+import { selectProtectedNamesSet } from './slices/protectSlice'
 import {
   selectInFlightDeleteNames,
   selectSelectedSkillNames,
@@ -481,15 +482,18 @@ export const selectVisibleSkillNames = createSelector(
  * Detect whether a visible agent-view row can use the reviewed bulk Unlink path.
  * @param skill - Visible skill row.
  * @param selectedAgentId - Active agent filter; null means global delete flow.
+ * @param protectedNames - Skill names locked by the user.
  * @returns True when bulk action can safely include this row.
  * @example
- * isBulkSelectableSkill(validSkill, 'cursor') // => true
+ * isBulkSelectableSkill(validSkill, 'cursor', new Set()) // => true
  */
 function isBulkSelectableSkill(
   skill: Skill,
   selectedAgentId: AgentId | null,
+  protectedNames: ReadonlySet<SkillName>,
 ): boolean {
   if (selectedAgentId === null) return true
+  if (protectedNames.has(skill.name)) return false
 
   return skill.symlinks.some(
     (symlink) =>
@@ -508,10 +512,12 @@ function isBulkSelectableSkill(
  * const names = useAppSelector(selectBulkSelectableVisibleSkillNames)
  */
 export const selectBulkSelectableVisibleSkillNames = createSelector(
-  [selectFilteredSkills, selectSelectedAgentId],
-  (filteredSkills, selectedAgentId): SkillName[] =>
+  [selectFilteredSkills, selectSelectedAgentId, selectProtectedNamesSet],
+  (filteredSkills, selectedAgentId, protectedNames): SkillName[] =>
     filteredSkills
-      .filter((skill) => isBulkSelectableSkill(skill, selectedAgentId))
+      .filter((skill) =>
+        isBulkSelectableSkill(skill, selectedAgentId, protectedNames),
+      )
       .map((skill) => skill.name),
 )
 


### PR DESCRIPTION
## Summary
- Gate agent-view unlink/delete X actions for protected skills and update the lock tooltip copy.
- Exclude protected skills from agent-view bulk unlink candidates while preserving global-view bulk delete selection.
- Add browser/unit coverage for protected row actions, selector eligibility, and protected-only bulk selection.

## Verification
- pnpm exec vitest run src/renderer/src/redux/selectors.test.ts src/renderer/src/components/skills/SkillItem.browser.test.tsx src/renderer/src/components/layout/MainContent.browser.test.tsx src/renderer/src/components/skills/SelectionToolbar.browser.test.tsx src/renderer/src/components/skills/BulkCopyToAgentsModal.browser.test.tsx
- pnpm exec eslint src/renderer/src/components/skills/SkillItem.tsx src/renderer/src/redux/selectors.ts src/renderer/src/components/skills/SkillItem.browser.test.tsx src/renderer/src/redux/selectors.test.ts src/renderer/src/components/layout/MainContent.browser.test.tsx src/renderer/src/components/skills/SelectionToolbar.browser.test.tsx src/renderer/src/components/skills/BulkCopyToAgentsModal.browser.test.tsx
- pnpm exec tsc --noEmit --pretty false
- pnpm validate (Vitest 175 files / 2260 tests and Storybook passed; blocked by unrelated existing fallow duplicate in Appearance.tsx/CodePreview.tsx and ignored .agents lint parse error)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 保護されたスキルに対する削除・アンリンク操作の制限が実装されました。

* **バグ修正**
  * エージェントビュー選択時に保護されたスキルの削除・アンリンク操作が無効になるように動作を改善しました。

* **テスト**
  * スキル保護機能に関する包括的なテストケースを追加し、テストカバレッジを拡充しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->