### PR TITLE
ci: add security maintenance hardening

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Keep security-sensitive workflow and release changes reviewed by the repo admin.
+* @ryota-murakami

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,10 @@
 # Keep security-sensitive workflow and release changes reviewed by the repo admin.
-* @ryota-murakami
+.github/ @ryota-murakami
+electron-builder.yml @ryota-murakami
+package.json @ryota-murakami
+pnpm-lock.yaml @ryota-murakami
+pnpm-workspace.yaml @ryota-murakami
+scripts/ @ryota-murakami
+resources/ @ryota-murakami
+website/src/components/Download.tsx @ryota-murakami
+website/src/components/Hero.tsx @ryota-murakami

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,44 @@
+name: Bug report
+description: Report a reproducible non-security bug.
+title: '[Bug]: '
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        If this is a security vulnerability, do not file a public issue. Follow SECURITY.md instead.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What happened?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Provide the shortest reliable reproduction.
+      placeholder: |
+        1. Open ...
+        2. Click ...
+        3. See ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Skills Desktop version
+      placeholder: 0.26.1
+  - type: input
+    id: macos
+    attributes:
+      label: macOS version and architecture
+      placeholder: macOS 15.x, Apple Silicon

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Report a security vulnerability
     url: https://github.com/laststance/skills-desktop/security/policy

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/laststance/skills-desktop/security/policy
+    about: Please do not report vulnerabilities through public GitHub issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,24 @@
+name: Feature request
+description: Suggest an improvement or new capability.
+title: '[Feature]: '
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user workflow would this improve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: What should Skills Desktop do?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '08:00'
+      timezone: Asia/Tokyo
+    groups:
+      production-dependencies:
+        dependency-type: production
+      development-dependencies:
+        dependency-type: development
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '08:30'
+      timezone: Asia/Tokyo

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+-
+
+## Test Plan
+
+- [ ] `pnpm validate`
+- [ ] `pnpm test:e2e`
+
+## Security Checklist
+
+- [ ] This change does not widen renderer access to Node.js, Electron, or direct filesystem APIs.
+- [ ] New IPC or filesystem behavior validates untrusted renderer input in the main process.
+- [ ] Dependency, workflow, or release changes preserve least-privilege permissions and pinned third-party Actions.
+- [ ] Security-sensitive behavior is documented or linked from `SECURITY.md` when relevant.

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,35 @@
+name: Scorecard
+
+on:
+  branch_protection_rule:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '41 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scorecard:
+    name: OpenSSF Scorecard
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true


### PR DESCRIPTION
## Summary
- add Dependabot updates for npm and GitHub Actions
- add OpenSSF Scorecard workflow with SARIF publishing
- add CODEOWNERS, PR template, and issue templates that route vulnerability reports to SECURITY.md

Refs #241

## Test plan
- `actionlint`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/dependabot.yml .github/workflows/*.yml .github/ISSUE_TEMPLATE/*.yml`\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * バグ報告・機能要望の issue テンプレートを追加し、入力を整理して共有しやすくしました。
  * PR テンプレートを追加し、要約・テスト計画・セキュリティ確認を記入しやすくしました。
* **改善**
  * Dependabot による依存関係と GitHub Actions の定期更新を設定しました。
  * OpenSSF Scorecard を自動実行し、結果を確認できるようにしました。
  * セキュリティ関連の変更のレビュー体制と報告案内を明確化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->