### PR TITLE
fix(bulk-select): Cmd+A selects filtered rows while search box focused

### DIFF
--- a/src/renderer/src/components/layout/MainContent.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.browser.test.tsx
@@ -633,6 +633,72 @@ describe('MainContent keyboard shortcuts (Cmd+A)', () => {
       document.body.removeChild(textInput)
     }
   })
+
+  it('selects every visible skill on Cmd+A even while the search box is focused, blurring it first', async () => {
+    const { screen, store } = await renderMainContent()
+    const { enterBulkSelectMode } =
+      await import('@/renderer/src/redux/slices/uiSlice')
+    const { fetchSkills } =
+      await import('@/renderer/src/redux/slices/skillsSlice')
+    const skillFixtures = [
+      {
+        name: 'task' as SkillName,
+        description: '',
+        path: '/skills/task' as never,
+        filesystemIdentity: directoryIdentity,
+        symlinkCount: 0,
+        symlinks: [],
+        isSource: true,
+        isOrphan: false,
+      },
+      {
+        name: 'tdd' as SkillName,
+        description: '',
+        path: '/skills/tdd' as never,
+        filesystemIdentity: directoryIdentity,
+        symlinkCount: 0,
+        symlinks: [],
+        isSource: true,
+        isOrphan: false,
+      },
+    ]
+
+    // Arrange — skills loaded and bulk mode on. The search box renders as
+    // <input type="search"> (asserted in SearchBox.browser.test.tsx); here we
+    // stand in a focused search input to exercise the handler's special case,
+    // mirroring the focused-text-field test above for a clean contrast pair.
+    store.dispatch(fetchSkills.fulfilled(skillFixtures, 'req-id'))
+    store.dispatch(enterBulkSelectMode())
+    await waitForBulkSelectReady(screen)
+
+    const searchInput = document.createElement('input')
+    searchInput.type = 'search'
+    document.body.appendChild(searchInput)
+    try {
+      // Act — the canonical flow: query typed, box still focused, user hits Cmd+A
+      searchInput.focus()
+      expect(document.activeElement).toBe(searchInput)
+      searchInput.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'a',
+          metaKey: true,
+          bubbles: true,
+        }),
+      )
+
+      // Assert — every filtered row is selected (pre-fix bug: nothing happened)...
+      const selectedNames = store.getState().skills.selectedSkillNames
+      expect(selectedNames).toContain('task')
+      expect(selectedNames).toContain('tdd')
+      expect(selectedNames.length).toBe(2)
+      // ...and the box was blurred so the browser didn't just select its own text
+      expect(document.activeElement).not.toBe(searchInput)
+    } finally {
+      // Removal in `finally` so a failing assertion doesn't leak a focused
+      // <input type="search"> into the reused Chromium page.
+      document.body.removeChild(searchInput)
+    }
+  })
 })
 
 describe('MainContent keyboard shortcuts (Esc 2-step)', () => {

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -122,6 +122,7 @@ import { refreshAllData } from '@/renderer/src/redux/thunks'
 import { flashFailedRows } from '@/renderer/src/utils/bulkOpVisuals'
 import { errorToastDescription } from '@/renderer/src/utils/errorToastDescription'
 import { isEditableTarget } from '@/renderer/src/utils/isEditableTarget'
+import { isSearchInput } from '@/renderer/src/utils/isSearchInput'
 import { pluralize } from '@/renderer/src/utils/pluralize'
 import {
   SOURCE_FILTER_MAX_VISIBLE_REPOS,
@@ -489,7 +490,6 @@ export const MainContent = React.memo(
     useCycleEffect(() => {
       if (activeTab !== 'installed') return
       const handleKey = (event: KeyboardEvent): void => {
-        if (isEditableTarget(document.activeElement)) return
         if (!bulkSelectModeRef.current) return
 
         // An open Radix dialog/alertdialog (e.g. the now always-mounted
@@ -506,11 +506,29 @@ export const MainContent = React.memo(
         )
           return
 
-        // Cmd/Ctrl+A: select all visible
-        if (
-          (event.metaKey || event.ctrlKey) &&
-          event.key.toLowerCase() === 'a'
-        ) {
+        const activeElement = document.activeElement
+        const isSelectAllChord =
+          (event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'a'
+
+        // Cmd/Ctrl+A while the search box is focused: the canonical bulk flow is
+        // "type a query → results filter → Cmd+A to grab the filtered rows". The
+        // search box keeps focus, so the browser would otherwise select the
+        // input's own text and nothing happens to the list. Blur the box first,
+        // then select all visible. Checked BEFORE the editable-target stand-down
+        // below so the search box is the one text surface we deliberately act on.
+        if (isSelectAllChord && isSearchInput(activeElement)) {
+          activeElement.blur()
+          event.preventDefault()
+          dispatch(selectAll(visibleNamesRef.current))
+          return
+        }
+
+        // Every other editable surface (rename fields, modal inputs, ...) keeps
+        // native behavior — stand down so the user's keystrokes reach the field.
+        if (isEditableTarget(activeElement)) return
+
+        // Cmd/Ctrl+A with focus outside any text field: select all visible.
+        if (isSelectAllChord) {
           event.preventDefault()
           dispatch(selectAll(visibleNamesRef.current))
           return

--- a/src/renderer/src/utils/isSearchInput.test.ts
+++ b/src/renderer/src/utils/isSearchInput.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from 'vitest'
+
+import { isSearchInput } from './isSearchInput'
+
+describe('isSearchInput', () => {
+  it('matches the search box so Cmd+A can grab filtered rows while it is focused', () => {
+    // Arrange — the skills filter renders as <input type="search">
+    const searchInput = document.createElement('input')
+    searchInput.type = 'search'
+
+    // Act
+    const result = isSearchInput(searchInput)
+
+    // Assert — the bulk-select handler should act on (and blur) this input
+    expect(result).toBe(true)
+  })
+
+  it('ignores ordinary text inputs so native Cmd+A still selects their text', () => {
+    // Arrange — a rename field or any other text input (default type="text")
+    const textInput = document.createElement('input')
+
+    // Act
+    const result = isSearchInput(textInput)
+
+    // Assert — only the search box is special-cased; text fields keep native Cmd+A
+    expect(result).toBe(false)
+  })
+
+  it('ignores textareas so multi-line editing keeps native Cmd+A', () => {
+    // Arrange — a <textarea> is editable but not a search box
+    const textarea = document.createElement('textarea')
+
+    // Act
+    const result = isSearchInput(textarea)
+
+    // Assert
+    expect(result).toBe(false)
+  })
+
+  it('treats no focus (null target) as not the search box', () => {
+    // Arrange — document.activeElement can be null before any focus
+    const target = null
+
+    // Act
+    const result = isSearchInput(target)
+
+    // Assert
+    expect(result).toBe(false)
+  })
+})

--- a/src/renderer/src/utils/isSearchInput.ts
+++ b/src/renderer/src/utils/isSearchInput.ts
@@ -1,0 +1,26 @@
+/**
+ * True when the target is the skills search box (`<input type="search">`). Used
+ * by the Installed-tab bulk-select keydown handler so Cmd/Ctrl+A can select all
+ * *filtered* rows even while the search box keeps focus — the handler blurs the
+ * box first, then selects. Deliberately narrower than `isEditableTarget` (which
+ * stands down for ALL text surfaces): here we want to ACT on the search box,
+ * while still leaving native Cmd+A intact for other editable fields.
+ *
+ * A type predicate so callers can `.blur()` the narrowed `HTMLInputElement`
+ * without an `as` cast. Accepts `EventTarget | null` to pair with both
+ * `event.target` and `document.activeElement`.
+ *
+ * @param target - The DOM target to test — usually `document.activeElement`
+ * @returns True when the target is an `<input type="search">`; false otherwise
+ * @example
+ * // Inside the bulk-select keydown handler:
+ * if (isSelectAllChord && isSearchInput(document.activeElement)) {
+ *   document.activeElement.blur() // narrowed to HTMLInputElement
+ *   dispatch(selectAll(visibleNames))
+ * }
+ */
+export function isSearchInput(
+  target: EventTarget | null,
+): target is HTMLInputElement {
+  return target instanceof HTMLInputElement && target.type === 'search'
+}


### PR DESCRIPTION
## Summary

Fixes the real behavior bug behind #228. In Installed-tab bulk-select mode, the canonical flow — type a query → results filter → press **Cmd+A** to grab the filtered rows — silently failed: the handler's global early-return `if (isEditableTarget(document.activeElement)) return` fired on the focused search box, so Cmd+A never reached the select-all branch. The browser selected the input's own text instead and nothing happened to the list.

(The OR-branch of #228's acceptance — a visible `⌘A` hint on the button — already shipped in #231. This PR implements the first branch: the actual behavior fix.)

## Changes

- **New `isSearchInput` util** (`src/renderer/src/utils/isSearchInput.ts`) — a `target is HTMLInputElement` type predicate matching `<input type="search">`, so the caller can `.blur()` the narrowed element without an `as` cast. Deliberately narrower than `isEditableTarget`: we want to *act* on the search box, while leaving native Cmd+A intact for other editable fields.
- **`handleKey` reorder** (`MainContent.tsx`) — the naive in-branch blur from the issue would be unreachable under the old global guard, so the search-box special-case is hoisted *above* the editable-target stand-down: blur the box → `preventDefault` → `dispatch(selectAll(visibleNamesRef.current))`. The open-dialog guard still runs first, so Cmd+A never leaks behind a modal.

## Behavior matrix (unchanged except the search box)

| Focus | Cmd+A |
|-------|-------|
| Search box (`type="search"`) | **blur + select all visible** ✅ (the fix) |
| Other text field (rename, modal input) | native text-select (unchanged) |
| Non-editable / list | select all visible (unchanged) |
| Any, with a modal open | modal owns it (unchanged) |

## Test Coverage

- `isSearchInput.test.ts` — 4 unit tests (search input ✓, text input ✗, textarea ✗, null ✗)
- `MainContent.browser.test.tsx` — new behavior test: Cmd+A while the search box is focused selects all + blurs the box. The existing "does not select on Cmd+A in a text field" test (arbitrary `<input>`) still passes — clean contrast pair.
- Full gate: `pnpm validate` (2268 tests) + `pnpm test:e2e` (60 passed). Changed files are lint + typecheck clean.

## Review

Two-axis `/review` (Standards + Spec) — both clean, no hard violations, no scope creep, all four edge cases (modal ordering, rename-input native Cmd+A, blur-then-select, focus/timing) verified.

Closes #228

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 一括選択モード中にCommand+Aキーボードショートカットを押した際の動作を改善しました。検索ボックスがフォーカスされている場合、検索テキストの選択ではなく、すべての表示項目が選択されるようになります。これによりキーボード操作がより直感的になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->