### PR TITLE
feat: bulk delete hidden agents skills folders

### DIFF
--- a/e2e/spec/delete-hidden-agents.e2e.ts
+++ b/e2e/spec/delete-hidden-agents.e2e.ts
@@ -180,7 +180,7 @@ test('hidden folder deletion keeps protected slots, visible agents, and shared s
 
     // Assert
     await expect(
-      appWindow.getByText('Deleted skills from 2 hidden agents'),
+      appWindow.getByText('Deleted skills from 1 hidden agent'),
     ).toBeVisible()
     await expect(dialog).toHaveCount(0)
     expect(() => lstatSync(folders.warpPath)).toThrow(/ENOENT/)

--- a/e2e/spec/delete-hidden-agents.e2e.ts
+++ b/e2e/spec/delete-hidden-agents.e2e.ts
@@ -213,11 +213,12 @@ test('hidden folder deletion keeps protected slots, visible agents, and shared s
     await expect(appWindow.getByText('2 hidden', { exact: true })).toBeVisible()
   } finally {
     // Match exact unique children so concurrent user Trash activity is never a cleanup target.
-    const ourTrashEntry = findMatchingTrashedAgentDir(
-      diffUserTrash(trashBefore).newPaths,
-      [folders.removableName],
-    )
-    if (ourTrashEntry) cleanupTrashEntries([ourTrashEntry])
+    const { newPaths } = diffUserTrash(trashBefore)
+    // Include the protected fixture so a protection regression cannot leave test data behind.
+    for (const childName of [folders.removableName, folders.protectedName]) {
+      const ourTrashEntry = findMatchingTrashedAgentDir(newPaths, [childName])
+      if (ourTrashEntry) cleanupTrashEntries([ourTrashEntry])
+    }
   }
 })
 

