### PR TITLE
chore: sync skills CLI agent definitions to 1.5.23

### DIFF
--- a/.claude/skills/skills-cli-sync/SKILL.md
+++ b/.claude/skills/skills-cli-sync/SKILL.md
@@ -149,7 +149,7 @@ Do not bump `package.json` `version` — releases are owned solely by
 
 ## Latest run (example — point-in-time, NOT part of the procedure)
 
-**2026-08-26 · v1.5.18 → v1.5.23** (+4 community agents)
+**2026-08-26 JST · v1.5.18 → v1.5.23** (+4 community agents)
 
 - **+4 agents:** `grok` (Grok Build) and `kimchi` (Kimchi) from v1.5.20,
   `minimax-code` (MiniMax Code) from v1.5.22, and `posit-assistant` (Posit
@@ -163,7 +163,8 @@ Do not bump `package.json` `version` — releases are owned solely by
   `zenflow` (dir collides with zencoder's `~/.zencoder/skills`).
 - **Edits:** bumped `SKILLS_CLI_VERSION` 1.5.18 → 1.5.23; updated the e2e pin,
   CLAUDE.md pinned-version cell, README/SPEC agent counts and table, website
-  metadata/copy, and `llms.txt`.
+  metadata/copy, `llms.txt`, and the website's download links to the current
+  v0.27.3 release assets.
 - Gates: `reconcile-agents.mjs` clean (73/73), prettier clean, `pnpm validate`
   green (180 files / 2313 tests), `pnpm test:e2e` green (61 tests), website
   lint/build green.

--- a/.claude/skills/skills-cli-sync/SKILL.md
+++ b/.claude/skills/skills-cli-sync/SKILL.md
@@ -149,6 +149,25 @@ Do not bump `package.json` `version` — releases are owned solely by
 
 ## Latest run (example — point-in-time, NOT part of the procedure)
 
+**2026-08-26 · v1.5.18 → v1.5.23** (+4 community agents)
+
+- **+4 agents:** `grok` (Grok Build) and `kimchi` (Kimchi) from v1.5.20,
+  `minimax-code` (MiniMax Code) from v1.5.22, and `posit-assistant` (Posit
+  Assistant) from v1.5.23. Each keeps its own global skills directory, so
+  `installDir = scanDir`; `AGENT_DEFINITIONS` 69 → 73.
+- **No migrations/rebrands:** zero app orphans; no id/cliId, path, or
+  display-name changes to existing agents. `UNIVERSAL_AGENT_IDS` stays 16
+  because all four additions use their own `skillsDir`.
+- **Excluded at this version:** `eve` and `promptscript`
+  (`globalSkillsDir: undefined`), `universal` (`showInUniversalList: false`),
+  `zenflow` (dir collides with zencoder's `~/.zencoder/skills`).
+- **Edits:** bumped `SKILLS_CLI_VERSION` 1.5.18 → 1.5.23; updated the e2e pin,
+  CLAUDE.md pinned-version cell, README/SPEC agent counts and table, website
+  metadata/copy, and `llms.txt`.
+- Gates: `reconcile-agents.mjs` clean (73/73), prettier clean, `pnpm validate`
+  green (180 files / 2313 tests), `pnpm test:e2e` green (61 tests), website
+  lint/build green.
+
 **2026-07-16 · v1.5.13 → v1.5.18** (+1 community agent)
 
 - **+1 agent:** `zcode` (ZCode, added upstream in v1.5.16) — own home dir

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ PRs are ready to ship only when `validate` and e2e both pass in that order.
 | Repository     | https://github.com/vercel-labs/skills (paths below are inside that repo)                       |
 | CLI agent list | `src/agents.ts`                                                                                |
 | CLI types      | `src/types.ts`                                                                                 |
-| Pinned version | `SKILLS_CLI_VERSION` in `src/shared/constants.ts` (currently `1.5.18`) — bump when re-syncing `AGENT_DEFINITIONS` against the upstream skills CLI |
+| Pinned version | `SKILLS_CLI_VERSION` in `src/shared/constants.ts` (currently `1.5.23`) — bump when re-syncing `AGENT_DEFINITIONS` against the upstream skills CLI |
 
 `AGENT_DEFINITIONS` in `src/shared/constants.ts` mirrors the CLI's agent
 list. Each entry: `id` (app state), `cliId` (`--agent` flag), `name`

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Skills Desktop provides a GUI to manage and monitor skills installed via [`npx s
 
 ## Features
 
-- **69 AI Agents Supported** - Auto-detects Claude Code, Cursor, Codex, Gemini CLI, and more
+- **73 AI Agents Supported** - Auto-detects Claude Code, Cursor, Codex, Gemini CLI, and more
 - **Symlink Status Visualization** - Valid (✓), Broken (◐), Inaccessible (!), Missing (○) indicators
 - **Customizable Dashboard** - Widget-based home view with skill stats, symlink health, agent coverage, bookmarks, and quick actions — drag, resize, and arrange across multiple pages
 - **54 Themes** - 34 OKLCH color themes (17 hues × light/dark) + 2 pure neutral + 18 tinted neutral
@@ -37,7 +37,7 @@ Skills Desktop provides a GUI to manage and monitor skills installed via [`npx s
 | Devin Desktop    | `~/.codeium/windsurf/skills/` |
 | OpenCode         | `~/.config/opencode/skills/`  |
 | Continue         | `~/.continue/skills/`         |
-| _...and 58 more_ |                               |
+| _...and 62 more_ |                               |
 
 ## Installation
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -122,6 +122,10 @@ Agent definitions are synced with [vercel-labs/skills CLI](https://github.com/ve
 | Tinycloud          | `tinycloud`       | `~/.tinycloud/skills/`              |
 | Zed                | `zed`             | `~/.zed/skills/`                    |
 | ZCode              | `zcode`           | `~/.zcode/skills/`                  |
+| Grok Build         | `grok`            | `~/.grok/skills/`                   |
+| Kimchi             | `kimchi`          | `~/.config/kimchi/harness/skills/`  |
+| MiniMax Code       | `minimax-code`    | `~/.minimax/skills/`                |
+| Posit Assistant    | `posit-assistant` | `~/.posit/assistant/skills/`        |
 
 **Detection Logic:**
 
@@ -135,7 +139,7 @@ Agent definitions are synced with [vercel-labs/skills CLI](https://github.com/ve
 ### Core Features
 
 - [x] Display source directory (`~/.agents/skills/`)
-- [x] Auto-detect installed AI agents (69 agents)
+- [x] Auto-detect installed AI agents (73 agents)
 - [x] List all installed skills with metadata
 - [x] Show symlink status per skill per agent
 - [x] Validate symlink integrity (valid/broken/inaccessible/missing)
@@ -929,7 +933,7 @@ APPLE_KEYCHAIN_PROFILE=skills-desktop pnpm build:mac
 **Sections:**
 
 - Hero with app screenshot
-- Feature grid (69 agents, symlink status, 37 theme presets)
+- Feature grid (73 agents, symlink status, 37 theme presets)
 - Download CTA linking to GitHub Release
 - OG image for social sharing
 

--- a/e2e/spec/marketplace-install-regression.e2e.ts
+++ b/e2e/spec/marketplace-install-regression.e2e.ts
@@ -162,14 +162,14 @@ test('Marketplace Install works when Electron starts with sparse macOS GUI PATH'
     await dialog.getByRole('button', { name: 'Install', exact: true }).click()
 
     // Assert — the fake npx ran with the pinned CLI version (SKILLS_CLI_VERSION
-    // is '1.5.18' in src/shared/constants.ts; hardcoded here so this test pins
+    // is '1.5.23' in src/shared/constants.ts; hardcoded here so this test pins
     // the literal command rather than computing the expectation from the same
     // constant the production command builds from) and the installed badge shows.
     await expect
       .poll(() => existsSync(markerPath), { timeout: 10_000 })
       .toBe(true)
     expect(readFileSync(markerPath, 'utf-8')).toContain(
-      'skills@1.5.18 add vercel-labs/skills',
+      'skills@1.5.23 add vercel-labs/skills',
     )
     await expect(
       appWindow.getByRole('img', { name: /find-skills is installed/i }),

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -144,6 +144,48 @@ describe('AGENT_DEFINITIONS', () => {
     expect(zcode?.scanDir).toBe('.zcode')
   })
 
+  it('exposes the four community agents added through CLI v1.5.23 with their upstream paths', () => {
+    // Arrange / Act
+    const addedAgents = [
+      'grok',
+      'kimchi',
+      'minimax-code',
+      'posit-assistant',
+    ].map((id) => AGENT_DEFINITIONS.find((agent) => agent.id === id))
+
+    // Assert
+    expect(addedAgents).toEqual([
+      {
+        id: 'grok',
+        cliId: 'grok',
+        name: 'Grok Build',
+        installDir: '.grok',
+        scanDir: '.grok',
+      },
+      {
+        id: 'kimchi',
+        cliId: 'kimchi',
+        name: 'Kimchi',
+        installDir: '.config/kimchi/harness',
+        scanDir: '.config/kimchi/harness',
+      },
+      {
+        id: 'minimax-code',
+        cliId: 'minimax-code',
+        name: 'MiniMax Code',
+        installDir: '.minimax',
+        scanDir: '.minimax',
+      },
+      {
+        id: 'posit-assistant',
+        cliId: 'posit-assistant',
+        name: 'Posit Assistant',
+        installDir: '.posit/assistant',
+        scanDir: '.posit/assistant',
+      },
+    ])
+  })
+
   it('maps Kimi internal id to the renamed kimi-code-cli CLI flag (1.5.10 rename)', () => {
     // The CLI renamed the --agent value to 'kimi-code-cli' and moved it to the
     // universal source. Internal id stays 'kimi-cli' so persisted Redux state

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -784,6 +784,37 @@ export const AGENT_DEFINITIONS = [
     installDir: '.zcode',
     scanDir: '.zcode',
   },
+  // Community agents added in skills CLI v1.5.20 (synced 2026-08-26).
+  {
+    id: 'grok',
+    cliId: 'grok',
+    name: 'Grok Build',
+    installDir: '.grok',
+    scanDir: '.grok',
+  },
+  {
+    id: 'kimchi',
+    cliId: 'kimchi',
+    name: 'Kimchi',
+    installDir: '.config/kimchi/harness',
+    scanDir: '.config/kimchi/harness',
+  },
+  // Community agent added in skills CLI v1.5.22 (synced 2026-08-26).
+  {
+    id: 'minimax-code',
+    cliId: 'minimax-code',
+    name: 'MiniMax Code',
+    installDir: '.minimax',
+    scanDir: '.minimax',
+  },
+  // Community agent added in skills CLI v1.5.23 (synced 2026-08-26).
+  {
+    id: 'posit-assistant',
+    cliId: 'posit-assistant',
+    name: 'Posit Assistant',
+    installDir: '.posit/assistant',
+    scanDir: '.posit/assistant',
+  },
 ] as const
 
 /**
@@ -986,7 +1017,7 @@ export const TERMINAL_APP_UI_LABELS: Record<
  * @example
  * spawn('npx', [`skills@${SKILLS_CLI_VERSION}`, 'find', 'react'])
  */
-export const SKILLS_CLI_VERSION = '1.5.18'
+export const SKILLS_CLI_VERSION = '1.5.23'
 
 /**
  * Canonical hostname for skills marketplace pages used by renderer/main

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -784,7 +784,7 @@ export const AGENT_DEFINITIONS = [
     installDir: '.zcode',
     scanDir: '.zcode',
   },
-  // Community agents added in skills CLI v1.5.20 (synced 2026-08-26).
+  // Community agents added in skills CLI v1.5.20 (synced 2026-08-26 JST).
   {
     id: 'grok',
     cliId: 'grok',
@@ -799,7 +799,7 @@ export const AGENT_DEFINITIONS = [
     installDir: '.config/kimchi/harness',
     scanDir: '.config/kimchi/harness',
   },
-  // Community agent added in skills CLI v1.5.22 (synced 2026-08-26).
+  // Community agent added in skills CLI v1.5.22 (synced 2026-08-26 JST).
   {
     id: 'minimax-code',
     cliId: 'minimax-code',
@@ -807,7 +807,7 @@ export const AGENT_DEFINITIONS = [
     installDir: '.minimax',
     scanDir: '.minimax',
   },
-  // Community agent added in skills CLI v1.5.23 (synced 2026-08-26).
+  // Community agent added in skills CLI v1.5.23 (synced 2026-08-26 JST).
   {
     id: 'posit-assistant',
     cliId: 'posit-assistant',

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -6,8 +6,8 @@ Skills Desktop scans your `~/.agents/skills/` directory and displays the symlink
 
 ## Download
 
-- [Download for macOS (Apple Silicon)](https://github.com/laststance/skills-desktop/releases/download/v0.27.2/skills-desktop-0.27.2-arm64.dmg): DMG installer for M1/M2/M3 Macs.
-- [Download for macOS (Intel)](https://github.com/laststance/skills-desktop/releases/download/v0.27.2/skills-desktop-0.27.2-x64.dmg): DMG installer for Intel-based Macs.
+- [Download for macOS (Apple Silicon)](https://github.com/laststance/skills-desktop/releases/download/v0.27.3/skills-desktop-0.27.3-arm64.dmg): DMG installer for M1/M2/M3 Macs.
+- [Download for macOS (Intel)](https://github.com/laststance/skills-desktop/releases/download/v0.27.3/skills-desktop-0.27.3-x64.dmg): DMG installer for Intel-based Macs.
 - [All Releases](https://github.com/laststance/skills-desktop/releases): View all versions and release notes.
 
 ## Core Features

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -1,6 +1,6 @@
 # Skills Desktop
 
-> Skills Desktop is a free, open-source macOS Electron app that visualizes AI agent skill symlinks. It helps developers manage and monitor skills installed via `npx skills add` across 69 AI agents including Claude Code, Cursor, Gemini CLI, and more.
+> Skills Desktop is a free, open-source macOS Electron app that visualizes AI agent skill symlinks. It helps developers manage and monitor skills installed via `npx skills add` across 73 AI agents including Claude Code, Cursor, Gemini CLI, and more.
 
 Skills Desktop scans your `~/.agents/skills/` directory and displays the symlink status (valid, broken, inaccessible, or missing) for each skill across all supported AI agents. Built with Electron, React 19, Redux Toolkit, and TypeScript.
 
@@ -13,7 +13,7 @@ Skills Desktop scans your `~/.agents/skills/` directory and displays the symlink
 ## Core Features
 
 - **Skill Visualization**: Real-time symlink status monitoring with valid/broken/inaccessible/missing indicators.
-- **69 AI Agents Support**: Claude Code, Cursor, Codex, Gemini CLI, GitHub Copilot, Cline, Roo Code, Amp, Goose, Devin Desktop, Continue, Trae, Junie, Kilo Code, OpenCode, Warp, Zed, ZCode, and more.
+- **73 AI Agents Support**: Claude Code, Cursor, Codex, Gemini CLI, GitHub Copilot, Cline, Roo Code, Amp, Goose, Devin Desktop, Continue, Trae, Junie, Kilo Code, OpenCode, Warp, Zed, ZCode, Grok Build, Kimchi, MiniMax Code, Posit Assistant, and more.
 - **Centralized Skills Hub**: All skills stored in `~/.agents/skills/` and symlinked to each agent directory.
 - **Native macOS Experience**: Electron-based desktop app with system integration.
 - **37 Theme Presets**: 54 visual themes across OKLCH color hues, pure neutrals, and shadcn/ui tinted neutrals.

--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -17,12 +17,12 @@ export const metadata: Metadata = {
   metadataBase: new URL('https://skills-desktop.vercel.app'),
   title: 'Skills Desktop - AI Agent Skills Manager',
   description:
-    'Visualize and manage installed Skills across 69 AI agents. See symlink status, discover skills, and keep your AI tools in sync.',
+    'Visualize and manage installed Skills across 73 AI agents. See symlink status, discover skills, and keep your AI tools in sync.',
   keywords: ['AI', 'Claude Code', 'Skills', 'Desktop App', 'macOS', 'Electron'],
   authors: [{ name: 'Laststance.io' }],
   openGraph: {
     title: 'Skills Desktop - AI Agent Skills Manager',
-    description: 'Visualize and manage installed Skills across 69 AI agents',
+    description: 'Visualize and manage installed Skills across 73 AI agents',
     url: 'https://skills-desktop.vercel.app',
     siteName: 'Skills Desktop',
     images: [
@@ -39,7 +39,7 @@ export const metadata: Metadata = {
   twitter: {
     card: 'summary_large_image',
     title: 'Skills Desktop - AI Agent Skills Manager',
-    description: 'Visualize and manage installed Skills across 69 AI agents',
+    description: 'Visualize and manage installed Skills across 73 AI agents',
     images: ['/og-image.png'],
   },
 }

--- a/website/src/components/Features.tsx
+++ b/website/src/components/Features.tsx
@@ -5,7 +5,7 @@ import { Monitor, Link2, Palette, Bot, FolderSync, Eye } from 'lucide-react'
 const features = [
   {
     icon: Bot,
-    title: '69 AI Agents Supported',
+    title: '73 AI Agents Supported',
     description:
       'Claude Code, Cursor, Gemini CLI, OpenAI Codex, GitHub Copilot, and dozens more agents auto-detected.',
   },

--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -20,7 +20,7 @@ export function Hero() {
           </h1>
 
           <p className="mb-10 max-w-2xl text-lg text-muted-foreground lg:text-xl">
-            Visualize installed Skills, check symlink status across 69 AI
+            Visualize installed Skills, check symlink status across 73 AI
             agents, and keep your development tools perfectly synchronized.
           </p>
 

--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -26,7 +26,7 @@ export function Hero() {
 
           <div className="flex flex-col gap-4 sm:flex-row">
             <a
-              href="https://github.com/laststance/skills-desktop/releases/download/v0.27.2/skills-desktop-0.27.2-arm64.dmg"
+              href="https://github.com/laststance/skills-desktop/releases/download/v0.27.3/skills-desktop-0.27.3-arm64.dmg"
               className="inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-8 py-3 text-lg font-semibold text-primary-foreground transition-all hover:bg-primary/90 hover:scale-105"
             >
               <Apple className="size-5" />
@@ -38,7 +38,7 @@ export function Hero() {
               </div>
             </a>
             <a
-              href="https://github.com/laststance/skills-desktop/releases/download/v0.27.2/skills-desktop-0.27.2-x64.dmg"
+              href="https://github.com/laststance/skills-desktop/releases/download/v0.27.3/skills-desktop-0.27.3-x64.dmg"
               className="inline-flex items-center justify-center gap-2 rounded-lg border border-border bg-card/50 px-8 py-3 text-lg font-semibold transition-all hover:bg-card hover:scale-105"
             >
               <Cpu className="size-5" />


### PR DESCRIPTION
## Summary

- sync `AGENT_DEFINITIONS` with vercel-labs/skills v1.5.23 by adding Grok Build, Kimchi, MiniMax Code, and Posit Assistant
- keep the 16-agent universal set and the existing four upstream exclusions unchanged
- bump the pinned Skills CLI/e2e command to 1.5.23 and refresh app/website documentation from 69 to 73 agents

## Validation

- `node .claude/skills/skills-cli-sync/reconcile-agents.mjs` (73/73)
- `npx prettier --check README.md SPEC.md CLAUDE.md`
- `pnpm validate` (180 files, 2313 tests)
- `pnpm test:e2e` (61 tests)
- `cd website && pnpm lint && pnpm build`

## Upstream audit

- no existing id/cliId, display-name, or path migrations
- excluded: `eve`, `promptscript`, `universal`, `zenflow` under the existing representation rules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 対応AIエージェントにGrok Build、Kimchi、MiniMax Code、Posit Assistantを追加しました。
  * 対応エージェント数を69から73へ拡大しました。

* **改善**
  * Skills CLIの対応バージョンを1.5.23へ更新しました。
  * Webサイトやドキュメントの対応エージェント情報を最新化しました。
  * macOS版ダウンロードをv0.27.3へ更新しました。

* **品質向上**
  * 新しいエージェントの設定とインストール・検出情報を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->