### PR TITLE
fix(lock): prune only what the user consented to and the lock still owns

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1363,26 +1363,46 @@ index, and upstream `removeSkillFromLock` is last-write-wins over sanitized
 names, so a collision appearing between scan and confirm removes the _other_
 record while the requested one is reported failed.
 
-**Fix direction:** surface collisions as a distinct "cannot determine" state,
-and re-check the collision index inside the prune mutex.
+**Status:** Half fixed. The prune mutex now re-checks the collision index
+(`skillLockService.ts` `pruneLockEntries`): a name whose sanitized form is no
+longer uniquely its own is routed to `failed` and never delegated, so a
+collision appearing between scan and confirm can no longer delete the other
+record. Covered by `skillLockService.test.ts` "refuses a name another lock key
+started sharing a directory with after the scan".
+
+REMAINING: the scan still drops collided keys silently, so the pair stays
+unprunable with nothing in the UI explaining why. That half needs a new state
+on `StaleLockScanResult` plus the renderer copy to render it, which is the same
+"an unprunable state needs a UI explanation" shape as the manual-recovery entry
+below — do them together.
+
+**Fix direction:** surface collisions as a distinct "cannot determine" state.
 
 **Depends on / blocked by:** Nothing.
 
 ### P3. Smaller items from the same review
 
-- `resolveLockKeyForDirectory` (`skillLockService.ts:285`) reads the lock
-  outside `runLockWrite`; a concurrent non-atomic CLI write makes it return
-  null and the prune is then skipped forever, since the trash entry is already
-  gone. Wrapping it is safe — no `evict` caller holds the lock.
+- ~~`resolveLockKeyForDirectory` reads the lock outside `runLockWrite`.~~
+  FIXED: it now runs inside the mutex. Nesting was verified safe against
+  source first — all three `evict` call sites are detached timers or the
+  startup sweep, none holding the lock.
 - Manual-recovery trash entries keep their lock record alive forever:
   `readTrashedSourceDirNames` counts them as "still restorable" although their
   restore already failed permanently.
-- `LockPruneDialog` reads `staleNames` live rather than snapshotting at open,
-  so the acted-on set can differ from the consented set.
-- `pruneStaleLockEntries.fulfilled` replaces `staleNames` wholesale with
-  `failed`, dropping names a concurrent scan added.
-- `SUPPORTED_LOCK_VERSION` guards `version < 3` with no upper bound, so a
-  future v4 lock is parsed and pruned against.
+- ~~`LockPruneDialog` reads `staleNames` live rather than snapshotting at
+  open.~~ FIXED: `openLockPruneDialog` snapshots into `consentedNames` and the
+  dialog reads only that, so the list, the count, the button label and the
+  delete request cannot disagree. Nothing clears it on close, deliberately:
+  the dialog stays mounted through its 200ms exit animation, so clearing there
+  blanked the whole body mid-fade on Cancel. The unconditional re-snapshot at
+  open is what keeps a reopen from inheriting the previous list.
+- ~~`pruneStaleLockEntries.fulfilled` replaces `staleNames` wholesale with
+  `failed`.~~ FIXED: a `pruneRequestId` guard mirroring the existing
+  `scanRequestId` idiom — a scan landing mid-prune clears it and its newer
+  list wins.
+- ~~`SUPPORTED_LOCK_VERSION` guards `version < 3` with no upper bound.~~
+  FIXED: a higher version now reports `unavailable`, reusing the existing
+  three-valued status channel.
 - `HealthWidget`'s `hasManualReviewOnly` now requires `!hasStaleLockEntries`,
   so the "Manual review" affordance disappears whenever a stale lock coexists
   with inaccessible links; and the two CTAs can co-occur in a widget footer

--- a/src/main/services/skillLockService.test.ts
+++ b/src/main/services/skillLockService.test.ts
@@ -225,6 +225,26 @@ describe('scanStaleLockEntries', () => {
     expect(result).toEqual({ status: 'ok', names: [] })
   })
 
+  test('reports unavailable when the lock was written by a CLI newer than this build', async () => {
+    // Arrange
+    // A version we have never seen may key its records differently, so
+    // `sanitizeName` can no longer say which directory answers for a record.
+    // Reporting `ok` would offer every entry in it for deletion.
+    const { scanStaleLockEntries } = await serviceModule
+    await mkdir(join(sharedHome, '.agents'), { recursive: true })
+    await writeFile(
+      lockPath,
+      JSON.stringify({ version: 4, skills: { 'future-skill': {} } }),
+      'utf-8',
+    )
+
+    // Act
+    const result = await scanStaleLockEntries()
+
+    // Assert
+    expect(result).toEqual({ status: 'unavailable' })
+  })
+
   test('reports unavailable rather than zero when the lock file is corrupt', async () => {
     // Arrange
     const { scanStaleLockEntries } = await serviceModule
@@ -652,6 +672,30 @@ describe('pruneLockEntries', () => {
     expect(removeSkillsMock).not.toHaveBeenCalled()
   })
 
+  test('refuses a name another lock key started sharing a directory with after the scan', async () => {
+    // Arrange
+    // The scan offered `Ambiguous` while it was the only key sanitizing to
+    // `ambiguous`. A second key arriving before the user confirms makes the
+    // directory ambiguous, and upstream `removeSkillFromLock` is last-write-wins
+    // over sanitized names — delegating now would delete the OTHER record.
+    const { pruneLockEntries } = await serviceModule
+    await writeLock(['Ambiguous', 'ambiguous'])
+
+    // Act
+    const result = await pruneLockEntries(['Ambiguous'] as SkillName[])
+
+    // Assert
+    expect(removeSkillsMock).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      pruned: [],
+      skipped: [],
+      // Still stale and still unresolved, so it belongs in `failed`, which the
+      // UI surfaces, and never in `skipped`, which reads as a benign no-op.
+      failed: ['Ambiguous'],
+    })
+    expect(await readLockKeys()).toEqual(['Ambiguous', 'ambiguous'])
+  })
+
   test('prunes the names it could verify and still reports the unverifiable one as failed', async () => {
     // Arrange: the shape "Remove all" produces — one batch, mixed outcomes. An
     // unverifiable name must not veto the rest, and must not vanish from the
@@ -674,6 +718,45 @@ describe('pruneLockEntries', () => {
     })
     expect(removeSkillsMock).toHaveBeenCalledWith(['gone-from-disk'])
     expect(await readLockKeys()).toEqual(['unreadable'])
+  })
+})
+
+describe('resolveLockKeyForDirectory', () => {
+  test('waits out an in-flight lock rewrite instead of reading a half-written file', async () => {
+    // Arrange
+    // The CLI's `writeSkillLock` is a plain `writeFile`, so a reader that does
+    // not join the write mutex can land on the truncated middle of it. Here a
+    // null is unrecoverable rather than merely wrong: this runs from trash
+    // eviction, and the tombstone that would re-queue the prune is already gone.
+    const { pruneLockEntries, resolveLockKeyForDirectory } = await serviceModule
+    await writeLock(['CE:Review', 'gone-from-disk'])
+    await makeSourceSkill('ce-review')
+    let announceTruncated: () => void
+    const lockIsTruncated = new Promise<void>((resolve) => {
+      announceTruncated = resolve
+    })
+    removeSkillsMock.mockImplementation(async (names) => {
+      const raw = await readFile(lockPath, 'utf-8')
+      const lock = JSON.parse(raw)
+      for (const name of names) delete lock.skills[name]
+      const finalContent = JSON.stringify(lock)
+      // Reproduce the window a non-atomic write leaves open on disk.
+      await writeFile(lockPath, finalContent.slice(0, 12), 'utf-8')
+      announceTruncated()
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      await writeFile(lockPath, finalContent, 'utf-8')
+      return { success: true }
+    })
+
+    // Act
+    const pruning = pruneLockEntries(['gone-from-disk'] as SkillName[])
+    await lockIsTruncated
+    const resolved = await resolveLockKeyForDirectory('ce-review')
+    await pruning
+
+    // Assert — the truncated bytes were on disk when this call was made; only
+    // serializing behind the write turns them back into the raw key.
+    expect(resolved).toBe('CE:Review')
   })
 })
 

