### PR TITLE
ci: update CodeQL actions together

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,12 +28,12 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           languages: javascript-typescript
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
 
   dependency-review:
     name: Dependency Review


### PR DESCRIPTION
## Summary

- Update `github/codeql-action/init` and `github/codeql-action/analyze` to v4.37.0.
- Keep both CodeQL action references pinned to the same SHA.
- Supersedes Dependabot PRs #263 and #264, which split the same workflow update and fail CodeQL independently.

## Test Plan

- [x] `actionlint .github/workflows/security.yml`
- [x] `pnpm validate`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * セキュリティスキャンに使用するCodeQLアクションを最新バージョン（v4.37.0）へ更新しました。
  * セキュリティチェックの構成や実行内容に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->