### PR TITLE
fix(skills): make protected delete state explicit

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -481,9 +481,9 @@ Row-level toggleable controls (lock/protection, bookmark) that exist to guard or
 - **Hover (off):** `opacity-70` — mid-state gives the interaction hint before commit.
 - **Active (on):** `opacity-100` + semantic color (`text-foreground` for protection, `text-amber-500` for bookmark) — the engaged state must be unambiguous. Protection also adds a compact, always-visible `Protected` badge beside the item name; a closed lock alone is too easy to misread as a passive icon.
 
-Always pair with a tooltip: `"Protected — cannot be deleted"` (on) / `"Click to protect"` (off). Lock semantics are not self-evident in operational UI.
+Always pair with a tooltip: `"Protected — cannot be deleted or removed"` (on) / `"Click to protect"` (off). Lock semantics are not self-evident in operational UI.
 
-In the global Skills view, a protected row keeps its destructive action slot visible as a muted, focusable `aria-disabled` control labelled `Unlock to delete`. Its styled tooltip must open on pointer hover and keyboard focus. Do not remove the control from the layout: disappearance makes users diagnose a missing action, while a stable disabled slot plus the `Protected` badge makes the cause and recovery path explicit. The active protection still blocks the handler and bulk-delete path; this treatment changes explanation, not safety.
+In the global Skills view, a protected row keeps its destructive action slot visible as a muted, focusable `aria-disabled` control with the accessible label `Delete ${skill.name} unavailable while protected` and the tooltip `Unlock to delete`. Its styled tooltip must open on pointer hover and keyboard focus. Do not remove the control from the layout: disappearance makes users diagnose a missing action, while a stable disabled slot plus the `Protected` badge makes the cause and recovery path explicit. The active protection still blocks the handler and bulk-delete path; this treatment changes explanation, not safety.
 
 ### Dialogs, Popovers, and Toasts
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -479,9 +479,11 @@ Row-level toggleable controls (lock/protection, bookmark) that exist to guard or
 
 - **Rest (off):** `opacity-40` always-visible — non-destructive value-add actions remain discoverable at rest per the visibility-asymmetry rule. Hover-only discovery is below the quality bar set by top-tier apps.
 - **Hover (off):** `opacity-70` — mid-state gives the interaction hint before commit.
-- **Active (on):** `opacity-100` + semantic color (`text-foreground` for protection, `text-amber-500` for bookmark) — the engaged state must be unambiguous.
+- **Active (on):** `opacity-100` + semantic color (`text-foreground` for protection, `text-amber-500` for bookmark) — the engaged state must be unambiguous. Protection also adds a compact, always-visible `Protected` badge beside the item name; a closed lock alone is too easy to misread as a passive icon.
 
 Always pair with a tooltip: `"Protected — cannot be deleted"` (on) / `"Click to protect"` (off). Lock semantics are not self-evident in operational UI.
+
+In the global Skills view, a protected row keeps its destructive action slot visible as a muted, focusable `aria-disabled` control labelled `Unlock to delete`. Its styled tooltip must open on pointer hover and keyboard focus. Do not remove the control from the layout: disappearance makes users diagnose a missing action, while a stable disabled slot plus the `Protected` badge makes the cause and recovery path explicit. The active protection still blocks the handler and bulk-delete path; this treatment changes explanation, not safety.
 
 ### Dialogs, Popovers, and Toasts
 

--- a/e2e/spec/regression.e2e.ts
+++ b/e2e/spec/regression.e2e.ts
@@ -1029,3 +1029,104 @@ test('skills list scroll position survives a background refetch (regression 5619
       ?.removeAttribute('data-e2e-scroll-target')
   })
 })
