### PR TITLE
Preserve protected skills during agent folder delete

### DIFF
--- a/src/main/ipc/ipc-schemas.test.ts
+++ b/src/main/ipc/ipc-schemas.test.ts
@@ -453,9 +453,21 @@ describe('destructive reviewed-path IPC schemas', () => {
           agentId: 'cursor',
           agentPath: '/tmp/.cursor/skills',
           filesystemIdentity: directoryIdentity,
+          protectedSkillPaths: ['/tmp/.cursor/skills/locked'],
         },
       ]).success,
     ).toBe(true)
+    // Act / Assert — protected paths still must be absolute.
+    expect(
+      removeAllSchema.safeParse([
+        {
+          agentId: 'cursor',
+          agentPath: '/tmp/.cursor/skills',
+          filesystemIdentity: directoryIdentity,
+          protectedSkillPaths: ['relative/locked'],
+        },
+      ]).success,
+    ).toBe(false)
   })
 })
 

--- a/src/main/ipc/ipc-schemas.ts
+++ b/src/main/ipc/ipc-schemas.ts
@@ -216,6 +216,7 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
       agentId: nonEmptyString,
       agentPath: absolutePathArg,
       filesystemIdentity: filesystemEntryIdentitySchema,
+      protectedSkillPaths: z.array(absolutePathArg).optional(),
     }),
   ]),
   'skills:deleteSkill': z.tuple([

--- a/src/main/ipc/skills.removeAllFromAgent.integration.test.ts
+++ b/src/main/ipc/skills.removeAllFromAgent.integration.test.ts
@@ -310,6 +310,46 @@ describe('skills:removeAllFromAgent handler', () => {
     expect(trashItemMock).toHaveBeenCalledTimes(2)
   })
 
+  it('stops protected-folder deletion before a swapped parent symlink can redirect the next child delete', async () => {
+    // Arrange
+    const cursorDir = join(tempHome, '.cursor', 'skills')
+    const evilDir = join(tempHome, 'evil-target')
+    const protectedLocal = join(cursorDir, 'z-protected-local')
+    trashItemMock.mockImplementationOnce(async (path: string) => {
+      await rm(path, { recursive: true, force: true })
+      await rm(cursorDir, { recursive: true, force: true })
+      await symlink(evilDir, cursorDir, 'dir')
+    })
+    await mkdir(join(cursorDir, 'a-unprotected-local'), { recursive: true })
+    await mkdir(join(cursorDir, 'b-unprotected-local'), { recursive: true })
+    await mkdir(protectedLocal, { recursive: true })
+    await mkdir(join(evilDir, 'b-unprotected-local'), { recursive: true })
+    const cursorIdentity = await reviewedIdentity(cursorDir)
+
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+
+    // Act
+    const handler = getRegisteredHandler('skills:removeAllFromAgent')
+    const result = await handler(
+      {},
+      {
+        agentId: 'cursor',
+        agentPath: cursorDir,
+        filesystemIdentity: cursorIdentity,
+        protectedSkillPaths: [protectedLocal],
+      },
+    )
+
+    // Assert
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/changed since review/i)
+    await expect(
+      lstat(join(evilDir, 'b-unprotected-local')),
+    ).resolves.toBeDefined()
+    expect(trashItemMock).toHaveBeenCalledTimes(1)
+  })
+
   it('rejects a same-path replacement before moving the agent dir to OS Trash', async () => {
     // Arrange
     const cursorDir = join(tempHome, '.cursor', 'skills')

--- a/src/main/ipc/skills.removeAllFromAgent.integration.test.ts
+++ b/src/main/ipc/skills.removeAllFromAgent.integration.test.ts
@@ -1,4 +1,4 @@
-import { lstat, mkdir, mkdtemp, rm, symlink } from 'node:fs/promises'
+import { lstat, mkdir, mkdtemp, readdir, rm, symlink } from 'node:fs/promises'
 import type * as NodeOs from 'node:os'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -33,10 +33,12 @@ function getRegisteredHandler(channel: string): (
     agentId: string
     agentPath: string
     filesystemIdentity?: FilesystemEntryIdentity
+    protectedSkillPaths?: string[]
   },
 ) => Promise<{
   success: boolean
   removedCount: number
+  preservedCount?: number
   error?: string
 }> {
   const registration = handleMock.mock.calls.find(([name]) => name === channel)
@@ -49,10 +51,12 @@ function getRegisteredHandler(channel: string): (
       agentId: string
       agentPath: string
       filesystemIdentity?: FilesystemEntryIdentity
+      protectedSkillPaths?: string[]
     },
   ) => Promise<{
     success: boolean
     removedCount: number
+    preservedCount?: number
     error?: string
   }>
 }
@@ -251,6 +255,59 @@ describe('skills:removeAllFromAgent handler', () => {
     expect(String(trashItemMock.mock.calls[0][0])).toContain(
       join(tempHome, '.cursor', 'skills.trash-'),
     )
+  })
+
+  it('keeps only protected skill entries when deleting an agent folder with protected skills', async () => {
+    // Arrange
+    trashItemMock.mockImplementation(async (path: string) => {
+      await rm(path, { recursive: true, force: true })
+    })
+    const cursorDir = join(tempHome, '.cursor', 'skills')
+    const sourceDir = join(tempHome, '.agents', 'skills')
+    const protectedSource = join(sourceDir, 'protected-source')
+    const unprotectedSource = join(sourceDir, 'unprotected-source')
+    const protectedLink = join(cursorDir, 'protected-link')
+    const protectedLocal = join(cursorDir, 'protected-local')
+    await mkdir(protectedSource, { recursive: true })
+    await mkdir(unprotectedSource, { recursive: true })
+    await mkdir(protectedLocal, { recursive: true })
+    await mkdir(join(cursorDir, 'unprotected-local'), { recursive: true })
+    await symlink(protectedSource, protectedLink)
+    await symlink(unprotectedSource, join(cursorDir, 'unprotected-link'))
+
+    const { registerSkillsHandlers } = await import('./skills')
+    registerSkillsHandlers()
+
+    // Act
+    const handler = getRegisteredHandler('skills:removeAllFromAgent')
+    const result = await handler(
+      {},
+      {
+        agentId: 'cursor',
+        agentPath: cursorDir,
+        filesystemIdentity: await reviewedIdentity(cursorDir),
+        protectedSkillPaths: [protectedLink, protectedLocal],
+      },
+    )
+
+    // Assert
+    expect(result).toEqual({
+      success: true,
+      removedCount: 2,
+      preservedCount: 2,
+    })
+    await expect(
+      readdir(cursorDir).then((entries) => entries.sort()),
+    ).resolves.toEqual(['protected-link', 'protected-local'])
+    await expect(lstat(protectedLink)).resolves.toBeDefined()
+    await expect(lstat(protectedLocal)).resolves.toBeDefined()
+    await expect(lstat(join(cursorDir, 'unprotected-link'))).rejects.toThrow(
+      /ENOENT/,
+    )
+    await expect(lstat(join(cursorDir, 'unprotected-local'))).rejects.toThrow(
+      /ENOENT/,
+    )
+    expect(trashItemMock).toHaveBeenCalledTimes(2)
   })
 
   it('rejects a same-path replacement before moving the agent dir to OS Trash', async () => {

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -14,6 +14,7 @@ import {
   isSharedAgentPath,
 } from '@/main/constants'
 import {
+  filesystemIdentityFromStats,
   isReviewedEntryUnchanged,
   isSameFilesystemIdentity,
 } from '@/main/services/filesystemIdentity'
@@ -193,36 +194,35 @@ async function restoreQuarantinedPath(
 }
 
 /**
- * Move a reviewed directory to OS Trash only after quarantined identity revalidation.
- * @param directoryPath - Reviewed directory path to trash.
- * @param reviewedIdentity - Filesystem identity captured at review time.
- * @param options - Human-readable stale error and optional skill-directory validation.
- * @returns void when the quarantined reviewed directory reaches OS Trash.
+ * Move a reviewed filesystem entry to OS Trash only after quarantined identity revalidation; used when a parent folder must keep protected siblings.
+ * @param entryPath - Reviewed file, symlink, or directory path to trash.
+ * @param reviewedIdentity - Filesystem identity captured before the quarantine rename.
+ * @param options - Human-readable stale error, directory requirement, and optional skill-directory validation.
+ * @returns void when the quarantined reviewed entry reaches OS Trash.
  * @example
- * await trashReviewedDirectory('/Users/me/.cursor/skills/task', identity, { staleMessage: 'Reviewed local skill folder changed since review', validateSkillDirectory: true })
+ * await trashReviewedFilesystemEntry('/Users/me/.cursor/skills/task', identity, { staleMessage: 'Reviewed entry changed', requireDirectory: false, validateSkillDirectory: false })
  */
-async function trashReviewedDirectory(
-  directoryPath: AbsolutePath,
+async function trashReviewedFilesystemEntry(
+  entryPath: AbsolutePath,
   reviewedIdentity: FilesystemEntryIdentity,
   options: {
     staleMessage: string
+    requireDirectory: boolean
     validateSkillDirectory: boolean
   },
 ): Promise<void> {
-  const quarantinePath = buildQuarantinePath(directoryPath, 'trash')
-  await fs.rename(directoryPath, quarantinePath)
+  const quarantinePath = buildQuarantinePath(entryPath, 'trash')
+  await fs.rename(entryPath, quarantinePath)
 
   try {
     const quarantinedStats = await fs.lstat(quarantinePath)
     if (
-      !quarantinedStats.isDirectory() ||
-      quarantinedStats.isSymbolicLink() ||
+      (options.requireDirectory &&
+        (!quarantinedStats.isDirectory() ||
+          quarantinedStats.isSymbolicLink())) ||
       !isSameFilesystemIdentity(quarantinedStats, reviewedIdentity)
     ) {
-      const restored = await restoreQuarantinedPath(
-        quarantinePath,
-        directoryPath,
-      )
+      const restored = await restoreQuarantinedPath(quarantinePath, entryPath)
       throw new Error(
         restored
           ? options.staleMessage
@@ -233,10 +233,7 @@ async function trashReviewedDirectory(
       options.validateSkillDirectory &&
       !(await isValidSkillDir(quarantinePath))
     ) {
-      const restored = await restoreQuarantinedPath(
-        quarantinePath,
-        directoryPath,
-      )
+      const restored = await restoreQuarantinedPath(quarantinePath, entryPath)
       throw new Error(
         restored
           ? 'Reviewed local skill folder is no longer a valid skill.'
@@ -246,7 +243,7 @@ async function trashReviewedDirectory(
 
     await shell.trashItem(quarantinePath)
   } catch (error) {
-    const restored = await restoreQuarantinedPath(quarantinePath, directoryPath)
+    const restored = await restoreQuarantinedPath(quarantinePath, entryPath)
     if (!restored) {
       throw new Error(
         `${extractErrorMessage(error)}; quarantined folder could not be restored from ${quarantinePath}`,
@@ -254,6 +251,75 @@ async function trashReviewedDirectory(
     }
     throw error
   }
+}
+
+/**
+ * Move a reviewed directory to OS Trash only after quarantined identity revalidation.
+ * @param directoryPath - Reviewed directory path to trash.
+ * @param reviewedIdentity - Filesystem identity captured at review time.
+ * @param options - Human-readable stale error and optional skill-directory validation.
+ * @returns void when the quarantined reviewed directory reaches OS Trash.
+ * @example await trashReviewedDirectory('/Users/me/.cursor/skills/task', identity, { staleMessage: 'Reviewed local skill folder changed since review', validateSkillDirectory: true })
+ */
+async function trashReviewedDirectory(
+  directoryPath: AbsolutePath,
+  reviewedIdentity: FilesystemEntryIdentity,
+  options: {
+    staleMessage: string
+    validateSkillDirectory: boolean
+  },
+): Promise<void> {
+  await trashReviewedFilesystemEntry(directoryPath, reviewedIdentity, {
+    ...options,
+    requireDirectory: true,
+  })
+}
+
+/**
+ * Normalize renderer-provided protected slots to direct children of the selected agent directory so only reviewed protected entries can survive deletion.
+ * @param agentPath - Selected agent skills directory from main-process constants.
+ * @param protectedSkillPaths - Renderer-scanned protected slots for this agent.
+ * @returns Resolved direct-child paths that should remain in place.
+ * @example normalizeProtectedAgentSlotPaths('/Users/me/.cursor/skills', ['/Users/me/.cursor/skills/task'])
+ */
+function normalizeProtectedAgentSlotPaths(
+  agentPath: AbsolutePath,
+  protectedSkillPaths: AbsolutePath[],
+): ReadonlySet<string> {
+  return new Set(
+    protectedSkillPaths.map((slotPath) =>
+      resolve(assertAgentSlotPath(slotPath, agentPath)),
+    ),
+  )
+}
+
+/**
+ * Trash one unprotected direct child of an agent skills folder after capturing its current identity; this leaves protected siblings untouched.
+ * @param entryPath - Direct child inside the reviewed agent skills folder.
+ * @returns True when an entry was removed, false when it was already gone.
+ * @example await trashUnprotectedAgentEntry('/Users/me/.cursor/skills/unlocked')
+ */
+async function trashUnprotectedAgentEntry(
+  entryPath: AbsolutePath,
+): Promise<boolean> {
+  let entryStats: Stats
+  try {
+    entryStats = await fs.lstat(entryPath)
+  } catch (error) {
+    if (errorCode(error) === 'ENOENT') return false
+    throw error
+  }
+
+  await trashReviewedFilesystemEntry(
+    entryPath,
+    filesystemIdentityFromStats(entryStats),
+    {
+      staleMessage: 'Reviewed agent skills folder entry changed since review.',
+      requireDirectory: false,
+      validateSkillDirectory: false,
+    },
+  )
+  return true
 }
 
 /**
@@ -797,12 +863,45 @@ export function registerSkillsHandlers(): void {
         }
       }
 
-      let removedCount = 0
+      const protectedSlotPaths = normalizeProtectedAgentSlotPaths(
+        derivedAgentPath,
+        options.protectedSkillPaths ?? [],
+      )
+      let entries: string[] = []
       try {
-        const entries = await fs.readdir(derivedAgentPath)
-        removedCount = entries.length
-      } catch {
+        entries = await fs.readdir(derivedAgentPath)
+      } catch (error) {
+        if (protectedSlotPaths.size > 0) {
+          throw new Error(
+            `Cannot inspect protected skills before deleting folder: ${extractErrorMessage(error)}`,
+          )
+        }
         // Directory may be unreadable (permissions) — proceed to trash anyway
+      }
+
+      const protectedExistingPaths = new Set(
+        entries
+          .map((entryName) => resolve(join(derivedAgentPath, entryName)))
+          .filter((entryPath) => protectedSlotPaths.has(entryPath)),
+      )
+
+      if (protectedExistingPaths.size > 0) {
+        let removedCount = 0
+        for (const entryName of entries) {
+          const entryPath = join(derivedAgentPath, entryName) as AbsolutePath
+          // Protected entries stay in place so the folder remains usable.
+          if (protectedExistingPaths.has(resolve(entryPath))) continue
+
+          // react-doctor-disable-next-line react-doctor/async-await-in-loop -- serial filesystem mutations preserve predictable Trash ordering and stop on the first protected-folder delete failure.
+          const removed = await trashUnprotectedAgentEntry(entryPath)
+          if (removed) removedCount++
+        }
+
+        return {
+          success: true,
+          removedCount,
+          preservedCount: protectedExistingPaths.size,
+        }
       }
 
       // Move to OS trash instead of hard-rm, but only after quarantining the
@@ -816,7 +915,7 @@ export function registerSkillsHandlers(): void {
         },
       )
 
-      return { success: true, removedCount }
+      return { success: true, removedCount: entries.length }
     } catch (error) {
       return {
         success: false,

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -323,6 +323,33 @@ async function trashUnprotectedAgentEntry(
 }
 
 /**
+ * Re-check the reviewed agent skills directory before each child deletion so same-path replacement cannot redirect the loop while child mutations update directory timestamps.
+ * @param agentPath - Reviewed agent skills directory.
+ * @param reviewedIdentity - Filesystem identity captured when the dialog opened.
+ * @returns void when the parent still matches the reviewed real directory.
+ * @example await assertReviewedAgentFolderStillCurrent('/Users/me/.cursor/skills', identity)
+ */
+async function assertReviewedAgentFolderStillCurrent(
+  agentPath: AbsolutePath,
+  reviewedIdentity: FilesystemEntryIdentity,
+): Promise<void> {
+  let parentStats: Stats
+  try {
+    parentStats = await fs.lstat(agentPath)
+  } catch {
+    throw new Error('Reviewed agent skills folder changed since review.')
+  }
+
+  if (
+    !parentStats.isDirectory() ||
+    parentStats.isSymbolicLink() ||
+    !isSameFilesystemIdentity(parentStats, reviewedIdentity)
+  ) {
+    throw new Error('Reviewed agent skills folder changed since review.')
+  }
+}
+
+/**
  * Remove an agent symlink path after the caller has already validated and
  * lstat'd it. Directories are refused here so destructive local-folder removal
  * remains isolated to the single-unlink confirmation path.
@@ -869,7 +896,7 @@ export function registerSkillsHandlers(): void {
       )
       let entries: string[] = []
       try {
-        entries = await fs.readdir(derivedAgentPath)
+        entries = (await fs.readdir(derivedAgentPath)).sort()
       } catch (error) {
         if (protectedSlotPaths.size > 0) {
           throw new Error(
@@ -888,6 +915,13 @@ export function registerSkillsHandlers(): void {
       if (protectedExistingPaths.size > 0) {
         let removedCount = 0
         for (const entryName of entries) {
+          // The parent folder can be replaced between readdir() and child
+          // deletion; re-check it before each mutation so the loop cannot
+          // follow a fresh symlink into an unrelated directory.
+          await assertReviewedAgentFolderStillCurrent(
+            derivedAgentPath,
+            options.filesystemIdentity,
+          )
           const entryPath = join(derivedAgentPath, entryName) as AbsolutePath
           // Protected entries stay in place so the folder remains usable.
           if (protectedExistingPaths.has(resolve(entryPath))) continue

--- a/src/renderer/src/components/sidebar/AgentDeleteDialog.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/AgentDeleteDialog.browser.test.tsx
@@ -3,7 +3,7 @@ import { Provider } from 'react-redux'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
-import type { Agent, FilesystemEntryIdentity } from '@/shared/types'
+import type { Agent, FilesystemEntryIdentity, Skill } from '@/shared/types'
 
 const mockRemoveAllFromAgent = vi.fn()
 const mockSkillsGetAll = vi.fn()
@@ -95,6 +95,8 @@ async function renderDeleteDialog(options: { agent?: Agent } = {}) {
     await import('@/renderer/src/redux/slices/agentsSlice')
   const { default: skillsReducer } =
     await import('@/renderer/src/redux/slices/skillsSlice')
+  const { default: protectReducer } =
+    await import('@/renderer/src/redux/slices/protectSlice')
   const { default: uiReducer } =
     await import('@/renderer/src/redux/slices/uiSlice')
   const { setAgentToDelete } =
@@ -105,6 +107,7 @@ async function renderDeleteDialog(options: { agent?: Agent } = {}) {
     reducer: {
       agents: agentsReducer,
       skills: skillsReducer,
+      protect: protectReducer,
       ui: uiReducer,
     },
   })
@@ -148,6 +151,59 @@ describe('AgentDeleteDialog confirm action', () => {
     await expect
       .poll(() => mockAgentsGetAll.mock.calls.length)
       .toBeGreaterThan(0)
+  })
+
+  it('sends protected agent slot paths so folder delete preserves them', async () => {
+    // Arrange
+    mockRemoveAllFromAgent.mockResolvedValue({
+      success: true,
+      removedCount: 1,
+      preservedCount: 1,
+    })
+    const agent = makeAgent({ name: 'Claude Code' as Agent['name'] })
+    const protectedSkill: Skill = {
+      name: 'protected-task',
+      description: 'Protected task',
+      path: '/Users/test/.agents/skills/protected-task',
+      symlinkCount: 1,
+      symlinks: [
+        {
+          agentId: 'claude-code',
+          agentName: 'Claude Code',
+          status: 'valid',
+          targetPath: '/Users/test/.agents/skills/protected-task',
+          linkPath: '/Users/test/.claude/skills/folder-basename',
+          isLocal: false,
+        },
+      ],
+      isSource: true,
+      isOrphan: false,
+    }
+    const { screen, store } = await renderDeleteDialog({ agent })
+    const { fetchSkills } =
+      await import('@/renderer/src/redux/slices/skillsSlice')
+    const { addProtection } =
+      await import('@/renderer/src/redux/slices/protectSlice')
+    store.dispatch(fetchSkills.fulfilled([protectedSkill], 'skills-request'))
+    store.dispatch(addProtection('protected-task'))
+
+    // Act
+    await screen.getByRole('button', { name: /^Delete$/i }).click()
+
+    // Assert
+    await expect
+      .poll(() => mockRemoveAllFromAgent.mock.calls.length)
+      .toBeGreaterThan(0)
+    expect(mockRemoveAllFromAgent).toHaveBeenCalledWith({
+      agentId: 'claude-code',
+      agentPath: '/Users/test/.claude/skills',
+      filesystemIdentity: directoryIdentity,
+      protectedSkillPaths: ['/Users/test/.claude/skills/folder-basename'],
+    })
+    expect(mockToastSuccess).toHaveBeenCalledWith(
+      'Deleted unprotected skills for Claude Code',
+      { description: 'Removed 1 items; kept 1 protected' },
+    )
   })
 
   it('surfaces the IPC failure reason in an error toast when deletion fails', async () => {

--- a/src/renderer/src/components/sidebar/AgentDeleteDialog.tsx
+++ b/src/renderer/src/components/sidebar/AgentDeleteDialog.tsx
@@ -30,9 +30,21 @@ export const AgentDeleteDialog = React.memo(
       const result = await dispatch(removeAllSymlinksFromAgent(agentToDelete))
 
       if (removeAllSymlinksFromAgent.fulfilled.match(result)) {
-        toast.success(`Deleted skills folder for ${result.payload.agentName}`, {
-          description: `Removed ${result.payload.removedCount} items`,
-        })
+        if (result.payload.preservedCount > 0) {
+          toast.success(
+            `Deleted unprotected skills for ${result.payload.agentName}`,
+            {
+              description: `Removed ${result.payload.removedCount} items; kept ${result.payload.preservedCount} protected`,
+            },
+          )
+        } else {
+          toast.success(
+            `Deleted skills folder for ${result.payload.agentName}`,
+            {
+              description: `Removed ${result.payload.removedCount} items`,
+            },
+          )
+        }
         refreshAllData(dispatch)
       } else {
         toast.error('Failed to delete skills folder', {

--- a/src/renderer/src/redux/slices/agentsSlice.test.ts
+++ b/src/renderer/src/redux/slices/agentsSlice.test.ts
@@ -24,7 +24,15 @@ vi.stubGlobal('window', {
 
 async function createTestStore() {
   const { default: agentsReducer } = await import('./agentsSlice')
-  return configureStore({ reducer: { agents: agentsReducer } })
+  const { default: skillsReducer } = await import('./skillsSlice')
+  const { default: protectReducer } = await import('./protectSlice')
+  return configureStore({
+    reducer: {
+      agents: agentsReducer,
+      skills: skillsReducer,
+      protect: protectReducer,
+    },
+  })
 }
 
 const sampleAgent: Agent = {
@@ -151,6 +159,7 @@ describe('agentsSlice', () => {
       agentId: 'claude-code',
       agentPath: '/home/user/.claude/skills',
       filesystemIdentity: directoryIdentity,
+      protectedSkillPaths: [],
     })
   })
 

--- a/src/renderer/src/redux/slices/agentsSlice.test.ts
+++ b/src/renderer/src/redux/slices/agentsSlice.test.ts
@@ -24,13 +24,29 @@ vi.stubGlobal('window', {
 
 async function createTestStore() {
   const { default: agentsReducer } = await import('./agentsSlice')
-  const { default: skillsReducer } = await import('./skillsSlice')
+  const { default: bookmarkReducer } = await import('./bookmarkSlice')
+  const { default: dashboardReducer } = await import('./dashboardSlice')
+  const { default: marketplaceReducer } = await import('./marketplaceSlice')
   const { default: protectReducer } = await import('./protectSlice')
+  const { default: settingsReducer } = await import('./settingsSlice')
+  const { default: skillsReducer } = await import('./skillsSlice')
+  const { default: themeReducer } = await import('./themeSlice')
+  const { default: uiReducer } = await import('./uiSlice')
+  const { default: updateReducer } = await import('./updateSlice')
+  const { default: widgetPickerReducer } = await import('./widgetPickerSlice')
   return configureStore({
     reducer: {
-      agents: agentsReducer,
+      theme: themeReducer,
       skills: skillsReducer,
+      agents: agentsReducer,
+      bookmarks: bookmarkReducer,
       protect: protectReducer,
+      ui: uiReducer,
+      update: updateReducer,
+      marketplace: marketplaceReducer,
+      dashboard: dashboardReducer,
+      widgetPicker: widgetPickerReducer,
+      settings: settingsReducer,
     },
   })
 }

--- a/src/renderer/src/redux/slices/agentsSlice.ts
+++ b/src/renderer/src/redux/slices/agentsSlice.ts
@@ -2,7 +2,7 @@ import type { PayloadAction } from '@reduxjs/toolkit'
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit'
 
 import type { RootState } from '@/renderer/src/redux/store'
-import type { Agent } from '@/shared/types'
+import type { AbsolutePath, Agent } from '@/shared/types'
 
 /**
  * Redux state for the Agents feature area.
@@ -38,27 +38,59 @@ export const fetchAgents = createAsyncThunk('agents/fetchAll', async () => {
 })
 
 /**
+ * Collect protected slots that physically live inside the selected agent folder so main can preserve those direct children while deleting everything else.
+ * @param state - Current Redux state containing protected names and scanned skills.
+ * @param agent - Agent whose skills folder is being deleted.
+ * @returns Absolute agent slot paths that should survive folder deletion.
+ * @example collectProtectedAgentSlotPaths(state, cursorAgent)
+ */
+function collectProtectedAgentSlotPaths(
+  state: RootState,
+  agent: Agent,
+): AbsolutePath[] {
+  const protectedNames = new Set(state.protect.items)
+
+  return state.skills.items
+    .filter((skill) => protectedNames.has(skill.name))
+    .flatMap((skill) =>
+      skill.symlinks
+        .filter(
+          (symlink) =>
+            symlink.agentId === agent.id && symlink.status !== 'missing',
+        )
+        .map((symlink) => symlink.linkPath),
+    )
+}
+
+/**
  * Delete a specific agent's entire skills folder
  * @param agent - Agent whose skills folder will be deleted
  * @returns Agent name and removed item count for toast notification
  */
 export const removeAllSymlinksFromAgent = createAsyncThunk(
   'agents/removeAllSymlinks',
-  async (agent: Agent) => {
+  async (agent: Agent, { getState }) => {
     if (!agent.filesystemIdentity) {
       throw new Error(
         'Agent skills folder changed since review. Rescan before deleting.',
       )
     }
+    const state = getState() as RootState
+    const protectedSkillPaths = collectProtectedAgentSlotPaths(state, agent)
     const result = await window.electron.skills.removeAllFromAgent({
       agentId: agent.id,
       agentPath: agent.path,
       filesystemIdentity: agent.filesystemIdentity,
+      protectedSkillPaths,
     })
     if (!result.success) {
       throw new Error(result.error || 'Failed to delete skills folder')
     }
-    return { agentName: agent.name, removedCount: result.removedCount }
+    return {
+      agentName: agent.name,
+      removedCount: result.removedCount,
+      preservedCount: result.preservedCount ?? 0,
+    }
   },
 )
 

--- a/src/renderer/src/redux/slices/agentsSlice.ts
+++ b/src/renderer/src/redux/slices/agentsSlice.ts
@@ -67,32 +67,37 @@ function collectProtectedAgentSlotPaths(
  * @param agent - Agent whose skills folder will be deleted
  * @returns Agent name and removed item count for toast notification
  */
-export const removeAllSymlinksFromAgent = createAsyncThunk(
-  'agents/removeAllSymlinks',
-  async (agent: Agent, { getState }) => {
-    if (!agent.filesystemIdentity) {
-      throw new Error(
-        'Agent skills folder changed since review. Rescan before deleting.',
-      )
-    }
-    const state = getState() as RootState
-    const protectedSkillPaths = collectProtectedAgentSlotPaths(state, agent)
-    const result = await window.electron.skills.removeAllFromAgent({
-      agentId: agent.id,
-      agentPath: agent.path,
-      filesystemIdentity: agent.filesystemIdentity,
-      protectedSkillPaths,
-    })
-    if (!result.success) {
-      throw new Error(result.error || 'Failed to delete skills folder')
-    }
-    return {
-      agentName: agent.name,
-      removedCount: result.removedCount,
-      preservedCount: result.preservedCount ?? 0,
-    }
+export const removeAllSymlinksFromAgent = createAsyncThunk<
+  {
+    agentName: Agent['name']
+    removedCount: number
+    preservedCount: number
   },
-)
+  Agent,
+  { state: RootState }
+>('agents/removeAllSymlinks', async (agent, { getState }) => {
+  if (!agent.filesystemIdentity) {
+    throw new Error(
+      'Agent skills folder changed since review. Rescan before deleting.',
+    )
+  }
+  const state = getState()
+  const protectedSkillPaths = collectProtectedAgentSlotPaths(state, agent)
+  const result = await window.electron.skills.removeAllFromAgent({
+    agentId: agent.id,
+    agentPath: agent.path,
+    filesystemIdentity: agent.filesystemIdentity,
+    protectedSkillPaths,
+  })
+  if (!result.success) {
+    throw new Error(result.error || 'Failed to delete skills folder')
+  }
+  return {
+    agentName: agent.name,
+    removedCount: result.removedCount,
+    preservedCount: result.preservedCount ?? 0,
+  }
+})
 
 const agentsSlice = createSlice({
   name: 'agents',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -898,9 +898,8 @@ export interface UnlinkResult {
 }
 
 /**
- * IPC argument for `skills:removeAllFromAgent` — wipes everything inside a single
- * agent's skills directory (used when resetting an agent).
- * @example { agentId: 'claude-code', agentPath: '/Users/me/.claude/skills' }
+ * IPC argument for `skills:removeAllFromAgent` — wipes one agent skills folder, unless protected slot paths are supplied so those direct children are left behind.
+ * @example { agentId: 'claude-code', agentPath: '/Users/me/.claude/skills', protectedSkillPaths: ['/Users/me/.claude/skills/locked'] }
  */
 export interface RemoveAllFromAgentOptions {
   /** Agent whose skills directory will be cleared. */
@@ -909,17 +908,21 @@ export interface RemoveAllFromAgentOptions {
   agentPath: AbsolutePath
   /** Review-time directory identity for the agent skills folder. */
   filesystemIdentity: FilesystemEntryIdentity
+  /** Protected direct-child slots to preserve when deleting the agent folder. */
+  protectedSkillPaths?: AbsolutePath[]
 }
 
 /**
  * Result from clearing an agent's skills folder.
- * @example { success: true, removedCount: 5 }
+ * @example { success: true, removedCount: 5, preservedCount: 1 }
  */
 export interface RemoveAllFromAgentResult {
   /** true if the folder was emptied successfully. */
   success: boolean
   /** Number of entries (symlinks and local folders) removed. @example 5 */
   removedCount: SkillCount
+  /** Number of protected entries intentionally left in the folder. @example 1 */
+  preservedCount?: SkillCount
   /** Failure reason when `success` is false. */
   error?: string
 }


### PR DESCRIPTION
## Summary
- Preserve protected agent skill entries when deleting an agent skills folder.
- Send reviewed protected agent slot paths through IPC so metadata-name/folder-basename drift is preserved safely.
- Delete only unprotected direct children when protected entries exist, leaving the folder with protected skills inside.
- Update success copy and add renderer/main/schema regression coverage.

## Verification
- pnpm exec vitest run src/main/ipc/skills.unlinkFromAgent.integration.test.ts src/main/ipc/skills.removeAllFromAgent.integration.test.ts src/main/ipc/ipc-schemas.test.ts src/renderer/src/redux/slices/agentsSlice.test.ts src/renderer/src/components/sidebar/AgentDeleteDialog.browser.test.tsx
- pnpm exec eslint src/main/ipc/skills.ts src/main/ipc/ipc-schemas.ts src/main/ipc/ipc-schemas.test.ts src/main/ipc/skills.removeAllFromAgent.integration.test.ts src/renderer/src/redux/slices/agentsSlice.ts src/renderer/src/redux/slices/agentsSlice.test.ts src/renderer/src/components/sidebar/AgentDeleteDialog.tsx src/renderer/src/components/sidebar/AgentDeleteDialog.browser.test.tsx src/shared/types.ts
- pnpm exec tsc --noEmit --pretty false
- git diff --check
- pnpm validate (full Vitest 175 files / 2262 tests and Storybook passed; local run blocked by pre-existing fallow duplicate in Appearance.tsx/CodePreview.tsx and ignored .agents lint parse error)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * エージェント削除時に保護スキルを保持できるようになりました。保持数（preservedCount）と削除数を返し、処理対象を適切に分けます。
* **テスト**
  * IPC境界の検証を拡張し、保護パスの絶対パス条件を確認するケースを追加しました。
  * 保護対象の残存と非保護の削除、結果数やシンボリックリンク差し替え時の挙動を統合テストで検証しました。
* **表示/仕様**
  * 削除成功時トーストを「保持あり/なし」で分岐更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->