### PR TITLE
feat: add Entire and Section opacity controls

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -277,8 +277,10 @@ Rules:
   24px hit area even when their visible track is thin.
 - In Section mode, each section paints its own background on a clear window
   canvas. Native window opacity stays at 1 so it does not multiply section
-  percentages. Settings, menus and dialogs remain fully legible outside those
-  section opacity layers.
+  percentages. Opacity applies to the complete section, including its content,
+  matching Entire mode's whole-window behavior within the selected region.
+  Settings, menus and dialogs remain fully legible outside those section
+  opacity layers.
 - Use existing theme surfaces and tabular percentages. Respect reduced motion
   and keep opacity transitions short and interruptible.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -263,6 +263,25 @@ Rules:
 - If introducing shadow tokens, keep them app-wide and named by elevation.
 - Use inset highlights sparingly for macOS-style window polish.
 
+### Window opacity
+
+- Settings → Appearance uses an **Entire / Section** segmented control. Entire
+  retains the existing window opacity and blur; Section independently adjusts
+  **Left** (agent sidebar), **Center** (Installed / Marketplace), and **Right**
+  (details / dashboard).
+- Preserve each mode's values when switching. Section values range from 45–100%
+  and start at 100%; each Reset changes only its own section.
+- Keep the three Section controls comparable: one aligned row per label, slider,
+  percentage, and Reset. All three rows and their resets must fit the standard
+  800 × 600 Settings window without scrolling. Range inputs need at least a
+  24px hit area even when their visible track is thin.
+- In Section mode, each section paints its own background on a clear window
+  canvas. Native window opacity stays at 1 so it does not multiply section
+  percentages. Settings, menus and dialogs remain fully legible outside those
+  section opacity layers.
+- Use existing theme surfaces and tabular percentages. Respect reduced motion
+  and keep opacity transitions short and interruptible.
+
 ## Motion
 
 Motion should clarify cause and effect without making the app feel animated.

--- a/TODOS.md
+++ b/TODOS.md
@@ -2,6 +2,24 @@
 
 Deferred items captured during planning. Pick up when scope and bandwidth allow.
 
+## Opacity design review follow-ups (2026-09-05)
+
+### P2. Open Settings should follow theme changes in the main window
+
+**Status:** Deferred; the theme synchronization code is unchanged by the opacity feature.
+
+**Finding:** Switching the main window from Dark to Light leaves an already-open Settings window in Dark until reload. This makes two windows from the same app look inconsistent.
+
+**Fix direction:** Synchronize theme changes to open Settings windows and cover the two-window interaction in Electron E2E.
+
+### P2. Main-window cards should fit the minimum desktop width
+
+**Status:** Deferred; the card and dashboard layouts are unchanged by the opacity feature.
+
+**Finding:** At 800 × 600, skill titles and dashboard metrics crowd within the 264px center/right panels even though the window itself does not overflow.
+
+**Fix direction:** Adapt card content and metrics to narrow panels while preserving the existing sidebar and three-column layout.
+
 ## Symlink Health cleanup subagent review follow-ups (2026-05-28)
 
 ### P0. Orphan cleanup must not reuse source skill deletion