+
+test('protected cards explain why Delete is unavailable while unlocked cards remain deletable', async ({
+  appWindow,
+  isolatedHome,
+}) => {
+  // Arrange — use the reported skill names in a fresh HOME and rescan them into Redux.
+  await waitForInitialScan(appWindow)
+  stageSourceSkill(isolatedHome, 'analyze-app')
+  stageSourceSkill(isolatedHome, 'brainstorm-plan')
+  await refreshSkillsState(appWindow)
+  await dispatchAction(appWindow, {
+    type: 'protect/addProtection',
+    payload: 'analyze-app',
+  })
+
+  // Act — isolate the protected row just as a user narrows a long skill list.
+  await dispatchAction(appWindow, {
+    type: 'ui/setSearchQuery',
+    payload: 'analyze-app',
+  })
+  const protectedCard = appWindow.locator('[data-skill-name="analyze-app"]')
+
+  // Assert — protection is visible without hover and Delete explains its disabled state.
+  await expect(
+    protectedCard.getByText('Protected', { exact: true }),
+  ).toBeVisible()
+  const protectedDeleteButton = protectedCard.getByRole('button', {
+    name: 'Delete analyze-app unavailable while protected',
+  })
+  await expect(protectedDeleteButton).toBeVisible()
+  await expect(protectedDeleteButton).toBeDisabled()
+  await protectedDeleteButton.focus()
+  await expect(
+    appWindow
+      .getByRole('tooltip')
+      .getByText('Unlock to delete', { exact: true }),
+  ).toBeVisible()
+  const recoveryTooltip = appWindow.getByRole('tooltip')
+  const recoveryTooltipId = (await recoveryTooltip.getAttribute('id')) ?? ''
+  expect(recoveryTooltipId).not.toBe('')
+  await expect(protectedDeleteButton).toHaveAttribute(
+    'aria-describedby',
+    recoveryTooltipId,
+  )
+
+  // Act — activate the focusable aria-disabled control from the keyboard.
+  await appWindow.keyboard.press('Enter')
+  const blockedActivationState = await getStoreState(appWindow, (state) => {
+    const root = state as {
+      ui: { bulkConfirm: unknown }
+      skills: { selectedSkill: unknown }
+    }
+    return {
+      bulkConfirm: root.ui.bulkConfirm,
+      selectedSkill: root.skills.selectedSkill,
+    }
+  })
+
+  // Assert — the guard opens no delete flow and does not select the card.
+  expect(blockedActivationState).toEqual({
+    bulkConfirm: null,
+    selectedSkill: null,
+  })
+
+  // Act — show the otherwise-identical unlocked row and reveal its destructive action.
+  await dispatchAction(appWindow, {
+    type: 'ui/setSearchQuery',
+    payload: 'brainstorm-plan',
+  })
+  const unlockedCard = appWindow.locator('[data-skill-name="brainstorm-plan"]')
+  await expect(unlockedCard).toBeVisible()
+  await unlockedCard.hover()
+
+  // Assert — no protection label leaks to the unlocked row and Delete stays enabled.
+  await expect(
+    unlockedCard.getByText('Protected', { exact: true }),
+  ).toHaveCount(0)
+  const unlockedDeleteButton = unlockedCard.getByRole('button', {
+    name: 'Delete brainstorm-plan',
+  })
+  await expect(unlockedDeleteButton).toBeVisible()
+  await expect(unlockedDeleteButton).toBeEnabled()
+
+  // Act — unlock the original row through the same control available to users.
+  await dispatchAction(appWindow, {
+    type: 'ui/setSearchQuery',
+    payload: 'analyze-app',
+  })
+  await protectedCard
+    .getByRole('button', { name: 'Unlock analyze-app' })
+    .click()
+
+  // Assert — the explanation clears and Delete becomes the normal enabled action.
+  await expect(
+    protectedCard.getByText('Protected', { exact: true }),
+  ).toHaveCount(0)
+  await protectedCard.hover()
+  await expect(
+    protectedCard.getByRole('button', { name: 'Delete analyze-app' }),
+  ).toBeEnabled()
+})

--- a/src/renderer/src/components/skills/SkillItem.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillItem.browser.test.tsx
@@ -1120,7 +1120,7 @@ describe('SkillItem protection', () => {
       .toBeInTheDocument()
   })
 
