### PR TITLE
chore(lint): enable React architecture rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,7 +7,7 @@ import reactYouMightNotNeedAnEffect from 'eslint-plugin-react-you-might-not-need
 import { defineConfig } from 'eslint/config'
 
 /**
- * Rules intentionally enabled for @laststance/react-next-eslint-plugin v2.2.0.
+ * Rules intentionally enabled for @laststance/react-next-eslint-plugin v2.3.0.
  * Keeping the list explicit means dependency upgrades cannot silently turn on a
  * new rule without a focused lint-fix pass in the same PR.
  *
@@ -26,6 +26,8 @@ const laststanceReactNextRuleNames = [
   'no-missing-component-display-name',
   'no-missing-key',
   'no-nested-component-definitions',
+  'no-prop-drilling',
+  'no-react-context',
   'no-set-state-prop-drilling',
   'no-use-reducer',
 ]

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@babel/core": "^8.0.1",
     "@electron/notarize": "^3.1.1",
-    "@laststance/react-next-eslint-plugin": "^2.2.0",
+    "@laststance/react-next-eslint-plugin": "^2.3.0",
     "@playwright/test": "^1.61.1",
     "@rolldown/plugin-babel": "^0.2.3",
     "@storybook/addon-a11y": "10.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,8 @@ importers:
         specifier: ^3.1.1
         version: 3.1.1
       '@laststance/react-next-eslint-plugin':
-        specifier: ^2.2.0
-        version: 2.2.0(eslint@10.7.0(jiti@2.7.0))
+        specifier: ^2.3.0
+        version: 2.3.0(eslint@10.7.0(jiti@2.7.0))
       '@playwright/test':
         specifier: ^1.61.1
         version: 1.61.1
@@ -1088,8 +1088,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@laststance/react-next-eslint-plugin@2.2.0':
-    resolution: {integrity: sha512-x/lMgiwNiS5g4yYfxAQCdih/k/Chs09SWoXXJBuRLHnfQnzb/52uH01iVLq6vZUuMvcy+tq9eDoyq2jQ3n6efw==}
+  '@laststance/react-next-eslint-plugin@2.3.0':
+    resolution: {integrity: sha512-EWMuYly74c0191n0ArIWfSsDCLvX4GDsVISt3gEXSROyOUilJfMKs6UMpzQi5D8L39fm2KVTp+qtcx+DBkoA3w==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       eslint: ^9.0.0 || ^10.0.0
@@ -5911,7 +5911,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@laststance/react-next-eslint-plugin@2.2.0(eslint@10.7.0(jiti@2.7.0))':
+  '@laststance/react-next-eslint-plugin@2.3.0(eslint@10.7.0(jiti@2.7.0))':
     dependencies:
       eslint: 10.7.0(jiti@2.7.0)
 

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -76,7 +76,6 @@ import {
   selectSelectedVisibleNames,
   selectSourceFilterViewModel,
 } from '@/renderer/src/redux/selectors'
-import type { SourceFilterRow } from '@/renderer/src/redux/selectors'
 import { setPreviewSkill } from '@/renderer/src/redux/slices/marketplaceSlice'
 import { selectProtectedNamesSet } from '@/renderer/src/redux/slices/protectSlice'
 import {
@@ -1540,13 +1539,21 @@ const SourceRepositoryFilterMenu = function SourceRepositoryFilterMenu({
               Select all repos
             </DropdownMenuItem>
             <DropdownMenuSeparator />
+            {/* Each repository row consumes the menu handlers here, avoiding a relay-only component. */}
             {sourceFilter.dropdownRows.map((row) => (
-              <SourceFacetCheckboxRow
+              <DropdownMenuCheckboxItem
                 key={row.source}
-                row={row}
-                onToggle={onToggleSource}
-                onKeepOpen={onKeepDropdownOpen}
-              />
+                checked={row.checked}
+                onCheckedChange={() => onToggleSource(row.source)}
+                onSelect={onKeepDropdownOpen}
+                aria-label={`${row.source}, ${row.count} ${pluralize(row.count, 'skill')}`}
+                className="gap-2"
+              >
+                <span className="min-w-0 flex-1 truncate">{row.source}</span>
+                <span className="ml-auto text-xs text-muted-foreground">
+                  {row.count}
+                </span>
+              </DropdownMenuCheckboxItem>
             ))}
           </>
         )}
