### PR TITLE
fix(main): take a single-instance lock so a second launch cannot delete live trash

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1269,6 +1269,9 @@ state either way. See `docs/adr/0001-prune-the-skill-lock-at-trash-eviction.md`
 
 ### P1. `startupCleanup` evicts live undo windows, with no single-instance lock
 
+**Status:** Fixed (second-instance half). The grace re-arm was investigated and
+deliberately not implemented — see below.
+
 The 24h age floor is gone, so every orphan tombstone is evicted on launch. Two
 consequences review flagged: a crash or force-quit inside the 15s undo window
 now destroys staged data on next launch (where 24h of manual Finder recovery
@@ -1276,12 +1279,33 @@ used to exist), and with no `requestSingleInstanceLock` anywhere in `src/main/`
 a second instance evicts the first instance's live tombstones out from under
 its on-screen Undo toast.
 
-**Fix direction:** re-derive each orphan's remaining grace from
-`manifest.deletedAt` and re-arm the existing evict timer for the remainder,
-evicting immediately only when the window has genuinely elapsed. Add a
-single-instance lock. Stale comments to fix at the same time:
-`src/main/index.ts:328-329` and `src/main/ipc/ipc-schemas.ts:95` both still
-describe the removed 24h TTL.
+**Fixed:** `src/main/index.ts` now takes `app.requestSingleInstanceLock()`
+immediately after the `E2E_USERDATA_DIR` override (Chromium keys the singleton
+on `userData`, so asking earlier would lock the developer's real profile and
+make every isolated e2e launch contend with a running dev app). A losing
+instance calls `app.quit()` AND returns at the top of the `whenReady` callback,
+because `app.quit()` does not cancel an already-registered `ready`. Covered by
+`e2e/spec/single-instance-lock.e2e.ts`, which asserts both that the second
+process exits on its own and that the first instance's staged tombstone
+survives; with the lock removed that second assertion fails. The two stale 24h
+comments (`src/main/index.ts`, `src/main/ipc/ipc-schemas.ts`) are corrected.
+
+**Not implemented — re-deriving grace from `manifest.deletedAt`:** the review
+proposed re-arming the evict timer for each orphan's remaining window. Checked
+against the code: restore is driven only by the Redux `UndoToast`, there is no
+trash-browsing UI and no `listTrash` IPC channel, and the bulk-delete copy
+promises restore "from the notification". So after a restart nothing in the app
+can restore a tombstone, and re-arming would keep an unrestorable directory
+alive for at most 15 more seconds without enabling any recovery. It also
+contradicts `trashService.lockPrune.test.ts:196`, whose rationale (a held
+tombstone keeps its lock record alive, so `skills -g update` reinstalls the
+deleted skill) still stands. The second-instance exposure this was co-filed
+with is closed by the lock above.
+
+**Reopen when:** a persistent restore affordance exists — a trash view, or an
+undo window rehydrated from disk on launch. At that point grace re-arming
+becomes meaningful, because there would finally be something to restore with.
+That is a feature, not a follow-up to this entry.
 
 **Depends on / blocked by:** Nothing.
 

--- a/e2e/spec/single-instance-lock.e2e.ts
+++ b/e2e/spec/single-instance-lock.e2e.ts
@@ -1,0 +1,87 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+import { test, expect } from '../fixtures/electron-app'
+
+/**
+ * End-to-end coverage for the single-instance lock in `src/main/index.ts`.
+ *
+ * Why this file exists: the lock is a two-process property, so no unit test
+ * can observe it. The bug it prevents is silent and destructive — a second
+ * launch runs `trashService.startupCleanup`, which sweeps EVERY orphan
+ * tombstone, including the ones the already-running instance is still showing
+ * an Undo button for. The user clicks Undo and their skill is gone.
+ *
+ * Asserting the second process merely exits is not enough: an instance could
+ * quit after its sweep already ran. Both halves are checked below.
+ */
+
+/**
+ * Path to the Electron binary. In a Node context the `electron` package's main
+ * export is the executable path string; its published TypeScript types
+ * describe the main-process API instead, so the cast is the only way to state
+ * what the runtime value actually is.
+ */
+const electronExecutable = require('electron') as unknown as string
+
+/** Directory name of the tombstone the second instance must not touch. */
+const LIVE_TOMBSTONE_ENTRY = '1900000000000-still-undoable-abcdef12'
+
+test('a second launch quits without sweeping the running instance live trash', async ({
+  isolatedHome,
+  appWindow,
+}) => {
+  // Arrange — `appWindow` is the primary instance, already past its own
+  // startupCleanup. Stage the tombstone AFTER that sweep so the only process
+  // that could remove it is the second instance we are about to launch. The
+  // future timestamp keeps the entry outside any grace arithmetic.
+  await appWindow.waitForLoadState('domcontentloaded')
+  const liveTombstoneDir = join(
+    isolatedHome,
+    '.agents',
+    '.trash',
+    LIVE_TOMBSTONE_ENTRY,
+  )
+  mkdirSync(liveTombstoneDir, { recursive: true })
+  writeFileSync(
+    join(liveTombstoneDir, 'manifest.json'),
+    JSON.stringify({
+      schemaVersion: 2,
+      kind: 'source-backed',
+      deletedAt: 1900000000000,
+      skillName: 'Still Undoable',
+      sourcePath: join(isolatedHome, '.agents', 'skills', 'still-undoable'),
+      symlinks: [],
+    }),
+    'utf-8',
+  )
+
+  // Act — launch a second instance against the same HOME and userData dir.
+  // Chromium keys its singleton on userData, so this is the real collision a
+  // user creates by double-clicking the app icon while it is already running.
+  const repoRoot = resolve(__dirname, '..', '..')
+  const secondInstance = spawnSync(
+    electronExecutable,
+    [resolve(repoRoot, 'out', 'main', 'index.mjs')],
+    {
+      env: {
+        ...process.env,
+        HOME: isolatedHome,
+        E2E_USERDATA_DIR: resolve(isolatedHome, 'userData'),
+        E2E_DISABLE_UPDATE: '1',
+        E2E_BACKGROUND_LAUNCH: '1',
+      },
+      timeout: 30_000,
+      encoding: 'utf-8',
+    },
+  )
+
+  // Assert — a null signal means the process ended on its own rather than
+  // being killed at the timeout, which is what an unlocked second instance
+  // would do: boot a window and keep running.
+  expect(secondInstance.signal).toBeNull()
+  // The whole point. Without the lock the second instance reaches
+  // `app.whenReady`, runs startupCleanup, and this directory is gone.
+  expect(existsSync(liveTombstoneDir)).toBe(true)
+})

