### PR TITLE
fix(deps): override vulnerable js-yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   '@electron/get@5>undici': 7.29.0
   ajv@8>fast-uri: 3.1.5
+  js-yaml: 4.3.1
   minimatch@10>brace-expansion: 5.0.9
   minimatch@3>brace-expansion: 1.1.18
   minimatch@5>brace-expansion: 2.1.4
@@ -3561,8 +3562,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -7228,7 +7229,7 @@ snapshots:
       hosted-git-info: 4.1.0
       isbinaryfile: 5.0.7
       jiti: 2.7.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       json5: 2.2.3
       lazy-val: 1.0.5
       minimatch: 10.2.5
@@ -7350,7 +7351,7 @@ snapshots:
       fs-extra: 10.1.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       sanitize-filename: 1.6.4
       source-map-support: 0.5.21
       stat-mode: 1.0.0
@@ -7572,7 +7573,7 @@ snapshots:
       app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
       builder-util: 26.15.3
       fs-extra: 10.1.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
     transitivePeerDependencies:
       - electron-builder-squirrel-windows
       - supports-color
@@ -7654,7 +7655,7 @@ snapshots:
     dependencies:
       builder-util-runtime: 9.7.0
       fs-extra: 10.1.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lazy-val: 1.0.5
       lodash.escaperegexp: 4.1.2
       lodash.isequal: 4.5.0
@@ -8351,7 +8352,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,7 @@ allowBuilds:
 overrides:
   '@electron/get@5>undici': 7.29.0
   'ajv@8>fast-uri': 3.1.5
+  js-yaml: 4.3.1
   'minimatch@10>brace-expansion': 5.0.9
   'minimatch@3>brace-expansion': 1.1.18
   'minimatch@5>brace-expansion': 2.1.4


### PR DESCRIPTION
## Summary

- force all root workspace consumers onto patched `js-yaml@4.3.1`
- regenerate the root pnpm lockfile so the production audit no longer resolves vulnerable `4.3.0`
- restore the failing Security workflow caused by GHSA-5p4m-2wfm-xmqj

## Test plan

- `CI=1 pnpm install --frozen-lockfile`
- `pnpm audit --prod --audit-level high`
- `pnpm validate`
- `kill-port 9222 && pnpm test:e2e`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * `js-yaml` の使用バージョンを 4.3.1 に統一しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->