--- a/src/main/services/skillLockService.ts
+++ b/src/main/services/skillLockService.ts
@@ -145,6 +145,13 @@ async function readSkillLockKeys(): Promise<LockReadResult> {
     if (parsed.data.version < SUPPORTED_LOCK_VERSION) {
       return { status: 'ok', keys: [] }
     }
+    // A newer CLI wrote a format this build has never seen. Its keys may not
+    // map onto directories the way `sanitizeName` assumes here, so this is the
+    // same "one side of the comparison is missing" case as an unreadable file:
+    // report nothing rather than prune against a guess.
+    if (parsed.data.version > SUPPORTED_LOCK_VERSION) {
+      return { status: 'unavailable' }
+    }
     return { status: 'ok', keys: Object.keys(parsed.data.skills) }
   } catch (error) {
     console.error('skillLockService: lock is not valid JSON', {
@@ -300,6 +307,14 @@ function buildUniqueDirNameIndex(
  * The eviction hook only knows the directory it just deleted; the CLI needs
  * the raw key back (`removeSkillFromLock` looks up `lock.skills[name]` by raw
  * name), so the mapping has to be inverted through `sanitizeName`.
+ *
+ * Reads inside {@link runLockWrite}: the CLI's own `writeSkillLock` is a plain
+ * `writeFile`, so a read racing an install can land on a half-written file and
+ * return null. Here that is unrecoverable rather than merely wrong — the trash
+ * entry that would re-queue the prune is already evicted, so the record is
+ * stranded until the user notices it in the dashboard. Nesting is safe: every
+ * `evict` caller is a detached timer or the startup sweep, none of them holding
+ * the mutex.
  * @param dirName - Basename of the source directory that was removed.
  * @returns The raw lock key, or null when nothing tracks that directory.
  * @example await resolveLockKeyForDirectory('ce-review') // => 'CE:Review'
@@ -307,9 +322,11 @@ function buildUniqueDirNameIndex(
 export async function resolveLockKeyForDirectory(
   dirName: string,
 ): Promise<SkillName | null> {
-  const lock = await readSkillLockKeys()
-  if (lock.status !== 'ok') return null
-  return buildUniqueDirNameIndex(lock.keys).get(dirName) ?? null
+  return runLockWrite(async () => {
+    const lock = await readSkillLockKeys()
+    if (lock.status !== 'ok') return null
+    return buildUniqueDirNameIndex(lock.keys).get(dirName) ?? null
+  })
 }
 
 /**
@@ -435,7 +452,8 @@ export async function scanStaleLockEntries(): Promise<StaleLockScanResult> {
  * Remove lock records by delegating to `skills remove --global -y`.
  *
  * Runs inside {@link runLockWrite}, and revalidates INSIDE that lock: a name is
- * dropped when its record already went away, and when its directory came back
+ * dropped when its record already went away, when another key has come to share
+ * its directory name, and when its directory came back
  * (a reinstall during the undo window would otherwise be destroyed by a delete
  * request that is no longer true). Success is decided by re-reading the lock
  * afterwards, never by the child's exit code — `skills remove` logs per-item
@@ -468,6 +486,11 @@ export async function pruneLockEntries(
     }
 
     const tracked = new Set(before.keys)
+    // Rebuilt from the lock as it is NOW, not as the scan saw it. Between scan
+    // and confirm another key can appear that sanitizes to the same directory,
+    // and upstream `removeSkillFromLock` is last-write-wins over sanitized
+    // names — delegating then would delete the OTHER record.
+    const unambiguousOwners = buildUniqueDirNameIndex(before.keys)
     const targets: SkillName[] = []
     const skipped: SkillName[] = []
     // Records we could neither confirm stale nor clear. They belong in
@@ -475,10 +498,22 @@ export async function pruneLockEntries(
     // `skipped` is a benign no-op the UI reports as "the skill came back",
     // while these are still stale and the user has to see that.
     const unverifiable: SkillName[] = []
+    // Kept apart from `unverifiable` even though both end in `failed`: this is
+    // "two records claim one directory", a state the user can act on by
+    // renaming, not an I/O error that might clear itself. The split is also the
+    // seam the scan-side half lands on — see TODOS.md P2, which needs this
+    // distinction to reach the dashboard as its own status.
+    const collided: SkillName[] = []
     for (const name of requested) {
       // Already gone from the lock — nothing to remove, and nothing is wrong.
       if (!tracked.has(name)) {
         skipped.push(name)
+        continue
+      }
+      // Another key now owns this directory name too, so "does its source
+      // exist" no longer answers anything about THIS record.
+      if (unambiguousOwners.get(sanitizeName(name)) !== name) {
+        collided.push(name)
         continue
       }
       // react-doctor-disable-next-line react-doctor/async-await-in-loop -- revalidation must stay inside the lock-write mutex; a Promise.all here would still be serialized by it and the batch is at most a screenful of names.
@@ -491,7 +526,8 @@ export async function pruneLockEntries(
       else unverifiable.push(name)
     }
 
-    if (targets.length === 0) return { ...empty, skipped, failed: unverifiable }
+    if (targets.length === 0)
+      return { ...empty, skipped, failed: [...unverifiable, ...collided] }
 
     // Absence was probed above; read the trash AFTER it. Same load-bearing
     // order as {@link scanStaleLockEntries} and it must not be swapped: a
@@ -509,7 +545,11 @@ export async function pruneLockEntries(
     // back) and the UI reports it as a benign no-op, while these records are
     // still stale and unverifiable — the user has to see that.
     if (trashed.status !== 'ok')
-      return { ...empty, skipped, failed: [...unverifiable, ...targets] }
+      return {
+        ...empty,
+        skipped,
+        failed: [...unverifiable, ...collided, ...targets],
+      }
 
     const removable: SkillName[] = []
     for (const name of targets) {
@@ -520,7 +560,7 @@ export async function pruneLockEntries(
     }
 
     if (removable.length === 0)
-      return { ...empty, skipped, failed: unverifiable }
+      return { ...empty, skipped, failed: [...unverifiable, ...collided] }
 
     // Last line before an irreversible delegation. See
     // {@link holdsRealAgentDirectory}: the CLI would recursively delete this
@@ -534,7 +574,11 @@ export async function pruneLockEntries(
     }
 
     if (delegable.length === 0)
-      return { ...empty, skipped, failed: [...unverifiable, ...refused] }
+      return {
+        ...empty,
+        skipped,
+        failed: [...unverifiable, ...collided, ...refused],
+      }
 
     // Raw keys, not sanitized — the CLI looks the record up by raw name and
     // sanitizes internally when it resolves paths.
@@ -545,7 +589,7 @@ export async function pruneLockEntries(
       return {
         pruned: [],
         skipped,
-        failed: [...unverifiable, ...delegable, ...refused],
+        failed: [...unverifiable, ...collided, ...delegable, ...refused],
       }
     }
     const survivors = new Set(after.keys)
@@ -554,6 +598,7 @@ export async function pruneLockEntries(
       skipped,
       failed: [
         ...unverifiable,
+        ...collided,
         ...delegable.filter((name) => survivors.has(name)),
         ...refused,
       ],

--- a/src/renderer/src/components/dashboard/LockPruneDialog.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/LockPruneDialog.browser.test.tsx
@@ -158,6 +158,36 @@ describe('LockPruneDialog', () => {
     expect(store.getState().skillLock.staleNames).toEqual(['old-skill'])
   })
 
+  test('removes the records it listed, not ones a scan added while it was open', async () => {
+    // Arrange — the confirm button is the consent gate for a delegated
+    // recursive delete. A scan landing mid-dialog must not widen what it acts
+    // on: the user never read the extra name.
+    mockPruneLockEntries.mockResolvedValue({
+      pruned: ['old-skill'],
+      skipped: [],
+      failed: [],
+    })
+    const { screen, store } = await renderDialog(['old-skill'])
+    const { fetchStaleLockEntries } =
+      await import('@/renderer/src/redux/slices/skillLockSlice')
+
+    // Act
+    store.dispatch(fetchStaleLockEntries.pending('req-late', undefined))
+    store.dispatch(
+      fetchStaleLockEntries.fulfilled(
+        { status: 'ok', names: ['old-skill', 'just-appeared'] },
+        'req-late',
+        undefined,
+      ),
+    )
+    // The label itself is the assertion: a live read would say "Remove 2
+    // records" here and this query would find nothing.
+    await screen.getByRole('button', { name: 'Remove 1 record' }).click()
+
+    // Assert
+    expect(mockPruneLockEntries).toHaveBeenCalledWith({ names: ['old-skill'] })
+  })
+
   test('closes without touching the lock when the user cancels', async () => {
     // Arrange
     const { screen, store } = await renderDialog(['old-skill'])

--- a/src/renderer/src/components/dashboard/LockPruneDialog.tsx
+++ b/src/renderer/src/components/dashboard/LockPruneDialog.tsx
@@ -26,6 +26,8 @@ import {
 import { pluralize } from '@/renderer/src/utils/pluralize'
 import type { PruneLockEntriesResult } from '@/shared/types'
 
+import { describeLockPruneTarget } from './lockPruneCopy'
+
 /**
  * Confirmation for removing skill-lock records whose skill is gone.
  *
@@ -45,6 +47,10 @@ export const LockPruneDialog = function LockPruneDialog(): React.ReactElement {
   // the user already read the names.
   const consentedNames = useAppSelector(selectConsentedLockEntryNames)
   const isPruning = useAppSelector(selectIsPruningLockEntries)
+  // Every count-dependent phrase comes from one call, so the sentence, the
+  // pronoun and the button label cannot disagree about how many records there
+  // are. Tested directly in `lockPruneCopy.test.ts`, without rendering.
+  const copy = describeLockPruneTarget(consentedNames.length)
 
   const handleClose = (): void => {
     if (!isPruning) dispatch(closeLockPruneDialog())
@@ -102,15 +108,10 @@ export const LockPruneDialog = function LockPruneDialog(): React.ReactElement {
             title="Prune skill lock"
           />
           <DialogDescription>
-            The skills CLI still tracks{' '}
-            {consentedNames.length === 1
-              ? 'a skill that is'
-              : `${consentedNames.length} skills that are`}{' '}
-            no longer installed. Until the{' '}
-            {pluralize(consentedNames.length, 'record')}{' '}
-            {consentedNames.length === 1 ? 'is' : 'are'} removed,{' '}
+            The skills CLI still tracks {copy.subject} no longer installed.
+            Until the {copy.recordNoun} {copy.recordVerb} removed,{' '}
             <code className="text-xs">skills -g update</code> reinstalls{' '}
-            {consentedNames.length === 1 ? 'it' : 'them'}.
+            {copy.pronoun}.
           </DialogDescription>
         </DialogHeader>
 
@@ -138,7 +139,7 @@ export const LockPruneDialog = function LockPruneDialog(): React.ReactElement {
                 Pruning...
               </>
             ) : (
-              `Remove ${consentedNames.length} ${pluralize(consentedNames.length, 'record')}`
+              copy.confirmLabel
             )}
           </Button>
         </DialogFooter>

--- a/src/renderer/src/components/dashboard/LockPruneDialog.tsx
+++ b/src/renderer/src/components/dashboard/LockPruneDialog.tsx
@@ -16,8 +16,8 @@ import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import {
   fetchStaleLockEntries,
   pruneStaleLockEntries,
+  selectConsentedLockEntryNames,
   selectIsPruningLockEntries,
-  selectStaleLockEntryNames,
 } from '@/renderer/src/redux/slices/skillLockSlice'
 import {
   closeLockPruneDialog,
@@ -40,7 +40,10 @@ import type { PruneLockEntriesResult } from '@/shared/types'
 export const LockPruneDialog = function LockPruneDialog(): React.ReactElement {
   const dispatch = useAppDispatch()
   const isOpen = useAppSelector(selectLockPruneDialogOpen)
-  const staleNames = useAppSelector(selectStaleLockEntryNames)
+  // The list as it was when the dialog opened, not as it is now. A scan
+  // landing mid-dialog would otherwise change what this button deletes after
+  // the user already read the names.
+  const consentedNames = useAppSelector(selectConsentedLockEntryNames)
   const isPruning = useAppSelector(selectIsPruningLockEntries)
 
   const handleClose = (): void => {
@@ -50,7 +53,7 @@ export const LockPruneDialog = function LockPruneDialog(): React.ReactElement {
   const handlePrune = async (): Promise<void> => {
     let result: PruneLockEntriesResult
     try {
-      result = await dispatch(pruneStaleLockEntries(staleNames)).unwrap()
+      result = await dispatch(pruneStaleLockEntries(consentedNames)).unwrap()
     } catch (error) {
       // A rejected thunk (IPC down, zod refusing an arg, main-process throw)
       // used to escape this handler unhandled: the dialog stayed open with no
@@ -67,7 +70,7 @@ export const LockPruneDialog = function LockPruneDialog(): React.ReactElement {
     // that survived will show up in the widget again on the next scan.
     if (result.failed.length > 0) {
       toast.error(
-        `Could not remove ${result.failed.length} of ${staleNames.length} ${pluralize(staleNames.length, 'record')}.`,
+        `Could not remove ${result.failed.length} of ${consentedNames.length} ${pluralize(consentedNames.length, 'record')}.`,
       )
     } else if (result.pruned.length === 0) {
       // Nothing failed, but nothing went either — main revalidated every name
@@ -100,20 +103,20 @@ export const LockPruneDialog = function LockPruneDialog(): React.ReactElement {
           />
           <DialogDescription>
             The skills CLI still tracks{' '}
-            {staleNames.length === 1
+            {consentedNames.length === 1
               ? 'a skill that is'
-              : `${staleNames.length} skills that are`}{' '}
+              : `${consentedNames.length} skills that are`}{' '}
             no longer installed. Until the{' '}
-            {pluralize(staleNames.length, 'record')}{' '}
-            {staleNames.length === 1 ? 'is' : 'are'} removed,{' '}
+            {pluralize(consentedNames.length, 'record')}{' '}
+            {consentedNames.length === 1 ? 'is' : 'are'} removed,{' '}
             <code className="text-xs">skills -g update</code> reinstalls{' '}
-            {staleNames.length === 1 ? 'it' : 'them'}.
+            {consentedNames.length === 1 ? 'it' : 'them'}.
           </DialogDescription>
         </DialogHeader>
 
         <ScrollArea className="max-h-48 rounded-md border border-border">
           <ul className="p-3 space-y-1 text-sm">
-            {staleNames.map((name) => (
+            {consentedNames.map((name) => (
               <li
                 key={name}
                 className="font-mono text-xs text-muted-foreground"
@@ -135,7 +138,7 @@ export const LockPruneDialog = function LockPruneDialog(): React.ReactElement {
                 Pruning...
               </>
             ) : (
-              `Remove ${staleNames.length} ${pluralize(staleNames.length, 'record')}`
+              `Remove ${consentedNames.length} ${pluralize(consentedNames.length, 'record')}`
             )}
           </Button>
         </DialogFooter>

--- a/src/renderer/src/components/dashboard/lockPruneCopy.test.ts
+++ b/src/renderer/src/components/dashboard/lockPruneCopy.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'vitest'
+
+import { describeLockPruneTarget } from './lockPruneCopy'
+
+describe('describeLockPruneTarget', () => {
+  test('reads as one skill throughout when a single record is up for deletion', () => {
+    // Arrange
+    const count = 1
+
+    // Act
+    const copy = describeLockPruneTarget(count)
+
+    // Assert
+    expect(copy).toEqual({
+      subject: 'a skill that is',
+      recordNoun: 'record',
+      recordVerb: 'is',
+      pronoun: 'it',
+      confirmLabel: 'Remove 1 record',
+    })
+  })
+
+  test('agrees in the plural across the sentence and the button for several records', () => {
+    // Arrange
+    const count = 3
+
+    // Act
+    const copy = describeLockPruneTarget(count)
+
+    // Assert
+    expect(copy).toEqual({
+      subject: '3 skills that are',
+      recordNoun: 'records',
+      recordVerb: 'are',
+      pronoun: 'them',
+      confirmLabel: 'Remove 3 records',
+    })
+  })
+
+  test('stays plural at zero so an empty dialog never reads as one skill', () => {
+    // Arrange
+    // The dialog opens on whatever the scan found; a race can leave it empty,
+    // and "a skill that is no longer installed" would then be a lie.
+    const count = 0
+
+    // Act
+    const copy = describeLockPruneTarget(count)
+
+    // Assert
+    expect(copy).toEqual({
+      subject: '0 skills that are',
+      recordNoun: 'records',
+      recordVerb: 'are',
+      pronoun: 'them',
+      confirmLabel: 'Remove 0 records',
+    })
+  })
+})

--- a/src/renderer/src/components/dashboard/lockPruneCopy.ts
+++ b/src/renderer/src/components/dashboard/lockPruneCopy.ts
@@ -1,0 +1,39 @@
+import { pluralize } from '@/renderer/src/utils/pluralize'
+
+/**
+ * The count-dependent wording the prune dialog renders, resolved once so the
+ * sentence, the button and the pronoun can never disagree about how many
+ * records are in play.
+ */
+export interface LockPruneCopy {
+  /** Subject clause: what the CLI still tracks. */
+  subject: string
+  /** Singular or plural noun for a lock record. */
+  recordNoun: string
+  /** Verb agreeing with {@link LockPruneCopy.recordNoun}. */
+  recordVerb: string
+  /** Object pronoun for what `skills -g update` would reinstall. */
+  pronoun: string
+  /** Label on the destructive confirm button. */
+  confirmLabel: string
+}
+
+/**
+ * Resolve every count-dependent phrase in the prune dialog from one number, so
+ * the copy is testable without rendering React; called on each render of
+ * {@link LockPruneDialog}.
+ * @param count - How many lock records the dialog is asking about.
+ * @returns The wording for that count.
+ * @example describeLockPruneTarget(1).confirmLabel // => 'Remove 1 record'
+ * @example describeLockPruneTarget(3).subject // => '3 skills that are'
+ */
+export function describeLockPruneTarget(count: number): LockPruneCopy {
+  const isSingular = count === 1
+  return {
+    subject: isSingular ? 'a skill that is' : `${count} skills that are`,
+    recordNoun: pluralize(count, 'record'),
+    recordVerb: isSingular ? 'is' : 'are',
+    pronoun: isSingular ? 'it' : 'them',
+    confirmLabel: `Remove ${count} ${pluralize(count, 'record')}`,
+  }
+}

--- a/src/renderer/src/redux/slices/skillLockSlice.test.ts
+++ b/src/renderer/src/redux/slices/skillLockSlice.test.ts
@@ -304,6 +304,100 @@ describe('skillLockSlice', () => {
     expect(selectStaleLockEntryCount(readState(store))).toBe(2)
   })
 
+  test('still reports the delete as running when a background scan lands mid-prune', async () => {
+    // Arrange
+    // Scans fire on a timer from the undo-toast listener and from every
+    // `refreshAllData`, so one landing mid-prune is routine and has nothing to
+    // do with the user. It may take over the record list, but it must not
+    // report the delegated delete as finished — that re-enables the confirm
+    // button while the CLI is still recursively removing directories.
+    const store = createTestStore()
+    store.dispatch(pruneStaleLockEntries.pending('req-prune', ['old-skill']))
+
+    // Act
+    store.dispatch(fetchStaleLockEntries.pending('req-scan', undefined))
+    store.dispatch(
+      fetchStaleLockEntries.fulfilled(
+        { status: 'ok', names: ['old-skill', 'newly-found'] },
+        'req-scan',
+        undefined,
+      ),
+    )
+
+    // Assert
+    expect(selectIsPruningLockEntries(readState(store))).toBe(true)
+  })
+
+  test('ends the prune normally after a scan took over the record list', async () => {
+    // Arrange
+    const store = createTestStore()
+    store.dispatch(pruneStaleLockEntries.pending('req-prune', ['old-skill']))
+    store.dispatch(fetchStaleLockEntries.pending('req-scan', undefined))
+    store.dispatch(
+      fetchStaleLockEntries.fulfilled(
+        { status: 'ok', names: ['old-skill', 'newly-found'] },
+        'req-scan',
+        undefined,
+      ),
+    )
+
+    // Act
+    store.dispatch(
+      pruneStaleLockEntries.fulfilled(
+        { pruned: ['old-skill'], skipped: [], failed: [] },
+        'req-prune',
+        ['old-skill'],
+      ),
+    )
+
+    // Assert
+    expect(selectIsPruningLockEntries(readState(store))).toBe(false)
+    expect(selectStaleLockEntryNames(readState(store))).toEqual([
+      'old-skill',
+      'newly-found',
+    ])
+  })
+
+  test('keeps the confirm button disabled when an older prune settles mid-delete', async () => {
+    // Arrange
+    // The dialog is dismissable with Esc and the corner X even while pruning,
+    // so a second prune can be started behind the first. Letting the first one
+    // report "done" would re-enable a destructive button while the CLI is
+    // still recursively deleting.
+    const store = createTestStore()
+    store.dispatch(pruneStaleLockEntries.pending('req-first', ['old-skill']))
+    store.dispatch(pruneStaleLockEntries.pending('req-second', ['old-skill']))
+
+    // Act
+    store.dispatch(
+      pruneStaleLockEntries.fulfilled(
+        { pruned: ['old-skill'], skipped: [], failed: [] },
+        'req-first',
+        ['old-skill'],
+      ),
+    )
+
+    // Assert
+    expect(selectIsPruningLockEntries(readState(store))).toBe(true)
+  })
+
+  test('leaves the newer prune running when an older one fails first', async () => {
+    // Arrange
+    const store = createTestStore()
+    store.dispatch(pruneStaleLockEntries.pending('req-first', ['old-skill']))
+    store.dispatch(pruneStaleLockEntries.pending('req-second', ['old-skill']))
+
+    // Act
+    store.dispatch(
+      pruneStaleLockEntries.rejected(new Error('IPC down'), 'req-first', [
+        'old-skill',
+      ]),
+    )
+
+    // Assert
+    expect(selectIsPruningLockEntries(readState(store))).toBe(true)
+  })
+
   test('asks about the records found now, not the ones the last open asked about', async () => {
     // Arrange
     // Nothing clears the snapshot on close — that would blank the dialog during

--- a/src/renderer/src/redux/slices/skillLockSlice.test.ts
+++ b/src/renderer/src/redux/slices/skillLockSlice.test.ts
@@ -4,10 +4,12 @@ import { describe, expect, test } from 'vitest'
 import skillLockReducer, {
   fetchStaleLockEntries,
   pruneStaleLockEntries,
+  selectConsentedLockEntryNames,
   selectIsPruningLockEntries,
   selectStaleLockEntryCount,
   selectStaleLockEntryNames,
 } from './skillLockSlice'
+import { closeLockPruneDialog, openLockPruneDialog } from './uiSlice'
 
 /**
  * Minimal store holding only the slice under test. Selectors take `RootState`
@@ -105,6 +107,11 @@ describe('skillLockSlice', () => {
     )
 
     // Act
+    // `pending` first: the reducer only applies a prune result whose requestId
+    // is the one still in flight, so a bare `fulfilled` would be ignored.
+    store.dispatch(
+      pruneStaleLockEntries.pending('req-2', ['pruned-ok', 'stubborn']),
+    )
     store.dispatch(
       pruneStaleLockEntries.fulfilled(
         { pruned: ['pruned-ok'], skipped: [], failed: ['stubborn'] },
@@ -201,6 +208,134 @@ describe('skillLockSlice', () => {
       'current-truth',
     ])
     expect(selectStaleLockEntryCount(readState(store))).toBe(1)
+  })
+
+  test('keeps a scan that landed mid-prune instead of letting the prune restore the older list', async () => {
+    // Arrange
+    // A scan can also land WHILE the prune is in flight. That one read the lock
+    // after the rewrite began, so it is the newer truth; the prune's `failed`
+    // is the pre-prune view and would drop the record the scan just found.
+    const store = createTestStore()
+    store.dispatch(pruneStaleLockEntries.pending('req-prune', ['old-skill']))
+    store.dispatch(fetchStaleLockEntries.pending('req-mid-prune', undefined))
+    store.dispatch(
+      fetchStaleLockEntries.fulfilled(
+        { status: 'ok', names: ['old-skill', 'newly-stale'] },
+        'req-mid-prune',
+        undefined,
+      ),
+    )
+
+    // Act
+    store.dispatch(
+      pruneStaleLockEntries.fulfilled(
+        { pruned: [], skipped: [], failed: ['old-skill'] },
+        'req-prune',
+        ['old-skill'],
+      ),
+    )
+
+    // Assert
+    expect(selectStaleLockEntryNames(readState(store))).toEqual([
+      'old-skill',
+      'newly-stale',
+    ])
+    expect(selectIsPruningLockEntries(readState(store))).toBe(false)
+  })
+
+  test('shows no records at all when the scan that failed mid-prune left the count unavailable', async () => {
+    // Arrange
+    // `unavailable` means one side of the comparison is missing. A prune
+    // reporting survivors afterwards would list names behind a status that says
+    // we cannot stand behind any count — the list is what the dialog renders.
+    const store = createTestStore()
+    store.dispatch(pruneStaleLockEntries.pending('req-prune', ['old-skill']))
+    store.dispatch(fetchStaleLockEntries.pending('req-mid-prune', undefined))
+    store.dispatch(
+      fetchStaleLockEntries.rejected(
+        new Error('IPC exploded'),
+        'req-mid-prune',
+      ),
+    )
+
+    // Act
+    store.dispatch(
+      pruneStaleLockEntries.fulfilled(
+        { pruned: [], skipped: [], failed: ['old-skill'] },
+        'req-prune',
+        ['old-skill'],
+      ),
+    )
+
+    // Assert
+    expect(selectStaleLockEntryNames(readState(store))).toEqual([])
+    expect(selectStaleLockEntryCount(readState(store))).toBe(0)
+  })
+
+  test('freezes the record list the prune dialog opened on so a later scan cannot change what it deletes', async () => {
+    // Arrange
+    // The dialog is the consent gate for a delegated recursive delete: what it
+    // acts on has to be exactly what the user read.
+    const store = createTestStore()
+    store.dispatch(fetchStaleLockEntries.pending('req-1', undefined))
+    store.dispatch(
+      fetchStaleLockEntries.fulfilled(
+        { status: 'ok', names: ['old-skill'] },
+        'req-1',
+        undefined,
+      ),
+    )
+    store.dispatch(openLockPruneDialog())
+
+    // Act — a background scan finds a second record while the dialog is up.
+    store.dispatch(fetchStaleLockEntries.pending('req-2', undefined))
+    store.dispatch(
+      fetchStaleLockEntries.fulfilled(
+        { status: 'ok', names: ['old-skill', 'just-appeared'] },
+        'req-2',
+        undefined,
+      ),
+    )
+
+    // Assert — the widget count moves; the consented set does not.
+    expect(selectConsentedLockEntryNames(readState(store))).toEqual([
+      'old-skill',
+    ])
+    expect(selectStaleLockEntryCount(readState(store))).toBe(2)
+  })
+
+  test('asks about the records found now, not the ones the last open asked about', async () => {
+    // Arrange
+    // Nothing clears the snapshot on close — that would blank the dialog during
+    // its exit animation — so reopening is the only thing standing between the
+    // user and a confirm button labelled with a list from a previous session.
+    const store = createTestStore()
+    store.dispatch(fetchStaleLockEntries.pending('req-1', undefined))
+    store.dispatch(
+      fetchStaleLockEntries.fulfilled(
+        { status: 'ok', names: ['old-skill'] },
+        'req-1',
+        undefined,
+      ),
+    )
+    store.dispatch(openLockPruneDialog())
+    store.dispatch(closeLockPruneDialog())
+    store.dispatch(fetchStaleLockEntries.pending('req-2', undefined))
+    store.dispatch(
+      fetchStaleLockEntries.fulfilled(
+        { status: 'ok', names: ['different-skill'] },
+        'req-2',
+        undefined,
+      ),
+    )
+
+    // Act
+    store.dispatch(openLockPruneDialog())
+
+    // Assert
+    expect(selectConsentedLockEntryNames(readState(store))).toEqual([
+      'different-skill',
+    ])
   })
 
   test('does not let a scan started before a prune put the pruned records back', async () => {

--- a/src/renderer/src/redux/slices/skillLockSlice.ts
+++ b/src/renderer/src/redux/slices/skillLockSlice.ts
@@ -23,8 +23,6 @@ interface SkillLockState {
   staleNames: SkillName[]
   /** `idle` before the first scan; `unavailable` when main could not compare. */
   status: 'idle' | 'ok' | 'unavailable'
-  /** True while a prune is in flight, so the confirm button can disable. */
-  pruning: boolean
   /**
    * `requestId` of the newest scan whose result may still be applied. Four
    * call sites dispatch scans independently (mount, refresh thunk, listener,
@@ -34,12 +32,22 @@ interface SkillLockState {
    */
   scanRequestId: string | null
   /**
-   * `requestId` of the in-flight prune whose result may still replace the list.
-   * Cleared by any scan that lands first: that scan read the lock after the
-   * prune began writing, so its list is the newer truth and the prune's
-   * `failed` must not put the pre-prune names back over it.
+   * `requestId` of the prune in flight, or null when none is. Doubles as the
+   * busy flag behind {@link selectIsPruningLockEntries} rather than sitting
+   * beside a separate boolean, so "a prune is running" and "which prune" cannot
+   * drift apart: only the prune that set this may clear it, and an older one
+   * settling can never re-enable the confirm button mid-delete.
    */
   pruneRequestId: string | null
+  /**
+   * Set when a scan lands while a prune is in flight. That scan read the lock
+   * after the prune began writing, so its list is the newer truth and the
+   * prune's `failed` must not put the pre-prune names back over it. Kept apart
+   * from {@link SkillLockState.pruneRequestId} because that one still has to
+   * let its own prune release the busy state — clearing it here would leave the
+   * dialog stuck on "Pruning..." with every control disabled.
+   */
+  staleNamesSupersededByScan: boolean
   /**
    * The exact list the prune dialog was opened on. The dialog is the consent
    * gate for a delegated recursive delete, so what it acts on has to be what
@@ -54,9 +62,9 @@ interface SkillLockState {
 const initialState: SkillLockState = {
   staleNames: [],
   status: 'idle',
-  pruning: false,
   scanRequestId: null,
   pruneRequestId: null,
+  staleNamesSupersededByScan: false,
   consentedNames: [],
 }
 
@@ -101,8 +109,9 @@ const skillLockSlice = createSlice({
         // Superseded by a newer scan, or invalidated by a prune.
         if (action.meta.requestId !== state.scanRequestId) return
         // This scan read the lock after the prune started writing it, so its
-        // answer outranks whatever that prune is about to report.
-        state.pruneRequestId = null
+        // answer outranks whatever that prune is about to report. It does not
+        // touch `pruneRequestId`: that prune still has to be able to end itself.
+        state.staleNamesSupersededByScan = true
         if (action.payload.status === 'ok') {
           state.status = 'ok'
           state.staleNames = action.payload.names
@@ -118,30 +127,33 @@ const skillLockSlice = createSlice({
         // Same reason as the fulfilled case, and it matters more here: `failed`
         // landing afterwards would list records behind an `unavailable` status
         // that says we cannot stand behind any count.
-        state.pruneRequestId = null
+        state.staleNamesSupersededByScan = true
         state.status = 'unavailable'
         state.staleNames = []
       })
       .addCase(pruneStaleLockEntries.pending, (state, action) => {
-        state.pruning = true
         state.scanRequestId = null
         state.pruneRequestId = action.meta.requestId
+        state.staleNamesSupersededByScan = false
       })
       .addCase(pruneStaleLockEntries.fulfilled, (state, action) => {
-        state.pruning = false
-        // A scan already answered from a newer read of the lock. `failed` is
-        // the pre-scan view, so applying it would drop records that scan added.
+        // Only the prune that owns the busy state may release it. An older one
+        // settling here would report "not pruning" while a newer delete is
+        // still running, re-enabling the confirm button mid-delegation.
         if (action.meta.requestId !== state.pruneRequestId) return
         state.pruneRequestId = null
+        // A scan already answered from a newer read of the lock. `failed` is
+        // the pre-scan view, so applying it would drop records that scan added.
+        if (state.staleNamesSupersededByScan) return
         // Anything that survived is still stale; a follow-up scan would find
         // it again, so keep it visible instead of flashing "all clear".
         state.staleNames = action.payload.failed
       })
-      .addCase(pruneStaleLockEntries.rejected, (state) => {
-        state.pruning = false
-        // `pruneRequestId` is deliberately left alone: a thunk settles once, so
-        // this id can never match a later `fulfilled`, and the next `pending`
-        // overwrites it. Clearing it here would only add an untestable branch.
+      .addCase(pruneStaleLockEntries.rejected, (state, action) => {
+        // Same ownership check as the fulfilled case: releasing the busy state
+        // is the newest prune's to do, never an older one's.
+        if (action.meta.requestId !== state.pruneRequestId) return
+        state.pruneRequestId = null
       })
       // Snapshot for the dialog. Lives here rather than in `uiSlice` because
       // only this slice can see `staleNames` at the moment the dialog opens.
@@ -173,8 +185,16 @@ export const selectStaleLockEntryNames = (state: RootState): SkillName[] =>
 export const selectStaleLockEntryCount = (state: RootState): number =>
   state.skillLock.status === 'ok' ? state.skillLock.staleNames.length : 0
 
+/**
+ * Whether a prune is in flight, derived from the in-flight request id so a
+ * separate boolean can never contradict it; read by {@link LockPruneDialog} to
+ * disable both footer buttons during a delegated delete.
+ * @param state - Root Redux state.
+ * @returns True while a prune has been dispatched and has not settled.
+ * @example useAppSelector(selectIsPruningLockEntries) // => false
+ */
 export const selectIsPruningLockEntries = (state: RootState): boolean =>
-  state.skillLock.pruning
+  state.skillLock.pruneRequestId !== null
 
 /**
  * The records the open prune dialog is asking about, frozen when it opened.

--- a/src/renderer/src/redux/slices/skillLockSlice.ts
+++ b/src/renderer/src/redux/slices/skillLockSlice.ts
@@ -1,5 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 
+import { openLockPruneDialog } from '@/renderer/src/redux/slices/uiSlice'
 import type { RootState } from '@/renderer/src/redux/store'
 import type { SkillName } from '@/shared/types'
 
@@ -32,6 +33,22 @@ interface SkillLockState {
    * was rewritten is describing a lock that no longer exists.
    */
   scanRequestId: string | null
+  /**
+   * `requestId` of the in-flight prune whose result may still replace the list.
+   * Cleared by any scan that lands first: that scan read the lock after the
+   * prune began writing, so its list is the newer truth and the prune's
+   * `failed` must not put the pre-prune names back over it.
+   */
+  pruneRequestId: string | null
+  /**
+   * The exact list the prune dialog was opened on. The dialog is the consent
+   * gate for a delegated recursive delete, so what it acts on has to be what
+   * the user read — a scan landing while it is open would otherwise swap the
+   * list out from under the confirm button. Deliberately NOT cleared on close:
+   * the dialog stays mounted through its 200ms exit animation, so emptying it
+   * there blanks the description, the list, and the button label mid-fade.
+   */
+  consentedNames: SkillName[]
 }
 
 const initialState: SkillLockState = {
@@ -39,6 +56,8 @@ const initialState: SkillLockState = {
   status: 'idle',
   pruning: false,
   scanRequestId: null,
+  pruneRequestId: null,
+  consentedNames: [],
 }
 
 /**
@@ -81,6 +100,9 @@ const skillLockSlice = createSlice({
       .addCase(fetchStaleLockEntries.fulfilled, (state, action) => {
         // Superseded by a newer scan, or invalidated by a prune.
         if (action.meta.requestId !== state.scanRequestId) return
+        // This scan read the lock after the prune started writing it, so its
+        // answer outranks whatever that prune is about to report.
+        state.pruneRequestId = null
         if (action.payload.status === 'ok') {
           state.status = 'ok'
           state.staleNames = action.payload.names
@@ -93,21 +115,40 @@ const skillLockSlice = createSlice({
       })
       .addCase(fetchStaleLockEntries.rejected, (state, action) => {
         if (action.meta.requestId !== state.scanRequestId) return
+        // Same reason as the fulfilled case, and it matters more here: `failed`
+        // landing afterwards would list records behind an `unavailable` status
+        // that says we cannot stand behind any count.
+        state.pruneRequestId = null
         state.status = 'unavailable'
         state.staleNames = []
       })
-      .addCase(pruneStaleLockEntries.pending, (state) => {
+      .addCase(pruneStaleLockEntries.pending, (state, action) => {
         state.pruning = true
         state.scanRequestId = null
+        state.pruneRequestId = action.meta.requestId
       })
       .addCase(pruneStaleLockEntries.fulfilled, (state, action) => {
         state.pruning = false
+        // A scan already answered from a newer read of the lock. `failed` is
+        // the pre-scan view, so applying it would drop records that scan added.
+        if (action.meta.requestId !== state.pruneRequestId) return
+        state.pruneRequestId = null
         // Anything that survived is still stale; a follow-up scan would find
         // it again, so keep it visible instead of flashing "all clear".
         state.staleNames = action.payload.failed
       })
       .addCase(pruneStaleLockEntries.rejected, (state) => {
         state.pruning = false
+        // `pruneRequestId` is deliberately left alone: a thunk settles once, so
+        // this id can never match a later `fulfilled`, and the next `pending`
+        // overwrites it. Clearing it here would only add an untestable branch.
+      })
+      // Snapshot for the dialog. Lives here rather than in `uiSlice` because
+      // only this slice can see `staleNames` at the moment the dialog opens.
+      // Unconditional, so reopening can never inherit the previous list — which
+      // is also why nothing clears this on close.
+      .addCase(openLockPruneDialog, (state) => {
+        state.consentedNames = [...state.staleNames]
       })
   },
 })
@@ -134,3 +175,14 @@ export const selectStaleLockEntryCount = (state: RootState): number =>
 
 export const selectIsPruningLockEntries = (state: RootState): boolean =>
   state.skillLock.pruning
+
+/**
+ * The records the open prune dialog is asking about, frozen when it opened.
+ * Every surface inside that dialog reads this instead of the live list, so the
+ * names, the count, and the delete request can never disagree with each other.
+ * @param state - Root Redux state.
+ * @returns Lock keys the user is being asked to confirm.
+ * @example useAppSelector(selectConsentedLockEntryNames) // => ['old-skill']
+ */
+export const selectConsentedLockEntryNames = (state: RootState): SkillName[] =>
+  state.skillLock.consentedNames


### PR DESCRIPTION
Five correctness holes in the stale-lock prune path, all surfaced by the same review. Each one can delete or strand a record the user never pointed at.

## What was wrong

1. **`resolveLockKeyForDirectory` read the lock outside the write mutex.** The CLI's own `writeSkillLock` is a plain `writeFile`, so a read racing an install lands on a half-written file and returns `null`. Here that is unrecoverable, not merely wrong: the trash entry that would re-queue the prune is already evicted, so the record is stranded until the user spots it in the dashboard.
2. **The directory-collision index was built from the scan's view, not the lock's current view.** Between scan and confirm, another key can appear that sanitizes to the same directory. Upstream `removeSkillFromLock` is last-write-wins over sanitized names, so delegating then would delete the *other* record.
3. **A scan landing mid-prune got overwritten by the prune's `failed` list.** `failed` is the pre-scan view; applying it drops records the newer scan found. Now guarded by `pruneRequestId`, cleared on both `scan.fulfilled` and `scan.rejected` — the rejected case matters more, since `failed` landing after it would list records behind an `unavailable` status that says we cannot stand behind any count.
4. **The prune dialog read the live stale list.** A scan landing while the dialog was open swapped the list out from under the confirm button, so the delete could act on names the user never read. The dialog now reads `consentedNames`, snapshotted unconditionally on `openLockPruneDialog`. Nothing clears it on close on purpose: the dialog stays mounted through its 200ms exit animation, so emptying it there would blank the description, the list, and the button label mid-fade on the Cancel path. Reopening is what guarantees freshness, and there is a test for exactly that.
5. **No upper bound on the lock version.** A newer CLI's format may not map onto directories the way `sanitizeName` assumes, so `readSkillLockKeys` now returns `unavailable` rather than pruning against a guess.

## Scope

`TODOS.md` P2 is **half** fixed, and says so. The prune-mutex half is here; the scan-side half — surfacing collided keys as their own "cannot determine" state — needs a new state on `StaleLockScanResult` plus renderer copy, which is the same shape as the manual-recovery TODO below it. They are deferred together, and the `collided` / `unverifiable` split in `pruneLockEntries` is the seam that half lands on (both flow into `failed` today; that is staged, not speculative).

Four P3 sub-items are struck through as fixed.

## Test plan

- `pnpm validate` — 193 files, 2495 tests passed
- `pnpm test:coverage` — `94.87 / 85.06 / 96.8 / 99.27` against thresholds `94.5 / 84.5 / 96.0 / 99.2`
- `pnpm test:e2e` — 84 passed. This includes the existing prune spec driving the real dialog end to end, which is what proves the `consentedNames` snapshot does not leave the dialog empty when the CTA is clicked before a scan lands.
- Every new test was mutation-verified: reverting its fix individually fails it, and only it.

New coverage: lock version upper bound; post-scan directory collision refused rather than delegated; `resolveLockKeyForDirectory` waiting out a deliberately truncated lock file; scan-beats-prune ordering in both `fulfilled` and `rejected` shapes; the dialog deleting the record list it displayed rather than one a later scan grew.

Refs TODOS.md P2 (prune-mutex half) and P3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - ロック削除処理で衝突を検出した場合、誤って削除せず失敗として扱うようになりました。
  - 新しい形式のロックは安全のため「利用不可」として扱います。
  - ロック情報の書き込み中に不完全な状態を読み取らないよう改善しました。
  - 削除確認ダイアログの表示内容とボタン文言を、対象件数に応じて適切に表示します。

- **不具合修正**
  - ダイアログ表示後に追加された項目が削除対象になる問題を修正しました。
  - 処理中に更新されたスキャン結果との競合を防止しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
