### PR TITLE
feat: suggest repository names (including Local) in Repo-scope search

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -347,6 +347,15 @@ Rules:
 - Placeholder text must stay lower contrast than real values.
 - Search should feel command-palette-adjacent: compact, keyboard-first,
   immediately scannable.
+- Inline suggestion lists (the Repo-scope search combobox) reuse the menu
+  surface — `rounded-md border bg-popover p-1 shadow-md`, `max-h-60` with
+  vertical scroll — anchored directly under the field with `mt-1`. Follow the
+  ARIA combobox pattern: `role="combobox"` + `aria-expanded` on the input,
+  `role="listbox"` / `role="option"` on the list, keyboard cursor via
+  `aria-activedescendant` (ArrowUp/Down wrap, Enter picks, Escape closes the
+  list before it clears the field). Highlight the active option with
+  `bg-accent`, never a second focus ring; options stay unfocusable so focus
+  never leaves the field.
 - Reset native form chrome to the token palette. macOS Chromium renders the
   `type="search"` clear control (`::-webkit-search-cancel-button`) in the system
   accent (blue), which breaks the muted OKLCH surface. Prefer a palette-matched

--- a/src/renderer/src/components/sidebar/BookmarkDetailModal.tsx
+++ b/src/renderer/src/components/sidebar/BookmarkDetailModal.tsx
@@ -17,6 +17,7 @@ import {
   clearSelectedBookmarkForDetail,
   selectSelectedBookmarkForDetail,
 } from '@/renderer/src/redux/slices/uiSlice'
+import { LOCAL_SOURCE_LABEL } from '@/shared/constants'
 
 /**
  * Modal dialog showing bookmark details with install/remove actions.
@@ -91,7 +92,9 @@ export const BookmarkDetailModal =
                   <ExternalLink className="h-3 w-3" />
                 </button>
               ) : (
-                <span className="text-sm text-muted-foreground/70">Local</span>
+                <span className="text-sm text-muted-foreground/70">
+                  {LOCAL_SOURCE_LABEL}
+                </span>
               )}
 
               <Separator />

--- a/src/renderer/src/components/skills/SearchBox.browser.test.tsx
+++ b/src/renderer/src/components/skills/SearchBox.browser.test.tsx
@@ -1,19 +1,26 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { Provider } from 'react-redux'
 import { describe, expect, it } from 'vitest'
+import { userEvent } from 'vitest/browser'
 import { render } from 'vitest-browser-react'
 
+import { repositoryId, type Skill } from '@/shared/types'
+
 /**
- * Build a store with only the slices SearchBox subscribes to. SkillItem-style
- * fixture stores include `skills`, `agents`, `bookmarks` — none of which the
- * search box reads, so omitting them keeps the test surface tight.
+ * Build a store with only the slices SearchBox subscribes to: `ui` for the
+ * query/scope and `skills` for the repo suggestion list. SkillItem-style
+ * fixture stores also carry `agents` and `bookmarks` — the search box never
+ * reads them, so omitting them keeps the test surface tight.
  */
 async function createStore() {
   const { default: uiReducer } =
     await import('@/renderer/src/redux/slices/uiSlice')
+  const { default: skillsReducer } =
+    await import('@/renderer/src/redux/slices/skillsSlice')
   return configureStore({
     reducer: {
       ui: uiReducer,
+      skills: skillsReducer,
     },
   })
 }
@@ -26,6 +33,51 @@ async function renderSearchBox() {
       <SearchBox />
     </Provider>,
   )
+  return { screen, store }
+}
+
+/**
+ * Minimal source-dir skill row; leaving `source` undefined models a hand-made
+ * skill that the list labels "Local".
+ */
+function makeSkill(name: string, source?: string): Skill {
+  return {
+    name,
+    description: '',
+    path: `/skills/${name}`,
+    symlinkCount: 0,
+    symlinks: [],
+    isSource: true,
+    isOrphan: false,
+    ...(source
+      ? {
+          source: repositoryId(source),
+          sourceUrl: `https://github.com/${source}.git`,
+        }
+      : {}),
+  }
+}
+
+/**
+ * Render in Repo scope with two repos plus one Local skill loaded, so the
+ * suggestion list has something to offer.
+ */
+async function renderRepoScopeSearchBox() {
+  const { screen, store } = await renderSearchBox()
+  const { fetchSkills } =
+    await import('@/renderer/src/redux/slices/skillsSlice')
+  const { setSearchScope } = await import('@/renderer/src/redux/slices/uiSlice')
+  store.dispatch(
+    fetchSkills.fulfilled(
+      [
+        makeSkill('task', 'vercel-labs/skills'),
+        makeSkill('azure-ai', 'microsoft/azure-skills'),
+        makeSkill('autofix'),
+      ],
+      'test-request',
+    ),
+  )
+  store.dispatch(setSearchScope('repo'))
   return { screen, store }
 }
 
