### PR TITLE
test: add native packaged-window rendering gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,13 +118,16 @@ E2E specs live in `e2e/spec/*.e2e.ts`. The suite uses `cp -al` hardlink snapshot
 ```bash
 # Build for macOS (requires code signing)
 APPLE_KEYCHAIN_PROFILE=skills-desktop pnpm build:mac
+
+# Verify that the packaged window reaches the native compositor (requires Screen Recording)
+pnpm test:release:macos-window
 ```
 
 ## Tech Stack
 
 | Component | Technology                                           |
 | --------- | ---------------------------------------------------- |
-| Framework | Electron 42                                          |
+| Framework | Electron 43                                          |
 | Frontend  | React 19 + TypeScript                                |
 | State     | Redux Toolkit + @laststance/redux-storage-middleware |
 | Styling   | Tailwind CSS + shadcn/ui                             |

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build:e2e": "E2E_BUILD=1 electron-vite build",
     "test:e2e": "pnpm build:e2e && playwright test --config=e2e/playwright.config.ts",
     "test:e2e:headed": "pnpm build:e2e && playwright test --config=e2e/playwright.config.ts --headed",
+    "test:release:macos-window": "node scripts/verify-macos-window-rendering.mjs",
     "gen:e2e-snapshot": "E2E_GEN_SNAPSHOT=1 pnpm test:e2e",
     "storybook": "cross-env NODE_OPTIONS=--require=./scripts/use-legacy-typescript-js-api.cjs storybook dev -p 6006",
     "storybook:build": "cross-env NODE_OPTIONS=--require=./scripts/use-legacy-typescript-js-api.cjs storybook build",

