### PR TITLE
fix(ci): classify code inspector build scripts

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,8 +1,12 @@
 allowBuilds:
+  # Click-to-source does not use Code Inspector's optional terminal probe.
+  '@code-inspector/core': false
   electron: true
   electron-winstaller: false
   esbuild: true
   fallow: false
+  # Keep the unused native PTY compiler blocked from install-time execution.
+  node-pty: false
   sharp: true
   unrs-resolver: true
 


### PR DESCRIPTION
## Summary

- Explicitly deny the unused Code Inspector terminal lifecycle scripts introduced by the development dependency update.
- Restore strict pnpm installs without allowing native node-gyp compilation or the optional PTY shell probe.
- Fix Build, Lint, Test, Typecheck, Fallow, Security audit, and E2E jobs that all stopped in Prepare.

## Test Plan

- [x] CI=true pnpm install --force --frozen-lockfile
- [x] CI=true pnpm install --frozen-lockfile
- [x] pnpm validate
- [x] pnpm test:e2e (61/61)
- [x] pnpm build
- [x] pnpm test:coverage (178 files, 2305 tests)
- [x] pnpm audit --prod --audit-level high

## Security Checklist

- [x] This change does not widen renderer access to Node.js, Electron, or direct filesystem APIs.
- [x] New IPC or filesystem behavior validates untrusted renderer input in the main process.
- [x] Dependency, workflow, or release changes preserve least-privilege permissions and pinned third-party Actions.
- [x] Security-sensitive behavior is documented or linked from SECURITY.md when relevant.

The inline allowBuilds comments document why the optional terminal scripts remain blocked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * インストール時のビルド許可設定を更新しました。
  * `@code-inspector/core` と `node-pty` の自動ビルドを無効化し、依存パッケージのセットアップ動作を調整しました。
  * 既存の Electron、esbuild などに関するビルド設定は維持されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->