--- a/e2e/spec/window-opacity.e2e.ts
+++ b/e2e/spec/window-opacity.e2e.ts
@@ -1,0 +1,299 @@
+import { mkdtempSync, realpathSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { Locator, Page } from '@playwright/test'
+
+import type { Settings } from '@/shared/settings'
+
+import { test, expect } from '../fixtures/electron-app'
+import { readSettingsFile, writeSettingsFile } from '../helpers/settings-file'
+
+const opacityTest = test.extend<{
+  initialSettings: Partial<Settings>
+  settingsWindow: Page
+}>({
+  initialSettings: [{ windowBackgroundBlurRadius: 24 }, { option: true }],
+  isolatedHome: async ({ initialSettings }, use) => {
+    const isolatedHome = realpathSync.native(
+      mkdtempSync(join(tmpdir(), 'skills-desktop-e2e-opacity-')),
+    )
+    try {
+      // Stage only this test's preferences before the shared fixture launches Electron.
+      writeSettingsFile(isolatedHome, initialSettings)
+      await use(isolatedHome)
+    } finally {
+      rmSync(isolatedHome, { recursive: true, force: true })
+    }
+  },
+  settingsWindow: async ({ electronApp, appWindow }, use) => {
+    const settingsWindowPromise = electronApp.waitForEvent('window')
+    await appWindow.getByRole('button', { name: 'Open settings' }).click()
+    const settingsWindow = await settingsWindowPromise
+    await settingsWindow.waitForLoadState('domcontentloaded')
+    await settingsWindow
+      .getByRole('button', { name: 'Appearance', exact: true })
+      .click()
+    await use(settingsWindow)
+  },
+})
+
+opacityTest(
+  'preserves the legacy Entire opacity when Section settings are first introduced',
+  async ({ appWindow, settingsWindow, electronApp, isolatedHome }) => {
+    // Arrange — the saved file has only the legacy blur radius, with no new fields.
+    const mainWindow = await electronApp.browserWindow(appWindow)
+
+    // Act — the Appearance window reads the migrated settings through preload IPC.
+    const entireSlider = settingsWindow.getByRole('slider', {
+      name: 'Opacity / Blur',
+    })
+
+    // Assert — existing users keep their selected opacity and the Entire mode.
+    await expect(
+      settingsWindow.getByRole('radio', { name: 'Entire' }),
+    ).toBeChecked()
+    await expect(entireSlider).toBeVisible()
+    await expect(entireSlider).toHaveValue('24')
+    await expect(entireSlider).toHaveAttribute('aria-valuetext', '72% / 24px')
+    await expect(
+      settingsWindow.getByRole('slider', { name: 'Left opacity' }),
+    ).toBeHidden()
+    await expect(appWindow.locator('[data-window-section="left"]')).toHaveCSS(
+      'opacity',
+      '1',
+    )
+    // Electron implements whole-window opacity on macOS and Windows only.
+    if (process.platform !== 'linux') {
+      await expect
+        .poll(async () => mainWindow.evaluate((window) => window.getOpacity()))
+        .toBeCloseTo(0.72, 2)
+    }
+    expect(readSettingsFile(isolatedHome)).toEqual({
+      windowBackgroundBlurRadius: 24,
+    })
+  },
+)
+
+opacityTest(
+  'saves independent section opacity and restores each mode without losing its values',
+  async ({ appWindow, settingsWindow, electronApp, isolatedHome }) => {
+    // Arrange — open the real Settings window with a saved Entire radius of 24.
+    const mainWindow = await electronApp.browserWindow(appWindow)
+    const leftSlider = settingsWindow.getByRole('slider', {
+      name: 'Left opacity',
+    })
+    const centerSlider = settingsWindow.getByRole('slider', {
+      name: 'Center opacity',
+    })
+    const rightSlider = settingsWindow.getByRole('slider', {
+      name: 'Right opacity',
+    })
+
+    // Act — keyboard input exercises the same native controls used by the desktop UI.
+    await settingsWindow.getByRole('radio', { name: 'Section' }).click()
+    await changeSectionOpacity(leftSlider, 65)
+    await changeSectionOpacity(centerSlider, 80)
+    await changeSectionOpacity(rightSlider, 95)
+
+    // Assert — all three persisted values reach the main window independently.
+    await expect
+      .poll(() => readSettingsFile(isolatedHome))
+      .toMatchObject({
+        windowOpacityMode: 'section',
+        windowBackgroundBlurRadius: 24,
+        leftSectionOpacityPercent: 65,
+        centerSectionOpacityPercent: 80,
+        rightSectionOpacityPercent: 95,
+      })
+    await expect(appWindow.locator('[data-window-section="left"]')).toHaveCSS(
+      'opacity',
+      '0.65',
+    )
+    await expect(appWindow.locator('[data-window-section="center"]')).toHaveCSS(
+      'opacity',
+      '0.8',
+    )
+    await expect(appWindow.locator('[data-window-section="right"]')).toHaveCSS(
+      'opacity',
+      '0.95',
+    )
+    await expect(appWindow.locator('[data-opacity-mode="section"]')).toHaveCSS(
+      'background-color',
+      'rgba(0, 0, 0, 0)',
+    )
+    // Electron reports RGB only here; capturePage below verifies the rendered alpha.
+    await expect
+      .poll(async () =>
+        mainWindow.evaluate((window) => ({
+          opacity: window.getOpacity(),
+          background: window.getBackgroundColor(),
+        })),
+      )
+      .toEqual({ opacity: 1, background: '#000000' })
+
+    // Act — reset only Right, then switch to the saved Entire mode and back.
+    await settingsWindow
+      .getByRole('button', { name: 'Reset to default: Right opacity' })
+      .click()
+    await expect
+      .poll(() => readSettingsFile(isolatedHome))
+      .toMatchObject({
+        leftSectionOpacityPercent: 65,
+        centerSectionOpacityPercent: 80,
+        rightSectionOpacityPercent: 100,
+      })
+    await expect(appWindow.locator('[data-window-section="right"]')).toHaveCSS(
+      'opacity',
+      '1',
+    )
+    await settingsWindow.getByRole('radio', { name: 'Entire' }).click()
+    await expect(
+      settingsWindow.getByRole('slider', { name: 'Opacity / Blur' }),
+    ).toHaveValue('24')
+    await expect(appWindow.locator('[data-window-section="left"]')).toHaveCSS(
+      'opacity',
+      '1',
+    )
+    await expect(appWindow.locator('[data-window-section="center"]')).toHaveCSS(
+      'opacity',
+      '1',
+    )
+    if (process.platform !== 'linux') {
+      await expect
+        .poll(async () => mainWindow.evaluate((window) => window.getOpacity()))
+        .toBeCloseTo(0.72, 2)
+    }
+    await settingsWindow.getByRole('radio', { name: 'Section' }).click()
+
+    // Assert — each mode retains its own values after the complete round trip.
+    await expect(leftSlider).toHaveValue('65')
+    await expect(centerSlider).toHaveValue('80')
+    await expect(rightSlider).toHaveValue('100')
+    await expect(rightSlider).toBeVisible()
+    await expect(
+      settingsWindow.getByRole('button', {
+        name: 'Reset to default: Right opacity',
+      }),
+    ).toBeDisabled()
+    await expect
+      .poll(() => readSettingsFile(isolatedHome))
+      .toMatchObject({
+        windowOpacityMode: 'section',
+        windowBackgroundBlurRadius: 24,
+        leftSectionOpacityPercent: 65,
+        centerSectionOpacityPercent: 80,
+        rightSectionOpacityPercent: 100,
+      })
+    await expect(appWindow.locator('[data-window-section="left"]')).toHaveCSS(
+      'opacity',
+      '0.65',
+    )
+    await expect(appWindow.locator('[data-window-section="center"]')).toHaveCSS(
+      'opacity',
+      '0.8',
+    )
+  },
+)
+
+opacityTest.describe('saved Section mode', () => {
+  opacityTest.use({
+    initialSettings: {
+      windowOpacityMode: 'section',
+      windowBackgroundBlurRadius: 0,
+      leftSectionOpacityPercent: 45,
+      centerSectionOpacityPercent: 70,
+      rightSectionOpacityPercent: 100,
+    },
+  })
+
+  opacityTest(
+    'launches with transparent section surfaces even when the saved Entire setting is opaque',
+    async ({ appWindow, settingsWindow, electronApp, isolatedHome }) => {
+      // Arrange — Section mode was saved before launch with an opaque legacy radius.
+      const mainWindow = await electronApp.browserWindow(appWindow)
+
+      // Act — let both native window creation and Settings hydration consume the file.
+      await expect(
+        settingsWindow.getByRole('radio', { name: 'Section' }),
+      ).toBeChecked()
+
+      // Assert — an opaque native backplate must not hide per-section transparency.
+      await expect
+        .poll(async () =>
+          mainWindow.evaluate((window) => ({
+            opacity: window.getOpacity(),
+            background: window.getBackgroundColor(),
+          })),
+        )
+        .toEqual({ opacity: 1, background: '#000000' })
+      await expect(appWindow.locator('[data-window-section="left"]')).toHaveCSS(
+        'opacity',
+        '0.45',
+      )
+      await expect(
+        appWindow.locator('[data-window-section="center"]'),
+      ).toHaveCSS('opacity', '0.7')
+      await expect(
+        appWindow.locator('[data-window-section="right"]'),
+      ).toHaveCSS('opacity', '1')
+      await expect(
+        settingsWindow.getByRole('slider', { name: 'Left opacity' }),
+      ).toHaveValue('45')
+      await expect(
+        settingsWindow.getByRole('slider', { name: 'Right opacity' }),
+      ).toBeVisible()
+      // Capture an interior pixel so rounded window corners cannot fake transparency.
+      const leftSectionCenter = await appWindow
+        .locator('[data-window-section="left"]')
+        .evaluate((element) => {
+          const bounds = element.getBoundingClientRect()
+          return {
+            x: Math.floor(bounds.x + bounds.width / 2),
+            y: Math.floor(bounds.y + bounds.height / 2),
+          }
+        })
+      const pixelAlpha = await mainWindow.evaluate(async (window, position) => {
+        const capture = await window.capturePage(
+          { ...position, width: 1, height: 1 },
+          { stayHidden: true },
+        )
+        return capture.toBitmap()[3]
+      }, leftSectionCenter)
+      expect(pixelAlpha).toBeGreaterThan(0)
+      expect(pixelAlpha).toBeLessThan(255)
+      expect(readSettingsFile(isolatedHome)).toEqual({
+        windowOpacityMode: 'section',
+        windowBackgroundBlurRadius: 0,
+        leftSectionOpacityPercent: 45,
+        centerSectionOpacityPercent: 70,
+        rightSectionOpacityPercent: 100,
+      })
+    },
+  )
+})
+
+/**
+ * Drive a Section slider through keyboard events when opacity E2Es change its saved percentage.
+ * @param slider - Native Section range input from the real Settings window.
+ * @param percent - Requested integer percentage between 45 and 100.
+ * @returns Resolves after the visible control reaches the requested percentage.
+ * @example
+ * await changeSectionOpacity(leftSlider, 65) // Left slider displays 65%.
+ */
+async function changeSectionOpacity(
+  slider: Locator,
+  percent: number,
+): Promise<void> {
+  await expect(slider).toBeVisible()
+  await slider.press('End')
+  // Start at the known maximum and use native one-percent keyboard steps.
+  for (
+    let currentPercent = 100;
+    currentPercent > percent;
+    currentPercent -= 1
+  ) {
+    await slider.press('ArrowLeft')
+  }
+  await expect(slider).toHaveValue(String(percent))
+}

--- a/e2e/spec/window-opacity.e2e.ts
+++ b/e2e/spec/window-opacity.e2e.ts
@@ -90,9 +90,11 @@ opacityTest(
       name: 'Right opacity',
     })
 
-    // Act — keyboard input exercises the same native controls used by the desktop UI.
+    // Act — fill the native ranges, with one arrow step preserving keyboard coverage.
     await settingsWindow.getByRole('radio', { name: 'Section' }).click()
-    await changeSectionOpacity(leftSlider, 65)
+    await changeSectionOpacity(leftSlider, 64)
+    await leftSlider.press('ArrowRight')
+    await expect(leftSlider).toHaveValue('65')
     await changeSectionOpacity(centerSlider, 80)
     await changeSectionOpacity(rightSlider, 95)
 
@@ -131,6 +133,11 @@ opacityTest(
         })),
       )
       .toEqual({ opacity: 1, background: '#000000' })
+    // The separate Settings window stays fully readable while main sections fade.
+    const preferencesWindow = await electronApp.browserWindow(settingsWindow)
+    expect(
+      await preferencesWindow.evaluate((window) => window.getOpacity()),
+    ).toBe(1)
 
     // Act — reset only Right, then switch to the saved Entire mode and back.
     await settingsWindow