--- a/e2e/spec/single-instance-lock.e2e.ts
+++ b/e2e/spec/single-instance-lock.e2e.ts
@@ -28,6 +28,15 @@ const electronExecutable = require('electron') as unknown as string
 /** Directory name of the tombstone the second instance must not touch. */
 const LIVE_TOMBSTONE_ENTRY = '1900000000000-still-undoable-abcdef12'
 
+/**
+ * Ceiling for the second instance, deliberately well under Playwright's 30s
+ * per-test timeout. At parity the two race, and an instance that refuses to
+ * quit would surface as a generic "Test timeout exceeded" instead of the
+ * assertions below, which name the actual defect. A locked-out instance exits
+ * in well under a second.
+ */
+const SECOND_INSTANCE_TIMEOUT_MS = 10_000
+
 test('a second launch quits without sweeping the running instance live trash', async ({
   isolatedHome,
   appWindow,
@@ -72,15 +81,18 @@ test('a second launch quits without sweeping the running instance live trash', a
         E2E_DISABLE_UPDATE: '1',
         E2E_BACKGROUND_LAUNCH: '1',
       },
-      timeout: 30_000,
+      timeout: SECOND_INSTANCE_TIMEOUT_MS,
       encoding: 'utf-8',
     },
   )
 
-  // Assert — a null signal means the process ended on its own rather than
-  // being killed at the timeout, which is what an unlocked second instance
-  // would do: boot a window and keep running.
-  expect(secondInstance.signal).toBeNull()
+  // Assert — `error` is set by spawnSync both when the binary never launched
+  // and when the timeout above had to kill the child, so checking it first
+  // closes a false green: a wrong binary path leaves the tombstone untouched
+  // for the trivial reason that no second instance ever ran. Status 0 is what
+  // a locked-out instance exits with after `app.quit()`.
+  expect(secondInstance.error).toBeUndefined()
+  expect(secondInstance.status).toBe(0)
   // The whole point. Without the lock the second instance reaches
   // `app.whenReady`, runs startupCleanup, and this directory is gone.
   expect(existsSync(liveTombstoneDir)).toBe(true)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -51,6 +51,30 @@ if (e2eUserDataDir) {
 }
 
 /**
+ * Whether this process won the single-instance lock. Requested here, after the
+ * `userData` override above, because Chromium keys the singleton on that
+ * directory — asking first would lock the developer's real profile and make
+ * every isolated e2e launch contend with a running dev app.
+ *
+ * A second instance must never reach `app.whenReady`: its `startupCleanup`
+ * would sweep the first instance's live tombstones out from under an on-screen
+ * Undo toast, deleting staged skill data the user can still see a button for.
+ */
+const isPrimaryInstance = app.requestSingleInstanceLock()
+if (!isPrimaryInstance) {
+  app.quit()
+}
+
+// Someone launched the app again while this instance owns the lock — surface
+// the window we already have instead of leaving them with a dead click.
+app.on('second-instance', () => {
+  const existingWindow = getMainWindow()
+  if (existingWindow === null) return
+  if (existingWindow.isMinimized()) existingWindow.restore()
+  existingWindow.focus()
+})
+
+/**
  * Default launch size used when the user has no persisted `windowSize`
  * preference. Mirrors the previous hard-coded constructor values; with no
  * preference the app maximizes on `ready-to-show` so users keep the original
@@ -299,6 +323,10 @@ function createMenu(): void {
 }
 
 app.whenReady().then(async () => {
+  // Lost the single-instance race. `app.quit()` above does not stop a pending
+  // `ready`, so bail before any init runs — startupCleanup especially.
+  if (!isPrimaryInstance) return
+
   // E2E: hide from Dock / Cmd-Tab BEFORE any other init runs. Done first
   // because `configureAboutPanel()` below calls `app.dock.setIcon()`,
   // which would briefly flash the Dock icon if the policy is still
@@ -325,8 +353,8 @@ app.whenReady().then(async () => {
   // swallows its own errors and falls back to defaults internally.
   await loadSettings()
 
-  // Sweep orphan trash entries older than 24h. Fire-and-forget: errors per
-  // entry are caught + logged inside trashService; we never block startup.
+  // Sweep every orphan trash entry. Fire-and-forget: errors per entry are
+  // caught + logged inside trashService; we never block startup.
   void runTrashStartupCleanup()
 
   // Configure the About panel before the menu wires up `role: 'about'`

--- a/src/main/ipc/ipc-schemas.ts
+++ b/src/main/ipc/ipc-schemas.ts
@@ -92,8 +92,9 @@ const localCopyRecordSchema = z.object({
  * Legacy v1 manifest (no kind discriminator — always source-backed).
  * Read-only path: never written by current code. Normalized to v2 source-backed
  * via Zod transform so consumers see one shape regardless of on-disk version.
- * Removable in a future major once the 24h startupCleanup TTL has flushed all
- * pre-upgrade tombstones.
+ * Removable in a future major once startupCleanup has swept all pre-upgrade
+ * tombstones — it evicts every orphan on launch, so one run of the new build
+ * is enough.
  */
 const manifestV1Schema = z
   .object({


### PR DESCRIPTION
## Problem

There is no `requestSingleInstanceLock` anywhere in `src/main/`. A second app
instance runs `trashService.startupCleanup`, which sweeps **every** orphan
tombstone — including the ones the already-running instance is still showing an
Undo button for. The user clicks Undo and their skill is gone.

Reported as the P1 `startupCleanup` entry in `TODOS.md`.

## Fix

`app.requestSingleInstanceLock()` in `src/main/index.ts`, placed **after** the
`E2E_USERDATA_DIR` override: Chromium keys its singleton on `userData`, so
asking earlier would lock the developer's real profile and make every isolated
e2e launch contend with a running dev app.

A losing instance does two things, not one — it calls `app.quit()` *and*
returns at the top of the `whenReady` callback. `app.quit()` does not cancel an
already-registered `ready`, so without the guard the loser still reaches
`startupCleanup` and the bug ships anyway.

A `second-instance` handler restores/focuses the existing window so relaunching
is not a dead click.

## Deliberately not implemented

The same TODO also proposed re-deriving each orphan's remaining undo grace from
`manifest.deletedAt` and re-arming the evict timer. Checked against the code and
dropped: restore is driven only by the Redux `UndoToast`, there is no
trash-browsing UI and no `listTrash` IPC channel, and the bulk-delete copy
promises restore "from the notification". After a restart nothing in the app can
restore a tombstone, so re-arming would keep an unrestorable directory alive for
at most 15 more seconds without enabling any recovery — and it contradicts
`trashService.lockPrune.test.ts:196`, whose rationale (a held tombstone keeps its
lock record alive, so `skills -g update` reinstalls the deleted skill) still
stands. `TODOS.md` records this with a concrete reopen trigger.

## Workflow change worth knowing

`pnpm dev` now refuses to boot while the packaged Skills Desktop app is open —
same app name, same `userData`, same lock. Standard Electron behavior, but it is
a visible change.

## Test plan

- `e2e/spec/single-instance-lock.e2e.ts` — launches a real second instance
  against the same HOME/`userData` and asserts **both** that it exits on its own
  and that the first instance's staged tombstone survives.
- Mutation-verified: replacing `app.requestSingleInstanceLock()` with `true`
  makes `expect(existsSync(liveTombstoneDir)).toBe(true)` fail with
  `Received: false` — the unlocked second instance really does sweep live trash.
- `pnpm validate` — exit 0 (193 files, 2487 tests)
- `pnpm test:e2e` — 84 passed
- `pnpm test:coverage` — exit 0 (94.89 stmts / 85.15 branches / 96.79 funcs / 99.27 lines)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - アプリの二重起動を防止し、既存のアプリウィンドウを前面に表示するようにしました。
  - 2つ目の起動要求は、タイムアウトせず正常に終了します。

- **バグ修正**
  - 二重起動時に、既存の復元対象データが誤って削除される問題を防止しました。
  - 起動ロック取得に失敗した場合、不要な初期化やクリーンアップを実行しないようにしました。

- **テスト**
  - 二重起動時の動作とデータ保持を検証するE2Eテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->