@@ -1859,45 +1866,6 @@ const BulkConfirmDialog = function BulkConfirmDialog({
         </DialogFooter>
       </DialogContent>
     </Dialog>
-  )
-}
-
-/**
- * One repo row in the source-filter dropdown — hoists the toggle handler so
- * `DropdownMenuCheckboxItem` doesn't receive a fresh inline arrow each render.
- * Mapped by MainContent.
- * @param row - Facet row: repo id, visible-skill count, and ticked state.
- * @param onToggle - Adds/removes this repo from the include filter.
- * @param onKeepOpen - `onSelect` handler that keeps the menu open on activation.
- * @returns A checkbox menu item labelling the repo id and its skill count.
- * @example
- * <SourceFacetCheckboxRow row={row} onToggle={handleToggleSource} onKeepOpen={handleKeepDropdownOpen} />
- */
-const SourceFacetCheckboxRow = function SourceFacetCheckboxRow({
-  row,
-  onToggle,
-  onKeepOpen,
-}: {
-  row: SourceFilterRow
-  onToggle: (source: RepositoryId) => void
-  onKeepOpen: (event: Event) => void
-}): React.ReactElement {
-  // Stable per-row toggle — re-created only when the row id or handler changes.
-  const handleCheckedChange = (): void => {
-    onToggle(row.source)
-  }
-
-  return (
-    <DropdownMenuCheckboxItem
-      checked={row.checked}
-      onCheckedChange={handleCheckedChange}
-      onSelect={onKeepOpen}
-      aria-label={`${row.source}, ${row.count} ${pluralize(row.count, 'skill')}`}
-      className="gap-2"
-    >
-      <span className="min-w-0 flex-1 truncate">{row.source}</span>
-      <span className="ml-auto text-xs text-muted-foreground">{row.count}</span>
-    </DropdownMenuCheckboxItem>
   )
 }
 

--- a/src/renderer/src/components/skills/FileContent.test.tsx
+++ b/src/renderer/src/components/skills/FileContent.test.tsx
@@ -1,0 +1,23 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+
+import { renderPlainTextCode } from './FileContent'
+
+describe('renderPlainTextCode', () => {
+  it('preserves source order, numbered rows, blank lines, and the selected font size', () => {
+    // Arrange
+    const lines = ['first line', '', 'third line']
+
+    // Act
+    const markup = renderToStaticMarkup(renderPlainTextCode(lines, 16))
+
+    // Assert
+    expect(markup).toContain('font-size:16px')
+    expect(markup).toMatch(/>1<\/td>.*first line/s)
+    expect(markup).toMatch(/>2<\/td>.*> <\/td>/s)
+    expect(markup).toMatch(/>3<\/td>.*third line/s)
+    expect(markup.indexOf('first line')).toBeLessThan(
+      markup.indexOf('third line'),
+    )
+  })
+})

