### PR TITLE
fix(code-preview): prevent FOUC on theme-only re-highlight (#221)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -292,11 +292,8 @@ Avoid:
 - Hover scale on dense controls.
 - Bouncy easing.
 - Animations that delay destructive actions or bulk workflows.
-- Flashing a plain or unstyled intermediate state while asynchronously
-  re-rendering already-styled content (theme swaps, syntax re-highlight,
-  re-fetch of an already-painted view). Hold the prior styled output until the
-  new render resolves; blank to a fallback only when there is no prior output to
-  keep. See Code theme for the canonical case (#221).
+- Flashing a plain or unstyled state while re-rendering already-styled content
+  (theme swap, syntax re-highlight, re-fetch of a painted view); see Code theme (#221).
 
 Respect `prefers-reduced-motion`; transitions should be removable without
 changing layout or meaning.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -184,6 +184,14 @@ output. Theme changes re-render the preview live across windows through the
 `settings:changed` broadcast. Curated pairs are the only surface — do not expose
 raw single-theme selection; a pair guarantees both light and dark legibility.
 
+Re-highlighting is async (Shiki resolves off the render path). On a **theme-only**
+change, keep the already-highlighted output mounted until the new render resolves,
+then swap colored → colored — never blank the pane to the plain-text fallback
+mid-swap. That blanking flash is the FOUC fixed in #221. Drop to the plain-text
+fallback only on a genuine **content or language** change, where there is no prior
+colored output worth preserving (and bleeding the previous file's colors would be
+wrong). The same rule generalizes: see Motion.
+
 ## Spacing and Layout
 
 The base grid is 4px. Keep spacing small but breathable.
@@ -284,6 +292,11 @@ Avoid:
 - Hover scale on dense controls.
 - Bouncy easing.
 - Animations that delay destructive actions or bulk workflows.
+- Flashing a plain or unstyled intermediate state while asynchronously
+  re-rendering already-styled content (theme swaps, syntax re-highlight,
+  re-fetch of an already-painted view). Hold the prior styled output until the
+  new render resolves; blank to a fallback only when there is no prior output to
+  keep. See Code theme for the canonical case (#221).
 
 Respect `prefers-reduced-motion`; transitions should be removable without
 changing layout or meaning.

--- a/src/renderer/src/components/skills/FileContent.codeTheme.browser.test.tsx
+++ b/src/renderer/src/components/skills/FileContent.codeTheme.browser.test.tsx
@@ -65,4 +65,104 @@ describe('FileContent code theme', () => {
       }),
     )
   })
+
+  it('keeps the previous colored output mounted during a theme-only switch, never flashing plain text', async () => {
+    // Arrange — the first highlight resolves with a recognizable theme-A marker.
+    const { FileContent } = await import('./FileContent')
+    mockCodeToHtml.mockResolvedValueOnce(
+      '<pre class="shiki"><code><span class="line">THEME_A_COLORED</span></code></pre>',
+    )
+    const screen = await render(
+      <FileContent
+        content={makeCodeContent('const x = 1\n')}
+        codeThemeId="github"
+      />,
+    )
+    await expect
+      .element(screen.getByText('THEME_A_COLORED'))
+      .toBeInTheDocument()
+
+    // The theme-B highlight hangs until resolved by hand, so the pane can be
+    // observed WHILE the new theme is still resolving.
+    let resolveThemeB: (html: string) => void = () => {}
+    mockCodeToHtml.mockReturnValueOnce(
+      new Promise<string>((resolve) => {
+        resolveThemeB = resolve
+      }),
+    )
+
+    // Act — switch ONLY the theme; content and language are identical.
+    await screen.rerender(
+      <FileContent
+        content={makeCodeContent('const x = 1\n')}
+        codeThemeId="vitesse"
+      />,
+    )
+    // Let the effect and any React flush settle, so an unguarded
+    // setHighlightedHtml(null) would already have blanked the pane to plain text.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await new Promise((resolve) => requestAnimationFrame(resolve))
+
+    // Assert — theme A's colored output is STILL mounted and the plain-text
+    // fallback table never appeared mid-swap (the FOUC guard for #221).
+    await expect
+      .element(screen.getByText('THEME_A_COLORED'))
+      .toBeInTheDocument()
+    expect(screen.container.querySelector('table')).toBeNull()
+
+    // Resolving theme B swaps colored -> colored with no intervening plain frame.
+    resolveThemeB(
+      '<pre class="shiki"><code><span class="line">THEME_B_COLORED</span></code></pre>',
+    )
+    await expect
+      .element(screen.getByText('THEME_B_COLORED'))
+      .toBeInTheDocument()
+  })
+
+  it('falls back to plain text while re-highlighting after a file switch, never bleeding the previous colors', async () => {
+    // Arrange — file A highlights with a recognizable marker.
+    const { FileContent } = await import('./FileContent')
+    mockCodeToHtml.mockResolvedValueOnce(
+      '<pre class="shiki"><code><span class="line">FILE_A_COLORED</span></code></pre>',
+    )
+    const screen = await render(
+      <FileContent
+        content={makeCodeContent('const fileA = 1\n')}
+        codeThemeId="vitesse"
+      />,
+    )
+    await expect.element(screen.getByText('FILE_A_COLORED')).toBeInTheDocument()
+
+    // File B's highlight hangs so the pane can be observed mid-switch.
+    let resolveFileB: (html: string) => void = () => {}
+    mockCodeToHtml.mockReturnValueOnce(
+      new Promise<string>((resolve) => {
+        resolveFileB = resolve
+      }),
+    )
+
+    // Act — switch to a DIFFERENT file (content changes, theme unchanged).
+    await screen.rerender(
+      <FileContent
+        content={makeCodeContent('const fileB = 2\n')}
+        codeThemeId="vitesse"
+      />,
+    )
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await new Promise((resolve) => requestAnimationFrame(resolve))
+
+    // Assert — file A's colors are gone (no stale bleed) and file B's source is
+    // shown via the plain-text fallback while Shiki re-highlights.
+    expect(screen.container.querySelector('.skill-code-preview')).toBeNull()
+    expect(screen.container.querySelector('table')).toBeInstanceOf(HTMLElement)
+    await expect
+      .element(screen.getByText(/const fileB = 2/))
+      .toBeInTheDocument()
+
+    // Resolving file B installs its colored output.
+    resolveFileB(
+      '<pre class="shiki"><code><span class="line">FILE_B_COLORED</span></code></pre>',
+    )
+    await expect.element(screen.getByText('FILE_B_COLORED')).toBeInTheDocument()
+  })
 })

