### PR TITLE
feat(dashboard): back Activity Timeline with a persisted event log (#178)

### DIFF
--- a/.storybook/storybook-utils.tsx
+++ b/.storybook/storybook-utils.tsx
@@ -546,6 +546,10 @@ export function installStorybookElectronMock(): void {
       },
       onChanged: () => cleanup,
     },
+    activity: {
+      list: async () => [],
+      onChanged: () => cleanup,
+    },
     folder: {
       revealInFinder: async () => ({ ok: true }),
       openInTerminal: async () => ({ ok: true }),

--- a/docs/activity-log.md
+++ b/docs/activity-log.md
@@ -1,0 +1,128 @@
+# Activity Log (Activity Timeline)
+
+The **activity log** is an append-only, cross-session record of skill mutations
+(add / remove / sync). The dashboard's **Activity Timeline** widget renders it.
+
+This implements [#178](https://github.com/laststance/skills-desktop/issues/178).
+It replaces the widget's earlier placeholder, which could only show the _last
+sync's_ per-item results (read from `uiSlice.syncResult`) and was wiped on
+restart.
+
+> **Status: dark.** The whole feature is gated behind
+> `FEATURE_FLAGS.ENABLE_DASHBOARD_EXPERIMENTAL` (`src/shared/featureFlags.ts`),
+> which is **off**. With the flag off: the widget is hidden from the picker
+> (`registry.ts` / `WidgetPicker.tsx`), the renderer sync hook is a no-op, and
+> the main-process recorder is a no-op. Shipping this PR therefore changes **zero
+> production behavior**. See [Acceptance criteria](#acceptance-criteria).
+
+## Architecture
+
+Persistence is **owned by the main process**, mirroring `settings.ts`. The
+renderer never touches the file; it caches a copy in Redux and converges via an
+IPC broadcast.
+
+```
+ mutation handler (skills.ts / sync.ts)
+        │  recordActivityEvents([...])         ← flag-gated, never throws
+        ▼
+ src/main/ipc/activity.ts
+        │  appendActivityEvents(inputs)         broadcastTypedEvent('activity:changed', log)
+        ▼                                                   │
+ src/main/services/activityLog.ts                          │ (to every window)
+        │  userData/activity-log.json (atomic temp+rename)  │
+        ▼                                                   ▼
+ disk  ◀── loadActivityLog() at boot          preload  window.electron.activity
+                                                        │  .list()      → activity:list (hydrate)
+                                                        │  .onChanged() → activity:changed (subscribe)
+                                                        ▼
+                                              useActivitySync() → activitySlice → widget
+```
+
+### Files
+
+| Layer        | File                                                        | Role                                                                  |
+| ------------ | ----------------------------------------------------------- | --------------------------------------------------------------------- |
+| Shared       | `src/shared/activityLog.ts`                                 | Zod `ActivityEventSchema`, types, `ActivityListOptions`               |
+| Shared       | `src/shared/constants.ts`                                   | `MAX_ACTIVITY_EVENTS = 200`                                           |
+| Main service | `src/main/services/activityLog.ts`                          | Load / cache / `appendActivityEvents` (atomic) / `listActivityEvents` |
+| Main IPC     | `src/main/ipc/activity.ts`                                  | `recordActivityEvents` (gate + broadcast) + `activity:list` handler   |
+| IPC contract | `ipc-channels.ts` / `ipc-contract.ts` / `ipc-schemas.ts`    | `activity:list`, `activity:changed` wiring                            |
+| Emit sites   | `src/main/ipc/skills.ts`, `src/main/ipc/sync.ts`            | Call `recordActivityEvents` after a successful mutation               |
+| Preload      | `src/preload/index.ts`                                      | `window.electron.activity.{list,onChanged}`                           |
+| Renderer     | `redux/slices/activitySlice.ts`, `hooks/useActivitySync.ts` | Redux cache + sync hook                                               |
+| Widget       | `components/dashboard/widgets/ActivityTimelineWidget.tsx`   | Render newest-first                                                   |
+
+## Event shape
+
+A deliberately **flat** record (not a discriminated union) so every row renders
+through one code path — `type` only selects the icon + accent color.
+
+```ts
+interface ActivityEvent {
+  id: string // uuid, stamped in main; React list key
+  timestamp: string // ISO-8601, main-process clock
+  type: 'created' | 'removed' | 'synced' | 'renamed'
+  skillName: string // a skill name, or a scope label like 'Sync'
+  agentName?: string // present for per-agent events; omitted for sync summaries
+  detail?: string // e.g. '10 created · 1 replaced · 5 skipped'
+}
+```
+
+Emit sites pass `ActivityEventInput` (`Omit<ActivityEvent, 'id' | 'timestamp'>`);
+the main process stamps `id` (uuid) and `timestamp`.
+
+## Recording rules
+
+`recordActivityEvents` is **best-effort by contract**:
+
+1. **Flag-gated** — returns immediately unless `ENABLE_DASHBOARD_EXPERIMENTAL`.
+2. **Never throws** — wraps the write in try/catch + `console.warn`. A skill was
+   already added/removed/synced on disk before we log it; a logging failure must
+   not turn a successful mutation into a reported error.
+3. **One atomic write per batch** — `appendActivityEvents` takes an array and
+   writes once. Callers that touch many skill×agent pairs must summarize.
+
+### Emit sites
+
+| Mutation                | Handler                 | Events                                                                                                                         |
+| ----------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Add to agents (symlink) | `skills:createSymlinks` | one `created` per successful agent                                                                                             |
+| Copy to agents          | `skills:copyToAgents`   | one `created` per successful agent                                                                                             |
+| Delete skill            | `skills:deleteSkill`    | one `removed` (detail = cascaded agent links)                                                                                  |
+| Bulk delete             | `skills:deleteSkills`   | one `removed` per deleted skill, batched into one write                                                                        |
+| Sync                    | `sync:execute`          | exactly one `synced` **summary** (counts in `detail`) — never per-item, or a sync touching dozens of pairs would flood the log |
+
+## Known gap: `renamed` has no emit site
+
+`renamed` is in the schema and the widget renders it, but **nothing emits it**:
+the app currently has no skill-rename feature (verified — no rename handler
+exists). It is defined now so that when a rename feature lands it flows through
+with zero schema/UI changes. This is an honest documented gap, not a stub that
+pretends to work.
+
+## Persistence
+
+- File: `app.getPath('userData')/activity-log.json` (a newest-first JSON array).
+- Capped ring buffer: trimmed to `MAX_ACTIVITY_EVENTS` (200) on every append;
+  older events fall off the tail.
+- Atomic write: temp file + `fs.rename`, so a crash mid-write can't corrupt it.
+- Tolerant load: missing file (first launch) → `[]` silently; malformed file →
+  `[]` + a `console.warn`. Activity history is non-critical and must never block
+  startup.
+
+## Acceptance criteria
+
+From #178:
+
+1. **Timeline shows events across operations + persists across restarts** — ✅
+   (`activity-log.json` + `loadActivityLog` at boot; covered by
+   `activityLog.test.ts` "persistence across restarts").
+2. **Add / remove / sync / rename produce entries** — ✅ for add/remove/sync (see
+   emit sites). `renamed` is schema- and UI-complete but unemitted — see
+   [Known gap](#known-gap-renamed-has-no-emit-site).
+3. **Widget promoted out of the experimental flag** — ⏸ **deferred to user
+   sign-off.** This PR builds the full feature _behind_ the off flag so the
+   widget's data path can be reviewed and tested without exposing it. Flipping
+   `ENABLE_DASHBOARD_EXPERIMENTAL` is the one outward-facing change and is held
+   back deliberately (same pattern as the deferred marketplace work). When the
+   flag flips, the recorder, the sync hook, and the widget activate together.

--- a/docs/activity-log.md
+++ b/docs/activity-log.md
@@ -21,7 +21,7 @@ Persistence is **owned by the main process**, mirroring `settings.ts`. The
 renderer never touches the file; it caches a copy in Redux and converges via an
 IPC broadcast.
 
-```
+```text
  mutation handler (skills.ts / sync.ts)
         │  recordActivityEvents([...])         ← flag-gated, never throws
         ▼

--- a/src/main/ipc/activity.ts
+++ b/src/main/ipc/activity.ts
@@ -1,0 +1,48 @@
+import {
+  appendActivityEvents,
+  listActivityEvents,
+} from '@/main/services/activityLog'
+import type { ActivityEventInput } from '@/shared/activityLog'
+import { FEATURE_FLAGS } from '@/shared/featureFlags'
+import { IPC_CHANNELS } from '@/shared/ipc-channels'
+
+import { typedHandle } from './typedHandle'
+import { broadcastTypedEvent } from './typedSend'
+
+/**
+ * Persist one or more activity events and broadcast the new log to every open
+ * window. Called by the sync + skills mutation handlers after a successful
+ * on-disk change. Two safety properties make it safe to call from any handler:
+ *  - **Dark by flag:** a no-op unless `ENABLE_DASHBOARD_EXPERIMENTAL` is on, so
+ *    shipping with the flag off adds zero production behavior.
+ *  - **Never throws:** a logging failure (disk full, etc.) is swallowed — the
+ *    triggering skill was already added/removed/synced on disk, so the mutation
+ *    must still report success.
+ * @param inputs - Events to record (the main process stamps `id` + `timestamp`).
+ * @returns Resolves once persisted + broadcast, or immediately when gated off / empty / on failure.
+ * @example
+ * await recordActivityEvents([{ type: 'created', skillName: 'azure-ai', agentName: 'Claude Code' }])
+ */
+export async function recordActivityEvents(
+  inputs: ActivityEventInput[],
+): Promise<void> {
+  if (!FEATURE_FLAGS.ENABLE_DASHBOARD_EXPERIMENTAL) return
+  if (inputs.length === 0) return
+  try {
+    const next = await appendActivityEvents(inputs)
+    broadcastTypedEvent(IPC_CHANNELS.ACTIVITY_CHANGED, next)
+  } catch (err) {
+    console.warn('[activity-log] failed to record events:', err)
+  }
+}
+
+/**
+ * Register the `activity:list` query handler so renderers can hydrate the
+ * timeline on mount. Updates arrive separately via the `activity:changed`
+ * broadcast emitted from {@link recordActivityEvents}.
+ */
+export function registerActivityHandlers(): void {
+  typedHandle(IPC_CHANNELS.ACTIVITY_LIST, (_event, options) =>
+    listActivityEvents(options),
+  )
+}

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -1,3 +1,4 @@
+import { registerActivityHandlers } from './activity'
 import { registerAgentsHandlers } from './agents'
 import { registerCliCommandHandlers } from './cliCommand'
 import { registerFilesHandlers } from './files'
@@ -26,6 +27,7 @@ export function registerAllHandlers(): void {
   registerFilesHandlers()
   registerUpdateHandlers()
   registerSyncHandlers()
+  registerActivityHandlers()
   registerShellHandlers()
   registerSettingsHandlers()
   registerFolderHandlers()

--- a/src/main/ipc/ipc-schemas.ts
+++ b/src/main/ipc/ipc-schemas.ts
@@ -333,6 +333,17 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
     }),
   ]),
 
+  // Activity timeline — optional paging options. Mirrors `sync:preview`'s
+  // 1-arg-possibly-undefined shape so typedInvoke can always forward the arg.
+  'activity:list': z.tuple([
+    z
+      .object({
+        limit: z.number().int().positive().optional(),
+        offset: z.number().int().nonnegative().optional(),
+      })
+      .optional(),
+  ]),
+
   // Shell — restrict to http/https to prevent opening arbitrary URI schemes
   'shell:openExternal': z.tuple([
     z.url().refine((u) => /^https?:\/\//i.test(u), {

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -46,6 +46,7 @@ import type {
   SkillName,
 } from '@/shared/types'
 
+import { recordActivityEvents } from './activity'
 import { typedHandle } from './typedHandle'
 import { typedSend } from './typedSend'
 
@@ -977,6 +978,17 @@ export function registerSkillsHandlers(): void {
         skillPath,
         options.filesystemIdentity,
       )
+      // Activity log (dark unless the experimental flag is on; never throws).
+      await recordActivityEvents([
+        {
+          type: 'removed',
+          skillName,
+          detail:
+            cascadeAgents.length > 0
+              ? `${cascadeAgents.length} agent link${cascadeAgents.length === 1 ? '' : 's'}`
+              : undefined,
+        },
+      ])
       return {
         success: true,
         symlinksRemoved,
@@ -1047,6 +1059,17 @@ export function registerSkillsHandlers(): void {
           })
         }
       }
+
+      // One `removed` event per successfully-deleted skill, batched into a
+      // single atomic write (dark unless the experimental flag is on).
+      await recordActivityEvents(
+        results
+          .filter((item) => item.outcome === 'deleted')
+          .map((item) => ({
+            type: 'removed' as const,
+            skillName: item.skillName,
+          })),
+      )
 
       const result: BulkDeleteResult = { items: results }
       return result
@@ -1172,6 +1195,9 @@ export function registerSkillsHandlers(): void {
     // still constrains each constructed linkPath to its target agent dir.
     validatePath(skillPath, getAllowedBases())
     let created = 0
+    // Names of agents that got the symlink — emitted as `created` activity
+    // events after the loop (one atomic write, dark unless the flag is on).
+    const createdAgentNames: string[] = []
     const failures: Array<{
       agentId: (typeof agentIds)[number]
       error: string
@@ -1201,6 +1227,7 @@ export function registerSkillsHandlers(): void {
         // Atomic: attempt symlink directly, handle EEXIST
         await fs.symlink(skillPath, linkPath)
         created++
+        createdAgentNames.push(agent.name)
       } catch (error) {
         if (errorCode(error) === 'EEXIST') {
           failures.push({ agentId, error: 'Already exists' })
@@ -1209,6 +1236,15 @@ export function registerSkillsHandlers(): void {
         }
       }
     }
+
+    // One `created` event per agent the skill was symlinked into.
+    await recordActivityEvents(
+      createdAgentNames.map((agentName) => ({
+        type: 'created' as const,
+        skillName,
+        agentName,
+      })),
+    )
 
     return { success: failures.length === 0, created, failures }
   })
@@ -1227,6 +1263,9 @@ export function registerSkillsHandlers(): void {
     const { skillName, sourcePath, targetAgentIds } = options
     validatePath(sourcePath, getAllowedBases())
     let copied = 0
+    // Names of agents that received a copy — emitted as `created` activity
+    // events after the loop (one atomic write, dark unless the flag is on).
+    const copiedAgentNames: string[] = []
     const failures: Array<{
       agentId: (typeof targetAgentIds)[number]
       error: string
@@ -1330,10 +1369,20 @@ export function registerSkillsHandlers(): void {
           })
         }
         copied++
+        copiedAgentNames.push(agent.name)
       } catch (error) {
         failures.push({ agentId, error: extractErrorMessage(error) })
       }
     }