--- a/e2e/spec/delete-hidden-agents.e2e.ts
+++ b/e2e/spec/delete-hidden-agents.e2e.ts
@@ -1,0 +1,396 @@
+import { randomUUID } from 'node:crypto'
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { join } from 'node:path'
+
+import type { Page } from '@playwright/test'
+
+import { test, expect } from '../fixtures/electron-app'
+import {
+  dispatchAction,
+  refreshSkillsState,
+  waitForInitialScan,
+} from '../helpers/redux'
+import {
+  canReadUserTrash,
+  cleanupTrashEntries,
+  diffUserTrash,
+  findMatchingTrashedAgentDir,
+  isSameVolumeAsUserTrash,
+  snapshotUserTrash,
+} from '../helpers/user-trash'
+
+/**
+ * Stage disposable hidden, visible, and shared agent slots for the real sidebar bulk-delete flow.
+ * @param isolatedHome - Per-test temporary HOME, never the user's agent directories.
+ * @param appWindow - Electron renderer whose scan and hidden settings need refreshing.
+ * @returns Fixture paths and unique names used to verify preservation and safely identify Trash entries.
+ * @example const folders = await stageHiddenFolders(isolatedHome, appWindow)
+ */
+async function stageHiddenFolders(isolatedHome: string, appWindow: Page) {
+  const protectedName = `hidden-keep-${randomUUID()}`
+  const removableName = `hidden-remove-${randomUUID()}`
+  const protectedSourcePath = join(
+    isolatedHome,
+    '.agents',
+    'skills',
+    protectedName,
+  )
+  const removableSourcePath = join(
+    isolatedHome,
+    '.agents',
+    'skills',
+    removableName,
+  )
+  const clinePath = join(isolatedHome, '.cline', 'skills')
+  const warpPath = join(isolatedHome, '.warp', 'skills')
+  const visiblePath = join(isolatedHome, '.roo', 'skills')
+  const sharedPath = join(isolatedHome, '.config', 'agents', 'skills')
+
+  // Refuse to reuse pre-existing whole-folder targets if the snapshot layout changes.
+  expect(existsSync(clinePath)).toBe(false)
+  expect(existsSync(warpPath)).toBe(false)
+  for (const sourcePath of [protectedSourcePath, removableSourcePath]) {
+    mkdirSync(sourcePath, { recursive: true })
+    writeFileSync(
+      join(sourcePath, 'SKILL.md'),
+      '# Hidden agent deletion fixture\n\nKeep source skill contents intact.\n',
+    )
+  }
+  for (const agentPath of [clinePath, warpPath, visiblePath, sharedPath]) {
+    mkdirSync(agentPath, { recursive: true })
+  }
+  symlinkSync(protectedSourcePath, join(clinePath, protectedName))
+  symlinkSync(removableSourcePath, join(warpPath, removableName))
+  symlinkSync(removableSourcePath, join(visiblePath, removableName))
+  symlinkSync(removableSourcePath, join(sharedPath, removableName))
+
+  await waitForInitialScan(appWindow)
+  await refreshSkillsState(appWindow)
+  await appWindow.evaluate(async () => {
+    const agents = await window.electron.agents.getAll()
+    const store = window.__store__ ?? window.__store
+    if (!store) throw new Error('Redux store unavailable in E2E build')
+    store.dispatch({ type: 'agents/fetchAll/fulfilled', payload: agents })
+    await window.electron.settings.set({
+      hiddenAgentIds: ['cline', 'warp', 'amp'],
+    })
+  })
+  await expect(appWindow.getByText('3 hidden', { exact: true })).toBeVisible()
+
+  return {
+    protectedName,
+    removableName,
+    protectedSourcePath,
+    removableSourcePath,
+    clinePath,
+    warpPath,
+    visiblePath,
+    sharedPath,
+  }
+}
+
+test('hidden agent actions open beside the collapsed disclosure and cancel keeps every folder', async ({
+  appWindow,
+  isolatedHome,
+}) => {
+  // Arrange
+  const folders = await stageHiddenFolders(isolatedHome, appWindow)
+  const hiddenDisclosure = appWindow.locator('details').filter({
+    has: appWindow.getByText('3 hidden', { exact: true }),
+  })
+  await expect(hiddenDisclosure).not.toHaveAttribute('open', '')
+
+  // Act
+  await appWindow.getByRole('button', { name: 'Hidden agent actions' }).click()
+  await appWindow
+    .getByRole('menuitem', { name: 'Delete skills folders...' })
+    .click()
+  const dialog = appWindow.getByRole('dialog', {
+    name: 'Delete hidden agents’ skills folders?',
+  })
+  await expect(dialog).toBeVisible()
+  await expect(
+    dialog.getByText(folders.clinePath, { exact: true }),
+  ).toBeVisible()
+  await expect(
+    dialog.getByText(folders.warpPath, { exact: true }),
+  ).toBeVisible()
+  await dialog.getByRole('button', { name: 'Cancel', exact: true }).click()
+
+  // Assert
+  await expect(dialog).toHaveCount(0)
+  await expect(hiddenDisclosure).not.toHaveAttribute('open', '')
+  expect(
+    lstatSync(join(folders.clinePath, folders.protectedName)).isSymbolicLink(),
+  ).toBe(true)
+  expect(
+    lstatSync(join(folders.warpPath, folders.removableName)).isSymbolicLink(),
+  ).toBe(true)
+  expect(existsSync(folders.protectedSourcePath)).toBe(true)
+  expect(existsSync(folders.removableSourcePath)).toBe(true)
+})
+
+test('hidden folder deletion keeps protected slots, visible agents, and shared source skills', async ({
+  appWindow,
+  isolatedHome,
+}) => {
+  // Arrange: OS Trash is uid-based even with isolated HOME; only our unique fixture is cleaned up.
+  test.skip(
+    !canReadUserTrash(),
+    'OS Trash inspection is unavailable for safe fixture cleanup',
+  )
+  test.skip(
+    !isSameVolumeAsUserTrash(isolatedHome),
+    'Isolated HOME must share the OS Trash volume',
+  )
+  const folders = await stageHiddenFolders(isolatedHome, appWindow)
+  await dispatchAction(appWindow, {
+    type: 'protect/addProtection',
+    payload: folders.protectedName,
+  })
+  await appWindow.getByRole('button', { name: 'Hidden agent actions' }).click()
+  await appWindow
+    .getByRole('menuitem', { name: 'Delete skills folders...' })
+    .click()
+  const dialog = appWindow.getByRole('dialog', {
+    name: 'Delete hidden agents’ skills folders?',
+  })
+  await expect(
+    dialog.getByText('1 protected skill entry will be kept.'),
+  ).toBeVisible()
+  const reviewedFolders = dialog.getByRole('list', {
+    name: 'Skills folders to delete',
+  })
+  await expect(reviewedFolders.getByText('Amp', { exact: true })).toHaveCount(0)
+  const trashBefore = snapshotUserTrash()
+
+  try {
+    // Act
+    await dialog
+      .getByRole('button', { name: 'Delete folders', exact: true })
+      .click()
+
+    // Assert
+    await expect(
+      appWindow.getByText('Deleted skills from 2 hidden agents'),
+    ).toBeVisible()
+    await expect(dialog).toHaveCount(0)
+    expect(() => lstatSync(folders.warpPath)).toThrow(/ENOENT/)
+    expect(
+      lstatSync(
+        join(folders.clinePath, folders.protectedName),
+      ).isSymbolicLink(),
+    ).toBe(true)
+    expect(
+      lstatSync(
+        join(folders.visiblePath, folders.removableName),
+      ).isSymbolicLink(),
+    ).toBe(true)
+    expect(
+      lstatSync(
+        join(folders.sharedPath, folders.removableName),
+      ).isSymbolicLink(),
+    ).toBe(true)
+    expect(
+      readFileSync(join(folders.removableSourcePath, 'SKILL.md'), 'utf8'),
+    ).toBe(
+      '# Hidden agent deletion fixture\n\nKeep source skill contents intact.\n',
+    )
+    expect(existsSync(join(folders.protectedSourcePath, 'SKILL.md'))).toBe(true)
+    expect(
+      findMatchingTrashedAgentDir(diffUserTrash(trashBefore).newPaths, [
+        folders.removableName,
+      ]),
+    ).toBeDefined()
+    await expect(appWindow.getByText('2 hidden', { exact: true })).toBeVisible()
+  } finally {
+    // Match exact unique children so concurrent user Trash activity is never a cleanup target.
+    const ourTrashEntry = findMatchingTrashedAgentDir(
+      diffUserTrash(trashBefore).newPaths,
+      [folders.removableName],
+    )
+    if (ourTrashEntry) cleanupTrashEntries([ourTrashEntry])
+  }
+})
+
+test('keyboard cancellation restores the hidden menu trigger without collapsing the agent list', async ({
+  appWindow,
+  isolatedHome,
+}) => {
+  // Arrange
+  const folders = await stageHiddenFolders(isolatedHome, appWindow)
+  const hiddenDisclosure = appWindow.locator('details').filter({
+    has: appWindow.getByText('3 hidden', { exact: true }),
+  })
+  await hiddenDisclosure.locator('summary').press('Enter')
+  await expect(hiddenDisclosure).toHaveAttribute('open', '')
+  const menuTrigger = appWindow.getByRole('button', {
+    name: 'Hidden agent actions',
+  })
+
+  // Act
+  await menuTrigger.press('Enter')
+  await expect(
+    appWindow.getByRole('menuitem', { name: 'Delete skills folders...' }),
+  ).toBeFocused()
+  await appWindow.keyboard.press('Enter')
+  const dialog = appWindow.getByRole('dialog', {
+    name: 'Delete hidden agents’ skills folders?',
+  })
+  await expect(dialog).toBeVisible()
+  await expect(
+    dialog.getByRole('button', { name: 'Cancel', exact: true }),
+  ).toBeFocused()
+  await appWindow.keyboard.press('Escape')
+
+  // Assert
+  await expect(dialog).toHaveCount(0)
+  await expect(menuTrigger).toBeFocused()
+  await expect(hiddenDisclosure).toHaveAttribute('open', '')
+  expect(
+    lstatSync(join(folders.clinePath, folders.protectedName)).isSymbolicLink(),
+  ).toBe(true)
+  expect(
+    lstatSync(join(folders.warpPath, folders.removableName)).isSymbolicLink(),
+  ).toBe(true)
+})
+
+test('deleting every hidden agent folder removes the hidden controls and restores sidebar focus', async ({
+  appWindow,
+  isolatedHome,
+}) => {
+  // Arrange
+  test.skip(!canReadUserTrash(), 'OS Trash inspection is unavailable')
+  test.skip(
+    !isSameVolumeAsUserTrash(isolatedHome),
+    'Isolated HOME must share the OS Trash volume',
+  )
+  const folders = await stageHiddenFolders(isolatedHome, appWindow)
+  await appWindow.evaluate(async () => {
+    await window.electron.settings.set({ hiddenAgentIds: ['cline', 'warp'] })
+  })
+  const sidebar = appWindow.getByRole('complementary', {
+    name: 'Agent sidebar',
+  })
+  await expect(sidebar.getByText('2 hidden', { exact: true })).toBeVisible()
+  await sidebar.getByRole('button', { name: 'Hidden agent actions' }).click()
+  await appWindow
+    .getByRole('menuitem', { name: 'Delete skills folders...' })
+    .click()
+  const dialog = appWindow.getByRole('dialog', {
+    name: 'Delete hidden agents’ skills folders?',
+  })
+  await expect(dialog).toBeVisible()
+  const trashBefore = snapshotUserTrash()
+
+  try {
+    // Act
+    await dialog
+      .getByRole('button', { name: 'Delete folders', exact: true })
+      .click()
+
+    // Assert
+    await expect(
+      appWindow.getByText('Deleted skills from 2 hidden agents'),
+    ).toBeVisible()
+    await expect(dialog).toHaveCount(0)
+    await expect(sidebar.getByText(/^\d+ hidden$/)).toHaveCount(0)
+    await expect(
+      sidebar.getByRole('button', { name: 'Hidden agent actions' }),
+    ).toHaveCount(0)
+    await expect(sidebar.getByText('Agents', { exact: true })).toBeFocused()
+    expect(existsSync(folders.clinePath)).toBe(false)
+    expect(existsSync(folders.warpPath)).toBe(false)
+    expect(existsSync(folders.protectedSourcePath)).toBe(true)
+    expect(existsSync(folders.removableSourcePath)).toBe(true)
+    expect(existsSync(folders.visiblePath)).toBe(true)
+    expect(existsSync(folders.sharedPath)).toBe(true)
+  } finally {
+    // Each match requires one per-test UUID child; unrelated Trash entries cannot match.
+    const { newPaths } = diffUserTrash(trashBefore)
+    for (const skillName of [folders.protectedName, folders.removableName]) {
+      const ourTrashEntry = findMatchingTrashedAgentDir(newPaths, [skillName])
+      if (ourTrashEntry) cleanupTrashEntries([ourTrashEntry])
+    }
+  }
+})
+
+test('a replaced hidden folder stays intact while deletion continues for the remaining hidden agents', async ({
+  appWindow,
+  isolatedHome,
+}) => {
+  // Arrange
+  test.skip(!canReadUserTrash(), 'OS Trash inspection is unavailable')
+  test.skip(
+    !isSameVolumeAsUserTrash(isolatedHome),
+    'Isolated HOME must share the OS Trash volume',
+  )
+  const folders = await stageHiddenFolders(isolatedHome, appWindow)
+  await appWindow.getByRole('button', { name: 'Hidden agent actions' }).click()
+  await appWindow
+    .getByRole('menuitem', { name: 'Delete skills folders...' })
+    .click()
+  const dialog = appWindow.getByRole('dialog', {
+    name: 'Delete hidden agents’ skills folders?',
+  })
+  await expect(
+    dialog.getByText(folders.clinePath, { exact: true }),
+  ).toBeVisible()
+  const reviewedInode = lstatSync(folders.clinePath).ino
+  const originalFolderPath = join(isolatedHome, '.cline', 'reviewed-skills')
+  // Keep the original inode alive so replacement detection never relies on clock timing or inode reuse.
+  renameSync(folders.clinePath, originalFolderPath)
+  mkdirSync(folders.clinePath)
+  const replacementMarkerName = `hidden-replacement-${randomUUID()}.txt`
+  const replacementMarkerPath = join(folders.clinePath, replacementMarkerName)
+  writeFileSync(replacementMarkerPath, 'Keep replacement contents.')
+  expect(lstatSync(folders.clinePath).ino).not.toBe(reviewedInode)
+  const trashBefore = snapshotUserTrash()
+
+  try {
+    // Act
+    await dialog
+      .getByRole('button', { name: 'Delete folders', exact: true })
+      .click()
+
+    // Assert
+    await expect(
+      appWindow.getByText('Some skills folders could not be deleted'),
+    ).toBeVisible()
+    await expect(
+      appWindow.getByText(
+        'Cline: Reviewed agent skills folder changed since review.',
+      ),
+    ).toBeVisible()
+    await expect(
+      appWindow.getByText('Deleted skills from 1 hidden agent'),
+    ).toBeVisible()
+    await expect(dialog).toHaveCount(0)
+    expect(readFileSync(replacementMarkerPath, 'utf8')).toBe(
+      'Keep replacement contents.',
+    )
+    expect(
+      lstatSync(
+        join(originalFolderPath, folders.protectedName),
+      ).isSymbolicLink(),
+    ).toBe(true)
+    expect(existsSync(folders.warpPath)).toBe(false)
+    expect(existsSync(folders.removableSourcePath)).toBe(true)
+    await expect(appWindow.getByText('2 hidden', { exact: true })).toBeVisible()
+  } finally {
+    // Also recover this test's replacement if the guard regresses and wrongly trashes it.
+    const { newPaths } = diffUserTrash(trashBefore)
+    for (const childName of [folders.removableName, replacementMarkerName]) {
+      const ourTrashEntry = findMatchingTrashedAgentDir(newPaths, [childName])
+      if (ourTrashEntry) cleanupTrashEntries([ourTrashEntry])
+    }
+  }
+})