--- a/scripts/macos-window-rendering-probe.swift
+++ b/scripts/macos-window-rendering-probe.swift
@@ -1,0 +1,282 @@
+import AppKit
+import CoreGraphics
+import Foundation
+import ImageIO
+
+/// Native image measurements used to distinguish rendered UI from a compositor-level flat surface.
+struct RenderingMetrics {
+  let width: Int
+  let height: Int
+  let sampledPixels: Int
+  let luminanceStandardDeviation: Double
+  let nonBackgroundRatio: Double
+  let quantizedColors: Int
+}
+
+/// A captured window and the variation measured inside its client area.
+struct RenderingProbeResult {
+  let windowID: CGWindowID
+  let metrics: RenderingMetrics
+}
+
+/// Operational failures are separate from the intentional blank-window exit code used by the release gate.
+enum RenderingProbeError: Error, CustomStringConvertible {
+  case usage
+  case noWindow(pid_t)
+  case screenRecordingPermissionMissing
+  case captureFailed(Int32)
+  case imageLoadFailed(String)
+  case bitmapFailed
+
+  var description: String {
+    switch self {
+    case .usage:
+      return
+        "usage: macos-window-rendering-probe <pid> <output.png> [timeout-seconds] | --image <input.png>"
+    case .noWindow(let pid):
+      return "no eligible visible layer-0 window appeared for PID \(pid)"
+    case .screenRecordingPermissionMissing:
+      return "Screen Recording permission is required to inspect the packaged app window"
+    case .captureFailed(let status):
+      return "screencapture failed with exit status \(status)"
+    case .imageLoadFailed(let path):
+      return "could not load PNG at \(path)"
+    case .bitmapFailed:
+      return "could not decode the captured PNG into an RGBA bitmap"
+    }
+  }
+}
+
+private let maximumBlankLuminanceStandardDeviation = 2.0
+private let maximumBlankNonBackgroundRatio = 0.01
+
+/// Finds the largest visible normal window owned by a process.
+/// @param pid Process identifier whose top-level window should be captured.
+/// @returns Core Graphics window number, or throws while no candidate exists.
+/// @example `try largestWindowID(for: 123)`
+func largestWindowID(for pid: pid_t) throws -> CGWindowID {
+  let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+  guard let entries = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[CFString: Any]]
+  else {
+    throw RenderingProbeError.noWindow(pid)
+  }
+
+  let candidates: [(CGWindowID, Double)] = entries.compactMap { entry in
+    guard
+      let ownerPID = entry[kCGWindowOwnerPID] as? NSNumber,
+      ownerPID.int32Value == pid,
+      let layer = entry[kCGWindowLayer] as? NSNumber,
+      layer.intValue == 0,
+      let windowNumber = entry[kCGWindowNumber] as? NSNumber,
+      let boundsDictionary = entry[kCGWindowBounds] as? NSDictionary,
+      let bounds = CGRect(dictionaryRepresentation: boundsDictionary),
+      bounds.width >= 200,
+      bounds.height >= 150
+    else {
+      return nil
+    }
+
+    return (CGWindowID(windowNumber.uint32Value), bounds.width * bounds.height)
+  }
+
+  guard let candidate = candidates.max(by: { $0.1 < $1.1 }) else {
+    throw RenderingProbeError.noWindow(pid)
+  }
+  return candidate.0
+}
+
+/// Captures one native window without sound or shadow so only app pixels are classified.
+/// @param windowID Core Graphics window number returned by `largestWindowID`.
+/// @param outputURL Destination PNG URL.
+/// @returns Nothing; throws when the system capture command fails.
+/// @example `try capture(windowID: 42, to: URL(fileURLWithPath: "/tmp/app.png"))`
+func capture(windowID: CGWindowID, to outputURL: URL) throws {
+  let process = Process()
+  process.executableURL = URL(fileURLWithPath: "/usr/sbin/screencapture")
+  process.arguments = ["-x", "-o", "-l", String(windowID), outputURL.path]
+  try process.run()
+  process.waitUntilExit()
+  guard process.terminationStatus == 0 else {
+    throw RenderingProbeError.captureFailed(process.terminationStatus)
+  }
+}
+
+/// Measures central client-area variation while ignoring borders and the title bar.
+/// @param imageURL Captured PNG to inspect.
+/// @returns Variation metrics that separate a flat renderer from real UI.
+/// @example `let metrics = try analyze(URL(fileURLWithPath: "/tmp/app.png"))`
+func analyze(_ imageURL: URL) throws -> RenderingMetrics {
+  guard
+    let source = CGImageSourceCreateWithURL(imageURL as CFURL, nil),
+    let image = CGImageSourceCreateImageAtIndex(source, 0, nil)
+  else {
+    throw RenderingProbeError.imageLoadFailed(imageURL.path)
+  }
+
+  let width = image.width
+  let height = image.height
+  let bytesPerPixel = 4
+  let bytesPerRow = width * bytesPerPixel
+  var pixels = [UInt8](repeating: 0, count: height * bytesPerRow)
+  guard
+    let context = CGContext(
+      data: &pixels,
+      width: width,
+      height: height,
+      bitsPerComponent: 8,
+      bytesPerRow: bytesPerRow,
+      space: CGColorSpaceCreateDeviceRGB(),
+      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    )
+  else {
+    throw RenderingProbeError.bitmapFailed
+  }
+  context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+  // Ignore borders and top chrome, then sample every fourth pixel so 4K windows stay fast.
+  let xStart = max(0, width / 20)
+  let xEnd = min(width, width - width / 20)
+  let yStart = max(0, height / 10)
+  let yEnd = min(height, height - height / 20)
+  var luminanceValues: [Double] = []
+  var histogram: [UInt32: Int] = [:]
+
+  for y in stride(from: yStart, to: yEnd, by: 4) {
+    for x in stride(from: xStart, to: xEnd, by: 4) {
+      let offset = y * bytesPerRow + x * bytesPerPixel
+      let red = pixels[offset]
+      let green = pixels[offset + 1]
+      let blue = pixels[offset + 2]
+      let luminance = 0.2126 * Double(red) + 0.7152 * Double(green) + 0.0722 * Double(blue)
+      luminanceValues.append(luminance)
+
+      // Five bits per channel absorbs antialiasing noise without hiding real UI colors.
+      let color = (UInt32(red >> 3) << 10) | (UInt32(green >> 3) << 5) | UInt32(blue >> 3)
+      histogram[color, default: 0] += 1
+    }
+  }
+
+  let count = max(1, luminanceValues.count)
+  let mean = luminanceValues.reduce(0, +) / Double(count)
+  let variance =
+    luminanceValues.reduce(0) { partial, value in
+      partial + (value - mean) * (value - mean)
+    } / Double(count)
+  let dominantCount = histogram.values.max() ?? count
+
+  return RenderingMetrics(
+    width: width,
+    height: height,
+    sampledPixels: count,
+    luminanceStandardDeviation: sqrt(variance),
+    nonBackgroundRatio: 1 - Double(dominantCount) / Double(count),
+    quantizedColors: histogram.count
+  )
+}
+
+/// Classifies the Electron 43 regression only when both luminance and color variation are nearly absent.
+/// @param metrics Captured image variation measurements.
+/// @returns `true` when the client area is effectively one flat color.
+/// @example `isEffectivelyBlank(metrics)`
+func isEffectivelyBlank(_ metrics: RenderingMetrics) -> Bool {
+  metrics.luminanceStandardDeviation < maximumBlankLuminanceStandardDeviation
+    && metrics.nonBackgroundRatio < maximumBlankNonBackgroundRatio
+}
+
+/// Prints stable machine-readable measurements for release logs and failure diagnosis.
+/// @param windowID Optional Core Graphics window identifier for live captures.
+/// @param imageURL PNG that produced the measurements.
+/// @param metrics Captured image variation measurements.
+/// @returns Nothing.
+/// @example `report(windowID: 42, imageURL: imageURL, metrics: metrics)`
+func report(windowID: CGWindowID?, imageURL: URL, metrics: RenderingMetrics) {
+  if let windowID {
+    print("windowID=\(windowID) png=\(imageURL.path)")
+  } else {
+    print("png=\(imageURL.path)")
+  }
+  print(
+    String(
+      format: "size=%dx%d samples=%d lumaStdDev=%.4f nonBackgroundRatio=%.6f quantizedColors=%d",
+      metrics.width,
+      metrics.height,
+      metrics.sampledPixels,
+      metrics.luminanceStandardDeviation,
+      metrics.nonBackgroundRatio,
+      metrics.quantizedColors
+    )
+  )
+  print("classification=\(isEffectivelyBlank(metrics) ? "SOLID_BLANK" : "REAL_UI")")
+}
+
+/// Polls the native compositor until real UI appears or the timeout proves the window stayed flat.
+/// @param pid Process identifier launched through macOS LaunchServices.
+/// @param outputURL Destination overwritten by each capture attempt.
+/// @param timeoutSeconds Maximum time to tolerate startup-only flat frames.
+/// @returns The first non-blank result, or the final blank result at timeout.
+/// @example `try waitForRenderedWindow(pid: 123, outputURL: imageURL, timeoutSeconds: 20)`
+func waitForRenderedWindow(
+  pid: pid_t,
+  outputURL: URL,
+  timeoutSeconds: TimeInterval
+) throws -> RenderingProbeResult {
+  guard CGPreflightScreenCaptureAccess() else {
+    throw RenderingProbeError.screenRecordingPermissionMissing
+  }
+
+  let deadline = Date().addingTimeInterval(timeoutSeconds)
+  var lastBlankResult: RenderingProbeResult?
+
+  repeat {
+    do {
+      let windowID = try largestWindowID(for: pid)
+      try capture(windowID: windowID, to: outputURL)
+      let result = RenderingProbeResult(windowID: windowID, metrics: try analyze(outputURL))
+      if !isEffectivelyBlank(result.metrics) {
+        return result
+      }
+      lastBlankResult = result
+    } catch RenderingProbeError.noWindow(_) {
+      // LaunchServices can report the process before WindowServer publishes its first window.
+    }
+
+    Thread.sleep(forTimeInterval: 0.4)
+  } while Date() < deadline
+
+  if let lastBlankResult {
+    return lastBlankResult
+  }
+  throw RenderingProbeError.noWindow(pid)
+}
+
+do {
+  if CommandLine.arguments.count == 3, CommandLine.arguments[1] == "--image" {
+    let imageURL = URL(fileURLWithPath: CommandLine.arguments[2])
+    let metrics = try analyze(imageURL)
+    report(windowID: nil, imageURL: imageURL, metrics: metrics)
+    exit(isEffectivelyBlank(metrics) ? 2 : 0)
+  }
+
+  guard
+    (3...4).contains(CommandLine.arguments.count),
+    let pid = pid_t(CommandLine.arguments[1]),
+    let timeoutSeconds = CommandLine.arguments.count == 4
+      ? TimeInterval(CommandLine.arguments[3])
+      : 20,
+    timeoutSeconds > 0
+  else {
+    throw RenderingProbeError.usage
+  }
+
+  let outputURL = URL(fileURLWithPath: CommandLine.arguments[2])
+  let result = try waitForRenderedWindow(
+    pid: pid,
+    outputURL: outputURL,
+    timeoutSeconds: timeoutSeconds
+  )
+  report(windowID: result.windowID, imageURL: outputURL, metrics: result.metrics)
+  exit(isEffectivelyBlank(result.metrics) ? 2 : 0)
+} catch {
+  fputs("error: \(error)\n", stderr)
+  exit(1)
+}