@@ -69,10 +121,11 @@ describe('SearchBox scope toggle', () => {
     // Act
     store.dispatch(setSearchScope('repo'))
 
-    // Assert
+    // Assert — repo scope also promotes the input to a combobox because it
+    // owns the repository suggestion list.
     await expect
       .element(
-        screen.getByRole('searchbox', { name: 'Search skills by repository' }),
+        screen.getByRole('combobox', { name: 'Search skills by repository' }),
       )
       .toBeInTheDocument()
   })
@@ -95,5 +148,138 @@ describe('SearchBox scope toggle', () => {
     await expect
       .element(screen.getByPlaceholder('Search by repository...'))
       .toBeInTheDocument()
+  })
+})
+
+describe('SearchBox repository suggestions', () => {
+  it('lists repository names and Local as suggestions when the repo search box is focused', async () => {
+    // Arrange
+    const { screen } = await renderRepoScopeSearchBox()
+
+    // Act — clicking focuses the input, which opens the list
+    await screen
+      .getByRole('combobox', { name: 'Search skills by repository' })
+      .click()
+
+    // Assert — every repo in view plus the Local pseudo-repo
+    await expect
+      .element(screen.getByRole('listbox', { name: 'Repository suggestions' }))
+      .toBeInTheDocument()
+    await expect
+      .element(screen.getByRole('option', { name: 'microsoft/azure-skills' }))
+      .toBeInTheDocument()
+    await expect
+      .element(screen.getByRole('option', { name: 'vercel-labs/skills' }))
+      .toBeInTheDocument()
+    await expect
+      .element(screen.getByRole('option', { name: 'Local' }))
+      .toBeInTheDocument()
+  })
+
+  it('narrows the suggestions to repositories containing the typed text', async () => {
+    // Arrange
+    const { screen } = await renderRepoScopeSearchBox()
+    const input = screen.getByRole('combobox', {
+      name: 'Search skills by repository',
+    })
+
+    // Act
+    await input.fill('azure')
+
+    // Assert
+    await expect
+      .element(screen.getByRole('option', { name: 'microsoft/azure-skills' }))
+      .toBeInTheDocument()
+    await expect
+      .poll(() =>
+        screen.getByRole('option', { name: 'vercel-labs/skills' }).query(),
+      )
+      .toBeNull()
+    await expect
+      .poll(() => screen.getByRole('option', { name: 'Local' }).query())
+      .toBeNull()
+  })
+
+  it('fills the search query with the clicked suggestion and closes the list', async () => {
+    // Arrange
+    const { screen, store } = await renderRepoScopeSearchBox()
+    await screen
+      .getByRole('combobox', { name: 'Search skills by repository' })
+      .click()
+
+    // Act
+    await screen.getByRole('option', { name: 'microsoft/azure-skills' }).click()
+
+    // Assert
+    await expect
+      .poll(() => store.getState().ui.searchQuery)
+      .toBe('microsoft/azure-skills')
+    await expect.poll(() => screen.getByRole('listbox').query()).toBeNull()
+  })
+
+  it('reopens the list when the still-focused input is clicked again after a pick', async () => {
+    // Arrange — a pick closes the list but leaves focus in the field, so a
+    // second click fires no focus event; the click itself must reopen it.
+    const { screen } = await renderRepoScopeSearchBox()
+    const input = screen.getByRole('combobox', {
+      name: 'Search skills by repository',
+    })
+    await input.click()
+    await screen.getByRole('option', { name: 'microsoft/azure-skills' }).click()
+    await expect.poll(() => screen.getByRole('listbox').query()).toBeNull()
+
+    // Act
+    await input.click()
+
+    // Assert — the picked repo is the only entry that still matches the query
+    await expect
+      .element(screen.getByRole('option', { name: 'microsoft/azure-skills' }))
+      .toBeInTheDocument()
+  })
+
+  it('sets the query to Local when the Local suggestion is chosen', async () => {
+    // Arrange
+    const { screen, store } = await renderRepoScopeSearchBox()
+    await screen
+      .getByRole('combobox', { name: 'Search skills by repository' })
+      .click()
+
+    // Act
+    await screen.getByRole('option', { name: 'Local' }).click()
+
+    // Assert — selectFilteredSkills matches source-less rows on this label
+    await expect.poll(() => store.getState().ui.searchQuery).toBe('Local')
+  })
+
+  it('picks the first suggestion with ArrowDown then Enter from the keyboard', async () => {
+    // Arrange
+    const { screen, store } = await renderRepoScopeSearchBox()
+    await screen
+      .getByRole('combobox', { name: 'Search skills by repository' })
+      .click()
+
+    // Act
+    await userEvent.keyboard('{ArrowDown}{Enter}')
+
+    // Assert — options are A→Z, so the first one is microsoft/azure-skills
+    await expect
+      .poll(() => store.getState().ui.searchQuery)
+      .toBe('microsoft/azure-skills')
+  })
+
+  it('offers no suggestion list while searching by skill name', async () => {
+    // Arrange
+    const { screen, store } = await renderRepoScopeSearchBox()
+    const { setSearchScope } =
+      await import('@/renderer/src/redux/slices/uiSlice')
+    store.dispatch(setSearchScope('name'))
+
+    // Act
+    await screen
+      .getByRole('searchbox', { name: 'Search skills by name' })
+      .click()
+
+    // Assert
+    await expect.poll(() => screen.getByRole('listbox').query()).toBeNull()
   })
 })