--- a/src/renderer/src/components/shared/DestructiveConfirmDialog.tsx
+++ b/src/renderer/src/components/shared/DestructiveConfirmDialog.tsx
@@ -18,6 +18,10 @@ interface DestructiveConfirmDialogProps {
   onClose: () => void
   /** Called when the user confirms the destructive action */
   onConfirm: () => void
+  /** Restores focus to a non-dialog trigger such as a closed overflow menu. */
+  onCloseAutoFocus?: React.ComponentProps<
+    typeof DialogContent
+  >['onCloseAutoFocus']
   /** Disables buttons and shows spinner while true */
   loading: boolean
   /** Dialog title text */
@@ -51,6 +55,7 @@ export const DestructiveConfirmDialog = function DestructiveConfirmDialog({
   open,
   onClose,
   onConfirm,
+  onCloseAutoFocus,
   loading,
   title,
   description,
@@ -63,7 +68,10 @@ export const DestructiveConfirmDialog = function DestructiveConfirmDialog({
 
   return (
     <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-100">
+      <DialogContent
+        className="sm:max-w-100"
+        onCloseAutoFocus={onCloseAutoFocus}
+      >
         <DialogHeader>
           <div className="flex items-center gap-2">
             <AlertTriangle className={`h-5 w-5 ${iconColor}`} />

--- a/src/renderer/src/components/sidebar/AgentsSection.tsx
+++ b/src/renderer/src/components/sidebar/AgentsSection.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef } from 'react'
 
 import { useInitialEffect } from '@/renderer/src/hooks/useInitialEffect'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
@@ -6,6 +6,7 @@ import { fetchAgents } from '@/renderer/src/redux/slices/agentsSlice'
 import { selectHiddenAgentIds } from '@/renderer/src/redux/slices/settingsSlice'
 
 import { AgentItem } from './AgentItem'
+import { HiddenAgentsMenu } from './HiddenAgentsMenu'
 
 /**
  * Sidebar section listing detected AI agents.
@@ -24,6 +25,7 @@ import { AgentItem } from './AgentItem'
  */
 export const AgentsSection = function AgentsSection(): React.ReactElement {
   const dispatch = useAppDispatch()
+  const headingRef = useRef<HTMLSpanElement>(null)
   const { items: agents, loading } = useAppSelector((state) => state.agents)
   const hiddenAgentIds = useAppSelector(selectHiddenAgentIds)
 
@@ -40,7 +42,7 @@ export const AgentsSection = function AgentsSection(): React.ReactElement {
   const missingAgents = agents.filter((a) => !a.exists)
   const totalInstalled = visibleInstalled.length + hiddenInstalled.length
 
-  if (loading) {
+  if (loading && agents.length === 0) {
     return (
       <div className="space-y-2">
         <div className="flex items-center gap-2 mb-3">
@@ -56,7 +58,11 @@ export const AgentsSection = function AgentsSection(): React.ReactElement {
   return (
     <div className="space-y-2">
       <div className="flex items-center gap-2 mb-3">
-        <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+        <span
+          ref={headingRef}
+          tabIndex={-1}
+          className="text-xs font-medium uppercase tracking-wider text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        >
           Agents
         </span>
         <span className="text-xs text-muted-foreground">
@@ -85,18 +91,25 @@ export const AgentsSection = function AgentsSection(): React.ReactElement {
         </div>
       )}
 
-      {hiddenInstalled.length > 0 && (
-        <details className="mt-4">
-          <summary className="text-xs text-muted-foreground cursor-pointer hover:text-foreground">
-            {hiddenInstalled.length} hidden
-          </summary>
-          <div className="mt-2 space-y-1">
-            {hiddenInstalled.map((agent) => (
-              <AgentItem key={agent.id} agent={agent} />
-            ))}
-          </div>
-        </details>
-      )}
+      <div className="relative">
+        {hiddenInstalled.length > 0 && (
+          <details className="mt-4">
+            <summary className="min-h-6 mr-7 content-center rounded-md text-xs text-muted-foreground cursor-pointer hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+              {hiddenInstalled.length} hidden
+            </summary>
+            <div className="mt-2 space-y-1">
+              {hiddenInstalled.map((agent) => (
+                <AgentItem key={agent.id} agent={agent} />
+              ))}
+            </div>
+          </details>
+        )}
+        {/* A sibling trigger keeps menu clicks independent of the disclosure. */}
+        <HiddenAgentsMenu
+          agents={hiddenInstalled}
+          focusFallbackRef={headingRef}
+        />
+      </div>
 
       {missingAgents.length > 0 && (
         <details className="mt-4">

--- a/src/renderer/src/components/sidebar/AgentsSection.tsx
+++ b/src/renderer/src/components/sidebar/AgentsSection.tsx
@@ -4,6 +4,7 @@ import { useInitialEffect } from '@/renderer/src/hooks/useInitialEffect'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import { fetchAgents } from '@/renderer/src/redux/slices/agentsSlice'
 import { selectHiddenAgentIds } from '@/renderer/src/redux/slices/settingsSlice'
+import { getHiddenAgentsLabel } from '@/renderer/src/utils/getHiddenAgentsLabel'
 
 import { AgentItem } from './AgentItem'
 import { HiddenAgentsMenu } from './HiddenAgentsMenu'
@@ -41,6 +42,7 @@ export const AgentsSection = function AgentsSection(): React.ReactElement {
   )
   const missingAgents = agents.filter((a) => !a.exists)
   const totalInstalled = visibleInstalled.length + hiddenInstalled.length
+  const hiddenAgentsLabel = getHiddenAgentsLabel(hiddenInstalled.length)
 
   if (loading && agents.length === 0) {
     return (
@@ -92,10 +94,10 @@ export const AgentsSection = function AgentsSection(): React.ReactElement {
       )}
 
       <div className="relative">
-        {hiddenInstalled.length > 0 && (
+        {hiddenAgentsLabel && (
           <details className="mt-4">
             <summary className="min-h-6 mr-7 content-center rounded-md text-xs text-muted-foreground cursor-pointer hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
-              {hiddenInstalled.length} hidden
+              {hiddenAgentsLabel}
             </summary>
             <div className="mt-2 space-y-1">
               {hiddenInstalled.map((agent) => (

--- a/src/renderer/src/components/sidebar/HiddenAgentsMenu.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/HiddenAgentsMenu.browser.test.tsx
@@ -1,0 +1,351 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import { render } from 'vitest-browser-react'
+
+import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
+import { DEFAULT_SETTINGS } from '@/shared/settings'
+import type { Agent, FilesystemEntryIdentity, Skill } from '@/shared/types'
+
+const mockRemoveAllFromAgent = vi.fn()
+const mockSkillsGetAll = vi.fn()
+const mockAgentsGetAll = vi.fn()
+const mockSourceGetStats = vi.fn()
+const mockToastSuccess = vi.fn()
+const mockToastError = vi.fn()
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}))
+
+const directoryIdentity: FilesystemEntryIdentity = {
+  kind: 'directory',
+  dev: 1,
+  ino: 2,
+  size: 96,
+  ctimeMs: 3,
+  mtimeMs: 4,
+}
+
+const cline: Agent = {
+  id: 'cline',
+  name: 'Cline',
+  path: '/Users/test/.cline/skills',
+  exists: true,
+  skillCount: 2,
+  localSkillCount: 0,
+  filesystemIdentity: directoryIdentity,
+}
+
+const warp: Agent = {
+  ...cline,
+  id: 'warp',
+  name: 'Warp',
+  path: '/Users/test/.warp/skills',
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  mockRemoveAllFromAgent.mockResolvedValue({ success: true, removedCount: 2 })
+  mockSkillsGetAll.mockResolvedValue([])
+  mockAgentsGetAll.mockResolvedValue([])
+  mockSourceGetStats.mockResolvedValue({})
+  // Keep the real Redux mutation and refresh behavior while replacing Electron IPC.
+  vi.stubGlobal('electron', {
+    skills: {
+      removeAllFromAgent: mockRemoveAllFromAgent,
+      getAll: mockSkillsGetAll,
+    },
+    agents: { getAll: mockAgentsGetAll },
+    source: { getStats: mockSourceGetStats },
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+/**
+ * Mount the hidden-agent action against real reducers for browser interaction tests.
+ * @param agents - Hidden installed agents offered by the sidebar.
+ * @returns Rendered menu and store for protection or visibility changes.
+ * @example await renderHiddenMenu([cline, warp])
+ */
+async function renderHiddenMenu(agents: Agent[] = [cline, warp]) {
+  const { default: agentsReducer } =
+    await import('@/renderer/src/redux/slices/agentsSlice')
+  const { default: skillsReducer } =
+    await import('@/renderer/src/redux/slices/skillsSlice')
+  const { default: protectReducer } =
+    await import('@/renderer/src/redux/slices/protectSlice')
+  const { default: uiReducer } =
+    await import('@/renderer/src/redux/slices/uiSlice')
+  const { default: settingsReducer } =
+    await import('@/renderer/src/redux/slices/settingsSlice')
+  const { HiddenAgentsMenu } = await import('./HiddenAgentsMenu')
+  const store = configureStore({
+    reducer: {
+      agents: agentsReducer,
+      skills: skillsReducer,
+      protect: protectReducer,
+      ui: uiReducer,
+      settings: settingsReducer,
+    },
+    preloadedState: {
+      settings: {
+        ...DEFAULT_SETTINGS,
+        hiddenAgentIds: agents.map((agent) => agent.id),
+      },
+    },
+  })
+  const screen = await render(
+    <Provider store={store}>
+      <TooltipProvider>
+        <HiddenAgentsMenu agents={agents} />
+      </TooltipProvider>
+    </Provider>,
+  )
+  await screen.getByRole('button', { name: 'Hidden agent actions' }).click()
+  await screen
+    .getByRole('menuitem', { name: 'Delete skills folders...' })
+    .click()
+  return { screen, store }
+}
+
+describe('Hidden agent folder deletion', () => {
+  it('reviews the hidden folder paths and cancels without deleting anything', async () => {
+    // Arrange
+    const { screen } = await renderHiddenMenu()
+    const dialog = screen.getByRole('dialog', {
+      name: 'Delete hidden agents’ skills folders?',
+    })
+    await expect.element(dialog).toBeVisible()
+    await expect
+      .element(dialog.getByText('Cline', { exact: true }))
+      .toBeVisible()
+    await expect
+      .element(dialog.getByText('Warp', { exact: true }))
+      .toBeVisible()
+    await expect
+      .element(dialog.getByText(cline.path, { exact: true }))
+      .toBeVisible()
+    await expect
+      .element(dialog.getByText(warp.path, { exact: true }))
+      .toBeVisible()
+
+    // Act
+    await dialog.getByRole('button', { name: 'Cancel', exact: true }).click()
+
+    // Assert
+    await expect.element(dialog).not.toBeInTheDocument()
+    expect(mockRemoveAllFromAgent).not.toHaveBeenCalled()
+    expect(mockSkillsGetAll).not.toHaveBeenCalled()
+    await expect
+      .element(screen.getByRole('button', { name: 'Hidden agent actions' }))
+      .toHaveFocus()
+
+    // Keyboard activation and Escape must preserve the same cancellation path.
+    await userEvent.keyboard('{Enter}')
+    await expect
+      .element(
+        screen.getByRole('menuitem', { name: 'Delete skills folders...' }),
+      )
+      .toHaveFocus()
+    await userEvent.keyboard('{Enter}')
+    await expect.element(dialog).toBeVisible()
+    await userEvent.keyboard('{Escape}')
+    await expect.element(dialog).not.toBeInTheDocument()
+    await expect
+      .element(screen.getByRole('button', { name: 'Hidden agent actions' }))
+      .toHaveFocus()
+    expect(mockRemoveAllFromAgent).not.toHaveBeenCalled()
+  })
+
+  it('deletes eligible hidden folders while excluding shared and unreviewed paths', async () => {
+    // Arrange
+    const sharedAgent: Agent = {
+      ...cline,
+      id: 'amp',
+      name: 'Amp',
+      path: '/Users/test/.config/agents/skills',
+    }
+    const aliasedAgent: Agent = {
+      ...warp,
+      filesystemIdentity: { ...directoryIdentity, kind: 'symlink' },
+    }
+    const { screen } = await renderHiddenMenu([
+      cline,
+      sharedAgent,
+      aliasedAgent,
+    ])
+
+    // Act
+    await screen
+      .getByRole('button', { name: 'Delete folders', exact: true })
+      .click()
+
+    // Assert
+    await expect.poll(() => mockToastSuccess.mock.calls.length).toBe(1)
+    expect(mockRemoveAllFromAgent).toHaveBeenCalledExactlyOnceWith({
+      agentId: 'cline',
+      agentPath: '/Users/test/.cline/skills',
+      filesystemIdentity: directoryIdentity,
+      protectedSkillPaths: [],
+    })
+    expect(mockToastSuccess).toHaveBeenCalledWith(
+      'Deleted skills from 1 hidden agent',
+      { description: 'Removed 2 items; kept 0 protected' },
+    )
+    expect(mockSkillsGetAll).toHaveBeenCalledTimes(1)
+    expect(mockAgentsGetAll).toHaveBeenCalledTimes(1)
+    expect(mockSourceGetStats).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps protected skill slots when deleting the remaining hidden-agent skills', async () => {
+    // Arrange
+    const { screen, store } = await renderHiddenMenu([cline])
+    const { fetchSkills } =
+      await import('@/renderer/src/redux/slices/skillsSlice')
+    const { addProtection } =
+      await import('@/renderer/src/redux/slices/protectSlice')
+    const protectedSkill: Skill = {
+      name: 'protected-task',
+      description: 'Protected source skill',
+      path: '/Users/test/.agents/skills/protected-task',
+      symlinkCount: 1,
+      symlinks: [
+        {
+          agentId: 'cline',
+          agentName: 'Cline',
+          status: 'valid',
+          targetPath: '/Users/test/.agents/skills/protected-task',
+          linkPath: '/Users/test/.cline/skills/protected-slot',
+          isLocal: false,
+        },
+      ],
+      isSource: true,
+      isOrphan: false,
+    }
+    store.dispatch(fetchSkills.fulfilled([protectedSkill], 'protected-skills'))
+    store.dispatch(addProtection('protected-task'))
+    mockRemoveAllFromAgent.mockResolvedValue({
+      success: true,
+      removedCount: 1,
+      preservedCount: 1,
+    })
+
+    // Act
+    await screen
+      .getByRole('button', { name: 'Delete folders', exact: true })
+      .click()
+
+    // Assert
+    await expect.poll(() => mockToastSuccess.mock.calls.length).toBe(1)
+    expect(mockRemoveAllFromAgent).toHaveBeenCalledExactlyOnceWith({
+      agentId: 'cline',
+      agentPath: '/Users/test/.cline/skills',
+      filesystemIdentity: directoryIdentity,
+      protectedSkillPaths: ['/Users/test/.cline/skills/protected-slot'],
+    })
+    expect(mockToastSuccess).toHaveBeenCalledWith(
+      'Deleted skills from 1 hidden agent',
+      { description: 'Removed 1 items; kept 1 protected' },
+    )
+  })
+
+  it('continues after one hidden folder fails and reports the failed agent', async () => {
+    // Arrange
+    mockRemoveAllFromAgent
+      .mockResolvedValueOnce({ success: false, error: 'Permission denied' })
+      .mockResolvedValueOnce({ success: true, removedCount: 2 })
+    const { screen } = await renderHiddenMenu()
+
+    // Act
+    await screen
+      .getByRole('button', { name: 'Delete folders', exact: true })
+      .click()
+
+    // Assert
+    await expect.poll(() => mockToastError.mock.calls.length).toBe(1)
+    expect(mockRemoveAllFromAgent).toHaveBeenNthCalledWith(2, {
+      agentId: 'warp',
+      agentPath: '/Users/test/.warp/skills',
+      filesystemIdentity: directoryIdentity,
+      protectedSkillPaths: [],
+    })
+    expect(mockToastError).toHaveBeenCalledWith(
+      'Some skills folders could not be deleted',
+      { description: 'Cline: Permission denied' },
+    )
+    expect(mockAgentsGetAll).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves an agent made visible after the deletion review was opened', async () => {
+    // Arrange
+    const { screen, store } = await renderHiddenMenu()
+    const { setSettings } =
+      await import('@/renderer/src/redux/slices/settingsSlice')
+    store.dispatch(
+      setSettings({ ...store.getState().settings, hiddenAgentIds: ['warp'] }),
+    )
+
+    // Act
+    await screen
+      .getByRole('button', { name: 'Delete folders', exact: true })
+      .click()
+
+    // Assert
+    await expect.poll(() => mockAgentsGetAll.mock.calls.length).toBe(1)
+    expect(mockRemoveAllFromAgent).toHaveBeenCalledExactlyOnceWith({
+      agentId: 'warp',
+      agentPath: '/Users/test/.warp/skills',
+      filesystemIdentity: directoryIdentity,
+      protectedSkillPaths: [],
+    })
+  })
+
+  it('skips an agent made visible while an earlier hidden folder is being deleted', async () => {
+    // Arrange
+    let finishFirstDeletion: (() => void) | undefined
+    mockRemoveAllFromAgent.mockImplementationOnce(
+      async () =>
+        new Promise((resolve) => {
+          finishFirstDeletion = () =>
+            resolve({ success: true, removedCount: 2 })
+        }),
+    )
+    const { screen, store } = await renderHiddenMenu()
+    const { setSettings } =
+      await import('@/renderer/src/redux/slices/settingsSlice')
+
+    // Act
+    await screen
+      .getByRole('button', { name: 'Delete folders', exact: true })
+      .click()
+    await expect.poll(() => mockRemoveAllFromAgent.mock.calls.length).toBe(1)
+    store.dispatch(
+      setSettings({ ...store.getState().settings, hiddenAgentIds: ['cline'] }),
+    )
+    if (!finishFirstDeletion)
+      throw new Error('First folder deletion did not start')
+    finishFirstDeletion()
+
+    // Assert
+    await expect.poll(() => mockToastError.mock.calls.length).toBe(1)
+    expect(mockRemoveAllFromAgent).toHaveBeenCalledExactlyOnceWith({
+      agentId: 'cline',
+      agentPath: '/Users/test/.cline/skills',
+      filesystemIdentity: directoryIdentity,
+      protectedSkillPaths: [],
+    })
+    expect(mockToastError).toHaveBeenCalledWith(
+      'Some skills folders could not be deleted',
+      { description: 'Warp: no longer hidden; skipped' },
+    )
+    expect(mockAgentsGetAll).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/sidebar/HiddenAgentsMenu.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/HiddenAgentsMenu.browser.test.tsx
@@ -257,6 +257,44 @@ describe('Hidden agent folder deletion', () => {
     )
   })
 
+  it.each([
+    {
+      scenario: 'only protected skills remain',
+      preservedCount: 1,
+      expectedDescription: 'Removed 0 items; kept 1 protected',
+    },
+    {
+      scenario: 'an empty skills folder is removed',
+      preservedCount: 0,
+      expectedDescription: 'Removed 0 items; kept 0 protected',
+    },
+  ])(
+    'confirms completion without claiming skill deletion when $scenario',
+    async ({ preservedCount, expectedDescription }) => {
+      // Arrange
+      mockRemoveAllFromAgent.mockResolvedValue({
+        success: true,
+        removedCount: 0,
+        preservedCount,
+      })
+      const { screen } = await renderHiddenMenu([cline])
+
+      // Act
+      await screen
+        .getByRole('button', { name: 'Delete folders', exact: true })
+        .click()
+
+      // Assert
+      await expect.poll(() => mockToastSuccess.mock.calls.length).toBe(1)
+      expect(mockToastSuccess).toHaveBeenCalledWith(
+        'Hidden agent cleanup complete',
+        {
+          description: expectedDescription,
+        },
+      )
+    },
+  )
+
   it('continues after one hidden folder fails and reports the failed agent', async () => {
     // Arrange
     mockRemoveAllFromAgent

--- a/src/renderer/src/components/sidebar/HiddenAgentsMenu.tsx
+++ b/src/renderer/src/components/sidebar/HiddenAgentsMenu.tsx
@@ -1,0 +1,137 @@
+import { MoreVertical, Trash2 } from 'lucide-react'
+import React, { useRef } from 'react'
+
+import { DestructiveConfirmDialog } from '@/renderer/src/components/shared/DestructiveConfirmDialog'
+import { Button } from '@/renderer/src/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/renderer/src/components/ui/dropdown-menu'
+import { useDeleteHiddenAgents } from '@/renderer/src/hooks/useDeleteHiddenAgents'
+import { pluralize } from '@/renderer/src/utils/pluralize'
+import type { Agent } from '@/shared/types'
+
+/**
+ * Adds the hidden-section overflow menu and a reviewed bulk folder-deletion dialog for AgentsSection.
+ * @param props - Installed agents hidden by the user's sidebar settings.
+ * @returns The menu trigger and confirmation dialog, kept mounted across rescans.
+ * @example <HiddenAgentsMenu agents={hiddenInstalled} />
+ */
+export function HiddenAgentsMenu({
+  agents,
+  focusFallbackRef,
+}: {
+  agents: Agent[]
+  focusFallbackRef?: React.RefObject<HTMLElement | null>
+}): React.ReactElement {
+  const deletion = useDeleteHiddenAgents(agents)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const confirmedRef = useRef(false)
+
+  return (
+    <>
+      {agents.length > 0 && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              ref={triggerRef}
+              variant="ghost"
+              size="icon"
+              className="absolute right-0 top-0 size-6 text-muted-foreground hover:text-foreground"
+              aria-label="Hidden agent actions"
+              disabled={deletion.isDeleting}
+            >
+              <MoreVertical aria-hidden="true" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="end"
+            onCloseAutoFocus={(event) => {
+              // Let the confirmation receive focus instead of the closing menu trigger.
+              if (deletion.review) event.preventDefault()
+            }}
+          >
+            <DropdownMenuItem
+              onSelect={() => {
+                confirmedRef.current = false
+                deletion.openReview()
+              }}
+              disabled={!deletion.canDelete}
+              className="text-destructive focus:text-destructive"
+              title={
+                deletion.canDelete
+                  ? undefined
+                  : 'No separate skills folders can be deleted'
+              }
+            >
+              <Trash2 aria-hidden="true" />
+              Delete skills folders...
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+      <DestructiveConfirmDialog
+        open={Boolean(deletion.review)}
+        onClose={deletion.closeReview}
+        onConfirm={() => {
+          confirmedRef.current = true
+          deletion.deleteAction()
+        }}
+        onCloseAutoFocus={(event) => {
+          event.preventDefault()
+          // Cleanup can remove the trigger during the rescan; the heading persists.
+          const focusTarget = confirmedRef.current
+            ? (focusFallbackRef?.current ?? triggerRef.current)
+            : (triggerRef.current ?? focusFallbackRef?.current)
+          focusTarget?.focus()
+        }}
+        loading={deletion.isDeleting}
+        title="Delete hidden agents’ skills folders?"
+        description={
+          <div className="space-y-3">
+            {Boolean(deletion.review?.skippedCount) && (
+              <p>
+                {deletion.review?.skippedCount} hidden{' '}
+                {pluralize(deletion.review?.skippedCount ?? 0, 'agent')} with
+                shared or unavailable folders will be skipped.
+              </p>
+            )}
+            {deletion.protectedCount > 0 && (
+              <p>
+                {deletion.protectedCount} protected skill{' '}
+                {pluralize(deletion.protectedCount, 'entry', 'entries')} will be
+                kept.
+              </p>
+            )}
+            <p>
+              Move these {deletion.review?.agents.length} skills folders and
+              their contents to Trash. Folders containing protected skills will
+              remain.
+            </p>
+            <ul
+              aria-label="Skills folders to delete"
+              className="max-h-48 overflow-y-auto space-y-2 rounded-md border p-3"
+            >
+              {deletion.review?.agents.map((agent) => (
+                <li key={agent.id}>
+                  <span className="block text-foreground">{agent.name}</span>
+                  <span className="block break-all font-mono text-xs">
+                    {agent.path}
+                  </span>
+                </li>
+              ))}
+            </ul>
+            <p>
+              Shared source skills and visible agents are kept. You can restore
+              deleted folders from Trash.
+            </p>
+          </div>
+        }
+        confirmLabel="Delete folders"
+        loadingLabel="Deleting folders..."
+      />
+    </>
+  )
+}

--- a/src/renderer/src/components/sidebar/HiddenAgentsMenu.tsx
+++ b/src/renderer/src/components/sidebar/HiddenAgentsMenu.tsx
@@ -10,7 +10,8 @@ import {
   DropdownMenuTrigger,
 } from '@/renderer/src/components/ui/dropdown-menu'
 import { useDeleteHiddenAgents } from '@/renderer/src/hooks/useDeleteHiddenAgents'
-import { pluralize } from '@/renderer/src/utils/pluralize'
+import { getHiddenAgentsDeleteNotices } from '@/renderer/src/utils/getHiddenAgentsDeleteNotices'
+import { getHiddenAgentsLabel } from '@/renderer/src/utils/getHiddenAgentsLabel'
 import type { Agent } from '@/shared/types'
 
 /**
@@ -29,10 +30,15 @@ export function HiddenAgentsMenu({
   const deletion = useDeleteHiddenAgents(agents)
   const triggerRef = useRef<HTMLButtonElement>(null)
   const confirmedRef = useRef(false)
+  const hiddenAgentsLabel = getHiddenAgentsLabel(agents.length)
+  const notices = getHiddenAgentsDeleteNotices(
+    deletion.review?.skippedCount ?? 0,
+    deletion.protectedCount,
+  )
 
   return (
     <>
-      {agents.length > 0 && (
+      {hiddenAgentsLabel && (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
@@ -91,20 +97,9 @@ export function HiddenAgentsMenu({
         title="Delete hidden agents’ skills folders?"
         description={
           <div className="space-y-3">
-            {Boolean(deletion.review?.skippedCount) && (
-              <p>
-                {deletion.review?.skippedCount} hidden{' '}
-                {pluralize(deletion.review?.skippedCount ?? 0, 'agent')} with
-                shared or unavailable folders will be skipped.
-              </p>
-            )}
-            {deletion.protectedCount > 0 && (
-              <p>
-                {deletion.protectedCount} protected skill{' '}
-                {pluralize(deletion.protectedCount, 'entry', 'entries')} will be
-                kept.
-              </p>
-            )}
+            {notices.map((notice) => (
+              <p key={notice}>{notice}</p>
+            ))}
             <p>
               Move these {deletion.review?.agents.length} skills folders and
               their contents to Trash. Folders containing protected skills will

--- a/src/renderer/src/hooks/useDeleteHiddenAgents.ts
+++ b/src/renderer/src/hooks/useDeleteHiddenAgents.ts
@@ -1,4 +1,4 @@
-import { useRef, useState, useTransition } from 'react'
+import { useRef, useTransition } from 'react'
 import { toast } from 'sonner'
 
 import {
@@ -11,6 +11,11 @@ import {
   removeAllSymlinksFromAgent,
 } from '@/renderer/src/redux/slices/agentsSlice'
 import { selectHiddenAgentIds } from '@/renderer/src/redux/slices/settingsSlice'
+import {
+  clearHiddenAgentsDeleteReview,
+  selectHiddenAgentsDeleteReview,
+  setHiddenAgentsDeleteReview,
+} from '@/renderer/src/redux/slices/uiSlice'
 import { refreshAllData } from '@/renderer/src/redux/thunks'
 import { getDeletableHiddenAgents } from '@/renderer/src/utils/getDeletableHiddenAgents'
 import { pluralize } from '@/renderer/src/utils/pluralize'
@@ -25,10 +30,7 @@ import type { Agent } from '@/shared/types'
 export function useDeleteHiddenAgents(agents: Agent[]) {
   const dispatch = useAppDispatch()
   const store = useAppStore()
-  const [review, setReview] = useState<{
-    agents: Agent[]
-    skippedCount: number
-  } | null>(null)
+  const review = useAppSelector(selectHiddenAgentsDeleteReview)
   const [isDeleting, startDeletion] = useTransition()
   const deletingRef = useRef(false)
   const eligibleAgents = getDeletableHiddenAgents(agents)
@@ -48,10 +50,12 @@ export function useDeleteHiddenAgents(agents: Agent[]) {
   const openReview = (): void => {
     // Keep the reviewed filesystem identities stable until confirmation.
     if (eligibleAgents.length === 0 || deletingRef.current) return
-    setReview({
-      agents: eligibleAgents,
-      skippedCount: agents.length - eligibleAgents.length,
-    })
+    dispatch(
+      setHiddenAgentsDeleteReview({
+        agents: eligibleAgents,
+        skippedCount: agents.length - eligibleAgents.length,
+      }),
+    )
   }
 
   /**
@@ -60,7 +64,7 @@ export function useDeleteHiddenAgents(agents: Agent[]) {
    * @example deletion.closeReview()
    */
   const closeReview = (): void => {
-    if (!deletingRef.current) setReview(null)
+    if (!deletingRef.current) dispatch(clearHiddenAgentsDeleteReview())
   }
 
   /**
@@ -111,7 +115,7 @@ export function useDeleteHiddenAgents(agents: Agent[]) {
         }
       } finally {
         deletingRef.current = false
-        setReview(null)
+        dispatch(clearHiddenAgentsDeleteReview())
         // Even a rejected folder operation can have removed some unprotected children.
         refreshAllData(dispatch)
       }

--- a/src/renderer/src/hooks/useDeleteHiddenAgents.ts
+++ b/src/renderer/src/hooks/useDeleteHiddenAgents.ts
@@ -1,0 +1,130 @@
+import { useRef, useState, useTransition } from 'react'
+import { toast } from 'sonner'
+
+import {
+  useAppDispatch,
+  useAppSelector,
+  useAppStore,
+} from '@/renderer/src/redux/hooks'
+import {
+  collectProtectedAgentSlotPaths,
+  removeAllSymlinksFromAgent,
+} from '@/renderer/src/redux/slices/agentsSlice'
+import { selectHiddenAgentIds } from '@/renderer/src/redux/slices/settingsSlice'
+import { refreshAllData } from '@/renderer/src/redux/thunks'
+import { getDeletableHiddenAgents } from '@/renderer/src/utils/getDeletableHiddenAgents'
+import { pluralize } from '@/renderer/src/utils/pluralize'
+import type { Agent } from '@/shared/types'
+
+/**
+ * Owns the reviewed folder snapshot and serial deletion when HiddenAgentsMenu opens or confirms its dialog.
+ * @param agents - Currently installed hidden agents shown by the sidebar.
+ * @returns Review state, protected count, pending status, and review/close/delete actions.
+ * @example const deletion = useDeleteHiddenAgents(hiddenInstalled)
+ */
+export function useDeleteHiddenAgents(agents: Agent[]) {
+  const dispatch = useAppDispatch()
+  const store = useAppStore()
+  const [review, setReview] = useState<{
+    agents: Agent[]
+    skippedCount: number
+  } | null>(null)
+  const [isDeleting, startDeletion] = useTransition()
+  const deletingRef = useRef(false)
+  const eligibleAgents = getDeletableHiddenAgents(agents)
+  const protectedCount = useAppSelector((state) =>
+    (review?.agents ?? []).reduce(
+      (count, agent) =>
+        count + collectProtectedAgentSlotPaths(state, agent).length,
+      0,
+    ),
+  )
+
+  /**
+   * Captures only eligible folders when the menu's delete item is selected.
+   * @returns Nothing; opens the confirmation when at least one folder is eligible.
+   * @example deletion.openReview()
+   */
+  const openReview = (): void => {
+    // Keep the reviewed filesystem identities stable until confirmation.
+    if (eligibleAgents.length === 0 || deletingRef.current) return
+    setReview({
+      agents: eligibleAgents,
+      skippedCount: agents.length - eligibleAgents.length,
+    })
+  }
+
+  /**
+   * Dismisses the confirmation from Cancel, Escape, or the backdrop while idle.
+   * @returns Nothing; active deletion keeps its dialog open.
+   * @example deletion.closeReview()
+   */
+  const closeReview = (): void => {
+    if (!deletingRef.current) setReview(null)
+  }
+
+  /**
+   * Runs the confirmed folders through the existing guarded deletion thunk and reports partial outcomes.
+   * @returns Nothing; the transition stays pending until every reviewed folder is attempted.
+   * @example deletion.deleteAction()
+   */
+  const deleteAction = (): void => {
+    // A synchronous guard prevents repeated activation before React repaints.
+    if (!review || deletingRef.current) return
+    deletingRef.current = true
+    startDeletion(async () => {
+      let completedCount = 0
+      let removedCount = 0
+      let preservedCount = 0
+      const failures: string[] = []
+
+      try {
+        // Preserve review order and continue so one inaccessible folder cannot block the rest.
+        for (const agent of review.agents) {
+          // Settings can change visibility while the previous folder is awaiting IPC.
+          if (!selectHiddenAgentIds(store.getState()).includes(agent.id)) {
+            failures.push(`${agent.name}: no longer hidden; skipped`)
+            continue
+          }
+          const result = await dispatch(removeAllSymlinksFromAgent(agent))
+          if (removeAllSymlinksFromAgent.fulfilled.match(result)) {
+            completedCount += 1
+            removedCount += result.payload.removedCount
+            preservedCount += result.payload.preservedCount
+          } else {
+            failures.push(`${agent.name}: ${result.error.message}`)
+          }
+        }
+
+        if (completedCount > 0) {
+          toast.success(
+            `Deleted skills from ${completedCount} hidden ${pluralize(completedCount, 'agent')}`,
+            {
+              description: `Removed ${removedCount} items; kept ${preservedCount} protected`,
+            },
+          )
+        }
+        if (failures.length > 0) {
+          toast.error('Some skills folders could not be deleted', {
+            description: failures.join('; '),
+          })
+        }
+      } finally {
+        deletingRef.current = false
+        setReview(null)
+        // Even a rejected folder operation can have removed some unprotected children.
+        refreshAllData(dispatch)
+      }
+    })
+  }
+
+  return {
+    review,
+    protectedCount,
+    isDeleting,
+    canDelete: eligibleAgents.length > 0,
+    openReview,
+    closeReview,
+    deleteAction,
+  }
+}

--- a/src/renderer/src/hooks/useDeleteHiddenAgents.ts
+++ b/src/renderer/src/hooks/useDeleteHiddenAgents.ts
@@ -78,6 +78,7 @@ export function useDeleteHiddenAgents(agents: Agent[]) {
     deletingRef.current = true
     startDeletion(async () => {
       let completedCount = 0
+      let deletedFromAgentCount = 0
       let removedCount = 0
       let preservedCount = 0
       const failures: string[] = []
@@ -93,6 +94,8 @@ export function useDeleteHiddenAgents(agents: Agent[]) {
           const result = await dispatch(removeAllSymlinksFromAgent(agent))
           if (removeAllSymlinksFromAgent.fulfilled.match(result)) {
             completedCount += 1
+            // A successful protected-only review must not claim that any skills were deleted.
+            if (result.payload.removedCount > 0) deletedFromAgentCount += 1
             removedCount += result.payload.removedCount
             preservedCount += result.payload.preservedCount
           } else {
@@ -102,7 +105,9 @@ export function useDeleteHiddenAgents(agents: Agent[]) {
 
         if (completedCount > 0) {
           toast.success(
-            `Deleted skills from ${completedCount} hidden ${pluralize(completedCount, 'agent')}`,
+            deletedFromAgentCount > 0
+              ? `Deleted skills from ${deletedFromAgentCount} hidden ${pluralize(deletedFromAgentCount, 'agent')}`
+              : 'Hidden agent cleanup complete',
             {
               description: `Removed ${removedCount} items; kept ${preservedCount} protected`,
             },

--- a/src/renderer/src/redux/hooks.ts
+++ b/src/renderer/src/redux/hooks.ts
@@ -1,6 +1,6 @@
-import { useDispatch, useSelector } from 'react-redux'
+import { useDispatch, useSelector, useStore } from 'react-redux'
 
-import type { RootState, AppDispatch } from './store'
+import type { RootState, AppDispatch, AppStore } from './store'
 
 /**
  * Typed dispatch hook for Redux actions
@@ -13,3 +13,10 @@ export const useAppDispatch = useDispatch.withTypes<AppDispatch>()
  * @returns Typed selector function
  */
 export const useAppSelector = useSelector.withTypes<RootState>()
+
+/**
+ * Reads the current provider store when asynchronous actions must recheck state after awaiting work.
+ * @returns The typed store whose getState reads the latest state without a render closure.
+ * @example const hiddenIds = useAppStore().getState().settings.hiddenAgentIds
+ */
+export const useAppStore = useStore.withTypes<AppStore>()

--- a/src/renderer/src/redux/slices/agentsSlice.ts
+++ b/src/renderer/src/redux/slices/agentsSlice.ts
@@ -44,7 +44,7 @@ export const fetchAgents = createAsyncThunk('agents/fetchAll', async () => {
  * @returns Absolute agent slot paths that should survive folder deletion.
  * @example collectProtectedAgentSlotPaths(state, cursorAgent)
  */
-function collectProtectedAgentSlotPaths(
+export function collectProtectedAgentSlotPaths(
   state: RootState,
   agent: Agent,
 ): AbsolutePath[] {

--- a/src/renderer/src/redux/slices/uiSlice.test.ts
+++ b/src/renderer/src/redux/slices/uiSlice.test.ts
@@ -133,6 +133,56 @@ const previewNoConflicts: SyncPreviewResult = {
   conflicts: [],
 }
 
+describe('uiSlice hidden agents deletion review', () => {
+  it('keeps the reviewed folder identities available until the confirmation closes', async () => {
+    // Arrange
+    const store = await createTestStore()
+    const { setHiddenAgentsDeleteReview, selectHiddenAgentsDeleteReview } =
+      await import('./uiSlice')
+
+    // Act
+    store.dispatch(
+      setHiddenAgentsDeleteReview({
+        agents: [
+          {
+            id: 'cline',
+            name: 'Cline',
+            path: '/home/user/.cline/skills',
+            exists: true,
+            skillCount: 1,
+            localSkillCount: 0,
+            filesystemIdentity: directoryIdentity,
+          },
+        ],
+        skippedCount: 2,
+      }),
+    )
+
+    // Assert
+    expect(selectHiddenAgentsDeleteReview(store.getState())).toMatchObject({
+      agents: [{ id: 'cline', filesystemIdentity: { ino: 2 } }],
+      skippedCount: 2,
+    })
+  })
+
+  it('clears the reviewed targets when deletion is canceled or completed', async () => {
+    // Arrange
+    const store = await createTestStore()
+    const {
+      setHiddenAgentsDeleteReview,
+      clearHiddenAgentsDeleteReview,
+      selectHiddenAgentsDeleteReview,
+    } = await import('./uiSlice')
+    store.dispatch(setHiddenAgentsDeleteReview({ agents: [], skippedCount: 2 }))
+
+    // Act
+    store.dispatch(clearHiddenAgentsDeleteReview())
+
+    // Assert
+    expect(selectHiddenAgentsDeleteReview(store.getState())).toBeNull()
+  })
+})
+
 describe('uiSlice activeTab', () => {
   it('opens on the Installed tab by default', async () => {
     // Arrange

--- a/src/renderer/src/redux/slices/uiSlice.ts
+++ b/src/renderer/src/redux/slices/uiSlice.ts
@@ -4,6 +4,7 @@ import { match } from 'ts-pattern'
 
 import type { RootState } from '@/renderer/src/redux/store'
 import type {
+  Agent,
   AgentId,
   AgentName,
   BookmarkedSkill,
@@ -221,6 +222,8 @@ interface UiState {
    * surface coordination with tabs, sync, and bulk operations.
    */
   symlinkCleanupDialogOpen: boolean
+  /** Reviewed hidden-agent folder identities; null closes the bulk deletion dialog. */
+  hiddenAgentsDeleteReview: { agents: Agent[]; skippedCount: number } | null
 }
 
 const initialState: UiState = {
@@ -244,6 +247,7 @@ const initialState: UiState = {
   bulkSelectMode: false,
   cleanupAgentTarget: null,
   symlinkCleanupDialogOpen: false,
+  hiddenAgentsDeleteReview: null,
 }
 
 /**
@@ -484,6 +488,28 @@ const uiSlice = createSlice({
       state.bulkConfirm = null
     },
     /**
+     * Captures reviewed folders when useDeleteHiddenAgents opens its confirmation.
+     * @param state - Mutable UI draft.
+     * @param action - Reviewed folder identities and skipped count.
+     * @returns Nothing; stores the review snapshot.
+     * @example dispatch(setHiddenAgentsDeleteReview({ agents: [], skippedCount: 1 }))
+     */
+    setHiddenAgentsDeleteReview: (
+      state,
+      action: PayloadAction<NonNullable<UiState['hiddenAgentsDeleteReview']>>,
+    ) => {
+      state.hiddenAgentsDeleteReview = action.payload
+    },
+    /**
+     * Clears reviewed folders when useDeleteHiddenAgents cancels or completes deletion.
+     * @param state - Mutable UI draft.
+     * @returns Nothing; closes the confirmation and releases its targets.
+     * @example dispatch(clearHiddenAgentsDeleteReview())
+     */
+    clearHiddenAgentsDeleteReview: (state) => {
+      state.hiddenAgentsDeleteReview = null
+    },
+    /**
      * Enter bulk-select mode. Reveals checkboxes on skill cards and activates
      * Cmd/Ctrl+A and Esc keyboard shortcuts. Does not touch selection state —
      * the user starts with an empty tick set and explicitly builds it up.
@@ -654,6 +680,8 @@ export const {
   clearUndoToastIfCurrent,
   setBulkConfirm,
   clearBulkConfirm,
+  setHiddenAgentsDeleteReview,
+  clearHiddenAgentsDeleteReview,
   enterBulkSelectMode,
   exitBulkSelectMode,
   setCleanupAgentTarget,
@@ -691,6 +719,15 @@ export const selectSelectedBookmarkForDetail = (
 ): BookmarkForDetail | null => state.ui.selectedBookmarkForDetail
 export const selectBulkConfirm = (state: RootState): BulkConfirmState | null =>
   state.ui.bulkConfirm
+/**
+ * Supplies the stable deletion snapshot when the hidden-agent hook renders its confirmation.
+ * @param state - Redux state containing the UI slice.
+ * @returns Reviewed folders and skipped count, or null while closed.
+ * @example selectHiddenAgentsDeleteReview(store.getState()) // null before review
+ */
+export const selectHiddenAgentsDeleteReview = (
+  state: Pick<RootState, 'ui'>,
+): UiState['hiddenAgentsDeleteReview'] => state.ui.hiddenAgentsDeleteReview
 export const selectBulkSelectMode = (state: RootState): boolean =>
   state.ui.bulkSelectMode
 /**

--- a/src/renderer/src/redux/store.ts
+++ b/src/renderer/src/redux/store.ts
@@ -67,3 +67,4 @@ setupListeners(store.dispatch)
 
 export type RootState = ReturnType<typeof store.getState>
 export type AppDispatch = typeof store.dispatch
+export type AppStore = typeof store

--- a/src/renderer/src/utils/getDeletableHiddenAgents.test.ts
+++ b/src/renderer/src/utils/getDeletableHiddenAgents.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Agent } from '@/shared/types'
+
+import { getDeletableHiddenAgents } from './getDeletableHiddenAgents'
+
+const hiddenAgent: Agent = {
+  id: 'cursor',
+  name: 'Cursor',
+  path: '/Users/test/.cursor/skills',
+  exists: true,
+  skillCount: 0,
+  localSkillCount: 0,
+  filesystemIdentity: {
+    kind: 'directory',
+    dev: 1,
+    ino: 2,
+    size: 96,
+    ctimeMs: 3,
+    mtimeMs: 4,
+  },
+}
+
+describe('hidden-agent bulk-delete eligibility', () => {
+  it('includes an empty dedicated folder and skips an absent folder', () => {
+    // Arrange
+    const hiddenAgents: Agent[] = [
+      hiddenAgent,
+      { ...hiddenAgent, id: 'codex', exists: false },
+    ]
+
+    // Act
+    const agents = getDeletableHiddenAgents(hiddenAgents)
+
+    // Assert
+    expect(agents.map((agent) => agent.id)).toEqual(['cursor'])
+  })
+
+  it('keeps the Amp and Replit shared skills directory out of bulk deletion', () => {
+    // Arrange
+    const hiddenAgents: Agent[] = [
+      { ...hiddenAgent, id: 'amp', path: '/Users/test/.config/agents/skills' },
+      {
+        ...hiddenAgent,
+        id: 'replit',
+        path: '/Users/test/.config/agents/skills',
+      },
+    ]
+
+    // Act
+    const agents = getDeletableHiddenAgents(hiddenAgents)
+
+    // Assert
+    expect(agents).toEqual([])
+    expect(getDeletableHiddenAgents([hiddenAgents[0]])).toEqual([])
+  })
+
+  it('includes Cline and Warp own folders despite their universal install destination', () => {
+    // Arrange
+    const hiddenAgents: Agent[] = [
+      { ...hiddenAgent, id: 'cline', path: '/Users/test/.cline/skills' },
+      { ...hiddenAgent, id: 'warp', path: '/Users/test/.warp/skills' },
+    ]
+
+    // Act
+    const agents = getDeletableHiddenAgents(hiddenAgents)
+
+    // Assert
+    expect(agents.map((agent) => agent.id)).toEqual(['cline', 'warp'])
+  })
+
+  it('skips symlinked folders and folders without a reviewed directory identity', () => {
+    // Arrange
+    const hiddenAgents: Agent[] = [
+      {
+        ...hiddenAgent,
+        filesystemIdentity: {
+          kind: 'symlink',
+          dev: 1,
+          ino: 2,
+          size: 20,
+          ctimeMs: 3,
+          mtimeMs: 4,
+        },
+      },
+      { ...hiddenAgent, id: 'codex', filesystemIdentity: undefined },
+    ]
+
+    // Act
+    const agents = getDeletableHiddenAgents(hiddenAgents)
+
+    // Assert
+    expect(agents).toEqual([])
+  })
+})

--- a/src/renderer/src/utils/getDeletableHiddenAgents.ts
+++ b/src/renderer/src/utils/getDeletableHiddenAgents.ts
@@ -1,0 +1,38 @@
+import { AGENT_DEFINITIONS } from '@/shared/constants'
+import type { Agent } from '@/shared/types'
+
+// The universal source and scan directories shared by agent definitions must stay intact.
+const sharedScanDirectories = new Set<string>([
+  '.agents',
+  ...AGENT_DEFINITIONS.filter((definition) =>
+    AGENT_DEFINITIONS.some(
+      (otherDefinition) =>
+        otherDefinition.id !== definition.id &&
+        otherDefinition.scanDir === definition.scanDir,
+    ),
+  ).map((definition) => definition.scanDir),
+])
+
+/**
+ * Select independently owned folders for the hidden-agent menu's bulk-delete review.
+ * @param hiddenAgents - Already-hidden agents from the sidebar's current scan.
+ * @returns Existing real directories whose definitions do not share a scan path.
+ * @example getDeletableHiddenAgents([hiddenCline, hiddenAmp]) // => [hiddenCline]
+ */
+export function getDeletableHiddenAgents(
+  hiddenAgents: readonly Agent[],
+): Agent[] {
+  return hiddenAgents.filter((agent) => {
+    const definition = AGENT_DEFINITIONS.find(
+      (candidate) => candidate.id === agent.id,
+    )
+
+    // Main revalidates the reviewed identity and resolves shared-path aliases before deletion.
+    return (
+      agent.exists &&
+      agent.filesystemIdentity?.kind === 'directory' &&
+      definition !== undefined &&
+      !sharedScanDirectories.has(definition.scanDir)
+    )
+  })
+}

--- a/src/renderer/src/utils/getHiddenAgentsDeleteNotices.test.ts
+++ b/src/renderer/src/utils/getHiddenAgentsDeleteNotices.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+
+import { getHiddenAgentsDeleteNotices } from './getHiddenAgentsDeleteNotices'
+
+describe('Hidden agents deletion exclusions', () => {
+  it('omits exclusion notices when every folder and skill is eligible', () => {
+    // Arrange
+    const skippedCount = 0
+    const protectedCount = 0
+    // Act
+    const notices = getHiddenAgentsDeleteNotices(skippedCount, protectedCount)
+    // Assert
+    expect(notices).toEqual([])
+  })
+
+  it('explains a single skipped agent without implying protected entries exist', () => {
+    // Arrange
+    const skippedCount = 1
+    const protectedCount = 0
+    // Act
+    const notices = getHiddenAgentsDeleteNotices(skippedCount, protectedCount)
+    // Assert
+    expect(notices).toEqual([
+      '1 hidden agent with shared or unavailable folders will be skipped.',
+    ])
+  })
+
+  it('explains a protected entry without implying shared folders were skipped', () => {
+    // Arrange
+    const skippedCount = 0
+    const protectedCount = 1
+    // Act
+    const notices = getHiddenAgentsDeleteNotices(skippedCount, protectedCount)
+    // Assert
+    expect(notices).toEqual(['1 protected skill entry will be kept.'])
+  })
+
+  it('explains both exclusions with plural labels when multiple entries are kept', () => {
+    // Arrange
+    const skippedCount = 2
+    const protectedCount = 3
+    // Act
+    const notices = getHiddenAgentsDeleteNotices(skippedCount, protectedCount)
+    // Assert
+    expect(notices).toEqual([
+      '2 hidden agents with shared or unavailable folders will be skipped.',
+      '3 protected skill entries will be kept.',
+    ])
+  })
+})

--- a/src/renderer/src/utils/getHiddenAgentsDeleteNotices.ts
+++ b/src/renderer/src/utils/getHiddenAgentsDeleteNotices.ts
@@ -1,0 +1,27 @@
+import { pluralize } from './pluralize'
+
+/**
+ * Explains preserved entries when HiddenAgentsMenu renders its deletion review.
+ * @param skippedCount - Hidden agents without an eligible dedicated folder.
+ * @param protectedCount - Protected skill entries in reviewed folders.
+ * @returns Non-empty notices in shared-folder then protected-skill order.
+ * @example getHiddenAgentsDeleteNotices(0, 1) // ['1 protected skill entry will be kept.']
+ */
+export function getHiddenAgentsDeleteNotices(
+  skippedCount: number,
+  protectedCount: number,
+): string[] {
+  const notices: string[] = []
+  // Omit zero-count notices so the dialog only describes meaningful exclusions.
+  if (skippedCount > 0) {
+    notices.push(
+      `${skippedCount} hidden ${pluralize(skippedCount, 'agent')} with shared or unavailable folders will be skipped.`,
+    )
+  }
+  if (protectedCount > 0) {
+    notices.push(
+      `${protectedCount} protected skill ${pluralize(protectedCount, 'entry', 'entries')} will be kept.`,
+    )
+  }
+  return notices
+}

--- a/src/renderer/src/utils/getHiddenAgentsLabel.test.ts
+++ b/src/renderer/src/utils/getHiddenAgentsLabel.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { getHiddenAgentsLabel } from './getHiddenAgentsLabel'
+
+describe('Hidden agents disclosure', () => {
+  it('hides the disclosure and overflow trigger when no installed agents are hidden', () => {
+    // Arrange
+    const hiddenAgentCount = 0
+    // Act
+    const label = getHiddenAgentsLabel(hiddenAgentCount)
+    // Assert
+    expect(label).toBeNull()
+  })
+
+  it('labels the disclosure with the number of hidden installed agents', () => {
+    // Arrange
+    const hiddenAgentCount = 3
+    // Act
+    const label = getHiddenAgentsLabel(hiddenAgentCount)
+    // Assert
+    expect(label).toBe('3 hidden')
+  })
+})

--- a/src/renderer/src/utils/getHiddenAgentsLabel.ts
+++ b/src/renderer/src/utils/getHiddenAgentsLabel.ts
@@ -1,0 +1,9 @@
+/**
+ * Hides empty agent disclosures when the sidebar and its overflow menu render.
+ * @param hiddenAgentCount - Number of installed agents hidden in Settings.
+ * @returns The disclosure label, or null when there are no hidden agents.
+ * @example getHiddenAgentsLabel(2) // '2 hidden'
+ */
+export function getHiddenAgentsLabel(hiddenAgentCount: number): string | null {
+  return hiddenAgentCount > 0 ? `${hiddenAgentCount} hidden` : null
+}


### PR DESCRIPTION
Add a kebab menu beside the sidebar's hidden-agent count to review and delete hidden agents' dedicated skills folders in bulk. Deletion uses the existing guarded Trash operation, keeps protected skills and shared folders, skips agents made visible during the batch, and reports partial failures.

Validation: `pnpm validate` (2,347 tests), E2E TypeScript check, and `pnpm test:e2e` (66 passed). Five Electron E2E cases cover cancellation, protected/shared/visible preservation, keyboard focus, complete removal, and folder replacement followed by continued deletion. Browser tests cover the Redux review state and accurate zero-deletion notifications; pure helper tests cover exclusion notices and hidden controls. Verified the menu and confirmation in the running Electron app.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 非表示エージェントのスキルフォルダーを一括削除できるメニューと確認画面を追加。
  - 削除対象、スキップ対象、保護対象を確認してから実行可能に。
  - 削除結果や保護された項目を通知し、完了後は適切な場所へフォーカスを戻します。
  - 非表示エージェント数をサイドバーに表示します。

- **テスト**
  - キャンセル、キーボード操作、共有フォルダーや保護項目の扱い、削除失敗時の動作を検証するテストを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->