--- a/scripts/macos-window-rendering-probe.swift
+++ b/scripts/macos-window-rendering-probe.swift
@@ -274,7 +274,9 @@ func waitForRenderedWindow(
       // LaunchServices can report the process before WindowServer publishes its first window.
     }
 
-    Thread.sleep(forTimeInterval: 0.4)
+    let sleepSeconds = min(0.4, deadline.timeIntervalSinceNow)
+    guard sleepSeconds > 0 else { break }
+    Thread.sleep(forTimeInterval: sleepSeconds)
   } while Date() < deadline
 
   if let lastBlankResult {
@@ -297,6 +299,7 @@ do {
     let timeoutSeconds = CommandLine.arguments.count == 4
       ? TimeInterval(CommandLine.arguments[3])
       : 20,
+    timeoutSeconds.isFinite,
     timeoutSeconds > 0
   else {
     throw RenderingProbeError.usage

--- a/scripts/macos-window-rendering-probe.swift
+++ b/scripts/macos-window-rendering-probe.swift
@@ -1,5 +1,7 @@
 import AppKit
 import CoreGraphics
+import Darwin
+import Dispatch
 import Foundation
 import ImageIO
 
@@ -25,6 +27,7 @@ enum RenderingProbeError: Error, CustomStringConvertible {
   case noWindow(pid_t)
   case screenRecordingPermissionMissing
   case captureFailed(Int32)
+  case captureTimedOut(TimeInterval)
   case imageLoadFailed(String)
   case bitmapFailed
 
@@ -39,6 +42,8 @@ enum RenderingProbeError: Error, CustomStringConvertible {
       return "Screen Recording permission is required to inspect the packaged app window"
     case .captureFailed(let status):
       return "screencapture failed with exit status \(status)"
+    case .captureTimedOut(let timeoutSeconds):
+      return "screencapture exceeded its \(timeoutSeconds)-second deadline"
     case .imageLoadFailed(let path):
       return "could not load PNG at \(path)"
     case .bitmapFailed:
@@ -88,14 +93,30 @@ func largestWindowID(for pid: pid_t) throws -> CGWindowID {
 /// Captures one native window without sound or shadow so only app pixels are classified.
 /// @param windowID Core Graphics window number returned by `largestWindowID`.
 /// @param outputURL Destination PNG URL.
+/// @param timeoutSeconds Maximum time allowed for the system capture child process.
 /// @returns Nothing; throws when the system capture command fails.
-/// @example `try capture(windowID: 42, to: URL(fileURLWithPath: "/tmp/app.png"))`
-func capture(windowID: CGWindowID, to outputURL: URL) throws {
+/// @example `try capture(windowID: 42, to: imageURL, timeoutSeconds: 5)`
+func capture(
+  windowID: CGWindowID,
+  to outputURL: URL,
+  timeoutSeconds: TimeInterval
+) throws {
   let process = Process()
+  let completion = DispatchSemaphore(value: 0)
   process.executableURL = URL(fileURLWithPath: "/usr/sbin/screencapture")
   process.arguments = ["-x", "-o", "-l", String(windowID), outputURL.path]
+  process.terminationHandler = { _ in completion.signal() }
   try process.run()
-  process.waitUntilExit()
+  let waitResult = completion.wait(timeout: .now() + timeoutSeconds)
+  if waitResult == .timedOut {
+    // Give the child a graceful exit first, then force-stop it so one OS hang cannot stall a release.
+    process.terminate()
+    if completion.wait(timeout: .now() + 1) == .timedOut && process.isRunning {
+      kill(process.processIdentifier, SIGKILL)
+      _ = completion.wait(timeout: .now() + 1)
+    }
+    throw RenderingProbeError.captureTimedOut(timeoutSeconds)
+  }
   guard process.terminationStatus == 0 else {
     throw RenderingProbeError.captureFailed(process.terminationStatus)
   }
@@ -230,7 +251,12 @@ func waitForRenderedWindow(
   repeat {
     do {
       let windowID = try largestWindowID(for: pid)
-      try capture(windowID: windowID, to: outputURL)
+      let remainingSeconds = max(0.1, deadline.timeIntervalSinceNow)
+      try capture(
+        windowID: windowID,
+        to: outputURL,
+        timeoutSeconds: remainingSeconds
+      )
       let result = RenderingProbeResult(windowID: windowID, metrics: try analyze(outputURL))
       if !isEffectivelyBlank(result.metrics) {
         return result

--- a/scripts/macos-window-rendering-probe.swift
+++ b/scripts/macos-window-rendering-probe.swift
@@ -251,13 +251,21 @@ func waitForRenderedWindow(
   repeat {
     do {
       let windowID = try largestWindowID(for: pid)
-      let remainingSeconds = max(0.1, deadline.timeIntervalSinceNow)
+      let remainingSeconds = deadline.timeIntervalSinceNow
+      guard remainingSeconds > 0 else { break }
       try capture(
         windowID: windowID,
         to: outputURL,
         timeoutSeconds: remainingSeconds
       )
       let result = RenderingProbeResult(windowID: windowID, metrics: try analyze(outputURL))
+      guard Date() < deadline else {
+        // Keep final blank metrics for diagnostics, but never accept UI observed after the deadline.
+        if isEffectivelyBlank(result.metrics) {
+          lastBlankResult = result
+        }
+        break
+      }
       if !isEffectivelyBlank(result.metrics) {
         return result
       }

--- a/scripts/verify-macos-window-rendering.mjs
+++ b/scripts/verify-macos-window-rendering.mjs
@@ -1,0 +1,327 @@
+import { constants } from 'node:fs'
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  realpath,
+  rm,
+  writeFile,
+} from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+import { tmpdir } from 'node:os'
+import { execFile, spawn } from 'node:child_process'
+import { promisify } from 'node:util'
+import { randomUUID } from 'node:crypto'
+
+const execFileAsync = promisify(execFile)
+const repoRoot = resolve(import.meta.dirname, '..')
+const probeSourcePath = join(
+  repoRoot,
+  'scripts',
+  'macos-window-rendering-probe.swift',
+)
+const probeTimeoutSeconds = 20
+
+/** Waits without blocking Node so launch and shutdown polling stay responsive.
+ * @param {number} milliseconds - Duration to wait.
+ * @returns {Promise<void>} Promise settled after the requested duration.
+ * @example await delay(400)
+ */
+function delay(milliseconds) {
+  return new Promise((settle) => setTimeout(settle, milliseconds))
+}
+
+/** Resolves an explicit app bundle or the current-architecture electron-builder output.
+ * @param {string | undefined} requestedPath - Optional `.app` path from the CLI.
+ * @returns {Promise<string>} Existing absolute app-bundle path.
+ * @example await resolveAppBundle('dist/mac-arm64/Skills Desktop.app')
+ */
+async function resolveAppBundle(requestedPath) {
+  const architectureDirectory = process.arch === 'arm64' ? 'mac-arm64' : 'mac'
+  const fallbackDirectory = process.arch === 'arm64' ? 'mac' : 'mac-arm64'
+  const candidates = requestedPath
+    ? [resolve(process.cwd(), requestedPath)]
+    : [
+        join(repoRoot, 'dist', architectureDirectory, 'Skills Desktop.app'),
+        join(repoRoot, 'dist', fallbackDirectory, 'Skills Desktop.app'),
+      ]
+
+  for (const candidate of candidates) {
+    try {
+      await access(candidate, constants.R_OK)
+      // LaunchServices reports the physical bundle path even when the CLI received a symlink.
+      return await realpath(candidate)
+    } catch {
+      // A release machine may have built only one architecture, so try the next known output.
+    }
+  }
+
+  throw new Error(
+    `Packaged app not found. Build it first or pass its path:\n  pnpm test:release:macos-window -- "/path/to/Skills Desktop.app"`,
+  )
+}
+
+/** Reads the bundle-declared executable instead of assuming it matches a possibly renamed `.app`.
+ * @param {string} appBundlePath - Absolute `.app` bundle path.
+ * @returns {Promise<string>} Absolute path to the bundle's main executable.
+ * @example await executablePathFor('/tmp/Renamed Skills.app')
+ */
+async function executablePathFor(appBundlePath) {
+  const infoPlistPath = join(appBundlePath, 'Contents', 'Info.plist')
+  const { stdout } = await execFileAsync('/usr/libexec/PlistBuddy', [
+    '-c',
+    'Print :CFBundleExecutable',
+    infoPlistPath,
+  ])
+  const executableName = stdout.trim()
+  if (!executableName) {
+    throw new Error(`CFBundleExecutable is missing from ${infoPlistPath}`)
+  }
+  return join(appBundlePath, 'Contents', 'MacOS', executableName)
+}
+
+/** Starts the app through LaunchServices with a unique token and isolated writable state.
+ * @param {string} appBundlePath - Signed package to verify.
+ * @param {string} homeDirectory - Temporary HOME used for skill scanning.
+ * @param {string} userDataDirectory - Temporary Electron userData directory.
+ * @param {string} launchToken - Unique argv marker used to discover the new app PID.
+ * @returns {import('node:child_process').ChildProcess} Waiting `open` process owned by this run.
+ * @example launchApp('/tmp/Skills Desktop.app', '/tmp/home', '/tmp/userData', 'token')
+ */
+function launchApp(
+  appBundlePath,
+  homeDirectory,
+  userDataDirectory,
+  launchToken,
+) {
+  return spawn(
+    '/usr/bin/open',
+    [
+      '-n',
+      '-F',
+      '-W',
+      '--env',
+      `HOME=${homeDirectory}`,
+      '--env',
+      `E2E_USERDATA_DIR=${userDataDirectory}`,
+      '--env',
+      'E2E_DISABLE_UPDATE=1',
+      '--env',
+      'E2E_BACKGROUND_LAUNCH=0',
+      '--env',
+      'ELECTRON_RUN_AS_NODE=',
+      appBundlePath,
+      '--args',
+      `--skills-desktop-window-smoke=${launchToken}`,
+    ],
+    { stdio: ['ignore', 'pipe', 'pipe'] },
+  )
+}
+
+/** Waits until `open` confirms that LaunchServices accepted the app request.
+ * @param {import('node:child_process').ChildProcess} openProcess - Process returned by `launchApp`.
+ * @returns {Promise<void>} Settles on spawn or rejects with the OS launch error.
+ * @example await waitForSpawn(openProcess)
+ */
+async function waitForSpawn(openProcess) {
+  await new Promise((settle, reject) => {
+    openProcess.once('spawn', settle)
+    openProcess.once('error', reject)
+  })
+}
+
+/** Finds the exact app instance LaunchServices created by matching executable path and unique argv.
+ * @param {string} executablePath - App bundle's main executable.
+ * @param {string} launchToken - Unique marker passed only to this launch.
+ * @param {number} timeoutMilliseconds - Maximum process-table polling time.
+ * @returns {Promise<number>} PID of the newly launched Electron main process.
+ * @example await findLaunchedAppPID(executable, token, 10000)
+ */
+async function findLaunchedAppPID(
+  executablePath,
+  launchToken,
+  timeoutMilliseconds,
+) {
+  const deadline = Date.now() + timeoutMilliseconds
+  while (Date.now() < deadline) {
+    const { stdout } = await execFileAsync('/bin/ps', ['-axo', 'pid=,command='])
+    let tokenOwnedMainPID
+    for (const line of stdout.split('\n')) {
+      const match = line.match(/^\s*(\d+)\s+(.+)$/)
+      if (!match) continue
+      const command = match[2]
+      if (command.includes(executablePath) && command.includes(launchToken)) {
+        return Number(match[1])
+      }
+      if (
+        command.includes('/Contents/MacOS/') &&
+        command.includes(launchToken)
+      ) {
+        // The UUID is passed only to this launch; retain a safe cleanup handle if ps normalizes paths differently.
+        tokenOwnedMainPID = Number(match[1])
+      }
+    }
+    if (tokenOwnedMainPID !== undefined) return tokenOwnedMainPID
+
+    // LaunchServices returns before Electron necessarily appears in the process table.
+    await delay(200)
+  }
+  throw new Error(
+    'LaunchServices did not create the packaged app process in time.',
+  )
+}
+
+/** Reports whether an OS process still exists without sending a terminating signal.
+ * @param {number} pid - Process identifier to probe.
+ * @returns {boolean} `true` while the process exists or cannot be signalled.
+ * @example isProcessRunning(123)
+ */
+function isProcessRunning(pid) {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return error?.code !== 'ESRCH'
+  }
+}
+
+/** Stops only the isolated app instance, allowing Electron helpers to follow their parent.
+ * @param {number | undefined} pid - App PID discovered from the unique launch token.
+ * @returns {Promise<void>} Settles after graceful exit or a final forced stop.
+ * @example await stopApp(123)
+ */
+async function stopApp(pid) {
+  if (pid === undefined || !isProcessRunning(pid)) return
+
+  process.kill(pid, 'SIGTERM')
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (!isProcessRunning(pid)) return
+    await delay(100)
+  }
+
+  // A hung release candidate must not outlive the smoke run or pollute the next attempt.
+  if (isProcessRunning(pid)) process.kill(pid, 'SIGKILL')
+}
+
+/** Stops the waiting `open -W` process when launch or probing fails early.
+ * @param {import('node:child_process').ChildProcess | undefined} openProcess - LaunchServices wrapper.
+ * @returns {void} Nothing.
+ * @example stopOpenProcess(openProcess)
+ */
+function stopOpenProcess(openProcess) {
+  if (openProcess?.exitCode === null) openProcess.kill('SIGTERM')
+}
+
+/** Writes deterministic startup preferences so the capture is opaque, bounded, and updater-free.
+ * @param {string} userDataDirectory - Isolated Electron profile directory.
+ * @returns {Promise<void>} Settles after settings.json is ready before launch.
+ * @example await writeSmokeSettings('/tmp/profile')
+ */
+async function writeSmokeSettings(userDataDirectory) {
+  await mkdir(userDataDirectory, { recursive: true })
+  await writeFile(
+    join(userDataDirectory, 'settings.json'),
+    JSON.stringify(
+      {
+        windowSize: { width: 1200, height: 800 },
+        windowBackgroundBlurRadius: 0,
+        autoDownloadUpdates: false,
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  )
+}
+
+/** Runs the signed-package native rendering gate and preserves artifacts only on failure.
+ * @returns {Promise<void>} Settles when a real native UI surface is observed.
+ * @example await main()
+ */
+async function main() {
+  if (process.platform !== 'darwin') {
+    throw new Error('The packaged-window rendering smoke test requires macOS.')
+  }
+
+  // pnpm preserves the conventional `--` separator in the child argv on some versions.
+  const requestedPaths = process.argv
+    .slice(2)
+    .filter((argument) => argument !== '--')
+  if (requestedPaths.length > 1) {
+    throw new Error('Pass at most one packaged `.app` path.')
+  }
+  const appBundlePath = await resolveAppBundle(requestedPaths[0])
+  const executablePath = await executablePathFor(appBundlePath)
+  await access(executablePath, constants.X_OK)
+
+  const temporaryRoot = await mkdtemp(
+    join(tmpdir(), 'skills-desktop-window-smoke-'),
+  )
+  const homeDirectory = join(temporaryRoot, 'home')
+  const userDataDirectory = join(temporaryRoot, 'userData')
+  const probeBinaryPath = join(temporaryRoot, 'macos-window-rendering-probe')
+  const screenshotPath = join(temporaryRoot, 'packaged-window.png')
+  const launchToken = randomUUID()
+  let appPID
+  let openProcess
+  let passed = false
+
+  try {
+    await mkdir(homeDirectory, { recursive: true })
+    await writeSmokeSettings(userDataDirectory)
+    console.log(`Building native rendering probe: ${probeSourcePath}`)
+    await execFileAsync('/usr/bin/xcrun', [
+      'swiftc',
+      '-O',
+      probeSourcePath,
+      '-o',
+      probeBinaryPath,
+    ])
+
+    console.log(`Launching packaged app: ${appBundlePath}`)
+    openProcess = launchApp(
+      appBundlePath,
+      homeDirectory,
+      userDataDirectory,
+      launchToken,
+    )
+    await waitForSpawn(openProcess)
+    appPID = await findLaunchedAppPID(executablePath, launchToken, 10_000)
+    console.log(`Inspecting native window for PID ${appPID}...`)
+
+    try {
+      const { stdout, stderr } = await execFileAsync(probeBinaryPath, [
+        String(appPID),
+        screenshotPath,
+        String(probeTimeoutSeconds),
+      ])
+      if (stdout) process.stdout.write(stdout)
+      if (stderr) process.stderr.write(stderr)
+    } catch (error) {
+      if (error?.stdout) process.stdout.write(error.stdout)
+      if (error?.stderr) process.stderr.write(error.stderr)
+      if (error?.code === 2) {
+        throw new Error(
+          `Packaged window stayed visually blank for ${probeTimeoutSeconds}s. Screenshot: ${screenshotPath}`,
+        )
+      }
+      throw error
+    }
+
+    passed = true
+    console.log('✅ Packaged macOS window contains rendered UI.')
+  } finally {
+    await stopApp(appPID)
+    stopOpenProcess(openProcess)
+    if (passed) {
+      await rm(temporaryRoot, { recursive: true, force: true })
+    } else {
+      console.error(`Smoke artifacts retained at: ${temporaryRoot}`)
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(`❌ ${error instanceof Error ? error.message : String(error)}`)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## Summary
- launch the packaged macOS app through LaunchServices with an isolated profile
- capture the real WindowServer surface and fail when the client area remains a single flat color
- retain failure screenshots while cleaning up app processes and successful temporary state
- document the release smoke command and update the Electron version in README

## Regression proof
- pristine official v0.27.0: SOLID_BLANK, lumaStdDev=0.0000, nonBackgroundRatio=0.000000, expected failure
- fixed signed v0.27.1: REAL_UI, lumaStdDev=24.0142, nonBackgroundRatio=0.489499, success
- symlinked and physically renamed app bundles: success with no leaked process

## Test Plan
- [x] pnpm validate
- [x] pnpm test:e2e (61 passed)
- [x] pnpm test:release:macos-window
- [x] xcrun swift-format lint --strict scripts/macos-window-rendering-probe.swift

## Security Checklist
- [x] This change does not widen renderer access to Node.js, Electron, or direct filesystem APIs.
- [x] No new IPC or renderer-controlled filesystem behavior is introduced.
- [x] No dependency or workflow permissions changed; system processes use argument arrays without shell interpolation.
- [x] No security-sensitive product behavior requires a SECURITY.md update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能 / テスト**
  * macOS向けに、パッケージ済みElectronアプリのネイティブ描画を自動で確認するリリース用スモークテストを追加しました。
  * 結果を「実UI表示」または「実質的にソリッドな空白」と判定し、終了コードで返すようにしました（検証コマンドも追加）。
* **ドキュメント**
  * 「Build」関連手順に、Screen Recordingが必要な旨と実行コマンドを追記しました。
  * Tech StackのElectron表記を43に更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->