+
+    // One `created` event per agent the skill was copied into.
+    await recordActivityEvents(
+      copiedAgentNames.map((agentName) => ({
+        type: 'created' as const,
+        skillName,
+        agentName,
+      })),
+    )
 
     return { success: failures.length === 0, copied, failures }
   })

--- a/src/main/ipc/sync.ts
+++ b/src/main/ipc/sync.ts
@@ -1,6 +1,7 @@
 import { syncExecute, syncPreview } from '@/main/services/syncService'
 import { IPC_CHANNELS } from '@/shared/ipc-channels'
 
+import { recordActivityEvents } from './activity'
 import { typedHandle } from './typedHandle'
 
 /**
@@ -12,6 +13,16 @@ export function registerSyncHandlers(): void {
   })
 
   typedHandle(IPC_CHANNELS.SYNC_EXECUTE, async (_, options) => {
-    return syncExecute(options)
+    const result = await syncExecute(options)
+    // One summary event per run — a sync can touch dozens of skill×agent
+    // pairs, so per-item events would flood the log. The counts go in `detail`.
+    await recordActivityEvents([
+      {
+        type: 'synced',
+        skillName: 'Sync',
+        detail: `${result.created} created · ${result.replaced} replaced · ${result.skipped} skipped`,
+      },
+    ])
+    return result
   })
 }

--- a/src/main/services/activityLog.test.ts
+++ b/src/main/services/activityLog.test.ts
@@ -183,6 +183,66 @@ describe('activity log persistence', () => {
         readFile(join(userDataDir, 'activity-log.json'), 'utf8'),
       ).rejects.toThrow()
     })
+
+    it('keeps every event when many appends race instead of dropping all but the last', async () => {
+      // Arrange
+      const { appendActivityEvents, getActivityLog } =
+        await importFreshActivityLog()
+
+      // Act: fire 20 appends at once WITHOUT awaiting between them — the exact
+      // interleaving where a naive read-modify-write lets each call read the
+      // same starting log and the last writer clobbers the other 19.
+      await Promise.all(
+        Array.from({ length: 20 }, async (_unused, index) =>
+          appendActivityEvents([
+            { type: 'created', skillName: `concurrent-${index}` },
+          ]),
+        ),
+      )
+
+      // Assert: all 20 distinct events survived in both the cache and on disk.
+      const log = getActivityLog()
+      expect(log).toHaveLength(20)
+      expect(new Set(log.map((event) => event.skillName)).size).toBe(20)
+      const onDisk = JSON.parse(
+        await readFile(join(userDataDir, 'activity-log.json'), 'utf8'),
+      )
+      expect(onDisk).toHaveLength(20)
+    })
+
+    it('keeps the queue alive so an append after a failed one still persists', async () => {
+      // Arrange: point userData at a regular FILE so the first append's mkdir
+      // rejects — without the chain's error-swallow this would wedge every
+      // later append.
+      const { appendActivityEvents } = await importFreshActivityLog()
+      const blockingFile = join(userDataDir, 'blocker')
+      await writeFile(blockingFile, 'x', 'utf8')
+      electronUserData.dir = blockingFile
+
+      // Act: the first append fails...
+      await expect(
+        appendActivityEvents([{ type: 'created', skillName: 'doomed' }]),
+      ).rejects.toThrow()
+
+      // ...then a real dir is restored and a second append runs.
+      electronUserData.dir = userDataDir
+      const log = await appendActivityEvents([
+        { type: 'created', skillName: 'after-failure' },
+      ])
+
+      // Assert: the post-failure append succeeded and persisted (queue not wedged).
+      expect(log.some((event) => event.skillName === 'after-failure')).toBe(
+        true,
+      )
+      const onDisk = JSON.parse(
+        await readFile(join(userDataDir, 'activity-log.json'), 'utf8'),
+      )
+      expect(
+        onDisk.some(
+          (event: { skillName: string }) => event.skillName === 'after-failure',
+        ),
+      ).toBe(true)
+    })
   })
 
   describe('listActivityEvents', () => {

--- a/src/main/services/activityLog.test.ts
+++ b/src/main/services/activityLog.test.ts
@@ -1,0 +1,238 @@
+import { mkdtempSync, realpathSync } from 'node:fs'
+import { readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+import { MAX_ACTIVITY_EVENTS } from '@/shared/constants'
+
+import type * as ActivityLogModule from './activityLog'
+
+// Mutable userData dir handed to `app.getPath('userData')`. Each test points it
+// at a fresh tmpdir so the real fs read/write/rename/mkdir paths in
+// activityLog.ts are exercised end-to-end, not a mock of them.
+const electronUserData = vi.hoisted(() => ({ dir: '' }))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (name: string) => {
+      if (name !== 'userData') {
+        throw new Error(`unexpected getPath(${name})`)
+      }
+      return electronUserData.dir
+    },
+  },
+}))
+
+/**
+ * Re-imports activityLog.ts with its module-level `cache` reset to `null`,
+ * which is how an app restart is simulated: a fresh import must re-read the log
+ * from disk rather than serving a warm in-memory cache.
+ * @returns Fresh activityLog module exports.
+ * @example
+ * const { loadActivityLog } = await importFreshActivityLog()
+ */
+async function importFreshActivityLog(): Promise<typeof ActivityLogModule> {
+  vi.resetModules()
+  return import('./activityLog')
+}
+
+describe('activity log persistence', () => {
+  let userDataDir: string
+
+  beforeEach(() => {
+    // Arrange a clean userData dir for each test, then point the mocked
+    // electron app at it.
+    userDataDir = realpathSync(mkdtempSync(join(tmpdir(), 'activity-log-svc-')))
+    electronUserData.dir = userDataDir
+  })
+
+  afterEach(async () => {
+    await rm(userDataDir, { recursive: true, force: true })
+  })
+
+  afterAll(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('loadActivityLog', () => {
+    it('returns an empty log silently on first launch when activity-log.json is absent', async () => {
+      // Arrange: a fresh userData dir with no file — the ENOENT path must NOT
+      // warn because a missing file is expected before the first event.
+      const { loadActivityLog } = await importFreshActivityLog()
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      // Act
+      const loaded = await loadActivityLog()
+
+      // Assert
+      expect(loaded).toEqual([])
+      expect(warnSpy).not.toHaveBeenCalled()
+      warnSpy.mockRestore()
+    })
+
+    it('falls back to an empty log and warns when activity-log.json holds malformed JSON', async () => {
+      // Arrange: a syntactically broken file triggers a non-ENOENT error, which
+      // must be logged so a corrupt file is visible in the dev console.
+      const { loadActivityLog } = await importFreshActivityLog()
+      await writeFile(
+        join(userDataDir, 'activity-log.json'),
+        '{ not json',
+        'utf8',
+      )
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      // Act
+      const loaded = await loadActivityLog()
+
+      // Assert
+      expect(loaded).toEqual([])
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[activity-log] failed to load, starting empty:',
+        expect.anything(),
+      )
+      warnSpy.mockRestore()
+    })
+  })
+
+  describe('appendActivityEvents', () => {
+    it('stamps an id + timestamp on each event and writes it to disk', async () => {
+      // Arrange
+      const { appendActivityEvents } = await importFreshActivityLog()
+
+      // Act
+      const log = await appendActivityEvents([
+        { type: 'created', skillName: 'azure-ai', agentName: 'Claude Code' },
+      ])
+
+      // Assert: the returned event is fully stamped and the same data is on disk.
+      expect(log).toHaveLength(1)
+      expect(log[0].id.length).toBeGreaterThan(0)
+      expect(log[0].timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+      expect(log[0].type).toBe('created')
+      const onDisk = JSON.parse(
+        await readFile(join(userDataDir, 'activity-log.json'), 'utf8'),
+      )
+      expect(onDisk[0].skillName).toBe('azure-ai')
+      expect(onDisk[0].agentName).toBe('Claude Code')
+    })
+
+    it('prepends each new batch so the most recent event sorts first', async () => {
+      // Arrange
+      const { appendActivityEvents } = await importFreshActivityLog()
+      await appendActivityEvents([
+        { type: 'created', skillName: 'first-skill' },
+      ])
+
+      // Act
+      const log = await appendActivityEvents([
+        { type: 'removed', skillName: 'second-skill' },
+      ])
+
+      // Assert: newest-first ordering across separate appends.
+      expect(log[0].skillName).toBe('second-skill')
+      expect(log[1].skillName).toBe('first-skill')
+    })
+
+    it('caps the log at MAX_ACTIVITY_EVENTS, dropping the oldest event', async () => {
+      // Arrange: fill the log to the cap, then append one more.
+      const { appendActivityEvents } = await importFreshActivityLog()
+      const fullBatch = Array.from(
+        { length: MAX_ACTIVITY_EVENTS },
+        (_unused, index) => ({
+          type: 'created' as const,
+          skillName: `batch-${index}`,
+        }),
+      )
+      await appendActivityEvents(fullBatch)
+
+      // Act: one more event past the cap.
+      const log = await appendActivityEvents([
+        { type: 'removed', skillName: 'newest-skill' },
+      ])
+
+      // Assert: still capped, newest at the front, and the oldest fell off.
+      expect(log).toHaveLength(MAX_ACTIVITY_EVENTS)
+      expect(log[0].skillName).toBe('newest-skill')
+      expect(
+        log.some(
+          (event) => event.skillName === `batch-${MAX_ACTIVITY_EVENTS - 1}`,
+        ),
+      ).toBe(false)
+    })
+
+    it('writes no file and returns the current log when given an empty batch', async () => {
+      // Arrange
+      const { appendActivityEvents } = await importFreshActivityLog()
+
+      // Act
+      const log = await appendActivityEvents([])
+
+      // Assert: the no-op short-circuits before any disk write.
+      expect(log).toEqual([])
+      await expect(
+        readFile(join(userDataDir, 'activity-log.json'), 'utf8'),
+      ).rejects.toThrow()
+    })
+  })
+
+  describe('listActivityEvents', () => {
+    it('returns a newest-first page bounded by limit and offset', async () => {
+      // Arrange: three separate appends → on-disk order [c, b, a].
+      const { appendActivityEvents, listActivityEvents } =
+        await importFreshActivityLog()
+      await appendActivityEvents([{ type: 'created', skillName: 'a' }])
+      await appendActivityEvents([{ type: 'created', skillName: 'b' }])
+      await appendActivityEvents([{ type: 'created', skillName: 'c' }])
+
+      // Act
+      const firstPage = listActivityEvents({ limit: 2 })
+      const secondPage = listActivityEvents({ offset: 2, limit: 2 })
+
+      // Assert
+      expect(firstPage.map((event) => event.skillName)).toEqual(['c', 'b'])
+      expect(secondPage.map((event) => event.skillName)).toEqual(['a'])
+    })
+  })
+
+  describe('persistence across restarts', () => {
+    it('reloads the events written by a previous app session', async () => {
+      // Arrange: session 1 records two events.
+      const session1 = await importFreshActivityLog()
+      await session1.appendActivityEvents([
+        {
+          type: 'synced',
+          skillName: 'Sync',
+          detail: '3 created · 0 replaced · 1 skipped',
+        },
+        { type: 'removed', skillName: 'old-skill' },
+      ])
+
+      // Act: simulate an app restart (fresh import resets the in-memory cache to
+      // null, so load must read the file written by session 1).
+      const session2 = await importFreshActivityLog()
+      const reloaded = await session2.loadActivityLog()
+
+      // Assert: the events survived the restart, newest-first, intact.
+      expect(reloaded).toHaveLength(2)
+      expect(reloaded[0]).toMatchObject({
+        type: 'synced',
+        skillName: 'Sync',
+        detail: '3 created · 0 replaced · 1 skipped',
+      })
+      expect(reloaded[1]).toMatchObject({
+        type: 'removed',
+        skillName: 'old-skill',
+      })
+    })
+  })
+})

--- a/src/main/services/activityLog.ts
+++ b/src/main/services/activityLog.ts
@@ -1,0 +1,136 @@
+import { promises as fs } from 'fs'
+import { randomUUID } from 'node:crypto'
+import { join } from 'path'
+
+import { app } from 'electron'
+
+import {
+  ActivityLogSchema,
+  type ActivityEvent,
+  type ActivityEventInput,
+  type ActivityListOptions,
+  type ActivityLog,
+} from '@/shared/activityLog'
+import { MAX_ACTIVITY_EVENTS } from '@/shared/constants'
+
+/**
+ * In-memory newest-first cache of the activity log. Populated by
+ * `loadActivityLog()` at boot and re-populated on every append. Renderers
+ * receive a snapshot via `activity:list` and a stream of updates via the
+ * `activity:changed` broadcast — they never read this file directly.
+ */
+let cache: ActivityLog | null = null
+
+/**
+ * Resolves the on-disk path for `activity-log.json`. Lazy because
+ * `app.getPath('userData')` is only valid after `app.whenReady()`; calling it
+ * at module-load time crashes Electron in tests.
+ * @returns Absolute path to the activity-log file.
+ * @example
+ * activityLogFilePath() // => '/Users/me/Library/Application Support/skills-desktop/activity-log.json'
+ */
+function activityLogFilePath(): string {
+  return join(app.getPath('userData'), 'activity-log.json')
+}
+
+/**
+ * Reads `activity-log.json` from disk and validates it with Zod. On any failure
+ * (missing file, malformed JSON, schema mismatch) an empty log is returned —
+ * activity history is non-critical and must never block startup; the next
+ * append writes a clean file.
+ * @returns
+ * - Validated newest-first events when the file exists and is valid.
+ * - `[]` on first launch (ENOENT) or any read/parse error.
+ * @example
+ * await loadActivityLog() // => [{ id: '…', type: 'synced', skillName: 'Sync', … }]
+ */
+export async function loadActivityLog(): Promise<ActivityLog> {
+  try {
+    const raw = await fs.readFile(activityLogFilePath(), 'utf8')
+    const parsed = JSON.parse(raw)
+    const validated = ActivityLogSchema.parse(parsed)
+    cache = validated
+    return validated
+  } catch (err) {
+    // ENOENT (first launch) is expected; other errors get logged so a corrupt
+    // file is visible in the dev console without blocking the widget.
+    const code = (err as NodeJS.ErrnoException).code
+    if (code !== 'ENOENT') {
+      console.warn('[activity-log] failed to load, starting empty:', err)
+    }
+    cache = []
+    return cache
+  }
+}
+
+/**
+ * Returns the in-memory activity-log snapshot, lazily seeding an empty log so
+ * IPC handlers can read synchronously without awaiting `loadActivityLog`.
+ * @returns The cached newest-first events (or `[]` if never loaded).
+ * @example
+ * getActivityLog() // => []
+ */
+export function getActivityLog(): ActivityLog {
+  if (cache === null) {
+    cache = []
+  }
+  return cache
+}
+
+/**
+ * Returns a newest-first slice of the activity log for the `activity:list`
+ * channel. Defaults to the whole capped log; `limit`/`offset` enable simple
+ * paging without exposing the cache reference.
+ * @param options - `{ limit, offset }`; both optional.
+ * @returns The requested window of events (a fresh array, newest-first).
+ * @example
+ * listActivityEvents({ limit: 20 })          // => newest 20 events
+ * listActivityEvents({ offset: 20, limit: 20 }) // => the next page
+ */
+export function listActivityEvents(options?: ActivityListOptions): ActivityLog {
+  const all = getActivityLog()
+  const offset = options?.offset ?? 0
+  const limit = options?.limit ?? MAX_ACTIVITY_EVENTS
+  return all.slice(offset, offset + limit)
+}
+
+/**
+ * Appends a batch of events to the front of the log and persists the whole
+ * file atomically (temp file + rename) so a crash mid-write cannot corrupt it.
+ * One write per batch — callers that touch many skill×agent pairs in a single
+ * operation (e.g. a sync) must pass one summary event, not N, to avoid both
+ * flooding the log and fanning out N atomic rewrites. The capped ring buffer
+ * drops the oldest events past `MAX_ACTIVITY_EVENTS`.
+ * @param inputs - Events without `id`/`timestamp`; both are stamped here.
+ * @returns
+ * - The new full newest-first log (also updates the cache).
+ * - The unchanged current log when `inputs` is empty (no disk write).
+ * @example
+ * await appendActivityEvents([{ type: 'created', skillName: 'azure-ai', agentName: 'Claude Code' }])
+ */
+export async function appendActivityEvents(
+  inputs: ActivityEventInput[],
+): Promise<ActivityLog> {
+  const current = getActivityLog()
+  if (inputs.length === 0) return current
+  // One instant for the whole batch: the events are simultaneous from the
+  // user's point of view, and a shared timestamp keeps a regenerated fixture
+  // deterministic. Each event still gets its own uuid for a stable React key.
+  const recordedAt = new Date().toISOString()
+  const stamped: ActivityEvent[] = inputs.map((input) => ({
+    ...input,
+    id: randomUUID(),
+    timestamp: recordedAt,
+  }))
+  // Newest-first ring buffer: the new batch goes to the front (input order
+  // preserved within the batch), then the tail past the cap is dropped.
+  const next = [...stamped, ...current].slice(0, MAX_ACTIVITY_EVENTS)
+  const target = activityLogFilePath()
+  const tempPath = `${target}.tmp`
+  // Ensure userData dir exists — first run on a fresh profile may lack it.
+  await fs.mkdir(app.getPath('userData'), { recursive: true })
+  await fs.writeFile(tempPath, JSON.stringify(next, null, 2), 'utf8')
+  await fs.rename(tempPath, target)
+  cache = next
+  return next
+}

--- a/src/main/services/activityLog.ts
+++ b/src/main/services/activityLog.ts
@@ -22,6 +22,18 @@ import { MAX_ACTIVITY_EVENTS } from '@/shared/constants'
 let cache: ActivityLog | null = null
 
 /**
+ * Serializes {@link appendActivityEvents}: each append chains onto the previous
+ * one so the read-modify-write inside it can't interleave. Two concurrent
+ * appends would otherwise both read the same `cache`, and the second to finish
+ * would overwrite the first — silently dropping events from both the cache and
+ * the file (a lost update).
+ */
+let appendChain: Promise<unknown> = Promise.resolve()
+
+/** Monotonic counter for unique temp-file names, so no two writes share a `.tmp`. */
+let tempWriteCounter = 0
+
+/**
  * Resolves the on-disk path for `activity-log.json`. Lazy because
  * `app.getPath('userData')` is only valid after `app.whenReady()`; calling it
  * at module-load time crashes Electron in tests.
@@ -100,7 +112,9 @@ export function listActivityEvents(options?: ActivityListOptions): ActivityLog {
  * One write per batch — callers that touch many skill×agent pairs in a single
  * operation (e.g. a sync) must pass one summary event, not N, to avoid both
  * flooding the log and fanning out N atomic rewrites. The capped ring buffer
- * drops the oldest events past `MAX_ACTIVITY_EVENTS`.
+ * drops the oldest events past `MAX_ACTIVITY_EVENTS`. Concurrent calls are
+ * serialized (see {@link appendChain}) so an interleaved read-modify-write can
+ * never lose an event.
  * @param inputs - Events without `id`/`timestamp`; both are stamped here.
  * @returns
  * - The new full newest-first log (also updates the cache).
@@ -109,6 +123,32 @@ export function listActivityEvents(options?: ActivityListOptions): ActivityLog {
  * await appendActivityEvents([{ type: 'created', skillName: 'azure-ai', agentName: 'Claude Code' }])
  */
 export async function appendActivityEvents(
+  inputs: ActivityEventInput[],
+): Promise<ActivityLog> {
+  // Chain onto the previous append so the read-modify-write in
+  // `appendActivityEventsUnsafe` is serialized — concurrent callers (e.g. a
+  // sync and a delete firing from different windows) would otherwise lost-update
+  // each other. The chain swallows the prior result/error so one failed append
+  // cannot wedge every later one.
+  const run = appendChain.then(async () => appendActivityEventsUnsafe(inputs))
+  appendChain = run.then(
+    () => undefined,
+    () => undefined,
+  )
+  return run
+}
+
+/**
+ * The raw read-modify-write behind {@link appendActivityEvents}. NOT safe to
+ * call concurrently — always go through `appendActivityEvents`, which serializes
+ * it. Stamps `id`/`timestamp`, prepends the batch, caps the ring buffer, then
+ * persists the whole file atomically (unique temp file + rename).
+ * @param inputs - Events without `id`/`timestamp`; both are stamped here.
+ * @returns The new full newest-first log, or the unchanged log for an empty batch.
+ * @example
+ * await appendActivityEventsUnsafe([{ type: 'created', skillName: 'azure-ai' }])
+ */
+async function appendActivityEventsUnsafe(
   inputs: ActivityEventInput[],
 ): Promise<ActivityLog> {
   const current = getActivityLog()
@@ -126,7 +166,9 @@ export async function appendActivityEvents(
   // preserved within the batch), then the tail past the cap is dropped.
   const next = [...stamped, ...current].slice(0, MAX_ACTIVITY_EVENTS)
   const target = activityLogFilePath()
-  const tempPath = `${target}.tmp`
+  // Unique temp name per write (pid + counter) so an unexpected overlap can't
+  // have two writers racing on one `.tmp` before the atomic rename.
+  const tempPath = `${target}.${process.pid}.${(tempWriteCounter += 1)}.tmp`
   // Ensure userData dir exists — first run on a fresh profile may lack it.
   await fs.mkdir(app.getPath('userData'), { recursive: true })
   await fs.writeFile(tempPath, JSON.stringify(next, null, 2), 'utf8')

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,5 +1,6 @@
 import { contextBridge } from 'electron'
 
+import type { ActivityEvent, ActivityListOptions } from '@/shared/activityLog'
 import { IPC_CHANNELS } from '@/shared/ipc-channels'
 import type { Settings, SettingsPatch } from '@/shared/settings'
 import type {
@@ -145,6 +146,16 @@ contextBridge.exposeInMainWorld('electron', {
     get: async () => typedInvoke('settings:get'),
     set: async (partial: SettingsPatch) => typedInvoke('settings:set', partial),
     onChanged: createIpcListener<Settings>(IPC_CHANNELS.SETTINGS_CHANGED),
+  },
+  // Activity timeline — append-only event log owned by main (userData/
+  // activity-log.json). Renderer hydrates via `activity:list` and converges
+  // via the `activity:changed` broadcast, mirroring the settings sync above.
+  activity: {
+    list: async (options?: ActivityListOptions) =>
+      typedInvoke('activity:list', options),
+    onChanged: createIpcListener<ActivityEvent[]>(
+      IPC_CHANNELS.ACTIVITY_CHANGED,
+    ),
   },
   // Folder actions — main-process-only because both `shell.openPath` and
   // `child_process.spawn('open', …)` are unavailable in sandboxed preload.

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -7,6 +7,7 @@ import { MainContent } from './components/layout/MainContent'
 import { Sidebar } from './components/layout/Sidebar'
 import { TooltipProvider } from './components/ui/tooltip'
 import { UpdateToast } from './components/UpdateToast'
+import { useActivitySync } from './hooks/useActivitySync'
 import { useReleaseNotesToast } from './hooks/useReleaseNotesToast'
 import { useSettingsSync } from './hooks/useSettingsSync'
 import { useUpdateNotification } from './hooks/useUpdateNotification'
@@ -108,6 +109,10 @@ const App = React.memo(function App(): React.ReactElement {
   // Hydrate the settings slice from the main-process JSON store and
   // subscribe to cross-window changes broadcast by `settings:set`.
   useSettingsSync()
+
+  // Hydrate + live-update the Activity Timeline from the main-process event
+  // log. No-op while the experimental dashboard flag is off (fully dark).
+  useActivitySync()
 
   // After auto-update + restart, fire a one-shot "What's new" toast on the
   // first launch of the new version with a link to the GitHub release notes.

--- a/src/renderer/src/components/dashboard/widgets/ActivityTimelineWidget.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/widgets/ActivityTimelineWidget.browser.test.tsx
@@ -4,56 +4,26 @@ import { describe, expect, it } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import '@/renderer/src/styles/globals.css'
-import type { SyncExecuteResult, SyncResultItem } from '@/shared/types'
+import type { ActivityEvent } from '@/shared/activityLog'
 
 /**
- * Build a SyncExecuteResult from just the per-item `details` the widget renders.
- * The summary counts (`created`/`replaced`/`skipped`/`errors`) are derived so
- * the fixture stays internally consistent even though the widget ignores them.
- * @param details - Per-item sync outcomes shown as timeline rows.
+ * Seed the activity slice with the given events and render the timeline inside
+ * a sized wrapper. Dispatching `setActivityEvents` is exactly what
+ * `useActivitySync` does after `activity:list` resolves, so this exercises the
+ * real renderer data path without mocking IPC.
+ * @param events - Newest-first events to seed, or [] for the pristine state.
  */
-function makeSyncResult(details: SyncResultItem[]): SyncExecuteResult {
-  const errors = details.flatMap((item) =>
-    item.action === 'error'
-      ? [
-          {
-            path: `/Users/test/.agents/skills/${item.skillName}`,
-            error: item.error,
-          },
-        ]
-      : [],
-  )
-  return {
-    success: errors.length === 0,
-    created: details.filter((item) => item.action === 'created').length,
-    replaced: details.filter((item) => item.action === 'replaced').length,
-    skipped: details.filter((item) => item.action === 'skipped').length,
-    errors,
-    details,
-  }
-}
-
-/**
- * Seed `ui.syncResult` with the given result (or leave it null) and render the
- * timeline inside a sized wrapper. Seeding via `executeSyncAction.fulfilled`
- * avoids mocking the sync IPC call.
- * @param syncResult - Result to seed, or null for the pristine "no activity" state.
- */
-async function renderTimeline(syncResult: SyncExecuteResult | null) {
+async function renderTimeline(events: ActivityEvent[]) {
   const [
-    { default: uiReducer, executeSyncAction },
+    { default: activityReducer, setActivityEvents },
     { ActivityTimelineWidget },
   ] = await Promise.all([
-    import('@/renderer/src/redux/slices/uiSlice'),
+    import('@/renderer/src/redux/slices/activitySlice'),
     import('./ActivityTimelineWidget'),
   ])
-  const store = configureStore({ reducer: { ui: uiReducer } })
-  if (syncResult) {
-    store.dispatch(
-      executeSyncAction.fulfilled(syncResult, 'req-sync', {
-        replaceConflicts: [],
-      }),
-    )
+  const store = configureStore({ reducer: { activity: activityReducer } })
+  if (events.length > 0) {
+    store.dispatch(setActivityEvents(events))
   }
 
   const screen = await render(
@@ -67,86 +37,110 @@ async function renderTimeline(syncResult: SyncExecuteResult | null) {
 }
 
 describe('ActivityTimelineWidget', () => {
-  it('shows the no-activity hint before any sync has run', async () => {
-    // Arrange + Act: no sync result seeded into the store.
-    const { screen } = await renderTimeline(null)
+  it('shows the no-activity hint before any activity has been recorded', async () => {
+    // Arrange + Act: no events seeded into the store.
+    const { screen } = await renderTimeline([])
 
     // Assert
     await expect.element(screen.getByText('No recent activity')).toBeVisible()
     await expect
-      .element(screen.getByText('Run Sync to see per-item results here.'))
+      .element(
+        screen.getByText('Add, remove, or sync skills to see activity here.'),
+      )
       .toBeVisible()
   })
 
-  it('lists each synced skill alongside its agent and action label', async () => {
-    // Arrange: three rows from one sync, distinct agents and actions.
-    const syncResult = makeSyncResult([
-      { skillName: 'alpha-skill', agentName: 'Claude Code', action: 'created' },
-      { skillName: 'beta-skill', agentName: 'Cursor', action: 'skipped' },
-      { skillName: 'gamma-skill', agentName: 'Codex', action: 'replaced' },
-    ])
+  it('lists each event with its skill, agent, and action label in newest-first order', async () => {
+    // Arrange: three events of distinct types, already newest-first.
+    const events: ActivityEvent[] = [
+      {
+        id: 'e1',
+        timestamp: '2026-06-18T10:00:00.000Z',
+        type: 'created',
+        skillName: 'alpha-skill',
+        agentName: 'Claude Code',
+      },
+      {
+        id: 'e2',
+        timestamp: '2026-06-18T09:00:00.000Z',
+        type: 'removed',
+        skillName: 'beta-skill',
+        agentName: 'Cursor',
+      },
+      {
+        id: 'e3',
+        timestamp: '2026-06-18T08:00:00.000Z',
+        type: 'synced',
+        skillName: 'Sync',
+        detail: '4 created · 0 replaced · 1 skipped',
+      },
+    ]
 
     // Act
-    const { screen } = await renderTimeline(syncResult)
+    const { screen } = await renderTimeline(events)
 
     // Assert: scope each assertion to its own row (`listitem`) so the test
-    // verifies same-row correspondence. A regression that scrambled which
-    // agent or action renders next to which skill would fail here, whereas a
-    // global text search would still pass. Rows render in sync-result order.
+    // verifies same-row correspondence. A regression that scrambled which agent
+    // or label renders next to which skill would fail here, whereas a global
+    // text search would still pass. Rows render in the seeded (newest-first) order.
     const rows = screen.getByRole('listitem')
     await expect.element(rows.nth(0)).toHaveTextContent('alpha-skill')
     await expect.element(rows.nth(0)).toHaveTextContent('Claude Code')
     await expect.element(rows.nth(0)).toHaveTextContent('created')
     await expect.element(rows.nth(1)).toHaveTextContent('beta-skill')
     await expect.element(rows.nth(1)).toHaveTextContent('Cursor')
-    await expect.element(rows.nth(1)).toHaveTextContent('skipped')
-    await expect.element(rows.nth(2)).toHaveTextContent('gamma-skill')
-    await expect.element(rows.nth(2)).toHaveTextContent('Codex')
-    await expect.element(rows.nth(2)).toHaveTextContent('replaced')
+    await expect.element(rows.nth(1)).toHaveTextContent('removed')
+    await expect.element(rows.nth(2)).toHaveTextContent('Sync')
+    await expect.element(rows.nth(2)).toHaveTextContent('synced')
   })
 
-  it('shows the failure reason on an errored sync row', async () => {
-    // Arrange: a single errored row carrying a permission-denied message.
-    const syncResult = makeSyncResult([
+  it('shows the detail text on a sync summary event that carries one', async () => {
+    // Arrange: a single sync summary event with a counts detail string.
+    const events: ActivityEvent[] = [
       {
-        skillName: 'delta-skill',
-        agentName: 'Claude Code',
-        action: 'error',
-        error: 'EACCES: permission denied',
+        id: 's1',
+        timestamp: '2026-06-18T10:00:00.000Z',
+        type: 'synced',
+        skillName: 'Sync',
+        detail: '10 created · 1 replaced · 5 skipped',
       },
-    ])
+    ]
 
     // Act
-    const { screen } = await renderTimeline(syncResult)
+    const { screen } = await renderTimeline(events)
 
-    // Assert: the row shows the skill, the error label, and the reason text.
-    await expect.element(screen.getByText('delta-skill')).toBeVisible()
-    await expect.element(screen.getByText('error')).toBeVisible()
+    // Assert: scope to the single row to avoid the 'Sync'/'synced' substring
+    // overlap (Playwright getByText is case-insensitive substring). The row
+    // carries the skill label, the action label, and the detail counts.
+    const row = screen.getByRole('listitem')
+    await expect.element(row).toHaveTextContent('Sync')
+    await expect.element(row).toHaveTextContent('synced')
     await expect
-      .element(screen.getByText('EACCES: permission denied'))
-      .toBeVisible()
+      .element(row)
+      .toHaveTextContent('10 created · 1 replaced · 5 skipped')
   })
 
-  it('omits the appended detail text for a non-error row whose detailText is null', async () => {
-    // Arrange: a skipped row — `match(item).otherwise(() => null)` makes
-    // detailText null, so the appended " — detail" span must not render. This
-    // covers the falsy branch of `{detailText && <span>…</span>}`, the
-    // complement of the errored-row test above.
-    const syncResult = makeSyncResult([
+  it('omits the appended detail separator for an event with no detail', async () => {
+    // Arrange: a `created` event with no detail — the appended " — detail" span
+    // must not render. Covers the falsy branch of `{event.detail && <span>…}`,
+    // the complement of the sync-summary test above.
+    const events: ActivityEvent[] = [
       {
+        id: 'c1',
+        timestamp: '2026-06-18T10:00:00.000Z',
+        type: 'created',
         skillName: 'epsilon-skill',
         agentName: 'Codex',
-        action: 'skipped',
       },
-    ])
+    ]
 
     // Act
-    const { screen } = await renderTimeline(syncResult)
+    const { screen } = await renderTimeline(events)
 
-    // Assert: the skill row and its status label show, but the em-dash detail
-    // separator (rendered only on the truthy detailText path) is absent.
+    // Assert: the skill row and its action label show, but the em-dash detail
+    // separator (rendered only on the truthy `event.detail` path) is absent.
     await expect.element(screen.getByText('epsilon-skill')).toBeVisible()
-    await expect.element(screen.getByText('skipped')).toBeVisible()
+    await expect.element(screen.getByText('created')).toBeVisible()
     expect(screen.getByText(/—/).query()).toBeNull()
   })
 })

--- a/src/renderer/src/components/dashboard/widgets/ActivityTimelineWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/ActivityTimelineWidget.tsx
@@ -1,20 +1,14 @@
-import {
-  AlertCircle,
-  FileClock,
-  MinusCircle,
-  Plus,
-  Replace,
-} from 'lucide-react'
+import { FileClock, MinusCircle, Plus, RefreshCw, Replace } from 'lucide-react'
 import React from 'react'
-import { match } from 'ts-pattern'
 
 import { useAppSelector } from '@/renderer/src/redux/hooks'
-import { selectSyncResult } from '@/renderer/src/redux/slices/uiSlice'
-import type { SyncResultAction, SyncResultItem } from '@/shared/types'
+import { selectActivityEvents } from '@/renderer/src/redux/slices/activitySlice'
+import type { ActivityEvent, ActivityEventType } from '@/shared/activityLog'
 
 // ----------------------------------------------------------------------------
-// Action → visual mapping. Centralizes the icon + color per action so the
-// row renderer stays small.
+// Event type → visual mapping. A Record (not a ts-pattern `match`) because each
+// row needs only a constant icon/color/label lookup — the row body is identical
+// across types, so there is nothing to branch on.
 // ----------------------------------------------------------------------------
 
 interface ActionVisual {
@@ -23,15 +17,23 @@ interface ActionVisual {
   label: string
 }
 
-const ACTION_VISUALS: Record<SyncResultAction, ActionVisual> = {
+const ACTION_VISUALS: Record<ActivityEventType, ActionVisual> = {
   created: { icon: Plus, accentClass: 'text-primary', label: 'created' },
-  replaced: { icon: Replace, accentClass: 'text-amber-400', label: 'replaced' },
-  skipped: {
+  removed: {
     icon: MinusCircle,
-    accentClass: 'text-muted-foreground',
-    label: 'skipped',
+    accentClass: 'text-destructive',
+    label: 'removed',
   },
-  error: { icon: AlertCircle, accentClass: 'text-destructive', label: 'error' },
+  // `synced` is a routine success event, NOT a needs-review/broken state, so it
+  // must NOT borrow `text-amber-400` (the app-wide broken/inaccessible hue).
+  // DESIGN.md caps amber at exactly two meanings (broken + bookmark) and names
+  // `text-foreground` as the safe default for a semantic with no dedicated hue.
+  synced: { icon: RefreshCw, accentClass: 'text-foreground', label: 'synced' },
+  renamed: {
+    icon: Replace,
+    accentClass: 'text-muted-foreground',
+    label: 'renamed',
+  },
 }
 
 // ----------------------------------------------------------------------------
@@ -39,20 +41,14 @@ const ACTION_VISUALS: Record<SyncResultAction, ActionVisual> = {
 // ----------------------------------------------------------------------------
 
 interface TimelineRowProps {
-  item: SyncResultItem
+  event: ActivityEvent
 }
 
 const TimelineRow = React.memo(function TimelineRow({
-  item,
+  event,
 }: TimelineRowProps): React.ReactElement {
-  const visual = ACTION_VISUALS[item.action]
+  const visual = ACTION_VISUALS[event.type]
   const Icon = visual.icon
-
-  // Error rows carry a message; non-error rows don't, so match on the
-  // discriminated union to pull the detail text safely.
-  const detailText = match(item)
-    .with({ action: 'error' }, (errorItem) => errorItem.error)
-    .otherwise(() => null)
 
   return (
     <li className="flex items-start gap-2 px-2 py-1 rounded-md hover:bg-muted/50">
@@ -62,17 +58,21 @@ const TimelineRow = React.memo(function TimelineRow({
       />
       <div className="flex-1 min-w-0 flex flex-col">
         <span className="text-[11px] text-foreground truncate">
-          <span className="font-medium">{item.skillName}</span>
-          <span className="text-muted-foreground"> · {item.agentName}</span>
+          <span className="font-medium">{event.skillName}</span>
+          {/* Agent is only present for per-agent events (add/remove); a sync
+              summary touches many agents, so the separator is omitted there. */}
+          {event.agentName && (
+            <span className="text-muted-foreground"> · {event.agentName}</span>
+          )}
         </span>
         <span
           className={`text-[10px] ${visual.accentClass} uppercase tracking-wide`}
         >
           {visual.label}
-          {detailText && (
+          {event.detail && (
             <span className="normal-case tracking-normal text-muted-foreground">
               {' — '}
-              {detailText}
+              {event.detail}
             </span>
           )}
         </span>
@@ -82,19 +82,18 @@ const TimelineRow = React.memo(function TimelineRow({
 })
 
 /**
- * Activity Timeline widget body (experimental).
- *
- * Today this surface only has one data source: the last sync execution
- * (`uiSlice.syncResult.details`). A proper timeline would need main-process
- * event tracking for add/remove/sync/rename. For now the widget shows the
- * most recent sync's per-item actions so the ecosystem hook exists and the
- * widget isn't empty when `ENABLE_DASHBOARD_EXPERIMENTAL` is on.
+ * Activity Timeline widget body. Renders the persisted activity log
+ * (newest-first) — add / remove / sync events surfaced from the main-process
+ * store via `useActivitySync`. Replaces the earlier last-sync-only placeholder
+ * with a real cross-session feed. Gated behind `ENABLE_DASHBOARD_EXPERIMENTAL`
+ * in the widget registry, so it stays hidden from the picker until that flag
+ * flips. See `docs/activity-log.md`.
  */
 export const ActivityTimelineWidget = React.memo(
   function ActivityTimelineWidget(): React.ReactElement {
-    const syncResult = useAppSelector(selectSyncResult)
+    const events = useAppSelector(selectActivityEvents)
 
-    if (!syncResult || syncResult.details.length === 0) {
+    if (events.length === 0) {
       return (
         <div className="h-full w-full flex flex-col items-center justify-center gap-1 px-4 text-center">
           <FileClock
@@ -103,7 +102,7 @@ export const ActivityTimelineWidget = React.memo(
           />
           <p className="text-xs text-muted-foreground">No recent activity</p>
           <p className="text-[10px] text-muted-foreground/70">
-            Run Sync to see per-item results here.
+            Add, remove, or sync skills to see activity here.
           </p>
         </div>
       )
@@ -112,14 +111,10 @@ export const ActivityTimelineWidget = React.memo(
     return (
       <div className="h-full w-full overflow-y-auto py-1">
         <ul className="flex flex-col gap-0.5 px-1">
-          {syncResult.details.map((item, index) => (
-            <TimelineRow
-              // Sync results aren't guaranteed to have unique (skill,agent)
-              // pairs across actions (e.g., replaced then errored in edge cases),
-              // so the array index is the reliable stable key.
-              key={`${item.skillName}-${item.agentName}-${index}`}
-              item={item}
-            />
+          {events.map((event) => (
+            // event.id is a stable uuid stamped by the main process — a proper
+            // key, unlike the index-based fallback the sync-only version needed.
+            <TimelineRow key={event.id} event={event} />
           ))}
         </ul>
       </div>

--- a/src/renderer/src/hooks/useActivitySync.test.tsx
+++ b/src/renderer/src/hooks/useActivitySync.test.tsx
@@ -221,4 +221,24 @@ describe('useActivitySync', () => {
       payload: SNAPSHOT_EVENTS,
     })
   })
+
+  it('logs and swallows a failed initial hydration instead of throwing an unhandled rejection', async () => {
+    // Arrange — the `activity:list` IPC rejects; the hydrate path must catch it.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    listMock.mockRejectedValue(new Error('IPC down'))
+
+    // Act — mount, then flush the rejected list() → .catch microtask chain.
+    await mountHook()
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    // Assert — the failure was logged, nothing was dispatched, nothing threw.
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[activity] failed to hydrate from main:',
+      expect.anything(),
+    )
+    expect(dispatchSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
 })

--- a/src/renderer/src/hooks/useActivitySync.test.tsx
+++ b/src/renderer/src/hooks/useActivitySync.test.tsx
@@ -1,0 +1,224 @@
+/**
+ * Node-lane tests for `useActivitySync` — the hook that wires the renderer's
+ * Redux activity slice to the main-process activity-log store over IPC.
+ *
+ * Structurally a mirror of `useSettingsSync`, with one extra gate: the whole
+ * subscribe/hydrate body is skipped unless `ENABLE_DASHBOARD_EXPERIMENTAL` is
+ * on. The flag-OFF early return is already exercised by the real `App.tsx`
+ * mount (flag ships false); these tests force the flag ON so the enabled data
+ * path — `activity:list` hydration, `activity:changed` subscription, and the
+ * unmount cleanup — runs for real under happy-dom.
+ *
+ * @vitest-environment happy-dom
+ */
+
+// The flag ships false, so without this override the hook returns early and the
+// IPC body never runs. Forcing it on is what exercises the enabled contract.
+vi.mock('@/shared/featureFlags', () => ({
+  FEATURE_FLAGS: { ENABLE_DASHBOARD_EXPERIMENTAL: true },
+}))
+
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ActivityLog } from '@/shared/activityLog'
+
+// The hook reads dispatch via the typed `useAppDispatch` wrapper. Mocking it to
+// return a spy lets us assert the dispatched action shape without standing up a
+// real Provider — and keeps the test pinned to the hook's IPC behavior.
+const dispatchSpy = vi.fn()
+vi.mock('@/renderer/src/redux/hooks', () => ({
+  useAppDispatch: () => dispatchSpy,
+}))
+
+// Keep `setActivityEvents` as an identity-tagged action creator so we can assert
+// the hook dispatches the EXACT payload it received from IPC, not just "something".
+vi.mock('@/renderer/src/redux/slices/activitySlice', () => ({
+  setActivityEvents: (payload: ActivityLog) => ({
+    type: 'activity/setActivityEvents',
+    payload,
+  }),
+}))
+
+import { useActivitySync } from './useActivitySync'
+
+/** Deferred promise handle so a test can resolve `activity.list()` on demand. */
+interface Deferred<Value> {
+  promise: Promise<Value>
+  resolve: (value: Value) => void
+}
+
+/**
+ * Builds a promise whose resolution a test controls, for driving the
+ * mount-before-resolve race in the late-write test.
+ * @returns A `{ promise, resolve }` pair.
+ * @example
+ * const d = createDeferred<ActivityLog>(); d.resolve([])
+ */
+function createDeferred<Value>(): Deferred<Value> {
+  let resolve!: (value: Value) => void
+  const promise = new Promise<Value>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+const SNAPSHOT_EVENTS: ActivityLog = [
+  {
+    id: 'e1',
+    timestamp: '2026-06-18T10:00:00.000Z',
+    type: 'created',
+    skillName: 'alpha-skill',
+    agentName: 'Claude Code',
+  },
+]
+
+const BROADCAST_EVENTS: ActivityLog = [
+  {
+    id: 's1',
+    timestamp: '2026-06-18T11:00:00.000Z',
+    type: 'synced',
+    skillName: 'Sync',
+    detail: '3 created · 0 replaced · 1 skipped',
+  },
+  ...SNAPSHOT_EVENTS,
+]
+
+let listMock: ReturnType<typeof vi.fn>
+let onChangedMock: ReturnType<typeof vi.fn>
+let unsubscribeMock: ReturnType<typeof vi.fn>
+let onChangedCallback: ((events: ActivityLog) => void) | null
+
+beforeEach(() => {
+  dispatchSpy.mockReset()
+  unsubscribeMock = vi.fn()
+  onChangedCallback = null
+
+  // `list()` resolves immediately with a one-event snapshot by default; tests
+  // that need to control timing override it with a deferred.
+  listMock = vi.fn().mockResolvedValue(SNAPSHOT_EVENTS)
+
+  // Capture the registered listener so a test can drive an `activity:changed`
+  // broadcast, and hand back the unsubscribe spy for the cleanup assertion.
+  onChangedMock = vi.fn((callback: (events: ActivityLog) => void) => {
+    onChangedCallback = callback
+    return unsubscribeMock
+  })
+
+  vi.stubGlobal('window', {
+    electron: {
+      activity: {
+        list: listMock,
+        onChanged: onChangedMock,
+      },
+    },
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+/**
+ * Mount `useActivitySync` on a fresh React root and return an `unmount` that
+ * tears the root down (running the hook's cleanup) inside `act`.
+ * @returns An object whose `unmount()` unmounts the root inside `act`.
+ */
+async function mountHook(): Promise<{ unmount: () => Promise<void> }> {
+  const container = document.createElement('div')
+  const root = createRoot(container)
+
+  function HookHarness(): null {
+    useActivitySync()
+    return null
+  }
+
+  await act(async () => {
+    root.render(<HookHarness />)
+  })
+
+  return {
+    unmount: async () => {
+      await act(async () => {
+        root.unmount()
+      })
+    },
+  }
+}
+
+describe('useActivitySync', () => {
+  it('hydrates the activity slice from the persisted snapshot on mount', async () => {
+    // Arrange — `list()` resolves with the snapshot (set in beforeEach)
+
+    // Act
+    await mountHook()
+
+    // Assert — the resolved snapshot is dispatched into the slice
+    expect(listMock).toHaveBeenCalledTimes(1)
+    expect(dispatchSpy).toHaveBeenCalledWith({
+      type: 'activity/setActivityEvents',
+      payload: SNAPSHOT_EVENTS,
+    })
+  })
+
+  it('subscribes to cross-process activity changes on mount', async () => {
+    // Arrange — beforeEach wires onChanged to capture the listener
+
+    // Act
+    await mountHook()
+
+    // Assert — exactly one live subscription is registered
+    expect(onChangedMock).toHaveBeenCalledTimes(1)
+    expect(typeof onChangedCallback).toBe('function')
+  })
+
+  it('propagates an activity-log change from the main process into the slice', async () => {
+    // Arrange — mount so the onChanged listener is registered
+    await mountHook()
+    dispatchSpy.mockClear()
+
+    // Act — simulate an `activity:changed` broadcast from the main process
+    await act(async () => {
+      onChangedCallback?.(BROADCAST_EVENTS)
+    })
+
+    // Assert — the broadcast payload flows straight into the slice
+    expect(dispatchSpy).toHaveBeenCalledTimes(1)
+    expect(dispatchSpy).toHaveBeenCalledWith({
+      type: 'activity/setActivityEvents',
+      payload: BROADCAST_EVENTS,
+    })
+  })
+
+  it('tears down the change subscription when the component unmounts', async () => {
+    // Arrange — mount registers the subscription
+    const { unmount } = await mountHook()
+
+    // Act
+    await unmount()
+
+    // Assert — cleanup runs the unsubscribe returned by onChanged
+    expect(unsubscribeMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips the late hydration dispatch when the component unmounts before the snapshot resolves', async () => {
+    // Arrange — make `list()` hang so we can unmount before it resolves
+    const deferred = createDeferred<ActivityLog>()
+    listMock.mockReturnValue(deferred.promise)
+
+    // Act — unmount first, THEN resolve the in-flight snapshot
+    const { unmount } = await mountHook()
+    await unmount()
+    await act(async () => {
+      deferred.resolve(SNAPSHOT_EVENTS)
+      await deferred.promise
+    })
+
+    // Assert — the cancelled guard drops the late write entirely
+    expect(dispatchSpy).not.toHaveBeenCalledWith({
+      type: 'activity/setActivityEvents',
+      payload: SNAPSHOT_EVENTS,
+    })
+  })
+})

--- a/src/renderer/src/hooks/useActivitySync.ts
+++ b/src/renderer/src/hooks/useActivitySync.ts
@@ -1,0 +1,49 @@
+import { useEffect } from 'react'
+
+import { useAppDispatch } from '@/renderer/src/redux/hooks'
+import { setActivityEvents } from '@/renderer/src/redux/slices/activitySlice'
+import { FEATURE_FLAGS } from '@/shared/featureFlags'
+
+/**
+ * Subscribes the Redux activity slice to the main-process event log, mirroring
+ * `useSettingsSync`.
+ *
+ * Two-step contract (when enabled):
+ *   1. On mount: pull a snapshot via `activity:list` and hydrate the slice.
+ *   2. While mounted: subscribe to `activity:changed` so an add/remove/sync in
+ *      the main process propagates to the timeline without polling.
+ *
+ * Gated on `ENABLE_DASHBOARD_EXPERIMENTAL`: while the flag is off the widget is
+ * hidden from the picker and the main-process recorder is a no-op, so there is
+ * nothing to hydrate or subscribe to and the effect returns early — keeping the
+ * feature fully dark with zero IPC traffic.
+ * @example
+ * function App() {
+ *   useActivitySync()
+ *   return <Layout />
+ * }
+ */
+export function useActivitySync(): void {
+  const dispatch = useAppDispatch()
+
+  useEffect(() => {
+    if (!FEATURE_FLAGS.ENABLE_DASHBOARD_EXPERIMENTAL) return
+
+    let isCancelled = false
+
+    void window.electron.activity.list().then((events) => {
+      // Skip the late write if the component unmounted between the IPC call
+      // and its resolution (same cleanup contract as useSettingsSync).
+      if (!isCancelled) dispatch(setActivityEvents(events))
+    })
+
+    const unsubscribe = window.electron.activity.onChanged((events) => {
+      dispatch(setActivityEvents(events))
+    })
+
+    return () => {
+      isCancelled = true
+      unsubscribe()
+    }
+  }, [dispatch])
+}

--- a/src/renderer/src/hooks/useActivitySync.ts
+++ b/src/renderer/src/hooks/useActivitySync.ts
@@ -31,11 +31,19 @@ export function useActivitySync(): void {
 
     let isCancelled = false
 
-    void window.electron.activity.list().then((events) => {
-      // Skip the late write if the component unmounted between the IPC call
-      // and its resolution (same cleanup contract as useSettingsSync).
-      if (!isCancelled) dispatch(setActivityEvents(events))
-    })
+    void window.electron.activity
+      .list()
+      .then((events) => {
+        // Skip the late write if the component unmounted between the IPC call
+        // and its resolution (same cleanup contract as useSettingsSync).
+        if (!isCancelled) dispatch(setActivityEvents(events))
+      })
+      .catch((err) => {
+        // Hydration is best-effort: a failed initial list must not surface as
+        // an unhandled rejection. Live updates still arrive via
+        // `activity:changed`, so the timeline just starts empty this session.
+        console.warn('[activity] failed to hydrate from main:', err)
+      })
 
     const unsubscribe = window.electron.activity.onChanged((events) => {
       dispatch(setActivityEvents(events))

--- a/src/renderer/src/redux/slices/activitySlice.ts
+++ b/src/renderer/src/redux/slices/activitySlice.ts
@@ -1,0 +1,44 @@
+import type { PayloadAction } from '@reduxjs/toolkit'
+import { createSlice } from '@reduxjs/toolkit'
+
+import type { RootState } from '@/renderer/src/redux/store'
+import type { ActivityEvent, ActivityLog } from '@/shared/activityLog'
+
+/**
+ * Renderer-side cache of the activity log owned by the main process.
+ *
+ * Source of truth lives at `app.getPath('userData')/activity-log.json`; this
+ * slice mirrors that newest-first array so the Activity Timeline widget reads
+ * it synchronously. Hydration + live updates flow through the `useActivitySync`
+ * hook — components must NOT call `window.electron.activity.list()` directly.
+ *
+ * Like the settings slice, it exposes only an idempotent `setActivityEvents`
+ * replacement (not per-event reducers) and is intentionally NOT persisted by
+ * `redux-storage-middleware`: persistence is owned by main, so layering
+ * localStorage on top would create a dual-write race.
+ */
+const initialState: ActivityLog = []
+
+const activitySlice = createSlice({
+  name: 'activity',
+  initialState,
+  reducers: {
+    setActivityEvents: (_state, action: PayloadAction<ActivityLog>) =>
+      action.payload,
+  },
+})
+
+export const { setActivityEvents } = activitySlice.actions
+export default activitySlice.reducer
+
+/**
+ * Renderer selector for the newest-first activity events. Centralizing the read
+ * here gives the widget one stable hook signature and the right place to swap
+ * the storage shape later.
+ * @param state - Root Redux state.
+ * @returns The newest-first list of recorded activity events.
+ * @example
+ * useAppSelector(selectActivityEvents) // => [{ id: '…', type: 'synced', skillName: 'Sync', … }]
+ */
+export const selectActivityEvents = (state: RootState): ActivityEvent[] =>
+  state.activity

--- a/src/renderer/src/redux/slices/agentsSlice.test.ts
+++ b/src/renderer/src/redux/slices/agentsSlice.test.ts
@@ -23,6 +23,7 @@ vi.stubGlobal('window', {
 })
 
 async function createTestStore() {
+  const { default: activityReducer } = await import('./activitySlice')
   const { default: agentsReducer } = await import('./agentsSlice')
   const { default: bookmarkReducer } = await import('./bookmarkSlice')
   const { default: dashboardReducer } = await import('./dashboardSlice')
@@ -47,6 +48,11 @@ async function createTestStore() {
       dashboard: dashboardReducer,
       widgetPicker: widgetPickerReducer,
       settings: settingsReducer,
+      // Mirror the production store (store.ts) so a `{ state: RootState }`
+      // thunk like removeAllSymlinksFromAgent type-checks against this store's
+      // dispatch — a missing slice here makes TestState ⊉ RootState and the
+      // thunk overload silently drops out (TS2769).
+      activity: activityReducer,
     },
   })
 }

--- a/src/renderer/src/redux/store.test.ts
+++ b/src/renderer/src/redux/store.test.ts
@@ -266,6 +266,7 @@ describe('store wiring (singleton assembly)', () => {
 
     // Assert — every key listed in combineReducers must be present and defined
     expect(Object.keys(state).sort()).toEqual([
+      'activity',
       'agents',
       'bookmarks',
       'dashboard',

--- a/src/renderer/src/redux/store.ts
+++ b/src/renderer/src/redux/store.ts
@@ -6,6 +6,7 @@ import { PERSIST_STATE_VERSION, PERSIST_STORAGE_KEY } from '@/shared/constants'
 
 import { listenerMiddleware } from './listener'
 import { migrateState } from './migrations'
+import activityReducer from './slices/activitySlice'
 import agentsReducer from './slices/agentsSlice'
 import bookmarkReducer from './slices/bookmarkSlice'
 import dashboardReducer from './slices/dashboardSlice'
@@ -37,6 +38,10 @@ const rootReducer = combineReducers({
   // Both the Settings window (General → Default tab) and the main window
   // (SkillDetail tab buttons) read and write `defaultSkillTab` here.
   settings: settingsReducer,
+  // Mirrors main-process activity-log.json (Activity Timeline widget).
+  // Like `settings`, NOT in the redux-storage-middleware `slices` array —
+  // persistence is owned by main, so localStorage here would dual-write.
+  activity: activityReducer,
 })
 
 type RootReducerState = ReturnType<typeof rootReducer>

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -1,3 +1,7 @@
+import type {
+  ActivityEvent,
+  ActivityListOptions,
+} from '../../../shared/activityLog'
 import type { Settings, SettingsPatch } from '../../../shared/settings'
 import type {
   AbsolutePath,
@@ -143,6 +147,10 @@ declare global {
         get: () => Promise<Settings>
         set: (partial: SettingsPatch) => Promise<Settings>
         onChanged: (callback: (settings: Settings) => void) => () => void
+      }
+      activity: {
+        list: (options?: ActivityListOptions) => Promise<ActivityEvent[]>
+        onChanged: (callback: (events: ActivityEvent[]) => void) => () => void
       }
       folder: {
         revealInFinder: (

--- a/src/shared/activityLog.ts
+++ b/src/shared/activityLog.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod'
+
+/**
+ * The kinds of activity the timeline records. `created` / `removed` / `synced`
+ * have live emit sites in the IPC mutation handlers; `renamed` is defined for
+ * completeness (the widget already renders it) but has NO emit site yet because
+ * the app currently ships no skill-rename feature — the moment one lands it
+ * flows through with zero schema/UI changes. See `docs/activity-log.md`.
+ */
+const ACTIVITY_EVENT_TYPES = [
+  'created',
+  'removed',
+  'synced',
+  'renamed',
+] as const
+
+/**
+ * One persisted activity-log entry. A deliberately FLAT shape (not a
+ * discriminated union) so every row renders through the same code path —
+ * `<skillName> · <agentName?>` then `<type label> — <detail?>`. `type` only
+ * selects the row's icon + accent color, so optional fields stay easier to
+ * read/validate than per-variant payloads would.
+ */
+const ActivityEventSchema = z.object({
+  /** Stable id (uuid) stamped in the main process; doubles as the React list key. */
+  id: z.string().min(1),
+  /** ISO-8601 instant the event was recorded, from the main-process clock. */
+  timestamp: z.string().min(1),
+  /** Which mutation produced the entry. */
+  type: z.enum(ACTIVITY_EVENT_TYPES),
+  /** Primary subject: a skill name, or a scope label like `Sync` for a sync summary. */
+  skillName: z.string().min(1),
+  /** Agent the mutation touched, when it maps to exactly one. Omitted for sync summaries. */
+  agentName: z.string().min(1).optional(),
+  /** Human-readable extra, e.g. `10 created · 1 replaced · 5 skipped` for a sync. */
+  detail: z.string().min(1).optional(),
+})
+
+/** Validates the whole on-disk log: a newest-first array of events. */
+export const ActivityLogSchema = z.array(ActivityEventSchema)
+
+/** One persisted activity-log entry. @see ActivityEventSchema */
+export type ActivityEvent = z.infer<typeof ActivityEventSchema>
+
+/** The union of recorded activity kinds (`'created' | 'removed' | 'synced' | 'renamed'`). */
+export type ActivityEventType = ActivityEvent['type']
+
+/** Newest-first list of activity events, as persisted on disk and broadcast to renderers. */
+export type ActivityLog = ActivityEvent[]
+
+/**
+ * Event payload as supplied by an emit site. The main process stamps `id` +
+ * `timestamp`, so callers never pass them.
+ * @example { type: 'created', skillName: 'azure-ai', agentName: 'Claude Code' }
+ */
+export type ActivityEventInput = Omit<ActivityEvent, 'id' | 'timestamp'>
+
+/**
+ * Query options for the `activity:list` IPC channel. Both fields are optional;
+ * defaults return the newest `MAX_ACTIVITY_EVENTS` events with no offset.
+ */
+export interface ActivityListOptions {
+  /** Max events to return, newest-first. */
+  limit?: number
+  /** How many newest events to skip before taking `limit` (simple paging). */
+  offset?: number
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1044,6 +1044,15 @@ export const SETTINGS_RANGE_DEBOUNCE_MS = 120
 export const BULK_PROGRESS_THRESHOLD = 10
 
 /**
+ * Hard cap on persisted activity-log entries. The main-process store keeps a
+ * newest-first ring buffer trimmed to this length so `activity-log.json` cannot
+ * grow unbounded; older events fall off the tail. 200 covers weeks of typical
+ * add / remove / sync activity while staying small enough to rewrite the whole
+ * file atomically on every append.
+ */
+export const MAX_ACTIVITY_EVENTS = 200
+
+/**
  * Max number of source repositories enumerated individually before the
  * source-repo filter collapses to a count summary. Drives BOTH the toolbar
  * pills (≤ cap → one chip per repo; > cap → a single "from N repos" chip) and

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -68,6 +68,12 @@ export const IPC_CHANNELS = {
   SETTINGS_SET: 'settings:set',
   SETTINGS_CHANGED: 'settings:changed',
 
+  // Activity timeline (dashboard) — append-only event log persisted under
+  // userData. `list` hydrates the widget on mount; `changed` broadcasts the
+  // new log after each recorded add/remove/sync.
+  ACTIVITY_LIST: 'activity:list',
+  ACTIVITY_CHANGED: 'activity:changed',
+
   // Folder actions (Reveal in Finder, Open in Terminal)
   FOLDER_REVEAL_IN_FINDER: 'folder:revealInFinder',
   FOLDER_OPEN_IN_TERMINAL: 'folder:openInTerminal',

--- a/src/shared/ipc-contract.test.ts
+++ b/src/shared/ipc-contract.test.ts
@@ -40,6 +40,7 @@ describe('IPC contract alignment', () => {
       [IPC_CHANNELS.SETTINGS_OPEN]: true,
       [IPC_CHANNELS.SETTINGS_GET]: true,
       [IPC_CHANNELS.SETTINGS_SET]: true,
+      [IPC_CHANNELS.ACTIVITY_LIST]: true,
       [IPC_CHANNELS.FOLDER_REVEAL_IN_FINDER]: true,
       [IPC_CHANNELS.FOLDER_OPEN_IN_TERMINAL]: true,
       [IPC_CHANNELS.WINDOW_GET_MAIN_BOUNDS]: true,
@@ -54,7 +55,7 @@ describe('IPC contract alignment', () => {
     // The `satisfies` clause above is a structural guard; this length check is
     // the trip-wire that forces a human PR diff when a channel is added.
     // Assert
-    expect(invokeChannelKeys).toHaveLength(35)
+    expect(invokeChannelKeys).toHaveLength(36)
   })
 
   it('forces a review by tripping when a push-event channel is added or removed', () => {
@@ -70,6 +71,7 @@ describe('IPC contract alignment', () => {
       [IPC_CHANNELS.UPDATE_DOWNLOADED]: true,
       [IPC_CHANNELS.UPDATE_ERROR]: true,
       [IPC_CHANNELS.SETTINGS_CHANGED]: true,
+      [IPC_CHANNELS.ACTIVITY_CHANGED]: true,
     } as const satisfies Record<keyof IpcEventContract, true>
 
     // Act
@@ -77,6 +79,6 @@ describe('IPC contract alignment', () => {
 
     // Runtime assertion: mapping covers exactly the contract keys
     // Assert
-    expect(eventChannelKeys).toHaveLength(9)
+    expect(eventChannelKeys).toHaveLength(10)
   })
 })

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -1,3 +1,4 @@
+import type { ActivityEvent, ActivityListOptions } from './activityLog'
 import type { Settings, SettingsPatch } from './settings'
 import type {
   AbsolutePath,
@@ -136,6 +137,13 @@ export interface IpcInvokeContract {
   'settings:open': { args: []; result: void }
   'settings:get': { args: []; result: Settings }
   'settings:set': { args: [SettingsPatch]; result: Settings }
+  'activity:list': {
+    // Always 1-arg (possibly `undefined`) to match the Zod tuple schema, like
+    // `sync:preview`: preload forwards the options arg even when it is
+    // `undefined`, so this contract reflects reality.
+    args: [ActivityListOptions | undefined]
+    result: ActivityEvent[]
+  }
   // Folder actions are intentionally typed as `Promise<FolderActionResult>`
   // (never throws) so the renderer can render a toast without try/catch.
   // Main-process exceptions get caught at the typedHandle boundary and
@@ -170,6 +178,7 @@ export interface IpcEventContract {
   'update:downloaded': UpdateInfo
   'update:error': UpdateErrorPayload
   'settings:changed': Settings
+  'activity:changed': ActivityEvent[]
 }
 
 /** Union of every request/response IPC invoke channel name in {@link IpcInvokeContract}. */


### PR DESCRIPTION
## What & why

Replaces the Activity Timeline widget's last-sync-only placeholder with a real, persisted activity log owned by the main process. The timeline now survives across syncs and app restarts and spans multiple event types. Implements #178.

## Changes

**Main process**
- `services/activityLog.ts` — Zod-validated, append-only store at `userData/activity-log.json`. Newest-first, trimmed to a 200-entry ring buffer (`MAX_ACTIVITY_EVENTS`), atomic temp+rename writes, `ENOENT`→empty on load (mirrors `settings.ts`).
- `ipc/activity.ts` — `recordActivityEvents()` (flag-gated no-op + **never-throws**, so a logging failure can't fail the triggering mutation) and the `activity:list` query handler.
- Emit sites: `created` (skills create/copy, one event per agent), `removed` (skills delete + bulk delete, batched into one write), `synced` (one summary per run with counts in `detail`).

**IPC**
- Typed `activity:list` (paged: `{ limit, offset }`) + `activity:changed` broadcast — channel + contract + Zod tuple + preload bridge + `electron.d.ts`, mirroring the settings sync. Contract trip-wire tests updated (36 invoke / 10 event).

**Renderer**
- `activitySlice` + `useActivitySync` hook hydrate on mount (`activity:list`) and converge via the `activity:changed` broadcast.
- Widget renders the real newest-first feed (was `selectSyncResult`-only); empty state retained.

**Docs**: `docs/activity-log.md`.

## 🏴 Ships dark behind a flag

Gated behind `ENABLE_DASHBOARD_EXPERIMENTAL = false`: the recorder early-returns, the widget is filtered out of the picker, and `useActivitySync` early-returns — **zero production behavior change**.

**AC3 ("promote out of the experimental flag") is deliberately deferred to sign-off** — this PR does **not** flip the flag. #178 stays open until then (hence "Implements", not "Closes").

## Notes for reviewers

- **`renamed` has no emit site**: the app ships no rename feature yet, so `renamed` is defined in the schema + widget for forward-compat but never emitted. Disclosed in `docs/activity-log.md`; a future rename feature flows through with zero schema/UI changes.
- **`useActivitySync` uses `useEffect`**, not `useSyncExternalStore` — a verbatim mirror of the existing `useSettingsSync`. Kept consistent with the established sync-hook pattern; migrating both hooks together is a possible follow-up.
- **`synced` accent is `text-foreground`, not amber**: DESIGN.md caps amber at two meanings (broken/needs-review + bookmark) and names `text-foreground` as the safe default for a third semantic — a sync is a routine success, not a needs-review state.
- **Pre-existing `fallow dupes` note**: the `Appearance.tsx ↔ CodePreview.tsx` clone group (3 shared settings reads) exists on `main`, is unrelated to this PR, and is reported-but-non-failing (`fallow dupes` exits 0 at 0.1%). Out of scope here.

## Verification

typecheck ✓ · eslint ✓ · vitest 2301 tests ✓ · coverage lines 99.92 / funcs 99.81 / branches 91.85 (all above the 99.8 / 99.8 / 90 thresholds) ✓ · fallow dead-code/dupes/health ✓ · storybook build ✓ · Electron e2e suite ✓


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * アクティビティタイムライン（Activity Log）をダッシュボードに追加。スキルの追加/削除/同期の履歴を永続化し、ウィジェットはメインプロセスの更新に追従して表示します。
  * 画面側でもイベント一覧の取得・購読が可能になりました。
* **Documentation**
  * Activity Log（Activity Timeline）仕様を追加。
* **Tests**
  * アクティビティログの永続化・順序・上限・ページング・同時追記・復旧をエンドツーエンド検証するテストを追加/更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->