--- a/src/renderer/src/components/skills/FileContent.tsx
+++ b/src/renderer/src/components/skills/FileContent.tsx
@@ -260,8 +260,7 @@ const SyntaxHighlightedCode = function SyntaxHighlightedCode({
     >
       {highlightedHtml ? (
         <div
-          // Font size is inline so the slider scales it; `.line` line-height in
-          // globals.css is unitless, so rows scale with the font.
+          // Font size stays on this node because preview tests and slider behavior share this DOM contract.
           style={{ fontSize: `${fontSizePx}px` }}
           className="skill-code-preview min-w-max font-mono"
           // Shiki escapes the source text before returning HTML; this injects
@@ -270,49 +269,27 @@ const SyntaxHighlightedCode = function SyntaxHighlightedCode({
           dangerouslySetInnerHTML={{ __html: highlightedHtml }}
         />
       ) : (
-        <PlainTextCode lines={plainTextLines} fontSizePx={fontSizePx} />
+        <table
+          style={{ fontSize: `${fontSizePx}px` }}
+          className="w-full min-w-max font-mono leading-[1.5]"
+        >
+          <tbody>
+            {/* Keep source line order and stable row numbers while Shiki loads. */}
+            {plainTextLines.map((line, index) => (
+              <tr key={index} className="hover:bg-foreground/5">
+                <td className="sticky left-0 z-10 w-12 bg-muted px-2 py-0 text-right text-muted-foreground select-none border-r border-border/50 align-top">
+                  {index + 1}
+                </td>
+                <td className="px-3 py-0 whitespace-pre text-foreground">
+                  {line || ' '}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       )}
       <div className="h-8" data-file-preview-bottom-spacer aria-hidden />
     </div>
-  )
-}
-
-interface PlainTextCodeProps {
-  lines: string[]
-  fontSizePx: number
-}
-
-/**
- * Immediate plain-text fallback shown while Shiki loads or when highlighting
- * fails for an unknown grammar.
- * @param lines - Raw content split on newline boundaries.
- * @param fontSizePx - Code font size; unitless line-height keeps rows scaling.
- * @returns Line-numbered plain text table.
- * @example
- * <PlainTextCode lines={['first', 'second']} fontSizePx={13} />
- */
-const PlainTextCode = function PlainTextCode({
-  lines,
-  fontSizePx,
-}: PlainTextCodeProps): React.ReactElement {
-  return (
-    <table
-      style={{ fontSize: `${fontSizePx}px` }}
-      className="w-full min-w-max font-mono leading-[1.5]"
-    >
-      <tbody>
-        {lines.map((line, idx) => (
-          <tr key={idx} className="hover:bg-foreground/5">
-            <td className="sticky left-0 z-10 w-12 bg-muted px-2 py-0 text-right text-muted-foreground select-none border-r border-border/50 align-top">
-              {idx + 1}
-            </td>
-            <td className="px-3 py-0 whitespace-pre text-foreground">
-              {line || ' '}
-            </td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
   )
 }
 

--- a/src/renderer/src/components/skills/FileContent.tsx
+++ b/src/renderer/src/components/skills/FileContent.tsx
@@ -169,6 +169,40 @@ interface SyntaxHighlightedCodeProps {
 }
 
 /**
+ * Build the deterministic plain-text table shown while Shiki loads or cannot parse a file.
+ * @param lines - Source lines in their original order.
+ * @param fontSizePx - Code font size applied to the fallback table.
+ * @returns A numbered table that preserves blank lines and source ordering.
+ * @example
+ * renderPlainTextCode(['const value = 1', ''], 13)
+ */
+export const renderPlainTextCode = function renderPlainTextCode(
+  lines: ReadonlyArray<string>,
+  fontSizePx: number,
+): React.ReactElement {
+  return (
+    <table
+      style={{ fontSize: `${fontSizePx}px` }}
+      className="w-full min-w-max font-mono leading-[1.5]"
+    >
+      <tbody>
+        {/* Keep source line order and stable row numbers while Shiki loads. */}
+        {lines.map((line, index) => (
+          <tr key={index} className="hover:bg-foreground/5">
+            <td className="sticky left-0 z-10 w-12 bg-muted px-2 py-0 text-right text-muted-foreground select-none border-r border-border/50 align-top">
+              {index + 1}
+            </td>
+            <td className="px-3 py-0 whitespace-pre text-foreground">
+              {line || ' '}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+/**
  * Highlight code asynchronously with Shiki.
  * @param content - Raw file text.
  * @param language - Shiki language identifier.
@@ -269,24 +303,7 @@ const SyntaxHighlightedCode = function SyntaxHighlightedCode({
           dangerouslySetInnerHTML={{ __html: highlightedHtml }}
         />
       ) : (
-        <table
-          style={{ fontSize: `${fontSizePx}px` }}
-          className="w-full min-w-max font-mono leading-[1.5]"
-        >
-          <tbody>
-            {/* Keep source line order and stable row numbers while Shiki loads. */}
-            {plainTextLines.map((line, index) => (
-              <tr key={index} className="hover:bg-foreground/5">
-                <td className="sticky left-0 z-10 w-12 bg-muted px-2 py-0 text-right text-muted-foreground select-none border-r border-border/50 align-top">
-                  {index + 1}
-                </td>
-                <td className="px-3 py-0 whitespace-pre text-foreground">
-                  {line || ' '}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        renderPlainTextCode(plainTextLines, fontSizePx)
       )}
       <div className="h-8" data-file-preview-bottom-spacer aria-hidden />
     </div>

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -660,6 +660,13 @@ export const SkillItem = function SkillItem({
         >
           <SkillItemOverlayActions
             skill={skill}
+            protectButton={
+              <ProtectButton
+                skillName={skill.name}
+                showBookmark={showBookmark}
+                hasXButton={showUnlinkButtonBase || showDeleteButtonBase}
+              />
+            }
             selectedAgentName={selectedAgentName}
             isLocalSkill={isLocalSkill}
             isProtected={isProtected}
@@ -667,7 +674,6 @@ export const SkillItem = function SkillItem({
             showBookmark={showBookmark}
             showUnlinkButton={showUnlinkButton}
             showDeleteButton={showDeleteButton}
-            hasXButton={showUnlinkButtonBase || showDeleteButtonBase}
             onUnlinkClick={handleUnlinkClick}
             onDeleteClick={handleDeleteClick}
             onToggleBookmark={handleToggleBookmark}
@@ -740,6 +746,7 @@ export const SkillItem = function SkillItem({
 
 interface SkillItemOverlayActionsProps {
   skill: Skill
+  protectButton: React.ReactNode
   selectedAgentName: string
   isLocalSkill: boolean
   isProtected: boolean
@@ -747,7 +754,6 @@ interface SkillItemOverlayActionsProps {
   showBookmark: boolean
   showUnlinkButton: boolean
   showDeleteButton: boolean
-  hasXButton: boolean
   onUnlinkClick: (event: React.MouseEvent) => void
   onDeleteClick: (event: React.MouseEvent) => void
   onToggleBookmark: (event: React.MouseEvent) => void
@@ -762,6 +768,7 @@ interface SkillItemOverlayActionsProps {
  */
 const SkillItemOverlayActions = function SkillItemOverlayActions({
   skill,
+  protectButton,
   selectedAgentName,
   isLocalSkill,
   isProtected,
@@ -769,7 +776,6 @@ const SkillItemOverlayActions = function SkillItemOverlayActions({
   showBookmark,
   showUnlinkButton,
   showDeleteButton,
-  hasXButton,
   onUnlinkClick,
   onDeleteClick,
   onToggleBookmark,
@@ -842,11 +848,7 @@ const SkillItemOverlayActions = function SkillItemOverlayActions({
         </Tooltip>
       ) : null}
 
-      <ProtectButton
-        skillName={skill.name}
-        showBookmark={showBookmark}
-        hasXButton={hasXButton}
-      />
+      {protectButton}
 
       {showBookmark ? (
         <Tooltip>

--- a/src/renderer/src/components/ui/toggle-group.test.tsx
+++ b/src/renderer/src/components/ui/toggle-group.test.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { injectToggleGroupDefaults, ToggleGroupItem } from './toggle-group'
+
+type ToggleGroupItemProps = React.ComponentProps<typeof ToggleGroupItem>
+
+describe('injectToggleGroupDefaults', () => {
+  it('applies group defaults to direct items while preserving item overrides', () => {
+    // Arrange
+    const children = [
+      <ToggleGroupItem key="defaulted" value="defaulted">
+        Defaulted
+      </ToggleGroupItem>,
+      <ToggleGroupItem
+        key="overridden"
+        value="overridden"
+        variant="default"
+        size="lg"
+      >
+        Overridden
+      </ToggleGroupItem>,
+    ]
+
+    // Act
+    const result = React.Children.toArray(
+      injectToggleGroupDefaults(children, 'outline', 'sm'),
+    )
+
+    // Assert
+    expect(result).toHaveLength(2)
+    expect(React.isValidElement<ToggleGroupItemProps>(result[0])).toBe(true)
+    expect(React.isValidElement<ToggleGroupItemProps>(result[1])).toBe(true)
+
+    if (
+      !React.isValidElement<ToggleGroupItemProps>(result[0]) ||
+      !React.isValidElement<ToggleGroupItemProps>(result[1])
+    ) {
+      throw new Error('Expected direct ToggleGroupItem children')
+    }
+
+    expect(result[0].props.variant).toBe('outline')
+    expect(result[0].props.size).toBe('sm')
+    expect(result[1].props.variant).toBe('default')
+    expect(result[1].props.size).toBe('lg')
+  })
+
+  it('leaves text, fragments, wrappers, and nested items unchanged', () => {
+    // Arrange
+    const fragment = (
+      <React.Fragment key="fragment">
+        <ToggleGroupItem value="fragment-item">Fragment item</ToggleGroupItem>
+      </React.Fragment>
+    )
+    const wrapper = (
+      <span key="wrapper">
+        <ToggleGroupItem value="nested-item">Nested item</ToggleGroupItem>
+      </span>
+    )
+
+    // Act
+    const result = React.Children.toArray(
+      injectToggleGroupDefaults(['Label', fragment, wrapper], 'outline', 'sm'),
+    )
+
+    // Assert
+    expect(result[0]).toBe('Label')
+    expect(React.isValidElement(result[1]) && result[1].type).toBe(
+      React.Fragment,
+    )
+    expect(
+      React.isValidElement<{ children: React.ReactNode }>(result[2]) &&
+        result[2].type,
+    ).toBe('span')
+
+    if (!React.isValidElement<{ children: React.ReactNode }>(result[2])) {
+      throw new Error('Expected wrapper element')
+    }
+
+    const nestedItem = React.Children.only(result[2].props.children)
+    expect(React.isValidElement<ToggleGroupItemProps>(nestedItem)).toBe(true)
+
+    if (!React.isValidElement<ToggleGroupItemProps>(nestedItem)) {
+      throw new Error('Expected nested ToggleGroupItem child')
+    }
+
+    expect(nestedItem.props.variant).toBeUndefined()
+    expect(nestedItem.props.size).toBeUndefined()
+  })
+})

--- a/src/renderer/src/components/ui/toggle-group.tsx
+++ b/src/renderer/src/components/ui/toggle-group.tsx
@@ -81,6 +81,38 @@ const ToggleGroupItem = function ToggleGroupItem({
   )
 }
 
+type ToggleGroupStyleProps = VariantProps<typeof toggleVariants>
+
+/**
+ * Apply group styles only to direct ToggleGroupItem children so wrappers and text remain untouched.
+ * @param children - Root children supplied to ToggleGroup.
+ * @param variant - Group variant used when an item has no override.
+ * @param size - Group size used when an item has no override.
+ * @returns Children with missing direct-item styles filled from the group.
+ * @example
+ * injectToggleGroupDefaults(<ToggleGroupItem value="name" />, 'outline', 'sm')
+ */
+export const injectToggleGroupDefaults = function injectToggleGroupDefaults(
+  children: React.ReactNode,
+  variant: ToggleGroupStyleProps['variant'],
+  size: ToggleGroupStyleProps['size'],
+): React.ReactNode {
+  return React.Children.map(children, (child): React.ReactNode => {
+    // Only direct ToggleGroupItem children receive defaults; text and wrappers pass through unchanged.
+    if (
+      !React.isValidElement<ToggleGroupStyleProps>(child) ||
+      child.type !== ToggleGroupItem
+    ) {
+      return child
+    }
+
+    return React.cloneElement(child, {
+      variant: child.props.variant ?? variant,
+      size: child.props.size ?? size,
+    })
+  })
+}
+
 /**
  * Composes a Radix group and injects shared styles into its direct ToggleGroupItem children.
  * @param props - Radix root props plus group-level variant, size, children, and ref.
@@ -100,23 +132,7 @@ const ToggleGroup = function ToggleGroup({
   ...props
 }: React.ComponentProps<typeof ToggleGroupPrimitive.Root> &
   VariantProps<typeof toggleVariants> & { ref?: React.Ref<HTMLDivElement> }) {
-  const styledChildren = React.Children.map(
-    children,
-    (child): React.ReactNode => {
-      // Only direct ToggleGroupItem children receive group defaults; text and wrappers pass through unchanged.
-      if (
-        !React.isValidElement<VariantProps<typeof toggleVariants>>(child) ||
-        child.type !== ToggleGroupItem
-      ) {
-        return child
-      }
-
-      return React.cloneElement(child, {
-        variant: child.props.variant ?? variant,
-        size: child.props.size ?? size,
-      })
-    },
-  )
+  const styledChildren = injectToggleGroupDefaults(children, variant, size)
 
   return (
     <ToggleGroupPrimitive.Root

--- a/src/renderer/src/components/ui/toggle-group.tsx
+++ b/src/renderer/src/components/ui/toggle-group.tsx
@@ -47,54 +47,11 @@ const toggleVariants = cva(
 )
 
 /**
- * Context that lets `ToggleGroup` push its `variant` / `size` down to every
- * `ToggleGroupItem` without callers having to repeat the props on each item.
- */
-const ToggleGroupContext = React.createContext<
-  VariantProps<typeof toggleVariants>
->({
-  size: 'default',
-  variant: 'default',
-})
-
-/**
- * Radix `ToggleGroup.Root` styled to match the shadcn default look.
- * Single-select (`type="single"`) is the common usage; pass `type="multiple"`
- * for checkbox-style toggle sets.
- *
+ * Renders one styled Radix option after ToggleGroup injects any missing group-level styles.
+ * @param props - Radix item props plus optional per-item variant, size, and ref.
+ * @returns One accessible toggle option button.
  * @example
- *   <ToggleGroup type="single" value={scope} onValueChange={(v) => v && setScope(v)}>
- *     <ToggleGroupItem value="name">Name</ToggleGroupItem>
- *     <ToggleGroupItem value="repo">Repo</ToggleGroupItem>
- *   </ToggleGroup>
- */
-const ToggleGroup = function ToggleGroup({
-  className,
-  variant,
-  size,
-  children,
-  ref,
-  ...props
-}: React.ComponentProps<typeof ToggleGroupPrimitive.Root> &
-  VariantProps<typeof toggleVariants> & { ref?: React.Ref<HTMLDivElement> }) {
-  // Context value for descendant ToggleGroupItems. React Compiler preserves
-  // referential stability when variant/size are unchanged. React 19's
-  // `<Context>` (no `.Provider`) is the new shorthand.
-  const contextValue = { variant, size }
-  return (
-    <ToggleGroupPrimitive.Root
-      ref={ref}
-      className={cn('flex items-center justify-center gap-1', className)}
-      {...props}
-    >
-      <ToggleGroupContext value={contextValue}>{children}</ToggleGroupContext>
-    </ToggleGroupPrimitive.Root>
-  )
-}
-
-/**
- * One option button inside a `ToggleGroup`. Inherits `variant` / `size` from
- * the surrounding group's context unless explicitly overridden.
+ * <ToggleGroupItem value="name">Name</ToggleGroupItem>
  */
 const ToggleGroupItem = function ToggleGroupItem({
   className,
@@ -107,14 +64,13 @@ const ToggleGroupItem = function ToggleGroupItem({
   VariantProps<typeof toggleVariants> & {
     ref?: React.Ref<HTMLButtonElement>
   }) {
-  const context = React.use(ToggleGroupContext)
   return (
     <ToggleGroupPrimitive.Item
       ref={ref}
       className={cn(
         toggleVariants({
-          variant: variant ?? context.variant,
-          size: size ?? context.size,
+          variant,
+          size,
         }),
         className,
       )}
@@ -122,6 +78,54 @@ const ToggleGroupItem = function ToggleGroupItem({
     >
       {children}
     </ToggleGroupPrimitive.Item>
+  )
+}
+
+/**
+ * Composes a Radix group and injects shared styles into its direct ToggleGroupItem children.
+ * @param props - Radix root props plus group-level variant, size, children, and ref.
+ * @returns One toggle group whose item-level overrides take precedence.
+ * @example
+ * <ToggleGroup type="single" value={scope} onValueChange={(value) => value && setScope(value)}>
+ *   <ToggleGroupItem value="name">Name</ToggleGroupItem>
+ *   <ToggleGroupItem value="repo">Repo</ToggleGroupItem>
+ * </ToggleGroup>
+ */
+const ToggleGroup = function ToggleGroup({
+  className,
+  variant,
+  size,
+  children,
+  ref,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Root> &
+  VariantProps<typeof toggleVariants> & { ref?: React.Ref<HTMLDivElement> }) {
+  const styledChildren = React.Children.map(
+    children,
+    (child): React.ReactNode => {
+      // Only direct ToggleGroupItem children receive group defaults; text and wrappers pass through unchanged.
+      if (
+        !React.isValidElement<VariantProps<typeof toggleVariants>>(child) ||
+        child.type !== ToggleGroupItem
+      ) {
+        return child
+      }
+
+      return React.cloneElement(child, {
+        variant: child.props.variant ?? variant,
+        size: child.props.size ?? size,
+      })
+    },
+  )
+
+  return (
+    <ToggleGroupPrimitive.Root
+      ref={ref}
+      className={cn('flex items-center justify-center gap-1', className)}
+      {...props}
+    >
+      {styledChildren}
+    </ToggleGroupPrimitive.Root>
   )
 }
 

--- a/src/renderer/src/redux/selectors.ts
+++ b/src/renderer/src/redux/selectors.ts
@@ -299,7 +299,7 @@ export const selectRepoFacetOptions = createSelector(
   },
 )
 
-export interface SourceFilterRow {
+interface SourceFilterRow {
   source: RepositoryId
   count: SkillCount
   /** True when this repo is in `selectedSources` (drives the checkbox tick). */


### PR DESCRIPTION
## Summary

- Update `@laststance/react-next-eslint-plugin` from 2.2.0 to 2.3.0.
- Enable `no-react-context` and `no-prop-drilling` at error severity.
- Resolve the five existing violations through local composition and inherited ownership without rule suppressions.
- Preserve ToggleGroup styling, code-preview typography, repository filters, and skill-row actions.

## Test Plan

- [x] `pnpm validate`
- [x] `pnpm test:e2e` — 61 passed

## Security Checklist

- [x] This change does not widen renderer access to Node.js, Electron, or direct filesystem APIs.
- [x] N/A — this change adds no IPC or filesystem behavior.
- [x] The dependency update preserves existing least-privilege permissions and pinned third-party Actions.
- [x] N/A — this change adds no security-sensitive behavior requiring `SECURITY.md` updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - ソースフィルターのドロップダウン操作とアクセシビリティ表示を整理しました。
  - コードプレビューのハイライト待機中や失敗時も、行番号付きで安定して表示されます。
  - トグルグループのサイズ・スタイル適用を改善しました。
  - スキル項目の保護ボタン表示を柔軟に扱えるようにしました。

- **保守**
  - ESLintルールを更新し、コード品質チェックを強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->