-  it('shows an "Unlock {name}" button when the skill is protected', async () => {
+  it('labels a protected skill and offers an Unlock action', async () => {
     // Arrange — dispatch addProtection before rendering so ProtectButton
     // receives isProtected=true and renders the Lock icon.
     const { screen, store } = await renderSkillItem(
@@ -1132,13 +1132,16 @@ describe('SkillItem protection', () => {
     // Act
     store.dispatch(addProtection('task' as SkillName))
 
-    // Assert — Lock icon + "Unlock task" label confirms the protected visual state.
+    // Assert — text makes protection scannable while the lock remains actionable.
     await expect
       .element(screen.getByRole('button', { name: /^Unlock task$/i }))
       .toBeInTheDocument()
+    await expect
+      .element(screen.getByText('Protected', { exact: true }))
+      .toBeVisible()
   })
 
-  it('hides the delete button when the skill is locked', async () => {
+  it('explains that delete is unavailable while the skill is protected', async () => {
     // Arrange
     const { screen, store } = await renderSkillItem(
       makeSkill({ name: 'task' as SkillName }),
@@ -1146,18 +1149,19 @@ describe('SkillItem protection', () => {
     const { addProtection } =
       await import('@/renderer/src/redux/slices/protectSlice')
 
-    // Act — lock the skill; protection gates showDeleteButton to false.
+    // Act — protect the skill so the destructive action becomes unavailable.
     store.dispatch(addProtection('task' as SkillName))
 
-    // Assert — delete button must be absent; clicking it with protection on
-    // would mean the fat-finger guard is broken. Use async assertion so React
-    // has time to re-render after the store dispatch.
-    await expect
-      .element(screen.getByRole('button', { name: /^Delete task$/i }))
-      .not.toBeInTheDocument()
+    // Assert — keep the stable action slot visible, but disable it and name why.
+    const deleteButton = screen.getByRole('button', {
+      name: /^Delete task unavailable while protected$/i,
+    })
+    await expect.element(deleteButton).toBeVisible()
+    await expect.element(deleteButton).toBeDisabled()
+    await expect.element(deleteButton).toHaveAttribute('aria-disabled', 'true')
   })
 
-  it('restores the delete button when the skill is unlocked', async () => {
+  it('removes the Protected label and enables delete after unlocking', async () => {
     // Arrange — start locked, then unlock.
     const { screen, store } = await renderSkillItem(
       makeSkill({ name: 'task' as SkillName }),
@@ -1169,10 +1173,13 @@ describe('SkillItem protection', () => {
     // Act
     store.dispatch(removeProtection('task' as SkillName))
 
-    // Assert — delete button reappears after unlocking.
+    // Assert — the visible status clears and the same destructive slot is usable.
+    const deleteButton = screen.getByRole('button', { name: /^Delete task$/i })
+    await expect.element(deleteButton).toBeInTheDocument()
+    await expect.element(deleteButton).not.toBeDisabled()
     await expect
-      .element(screen.getByRole('button', { name: /^Delete task$/i }))
-      .toBeInTheDocument()
+      .element(screen.getByText('Protected', { exact: true }))
+      .not.toBeInTheDocument()
   })
 
   it('hides the agent-view unlink button when the skill is locked', async () => {

--- a/src/renderer/src/components/skills/SkillItem.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillItem.browser.test.tsx
@@ -1152,12 +1152,11 @@ describe('SkillItem protection', () => {
     // Act — protect the skill so the destructive action becomes unavailable.
     store.dispatch(addProtection('task' as SkillName))
 
-    // Assert — keep the stable action slot visible, but disable it and name why.
+    // Assert — keep the stable action slot visible, expose its ARIA state, and name why.
     const deleteButton = screen.getByRole('button', {
       name: /^Delete task unavailable while protected$/i,
     })
     await expect.element(deleteButton).toBeVisible()
-    await expect.element(deleteButton).toBeDisabled()
     await expect.element(deleteButton).toHaveAttribute('aria-disabled', 'true')
   })
 

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -13,6 +13,7 @@ import {
 import React, { useCallback, useMemo, useRef, useState } from 'react'
 
 import { StatusBadge } from '@/renderer/src/components/status/StatusBadge'
+import { badgeVariants } from '@/renderer/src/components/ui/badge'
 import { Button } from '@/renderer/src/components/ui/button'
 import { Card, CardContent } from '@/renderer/src/components/ui/card'
 import { Checkbox } from '@/renderer/src/components/ui/checkbox'
@@ -97,7 +98,7 @@ interface ProtectButtonProps {
 
 /**
  * Lock / unlock toggle shown on every skill row. Manages its own Redux state
- * so the parent SkillItem only needs `isProtected` for the delete-button gate.
+ * so the parent SkillItem only needs `isProtected` for status and action guards.
  * @param props - Skill name, bookmark visibility, and X-button visibility for positioning.
  * @returns Tooltip-wrapped lock icon button that dispatches protect actions.
  * @example
@@ -284,6 +285,7 @@ interface SkillTitleRowProps {
   isLinked: boolean
   isLocalSkill: boolean
   isInaccessibleSkill: boolean
+  isProtected: boolean
   showAddButton: boolean
   showGStackBadge: boolean
   onAddClick: React.MouseEventHandler<HTMLButtonElement>
@@ -294,13 +296,14 @@ interface SkillTitleRowProps {
  * @param props - Skill state flags and Add click handler for one list row.
  * @returns Header row with a clean skill heading plus adjacent actions.
  * @example
- * <SkillTitleRow skill={skill} isLinked={false} isLocalSkill={false} isInaccessibleSkill={false} showAddButton showGStackBadge={false} onAddClick={handleAddClick} />
+ * <SkillTitleRow skill={skill} isLinked={false} isLocalSkill={false} isInaccessibleSkill={false} isProtected={false} showAddButton showGStackBadge={false} onAddClick={handleAddClick} />
  */
 const SkillTitleRow = React.memo(function SkillTitleRow({
   skill,
   isLinked,
   isLocalSkill,
   isInaccessibleSkill,
+  isProtected,
   showAddButton,
   showGStackBadge,
   onAddClick,
@@ -321,6 +324,18 @@ const SkillTitleRow = React.memo(function SkillTitleRow({
           />
         )}
         <span className="truncate">{skill.name}</span>
+        {isProtected && (
+          <span
+            data-testid={`skill-protected-badge-${skill.name}`}
+            className={cn(
+              badgeVariants({ variant: 'outline' }),
+              'h-5 shrink-0 gap-1 border-border bg-muted px-1.5 py-0 text-[10px] font-semibold leading-none text-foreground',
+            )}
+          >
+            <Lock className="h-3 w-3" aria-hidden="true" />
+            <span>Protected</span>
+          </span>
+        )}
         {isInaccessibleSkill && (
           <span
             // react-doctor-disable-next-line react-doctor/prefer-tag-over-role -- composed "inaccessible" text status badge collapsed to one labelled graphic via role="img"+aria-label. <img> needs a src and cannot contain the badge text.
@@ -427,9 +442,8 @@ export const SkillItem = React.memo(function SkillItem({
     selectedLocalSkillInfo,
     showGStackBadge,
   } = getSkillItemVisibility(selectedAgentId, skill)
-  // Protected skills hide every destructive X action, including agent-view
-  // unlink/delete, so the lock copy matches the actual behavior.
-  const showDeleteButton = showDeleteButtonBase && !isProtected
+  // Global Delete keeps its slot while protected so the disabled action explains why it cannot run.
+  const showDeleteButton = showDeleteButtonBase
   const showUnlinkButton = showUnlinkButtonBase && !isProtected
   const isBulkSelectable = canBulkSelectRenderedSkill(
     selectedAgentId,
@@ -676,6 +690,7 @@ export const SkillItem = React.memo(function SkillItem({
             skill={skill}
             selectedAgentName={selectedAgentName}
             isLocalSkill={isLocalSkill}
+            isProtected={isProtected}
             isBookmarked={isBookmarked}
             showBookmark={showBookmark}
             showUnlinkButton={showUnlinkButton}
@@ -718,6 +733,7 @@ export const SkillItem = React.memo(function SkillItem({
                   isLinked={isLinked}
                   isLocalSkill={isLocalSkill}
                   isInaccessibleSkill={isInaccessibleSkill}
+                  isProtected={isProtected}
                   showAddButton={showAddButton}
                   showGStackBadge={showGStackBadge}
                   onAddClick={handleAddClick}
@@ -752,6 +768,7 @@ interface SkillItemOverlayActionsProps {
   skill: Skill
   selectedAgentName: string
   isLocalSkill: boolean
+  isProtected: boolean
   isBookmarked: boolean
   showBookmark: boolean
   showUnlinkButton: boolean
@@ -763,8 +780,8 @@ interface SkillItemOverlayActionsProps {
 }
 
 /**
- * Renders the row overlay buttons after SkillItem decides which actions are legal.
- * @param props - Skill row action visibility plus handlers wired by SkillItem.
+ * Renders row overlay buttons after SkillItem decides action visibility and availability.
+ * @param props - Skill row action visibility, protection state, and handlers wired by SkillItem.
  * @returns Top-right unlink/delete, protect, and bookmark controls for one row.
  * @example
  * <SkillItemOverlayActions skill={skill} selectedAgentName="Claude" showBookmark={true} />
@@ -773,6 +790,7 @@ const SkillItemOverlayActions = React.memo(function SkillItemOverlayActions({
   skill,
   selectedAgentName,
   isLocalSkill,
+  isProtected,
   isBookmarked,
   showBookmark,
   showUnlinkButton,
@@ -782,6 +800,35 @@ const SkillItemOverlayActions = React.memo(function SkillItemOverlayActions({
   onDeleteClick,
   onToggleBookmark,
 }: SkillItemOverlayActionsProps): React.ReactElement {
+  const globalDeleteButton = showDeleteButton ? (
+    <button
+      type="button"
+      onClick={(event) => {
+        // aria-disabled keeps the recovery tooltip keyboard-accessible without activating the card.
+        if (isProtected) {
+          event.stopPropagation()
+          return
+        }
+        onDeleteClick(event)
+      }}
+      aria-disabled={isProtected}
+      aria-label={
+        isProtected
+          ? `Delete ${skill.name} unavailable while protected`
+          : `Delete ${skill.name}`
+      }
+      data-testid={`skill-delete-${skill.name}`}
+      className={cn(
+        'absolute top-1.5 right-0 min-h-11 min-w-11 flex items-center justify-center rounded-md z-10 transition-opacity focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+        isProtected
+          ? 'cursor-not-allowed text-muted-foreground opacity-40'
+          : 'text-muted-foreground opacity-0 hover:bg-destructive/10 hover:text-destructive group-hover:opacity-100 focus-visible:opacity-100',
+      )}
+    >
+      <X className="h-3.5 w-3.5" />
+    </button>
+  ) : null
+
   return (
     <>
       {showUnlinkButton ? (
@@ -808,20 +855,16 @@ const SkillItemOverlayActions = React.memo(function SkillItemOverlayActions({
         </Tooltip>
       ) : null}
 
-      {showDeleteButton ? (
+      {globalDeleteButton ? (
         <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              onClick={onDeleteClick}
-              aria-label={`Delete ${skill.name}`}
-              data-testid={`skill-delete-${skill.name}`}
-              className="absolute top-1.5 right-0 min-h-11 min-w-11 flex items-center justify-center rounded-md hover:bg-destructive/10 text-muted-foreground hover:text-destructive z-10 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-            >
-              <X className="h-3.5 w-3.5" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="left">Delete</TooltipContent>
+          <TooltipTrigger asChild>{globalDeleteButton}</TooltipTrigger>
+          {/* Keep the recovery hint clear of the adjacent Unlock control. */}
+          <TooltipContent
+            side={isProtected ? 'bottom' : 'left'}
+            align={isProtected ? 'end' : 'center'}
+          >
+            {isProtected ? 'Unlock to delete' : 'Delete'}
+          </TooltipContent>
         </Tooltip>
       ) : null}
 

--- a/src/renderer/src/components/skills/skillItemHelpers.test.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.test.ts
@@ -845,8 +845,8 @@ describe('getCardContentPaddingClass', () => {
   })
 
   it('reserves a single-button gutter when only the lock button shows', () => {
-    // Arrange — locked skill whose delete button is hidden (protected) and has
-    // no bookmark: lock sits alone at right-0.
+    // Arrange — an agent-view row with no unlink action or bookmark keeps only
+    // the lock control at right-0.
     const flags = {
       showProtect: true,
       showBookmark: false,

--- a/src/renderer/src/components/skills/skillItemHelpers.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.ts
@@ -116,7 +116,7 @@ export function getSkillItemVisibility(
   return {
     // Delete is the primary cleanup action for orphans in global view —
     // sweeping the dangling row removes every agent-side symlink at once.
-    // Protected skills hide the delete button entirely; unlock before deleting.
+    // Protected skills keep this slot visible but disabled; unlock before deleting.
     showDeleteButton: !selectedAgentId,
     // Orphan skills have no live source to symlink _to_, so the Add button
     // (which opens AddSymlinkModal / CopyToAgentsModal) would surface a flow


### PR DESCRIPTION
## Summary

- Add an always-visible `Protected` badge so locked skill cards communicate their state without relying on the lock icon alone.
- Keep the global Delete action visible as a focusable `aria-disabled` control while protected, with an accessible `Unlock to delete` tooltip and an activation guard.
- Add browser and Electron E2E regression coverage for protected `analyze-app`, unlocked `brainstorm-plan`, keyboard activation, and the unlock transition.
- Document the protected-card interaction contract in `DESIGN.md`.

## Test Plan

- [x] `pnpm validate`
- [x] `pnpm test:e2e` (61 passed)

## Security Checklist

- [x] This change does not widen renderer access to Node.js, Electron, or direct filesystem APIs.
- [x] No new IPC or filesystem behavior is introduced.
- [x] No dependency, workflow, or release permission is changed.
- [x] Existing single-item and bulk-delete protection remains enforced; this change only clarifies the protected state and recovery path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 保護されたアイテムに「Protected」バッジを常時表示するようになりました。
  * 保護中は削除ボタンを非表示にせず、無効化したうえで「Unlock to delete」から理由を確認できます（ホバー/キーボード操作でも表示）。
  * 保護を解除すると、バッジ非表示・削除が通常どおり有効に戻ります。  
* **バグ修正**
  * 保護中の削除（クリック/一括削除）が発火しないようにしました。  
* **テスト**
  * 保護/解除の動作と削除無効化を確認する回帰テストを追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->