--- a/src/renderer/src/components/skills/SearchBox.browser.test.tsx
+++ b/src/renderer/src/components/skills/SearchBox.browser.test.tsx
@@ -221,15 +221,16 @@ describe('SearchBox repository suggestions', () => {
     // Arrange — a pick closes the list but leaves focus in the field, so a
     // second click fires no focus event; the click itself must reopen it.
     const { screen } = await renderRepoScopeSearchBox()
-    const input = screen.getByRole('combobox', {
-      name: 'Search skills by repository',
-    })
-    await input.click()
+    await screen
+      .getByRole('combobox', { name: 'Search skills by repository' })
+      .click()
     await screen.getByRole('option', { name: 'microsoft/azure-skills' }).click()
     await expect.poll(() => screen.getByRole('listbox').query()).toBeNull()
 
-    // Act
-    await input.click()
+    // Act — re-query the combobox from the post-pick DOM before clicking
+    await screen
+      .getByRole('combobox', { name: 'Search skills by repository' })
+      .click()
 
     // Assert — the picked repo is the only entry that still matches the query
     await expect

--- a/src/renderer/src/components/skills/SearchBox.tsx
+++ b/src/renderer/src/components/skills/SearchBox.tsx
@@ -1,12 +1,17 @@
 import { Search } from 'lucide-react'
-import React from 'react'
+import React, { useId, useState } from 'react'
 
 import {
   SegmentedControl,
   type SegmentedControlOption,
 } from '@/renderer/src/components/shared/segmented-control'
 import { Input } from '@/renderer/src/components/ui/input'
+import { cn } from '@/renderer/src/lib/utils'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
+import {
+  selectRepoSearchSuggestions,
+  type RepoSearchSuggestion,
+} from '@/renderer/src/redux/selectors'
 import {
   selectSearchQuery,
   selectSearchScope,
@@ -42,22 +47,98 @@ const SEARCH_SCOPE_OPTIONS: ReadonlyArray<SegmentedControlOption<SearchScope>> =
   ]
 
 /**
- * Search box for filtering skills. Combines a Name/Repo scope toggle with a
- * text input. The scope decides which `Skill` field the query matches against
- * — see `selectFilteredSkills` for the actual filter logic.
+ * Installed-tab search box: Name/Repo scope toggle + input whose query feeds
+ * {@link selectFilteredSkills}. In Repo scope the input is an ARIA combobox
+ * offering {@link selectRepoSearchSuggestions} in a listbox; picking one fills the query.
+ * @returns Toolbar search control mounted by {@link MainContent}
+ * @example
+ * <SearchBox />
  */
 export const SearchBox = function SearchBox(): React.ReactElement {
   const dispatch = useAppDispatch()
   const searchQuery = useAppSelector(selectSearchQuery)
   const searchScope = useAppSelector(selectSearchScope)
+  const repoSuggestions = useAppSelector(selectRepoSearchSuggestions)
   const copy = SCOPE_COPY[searchScope]
+  const listboxId = useId()
+  // Listbox visibility + keyboard cursor; -1 means no option is highlighted.
+  const [isListOpen, setIsListOpen] = useState(false)
+  const [activeIndex, setActiveIndex] = useState(-1)
+
+  // The selector already narrows suggestions to the typed query; Name scope
+  // simply never offers any.
+  const isRepoScope = searchScope === 'repo'
+  const visibleSuggestions = isRepoScope ? repoSuggestions : []
+  const showListbox = isListOpen && visibleSuggestions.length > 0
+  // Clamp: the cursor can outlive a list that shrank after a keystroke.
+  const highlightedIndex =
+    activeIndex < visibleSuggestions.length ? activeIndex : -1
+  const optionId = (index: number): string => `${listboxId}-option-${index}`
+
+  const openList = (): void => setIsListOpen(true)
+
+  const closeList = (): void => {
+    setIsListOpen(false)
+    setActiveIndex(-1)
+  }
+
+  const pickSuggestion = (suggestion: RepoSearchSuggestion): void => {
+    dispatch(setSearchQuery(suggestion))
+    closeList()
+  }
 
   const handleScopeChange = (scope: SearchScope): void => {
     dispatch(setSearchScope(scope))
+    closeList()
   }
 
   const handleQueryChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
     dispatch(setSearchQuery(e.target.value))
+    setIsListOpen(true)
+    setActiveIndex(-1)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
+    if (!isRepoScope) return
+    switch (e.key) {
+      case 'ArrowDown':
+        // Wraps to the top after the last option; also reopens a closed list.
+        e.preventDefault()
+        setIsListOpen(true)
+        setActiveIndex(
+          highlightedIndex + 1 < visibleSuggestions.length
+            ? highlightedIndex + 1
+            : 0,
+        )
+        break
+      case 'ArrowUp':
+        e.preventDefault()
+        setIsListOpen(true)
+        setActiveIndex(
+          highlightedIndex > 0
+            ? highlightedIndex - 1
+            : visibleSuggestions.length - 1,
+        )
+        break
+      case 'Enter': {
+        const highlighted = visibleSuggestions[highlightedIndex]
+        if (showListbox && highlighted !== undefined) {
+          e.preventDefault()
+          pickSuggestion(highlighted)
+        }
+        break
+      }
+      case 'Escape':
+        // Only swallow Escape while the list is open so the native
+        // type="search" clear-on-Escape still works once it is closed.
+        if (showListbox) {
+          e.preventDefault()
+          closeList()
+        }
+        break
+      default:
+        break
+    }
   }
 
   return (
@@ -75,12 +156,57 @@ export const SearchBox = function SearchBox(): React.ReactElement {
         <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
         <Input
           type="search"
+          // Repo scope follows the ARIA combobox pattern; Name scope stays a
+          // plain native searchbox because it never opens a list.
+          role={isRepoScope ? 'combobox' : undefined}
           aria-label={copy.ariaLabel}
+          aria-autocomplete={isRepoScope ? 'list' : undefined}
+          aria-expanded={isRepoScope ? showListbox : undefined}
+          aria-controls={showListbox ? listboxId : undefined}
+          aria-activedescendant={
+            highlightedIndex >= 0 ? optionId(highlightedIndex) : undefined
+          }
+          autoComplete="off"
           placeholder={copy.placeholder}
           value={searchQuery}
           onChange={handleQueryChange}
+          onFocus={openList}
+          // Re-clicking the already-focused field (after a pick or Escape)
+          // fires no focus event, so click reopens the list too.
+          onClick={openList}
+          onBlur={closeList}
+          onKeyDown={handleKeyDown}
           className="pl-10 bg-background"
         />
+        {showListbox && (
+          <ul
+            id={listboxId}
+            role="listbox"
+            aria-label="Repository suggestions"
+            // preventDefault on the whole list (options, padding, scrollbar)
+            // keeps focus in the input so onBlur cannot close it mid-click.
+            onMouseDown={(e) => e.preventDefault()}
+            className="absolute left-0 right-0 top-full z-50 mt-1 max-h-60 overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-0 duration-150"
+          >
+            {visibleSuggestions.map((suggestion, index) => (
+              <li
+                key={suggestion}
+                id={optionId(index)}
+                role="option"
+                aria-selected={index === highlightedIndex}
+                className={cn(
+                  'flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm',
+                  index === highlightedIndex &&
+                    'bg-accent text-accent-foreground',
+                )}
+                onMouseEnter={() => setActiveIndex(index)}
+                onClick={() => pickSuggestion(suggestion)}
+              >
+                <span className="min-w-0 truncate">{suggestion}</span>
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
     </div>
   )

--- a/src/renderer/src/components/skills/SearchBox.tsx
+++ b/src/renderer/src/components/skills/SearchBox.tsx
@@ -186,7 +186,7 @@ export const SearchBox = function SearchBox(): React.ReactElement {
             // preventDefault on the whole list (options, padding, scrollbar)
             // keeps focus in the input so onBlur cannot close it mid-click.
             onMouseDown={(e) => e.preventDefault()}
-            className="absolute left-0 right-0 top-full z-50 mt-1 max-h-60 overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-0 duration-150"
+            className="absolute left-0 right-0 top-full z-50 mt-1 max-h-60 overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-0 duration-150 motion-reduce:animate-none"
           >
             {visibleSuggestions.map((suggestion, index) => (
               <li

--- a/src/renderer/src/components/skills/SourceLink.tsx
+++ b/src/renderer/src/components/skills/SourceLink.tsx
@@ -4,6 +4,7 @@ import { match } from 'ts-pattern'
 
 import { useAppDispatch } from '@/renderer/src/redux/hooks'
 import { setSelectedSources } from '@/renderer/src/redux/slices/uiSlice'
+import { LOCAL_SOURCE_LABEL } from '@/shared/constants'
 import type { HttpUrl, RepositoryId } from '@/shared/types'
 
 import { getSourceLinkModel } from './sourceLinkHelpers'
@@ -51,7 +52,9 @@ export const SourceLink = function SourceLink({
   // SourceLinkModel has three render modes; new modes must add explicit JSX here.
   return match(model)
     .with({ kind: 'local' }, () => (
-      <span className="text-sm text-muted-foreground/70 mb-2 block">Local</span>
+      <span className="text-sm text-muted-foreground/70 mb-2 block">
+        {LOCAL_SOURCE_LABEL}
+      </span>
     ))
     .with({ kind: 'text' }, ({ source }) => (
       <span className="text-sm text-muted-foreground inline-flex items-center gap-1 mb-2">

--- a/src/renderer/src/redux/selectors.test.ts
+++ b/src/renderer/src/redux/selectors.test.ts
@@ -22,6 +22,7 @@ import {
   selectFilteredSkillCount,
   selectHiddenSelectedCount,
   selectRepoFacetOptions,
+  selectRepoSearchSuggestions,
   selectSelectedCount,
   selectSelectedSkillNamesSet,
   selectSelectedVisibleSkillObjects,
@@ -944,6 +945,48 @@ describe('selectFilteredSkills', () => {
     expect(result.map((s) => s.name)).toEqual([])
   })
 
+  it('surfaces source-less skills when the repo-scope query is the Local label', () => {
+    // Arrange — the SearchBox offers "Local" as a pseudo-repo suggestion;
+    // picking it must narrow to skills without a source, and typing it by
+    // hand is case-insensitive like every other repo query.
+    const skills = [
+      makeSkill('handmade', 'cursor'), // no source — displayed as "Local"
+      makeSkill('task', 'cursor', false, 'vercel-labs/skills'),
+    ]
+    const state = buildState({
+      skills,
+      searchQuery: 'local',
+      searchScope: 'repo',
+    })
+
+    // Act
+    const result = selectFilteredSkills(state as never)
+
+    // Assert
+    expect(result.map((s) => s.name)).toEqual(['handmade'])
+  })
+
+  it('keeps Local skills out of repo-scope results while a partial query is being typed', () => {
+    // Arrange — "Local" is an exact keyword, not a substring target: typing
+    // "lo" on the way to a repo name must not flood the list with every
+    // source-less skill (the pre-suggestion behaviour users relied on).
+    const skills = [
+      makeSkill('handmade', 'cursor'), // no source — displayed as "Local"
+      makeSkill('task', 'cursor', false, 'vercel-labs/skills'),
+    ]
+    const state = buildState({
+      skills,
+      searchQuery: 'lo',
+      searchScope: 'repo',
+    })
+
+    // Act
+    const result = selectFilteredSkills(state as never)
+
+    // Assert — no repo contains "lo" and Local needs the full keyword
+    expect(result.map((s) => s.name)).toEqual([])
+  })
+
   it('narrows to a single repo when only the source pill is set and no query is typed', () => {
     // Arrange
     const skills = [
@@ -1833,5 +1876,91 @@ describe('selectSourceFilterViewModel', () => {
 
     // Assert — there is still a repo left to add, so the action stays live
     expect(viewModel.isSelectAllDisabled).toBe(false)
+  })
+})
+
+describe('selectRepoSearchSuggestions', () => {
+  it('lists every repo in view A→Z with Local last when a source-less skill is present', () => {
+    // Arrange
+    const skills = [
+      makeSkill('z-task', 'cursor', false, 'vercel-labs/skills'),
+      makeSkill('a-task', 'cursor', false, 'microsoft/azure-skills'),
+      makeSkill('handmade', 'cursor'), // no source → "Local"
+    ]
+    const state = buildState({ skills })
+
+    // Act
+    const suggestions = selectRepoSearchSuggestions(state as never)
+
+    // Assert
+    expect(suggestions).toEqual([
+      'microsoft/azure-skills',
+      'vercel-labs/skills',
+      'Local',
+    ])
+  })
+
+  it('omits Local when every skill in view has a source repo', () => {
+    // Arrange
+    const skills = [makeSkill('task', 'cursor', false, 'vercel-labs/skills')]
+    const state = buildState({ skills })
+
+    // Act
+    const suggestions = selectRepoSearchSuggestions(state as never)
+
+    // Assert
+    expect(suggestions).toEqual(['vercel-labs/skills'])
+  })
+
+  it('narrows suggestions to entries containing the typed query, case-insensitively', () => {
+    // Arrange
+    const skills = [
+      makeSkill('task', 'cursor', false, 'vercel-labs/skills'),
+      makeSkill('azure', 'cursor', false, 'microsoft/azure-skills'),
+      makeSkill('handmade', 'cursor'),
+    ]
+    const state = buildState({ skills, searchQuery: 'MICRO' })
+
+    // Act
+    const suggestions = selectRepoSearchSuggestions(state as never)
+
+    // Assert — Local drops out too: "Local" does not contain "micro"
+    expect(suggestions).toEqual(['microsoft/azure-skills'])
+  })
+
+  it('keeps offering Local for a partial query like "loc" so the keyword stays discoverable', () => {
+    // Arrange — rows only match the full "Local" keyword, so the suggestion
+    // list is how a user completes it.
+    const skills = [
+      makeSkill('task', 'cursor', false, 'vercel-labs/skills'),
+      makeSkill('handmade', 'cursor'),
+    ]
+    const state = buildState({ skills, searchQuery: 'loc' })
+
+    // Act
+    const suggestions = selectRepoSearchSuggestions(state as never)
+
+    // Assert
+    expect(suggestions).toEqual(['Local'])
+  })
+
+  it('offers only the ticked repos while the repo include filter is active', () => {
+    // Arrange — the include filter hides the other repos and every Local row,
+    // so suggesting them would guarantee an empty result.
+    const skills = [
+      makeSkill('a', 'cursor', false, 'vercel-labs/skills'),
+      makeSkill('b', 'cursor', false, 'pbakaus/impeccable'),
+      makeSkill('handmade', 'cursor'),
+    ]
+    const state = buildState({
+      skills,
+      selectedSources: [repositoryId('pbakaus/impeccable')],
+    })
+
+    // Act
+    const suggestions = selectRepoSearchSuggestions(state as never)
+
+    // Assert
+    expect(suggestions).toEqual(['pbakaus/impeccable'])
   })
 })

--- a/src/renderer/src/redux/selectors.ts
+++ b/src/renderer/src/redux/selectors.ts
@@ -3,7 +3,10 @@ import { match } from 'ts-pattern'
 
 import { formatRepositoryFacetLabel } from '@/renderer/src/utils/formatRepositoryFacetLabel'
 import { isGStackManagedForAgent } from '@/renderer/src/utils/gstackSkill'
-import { SOURCE_FILTER_MAX_VISIBLE_REPOS } from '@/shared/constants'
+import {
+  LOCAL_SOURCE_LABEL,
+  SOURCE_FILTER_MAX_VISIBLE_REPOS,
+} from '@/shared/constants'
 import type {
   AgentId,
   RepositoryId,
@@ -38,6 +41,9 @@ interface RepoFacetOption {
   source: RepositoryId
   count: SkillCount
 }
+
+/** One Repo-scope search suggestion: a real repo id or the "Local" pseudo-repo. */
+export type RepoSearchSuggestion = RepositoryId | typeof LOCAL_SOURCE_LABEL
 
 /**
  * Detect whether one scanner slot belongs to the active agent list.
@@ -161,6 +167,24 @@ function applyAgentAndTypeFilters(
 }
 
 /**
+ * Memoized agent/type-filtered population that the Installed row list, repo
+ * facet, search suggestions, and hidden-Local count all start from, so they
+ * share one pass instead of each re-running {@link applyAgentAndTypeFilters}.
+ * @returns Skills surviving the agent view + skill-type include/exclude filters
+ * @example
+ * selectVisibleByAgentAndType(state) // => Skill[] before repo filter, search, and sort
+ */
+const selectVisibleByAgentAndType = createSelector(
+  [
+    selectSkillsItems,
+    selectSelectedAgentId,
+    selectSkillTypeFilter,
+    selectExcludedSkillTypeFilters,
+  ],
+  applyAgentAndTypeFilters,
+)
+
+/**
  * Memoized selector for filtered and sorted skills list.
  * Applies (in order): agent/type include, type excludes, source-repo include
  * filter, scope-aware search query, and name sort.
@@ -169,8 +193,8 @@ function applyAgentAndTypeFilters(
  * - `'name'` — case-insensitive substring match against `skill.name` (the
  *   original behavior; preserved when no toggle is wired).
  * - `'repo'` — case-insensitive substring match against `skill.source`. Skills
- *   with no `source` (Local-only skills) are excluded in this mode because
- *   they have no repo string to match.
+ *   with no `source` match only the exact keyword "Local" (the suggestion
+ *   list's pseudo-repo, {@link LOCAL_SOURCE_LABEL}), never a partial query.
  *
  * The source-repo include filter (`selectedSources`) keeps only skills whose
  * `source` is in the ticked set; an empty set is a no-op (all repos shown).
@@ -184,31 +208,14 @@ function applyAgentAndTypeFilters(
  */
 export const selectFilteredSkills = createSelector(
   [
-    selectSkillsItems,
+    selectVisibleByAgentAndType,
     selectSearchQuery,
     selectSearchScope,
-    selectSelectedAgentId,
     selectSelectedSources,
     selectSortOrder,
-    selectSkillTypeFilter,
-    selectExcludedSkillTypeFilters,
   ],
-  (
-    skills,
-    searchQuery,
-    searchScope,
-    selectedAgentId,
-    selectedSources,
-    sortOrder,
-    skillTypeFilter,
-    excludedSkillTypeFilters,
-  ) => {
-    let result = applyAgentAndTypeFilters(
-      skills,
-      selectedAgentId,
-      skillTypeFilter,
-      excludedSkillTypeFilters,
-    )
+  (visibleSkills, searchQuery, searchScope, selectedSources, sortOrder) => {
+    let result = visibleSkills
 
     // Source-repo include filter — keep only ticked repos. An empty set is a
     // no-op. Local skills (source undefined) can never be in the set, so they
@@ -228,9 +235,14 @@ export const selectFilteredSkills = createSelector(
       const query = searchQuery.toLowerCase()
       result = match(searchScope)
         .with('repo', () =>
-          // Local skills have no `source`; in repo mode they cannot match.
+          // Source-less skills are reachable only through the exact "Local"
+          // keyword (the suggestion list's pseudo-repo). A partial query such
+          // as "lo" keeps matching repos alone, so Local rows never flood the
+          // results mid-typing and a skill name never leaks into repo results.
           result.filter((skill) =>
-            skill.source ? skill.source.toLowerCase().includes(query) : false,
+            skill.source
+              ? skill.source.toLowerCase().includes(query)
+              : query === LOCAL_SOURCE_LABEL.toLowerCase(),
           ),
         )
         .with('name', () =>
@@ -270,25 +282,9 @@ export const selectFilteredSkillCount = createSelector(
  * const repoOptions = useAppSelector(selectRepoFacetOptions)
  */
 export const selectRepoFacetOptions = createSelector(
-  [
-    selectSkillsItems,
-    selectSelectedAgentId,
-    selectSkillTypeFilter,
-    selectExcludedSkillTypeFilters,
-  ],
-  (
-    skills,
-    selectedAgentId,
-    skillTypeFilter,
-    excludedSkillTypeFilters,
-  ): RepoFacetOption[] => {
+  [selectVisibleByAgentAndType],
+  (visibleByAgentAndType): RepoFacetOption[] => {
     const sourceCounts = new Map<RepositoryId, number>()
-    const visibleByAgentAndType = applyAgentAndTypeFilters(
-      skills,
-      selectedAgentId,
-      skillTypeFilter,
-      excludedSkillTypeFilters,
-    )
     for (const skill of visibleByAgentAndType) {
       if (!skill.source) continue
       sourceCounts.set(skill.source, (sourceCounts.get(skill.source) ?? 0) + 1)
@@ -296,6 +292,52 @@ export const selectRepoFacetOptions = createSelector(
     return [...sourceCounts.entries()]
       .sort(([sourceA], [sourceB]) => sourceA.localeCompare(sourceB))
       .map(([source, count]) => ({ source, count }))
+  },
+)
+
+/**
+ * Repo-scope suggestions for the SearchBox listbox: repos in view (plus "Local"
+ * when a source-less skill is in view) that contain the typed query. Shares
+ * {@link selectFilteredSkills}'s population, so a picked entry never yields 0 rows.
+ * @returns Case-insensitive matches, repos A→Z with {@link LOCAL_SOURCE_LABEL} last
+ * @example
+ * useAppSelector(selectRepoSearchSuggestions) // query "micro" => ['microsoft/azure-skills', 'microsoft/webwright']
+ */
+export const selectRepoSearchSuggestions = createSelector(
+  [
+    selectRepoFacetOptions,
+    selectVisibleByAgentAndType,
+    selectSelectedSources,
+    selectSearchQuery,
+  ],
+  (
+    facetOptions,
+    visibleSkills,
+    selectedSources,
+    searchQuery,
+  ): RepoSearchSuggestion[] => {
+    // Same normalization as the row filter so a suggestion and its rows agree.
+    const query = searchQuery.toLowerCase()
+    const matchesQuery = (candidate: string): boolean =>
+      candidate.toLowerCase().includes(query)
+    const repos = facetOptions.map((option) => option.source)
+
+    // An active repo include filter hides every other repo AND all Local rows
+    // (see selectFilteredSkills), so only the ticked repos can still match.
+    if (selectedSources.length > 0) {
+      const includedSources = new Set(selectedSources)
+      return repos.filter(
+        (repo) => includedSources.has(repo) && matchesQuery(repo),
+      )
+    }
+
+    const suggestions: RepoSearchSuggestion[] = repos.filter(matchesQuery)
+    // Offer "Local" only when a source-less skill is actually in view.
+    const hasLocalSkill = visibleSkills.some((skill) => !skill.source)
+    if (hasLocalSkill && matchesQuery(LOCAL_SOURCE_LABEL)) {
+      suggestions.push(LOCAL_SOURCE_LABEL)
+    }
+    return suggestions
   },
 )
 
@@ -365,31 +407,17 @@ function formatSourceFilterAriaLabel(selectedSources: RepositoryId[]): string {
  * Consolidated view-model for the Installed toolbar's source-repo include
  * filter. Folds the active selection, the (agent/type-gated) facet options,
  * and the hidden-local count into one memoized shape — see
- * `SourceFilterViewModel` for field semantics. Recomputes the agent/type
- * population internally for `localHiddenCount` rather than coupling
- * `selectRepoFacetOptions` to that concern.
+ * `SourceFilterViewModel` for field semantics. Reads the shared agent/type
+ * population ({@link selectVisibleByAgentAndType}) for `localHiddenCount`
+ * rather than coupling {@link selectRepoFacetOptions} to that concern.
  * @returns SourceFilterViewModel
  * @example
  * const sourceFilter = useAppSelector(selectSourceFilterViewModel)
  * // sourceFilter.triggerLabel === '2 repos'
  */
 export const selectSourceFilterViewModel = createSelector(
-  [
-    selectSkillsItems,
-    selectSelectedAgentId,
-    selectSkillTypeFilter,
-    selectExcludedSkillTypeFilters,
-    selectSelectedSources,
-    selectRepoFacetOptions,
-  ],
-  (
-    skills,
-    selectedAgentId,
-    skillTypeFilter,
-    excludedSkillTypeFilters,
-    selectedSources,
-    facetOptions,
-  ): SourceFilterViewModel => {
+  [selectVisibleByAgentAndType, selectSelectedSources, selectRepoFacetOptions],
+  (visibleSkills, selectedSources, facetOptions): SourceFilterViewModel => {
     const facetSourceSet = new Set(facetOptions.map((option) => option.source))
     const countBySource = new Map<RepositoryId, number>(
       facetOptions.map((option): [RepositoryId, number] => [
@@ -423,13 +451,7 @@ export const selectSourceFilterViewModel = createSelector(
     // it answers "how many local skills did the repo filter hide?".
     let localHiddenCount = 0
     if (selectedSources.length > 0) {
-      const population = applyAgentAndTypeFilters(
-        skills,
-        selectedAgentId,
-        skillTypeFilter,
-        excludedSkillTypeFilters,
-      )
-      for (const skill of population) {
+      for (const skill of visibleSkills) {
         if (!skill.source) localHiddenCount += 1
       }
     }

--- a/src/renderer/src/redux/slices/uiSlice.ts
+++ b/src/renderer/src/redux/slices/uiSlice.ts
@@ -59,7 +59,8 @@ export type ActiveTab = 'installed' | 'marketplace'
  * Which field the search box matches against.
  * - `'name'` — matches `Skill.name` (default; previous behavior).
  * - `'repo'` — matches `Skill.source` (e.g. `"vercel-labs/skills"`).
- *   Local skills with no `source` are excluded from results in this mode.
+ *   Skills with no `source` match only the exact "Local" keyword offered by
+ *   the search box's suggestion list — never a partial query.
  */
 export type SearchScope = 'name' | 'repo'
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1116,6 +1116,15 @@ export const SOURCE_FILTER_MAX_VISIBLE_REPOS = 3
 export const REPOSITORY_FACET_LABEL_MAX_CHARS = 28
 
 /**
+ * Label for a skill with no `source` repository, shared by the row/bookmark
+ * "Local" labels, repo-scope search matching, and the search suggestion list
+ * so picking the Local suggestion returns exactly the rows that display it.
+ * @example
+ * <span>{LOCAL_SOURCE_LABEL}</span> // => "Local"
+ */
+export const LOCAL_SOURCE_LABEL = 'Local'
+
+/**
  * Minimum tap-target size (px) for interactive elements. Floor set by both
  * Apple HIG (44×44 pt) and WCAG 2.2 AA (target size 24 CSS px minimum, 44
  * recommended) — keeping a single source of truth here means adding a new


### PR DESCRIPTION
## Summary

In **Repo** scope the Installed search input now behaves as an ARIA combobox: focusing, clicking, or typing opens a listbox of the repositories currently in view (A→Z) plus a **Local** pseudo-repo when a source-less skill is in view, narrowed by the typed text. ArrowUp/ArrowDown wrap, Enter picks, Escape closes the list (a second Escape still clears the field natively), and clicking an option fills the query.

- `selectRepoSearchSuggestions` builds the list from the same agent/type population as the "All repos" facet, restricts it to the ticked repos while the include filter is active, and filters by the query, so a picked entry never yields zero rows.
- Repo-scope row filter: source-less skills match only the exact `Local` keyword (case-insensitive), so partial queries never flood results with Local rows and skill names never leak into repo results (existing guard kept).
- `selectVisibleByAgentAndType`: one memoized agent/type population shared by the row list, repo facet, suggestions, and hidden-Local count (replaces four identical `applyAgentAndTypeFilters` calls).
- `LOCAL_SOURCE_LABEL` is now the single source for the SourceLink / BookmarkDetailModal "Local" labels, the matching keyword, and the suggestion entry.
- `DESIGN.md` documents the inline suggestion-list pattern (menu surface, combobox ARIA, keyboard model).

Name scope is unchanged (plain native searchbox, no list).

## Test plan

- [x] `pnpm validate` — lint, typecheck, fallow, storybook build, 2327 unit/browser tests (new: 6 selector tests, 7 SearchBox browser tests)
- [x] `pnpm test:e2e` — 61/61
- [x] Manual via `playwright-cli` CDP attach: Repo scope lists 30 repos + Local, `micro` narrows to 3, ArrowDown+Enter fills `microsoft/azure-skills` and closes the list, picking Local narrows to source-less skills, re-click reopens the list
- [x] `/code-review --fix max` (Standards + Spec axes) — all findings addressed before opening this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - Repo検索でリポジトリ候補を表示し、入力・選択・キーボード操作で検索条件を設定できるようになりました。
  - 候補は入力内容に応じて絞り込まれ、選択した項目を再表示できます。
  - ローカルスキルは「Local」として表示され、完全一致時のみ検索対象になります。
  - Name検索では候補リストを表示しません。
- **ドキュメント**
  - 候補リストの表示、アクセシビリティ、キーボード操作に関する仕様を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->