--- a/src/renderer/src/components/skills/FileContent.tsx
+++ b/src/renderer/src/components/skills/FileContent.tsx
@@ -1,5 +1,5 @@
 import { BookOpenText, Code2, FileQuestion } from 'lucide-react'
-import React, { useMemo, useState } from 'react'
+import React, { useMemo, useRef, useState } from 'react'
 import ReactMarkdown, { type Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { match } from 'ts-pattern'
@@ -183,10 +183,29 @@ const SyntaxHighlightedCode = React.memo(function SyntaxHighlightedCode({
 }: SyntaxHighlightedCodeProps): React.ReactElement {
   const [highlightedHtml, setHighlightedHtml] = useState<string | null>(null)
   const plainTextLines = useMemo(() => content.split('\n'), [content])
+  // Identifies which (content + language) the live `highlightedHtml` belongs to.
+  // A theme-only re-highlight leaves this unchanged, so the existing colored
+  // output stays mounted and is swapped only when the new theme resolves —
+  // blanking it first would flash the plain-text fallback (FOUC, #221). A
+  // content/language change DOES update this, so the pane blanks to plain text
+  // and never bleeds the previous file's colors into the new file's preview.
+  const highlightedSourceRef = useRef<{
+    content: string
+    language: string
+  } | null>(null)
 
   useCycleEffect(() => {
     let cancelled = false
-    setHighlightedHtml(null)
+    // Only blank on a genuine source change; a theme-only switch keeps the
+    // previous colored HTML visible until the new theme finishes highlighting.
+    const sourceChanged =
+      highlightedSourceRef.current === null ||
+      highlightedSourceRef.current.content !== content ||
+      highlightedSourceRef.current.language !== language
+    if (sourceChanged) {
+      setHighlightedHtml(null)
+    }
+    highlightedSourceRef.current = { content, language }
     // Resolve inside the effect so a theme change re-runs highlighting; the
     // light/dark keys feed the --shiki-light / --shiki-dark CSS var bridge.
     const codeTheme = resolveCodeTheme(codeThemeId)

--- a/src/renderer/src/components/skills/FileContent.tsx
+++ b/src/renderer/src/components/skills/FileContent.tsx
@@ -196,8 +196,7 @@ const SyntaxHighlightedCode = React.memo(function SyntaxHighlightedCode({
 
   useCycleEffect(() => {
     let cancelled = false
-    // Only blank on a genuine source change; a theme-only switch keeps the
-    // previous colored HTML visible until the new theme finishes highlighting.
+    // Blank only on a genuine source change (rationale on highlightedSourceRef above).
     const sourceChanged =
       highlightedSourceRef.current === null ||
       highlightedSourceRef.current.content !== content ||


### PR DESCRIPTION
## What & why

Fixes #221 — the code-preview pane flashed its **plain-text fallback** for one frame whenever the syntax theme changed (Settings → Appearance → Code theme), a FOUC (flash of unstyled content). Shiki re-highlights asynchronously off the render path, and the effect blanked `highlightedHtml` unconditionally before the new colored render resolved — so a *theme-only* change momentarily dropped to uncolored text, then snapped back.

## Root cause

`FileContent.tsx`'s highlight effect set `highlightedHtml = null` on every run (including theme-only re-runs). On a theme change the source is unchanged, so blanking served no purpose except to expose the plain-text fallback for one async tick → the flash.

## Fix

A ref-based **source-identity guard** (`highlightedSourceRef`) records the `{content, language}` the live `highlightedHtml` belongs to. The effect now blanks **only on a genuine content/language change** — a theme-only re-highlight keeps the already-colored output mounted and swaps colored → colored once the new theme resolves. A real file switch still drops to plain text (and never bleeds the previous file's colors into the new preview).

- `src/renderer/src/components/skills/FileContent.tsx` — the guard + conditional blank.
- Effect deps unchanged (`[content, language, codeThemeId]`); component is prop-driven with **no remount `key`**, so the swap happens in place.

## Verification (5 independent lines of evidence)

This is a **motion / no-flash** property, so per the repo rule it was verified by recording and frame-inspecting, not by static checks:

1. **3 deterministic browser tests** (`FileContent.codeTheme.browser.test.tsx`, Chromium lane) that freeze the intermediate async frame with a hanging re-highlight promise and assert the colored `<table>` stays mounted (theme-only) / plain text shows without color bleed (file switch).
2. **120fps rAF probe** over a **real, settings-driven** Catppuccin→Vitesse swap on a ProMotion display: `sawTable:false`, `sawBlank:false` across all 354 sampled frames (every frame `p:1 tbl:0` — colored throughout, never blanked).
3. **Cross-window propagation** confirmed (Settings is a separate BrowserWindow; `settings:changed` broadcast): `#24292e → #4c4f69 → #393a34` color transitions observed end-to-end.
4. **Recorded webm + extracted frames** show a continuous colored preview through the swap (no plain-text frame).
5. **Code inspection**: prop-driven effect, no remount key in `CodePreview.tsx` (`React.memo`, `<TabsPrimitive.Content>` value unchanged by theme).

## Design system

`DESIGN.md` updated to codify the rule this bug violated (it had no rule for it — design-review surfaced the deficiency):
- Code theme section: on a theme-only change, keep highlighted output mounted until the new render resolves, then swap colored → colored; drop to plain-text fallback only on content/language change.
- Motion "Avoid:" list: don't flash a plain/unstyled state while re-rendering already-styled content (theme swap, syntax re-highlight, re-fetch of a painted view); see #221.

## Quality gate

- `pnpm validate`: **test 2270 passed, typecheck, dead-code, complexity (health), storybook:build all green.** The two non-green sub-checks are **pre-existing and unrelated to this branch** (this branch touches only `FileContent.tsx`, its test, and `DESIGN.md`):
  - `lint`: a single `Parsing error` on `.agents/skills/skills-cli-sync/reconcile-agents.mjs` — a local-only typescript-eslint project-service quirk on a file this branch does not touch; CI lint is green (documented in #232/#233).
  - `fallow:dupes`: a pre-existing clone group `Appearance.tsx ↔ CodePreview.tsx` (neither file touched here); the check **exits 0** (non-gating).
  - My two changed `.tsx` files are eslint-clean.
- `pnpm test:e2e`: **60 passed (1.2m), exit 0** — full Electron e2e suite green.

Closes #221


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * テーマ切り替え時のちらつき（フラッシュ）を排除。既存の色付き表示を保持。
  * ファイル切り替え時に前の着色が混入しないよう改善。

* **テスト**
  * テーマ・ファイル切り替え時の表示動作を検証するテストを追加。

* **ドキュメント**
  * 非同期再ハイライト中の表示制御ルールをデザイン仕様書に記載。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->