### PR TITLE
fix(deps): override vulnerable website nanoid

### DIFF
--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   minimatch@10>brace-expansion: 5.0.9
+  nanoid: 3.3.18
   postcss: 8.5.23
   sharp: 0.35.3
 
@@ -1011,8 +1012,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2063,7 +2064,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -2123,7 +2124,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -4,5 +4,6 @@ allowBuilds:
 # Next.js still pins vulnerable transitive versions that Dependabot cannot lift automatically.
 overrides:
   'minimatch@10>brace-expansion': 5.0.9
+  nanoid: 3.3.18
   postcss: 8.5.23
   sharp: 0.35.3


### PR DESCRIPTION
## Summary

- force the website workspace onto patched `nanoid@3.3.18`
- regenerate the independent website lockfile
- resolve GHSA-2v37-7h3g-55p8 and the failing Dependabot security update

## Test plan

- `CI=1 pnpm install --frozen-lockfile` (from `website/`)
- `pnpm audit --prod --audit-level high` (from `website/`)
- `pnpm lint` (from `website/`)
- `pnpm build` (from `website/`)
- `pnpm validate`
- `kill-port 9222 && pnpm test:e2e`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * nanoidのバージョンを3.3.18に固定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->