@@ -274,7 +281,7 @@ opacityTest.describe('saved Section mode', () => {
 })
 
 /**
- * Drive a Section slider through keyboard events when opacity E2Es change its saved percentage.
+ * Set a native Section range when opacity E2Es exercise its change and persistence flow.
  * @param slider - Native Section range input from the real Settings window.
  * @param percent - Requested integer percentage between 45 and 100.
  * @returns Resolves after the visible control reaches the requested percentage.
@@ -286,14 +293,6 @@ async function changeSectionOpacity(
   percent: number,
 ): Promise<void> {
   await expect(slider).toBeVisible()
-  await slider.press('End')
-  // Start at the known maximum and use native one-percent keyboard steps.
-  for (
-    let currentPercent = 100;
-    currentPercent > percent;
-    currentPercent -= 1
-  ) {
-    await slider.press('ArrowLeft')
-  }
+  await slider.fill(String(percent))
   await expect(slider).toHaveValue(String(percent))
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -89,8 +89,12 @@ function createWindow(): void {
     show: false,
     backgroundColor: getMainWindowBackgroundColor(
       settings.windowBackgroundBlurRadius,
+      settings.windowOpacityMode,
     ),
-    opacity: getMainWindowOpacity(settings.windowBackgroundBlurRadius),
+    opacity: getMainWindowOpacity(
+      settings.windowBackgroundBlurRadius,
+      settings.windowOpacityMode,
+    ),
     // Required for the clear BrowserWindow backplate and real window opacity
     // to reveal the desktop behind the app when the Appearance slider is on.
     transparent: true,
@@ -103,7 +107,11 @@ function createWindow(): void {
       webviewTag: true,
     },
   })
-  applyWindowBackgroundBlur(window, settings.windowBackgroundBlurRadius)
+  applyWindowBackgroundBlur(
+    window,
+    settings.windowBackgroundBlurRadius,
+    settings.windowOpacityMode,
+  )
   setMainWindow(window)
 
   window.on('closed', () => {

--- a/src/main/ipc/ipc-schemas.test.ts
+++ b/src/main/ipc/ipc-schemas.test.ts
@@ -525,6 +525,44 @@ describe('folder:* channels', () => {
 describe('settings:set lockstep with SettingsSchema', () => {
   const schema = IPC_ARG_SCHEMAS['settings:set']!
 
+  it('accepts independent opacity settings while preserving the absence of unrelated fields', () => {
+    // Arrange
+    const patch = {
+      windowOpacityMode: 'section',
+      leftSectionOpacityPercent: 65,
+    }
+    // Act
+    const parsed = schema.parse([patch])
+    // Assert
+    expect(parsed).toEqual([
+      { windowOpacityMode: 'section', leftSectionOpacityPercent: 65 },
+    ])
+  })
+
+  it('does not reset opacity preferences during an unrelated settings write', () => {
+    // Arrange
+    const patch = { codeFontSizePx: 16 }
+    // Act
+    const parsed = schema.parse([patch])
+    // Assert
+    expect(parsed).toEqual([{ codeFontSizePx: 16 }])
+  })
+
+  it.each([
+    { leftSectionOpacityPercent: 44 },
+    { centerSectionOpacityPercent: 101 },
+    { rightSectionOpacityPercent: 65.5 },
+    { windowOpacityMode: 'invalid' },
+  ])(
+    'refuses unsupported opacity values before writing settings: %j',
+    (patch) => {
+      // Arrange / Act
+      const result = schema.safeParse([patch])
+      // Assert
+      expect(result.success).toBe(false)
+    },
+  )
+
   it('lets the user persist a preferredTerminal choice', () => {
     // Arrange / Act / Assert
     expect(schema.safeParse([{ preferredTerminal: 'iterm' }]).success).toBe(

--- a/src/main/ipc/ipc-schemas.ts
+++ b/src/main/ipc/ipc-schemas.ts
@@ -6,8 +6,10 @@ import {
   CODE_FONT_SIZE_SCHEMA,
   INSTALLED_SEARCH_COUNT_DISPLAY_OPTIONS,
   MARKDOWN_FONT_SIZE_SCHEMA,
+  SECTION_OPACITY_PERCENT_SCHEMA,
   SettingsSchema,
   WINDOW_BACKGROUND_BLUR_RADIUS_SCHEMA,
+  WINDOW_OPACITY_MODE_SCHEMA,
 } from '@/shared/settings'
 
 /**
@@ -371,6 +373,10 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
       // unrelated partial settings writes do not reset blur to zero.
       windowBackgroundBlurRadius:
         WINDOW_BACKGROUND_BLUR_RADIUS_SCHEMA.optional(),
+      windowOpacityMode: WINDOW_OPACITY_MODE_SCHEMA.optional(),
+      leftSectionOpacityPercent: SECTION_OPACITY_PERCENT_SCHEMA.optional(),
+      centerSectionOpacityPercent: SECTION_OPACITY_PERCENT_SCHEMA.optional(),
+      rightSectionOpacityPercent: SECTION_OPACITY_PERCENT_SCHEMA.optional(),
       // Preview font sizes + code theme. Shared non-defaulting schemas, kept
       // `.optional()` (not chained off a defaulted SettingsSchema field) so an
       // unrelated partial settings:set never materializes a default and

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -39,13 +39,18 @@ export function registerSettingsHandlers(): void {
     // and trigger a redundant Redux replace in every open window.
     if (next !== before) {
       if (
-        next.windowBackgroundBlurRadius !== before.windowBackgroundBlurRadius
+        next.windowBackgroundBlurRadius !== before.windowBackgroundBlurRadius ||
+        next.windowOpacityMode !== before.windowOpacityMode
       ) {
         const mainWindow = getMainWindow()
         // Settings can outlive the main window on macOS; a closed main window
         // simply receives the persisted blur the next time it is created.
         if (mainWindow !== null) {
-          applyWindowBackgroundBlur(mainWindow, next.windowBackgroundBlurRadius)
+          applyWindowBackgroundBlur(
+            mainWindow,
+            next.windowBackgroundBlurRadius,
+            next.windowOpacityMode,
+          )
         }
       }
       // Push the auto-download preference onto the live updater so a

--- a/src/main/services/settings.test.ts
+++ b/src/main/services/settings.test.ts
@@ -394,6 +394,78 @@ describe('settings persistence', () => {
   })
 
   describe('saveSettings', () => {
+    it('keeps every section opacity when multiple sliders save concurrently', async () => {
+      // Arrange
+      const { saveSettings, getSettings } = await importFreshSettings()
+
+      // Act — overlap the independent slider commits before any file write finishes.
+      const results = await Promise.allSettled([
+        saveSettings({ leftSectionOpacityPercent: 65 }),
+        saveSettings({ centerSectionOpacityPercent: 80 }),
+        saveSettings({ rightSectionOpacityPercent: 95 }),
+      ])
+
+      // Assert — both the cache and the persisted file retain all three changes.
+      expect(results.map((result) => result.status)).toEqual([
+        'fulfilled',
+        'fulfilled',
+        'fulfilled',
+      ])
+      expect(getSettings()).toMatchObject({
+        leftSectionOpacityPercent: 65,
+        centerSectionOpacityPercent: 80,
+        rightSectionOpacityPercent: 95,
+      })
+      expect(
+        JSON.parse(await readFile(join(userDataDir, 'settings.json'), 'utf8')),
+      ).toMatchObject({
+        leftSectionOpacityPercent: 65,
+        centerSectionOpacityPercent: 80,
+        rightSectionOpacityPercent: 95,
+      })
+    })
+
+    it('keeps a reset made while the previous opacity change is still being saved', async () => {
+      // Arrange
+      const { saveSettings, getSettings } = await importFreshSettings()
+
+      // Act — the reset matches the old cache but must follow the pending change.
+      await Promise.all([
+        saveSettings({ leftSectionOpacityPercent: 45 }),
+        saveSettings({ leftSectionOpacityPercent: 100 }),
+      ])
+
+      // Assert
+      expect(getSettings().leftSectionOpacityPercent).toBe(100)
+      expect(
+        JSON.parse(await readFile(join(userDataDir, 'settings.json'), 'utf8'))
+          .leftSectionOpacityPercent,
+      ).toBe(100)
+    })
+
+    it('continues saving valid settings after a queued update fails validation', async () => {
+      // Arrange
+      const { saveSettings, getSettings } = await importFreshSettings()
+
+      // Act
+      const results = await Promise.allSettled([
+        saveSettings({ leftSectionOpacityPercent: 20 }),
+        saveSettings({ rightSectionOpacityPercent: 90 }),
+      ])
+
+      // Assert — one rejected patch cannot prevent later preferences from saving.
+      expect(results[0]?.status).toBe('rejected')
+      expect(results[1]?.status).toBe('fulfilled')
+      expect(getSettings()).toMatchObject({
+        leftSectionOpacityPercent: 100,
+        rightSectionOpacityPercent: 90,
+      })
+      expect(
+        JSON.parse(await readFile(join(userDataDir, 'settings.json'), 'utf8'))
+          .rightSectionOpacityPercent,
+      ).toBe(90)
+    })
+
     it('writes the merged settings to disk and returns the new full settings object', async () => {
       // Arrange
       const { saveSettings } = await importFreshSettings()

--- a/src/main/services/settings.test.ts
+++ b/src/main/services/settings.test.ts
@@ -297,12 +297,16 @@ describe('settings persistence', () => {
       // Act
       const loaded = await loadSettings()
 
-      // Assert — the three preview-typography fields are absent from this
+      // Assert — the newer appearance fields are absent from this
       // legacy on-disk file, so the schema backfills their defaults.
       expect(loaded).toEqual({
         defaultSkillTab: 'info',
         preferredTerminal: 'terminal',
         windowBackgroundBlurRadius: 0,
+        windowOpacityMode: 'entire',
+        leftSectionOpacityPercent: 100,
+        centerSectionOpacityPercent: 100,
+        rightSectionOpacityPercent: 100,
         markdownFontSizePx: 14,
         codeFontSizePx: 13,
         codeThemeId: 'github',

--- a/src/main/services/settings.ts
+++ b/src/main/services/settings.ts
@@ -19,6 +19,9 @@ import {
  */
 let cache: Settings | null = null
 
