### PR TITLE
fix: show skill Location above Symlink Status

### DIFF
--- a/src/renderer/src/components/skills/SkillDetail.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillDetail.browser.test.tsx
@@ -316,8 +316,9 @@ describe('SkillDetail Info path copy', () => {
       .toHaveTextContent(/Inaccessible:\s*1/)
   })
 
-  it('keeps Location paths visible after scrolling the Info tab inside detail chrome', async () => {
-    // Arrange
+  it('keeps Location paths visible inside detail chrome when Info tab overflows', async () => {
+    // Arrange — Location sits above Symlink Status; a long status list still
+    // overflows the fixed-height shell so chrome clipping stays regression-covered.
     const layoutStyleElement = installLayoutStyles()
     const { agents, skill } = makeOverflowSkillFixture()
     try {
@@ -336,9 +337,9 @@ describe('SkillDetail Info path copy', () => {
       expect(detailShell).toBeInstanceOf(HTMLElement)
       expect(infoScroller).toBeInstanceOf(HTMLElement)
 
-      // Act
+      // Act — bring Location into view without scrolling past it into Status rows
       const scrollPane = infoScroller as HTMLElement
-      scrollPane.scrollTop = scrollPane.scrollHeight
+      symlinkPath.scrollIntoView({ block: 'nearest' })
       await new Promise<void>((resolve) => {
         requestAnimationFrame(() => resolve())
       })
@@ -348,9 +349,13 @@ describe('SkillDetail Info path copy', () => {
       expect(
         Math.round((detailShell as HTMLElement).getBoundingClientRect().height),
       ).toBe(DETAIL_PANEL_TEST_HEIGHT_PX)
-      expect(symlinkPath.getBoundingClientRect().bottom).toBeLessThanOrEqual(
-        (detailShell as HTMLElement).getBoundingClientRect().bottom +
-          VISIBLE_BOUNDS_TOLERANCE_PX,
+      const shellBounds = (detailShell as HTMLElement).getBoundingClientRect()
+      const pathBounds = symlinkPath.getBoundingClientRect()
+      expect(pathBounds.top).toBeGreaterThanOrEqual(
+        shellBounds.top - VISIBLE_BOUNDS_TOLERANCE_PX,
+      )
+      expect(pathBounds.bottom).toBeLessThanOrEqual(
+        shellBounds.bottom + VISIBLE_BOUNDS_TOLERANCE_PX,
       )
     } finally {
       layoutStyleElement.remove()

--- a/src/renderer/src/components/skills/SkillDetail.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillDetail.browser.test.tsx
@@ -316,7 +316,7 @@ describe('SkillDetail Info path copy', () => {
       .toHaveTextContent(/Inaccessible:\s*1/)
   })
 
-  it('keeps Location paths visible inside detail chrome when Info tab overflows', async () => {
+  it('keeps Location above Symlink Status and visible at scrollTop 0 when Info overflows', async () => {
     // Arrange — Location sits above Symlink Status; a long status list still
     // overflows the fixed-height shell so chrome clipping stays regression-covered.
     const layoutStyleElement = installLayoutStyles()
@@ -332,29 +332,40 @@ describe('SkillDetail Info path copy', () => {
       const infoScroller = screen.container.querySelector(
         '[data-skill-info-scroll]',
       )
-      const symlinkPath = screen.getByText(CURSOR_PATH).element()
+      const locationHeading = screen.getByText('Location').element()
+      const symlinkStatusHeading = screen.getByText('Symlink Status').element()
 
       expect(detailShell).toBeInstanceOf(HTMLElement)
       expect(infoScroller).toBeInstanceOf(HTMLElement)
 
-      // Act — bring Location into view without scrolling past it into Status rows
+      // Assert — DOM order: Location must precede Symlink Status (layout contract)
+      expect(
+        locationHeading.compareDocumentPosition(symlinkStatusHeading) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy()
+
+      // Act — fixed known scroll position (never scrollIntoView: that would also
+      // pull a bottom-placed Location into view and hide the regression)
       const scrollPane = infoScroller as HTMLElement
-      symlinkPath.scrollIntoView({ block: 'nearest' })
+      scrollPane.scrollTop = 0
       await new Promise<void>((resolve) => {
         requestAnimationFrame(() => resolve())
       })
 
-      // Assert
+      // Assert — at scrollTop 0, Location heading stays inside detail chrome.
+      // Path rows may sit just below the fold; the heading is the order-sensitive
+      // signal that would fall below the shell if Location were under Status.
+      expect(scrollPane.scrollTop).toBe(0)
       expect(scrollPane.scrollHeight).toBeGreaterThan(scrollPane.clientHeight)
       expect(
         Math.round((detailShell as HTMLElement).getBoundingClientRect().height),
       ).toBe(DETAIL_PANEL_TEST_HEIGHT_PX)
       const shellBounds = (detailShell as HTMLElement).getBoundingClientRect()
-      const pathBounds = symlinkPath.getBoundingClientRect()
-      expect(pathBounds.top).toBeGreaterThanOrEqual(
+      const locationBounds = locationHeading.getBoundingClientRect()
+      expect(locationBounds.top).toBeGreaterThanOrEqual(
         shellBounds.top - VISIBLE_BOUNDS_TOLERANCE_PX,
       )
-      expect(pathBounds.bottom).toBeLessThanOrEqual(
+      expect(locationBounds.top).toBeLessThanOrEqual(
         shellBounds.bottom + VISIBLE_BOUNDS_TOLERANCE_PX,
       )
     } finally {

--- a/src/renderer/src/components/skills/SkillDetail.tsx
+++ b/src/renderer/src/components/skills/SkillDetail.tsx
@@ -280,19 +280,6 @@ const InfoView = React.memo(function InfoView({
       <Separator className="my-4" />
 
       <div>
-        <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wider mb-3">
-          Symlink Status
-        </h3>
-        <div className="space-y-2">
-          {filteredSymlinks.map((symlink) => (
-            <SymlinkStatus key={symlink.agentId} symlink={symlink} />
-          ))}
-        </div>
-      </div>
-
-      <Separator className="my-4" />
-
-      <div>
         <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wider mb-2">
           Location
         </h3>
@@ -319,6 +306,19 @@ const InfoView = React.memo(function InfoView({
             onCopy={copyPath}
           />
         )}
+      </div>
+
+      <Separator className="my-4" />
+
+      <div>
+        <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wider mb-3">
+          Symlink Status
+        </h3>
+        <div className="space-y-2">
+          {filteredSymlinks.map((symlink) => (
+            <SymlinkStatus key={symlink.agentId} symlink={symlink} />
+          ))}
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- Move the skill Info-tab **Location** path section above **Symlink Status** so the filesystem path is visible without scrolling past agent status rows
- Update the overflow/chrome regression test to match the new section order

## Test plan
- [ ] Open a skill → Info tab and confirm Location appears above Symlink Status
- [ ] In global view, confirm single Path + Copy still works
- [ ] In agent view, confirm Source Files / Symlink rows still copy correctly
- [ ] With many agents installed, confirm Info tab still scrolls and Location stays within the detail panel chrome

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * スキル詳細の Info タブで、Location（シンボリックリンク先）が Symlink Status より前に表示されるようになりました。
  * 詳細情報の余白を調整し、見やすさを向上しました。
  * Location が詳細パネル内で適切に表示されるよう、表示領域に関する挙動を改善しました。
* **テスト**
  * Info タブ関連の回帰テストを更新し、表示順とスクロール開始時の表示・クリップ状態を確認するようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->