### PR TITLE
chore: sync skills CLI pin to 1.5.13

### DIFF
--- a/.claude/skills/skills-cli-sync/SKILL.md
+++ b/.claude/skills/skills-cli-sync/SKILL.md
@@ -149,6 +149,26 @@ Do not bump `package.json` `version` — releases are owned solely by
 
 ## Latest run (example — point-in-time, NOT part of the procedure)
 
+**2026-06-24 · v1.5.11 → v1.5.13** (version pin + excluded upstream agent)
+
+- **No app agent-list change:** upstream `name:` set is 72 and app `cliId` set
+  stays 68. The only upstream addition since v1.5.11 that is not already
+  mirrored is `eve`, which has `globalSkillsDir: undefined`, so Phase 4 excludes
+  it. App orphans remained zero.
+- **Unchanged derived sets:** `AGENT_DEFINITIONS` stayed 68,
+  `UNIVERSAL_AGENT_IDS` stayed 16, with no `id`/`cliId` migrations and no
+  display-name rebrands.
+- **Excluded at this version:** `eve` and `promptscript`
+  (`globalSkillsDir: undefined`), `universal` (`showInUniversalList: false`),
+  `zenflow` (dir collides with zencoder's `~/.zencoder/skills`).
+- **Edits:** bumped `SKILLS_CLI_VERSION` 1.5.11 → 1.5.13; bumped the e2e pin
+  (`marketplace-install-regression.e2e.ts` literal `skills@1.5.13 add …` +
+  comment); bumped the CLAUDE.md/AGENTS.md Domain-Concepts pinned-version cell;
+  ignored local `.agents/**` in ESLint so repo-local skill copies do not break
+  `pnpm validate`.
+- Gates: `reconcile-agents.mjs` clean, prettier clean, `pnpm validate` green,
+  `pnpm test:e2e` green (60 tests).
+
 **2026-06-14 · v1.5.10 → v1.5.11** (version-only bump)
 
 - **No agent-list change:** `src/agents.ts` is byte-identical between v1.5.10

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ PRs are ready to ship only when `validate` and e2e both pass in that order.
 | Repository     | https://github.com/vercel-labs/skills (paths below are inside that repo)                       |
 | CLI agent list | `src/agents.ts`                                                                                |
 | CLI types      | `src/types.ts`                                                                                 |
-| Pinned version | `SKILLS_CLI_VERSION` in `src/shared/constants.ts` (currently `1.5.11`) — bump when re-syncing `AGENT_DEFINITIONS` against the upstream skills CLI |
+| Pinned version | `SKILLS_CLI_VERSION` in `src/shared/constants.ts` (currently `1.5.13`) — bump when re-syncing `AGENT_DEFINITIONS` against the upstream skills CLI |
 
 `AGENT_DEFINITIONS` in `src/shared/constants.ts` mirrors the CLI's agent
 list. Each entry: `id` (app state), `cliId` (`--agent` flag), `name`

--- a/e2e/spec/marketplace-install-regression.e2e.ts
+++ b/e2e/spec/marketplace-install-regression.e2e.ts
@@ -162,14 +162,14 @@ test('Marketplace Install works when Electron starts with sparse macOS GUI PATH'
     await dialog.getByRole('button', { name: 'Install', exact: true }).click()
 
     // Assert — the fake npx ran with the pinned CLI version (SKILLS_CLI_VERSION
-    // is '1.5.11' in src/shared/constants.ts; hardcoded here so this test pins
+    // is '1.5.13' in src/shared/constants.ts; hardcoded here so this test pins
     // the literal command rather than computing the expectation from the same
     // constant the production command builds from) and the installed badge shows.
     await expect
       .poll(() => existsSync(markerPath), { timeout: 10_000 })
       .toBe(true)
     expect(readFileSync(markerPath, 'utf-8')).toContain(
-      'skills@1.5.11 add vercel-labs/skills',
+      'skills@1.5.13 add vercel-labs/skills',
     )
     await expect(
       appWindow.getByRole('img', { name: /find-skills is installed/i }),

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -111,6 +111,8 @@ export default defineConfig([
       'website/**',
       // Agent tooling (Claude Code skills), not app source — keep out of linting.
       '.claude/**',
+      // Local agent skills are ignored by git but may exist while running skills.
+      '.agents/**',
     ],
   },
   // React "You Might Not Need an Effect" rules (explicit instead of configs.recommended)

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -978,7 +978,7 @@ export const TERMINAL_APP_UI_LABELS: Record<
  * @example
  * spawn('npx', [`skills@${SKILLS_CLI_VERSION}`, 'find', 'react'])
  */
-export const SKILLS_CLI_VERSION = '1.5.11'
+export const SKILLS_CLI_VERSION = '1.5.13'
 
 /**
  * Canonical hostname for skills marketplace pages used by renderer/main


### PR DESCRIPTION
## Summary
- bump SKILLS_CLI_VERSION and the marketplace install regression pin to skills CLI 1.5.13
- confirm upstream v1.5.13 agent definitions still resolve to 68 app-supported agents after exclusions
- document the sync run and ignore local .agents skill copies in ESLint

## Validation
- node .agents/skills/skills-cli-sync/reconcile-agents.mjs
- npx prettier --check README.md SPEC.md CLAUDE.md eslint.config.mjs .claude/skills/skills-cli-sync/SKILL.md .agents/skills/skills-cli-sync/SKILL.md
- pnpm validate
- pnpm test:e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Skills CLI の参照バージョンを 1.5.13 に更新しました。
  * インストール時の検証内容を最新のバージョンに合わせて更新しました。

* **テスト**
  * インストール回帰テストを最新バージョンに追従させました。

* **その他**
  * 一部の非対象ファイルを静的チェックの対象外にしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->