+/** Serializes preference writes so overlapping IPC patches cannot share a stale cache or temp file. */
+let settingsSaveQueue: Promise<void> = Promise.resolve()
+
 /**
  * Resolves the on-disk path for `settings.json`. Lazy because
  * `app.getPath('userData')` is only valid after `app.whenReady()`; calling
@@ -129,10 +132,7 @@ export function areSettingsEqual(a: Settings, b: Settings): boolean {
 }
 
 /**
- * Merges `partial` over the current settings and writes the result
- * atomically (temp file + rename) so a crash mid-write cannot corrupt
- * the file. The merged value is validated with Zod before disk write —
- * an invalid `partial` rejects the whole call.
+ * Queue IPC preference patches to merge and write atomically after earlier saves finish.
  * @param partial - Subset of fields to overwrite
  * @returns
  * - On success: the new full Settings object (also updates the cache)
@@ -142,6 +142,24 @@ export function areSettingsEqual(a: Settings, b: Settings): boolean {
  * // => { defaultSkillTab: 'info' }
  */
 export async function saveSettings(partial: SettingsPatch): Promise<Settings> {
+  const pendingSave = settingsSaveQueue.then(async () =>
+    persistSettingsPatch(partial),
+  )
+  // Preserve this caller's rejection while allowing the next queued save to proceed.
+  settingsSaveQueue = pendingSave.then(
+    () => undefined,
+    () => undefined,
+  )
+  return pendingSave
+}
+
+/**
+ * Merge and persist one patch when saveSettings reaches it in the serialized write queue.
+ * @param partial - Preference fields to merge into the latest successfully saved snapshot.
+ * @returns Updated cached settings, or the same snapshot for a no-op; rejects on validation or disk failure.
+ * @example await persistSettingsPatch({ leftSectionOpacityPercent: 65 }) // Saved Left opacity is 65%.
+ */
+async function persistSettingsPatch(partial: SettingsPatch): Promise<Settings> {
   const current = getSettings()
   const merged = SettingsSchema.parse({ ...current, ...partial })
   // No-op guard: when nothing actually changed (e.g. tapping the

--- a/src/main/utils/windowBackgroundBlur.test.ts
+++ b/src/main/utils/windowBackgroundBlur.test.ts
@@ -57,6 +57,52 @@ function makeWindowMock() {
  * Pin native BrowserWindow blur behavior without creating Electron 43 overlay layers.
  */
 describe('windowBackgroundBlur helpers', () => {
+  it('removes the Entire effect before applying independent section transparency', () => {
+    // Arrange
+    const { window, contentView } = makeWindowMock()
+
+    // Act
+    applyWindowBackgroundBlur(window, 24, 'section')
+
+    // Assert
+    expect(window.setOpacity).toHaveBeenCalledWith(1)
+    expect(window.setBackgroundColor).toHaveBeenCalledWith('#00000000')
+    expectMacVibrancy(window, null)
+    expect(contentView.setBackgroundColor).not.toHaveBeenCalled()
+    expect(contentView.setBackgroundBlur).not.toHaveBeenCalled()
+  })
+
+  it('starts Section mode with a clear native backplate even when Entire blur is disabled', () => {
+    // Arrange
+    const savedEntireRadius = 0
+
+    // Act
+    const background = getMainWindowBackgroundColor(
+      savedEntireRadius,
+      'section',
+    )
+    const opacity = getMainWindowOpacity(savedEntireRadius, 'section')
+
+    // Assert
+    expect(background).toBe('#00000000')
+    expect(opacity).toBe(1)
+    expect(shouldUseNativeWindowBlur(24, 'section')).toBe(false)
+  })
+
+  it('restores the saved Entire intensity when switching back from Section mode', () => {
+    // Arrange
+    const { window } = makeWindowMock()
+    applyWindowBackgroundBlur(window, 24, 'section')
+    vi.clearAllMocks()
+
+    // Act
+    applyWindowBackgroundBlur(window, 24, 'entire')
+
+    // Assert
+    expect(window.setOpacity).toHaveBeenCalledWith(0.72)
+    expect(window.setBackgroundColor).toHaveBeenCalledWith('#00000000')
+    expectMacVibrancy(window, 'under-window')
+  })
   it('floors negative, truncates fractional, and caps over-max persisted blur radii to the supported range', () => {
     // Arrange
     const negativeRadius = -12

--- a/src/main/utils/windowBackgroundBlur.ts
+++ b/src/main/utils/windowBackgroundBlur.ts
@@ -4,6 +4,7 @@ import {
   getWindowBackgroundOpacity,
   normalizeWindowBackgroundBlurRadius,
 } from '@/shared/settings'
+import type { Settings } from '@/shared/settings'
 
 /**
  * Opaque launch color matching the app's dark background token.
@@ -13,7 +14,7 @@ import {
 export const MAIN_WINDOW_OPAQUE_BACKGROUND = 'rgb(10, 15, 28)'
 
 /**
- * Fully transparent BrowserWindow backplate used when real window opacity is on.
+ * Clear BrowserWindow backplate that lets window or section opacity reveal the desktop.
  */
 export const MAIN_WINDOW_TRANSPARENT_BACKGROUND = '#00000000'
 
@@ -24,35 +25,50 @@ export { normalizeWindowBackgroundBlurRadius } from '@/shared/settings'
 /**
  * Decide whether the native macOS material blur should be enabled.
  * @param blurRadius - Normalized or raw blur radius.
+ * @param opacityMode - Section mode uses renderer transparency without a whole-window material.
  * @returns true when the Appearance setting asks for a non-opaque window.
  * @example
  * shouldUseNativeWindowBlur(48) // => true
  */
-export function shouldUseNativeWindowBlur(blurRadius: number): boolean {
-  return normalizeWindowBackgroundBlurRadius(blurRadius) > 0
+export function shouldUseNativeWindowBlur(
+  blurRadius: number,
+  opacityMode: Settings['windowOpacityMode'] = 'entire',
+): boolean {
+  return (
+    opacityMode === 'entire' &&
+    normalizeWindowBackgroundBlurRadius(blurRadius) > 0
+  )
 }
 
 /**
  * Convert the blur slider into the real Electron window opacity.
  * @param blurRadius - Normalized or raw blur radius.
- * @returns Whole-window opacity from opaque to transparent.
+ * @param opacityMode - Section mode keeps native opacity at one to avoid multiplying section values.
+ * @returns Saved whole-window opacity in Entire mode, or 1 in Section mode.
  * @example
  * getMainWindowOpacity(48) // => 0.45
  */
-export function getMainWindowOpacity(blurRadius: number): number {
-  return getWindowBackgroundOpacity(blurRadius)
+export function getMainWindowOpacity(
+  blurRadius: number,
+  opacityMode: Settings['windowOpacityMode'] = 'entire',
+): number {
+  return opacityMode === 'section' ? 1 : getWindowBackgroundOpacity(blurRadius)
 }
 
 /**
  * Pick the BrowserWindow backplate color for the current transparency mode.
  * @param blurRadius - Normalized or raw blur radius.
- * @returns Opaque color when blur is off; clear backplate when blur is on.
+ * @param opacityMode - Section mode always requires a clear native backplate.
+ * @returns Opaque color for unblurred Entire mode; a clear backplate for Section mode or blur.
  * @example
  * getMainWindowBackgroundColor(48) // => '#00000000'
  */
-export function getMainWindowBackgroundColor(blurRadius: number): string {
+export function getMainWindowBackgroundColor(
+  blurRadius: number,
+  opacityMode: Settings['windowOpacityMode'] = 'entire',
+): string {
   const normalizedRadius = normalizeWindowBackgroundBlurRadius(blurRadius)
-  if (normalizedRadius > 0) {
+  if (opacityMode === 'section' || normalizedRadius > 0) {
     // The renderer paints the app chrome; Electron's native backplate must stay
     // clear so BrowserWindow.setOpacity can reveal the desktop underneath.
     return MAIN_WINDOW_TRANSPARENT_BACKGROUND
@@ -64,6 +80,7 @@ export function getMainWindowBackgroundColor(blurRadius: number): string {
  * Apply Appearance blur behind renderer content using BrowserWindow-native effects.
  * @param window - Main BrowserWindow instance.
  * @param blurRadius - Legacy-named Appearance transparency intensity.
+ * @param opacityMode - Selected scope from Appearance; the saved Entire intensity remains untouched.
  * @returns Nothing; updates the live BrowserWindow in place.
  * @example
  * applyWindowBackgroundBlur(mainWindow, settings.windowBackgroundBlurRadius)
@@ -71,18 +88,24 @@ export function getMainWindowBackgroundColor(blurRadius: number): string {
 export function applyWindowBackgroundBlur(
   window: BrowserWindow,
   blurRadius: number,
+  opacityMode: Settings['windowOpacityMode'] = 'entire',
 ): void {
   const normalizedRadius = normalizeWindowBackgroundBlurRadius(blurRadius)
-  const backgroundColor = getMainWindowBackgroundColor(normalizedRadius)
-  const windowOpacity = getMainWindowOpacity(normalizedRadius)
-  const shouldEnableNativeBlur = shouldUseNativeWindowBlur(normalizedRadius)
+  const backgroundColor = getMainWindowBackgroundColor(
+    normalizedRadius,
+    opacityMode,
+  )
+  const windowOpacity = getMainWindowOpacity(normalizedRadius, opacityMode)
+  const shouldEnableNativeBlur = shouldUseNativeWindowBlur(
+    normalizedRadius,
+    opacityMode,
+  )
 
   window.setOpacity(windowOpacity)
   window.setBackgroundColor(backgroundColor)
   /* v8 ignore next -- one OS run cannot cover both platform arms, and setVibrancy must never run off macOS */
   if (process.platform === 'darwin') {
-    // macOS vibrancy supplies the system material seen through the transparent
-    // Chromium surface. Turning it off at radius 0 restores the solid app.
+    // Section mode disables the whole-window material so each region can reveal the desktop independently.
     window.setVibrancy(shouldEnableNativeBlur ? MACOS_VIBRANCY_MATERIAL : null)
   }
 

--- a/src/renderer/settings/sections/Appearance.browser.test.tsx
+++ b/src/renderer/settings/sections/Appearance.browser.test.tsx
@@ -43,6 +43,86 @@ async function createStore(
 }
 
 describe('Settings → Appearance', () => {
+  it('preserves the Entire intensity and independent percentages when switching opacity modes', async () => {
+    // Arrange
+    const store = await createStore({
+      windowBackgroundBlurRadius: 24,
+      leftSectionOpacityPercent: 65,
+      centerSectionOpacityPercent: 80,
+      rightSectionOpacityPercent: 95,
+    })
+    const { Appearance } = await import('./Appearance')
+    const screen = await render(
+      <Provider store={store}>
+        <Appearance />
+      </Provider>,
+    )
+
+    // Act
+    await screen.getByRole('radio', { name: 'Section', exact: true }).click()
+    const leftSlider = screen.getByRole('slider', { name: 'Left opacity' })
+    await expect.element(leftSlider).toBeVisible()
+    await expect.element(leftSlider).toHaveValue('65')
+    await leftSlider.fill('70')
+    await expect
+      .poll(() => mockSettingsSet.mock.calls)
+      .toContainEqual([{ leftSectionOpacityPercent: 70 }])
+    await screen.getByRole('radio', { name: 'Entire', exact: true }).click()
+
+    // Assert
+    await expect
+      .element(screen.getByRole('slider', { name: 'Opacity / Blur' }))
+      .toHaveValue('24')
+    await screen.getByRole('radio', { name: 'Section', exact: true }).click()
+    await expect.element(leftSlider).toHaveValue('70')
+    await expect
+      .element(screen.getByRole('slider', { name: 'Center opacity' }))
+      .toHaveValue('80')
+    await expect
+      .element(screen.getByRole('slider', { name: 'Right opacity' }))
+      .toHaveValue('95')
+    expect(mockSettingsSet).toHaveBeenCalledWith({
+      windowOpacityMode: 'section',
+    })
+    expect(mockSettingsSet).toHaveBeenCalledWith({
+      windowOpacityMode: 'entire',
+    })
+  })
+
+  it('resets only the chosen section to full opacity', async () => {
+    // Arrange
+    const store = await createStore({
+      windowOpacityMode: 'section',
+      leftSectionOpacityPercent: 65,
+      centerSectionOpacityPercent: 80,
+      rightSectionOpacityPercent: 95,
+    })
+    const { Appearance } = await import('./Appearance')
+    const screen = await render(
+      <Provider store={store}>
+        <Appearance />
+      </Provider>,
+    )
+
+    // Act
+    await screen
+      .getByRole('button', { name: 'Reset to default: Right opacity' })
+      .click()
+
+    // Assert
+    await expect
+      .element(screen.getByRole('slider', { name: 'Right opacity' }))
+      .toHaveValue('100')
+    await expect
+      .element(screen.getByRole('slider', { name: 'Left opacity' }))
+      .toHaveValue('65')
+    await expect
+      .element(screen.getByRole('slider', { name: 'Center opacity' }))
+      .toHaveValue('80')
+    expect(mockSettingsSet).toHaveBeenCalledExactlyOnceWith({
+      rightSectionOpacityPercent: 100,
+    })
+  })
   it('persists Toolbar text when the Installed search count display is changed', async () => {
     // Arrange
     const store = await createStore()

--- a/src/renderer/settings/sections/Appearance.tsx
+++ b/src/renderer/settings/sections/Appearance.tsx
@@ -9,7 +9,10 @@ import { selectPreviewAppearanceSettings } from '@/renderer/src/redux/slices/set
 import {
   CODE_THEME_DEFINITIONS,
   CODE_THEME_IDS,
+  SECTION_OPACITY_MAX_PERCENT,
+  SECTION_OPACITY_MIN_PERCENT,
   SETTINGS_RANGE_DEBOUNCE_MS,
+  WINDOW_OPACITY_MODE_OPTIONS,
 } from '@/shared/constants'
 import type { CodeThemeId } from '@/shared/constants'
 import {
@@ -30,6 +33,24 @@ import type { Settings } from '@/shared/settings'
 import { SectionFrame, SectionRow } from './SectionFrame'
 
 const BACKGROUND_BLUR_LABEL = 'Opacity / Blur'
+const OPACITY_MODE_LABELS: Record<Settings['windowOpacityMode'], string> = {
+  entire: 'Entire',
+  section: 'Section',
+}
+const OPACITY_MODE_DESCRIPTIONS: Record<Settings['windowOpacityMode'], string> =
+  {
+    entire: 'Adjust opacity and background blur for the entire main window.',
+    section: 'Adjust the sidebar, main content, and details independently.',
+  }
+const OPACITY_MODE_CHOICES = WINDOW_OPACITY_MODE_OPTIONS.map((value) => ({
+  value,
+  label: OPACITY_MODE_LABELS[value],
+}))
+const SECTION_OPACITY_CONTROLS = [
+  { key: 'leftSectionOpacityPercent', label: 'Left' },
+  { key: 'centerSectionOpacityPercent', label: 'Center' },
+  { key: 'rightSectionOpacityPercent', label: 'Right' },
+] as const
 const MARKDOWN_FONT_SIZE_LABEL = 'Reading font size'
 const CODE_FONT_SIZE_LABEL = 'Code font size'
 const CODE_THEME_LABEL = 'Code theme'
@@ -250,6 +271,9 @@ export const Appearance = function Appearance(): React.ReactElement {
   const windowBackgroundBlurRadius = useAppSelector(
     (state) => state.settings.windowBackgroundBlurRadius,
   )
+  const windowOpacityMode = useAppSelector(
+    (state) => state.settings.windowOpacityMode,
+  )
   const { markdownFontSizePx, codeFontSizePx, codeThemeId } = useAppSelector(
     selectPreviewAppearanceSettings,
   )
@@ -306,19 +330,42 @@ export const Appearance = function Appearance(): React.ReactElement {
       </SectionRow>
 
       <SectionRow
-        label={BACKGROUND_BLUR_LABEL}
-        description="Surface opacity and background blur for the main window."
+        label="Opacity"
+        description="Choose how to control the main window’s transparency."
       >
-        <RangeSettingControl
-          label={BACKGROUND_BLUR_LABEL}
-          min={WINDOW_BACKGROUND_BLUR_MIN_RADIUS}
-          max={WINDOW_BACKGROUND_BLUR_MAX_RADIUS}
-          draft={blur.draft}
-          isDefault={blur.isDefault}
-          formatValue={formatBlurValue}
-          onValueChange={blur.change}
-          onReset={blur.reset}
+        <SegmentedControl
+          aria-label="Opacity mode"
+          size="sm"
+          value={windowOpacityMode}
+          onValueChange={(nextMode) =>
+            updateSettings({ windowOpacityMode: nextMode })
+          }
+          options={OPACITY_MODE_CHOICES}
         />
+        <p className="mt-2 text-xs text-muted-foreground">
+          {OPACITY_MODE_DESCRIPTIONS[windowOpacityMode]}
+        </p>
+        {/* Keep both modes mounted so switching retains drafts and pending saves. */}
+        <div hidden={windowOpacityMode !== 'entire'} className="mt-4">
+          <RangeSettingControl
+            label={BACKGROUND_BLUR_LABEL}
+            min={WINDOW_BACKGROUND_BLUR_MIN_RADIUS}
+            max={WINDOW_BACKGROUND_BLUR_MAX_RADIUS}
+            draft={blur.draft}
+            isDefault={blur.isDefault}
+            formatValue={formatBlurValue}
+            onValueChange={blur.change}
+            onReset={blur.reset}
+          />
+        </div>
+        <div
+          hidden={windowOpacityMode !== 'section'}
+          className="mt-4 space-y-4"
+        >
+          {SECTION_OPACITY_CONTROLS.map((control) => (
+            <SectionOpacityControl key={control.key} control={control} />
+          ))}
+        </div>
       </SectionRow>
 
       <SectionRow
@@ -364,4 +411,51 @@ export const Appearance = function Appearance(): React.ReactElement {
       </SectionRow>
     </SectionFrame>
   )
+}
+
+/**
+ * Persists one independently resettable section slider when Appearance renders its Section controls.
+ * @param control - Saved numeric field and its visible section label.
+ * @returns Labeled opacity slider with a percentage and reset action.
+ * @example <SectionOpacityControl control={{ key: 'leftSectionOpacityPercent', label: 'Left' }} />
+ */
+function SectionOpacityControl({
+  control,
+}: {
+  control: (typeof SECTION_OPACITY_CONTROLS)[number]
+}): React.ReactElement {
+  const opacityPercent = useAppSelector((state) => state.settings[control.key])
+  const updateSettings = useUpdateSettings()
+  const opacity = useDraftRangeSetting(
+    opacityPercent,
+    SECTION_OPACITY_MAX_PERCENT,
+    (nextPercent) => updateSettings({ [control.key]: nextPercent }),
+    SETTINGS_RANGE_DEBOUNCE_MS,
+  )
+
+  return (
+    <div className="space-y-2">
+      <div className="text-sm font-medium">{control.label}</div>
+      <RangeSettingControl
+        label={`${control.label} opacity`}
+        min={SECTION_OPACITY_MIN_PERCENT}
+        max={SECTION_OPACITY_MAX_PERCENT}
+        draft={opacity.draft}
+        isDefault={opacity.isDefault}
+        formatValue={formatOpacityPercent}
+        onValueChange={opacity.change}
+        onReset={opacity.reset}
+      />
+    </div>
+  )
+}
+
+/**
+ * Labels section slider values when Appearance updates a draft or announces it to assistive technology.
+ * @param opacityPercent - Current section opacity percentage.
+ * @returns Percentage shown beside the slider.
+ * @example formatOpacityPercent(65) // '65%'
+ */
+function formatOpacityPercent(opacityPercent: number): string {
+  return `${opacityPercent}%`
 }

--- a/src/renderer/settings/sections/Appearance.tsx
+++ b/src/renderer/settings/sections/Appearance.tsx
@@ -145,7 +145,7 @@ const SettingRangeInput = function SettingRangeInput({
       onChange={handleInputChange}
       aria-label={label}
       aria-valuetext={valueText}
-      className="h-2 min-w-0 flex-1 accent-primary rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+      className="h-6 min-w-0 flex-1 accent-primary rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
     />
   )
 }

--- a/src/renderer/settings/sections/Appearance.tsx
+++ b/src/renderer/settings/sections/Appearance.tsx
@@ -343,10 +343,7 @@ export const Appearance = function Appearance(): React.ReactElement {
         />
       </SectionRow>
 
-      <SectionRow
-        label="Opacity"
-        description="Choose how to control the main window’s transparency."
-      >
+      <SectionRow label="Opacity">
         <SegmentedControl
           aria-label="Opacity mode"
           size="sm"

--- a/src/renderer/settings/sections/Appearance.tsx
+++ b/src/renderer/settings/sections/Appearance.tsx
@@ -4,6 +4,7 @@ import { SegmentedControl } from '@/renderer/src/components/shared/segmented-con
 import { Button } from '@/renderer/src/components/ui/button'
 import { useDraftRangeSetting } from '@/renderer/src/hooks/useDraftRangeSetting'
 import { useUpdateSettings } from '@/renderer/src/hooks/useUpdateSettings'
+import { cn } from '@/renderer/src/lib/utils'
 import { useAppSelector } from '@/renderer/src/redux/hooks'
 import { selectPreviewAppearanceSettings } from '@/renderer/src/redux/slices/settingsSlice'
 import {
@@ -156,6 +157,7 @@ interface RangeSettingControlProps {
   max: number
   draft: number
   isDefault: boolean
+  isCompact?: boolean
   formatValue: (value: number) => string
   onValueChange: (value: number) => void
   onReset: () => void
@@ -169,6 +171,7 @@ interface RangeSettingControlProps {
  * @param max - Slider upper bound.
  * @param draft - Current draft value driving slider + badge.
  * @param isDefault - Disables Reset when the draft already equals the default.
+ * @param isCompact - Keeps the value and reset inline for the three comparable Section sliders.
  * @param formatValue - Renders the value badge text.
  * @param onValueChange - Slider change handler.
  * @param onReset - Reset-to-default handler.
@@ -182,13 +185,19 @@ const RangeSettingControl = function RangeSettingControl({
   max,
   draft,
   isDefault,
+  isCompact = false,
   formatValue,
   onValueChange,
   onReset,
 }: RangeSettingControlProps): React.ReactElement {
   return (
-    <div className="flex max-w-md flex-col gap-2">
-      <div className="flex items-center gap-3">
+    <div
+      className={cn(
+        'flex max-w-md gap-2',
+        isCompact ? 'items-center' : 'flex-col',
+      )}
+    >
+      <div className="flex min-w-0 flex-1 items-center gap-3">
         <SettingRangeInput
           value={draft}
           min={min}
@@ -198,7 +207,12 @@ const RangeSettingControl = function RangeSettingControl({
           onValueChange={onValueChange}
         />
 
-        <span className="w-20 whitespace-nowrap text-right text-sm tabular-nums text-muted-foreground">
+        <span
+          className={cn(
+            'shrink-0 whitespace-nowrap text-right text-sm tabular-nums text-muted-foreground',
+            isCompact ? 'w-10' : 'w-20',
+          )}
+        >
           {formatValue(draft)}
         </span>
       </div>
@@ -208,10 +222,10 @@ const RangeSettingControl = function RangeSettingControl({
         size="sm"
         onClick={onReset}
         disabled={isDefault}
-        className="w-fit"
+        className="w-fit shrink-0"
         aria-label={`Reset to default: ${label}`}
       >
-        Reset to default
+        {isCompact ? 'Reset' : 'Reset to default'}
       </Button>
     </div>
   )
@@ -434,9 +448,10 @@ function SectionOpacityControl({
   )
 
   return (
-    <div className="space-y-2">
+    <div className="grid max-w-md grid-cols-[3.5rem_minmax(0,1fr)] items-center gap-3">
       <div className="text-sm font-medium">{control.label}</div>
       <RangeSettingControl
+        isCompact
         label={`${control.label} opacity`}
         min={SECTION_OPACITY_MIN_PERCENT}
         max={SECTION_OPACITY_MAX_PERCENT}

--- a/src/renderer/src/App.browser.test.tsx
+++ b/src/renderer/src/App.browser.test.tsx
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import '@/renderer/src/styles/globals.css'
-import { DEFAULT_SETTINGS } from '@/shared/settings'
+import { DEFAULT_SETTINGS, type Settings } from '@/shared/settings'
 
 import settingsReducer from './redux/slices/settingsSlice'
 import themeReducer from './redux/slices/themeSlice'
@@ -59,12 +59,12 @@ vi.mock('./hooks/useUpdateNotification', () => ({
 /**
  * Render App with only the slices it reads directly. Heavy child panels are
  * mocked so this test can focus on the window-surface paint contract.
- * @param windowBackgroundBlurRadius - Slider value persisted in settings.
+ * @param settings - Appearance fields persisted in settings.
  * @returns Browser test screen for the rendered shell.
  * @example
- * renderAppWithBlur(24)
+ * renderAppWithSettings({ windowBackgroundBlurRadius: 24 })
  */
-async function renderAppWithBlur(windowBackgroundBlurRadius: number) {
+async function renderAppWithSettings(settings: Partial<Settings>) {
   const { default: App } = await import('./App')
   const store = configureStore({
     reducer: {
@@ -72,7 +72,7 @@ async function renderAppWithBlur(windowBackgroundBlurRadius: number) {
       theme: themeReducer,
     },
     preloadedState: {
-      settings: { ...DEFAULT_SETTINGS, windowBackgroundBlurRadius },
+      settings: { ...DEFAULT_SETTINGS, ...settings },
     },
   })
 
@@ -86,7 +86,9 @@ async function renderAppWithBlur(windowBackgroundBlurRadius: number) {
 describe('App window surface', () => {
   it('keeps the renderer surface solid while Electron owns opacity', async () => {
     // Arrange — render the shell with a non-zero blur radius persisted
-    const screen = await renderAppWithBlur(24)
+    const screen = await renderAppWithSettings({
+      windowBackgroundBlurRadius: 24,
+    })
 
     // Act — read the painted window-background surface element
     const surface = screen
@@ -96,5 +98,52 @@ describe('App window surface', () => {
     // Assert — the renderer surface stays opaque and never flags translucency
     expect(surface.style.backgroundColor).toBe('var(--background)')
     expect(surface.dataset['windowTranslucent']).toBeUndefined()
+  })
+
+  it('reveals the desktop through independently transparent sections', async () => {
+    // Arrange
+    const screen = await renderAppWithSettings({
+      windowOpacityMode: 'section',
+      windowBackgroundBlurRadius: 24,
+      leftSectionOpacityPercent: 65,
+      centerSectionOpacityPercent: 80,
+      rightSectionOpacityPercent: 95,
+    })
+    // Act
+    const surface = screen.getByTestId('window-background-surface').element()
+    // Assert
+    expect(surface).toHaveStyle({ backgroundColor: 'transparent' })
+    expect(surface.querySelector('[data-window-section="left"]')).toHaveStyle({
+      opacity: '0.65',
+    })
+    expect(surface.querySelector('[data-window-section="center"]')).toHaveStyle(
+      { opacity: '0.8' },
+    )
+    expect(surface.querySelector('[data-window-section="right"]')).toHaveStyle({
+      opacity: '0.95',
+    })
+  })
+
+  it('leaves every section opaque when Entire mode owns the window opacity', async () => {
+    // Arrange
+    const screen = await renderAppWithSettings({
+      windowOpacityMode: 'entire',
+      windowBackgroundBlurRadius: 24,
+      leftSectionOpacityPercent: 65,
+      centerSectionOpacityPercent: 80,
+      rightSectionOpacityPercent: 95,
+    })
+    // Act
+    const surface = screen.getByTestId('window-background-surface').element()
+    // Assert
+    expect(surface.querySelector('[data-window-section="left"]')).toHaveStyle({
+      opacity: '1',
+    })
+    expect(surface.querySelector('[data-window-section="center"]')).toHaveStyle(
+      { opacity: '1' },
+    )
+    expect(surface.querySelector('[data-window-section="right"]')).toHaveStyle({
+      opacity: '1',
+    })
   })
 })

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -147,6 +147,7 @@ const App = function App(): React.ReactElement {
             opacityMode === 'section' ? 'transparent' : 'var(--background)',
         }}
       >
+        {/* Fade the complete region, matching Entire mode; floating portals stay outside. */}
         <div
           data-window-section="left"
           className="flex h-full shrink-0 transition-opacity duration-150 motion-reduce:transition-none"

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -12,6 +12,7 @@ import { useReleaseNotesToast } from './hooks/useReleaseNotesToast'
 import { useSettingsSync } from './hooks/useSettingsSync'
 import { useUpdateNotification } from './hooks/useUpdateNotification'
 import { useAppSelector } from './redux/hooks'
+import { getWindowSectionOpacity } from './utils/getWindowSectionOpacity'
 
 const separatorClass =
   'bg-border hover:bg-primary/50 active:bg-primary transition-colors cursor-col-resize'
@@ -99,7 +100,7 @@ const toasterStyle = {
 
 /**
  * Skills Desktop main application component
- * Layout: Sidebar (240px) | Main | Detail
+ * Layout: Sidebar (272px) | Main | Detail, with independently controlled section opacity.
  * Theme application is handled by Redux listener middleware
  */
 const App = function App(): React.ReactElement {
@@ -121,23 +122,61 @@ const App = function App(): React.ReactElement {
   // Drive sonner's theme prop from the persisted redux mode so toasts honor
   // the user's light/dark choice. Pre-fix this was hardcoded `theme="dark"`.
   const mode = useAppSelector((state) => state.theme.mode)
+  const opacityMode = useAppSelector(
+    (state) => state.settings.windowOpacityMode,
+  )
+  const leftOpacity = useAppSelector(
+    (state) => state.settings.leftSectionOpacityPercent,
+  )
+  const centerOpacity = useAppSelector(
+    (state) => state.settings.centerSectionOpacityPercent,
+  )
+  const rightOpacity = useAppSelector(
+    (state) => state.settings.rightSectionOpacityPercent,
+  )
 
   return (
     <TooltipProvider delayDuration={200}>
       <div
         data-testid="window-background-surface"
+        data-opacity-mode={opacityMode}
         className="window-background-surface flex h-screen text-foreground window-glow transition-[background-color]"
-        // Renderer paints a solid surface while BrowserWindow.setOpacity controls real desktop transparency.
-        style={{ backgroundColor: 'var(--background)' }}
+        // Section backgrounds must composite onto a clear surface to reveal the desktop independently.
+        style={{
+          backgroundColor:
+            opacityMode === 'section' ? 'transparent' : 'var(--background)',
+        }}
       >
-        <Sidebar />
+        <div
+          data-window-section="left"
+          className="flex h-full shrink-0 transition-opacity duration-150 motion-reduce:transition-none"
+          style={{ opacity: getWindowSectionOpacity(opacityMode, leftOpacity) }}
+        >
+          <Sidebar />
+        </div>
         <Group orientation="horizontal" className="flex-1 h-full">
           <Panel defaultSize="50%" minSize="20%">
-            <MainContent />
+            <div
+              data-window-section="center"
+              className="h-full bg-background transition-opacity duration-150 motion-reduce:transition-none"
+              style={{
+                opacity: getWindowSectionOpacity(opacityMode, centerOpacity),
+              }}
+            >
+              <MainContent />
+            </div>
           </Panel>
           <Separator className={separatorClass} />
           <Panel defaultSize="50%" minSize="20%">
-            <DetailPanel />
+            <div
+              data-window-section="right"
+              className="h-full bg-background transition-opacity duration-150 motion-reduce:transition-none"
+              style={{
+                opacity: getWindowSectionOpacity(opacityMode, rightOpacity),
+              }}
+            >
+              <DetailPanel />
+            </div>
           </Panel>
         </Group>
       </div>

--- a/src/renderer/src/utils/getWindowSectionOpacity.test.ts
+++ b/src/renderer/src/utils/getWindowSectionOpacity.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import { getWindowSectionOpacity } from './getWindowSectionOpacity'
+
+describe('Independent window section opacity', () => {
+  it('keeps saved section values from multiplying the native Entire opacity', () => {
+    // Arrange
+    const savedOpacityPercent = 65
+    // Act
+    const opacity = getWindowSectionOpacity('entire', savedOpacityPercent)
+    // Assert
+    expect(opacity).toBe(1)
+  })
+
+  it.each([
+    { percent: 45, expectedOpacity: 0.45 },
+    { percent: 65, expectedOpacity: 0.65 },
+    { percent: 100, expectedOpacity: 1 },
+  ])(
+    'applies $percent percent to a section when Section mode is selected',
+    ({ percent, expectedOpacity }) => {
+      // Arrange
+      const opacityMode = 'section'
+      // Act
+      const opacity = getWindowSectionOpacity(opacityMode, percent)
+      // Assert
+      expect(opacity).toBe(expectedOpacity)
+    },
+  )
+})

--- a/src/renderer/src/utils/getWindowSectionOpacity.ts
+++ b/src/renderer/src/utils/getWindowSectionOpacity.ts
@@ -1,0 +1,18 @@
+import { SECTION_OPACITY_MAX_PERCENT } from '@/shared/constants'
+import type { Settings } from '@/shared/settings'
+
+/**
+ * Applies independent section opacity when App renders Section mode, leaving Entire opacity to Electron.
+ * @param opacityMode - Current scope selected in Appearance.
+ * @param opacityPercent - Validated saved percentage for one section.
+ * @returns CSS opacity from 0.45 to 1; always 1 in Entire mode.
+ * @example getWindowSectionOpacity('section', 65) // 0.65
+ */
+export function getWindowSectionOpacity(
+  opacityMode: Settings['windowOpacityMode'],
+  opacityPercent: number,
+): number {
+  return opacityMode === 'section'
+    ? opacityPercent / SECTION_OPACITY_MAX_PERCENT
+    : 1
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1074,6 +1074,12 @@ export const SEARCH_DEBOUNCE_MS = 300
  */
 export const SETTINGS_RANGE_DEBOUNCE_MS = 120
 
+/** Appearance modes keep the legacy whole-window effect separate from independent section opacity. */
+export const WINDOW_OPACITY_MODE_OPTIONS = ['entire', 'section'] as const
+/** Section opacity bounds preserve the existing window opacity floor and an opaque default. */
+export const SECTION_OPACITY_MIN_PERCENT = 45
+export const SECTION_OPACITY_MAX_PERCENT = 100
+
 /**
  * Batch size at which bulk ops surface a live per-item progress counter in the
  * toolbar. Below this, the final `.fulfilled` toast is a better UX than a

--- a/src/shared/settings.test.ts
+++ b/src/shared/settings.test.ts
@@ -24,6 +24,56 @@ import {
  * settings.json on disk.
  */
 describe('SettingsSchema', () => {
+  it('keeps legacy window transparency in Entire mode and starts each section opaque', () => {
+    // Arrange
+    const legacySettings = { windowBackgroundBlurRadius: 24 }
+    // Act
+    const settings = SettingsSchema.parse(legacySettings)
+    // Assert
+    expect(settings).toMatchObject({
+      windowBackgroundBlurRadius: 24,
+      windowOpacityMode: 'entire',
+      leftSectionOpacityPercent: 100,
+      centerSectionOpacityPercent: 100,
+      rightSectionOpacityPercent: 100,
+    })
+  })
+
+  it('restores independent section percentages without changing the saved Entire intensity', () => {
+    // Arrange
+    const persistedSettings = {
+      windowBackgroundBlurRadius: 24,
+      windowOpacityMode: 'section',
+      leftSectionOpacityPercent: 45,
+      centerSectionOpacityPercent: 75,
+      rightSectionOpacityPercent: 100,
+    }
+    // Act
+    const settings = SettingsSchema.parse(persistedSettings)
+    // Assert
+    expect(settings).toMatchObject({
+      windowBackgroundBlurRadius: 24,
+      windowOpacityMode: 'section',
+      leftSectionOpacityPercent: 45,
+      centerSectionOpacityPercent: 75,
+      rightSectionOpacityPercent: 100,
+    })
+  })
+
+  it.each([
+    { leftSectionOpacityPercent: 44 },
+    { centerSectionOpacityPercent: 101 },
+    { rightSectionOpacityPercent: 65.5 },
+    { windowOpacityMode: 'invalid' },
+  ])(
+    'rejects an unsupported saved opacity setting: %j',
+    (persistedSettings) => {
+      // Arrange / Act
+      const result = SettingsSchema.safeParse(persistedSettings)
+      // Assert
+      expect(result.success).toBe(false)
+    },
+  )
   it('fills in every default field when parsing an empty settings object', () => {
     // Arrange / Act
     const parsed = SettingsSchema.parse({})

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -4,7 +4,10 @@ import {
   AGENT_IDS,
   CODE_THEME_IDS,
   DEFAULT_CODE_THEME_ID,
+  SECTION_OPACITY_MAX_PERCENT,
+  SECTION_OPACITY_MIN_PERCENT,
   TERMINAL_APP_IDS,
+  WINDOW_OPACITY_MODE_OPTIONS,
 } from './constants'
 import type { AgentId } from './types'
 
@@ -112,6 +115,14 @@ export const WINDOW_BACKGROUND_BLUR_RADIUS_SCHEMA = z
   .min(WINDOW_BACKGROUND_BLUR_MIN_RADIUS)
   .max(WINDOW_BACKGROUND_BLUR_MAX_RADIUS)
 
+/** Non-defaulting opacity schemas keep unrelated IPC patches from resetting saved modes or sections. */
+export const WINDOW_OPACITY_MODE_SCHEMA = z.enum(WINDOW_OPACITY_MODE_OPTIONS)
+export const SECTION_OPACITY_PERCENT_SCHEMA = z
+  .number()
+  .int()
+  .min(SECTION_OPACITY_MIN_PERCENT)
+  .max(SECTION_OPACITY_MAX_PERCENT)
+
 /**
  * Non-defaulting preview font-size schemas shared by disk and IPC boundaries.
  * `SettingsSchema` adds the persisted default; the IPC schema keeps them
@@ -208,6 +219,10 @@ const HIDDEN_AGENT_IDS_SCHEMA = z
  * - `windowBackgroundBlurRadius`: main-window transparency intensity backed
  *   by BrowserWindow opacity and macOS vibrancy. `0` disables the translucent
  *   surface and restores the opaque app background.
+ * - `windowOpacityMode`: applies the existing whole-window effect (`entire`)
+ *   or independent renderer section opacity (`section`). Switching preserves both sets of values.
+ * - `leftSectionOpacityPercent`, `centerSectionOpacityPercent`, `rightSectionOpacityPercent`:
+ *   bounded opacity percentages for the sidebar, main content, and detail inspector.
  * - `markdownFontSizePx`: body font size (CSS px) for the file preview's
  *   Markdown reading mode. Heading/code sizes scale proportionally (em).
  * - `codeFontSizePx`: font size (CSS px) for the Shiki syntax-highlighted
@@ -234,7 +249,7 @@ const HIDDEN_AGENT_IDS_SCHEMA = z
  * so unknown keys are rejected at the IPC boundary (defense in depth).
  *
  * @example
- * SettingsSchema.parse({}) // { defaultSkillTab: 'files', preferredTerminal: 'terminal', windowBackgroundBlurRadius: 0, markdownFontSizePx: 14, codeFontSizePx: 13, codeThemeId: 'github', installedSearchCountDisplay: 'tab', hiddenAgentIds: [], autoDownloadUpdates: false }
+ * SettingsSchema.parse({}).windowOpacityMode // 'entire'; legacy settings keep their existing appearance
  */
 export const SettingsSchema = z.object({
   defaultSkillTab: z.enum(['files', 'info']).default('files'),
@@ -243,6 +258,16 @@ export const SettingsSchema = z.object({
   windowSize: windowSizeSchema,
   windowBackgroundBlurRadius: WINDOW_BACKGROUND_BLUR_RADIUS_SCHEMA.default(
     WINDOW_BACKGROUND_BLUR_MIN_RADIUS,
+  ),
+  windowOpacityMode: WINDOW_OPACITY_MODE_SCHEMA.default('entire'),
+  leftSectionOpacityPercent: SECTION_OPACITY_PERCENT_SCHEMA.default(
+    SECTION_OPACITY_MAX_PERCENT,
+  ),
+  centerSectionOpacityPercent: SECTION_OPACITY_PERCENT_SCHEMA.default(
+    SECTION_OPACITY_MAX_PERCENT,
+  ),
+  rightSectionOpacityPercent: SECTION_OPACITY_PERCENT_SCHEMA.default(
+    SECTION_OPACITY_MAX_PERCENT,
   ),
   markdownFontSizePx: MARKDOWN_FONT_SIZE_SCHEMA.default(
     MARKDOWN_FONT_SIZE_DEFAULT_PX,
@@ -270,6 +295,10 @@ export const SettingsSchema = z.object({
  *   preferredTerminal: 'iterm',
  *   windowSize: { width: 1280, height: 800 },
  *   windowBackgroundBlurRadius: 24,
+ *   windowOpacityMode: 'section',
+ *   leftSectionOpacityPercent: 65,
+ *   centerSectionOpacityPercent: 80,
+ *   rightSectionOpacityPercent: 95,
  *   markdownFontSizePx: 14,
  *   codeFontSizePx: 13,
  *   codeThemeId: 'github',
@@ -296,6 +325,10 @@ export const DEFAULT_SETTINGS: Settings = {
   defaultSkillTab: 'files',
   preferredTerminal: 'terminal',
   windowBackgroundBlurRadius: WINDOW_BACKGROUND_BLUR_MIN_RADIUS,
+  windowOpacityMode: 'entire',
+  leftSectionOpacityPercent: SECTION_OPACITY_MAX_PERCENT,
+  centerSectionOpacityPercent: SECTION_OPACITY_MAX_PERCENT,
+  rightSectionOpacityPercent: SECTION_OPACITY_MAX_PERCENT,
   markdownFontSizePx: MARKDOWN_FONT_SIZE_DEFAULT_PX,
   codeFontSizePx: CODE_FONT_SIZE_DEFAULT_PX,
   codeThemeId: DEFAULT_CODE_THEME_ID,


### PR DESCRIPTION
## Summary

Appearance now supports independent opacity for the sidebar, main content, and details. Entire preserves the existing whole-window opacity and blur setting; Section saves separate 45–100% values and resets for Left, Center, and Right. Each complete region fades, matching Entire mode's behavior at section scope. Settings and floating menus/dialogs stay outside those layers.

Concurrent settings saves now run in order, preserving rapid slider changes and resets instead of racing on a shared temporary file. Three persistence regressions cover concurrent fields, a queued reset, and recovery after rejection.

Section mode keeps native window opacity at 1 with a transparent backplate, and legacy settings retain Entire mode. The design review enlarged slider hit areas, aligned the controls to fit the standard Settings window, and removed repeated instructions. DESIGN.md records these conventions; TODOS.md tracks two adjacent findings.

## Test Plan

- [x] `pnpm validate`: lint, 2,373 unit/browser tests, type checks, fallow checks, and Storybook build.
- [x] `pnpm test:e2e`: 69 Electron tests, including 3 new cases for legacy settings, independent changes/resets and mode preservation, and Section startup. Assertions cover settings on disk, native window opacity, captured pixel alpha, and an opaque Settings window.
- [x] Electron CDP verification in Light/Dark, standard/expanded windows, keyboard operation, and reduced motion.

## Security Checklist

- [x] This change does not widen renderer access to Node.js, Electron, or direct filesystem APIs.
- [x] New settings inputs are validated in the main process through the existing typed IPC path; no new filesystem behavior.
- [x] No dependency, workflow, or release-permission changes in this PR.
- [x] No new security boundary or destructive behavior; existing SECURITY.md guidance remains applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 外観設定で、ウィンドウ全体または左・中央・右セクションごとに不透明度を調整できるようになりました。
  * セクションの不透明度は45〜100%で設定でき、各セクションを個別にリセットできます。
  * 設定値は保存・復元され、既存の設定も引き続き利用できます。
* **改善**
  * セクションごとの不透明度設定時も、背景ぼかしやテーマ表示が適切に反映されます。
  * 複数の設定変更を続けて行った場合も、保存内容が安定して反映されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->