### PR TITLE
feat(filter): add Unique skill-type filter for single-agent skills

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -74,6 +74,7 @@ Status colors must remain semantically stable:
 | Orphan / destructive  | `--destructive`          |
 | Local skill type      | Emerald                  |
 | G-Stack skill type    | `--gstack`               |
+| Unique skill type     | Violet (theme-invariant) |
 
 Amber shades — Tailwind ships several amber steps; pin them by role so the
 "needs review" hue stays consistent and reviews don't churn:
@@ -488,6 +489,8 @@ Always pair with a tooltip: `"Protected — cannot be deleted"` (on) / `"Click t
 - Popovers should be visually above panels through shadow and border.
 - Toasts should stay compact, readable, and not shift as timers update.
 - Use motion only for entrance/exit and progress continuity.
+
+**Tooltips — styled vs native.** Use the shadcn `Tooltip` component (themed, fast, the app standard) for hints on standalone trigger elements: icon buttons, agent/skill rows, toggles. **Inside an open Radix menu** (`DropdownMenuItem` / `DropdownMenuRadioItem`), use the native `title` attribute instead — a Radix `Tooltip` nested inside a Radix menu fights the menu's focus/pointer trapping, and the app's `Tooltip` is only ever composed on triggers, never on items within open menu content. The skill-type filter's "Unique" radio item uses `title="Available to only one agent"` for this reason. Reserve hints for labels that aren't self-evident; never tooltip self-explanatory items (see Core Principle: "no obvious tooltips").
 
 ### Bulk Destructive Dialogs with Skipped Items
 

--- a/src/renderer/src/components/layout/MainContent.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.browser.test.tsx
@@ -1775,6 +1775,142 @@ describe('MainContent SkillTypeFilter dropdown options', () => {
     ).not.toBeNull()
   })
 
+  it('offers a Unique filter marked with a violet dot and a discoverability hint when an agent is selected', async () => {
+    // Arrange
+    const { screen, store } = await renderMainContent()
+    const { fetchAgents } =
+      await import('@/renderer/src/redux/slices/agentsSlice')
+    const { selectAgent } = await import('@/renderer/src/redux/slices/uiSlice')
+
+    store.dispatch(
+      fetchAgents.fulfilled(
+        [
+          {
+            id: 'cursor',
+            name: 'Cursor',
+            path: '/Users/me/.cursor/skills' as never,
+            exists: true,
+            skillCount: 0,
+            localSkillCount: 0,
+          },
+        ],
+        'req-id',
+      ),
+    )
+    store.dispatch(selectAgent('cursor'))
+
+    // Act
+    // Open the dropdown — Unique is the single-agent skill type filter.
+    await screen
+      .getByRole('button', { name: /Skill type filter: All/i })
+      .click()
+
+    // Assert
+    const uniqueItem = screen.getByRole('menuitemradio', { name: /Unique/i })
+    await expect.element(uniqueItem).toBeInTheDocument()
+    const uniqueItemElement = uniqueItem.element()
+    const dot = uniqueItemElement.querySelector('.bg-violet-400')
+    expect(
+      dot,
+      'Unique menu item should contain a span with bg-violet-400',
+    ).not.toBeNull()
+    // The hint makes the opaque "Unique" label discoverable on hover.
+    expect(uniqueItemElement.getAttribute('title')).toBe(
+      'Available to only one agent',
+    )
+  })
+
+  it('narrows the visible list to only single-agent skills when the Unique filter is chosen', async () => {
+    // Arrange
+    const { screen, store } = await renderMainContent()
+    const { fetchAgents } =
+      await import('@/renderer/src/redux/slices/agentsSlice')
+    const { selectAgent } = await import('@/renderer/src/redux/slices/uiSlice')
+    const { fetchSkills } =
+      await import('@/renderer/src/redux/slices/skillsSlice')
+
+    // A skill available to exactly one agent (a lone valid slot in cursor).
+    const uniqueSkill: Skill = {
+      name: 'cursor-unique' as SkillName,
+      description: '',
+      path: '/skills/cursor-unique' as never,
+      symlinkCount: 1,
+      symlinks: [
+        {
+          agentId: 'cursor' as never,
+          agentName: 'Cursor' as never,
+          linkPath: '/cursor/skills/cursor-unique' as never,
+          targetPath: '/skills/cursor-unique' as never,
+          status: 'valid',
+          isLocal: false,
+        },
+      ],
+      isSource: true,
+      isOrphan: false,
+    }
+    // A skill shared by two agents — visible in the cursor view, but NOT unique.
+    const sharedSkill: Skill = {
+      name: 'shared-two' as SkillName,
+      description: '',
+      path: '/skills/shared-two' as never,
+      symlinkCount: 2,
+      symlinks: [
+        {
+          agentId: 'cursor' as never,
+          agentName: 'Cursor' as never,
+          linkPath: '/cursor/skills/shared-two' as never,
+          targetPath: '/skills/shared-two' as never,
+          status: 'valid',
+          isLocal: false,
+        },
+        {
+          agentId: 'codex' as never,
+          agentName: 'Codex' as never,
+          linkPath: '/codex/skills/shared-two' as never,
+          targetPath: '/skills/shared-two' as never,
+          status: 'valid',
+          isLocal: false,
+        },
+      ],
+      isSource: true,
+      isOrphan: false,
+    }
+
+    store.dispatch(
+      fetchAgents.fulfilled(
+        [
+          {
+            id: 'cursor',
+            name: 'Cursor',
+            path: '/Users/me/.cursor/skills' as never,
+            exists: true,
+            skillCount: 0,
+            localSkillCount: 0,
+          },
+        ],
+        'req-id',
+      ),
+    )
+    store.dispatch(selectAgent('cursor'))
+    store.dispatch(fetchSkills.fulfilled([uniqueSkill, sharedSkill], 'req-id'))
+
+    // Act
+    await screen
+      .getByRole('button', { name: /Skill type filter: All/i })
+      .click()
+    await screen.getByRole('menuitemradio', { name: /Unique/i }).click()
+
+    // Assert
+    // Slice state — single source of truth that the selector reads from.
+    expect(store.getState().ui.skillTypeFilter).toBe('unique')
+
+    // Selector view — only the single-agent skill survives the filter.
+    const { selectFilteredSkills } =
+      await import('@/renderer/src/redux/selectors')
+    const filtered = selectFilteredSkills(store.getState() as never)
+    expect(filtered.map((skill) => skill.name)).toEqual(['cursor-unique'])
+  })
+
   it('narrows the visible list to only orphan skills when the Orphan filter is chosen', async () => {
     // Arrange
     const { screen, store } = await renderMainContent()

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -144,12 +144,24 @@ const SKILL_TYPE_FILTER_OPTIONS: {
   label: string
   /** Colored dot class to match skill type visual indicators */
   dotClass?: string
+  /**
+   * Optional hover hint surfaced as a native tooltip. Used for modes whose
+   * label is not self-explanatory (Unique reads as opaque without it) so the
+   * filter is discoverable without docs. @see issue #203
+   */
+  hint?: string
 }[] = [
   { value: 'all', label: 'All' },
   { value: 'symlinked', label: 'Symlinked', dotClass: 'bg-success' },
   { value: 'local', label: 'Local', dotClass: 'bg-emerald-400' },
   { value: 'gstack', label: 'G-Stack', dotClass: 'bg-gstack' },
   { value: 'orphan', label: 'Orphan', dotClass: 'bg-destructive' },
+  {
+    value: 'unique',
+    label: 'Unique',
+    dotClass: 'bg-violet-400',
+    hint: 'Available to only one agent',
+  },
 ]
 
 const EXCLUDABLE_SKILL_TYPE_FILTER_OPTIONS = SKILL_TYPE_FILTER_OPTIONS.filter(
@@ -159,6 +171,7 @@ const EXCLUDABLE_SKILL_TYPE_FILTER_OPTIONS = SKILL_TYPE_FILTER_OPTIONS.filter(
     value: ExcludableSkillTypeFilter
     label: string
     dotClass?: string
+    hint?: string
   } => option.value !== 'all',
 )
 
@@ -634,6 +647,9 @@ export const MainContent = React.memo(
         },
         orphan: () => {
           handleToggleExcludedSkillTypeFilter('orphan')
+        },
+        unique: () => {
+          handleToggleExcludedSkillTypeFilter('unique')
         },
       }),
       [handleToggleExcludedSkillTypeFilter],
@@ -1269,6 +1285,7 @@ export const MainContent = React.memo(
                         <DropdownMenuRadioItem
                           key={option.value}
                           value={option.value}
+                          title={option.hint}
                           className="gap-2"
                         >
                           {option.dotClass ? (

--- a/src/renderer/src/components/skills/skillsListHelpers.test.ts
+++ b/src/renderer/src/components/skills/skillsListHelpers.test.ts
@@ -198,6 +198,37 @@ describe('getEmptyListMessage', () => {
     expect(message).toBe('No G-Stack skills for this agent')
   })
 
+  it('shows the unique-only empty state when the type filter is unique', () => {
+    // Arrange: a selected agent with the unique type filter and no other narrow.
+    // Act
+    const message = getEmptyListMessage({
+      searchQuery: '',
+      selectedSources: [],
+      selectedAgentId: 'cursor',
+      skillTypeFilter: 'unique',
+    })
+
+    // Assert
+    expect(message).toBe('No unique skills for this agent')
+  })
+
+  it('appends a single excluded unique type to the agent-only empty state', () => {
+    // Arrange: a selected agent excluding the unique type under the all include.
+    // Act
+    const message = getEmptyListMessage({
+      searchQuery: '',
+      selectedSources: [],
+      selectedAgentId: 'cursor',
+      skillTypeFilter: 'all',
+      excludedSkillTypeFilters: ['unique'],
+    })
+
+    // Assert
+    expect(message).toBe(
+      'No skills installed for this agent while excluding unique',
+    )
+  })
+
   it('shows the generic agent empty state when an agent is selected and no type filter narrows it', () => {
     // Arrange: a selected agent with the all type filter (no narrowing).
     // Act

--- a/src/renderer/src/components/skills/skillsListHelpers.ts
+++ b/src/renderer/src/components/skills/skillsListHelpers.ts
@@ -20,6 +20,7 @@ const SKILL_TYPE_FILTER_LABELS = {
   local: 'local',
   gstack: 'G-Stack',
   orphan: 'orphan',
+  unique: 'unique',
 } as const satisfies Record<SkillTypeFilter, string>
 
 const EXCLUDED_SKILL_TYPE_FILTER_LABELS = {
@@ -27,6 +28,7 @@ const EXCLUDED_SKILL_TYPE_FILTER_LABELS = {
   local: 'local',
   gstack: 'G-Stack',
   orphan: 'orphan',
+  unique: 'unique',
 } as const satisfies Record<ExcludableSkillTypeFilter, string>
 
 /**
@@ -108,7 +110,7 @@ function formatSelectedSourcesPhrase(selectedSources: RepositoryId[]): string {
  * - When `selectedSources` is non-empty: `"No skills from <repo>"` (or
  *   `"the selected repositories"` when more than one repo is selected)
  * - When `selectedAgentId` is set AND `skillTypeFilter !== 'all'`:
- *   `"No <symlinked|local|G-Stack|orphan> skills for this agent"`
+ *   `"No <symlinked|local|G-Stack|orphan|unique> skills for this agent"`
  * - When only `selectedAgentId` is set: `"No skills installed for this agent"`
  * - Otherwise: `"No skills match your filter"`
  * Active excludes append `" while excluding <types>"` to whichever branch wins.

--- a/src/renderer/src/redux/selectors.test.ts
+++ b/src/renderer/src/redux/selectors.test.ts
@@ -176,6 +176,51 @@ const makeSkill = (
     : {}),
 })
 
+/**
+ * Build a skill spanning several agent slots — `makeSkill` only models one
+ * agent, but the `'unique'` filter is about availability ACROSS agents, so
+ * these tests need multi-slot skills. Each slot defaults to a valid symlink.
+ * @param name - Skill name; also seeds the per-slot link/target paths.
+ * @param slots - Per-agent slot specs (status defaults to `'valid'`, isLocal to false).
+ * @param options.isOrphan - Mark the skill orphan (and non-source) to mirror scanner output.
+ * @returns A `Skill` with one `symlinks` entry per slot; `symlinkCount` counts valid non-local slots; `isSource` is `true` unless `isOrphan`.
+ * @example
+ * makeMultiSlotSkill('u', [{ agentId: 'cursor' }, { agentId: 'codex' }]) // 2 valid slots
+ */
+const makeMultiSlotSkill = (
+  name: string,
+  slots: {
+    agentId: AgentId
+    isLocal?: boolean
+    status?: SymlinkInfo['status']
+  }[],
+  options: { isOrphan?: boolean } = {},
+): Skill => {
+  const symlinks: SymlinkInfo[] = slots.map((slot) => {
+    const isLocal = slot.isLocal ?? false
+    return {
+      agentId: slot.agentId as SymlinkInfo['agentId'],
+      agentName: slot.agentId as SymlinkInfo['agentName'],
+      linkPath: `/home/user/.${slot.agentId}/skills/${name}`,
+      targetPath: isLocal
+        ? `/home/user/.${slot.agentId}/skills/${name}`
+        : `/home/user/.agents/skills/${name}`,
+      status: slot.status ?? 'valid',
+      isLocal,
+    }
+  })
+  return {
+    name,
+    description: `${name} skill`,
+    path: `/home/user/.agents/skills/${name}`,
+    symlinkCount: symlinks.filter((s) => s.status === 'valid' && !s.isLocal)
+      .length,
+    symlinks,
+    isSource: !options.isOrphan,
+    isOrphan: options.isOrphan ?? false,
+  }
+}
+
 describe('selectFilteredSkillCount', () => {
   it('counts the visible Installed rows that survived the active filters', () => {
     // Arrange — two unfiltered source skills, both visible
@@ -705,7 +750,7 @@ describe('selectFilteredSkills', () => {
     expect(result).toHaveLength(0)
   })
 
-  it.each(['all', 'symlinked', 'local', 'gstack', 'orphan'] as const)(
+  it.each(['all', 'symlinked', 'local', 'gstack', 'orphan', 'unique'] as const)(
     'ignores the skillTypeFilter (%s) in the SourceCard view where source-only filtering rules',
     (skillTypeFilter) => {
       // Arrange — SourceCard view applies its own source-only filter, so
@@ -724,6 +769,142 @@ describe('selectFilteredSkills', () => {
       expect(result.map((s) => s.name)).toEqual(['task'])
     },
   )
+
+  it('shows a skill that is a real folder in only the selected agent under the Unique filter', () => {
+    // Arrange — one real-folder slot, one agent → available to exactly one agent.
+    const skills = [makeSkill('solo-local', 'claude-code', true)]
+    const state = buildState({
+      skills,
+      selectedAgentId: 'claude-code',
+      skillTypeFilter: 'unique',
+    })
+
+    // Act
+    const result = selectFilteredSkills(state as never)
+
+    // Assert
+    expect(result.map((s) => s.name)).toEqual(['solo-local'])
+  })
+
+  it('shows a lone valid symlink under Unique because Unique asks "how many agents", not "is it a symlink"', () => {
+    // Arrange — single valid symlink (isLocal false) in only the selected agent.
+    const skills = [makeSkill('solo-symlink', 'cursor', false)]
+    const state = buildState({
+      skills,
+      selectedAgentId: 'cursor',
+      skillTypeFilter: 'unique',
+    })
+
+    // Act
+    const result = selectFilteredSkills(state as never)
+
+    // Assert
+    expect(result.map((s) => s.name)).toEqual(['solo-symlink'])
+  })
+
+  it('hides a non-symlink skill duplicated across two agents, even viewed from an owning agent (Unique is not Local)', () => {
+    // Arrange — two valid real-folder slots → available to 2 agents → NOT unique,
+    // though every slot is Local. Viewed from claude-code, which owns one copy.
+    const skills = [
+      makeMultiSlotSkill('dup-local', [
+        { agentId: 'claude-code', isLocal: true },
+        { agentId: 'cursor', isLocal: true },
+      ]),
+    ]
+    const state = buildState({
+      skills,
+      selectedAgentId: 'claude-code',
+      skillTypeFilter: 'unique',
+    })
+
+    // Act
+    const result = selectFilteredSkills(state as never)
+
+    // Assert
+    expect(result).toHaveLength(0)
+  })
+
+  it('hides a universal skill that is valid-symlinked into many agents under Unique', () => {
+    // Arrange — one source, valid symlinks in three agents → 3 valid slots.
+    const skills = [
+      makeMultiSlotSkill('universal', [
+        { agentId: 'claude-code' },
+        { agentId: 'cursor' },
+        { agentId: 'codex' },
+      ]),
+    ]
+    const state = buildState({
+      skills,
+      selectedAgentId: 'claude-code',
+      skillTypeFilter: 'unique',
+    })
+
+    // Act
+    const result = selectFilteredSkills(state as never)
+
+    // Assert
+    expect(result).toHaveLength(0)
+  })
+
+  it('hides a skill whose only valid slot belongs to a different agent than the one in view', () => {
+    // Arrange — unique to cursor, but the list is filtered for claude-code.
+    const skills = [makeSkill('cursor-only', 'cursor', true)]
+    const state = buildState({
+      skills,
+      selectedAgentId: 'claude-code',
+      skillTypeFilter: 'unique',
+    })
+
+    // Act
+    const result = selectFilteredSkills(state as never)
+
+    // Assert
+    expect(result).toHaveLength(0)
+  })
+
+  it('treats a skill as Unique when its sole valid slot sits beside a broken slot in another agent', () => {
+    // Arrange — valid in claude-code, broken symlink in cursor. A broken slot is
+    // not "available", so the skill is still reachable by exactly one agent.
+    const skills = [
+      makeMultiSlotSkill('one-valid-one-broken', [
+        { agentId: 'claude-code', isLocal: true, status: 'valid' },
+        { agentId: 'cursor', isLocal: false, status: 'broken' },
+      ]),
+    ]
+    const state = buildState({
+      skills,
+      selectedAgentId: 'claude-code',
+      skillTypeFilter: 'unique',
+    })
+
+    // Act
+    const result = selectFilteredSkills(state as never)
+
+    // Assert
+    expect(result.map((s) => s.name)).toEqual(['one-valid-one-broken'])
+  })
+
+  it('hides an orphan skill under Unique because orphans carry only broken slots (available to no agent)', () => {
+    // Arrange — orphan: a broken slot only, zero valid slots anywhere.
+    const skills = [
+      makeMultiSlotSkill(
+        'orphan-skill',
+        [{ agentId: 'claude-code', isLocal: false, status: 'broken' }],
+        { isOrphan: true },
+      ),
+    ]
+    const state = buildState({
+      skills,
+      selectedAgentId: 'claude-code',
+      skillTypeFilter: 'unique',
+    })
+
+    // Act
+    const result = selectFilteredSkills(state as never)
+
+    // Assert
+    expect(result).toHaveLength(0)
+  })
 
   it('matches a repo-scope query against the skill repository slug', () => {
     // Arrange

--- a/src/renderer/src/redux/selectors.ts
+++ b/src/renderer/src/redux/selectors.ts
@@ -99,6 +99,23 @@ function matchesSkillTypeFilter(
       () =>
         skill.isOrphan === true && skill.symlinks.some(hasSelectedAgentSlot),
     )
+    .with('unique', () => {
+      // "Available to exactly one agent." Count slots the scanner marked usable:
+      // status 'valid' covers both a working symlink and a present real folder
+      // (see symlinkChecker), so a universal skill (many valid symlinks) and a
+      // skill duplicated across agents (>=2 valid slots) are both excluded —
+      // exactly the distinction from 'local'. The agentId equality below
+      // intentionally subsumes the hasSelectedAgentSlot guard the sibling arms
+      // use: if the lone valid slot belongs to the selected agent, the skill is
+      // by definition in this agent's view, so a separate slot guard would be
+      // redundant. Do not add one.
+      const validSlots = skill.symlinks.filter(
+        (slot) => slot.status === 'valid',
+      )
+      return (
+        validSlots.length === 1 && validSlots[0].agentId === selectedAgentId
+      )
+    })
     .exhaustive()
 }
 

--- a/src/renderer/src/redux/slices/uiSlice.test.ts
+++ b/src/renderer/src/redux/slices/uiSlice.test.ts
@@ -1450,7 +1450,7 @@ describe('uiSlice source filter (selectedSources)', () => {
 })
 
 describe('getAvailableExcludeTypes offered subtractions per include mode', () => {
-  it('offers G-Stack and orphan as the only valid excludes while including symlinked skills', async () => {
+  it('offers G-Stack, orphan, and unique as valid excludes while including symlinked skills', async () => {
     // Arrange
     const { getAvailableExcludeTypes } = await import('./uiSlice')
 
@@ -1458,17 +1458,40 @@ describe('getAvailableExcludeTypes offered subtractions per include mode', () =>
     const offered = getAvailableExcludeTypes('symlinked')
 
     // Assert
-    expect(offered).toEqual(['gstack', 'orphan'])
+    expect(offered).toEqual(['gstack', 'orphan', 'unique'])
   })
 
-  it('offers only G-Stack as a valid exclude while including orphan skills', async () => {
+  it('offers symlinked, local, and G-Stack — but not orphan — as excludes while including unique skills', async () => {
+    // Arrange
+    const { getAvailableExcludeTypes } = await import('./uiSlice')
+
+    // Act
+    const offered = getAvailableExcludeTypes('unique')
+
+    // Assert — orphan omitted: an orphan skill has no valid slots, so it can
+    // never also be unique (orphan ∩ unique = ∅).
+    expect(offered).toEqual(['symlinked', 'local', 'gstack'])
+  })
+
+  it('offers G-Stack and unique as the valid excludes while including local skills', async () => {
+    // Arrange
+    const { getAvailableExcludeTypes } = await import('./uiSlice')
+
+    // Act
+    const offered = getAvailableExcludeTypes('local')
+
+    // Assert
+    expect(offered).toEqual(['gstack', 'unique'])
+  })
+
+  it('does NOT offer unique as an exclude while including orphan skills (orphans are never unique)', async () => {
     // Arrange
     const { getAvailableExcludeTypes } = await import('./uiSlice')
 
     // Act
     const offered = getAvailableExcludeTypes('orphan')
 
-    // Assert
+    // Assert — unchanged from before unique existed; guards orphan ∩ unique = ∅.
     expect(offered).toEqual(['gstack'])
   })
 
@@ -1484,6 +1507,60 @@ describe('getAvailableExcludeTypes offered subtractions per include mode', () =>
 
     // Assert
     expect(store.getState().ui.excludedSkillTypeFilters).toEqual(['orphan'])
+  })
+
+  it('lets the user exclude unique skills while the local include mode is active', async () => {
+    // Arrange
+    const store = await createTestStore()
+    const { setSkillTypeFilter, toggleExcludedSkillTypeFilter } =
+      await import('./uiSlice')
+    store.dispatch(setSkillTypeFilter('local'))
+
+    // Act
+    store.dispatch(toggleExcludedSkillTypeFilter('unique'))
+
+    // Assert
+    expect(store.getState().ui.excludedSkillTypeFilters).toEqual(['unique'])
+  })
+
+  it('refuses to exclude unique while the orphan include mode is active', async () => {
+    // Arrange
+    const store = await createTestStore()
+    const { setSkillTypeFilter, toggleExcludedSkillTypeFilter } =
+      await import('./uiSlice')
+    store.dispatch(setSkillTypeFilter('orphan'))
+
+    // Act — orphan ∩ unique = ∅, so excluding unique here must be a no-op.
+    store.dispatch(toggleExcludedSkillTypeFilter('unique'))
+
+    // Assert
+    expect(store.getState().ui.excludedSkillTypeFilters).toEqual([])
+  })
+
+  it('drops a now-invalid unique exclude when the include filter narrows to orphan', async () => {
+    // Arrange — exclude unique under the permissive "all" include, then narrow.
+    const store = await createTestStore()
+    const { setSkillTypeFilter, toggleExcludedSkillTypeFilter } =
+      await import('./uiSlice')
+    store.dispatch(toggleExcludedSkillTypeFilter('unique'))
+
+    // Act — narrowing to orphan must prune unique (unavailable for orphan).
+    store.dispatch(setSkillTypeFilter('orphan'))
+
+    // Assert
+    expect(store.getState().ui.excludedSkillTypeFilters).toEqual([])
+  })
+
+  it('accepts unique as the active include filter', async () => {
+    // Arrange
+    const store = await createTestStore()
+    const { setSkillTypeFilter } = await import('./uiSlice')
+
+    // Act
+    store.dispatch(setSkillTypeFilter('unique'))
+
+    // Assert
+    expect(store.getState().ui.skillTypeFilter).toBe('unique')
   })
 })
 

--- a/src/renderer/src/redux/slices/uiSlice.ts
+++ b/src/renderer/src/redux/slices/uiSlice.ts
@@ -40,13 +40,19 @@ export type BookmarkForDetail = BookmarkedSkill & { isInstalled: boolean }
 
 /** Sort direction for the skill-name sort (A→Z vs Z→A). */
 export type SortOrder = 'asc' | 'desc'
-/** Positive skill-type include mode for the agent-view list filter. */
+/**
+ * Positive skill-type include mode for the agent-view list filter.
+ * `'unique'` = available to exactly one agent (exactly one `status: 'valid'`
+ * slot across all agents); orthogonal to `'local'`, which only asks whether the
+ * slot is a real folder vs a symlink. See `matchesSkillTypeFilter`.
+ */
 export type SkillTypeFilter =
   | 'all'
   | 'symlinked'
   | 'local'
   | 'gstack'
   | 'orphan'
+  | 'unique'
 /** SkillTypeFilter minus `'all'` — the type modes that can be subtracted as excludes. */
 export type ExcludableSkillTypeFilter = Exclude<SkillTypeFilter, 'all'>
 /**
@@ -293,19 +299,25 @@ export const executeSyncAction = createAsyncThunk(
  * @param skillTypeFilter - The active positive include mode.
  * @returns Exclude filters that can subtract at least one possible row.
  * @example
- * getAvailableExcludeTypes('local') // => ['gstack']
+ * getAvailableExcludeTypes('local') // => ['gstack', 'unique']
  */
 export function getAvailableExcludeTypes(
   skillTypeFilter: SkillTypeFilter,
 ): ExcludableSkillTypeFilter[] {
-  // SkillTypeFilter has five include modes; new modes must declare valid exclusions here.
+  // SkillTypeFilter has six include modes; new modes must declare valid exclusions here.
+  // 'unique' (available to exactly one agent) is orthogonal to symlink-shape and
+  // management-status, so it co-occurs with — and can subtract from — every mode
+  // EXCEPT 'orphan': orphan skills carry zero 'valid' slots (skillScanner builds
+  // them broken/missing), so orphan ∩ unique = ∅. The relation is symmetric, so
+  // 'unique' likewise omits 'orphan' from its own exclude list.
   return match(skillTypeFilter)
     .returnType<ExcludableSkillTypeFilter[]>()
-    .with('all', () => ['symlinked', 'local', 'gstack', 'orphan'])
-    .with('symlinked', () => ['gstack', 'orphan'])
-    .with('local', () => ['gstack'])
-    .with('gstack', () => ['symlinked', 'local', 'orphan'])
+    .with('all', () => ['symlinked', 'local', 'gstack', 'orphan', 'unique'])
+    .with('symlinked', () => ['gstack', 'orphan', 'unique'])
+    .with('local', () => ['gstack', 'unique'])
+    .with('gstack', () => ['symlinked', 'local', 'orphan', 'unique'])
     .with('orphan', () => ['gstack'])
+    .with('unique', () => ['symlinked', 'local', 'gstack'])
     .exhaustive()
 }
 


### PR DESCRIPTION
## What

Adds a **Unique** option to the agent-view skill-type filter (issue #203). Unique surfaces skills available to **exactly one agent** — deliberately orthogonal to **Local** (which only asks "is it a symlink?").

## How

A skill matches `unique` when it has exactly one `status: 'valid'` symlink slot **and** that slot's `agentId` equals the selected agent. Because `status: 'valid'` covers both a working symlink and a present real folder, the count reflects "how many agents can use it," per the spec:

- Real folder in one agent's dir → **Unique**
- Same skill copied across ≥2 agents → **not** Unique
- Universal skill (one folder, ~13 agents) → **not** Unique

The filter is **agent-view-only** (ignored in source view), so uniqueness is anchored to the viewed agent. `orphan ∩ unique = ∅` because orphans carry only `broken` slots.

## Changes

- `selectors.ts` — `'unique'` arm in `matchesSkillTypeFilter` (+ 7 predicate tests)
- `uiSlice.ts` — `'unique'` in the `SkillTypeFilter` union + `getAvailableExcludeTypes` exclude matrix (+ tests)
- `MainContent.tsx` — Unique picker option: violet dot + native `title` hint ("Available to only one agent")
- `skillsListHelpers.ts` — empty-state + exclude labels
- `DESIGN.md` — Unique = Violet status color; new "Tooltips — styled vs native" rule (native `title` inside Radix menus, shadcn `Tooltip` on triggers)

## Scope notes

- **A global "unique across all agents" list is out of scope** — this implements the agent-scoped filter the issue's acceptance criteria describe.
- Test fixtures keep the existing `as` / `as never` branded-type casts for consistency with the surrounding `makeSkill` helper; repo-wide removal is owned by the `migrate-to-shoehorn` migration, not this PR.

## Verification

- `pnpm validate`: **2288 tests pass**, typecheck / fallow / storybook clean (lint fails only on the pre-existing `.agents/skills/skills-cli-sync/reconcile-agents.mjs` project-service quirk, untouched here; all 8 changed code files lint clean)
- `pnpm test:e2e`: 59 pass + 1 known parallel-load flake (`undo-toast` — green in isolation, unrelated to this diff)
- design-review: violet dot is ~130° hue-separated from Local's emerald (`oklch 293.5°` vs `163.2°`); both Include + Exclude sections render the option; tooltip decision validated and folded into DESIGN.md

Closes #203


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 「Unique」スキルフィルタを追加。選択中のエージェントにのみ属するスキルを絞り込めます。
  * スキルフィルタのUIに説明ツールチップを追加し、各フィルタオプションの機能を明確化しました。

* **ドキュメント**
  * デザインドキュメントにツールチップの使用ルールとUnique スキル型の定義を追加しました。

* **テスト**
  * 新フィルタ機能の包括的なテストカバレッジを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->