### PR TITLE
docs: add security policy and posture overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Platform: macOS](https://img.shields.io/badge/Platform-macOS-lightgrey.svg)](https://www.apple.com/macos/)
 [![codecov](https://codecov.io/gh/laststance/skills-desktop/branch/main/graph/badge.svg)](https://codecov.io/gh/laststance/skills-desktop)
+[![Security Policy](https://img.shields.io/badge/Security-Policy-green.svg)](SECURITY.md)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/laststance/skills-desktop)
 
 <p align="center">
@@ -46,6 +47,24 @@ Download the latest release from [GitHub Releases](https://github.com/laststance
 | ------------------------ | -------------------------------- |
 | Apple Silicon (M1/M2/M3) | `skills-desktop-x.x.x-arm64.dmg` |
 | Intel Mac                | `skills-desktop-x.x.x-x64.dmg`   |
+
+## Security
+
+Please report vulnerabilities through the process described in
+[SECURITY.md](SECURITY.md), not through public issues.
+
+Skills Desktop keeps local filesystem access behind Electron preload IPC. The
+main and settings windows use sandboxed, context-isolated renderers with Node.js
+integration disabled. Main-process handlers validate IPC arguments, restrict
+file reads to known skills directories, restrict external links to http(s), and
+allow marketplace webviews only from the expected skills.sh origin.
+
+macOS releases are built with Developer ID signing, notarization, and the
+hardened runtime enabled. The security posture tracked for
+[issue #241](https://github.com/laststance/skills-desktop/issues/241) includes
+CodeQL, dependency review, production dependency audit, GitHub secret scanning,
+Dependabot security updates, least-privilege Actions permissions, and branch
+protection.
 
 ## Development
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,66 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are provided for the latest released version of Skills Desktop.
+Please update to the newest release before reporting a suspected vulnerability
+unless the issue only affects the current development branch.
+
+## Reporting a Vulnerability
+
+Please do not report security vulnerabilities through public GitHub issues.
+Use GitHub's private vulnerability reporting flow for this repository when it is
+available. If private reporting is unavailable, contact the maintainer through
+the Laststance.io GitHub organization and include a short note that the report
+is security-sensitive.
+
+Include:
+
+- affected Skills Desktop version or commit
+- macOS version and architecture
+- reproduction steps or proof of concept
+- expected impact
+- whether the issue requires local filesystem access, a malicious skill, a
+  malicious marketplace listing, or a compromised update channel
+
+## Response Targets
+
+- Initial acknowledgement: within 7 days
+- Triage update: within 14 days when reproduction details are sufficient
+- Coordinated disclosure: after a fix is available, or earlier if public risk
+  requires it
+
+These are targets, not guarantees, because this is an open-source project with
+limited maintainer capacity.
+
+## Scope
+
+In scope:
+
+- Electron main/preload/renderer privilege boundary issues
+- IPC validation bypasses
+- unintended filesystem access outside configured skills directories
+- unsafe external link, webview, or marketplace preview behavior
+- update, signing, notarization, or release artifact integrity issues
+- CI/CD, dependency, and GitHub Actions supply-chain risks
+
+Out of scope:
+
+- issues requiring arbitrary local code execution before launching the app
+- denial of service from intentionally corrupt local development checkouts
+- social engineering against maintainers or users
+- vulnerabilities in third-party services that are not controlled by this repo
+
+## Security Posture
+
+Skills Desktop is an Electron app that manages local skills directories. The app
+keeps renderer filesystem access behind preload IPC, runs BrowserWindows with
+sandboxing and context isolation, disables Node.js integration in renderers,
+validates IPC arguments in the main process, validates filesystem paths against
+allowed skills locations, restricts external links to http(s), and notarizes
+macOS release builds with the hardened runtime enabled.
+
+GitHub security automation is tracked in issue #241 and includes CodeQL,
+dependency review, production dependency audit, secret scanning, Dependabot
+security updates, least-privilege GitHub Actions permissions, and branch
+protection.


### PR DESCRIPTION
## Summary
- add SECURITY.md with supported versions, vulnerability reporting, scope, response targets, and posture notes
- add README Security section and visible Security Policy badge
- document existing Electron hardening and release assurance for #241

Refs #241

## Test plan
- docs-only change; no local test run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * セキュリティポリシーの案内をREADMEに追加し、脆弱性報告先と重要な安全上の注意事項を明記しました。
  * 新しいセキュリティポリシー文書を追加し、報告手順、対応目安、対象範囲と除外範囲を整理しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->