### PR TITLE
chore: sync skills CLI agent definitions to 1.5.18

### DIFF
--- a/.claude/skills/skills-cli-sync/SKILL.md
+++ b/.claude/skills/skills-cli-sync/SKILL.md
@@ -149,6 +149,25 @@ Do not bump `package.json` `version` — releases are owned solely by
 
 ## Latest run (example — point-in-time, NOT part of the procedure)
 
+**2026-07-16 · v1.5.13 → v1.5.18** (+1 community agent)
+
+- **+1 agent:** `zcode` (ZCode, added upstream in v1.5.16) — own home dir
+  `~/.zcode/skills`, so `installDir = scanDir = '.zcode'` (no universal-source
+  divergence). `AGENT_DEFINITIONS` 68 → 69; `UNIVERSAL_AGENT_IDS` stays 16
+  (zcode's `skillsDir` is `.zcode/skills`, not `.agents/skills`).
+- **No migrations/rebrands:** zero app orphans; no id/cliId or display-name
+  changes. Upstream `types.ts` only widened its own AgentName union.
+- **Excluded at this version:** `eve` and `promptscript`
+  (`globalSkillsDir: undefined`), `universal` (`showInUniversalList: false`),
+  `zenflow` (dir collides with zencoder's `~/.zencoder/skills`).
+- **Edits:** bumped `SKILLS_CLI_VERSION` 1.5.13 → 1.5.18; bumped the e2e pin
+  (`marketplace-install-regression.e2e.ts` literal `skills@1.5.18 add …` +
+  comment); bumped the CLAUDE.md Domain-Concepts pinned-version cell; agent
+  count 68 → 69 in README/SPEC + website copy (Hero, Features, layout,
+  llms.txt — llms.txt was still at a stale 54).
+- Gates: `reconcile-agents.mjs` clean (69/69), prettier clean, `pnpm validate`
+  green, `pnpm test:e2e` green.
+
 **2026-06-24 · v1.5.11 → v1.5.13** (version pin + excluded upstream agent)
 
 - **No app agent-list change:** upstream `name:` set is 72 and app `cliId` set

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ PRs are ready to ship only when `validate` and e2e both pass in that order.
 | Repository     | https://github.com/vercel-labs/skills (paths below are inside that repo)                       |
 | CLI agent list | `src/agents.ts`                                                                                |
 | CLI types      | `src/types.ts`                                                                                 |
-| Pinned version | `SKILLS_CLI_VERSION` in `src/shared/constants.ts` (currently `1.5.13`) — bump when re-syncing `AGENT_DEFINITIONS` against the upstream skills CLI |
+| Pinned version | `SKILLS_CLI_VERSION` in `src/shared/constants.ts` (currently `1.5.18`) — bump when re-syncing `AGENT_DEFINITIONS` against the upstream skills CLI |
 
 `AGENT_DEFINITIONS` in `src/shared/constants.ts` mirrors the CLI's agent
 list. Each entry: `id` (app state), `cliId` (`--agent` flag), `name`

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Skills Desktop provides a GUI to manage and monitor skills installed via [`npx s
 | Devin Desktop    | `~/.codeium/windsurf/skills/` |
 | OpenCode         | `~/.config/opencode/skills/`  |
 | Continue         | `~/.continue/skills/`         |
-| _...and 57 more_ |                               |
+| _...and 58 more_ |                               |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Skills Desktop provides a GUI to manage and monitor skills installed via [`npx s
 
 ## Features
 
-- **68 AI Agents Supported** - Auto-detects Claude Code, Cursor, Codex, Gemini CLI, and more
+- **69 AI Agents Supported** - Auto-detects Claude Code, Cursor, Codex, Gemini CLI, and more
 - **Symlink Status Visualization** - Valid (✓), Broken (◐), Inaccessible (!), Missing (○) indicators
 - **Customizable Dashboard** - Widget-based home view with skill stats, symlink health, agent coverage, bookmarks, and quick actions — drag, resize, and arrange across multiple pages
 - **54 Themes** - 34 OKLCH color themes (17 hues × light/dark) + 2 pure neutral + 18 tinted neutral

--- a/SPEC.md
+++ b/SPEC.md
@@ -121,6 +121,7 @@ Agent definitions are synced with [vercel-labs/skills CLI](https://github.com/ve
 | Terramind          | `terramind`       | `~/.terramind/skills/`              |
 | Tinycloud          | `tinycloud`       | `~/.tinycloud/skills/`              |
 | Zed                | `zed`             | `~/.zed/skills/`                    |
+| ZCode              | `zcode`           | `~/.zcode/skills/`                  |
 
 **Detection Logic:**
 
@@ -134,7 +135,7 @@ Agent definitions are synced with [vercel-labs/skills CLI](https://github.com/ve
 ### Core Features
 
 - [x] Display source directory (`~/.agents/skills/`)
-- [x] Auto-detect installed AI agents (68 agents)
+- [x] Auto-detect installed AI agents (69 agents)
 - [x] List all installed skills with metadata
 - [x] Show symlink status per skill per agent
 - [x] Validate symlink integrity (valid/broken/inaccessible/missing)
@@ -928,7 +929,7 @@ APPLE_KEYCHAIN_PROFILE=skills-desktop pnpm build:mac
 **Sections:**
 
 - Hero with app screenshot
-- Feature grid (68 agents, symlink status, 37 theme presets)
+- Feature grid (69 agents, symlink status, 37 theme presets)
 - Download CTA linking to GitHub Release
 - OG image for social sharing
 

--- a/e2e/spec/marketplace-install-regression.e2e.ts
+++ b/e2e/spec/marketplace-install-regression.e2e.ts
@@ -162,14 +162,14 @@ test('Marketplace Install works when Electron starts with sparse macOS GUI PATH'
     await dialog.getByRole('button', { name: 'Install', exact: true }).click()
 
     // Assert — the fake npx ran with the pinned CLI version (SKILLS_CLI_VERSION
-    // is '1.5.13' in src/shared/constants.ts; hardcoded here so this test pins
+    // is '1.5.18' in src/shared/constants.ts; hardcoded here so this test pins
     // the literal command rather than computing the expectation from the same
     // constant the production command builds from) and the installed badge shows.
     await expect
       .poll(() => existsSync(markerPath), { timeout: 10_000 })
       .toBe(true)
     expect(readFileSync(markerPath, 'utf-8')).toContain(
-      'skills@1.5.13 add vercel-labs/skills',
+      'skills@1.5.18 add vercel-labs/skills',
     )
     await expect(
       appWindow.getByRole('img', { name: /find-skills is installed/i }),

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -135,6 +135,15 @@ describe('AGENT_DEFINITIONS', () => {
     expect(ids).toContain('zed')
   })
 
+  it('exposes the ZCode community agent added in CLI v1.5.16', () => {
+    // Act
+    const zcode = AGENT_DEFINITIONS.find((a) => a.id === 'zcode')
+    // Assert — own home dir (~/.zcode/skills), so no universal-source scanDir divergence
+    expect(zcode?.cliId).toBe('zcode')
+    expect(zcode?.installDir).toBe('.zcode')
+    expect(zcode?.scanDir).toBe('.zcode')
+  })
+
   it('maps Kimi internal id to the renamed kimi-code-cli CLI flag (1.5.10 rename)', () => {
     // The CLI renamed the --agent value to 'kimi-code-cli' and moved it to the
     // universal source. Internal id stays 'kimi-cli' so persisted Redux state

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -776,6 +776,14 @@ export const AGENT_DEFINITIONS = [
     installDir: '.agents',
     scanDir: '.zed',
   },
+  // Community agent added in skills CLI v1.5.16 (synced 2026-07-16).
+  {
+    id: 'zcode',
+    cliId: 'zcode',
+    name: 'ZCode',
+    installDir: '.zcode',
+    scanDir: '.zcode',
+  },
 ] as const
 
 /**
@@ -978,7 +986,7 @@ export const TERMINAL_APP_UI_LABELS: Record<
  * @example
  * spawn('npx', [`skills@${SKILLS_CLI_VERSION}`, 'find', 'react'])
  */
-export const SKILLS_CLI_VERSION = '1.5.13'
+export const SKILLS_CLI_VERSION = '1.5.18'
 
 /**
  * Canonical hostname for skills marketplace pages used by renderer/main

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -13,7 +13,7 @@ Skills Desktop scans your `~/.agents/skills/` directory and displays the symlink
 ## Core Features
 
 - **Skill Visualization**: Real-time symlink status monitoring with valid/broken/inaccessible/missing indicators.
-- **69 AI Agents Support**: Claude Code, Cursor, Gemini CLI, OpenAI Codex, GitHub Copilot, Cline, Roo Code, Amp, Goose, Aider, Windsurf, Zed, Continue, PearAI, Void, Melty, Trae, Junie, Kilo Code, Blackbox AI, OpenCode, and more.
+- **69 AI Agents Support**: Claude Code, Cursor, Codex, Gemini CLI, GitHub Copilot, Cline, Roo Code, Amp, Goose, Devin Desktop, Continue, Trae, Junie, Kilo Code, OpenCode, Warp, Zed, ZCode, and more.
 - **Centralized Skills Hub**: All skills stored in `~/.agents/skills/` and symlinked to each agent directory.
 - **Native macOS Experience**: Electron-based desktop app with system integration.
 - **37 Theme Presets**: 54 visual themes across OKLCH color hues, pure neutrals, and shadcn/ui tinted neutrals.

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -1,6 +1,6 @@
 # Skills Desktop
 
-> Skills Desktop is a free, open-source macOS Electron app that visualizes AI agent skill symlinks. It helps developers manage and monitor skills installed via `npx skills add` across 54 AI agents including Claude Code, Cursor, Gemini CLI, and more.
+> Skills Desktop is a free, open-source macOS Electron app that visualizes AI agent skill symlinks. It helps developers manage and monitor skills installed via `npx skills add` across 69 AI agents including Claude Code, Cursor, Gemini CLI, and more.
 
 Skills Desktop scans your `~/.agents/skills/` directory and displays the symlink status (valid, broken, inaccessible, or missing) for each skill across all supported AI agents. Built with Electron, React 19, Redux Toolkit, and TypeScript.
 
@@ -13,7 +13,7 @@ Skills Desktop scans your `~/.agents/skills/` directory and displays the symlink
 ## Core Features
 
 - **Skill Visualization**: Real-time symlink status monitoring with valid/broken/inaccessible/missing indicators.
-- **54 AI Agents Support**: Claude Code, Cursor, Gemini CLI, OpenAI Codex, GitHub Copilot, Cline, Roo Code, Amp, Goose, Aider, Windsurf, Zed, Continue, PearAI, Void, Melty, Trae, Junie, Kilo Code, Blackbox AI, OpenCode, and more.
+- **69 AI Agents Support**: Claude Code, Cursor, Gemini CLI, OpenAI Codex, GitHub Copilot, Cline, Roo Code, Amp, Goose, Aider, Windsurf, Zed, Continue, PearAI, Void, Melty, Trae, Junie, Kilo Code, Blackbox AI, OpenCode, and more.
 - **Centralized Skills Hub**: All skills stored in `~/.agents/skills/` and symlinked to each agent directory.
 - **Native macOS Experience**: Electron-based desktop app with system integration.
 - **37 Theme Presets**: 54 visual themes across OKLCH color hues, pure neutrals, and shadcn/ui tinted neutrals.

--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -17,12 +17,12 @@ export const metadata: Metadata = {
   metadataBase: new URL('https://skills-desktop.vercel.app'),
   title: 'Skills Desktop - AI Agent Skills Manager',
   description:
-    'Visualize and manage installed Skills across 68 AI agents. See symlink status, discover skills, and keep your AI tools in sync.',
+    'Visualize and manage installed Skills across 69 AI agents. See symlink status, discover skills, and keep your AI tools in sync.',
   keywords: ['AI', 'Claude Code', 'Skills', 'Desktop App', 'macOS', 'Electron'],
   authors: [{ name: 'Laststance.io' }],
   openGraph: {
     title: 'Skills Desktop - AI Agent Skills Manager',
-    description: 'Visualize and manage installed Skills across 68 AI agents',
+    description: 'Visualize and manage installed Skills across 69 AI agents',
     url: 'https://skills-desktop.vercel.app',
     siteName: 'Skills Desktop',
     images: [
@@ -39,7 +39,7 @@ export const metadata: Metadata = {
   twitter: {
     card: 'summary_large_image',
     title: 'Skills Desktop - AI Agent Skills Manager',
-    description: 'Visualize and manage installed Skills across 68 AI agents',
+    description: 'Visualize and manage installed Skills across 69 AI agents',
     images: ['/og-image.png'],
   },
 }

--- a/website/src/components/Features.tsx
+++ b/website/src/components/Features.tsx
@@ -5,7 +5,7 @@ import { Monitor, Link2, Palette, Bot, FolderSync, Eye } from 'lucide-react'
 const features = [
   {
     icon: Bot,
-    title: '68 AI Agents Supported',
+    title: '69 AI Agents Supported',
     description:
       'Claude Code, Cursor, Gemini CLI, OpenAI Codex, GitHub Copilot, and dozens more agents auto-detected.',
   },

--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -20,7 +20,7 @@ export function Hero() {
           </h1>
 
           <p className="mb-10 max-w-2xl text-lg text-muted-foreground lg:text-xl">
-            Visualize installed Skills, check symlink status across 68 AI
+            Visualize installed Skills, check symlink status across 69 AI
             agents, and keep your development tools perfectly synchronized.
           </p>
 


### PR DESCRIPTION
## Summary

- Sync `AGENT_DEFINITIONS` with upstream [vercel-labs/skills](https://github.com/vercel-labs/skills) **v1.5.13 → v1.5.18**: adds the one new eligible agent, **`zcode` (ZCode**, upstream v1.5.16) with its own home dir (`installDir = scanDir = '.zcode'`, no universal-source divergence). Agent count 68 → 69, zero app orphans, no id/cliId migrations or display-name rebrands.
- `UNIVERSAL_AGENT_IDS` unchanged (16) — zcode's `skillsDir` is `.zcode/skills`, not the universal `.agents/skills`. Standing exclusions also unchanged: `eve` / `promptscript` (`globalSkillsDir: undefined`), `universal` (`showInUniversalList: false`), `zenflow` (dir collides with zencoder).
- Bump `SKILLS_CLI_VERSION` 1.5.13 → 1.5.18 (+ the hardcoded e2e pin in `marketplace-install-regression.e2e.ts`), add a `constants.test.ts` case for zcode, and refresh agent counts in README/SPEC/CLAUDE.md and website copy (Hero, Features, layout metadata). `website/public/llms.txt` was still at a stale **54** agents from before the v1.5.10 sync — brought to 69.

## Test plan

- [x] `node .claude/skills/skills-cli-sync/reconcile-agents.mjs` — 69/69 reconciled, no constants ↔ SPEC drift
- [x] `npx prettier --check README.md SPEC.md CLAUDE.md website/src/...` — clean
- [x] `pnpm validate` — green (178 files, 2307 tests)
- [x] `pnpm test:e2e` — 61/61 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ZCodeをサポートし、対応AIエージェント数が69件になりました。
* **改善**
  * Skills CLIの固定バージョンを1.5.18へ更新しました。
  * Webサイト、README、仕様書、対応情報のエージェント数表示を69件に統一しました。
* **テスト**
  * 最新CLIバージョンに合わせてインストール回帰E2Eの期待値を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->