### PR TITLE
fix(lock): explain the stale records the prune cannot touch

### DIFF
--- a/.storybook/storybook-utils.tsx
+++ b/.storybook/storybook-utils.tsx
@@ -489,7 +489,11 @@ export function installStorybookElectronMock(): void {
       onDeleteProgress: () => cleanup,
       // Stories never touch the real lock file; a clean scan keeps the
       // stale-lock row and its CTA out of every dashboard snapshot.
-      scanStaleLockEntries: async () => ({ status: 'ok' as const, names: [] }),
+      scanStaleLockEntries: async () => ({
+        status: 'ok' as const,
+        names: [],
+        unprunable: [],
+      }),
       pruneLockEntries: async () => ({ pruned: [], skipped: [], failed: [] }),
     },
     agents: {

--- a/TODOS.md
+++ b/TODOS.md
@@ -1259,10 +1259,24 @@ who ran `skills add --copy`, which creates no universal source at all and so
 reads as permanently stale — gets a lock record that can never be pruned and
 no explanation in the UI.
 
+**Status:** Half fixed — the dead end is explained, the delegation decision is
+still open.
+
+The scan now runs `holdsRealAgentDirectory` over the names it already proved
+stale and reports them as `unprunable` with `reason: 'agent-copy'`, so the user
+is told before clicking a button that would only ever report a failure. Cost is
+bounded by the stale list (normally empty), not the lock size: running it per
+lock key on a timer-fired scan would have been a filesystem storm, which is why
+the check lives after the absence probe rather than beside it. The prune keeps
+its own copy of the check as the TOCTOU backstop.
+
+REMAINING: the record still cannot be pruned at all. That needs the delegation
+decision below, which is an architecture call, not a UI one.
+
 **Fix direction:** either narrow the delegation (pass `--agent` restricted to
 universal-source agents), or stop delegating and edit the lock directly,
-accepting ownership of the lock format. Surface a distinct "cannot prune"
-state either way. See `docs/adr/0001-prune-the-skill-lock-at-trash-eviction.md`
+accepting ownership of the lock format. See
+`docs/adr/0001-prune-the-skill-lock-at-trash-eviction.md`
 (corrected 2026-09-06).
 
 **Depends on / blocked by:** Nothing.
@@ -1363,22 +1377,26 @@ index, and upstream `removeSkillFromLock` is last-write-wins over sanitized
 names, so a collision appearing between scan and confirm removes the _other_
 record while the requested one is reported failed.
 
-**Status:** Half fixed. The prune mutex now re-checks the collision index
+**Status:** Fixed.
+
+Prune half: the prune mutex re-checks the collision index
 (`skillLockService.ts` `pruneLockEntries`): a name whose sanitized form is no
 longer uniquely its own is routed to `failed` and never delegated, so a
 collision appearing between scan and confirm can no longer delete the other
 record. Covered by `skillLockService.test.ts` "refuses a name another lock key
 started sharing a directory with after the scan".
 
-REMAINING: the scan still drops collided keys silently, so the pair stays
-unprunable with nothing in the UI explaining why. That half needs a new state
-on `StaleLockScanResult` plus the renderer copy to render it, which is the same
-"an unprunable state needs a UI explanation" shape as the manual-recovery entry
-below — do them together.
+Scan half: `StaleLockScanResult` now carries
+`unprunable: { name, reason }[]`, and a collided key is reported there with
+`reason: 'name-collision'` instead of being dropped. `LockPruneDialog` renders
+the pair with one sentence saying why removing either could remove the wrong
+record, and the Symlink Health count includes blocked records so an all-blocked
+lock cannot report "Healthy". No extra I/O: the collision set falls straight out
+of the index the scan already builds.
 
-**Fix direction:** surface collisions as a distinct "cannot determine" state.
-
-**Depends on / blocked by:** Nothing.
+Note the grouping in the old text was wrong. Only the agent-copy entry (P1
+above) shares this shape; the manual-recovery entry below turned out to be a
+scan false-negative, not an unprunable state — see there.
 
 ### P3. Smaller items from the same review
 
@@ -1386,9 +1404,24 @@ below — do them together.
   FIXED: it now runs inside the mutex. Nesting was verified safe against
   source first — all three `evict` call sites are detached timers or the
   startup sweep, none holding the lock.
-- Manual-recovery trash entries keep their lock record alive forever:
+- ~~Manual-recovery trash entries keep their lock record alive forever:
   `readTrashedSourceDirNames` counts them as "still restorable" although their
-  restore already failed permanently.
+  restore already failed permanently.~~ FIXED, and it was worse than filed. Both
+  source-backed writers of the `.manual-recovery` marker run BEFORE the manifest
+  exists (`trashService.ts` source-move failure, and manifest-write rollback), so
+  the entry read as ENOENT on a parseable tombstone id — which
+  `readTrashedSourceDirNames` treats as "one of our entries caught mid-write" and
+  answers `unavailable` for the whole scan. `startupCleanup` deliberately never
+  sweeps a marked entry, so that was permanent: one stuck entry killed the
+  stale-lock feature outright and failed every prune closed, with no way back.
+  `readTrashedSourceDirNames` now checks the marker first, which both keeps the
+  scan alive and stops a terminally-stuck entry counting as a live undo window.
+  The marker filename moved to `@/main/constants` so both services read one
+  source (the import direction between them is already spent).
+- ~~The prune dialog's corner X stayed clickable mid-prune.~~ FIXED:
+  `hideCloseButton={isPruning}`. `handleClose` already refused to close during a
+  prune, so Esc and outside-click were never a gap — the X was simply a visible
+  control that silently did nothing.
 - ~~`LockPruneDialog` reads `staleNames` live rather than snapshotting at
   open.~~ FIXED: `openLockPruneDialog` snapshots into `consentedNames` and the
   dialog reads only that, so the list, the count, the button label and the
@@ -1410,8 +1443,11 @@ below — do them together.
 - Feature copy uses four nouns for one concept ("deleted skills", "records",
   "stale records", "skills that are no longer installed") against the internal
   `StaleLockEntry` naming. Pick one.
-- `PruneLockEntriesResult.skipped` has no reader in the renderer.
-- Dead JSDoc link `{@link skillLockService}` at `skillsCliService.ts:184`.
+- ~~`PruneLockEntriesResult.skipped` has no reader in the renderer.~~ Not true
+  as filed: `LockPruneDialog.tsx` reads it for the "Kept N records" toast on the
+  nothing-pruned branch.
+- Dead JSDoc link `{@link skillLockService}` at `skillsCliService.ts:210`
+  (the line number in the original filing has drifted; the link itself is real).
 - No E2E reaches the npx-unavailable prune path. `e2e/spec/skill-lock-prune.e2e.ts`
   (added by /qa on `feat/prune-stale-skill-lock-entries`, 2026-09-06) covers
   every guard plus one real `npx skills remove`, but the branch where the CLI

--- a/e2e/spec/skill-lock-prune.e2e.ts
+++ b/e2e/spec/skill-lock-prune.e2e.ts
@@ -186,7 +186,11 @@ test('reports only the lock record whose skill directory was deleted outside the
 
   // Assert: only the tracked-and-missing record is stale. A skill that is
   // present stays out, and a skill the lock never knew about is never invented.
-  expect(result).toEqual({ status: 'ok', names: [CONTROL_STALE_KEY] })
+  expect(result).toEqual({
+    status: 'ok',
+    names: [CONTROL_STALE_KEY],
+    unprunable: [],
+  })
 })
 
 test('refuses to call the whole lock stale when the skills source root is missing', async ({
@@ -220,10 +224,14 @@ test('keeps a lock key out of the stale list when only its sanitized form is on 
   const result = await scanStaleLockEntries(appWindow)
 
   // Assert: the control proves the scan ran; the divergent key is not stale.
-  expect(result).toEqual({ status: 'ok', names: [CONTROL_STALE_KEY] })
+  expect(result).toEqual({
+    status: 'ok',
+    names: [CONTROL_STALE_KEY],
+    unprunable: [],
+  })
 })
 
-test('excludes both lock keys when two of them sanitize to the same directory name', async ({
+test('reports both lock keys that sanitize to one directory name as blocked, never as deletable', async ({
   appWindow,
   isolatedHome,
 }) => {
@@ -238,8 +246,17 @@ test('excludes both lock keys when two of them sanitize to the same directory na
   // Act
   const result = await scanStaleLockEntries(appWindow)
 
-  // Assert: pruning a collided key could strand the twin that still exists.
-  expect(result).toEqual({ status: 'ok', names: [CONTROL_STALE_KEY] })
+  // Assert: pruning a collided key could strand the twin that still exists, so
+  // neither is offered — but the pair is named, not dropped, or the user has no
+  // way to learn why `skills -g update` keeps bringing them back.
+  expect(result).toEqual({
+    status: 'ok',
+    names: [CONTROL_STALE_KEY],
+    unprunable: [
+      { name: 'lock-prune/dup', reason: 'name-collision' },
+      { name: 'lock-prune:dup', reason: 'name-collision' },
+    ],
+  })
 })
 
 test('keeps a skill inside its undo window out of the stale list', async ({
@@ -254,7 +271,11 @@ test('keeps a skill inside its undo window out of the stale list', async ({
   const result = await scanStaleLockEntries(appWindow)
 
   // Assert: offering to prune it would strand the skill Undo brings back.
-  expect(result).toEqual({ status: 'ok', names: [CONTROL_STALE_KEY] })
+  expect(result).toEqual({
+    status: 'ok',
+    names: [CONTROL_STALE_KEY],
+    unprunable: [],
+  })
 })
 
 test('refuses to report a corrupt lock as zero stale records', async ({
@@ -282,7 +303,7 @@ test('reports no stale records when the lock tracks nothing', async ({
   const result = await scanStaleLockEntries(appWindow)
 
   // Assert
-  expect(result).toEqual({ status: 'ok', names: [] })
+  expect(result).toEqual({ status: 'ok', names: [], unprunable: [] })
 })
 
 test('refuses to prune a lock key that still owns a real directory inside an agent', async ({

--- a/e2e/types.d.ts
+++ b/e2e/types.d.ts
@@ -216,7 +216,15 @@ declare global {
          * as "nothing to prune".
          */
         scanStaleLockEntries: () => Promise<
-          { status: 'ok'; names: string[] } | { status: 'unavailable' }
+          | {
+              status: 'ok'
+              names: string[]
+              unprunable: {
+                name: string
+                reason: 'name-collision' | 'agent-copy'
+              }[]
+            }
+          | { status: 'unavailable' }
         >
         pruneLockEntries: (options: { names: string[] }) => Promise<{
           pruned: string[]

--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -19,6 +19,15 @@ export const SOURCE_DIR = join(homedir(), '.agents', 'skills')
 export const TRASH_DIR = join(homedir(), '.agents', '.trash')
 
 /**
+ * Filename that marks a trash entry as terminal: its automatic restore already
+ * failed for good, so `startupCleanup` must never sweep it and the lock scan
+ * must never count it as "still restorable". Lives here for the same reason as
+ * {@link TRASH_DIR} — both services read it and the import direction between
+ * them is already spent (`trashService` imports `skillLockService`).
+ */
+export const MANUAL_RECOVERY_MARKER = '.manual-recovery'
+
+/**
  * Supported AI agents with their full skills directory paths.
  *
  * Built from `scanDir` (always required on AGENT_DEFINITIONS). For most

--- a/src/main/services/skillLockService.test.ts
+++ b/src/main/services/skillLockService.test.ts
@@ -97,6 +97,40 @@ async function makeTombstone(dirName: string): Promise<void> {
   )
 }
 
+/**
+ * Stage a trash entry that failed its automatic restore, exactly as
+ * `trashService` leaves one: the marker is written while no manifest exists,
+ * because both source-backed writers run before the manifest is created.
+ * @param dirName - Basename of the source directory the entry was staged from.
+ * @param withManifest - Also write a valid manifest (a shape today's writers never produce).
+ * @example await makeManualRecoveryEntry('stuck-skill')
+ */
+async function makeManualRecoveryEntry(
+  dirName: string,
+  withManifest = false,
+): Promise<void> {
+  if (withManifest) await makeTombstone(dirName)
+  const entryDir = join(trashDir, `1700000000000-${dirName}-aaaaaaaa`)
+  await mkdir(entryDir, { recursive: true })
+  await writeFile(
+    join(entryDir, '.manual-recovery'),
+    'manual recovery required\nreason: test\n',
+    'utf-8',
+  )
+}
+
+/**
+ * Give an agent a REAL directory (not a symlink) under a skill name, the state
+ * that makes `skills remove --global` destructive.
+ * @param dirName - Sanitized skill directory name.
+ * @example await makeAgentOwnedDir('agent-owned')
+ */
+async function makeAgentOwnedDir(dirName: string): Promise<void> {
+  const dir = join(sharedHome, '.claude', 'skills', dirName)
+  await mkdir(dir, { recursive: true })
+  await writeFile(join(dir, 'SKILL.md'), '# local\n', 'utf-8')
+}
+
 /** Read the lock keys straight off disk, bypassing the service under test. */
 async function readLockKeys(): Promise<string[]> {
   const raw = await readFile(lockPath, 'utf-8')
@@ -137,7 +171,11 @@ describe('scanStaleLockEntries', () => {
     const result = await scanStaleLockEntries()
 
     // Assert
-    expect(result).toEqual({ status: 'ok', names: ['deleted-in-finder'] })
+    expect(result).toEqual({
+      status: 'ok',
+      names: ['deleted-in-finder'],
+      unprunable: [],
+    })
   })
 
   test('settles a queued prune before counting, so it never offers work already in flight', async () => {
@@ -152,7 +190,7 @@ describe('scanStaleLockEntries', () => {
     const result = await scanStaleLockEntries()
 
     // Assert
-    expect(result).toEqual({ status: 'ok', names: [] })
+    expect(result).toEqual({ status: 'ok', names: [], unprunable: [] })
     expect(await readLockKeys()).toEqual([])
   })
 
@@ -168,7 +206,7 @@ describe('scanStaleLockEntries', () => {
     const result = await scanStaleLockEntries()
 
     // Assert
-    expect(result).toEqual({ status: 'ok', names: [] })
+    expect(result).toEqual({ status: 'ok', names: [], unprunable: [] })
   })
 
   test('reports unavailable rather than flagging every record when the source dir cannot be read', async () => {
@@ -222,7 +260,7 @@ describe('scanStaleLockEntries', () => {
     const result = await scanStaleLockEntries()
 
     // Assert
-    expect(result).toEqual({ status: 'ok', names: [] })
+    expect(result).toEqual({ status: 'ok', names: [], unprunable: [] })
   })
 
   test('reports unavailable when the lock was written by a CLI newer than this build', async () => {
@@ -266,7 +304,7 @@ describe('scanStaleLockEntries', () => {
     const result = await scanStaleLockEntries()
 
     // Assert
-    expect(result).toEqual({ status: 'ok', names: [] })
+    expect(result).toEqual({ status: 'ok', names: [], unprunable: [] })
   })
 
   test('matches a lock key against its sanitized directory name', async () => {
@@ -281,13 +319,14 @@ describe('scanStaleLockEntries', () => {
     const result = await scanStaleLockEntries()
 
     // Assert
-    expect(result).toEqual({ status: 'ok', names: [] })
+    expect(result).toEqual({ status: 'ok', names: [], unprunable: [] })
   })
 
-  test('excludes both lock keys that normalize onto the same directory name', async () => {
+  test('reports both lock keys that normalize onto the same directory name as blocked rather than dropping them', async () => {
     // Arrange
     // One directory cannot answer "is this record's skill gone" for two keys,
-    // and prune is not allowed to guess about deletion.
+    // so neither may be offered for deletion. Dropping them silently is what
+    // left the pair unprunable forever with nothing in the UI saying why.
     const { scanStaleLockEntries } = await serviceModule
     await writeLock(['Ambiguous', 'ambiguous'])
 
@@ -295,7 +334,116 @@ describe('scanStaleLockEntries', () => {
     const result = await scanStaleLockEntries()
 
     // Assert
-    expect(result).toEqual({ status: 'ok', names: [] })
+    expect(result).toEqual({
+      status: 'ok',
+      names: [],
+      unprunable: [
+        { name: 'ambiguous', reason: 'name-collision' },
+        { name: 'Ambiguous', reason: 'name-collision' },
+      ],
+    })
+  })
+
+  test('blocks a record an agent still holds a real folder for instead of offering it for deletion', async () => {
+    // Arrange
+    // `skills remove --global` rm -rf's <agent>/skills/<name> with no symlink
+    // check, so delegating here would delete the user's own files. Offering the
+    // record anyway meant the only way to learn that was to click Remove and
+    // read a failure, forever.
+    const { scanStaleLockEntries } = await serviceModule
+    await writeLock(['agent-owned'])
+    await makeAgentOwnedDir('agent-owned')
+
+    // Act
+    const result = await scanStaleLockEntries()
+
+    // Assert
+    expect(result).toEqual({
+      status: 'ok',
+      names: [],
+      unprunable: [{ name: 'agent-owned', reason: 'agent-copy' }],
+    })
+  })
+
+  test('still offers a record whose only agent copy is a symlink', async () => {
+    // Arrange
+    // The guard is about REAL directories. A symlink is what a normal install
+    // leaves behind, so treating it as blocking would make every stale record
+    // unprunable and the feature would do nothing at all.
+    const { scanStaleLockEntries } = await serviceModule
+    await writeLock(['linked-only'])
+    await mkdir(join(sharedHome, '.claude', 'skills'), { recursive: true })
+    await symlink(
+      join(sourceDir, 'linked-only'),
+      join(sharedHome, '.claude', 'skills', 'linked-only'),
+    )
+
+    // Act
+    const result = await scanStaleLockEntries()
+
+    // Assert
+    expect(result).toEqual({
+      status: 'ok',
+      names: ['linked-only'],
+      unprunable: [],
+    })
+  })
+
+  test('keeps scanning when a trash entry was left for manual recovery with no manifest', async () => {
+    // Arrange
+    // Both source-backed writers of the marker run BEFORE the manifest exists,
+    // so the entry reads as ENOENT. Without the marker check that looks like one
+    // of our own entries caught mid-write and takes the whole scan to
+    // `unavailable` — permanently, because startup cleanup never sweeps a marked
+    // entry. The feature would be dead for that user with no way back.
+    const { scanStaleLockEntries } = await serviceModule
+    await writeLock(['stuck-skill'])
+    await makeManualRecoveryEntry('stuck-skill')
+
+    // Act
+    const result = await scanStaleLockEntries()
+
+    // Assert
+    expect(result).toEqual({
+      status: 'ok',
+      names: ['stuck-skill'],
+      unprunable: [],
+    })
+  })
+
+  test('stops treating a manual-recovery entry as a live undo window', async () => {
+    // Arrange
+    // Its automatic restore already failed for good, so counting it as "still
+    // restorable" only kept the lock record alive for `skills -g update` to
+    // reinstall a skill the user deleted.
+    const { scanStaleLockEntries } = await serviceModule
+    await writeLock(['stuck-skill'])
+    await makeManualRecoveryEntry('stuck-skill', true)
+
+    // Act
+    const result = await scanStaleLockEntries()
+
+    // Assert
+    expect(result).toEqual({
+      status: 'ok',
+      names: ['stuck-skill'],
+      unprunable: [],
+    })
+  })
+
+  test('still holds a record back for an ordinary tombstone inside its undo window', async () => {
+    // Arrange
+    // The discriminating case for the two tests above: without the marker, a
+    // staged delete is restorable and its record must NOT be reported stale.
+    const { scanStaleLockEntries } = await serviceModule
+    await writeLock(['undoable'])
+    await makeTombstone('undoable')
+
+    // Act
+    const result = await scanStaleLockEntries()
+
+    // Assert
+    expect(result).toEqual({ status: 'ok', names: [], unprunable: [] })
   })
 
   test('does not report a skill whose folder exists but has no readable SKILL.md', async () => {
@@ -310,7 +458,7 @@ describe('scanStaleLockEntries', () => {
     const result = await scanStaleLockEntries()
 
     // Assert
-    expect(result).toEqual({ status: 'ok', names: [] })
+    expect(result).toEqual({ status: 'ok', names: [], unprunable: [] })
   })
 
   test('reads the lock from XDG_STATE_HOME when the CLI would', async () => {
@@ -331,7 +479,11 @@ describe('scanStaleLockEntries', () => {
     const result = await scanStaleLockEntries()
 
     // Assert
-    expect(result).toEqual({ status: 'ok', names: ['xdg-only-skill'] })
+    expect(result).toEqual({
+      status: 'ok',
+      names: ['xdg-only-skill'],
+      unprunable: [],
+    })
   })
 
   test('treats a trash entry still being staged as unreadable rather than foreign', async () => {
@@ -392,7 +544,11 @@ describe('scanStaleLockEntries', () => {
     const result = await scanStaleLockEntries()
 
     // Assert
-    expect(result).toEqual({ status: 'ok', names: ['deleted-in-finder'] })
+    expect(result).toEqual({
+      status: 'ok',
+      names: ['deleted-in-finder'],
+      unprunable: [],
+    })
   })
 })
 

--- a/src/main/services/skillLockService.test.ts
+++ b/src/main/services/skillLockService.test.ts
@@ -338,8 +338,8 @@ describe('scanStaleLockEntries', () => {
       status: 'ok',
       names: [],
       unprunable: [
-        { name: 'ambiguous', reason: 'name-collision' },
         { name: 'Ambiguous', reason: 'name-collision' },
+        { name: 'ambiguous', reason: 'name-collision' },
       ],
     })
   })

--- a/src/main/services/skillLockService.test.ts
+++ b/src/main/services/skillLockService.test.ts
@@ -3,7 +3,15 @@ import { mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from 'vitest'
 
 import type { SkillName } from '@/shared/types'
 
@@ -139,6 +147,10 @@ async function readLockKeys(): Promise<string[]> {
 
 beforeEach(async () => {
   await rm(join(sharedHome, '.agents'), { recursive: true, force: true })
+  // `.claude` too: the agent-copy tests stage a real directory there, and one
+  // surviving into a later test would refuse every prune that followed it.
+  // Clearing both trees here is what lets those tests skip their own cleanup.
+  await rm(join(sharedHome, '.claude'), { recursive: true, force: true })
   await mkdir(sourceDir, { recursive: true })
   removeSkillsMock.mockReset()
   // Default fake CLI: removes every requested key from the lock.
@@ -158,6 +170,13 @@ beforeEach(async () => {
 
 afterEach(() => {
   delete process.env.XDG_STATE_HOME
+})
+
+// `sharedHome` is created once at module load and every test writes inside it,
+// so nothing may remove it until the file is done. Without this each run leaves
+// another `skills-lock-it-*` directory behind in the system temp dir.
+afterAll(async () => {
+  await rm(sharedHome, { recursive: true, force: true })
 })
 
 describe('scanStaleLockEntries', () => {
@@ -643,23 +662,17 @@ describe('pruneLockEntries', () => {
     await mkdir(agentOwnedDir, { recursive: true })
     await writeFile(join(agentOwnedDir, 'SKILL.md'), '# local\n', 'utf-8')
 
-    try {
-      // Act
-      const result = await pruneLockEntries(['agent-owned'] as SkillName[])
+    // Act
+    const result = await pruneLockEntries(['agent-owned'] as SkillName[])
 
-      // Assert
-      expect(removeSkillsMock).not.toHaveBeenCalled()
-      expect(result).toEqual({
-        pruned: [],
-        skipped: [],
-        failed: ['agent-owned'],
-      })
-      expect(await readLockKeys()).toEqual(['agent-owned'])
-    } finally {
-      // Cleanup has to run even on a failed assertion: beforeEach only clears
-      // `.agents`, so a leftover agent dir would refuse every later prune.
-      await rm(join(sharedHome, '.claude'), { recursive: true, force: true })
-    }
+    // Assert
+    expect(removeSkillsMock).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      pruned: [],
+      skipped: [],
+      failed: ['agent-owned'],
+    })
+    expect(await readLockKeys()).toEqual(['agent-owned'])
   })
 
   test('still prunes when the agent-side path is only a symlink to the deleted source', async () => {
@@ -675,20 +688,16 @@ describe('pruneLockEntries', () => {
       join(agentSkillsDir, 'linked-only'),
     )
 
-    try {
-      // Act
-      const result = await pruneLockEntries(['linked-only'] as SkillName[])
+    // Act
+    const result = await pruneLockEntries(['linked-only'] as SkillName[])
 
-      // Assert
-      expect(removeSkillsMock).toHaveBeenCalledWith(['linked-only'])
-      expect(result).toEqual({
-        pruned: ['linked-only'],
-        skipped: [],
-        failed: [],
-      })
-    } finally {
-      await rm(join(sharedHome, '.claude'), { recursive: true, force: true })
-    }
+    // Assert
+    expect(removeSkillsMock).toHaveBeenCalledWith(['linked-only'])
+    expect(result).toEqual({
+      pruned: ['linked-only'],
+      skipped: [],
+      failed: [],
+    })
   })
 
   test('refuses to prune every record when the source root itself is gone', async () => {

--- a/src/main/services/skillLockService.ts
+++ b/src/main/services/skillLockService.ts
@@ -193,19 +193,6 @@ type TrashReadResult =
   { status: 'ok'; dirNames: Set<string> } | { status: 'unavailable' }
 
 /**
- * Directory names currently staged in the trash, from each entry's manifest.
- * A skill waiting out its undo window still has a lock record doing its job, so
- * it must be excluded from detection. Local-only tombstones never had a source
- * directory and so never had a lock record.
- * @returns
- * - `ok` with the staged source-directory basenames when the trash was readable
- * - `ok` with an empty set when there is no trash directory at all (fresh install)
- * - `unavailable` when the trash exists but cannot be read — reporting an empty
- *   set there would flag every skill mid-undo as stale, and Undo would then
- *   restore it with its lock record already pruned
- * @example await readTrashedSourceDirNames() // => { status: 'ok', dirNames: Set { 'theme-generator' } }
- */
-/**
  * True when a trash entry carries the terminal manual-recovery marker.
  * Read by {@link readTrashedSourceDirNames} before the manifest, because both
  * source-backed writers of the marker run BEFORE the manifest exists.
@@ -219,11 +206,24 @@ async function isManualRecoveryEntry(entryDir: string): Promise<boolean> {
     return true
   } catch {
     // Absent, or unreadable. Neither is proof of a terminal entry, so fall
-    // through to the manifest read below — that path already fails closed.
+    // through to the caller's manifest read — that path already fails closed.
     return false
   }
 }
 
+/**
+ * Directory names currently staged in the trash, from each entry's manifest.
+ * A skill waiting out its undo window still has a lock record doing its job, so
+ * it must be excluded from detection. Local-only tombstones never had a source
+ * directory and so never had a lock record.
+ * @returns
+ * - `ok` with the staged source-directory basenames when the trash was readable
+ * - `ok` with an empty set when there is no trash directory at all (fresh install)
+ * - `unavailable` when the trash exists but cannot be read — reporting an empty
+ *   set there would flag every skill mid-undo as stale, and Undo would then
+ *   restore it with its lock record already pruned
+ * @example await readTrashedSourceDirNames() // => { status: 'ok', dirNames: Set { 'theme-generator' } }
+ */
 async function readTrashedSourceDirNames(): Promise<TrashReadResult> {
   const dirNames = new Set<string>()
   let entries: string[]

--- a/src/main/services/skillLockService.ts
+++ b/src/main/services/skillLockService.ts
@@ -506,7 +506,12 @@ export async function scanStaleLockEntries(): Promise<StaleLockScanResult> {
   return {
     status: 'ok',
     names: names.sort(),
-    unprunable: unprunable.sort((a, b) => a.name.localeCompare(b.name)),
+    // Code-unit order, matching `names.sort()` above. `localeCompare` would
+    // order these differently under the renderer's ICU than under the node
+    // test lane, which is not something a result shape should depend on.
+    unprunable: unprunable.sort((a, b) =>
+      a.name < b.name ? -1 : a.name > b.name ? 1 : 0,
+    ),
   }
 }
 

--- a/src/main/services/skillLockService.ts
+++ b/src/main/services/skillLockService.ts
@@ -4,7 +4,7 @@ import { basename, join } from 'node:path'
 
 import { z } from 'zod'
 
-import { SOURCE_DIR, TRASH_DIR } from '@/main/constants'
+import { MANUAL_RECOVERY_MARKER, SOURCE_DIR, TRASH_DIR } from '@/main/constants'
 import { manifestSchema, tombstoneIdSchema } from '@/main/ipc/ipc-schemas'
 import { errorCode, isMissingPathError } from '@/main/utils/errorCode'
 import { extractErrorMessage } from '@/main/utils/errors'
@@ -14,6 +14,7 @@ import type {
   PruneLockEntriesResult,
   SkillName,
   StaleLockScanResult,
+  UnprunableLockEntry,
 } from '@/shared/types'
 
 import { skillsCliService } from './skillsCliService'
@@ -204,6 +205,25 @@ type TrashReadResult =
  *   restore it with its lock record already pruned
  * @example await readTrashedSourceDirNames() // => { status: 'ok', dirNames: Set { 'theme-generator' } }
  */
+/**
+ * True when a trash entry carries the terminal manual-recovery marker.
+ * Read by {@link readTrashedSourceDirNames} before the manifest, because both
+ * source-backed writers of the marker run BEFORE the manifest exists.
+ * @param entryDir - Trash entry directory under `TRASH_DIR`.
+ * @returns true only on proof the marker is there.
+ * @example await isManualRecoveryEntry('/Users/me/.agents/.trash/2026-...') // => false
+ */
+async function isManualRecoveryEntry(entryDir: string): Promise<boolean> {
+  try {
+    await fs.access(join(entryDir, MANUAL_RECOVERY_MARKER))
+    return true
+  } catch {
+    // Absent, or unreadable. Neither is proof of a terminal entry, so fall
+    // through to the manifest read below — that path already fails closed.
+    return false
+  }
+}
+
 async function readTrashedSourceDirNames(): Promise<TrashReadResult> {
   const dirNames = new Set<string>()
   let entries: string[]
@@ -224,12 +244,23 @@ async function readTrashedSourceDirNames(): Promise<TrashReadResult> {
   let hasUnreadableEntry = false
   const manifests = await Promise.all(
     entries.map(async (entryName) => {
+      const entryDir = join(TRASH_DIR, entryName)
+      // Checked BEFORE the manifest, and it is load-bearing. Both source-backed
+      // writers of this marker (`trashService` at the source-move failure and
+      // at the manifest-write rollback) run while no manifest exists yet, so
+      // without this the ENOENT below reads as "one of our entries caught
+      // mid-write" and takes the whole scan to `unavailable` — permanently,
+      // since `startupCleanup` deliberately never sweeps a marked entry.
+      //
+      // Returning null also stops the entry counting as "still restorable":
+      // its automatic restore already failed for good, so holding the lock
+      // record alive just lets `skills -g update` reinstall a deleted skill.
+      // Where the source is still at its original path (the EXDEV arm), the
+      // per-key presence probe already keeps that record out of the stale list.
+      if (await isManualRecoveryEntry(entryDir)) return null
       let raw: string
       try {
-        raw = await fs.readFile(
-          join(TRASH_DIR, entryName, 'manifest.json'),
-          'utf-8',
-        )
+        raw = await fs.readFile(join(entryDir, 'manifest.json'), 'utf-8')
       } catch (error) {
         // A foreign file in the trash simply has no manifest. Any other read
         // failure is an entry we cannot see into, and it may be the one holding
@@ -410,13 +441,22 @@ export async function scanStaleLockEntries(): Promise<StaleLockScanResult> {
   // is never observed half-written.
   const lock = await runLockWrite(readSkillLockKeys)
   if (lock.status !== 'ok') return { status: 'unavailable' }
-  if (lock.keys.length === 0) return { status: 'ok', names: [] }
+  if (lock.keys.length === 0) return { status: 'ok', names: [], unprunable: [] }
 
   // Probe the source root first. If it is missing or unreadable, every lookup
   // below would report ENOENT and the whole lock would present as stale.
   if (!(await isSourceRootReadable())) return { status: 'unavailable' }
 
   const byDirName = buildUniqueDirNameIndex(lock.keys)
+
+  // `buildUniqueDirNameIndex` deletes every directory name two keys claim, so
+  // a key with no entry there is exactly a collided one. Reported rather than
+  // dropped: silently omitting them is what left a colliding pair unprunable
+  // with nothing in the UI saying why, while `skills -g update` kept
+  // resurrecting both. No extra I/O — the index is already built.
+  const collided: UnprunableLockEntry[] = lock.keys
+    .filter((key) => !byDirName.has(sanitizeName(key)))
+    .map((name) => ({ name, reason: 'name-collision' }))
 
   // Probe absence FIRST, read the trash SECOND. The order is load-bearing and
   // must not be swapped back: a delete landing mid-scan moves the source dir
@@ -438,14 +478,36 @@ export async function scanStaleLockEntries(): Promise<StaleLockScanResult> {
   const trashed = await readTrashedSourceDirNames()
   if (trashed.status !== 'ok') return { status: 'unavailable' }
 
-  const names: SkillName[] = []
+  const stale: SkillName[] = []
   for (const [dirName, key] of byDirName) {
     // Still restorable from the trash: the record is not stale yet.
     if (!absentDirNames.has(dirName) || trashed.dirNames.has(dirName)) continue
-    names.push(key)
+    stale.push(key)
   }
 
-  return { status: 'ok', names: names.sort() }
+  // Runs over the already-proven-stale list ONLY, never the whole lock. Each
+  // call is one `lstat` per agent, and this scan fires on a timer and on every
+  // refresh — over every key it would be a filesystem storm, over a stale list
+  // that is normally empty it costs nothing. The prune keeps its own copy of
+  // this check as the TOCTOU backstop; this one exists so the user is told
+  // BEFORE clicking a button that would only ever report a failure.
+  const holdsAgentCopy = await Promise.all(
+    stale.map(async (key) => holdsRealAgentDirectory(sanitizeName(key))),
+  )
+
+  const names = stale.filter((_, index) => !holdsAgentCopy[index])
+  const unprunable: UnprunableLockEntry[] = [
+    ...collided,
+    ...stale
+      .filter((_, index) => holdsAgentCopy[index])
+      .map((name): UnprunableLockEntry => ({ name, reason: 'agent-copy' })),
+  ]
+
+  return {
+    status: 'ok',
+    names: names.sort(),
+    unprunable: unprunable.sort((a, b) => a.name.localeCompare(b.name)),
+  }
 }
 
 /**

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -6,7 +6,12 @@ import { basename, dirname, join, resolve } from 'node:path'
 import { match } from 'ts-pattern'
 import type { z } from 'zod'
 
-import { AGENTS, SOURCE_DIR, TRASH_DIR } from '@/main/constants'
+import {
+  AGENTS,
+  MANUAL_RECOVERY_MARKER,
+  SOURCE_DIR,
+  TRASH_DIR,
+} from '@/main/constants'
 import { manifestSchema } from '@/main/ipc/ipc-schemas'
 import { errorCode, isMissingPathError } from '@/main/utils/errorCode'
 import { extractErrorMessage } from '@/main/utils/errors'
@@ -49,9 +54,6 @@ const STARTUP_CLEANUP_CONCURRENCY = 4
 
 /** Number of random bytes in the `rand8hex` suffix (4 bytes = 8 hex chars). */
 const RAND_SUFFIX_BYTES = 4
-
-/** Marker file for trash entries that contain data the user must recover by hand. */
-const MANUAL_RECOVERY_MARKER = '.manual-recovery'
 
 /**
  * In-process map of scheduled evict timers. Keys are tombstone ids; values are

--- a/src/renderer/src/components/dashboard/LockPruneBanner.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/LockPruneBanner.browser.test.tsx
@@ -37,7 +37,7 @@ async function renderBanner(staleLockNames: string[], dismissed = false) {
   store.dispatch(fetchStaleLockEntries.pending('req-lock', undefined))
   store.dispatch(
     fetchStaleLockEntries.fulfilled(
-      { status: 'ok', names: staleLockNames },
+      { status: 'ok', names: staleLockNames, unprunable: [] },
       'req-lock',
       undefined,
     ),

--- a/src/renderer/src/components/dashboard/LockPruneBanner.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/LockPruneBanner.browser.test.tsx
@@ -91,6 +91,21 @@ describe('LockPruneBanner', () => {
     ).toBeNull()
   })
 
+  test('counts only the records it can actually prune, not every stale one', async () => {
+    // Arrange / Act — one prunable record alongside one the scan blocked. The
+    // all-blocked case above passes under any gate that hides the banner when
+    // something is blocked; only a mix proves the sentence counts the prunable
+    // subset rather than every record needing attention.
+    const { screen } = await renderBanner(['plain-stale'], false, [
+      { name: 'agent-copy-skill', reason: 'agent-copy' },
+    ])
+
+    // Assert
+    await expect
+      .element(screen.getByText(/still tracks 1 deleted skill,/))
+      .toBeVisible()
+  })
+
   test('opens the prune dialog from the announcement CTA', async () => {
     // Arrange
     const { screen, store } = await renderBanner(['old-skill'])

--- a/src/renderer/src/components/dashboard/LockPruneBanner.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/LockPruneBanner.browser.test.tsx
@@ -4,16 +4,22 @@ import { describe, expect, test } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import '@/renderer/src/styles/globals.css'
+import type { UnprunableLockEntry } from '@/shared/types'
 
 /**
  * Render the announcement with real reducers so dismissal and the CTA go
  * through the same Redux path the app uses.
  * @param staleLockNames - Stale records to seed; empty means nothing to announce.
  * @param dismissed - Whether the user already dismissed the announcement.
+ * @param unprunable - Blocked records to seed alongside the prunable ones.
  * @returns Browser screen and store.
  * @example const { screen } = await renderBanner(['old-skill'])
  */
-async function renderBanner(staleLockNames: string[], dismissed = false) {
+async function renderBanner(
+  staleLockNames: string[],
+  dismissed = false,
+  unprunable: UnprunableLockEntry[] = [],
+) {
   const [
     { default: dashboardReducer, dismissLockPruneBanner },
     { default: skillLockReducer, fetchStaleLockEntries },
@@ -37,7 +43,7 @@ async function renderBanner(staleLockNames: string[], dismissed = false) {
   store.dispatch(fetchStaleLockEntries.pending('req-lock', undefined))
   store.dispatch(
     fetchStaleLockEntries.fulfilled(
-      { status: 'ok', names: staleLockNames, unprunable: [] },
+      { status: 'ok', names: staleLockNames, unprunable },
       'req-lock',
       undefined,
     ),
@@ -66,6 +72,18 @@ describe('LockPruneBanner', () => {
   test('stays hidden when the lock and the installed skills already agree', async () => {
     // Arrange / Act
     const { screen } = await renderBanner([])
+
+    // Assert
+    expect(
+      screen.getByRole('button', { name: 'Prune lock' }).query(),
+    ).toBeNull()
+  })
+
+  test('stays hidden when every stale record is blocked from being pruned', async () => {
+    // Arrange / Act
+    const { screen } = await renderBanner([], false, [
+      { name: 'agent-copy-skill', reason: 'agent-copy' },
+    ])
 
     // Assert
     expect(

--- a/src/renderer/src/components/dashboard/LockPruneBanner.tsx
+++ b/src/renderer/src/components/dashboard/LockPruneBanner.tsx
@@ -22,6 +22,11 @@ import { pluralize } from '@/renderer/src/utils/pluralize'
 export const LockPruneBanner =
   function LockPruneBanner(): React.ReactElement | null {
     const dispatch = useAppDispatch()
+    // Prunable records only, deliberately narrower than the widget's
+    // `selectLockRecordsNeedingAttention`. Every sentence below promises a
+    // prune, and blocked records cannot be pruned — announcing them here would
+    // hand the user a button that can only tell them no. The widget is the
+    // surface that reports those, and it says "Review lock" instead.
     const staleCount = useAppSelector(selectStaleLockEntryCount)
     const isDismissed = useAppSelector(selectLockPruneBannerDismissed)
 

--- a/src/renderer/src/components/dashboard/LockPruneDialog.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/LockPruneDialog.browser.test.tsx
@@ -296,6 +296,39 @@ describe('LockPruneDialog', () => {
       .toBeVisible()
   })
 
+  test('stops offering a record the scan blocked while the dialog was open', async () => {
+    // Arrange
+    const { screen, store } = await renderDialog([
+      'plain-stale',
+      'agent-copy-skill',
+    ])
+    const { fetchStaleLockEntries } =
+      await import('@/renderer/src/redux/slices/skillLockSlice')
+
+    // Act - an agent copy appears under one of the consented names mid-dialog.
+    store.dispatch(fetchStaleLockEntries.pending('req-lock-2', undefined))
+    store.dispatch(
+      fetchStaleLockEntries.fulfilled(
+        {
+          status: 'ok',
+          names: ['plain-stale'],
+          unprunable: [{ name: 'agent-copy-skill', reason: 'agent-copy' }],
+        },
+        'req-lock-2',
+        undefined,
+      ),
+    )
+
+    // Assert - the button drops it rather than promising a delete the blocked
+    // section on the same screen says is impossible.
+    await expect
+      .element(screen.getByRole('button', { name: 'Remove 1 record' }))
+      .toBeVisible()
+    await expect
+      .element(screen.getByText('1 record needs attention first'))
+      .toBeVisible()
+  })
+
   test('offers no delete button at all when every stale record is blocked', async () => {
     // Arrange
     // This is the dead end the feature used to have: nothing prunable meant no

--- a/src/renderer/src/components/dashboard/LockPruneDialog.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/LockPruneDialog.browser.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import '@/renderer/src/styles/globals.css'
+import type { StaleLockScanResult } from '@/shared/types'
 
 const mockToastSuccess = vi.fn()
 const mockToastError = vi.fn()
@@ -18,7 +19,10 @@ vi.mock('sonner', () => ({
 }))
 
 const mockPruneLockEntries = vi.fn()
-const mockScanStaleLockEntries = vi.fn()
+// Typed against the real channel: an untyped `vi.fn()` let these fixtures drop
+// a field the reducer then wrote as `undefined`, and the failure surfaced as a
+// render crash in an unrelated test rather than here.
+const mockScanStaleLockEntries = vi.fn<() => Promise<StaleLockScanResult>>()
 const mockGetSkills = vi.fn()
 const mockGetAgents = vi.fn()
 const mockGetSourceStats = vi.fn()
@@ -40,7 +44,13 @@ vi.stubGlobal('electron', {
  * @returns Browser screen and store.
  * @example const { screen } = await renderDialog(['old-skill'])
  */
-async function renderDialog(staleLockNames: string[]) {
+async function renderDialog(
+  staleLockNames: string[],
+  unprunable: {
+    name: string
+    reason: 'name-collision' | 'agent-copy'
+  }[] = [],
+) {
   const [
     { default: skillLockReducer, fetchStaleLockEntries },
     { default: uiReducer, openLockPruneDialog },
@@ -58,7 +68,7 @@ async function renderDialog(staleLockNames: string[]) {
   store.dispatch(fetchStaleLockEntries.pending('req-lock', undefined))
   store.dispatch(
     fetchStaleLockEntries.fulfilled(
-      { status: 'ok', names: staleLockNames },
+      { status: 'ok', names: staleLockNames, unprunable },
       'req-lock',
       undefined,
     ),
@@ -76,7 +86,11 @@ async function renderDialog(staleLockNames: string[]) {
 beforeEach(() => {
   mockPruneLockEntries.mockReset()
   mockScanStaleLockEntries.mockReset()
-  mockScanStaleLockEntries.mockResolvedValue({ status: 'ok', names: [] })
+  mockScanStaleLockEntries.mockResolvedValue({
+    status: 'ok',
+    names: [],
+    unprunable: [],
+  })
   mockToastSuccess.mockReset()
   mockToastError.mockReset()
   mockToastInfo.mockReset()
@@ -126,6 +140,7 @@ describe('LockPruneDialog', () => {
     mockScanStaleLockEntries.mockResolvedValue({
       status: 'ok',
       names: ['stubborn'],
+      unprunable: [],
     })
     const { screen, store } = await renderDialog(['stubborn'])
 
@@ -145,6 +160,7 @@ describe('LockPruneDialog', () => {
     mockScanStaleLockEntries.mockResolvedValue({
       status: 'ok',
       names: ['old-skill'],
+      unprunable: [],
     })
     const { screen, store } = await renderDialog(['old-skill'])
 
@@ -175,7 +191,7 @@ describe('LockPruneDialog', () => {
     store.dispatch(fetchStaleLockEntries.pending('req-late', undefined))
     store.dispatch(
       fetchStaleLockEntries.fulfilled(
-        { status: 'ok', names: ['old-skill', 'just-appeared'] },
+        { status: 'ok', names: ['old-skill', 'just-appeared'], unprunable: [] },
         'req-late',
         undefined,
       ),
@@ -209,7 +225,11 @@ describe('LockPruneDialog', () => {
       skipped: ['came-back'],
       failed: [],
     })
-    mockScanStaleLockEntries.mockResolvedValue({ status: 'ok', names: [] })
+    mockScanStaleLockEntries.mockResolvedValue({
+      status: 'ok',
+      names: [],
+      unprunable: [],
+    })
     const { screen } = await renderDialog(['came-back'])
 
     // Act
@@ -231,7 +251,11 @@ describe('LockPruneDialog', () => {
       skipped: [],
       failed: [],
     })
-    mockScanStaleLockEntries.mockResolvedValue({ status: 'ok', names: [] })
+    mockScanStaleLockEntries.mockResolvedValue({
+      status: 'ok',
+      names: [],
+      unprunable: [],
+    })
     const { screen } = await renderDialog(['old-skill'])
 
     // Act
@@ -244,5 +268,84 @@ describe('LockPruneDialog', () => {
       )
     })
     expect(mockToastInfo).not.toHaveBeenCalled()
+  })
+  test('explains why a blocked record cannot be removed instead of listing it as deletable', async () => {
+    // Arrange
+    // The scan refused this one because an agent holds a real folder under the
+    // name. Offering it beside the removable records would send it to main, and
+    // main would only refuse it again.
+    const { screen } = await renderDialog(
+      ['removable'],
+      [{ name: 'agent-owned', reason: 'agent-copy' }],
+    )
+
+    // Assert
+    await expect.element(screen.getByText('agent-owned')).toBeVisible()
+    await expect
+      .element(screen.getByText('1 record needs attention first'))
+      .toBeVisible()
+    await expect
+      .element(
+        screen.getByText(
+          'An agent holds a real folder under this name, not a link — removing the record would delete that folder with it.',
+        ),
+      )
+      .toBeVisible()
+    await expect
+      .element(screen.getByRole('button', { name: 'Remove 1 record' }))
+      .toBeVisible()
+  })
+
+  test('offers no delete button at all when every stale record is blocked', async () => {
+    // Arrange
+    // This is the dead end the feature used to have: nothing prunable meant no
+    // CTA, no dialog, and no explanation anywhere. A "Remove 0 records" button
+    // would be just as wrong.
+    const { screen } = await renderDialog(
+      [],
+      [
+        { name: 'ambiguous', reason: 'name-collision' },
+        { name: 'Ambiguous', reason: 'name-collision' },
+      ],
+    )
+
+    // Assert
+    await expect
+      .element(screen.getByText('2 records need attention first'))
+      .toBeVisible()
+    await expect
+      .element(screen.getByRole('button', { name: 'Got it' }))
+      .toBeVisible()
+    expect(
+      screen.getByRole('button', { name: /^Remove/ }).elements(),
+    ).toHaveLength(0)
+  })
+
+  test('hides the corner close button while a prune is running', async () => {
+    // Arrange
+    // `handleClose` already refuses to close mid-prune, so leaving the X on
+    // screen rendered a control that silently did nothing when clicked.
+    let releasePrune: (result: unknown) => void = () => {}
+    mockPruneLockEntries.mockReturnValue(
+      new Promise((resolve) => {
+        releasePrune = resolve
+      }),
+    )
+    const { screen } = await renderDialog(['old-skill'])
+    await expect
+      .element(screen.getByRole('button', { name: 'Close' }))
+      .toBeVisible()
+
+    // Act
+    await screen.getByRole('button', { name: 'Remove 1 record' }).click()
+
+    // Assert
+    await expect
+      .element(screen.getByRole('button', { name: 'Pruning...' }))
+      .toBeVisible()
+    expect(
+      screen.getByRole('button', { name: 'Close' }).elements(),
+    ).toHaveLength(0)
+    releasePrune({ pruned: ['old-skill'], skipped: [], failed: [] })
   })
 })

--- a/src/renderer/src/components/dashboard/LockPruneDialog.tsx
+++ b/src/renderer/src/components/dashboard/LockPruneDialog.tsx
@@ -57,9 +57,6 @@ export const LockPruneDialog = function LockPruneDialog(): React.ReactElement {
   // freezing it would only let the dialog keep showing a reason a later scan
   // already cleared.
   const unprunableEntries = useAppSelector(selectUnprunableLockEntries)
-  // Every count-dependent phrase comes from one call, so the sentence, the
-  // pronoun and the button label cannot disagree about how many records there
-  // are. Tested directly in `lockPruneCopy.test.ts`, without rendering.
   // A scan landing while the dialog is open can move a consented name into the
   // blocked list — an agent copy appearing mid-dialog does exactly that. Left
   // alone, the same record would sit in the delete list AND in the section
@@ -70,6 +67,9 @@ export const LockPruneDialog = function LockPruneDialog(): React.ReactElement {
   const removableNames = consentedNames.filter(
     (name) => !blockedNames.has(name),
   )
+  // Every count-dependent phrase comes from one call, so the sentence, the
+  // pronoun and the button label cannot disagree about how many records there
+  // are. Tested directly in `lockPruneCopy.test.ts`, without rendering.
   const copy = describeLockPruneTarget(removableNames.length)
   // The dialog is reachable with nothing to remove: a user whose stale records
   // are ALL blocked still needs to reach the explanation. Without this the

--- a/src/renderer/src/components/dashboard/LockPruneDialog.tsx
+++ b/src/renderer/src/components/dashboard/LockPruneDialog.tsx
@@ -29,6 +29,7 @@ import type { PruneLockEntriesResult } from '@/shared/types'
 
 import {
   describeLockPruneTarget,
+  selectRemovableNames,
   describeUnprunableReason,
   describeUnprunableSection,
 } from './lockPruneCopy'
@@ -60,13 +61,9 @@ export const LockPruneDialog = function LockPruneDialog(): React.ReactElement {
   // A scan landing while the dialog is open can move a consented name into the
   // blocked list — an agent copy appearing mid-dialog does exactly that. Left
   // alone, the same record would sit in the delete list AND in the section
-  // explaining it cannot be deleted. Filtering only ever removes names from
-  // what the button sends, so the consent snapshot still holds: the user can
-  // never have more deleted than they read.
-  const blockedNames = new Set(unprunableEntries.map((entry) => entry.name))
-  const removableNames = consentedNames.filter(
-    (name) => !blockedNames.has(name),
-  )
+  // explaining it cannot be deleted. Extracted so the invariant is tested on
+  // its own in `lockPruneCopy.test.ts`, without rendering the dialog.
+  const removableNames = selectRemovableNames(consentedNames, unprunableEntries)
   // Every count-dependent phrase comes from one call, so the sentence, the
   // pronoun and the button label cannot disagree about how many records there
   // are. Tested directly in `lockPruneCopy.test.ts`, without rendering.

--- a/src/renderer/src/components/dashboard/LockPruneDialog.tsx
+++ b/src/renderer/src/components/dashboard/LockPruneDialog.tsx
@@ -18,6 +18,7 @@ import {
   pruneStaleLockEntries,
   selectConsentedLockEntryNames,
   selectIsPruningLockEntries,
+  selectUnprunableLockEntries,
 } from '@/renderer/src/redux/slices/skillLockSlice'
 import {
   closeLockPruneDialog,
@@ -26,7 +27,11 @@ import {
 import { pluralize } from '@/renderer/src/utils/pluralize'
 import type { PruneLockEntriesResult } from '@/shared/types'
 
-import { describeLockPruneTarget } from './lockPruneCopy'
+import {
+  describeLockPruneTarget,
+  describeUnprunableReason,
+  describeUnprunableSection,
+} from './lockPruneCopy'
 
 /**
  * Confirmation for removing skill-lock records whose skill is gone.
@@ -47,10 +52,19 @@ export const LockPruneDialog = function LockPruneDialog(): React.ReactElement {
   // the user already read the names.
   const consentedNames = useAppSelector(selectConsentedLockEntryNames)
   const isPruning = useAppSelector(selectIsPruningLockEntries)
+  // Read live rather than snapshotted like `consentedNames`. That snapshot
+  // exists because the confirm button ACTS on it; nothing acts on this list, so
+  // freezing it would only let the dialog keep showing a reason a later scan
+  // already cleared.
+  const unprunableEntries = useAppSelector(selectUnprunableLockEntries)
   // Every count-dependent phrase comes from one call, so the sentence, the
   // pronoun and the button label cannot disagree about how many records there
   // are. Tested directly in `lockPruneCopy.test.ts`, without rendering.
   const copy = describeLockPruneTarget(consentedNames.length)
+  // The dialog is reachable with nothing to remove: a user whose stale records
+  // are ALL blocked still needs to reach the explanation. Without this the
+  // whole body would read "0 skills" behind a "Remove 0 records" button.
+  const hasRemovableRecords = consentedNames.length > 0
 
   const handleClose = (): void => {
     if (!isPruning) dispatch(closeLockPruneDialog())
@@ -100,7 +114,10 @@ export const LockPruneDialog = function LockPruneDialog(): React.ReactElement {
 
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>
-      <DialogContent className="max-w-md">
+      {/* The X is hidden rather than left to no-op: `handleClose` already
+          refuses to close mid-prune, so a visible control that does nothing
+          is the only thing the guard was still missing. */}
+      <DialogContent className="max-w-md" hideCloseButton={isPruning}>
         <DialogHeader>
           <DialogIconHeader
             icon={FileWarning}
@@ -108,40 +125,83 @@ export const LockPruneDialog = function LockPruneDialog(): React.ReactElement {
             title="Prune skill lock"
           />
           <DialogDescription>
-            The skills CLI still tracks {copy.subject} no longer installed.
-            Until the {copy.recordNoun} {copy.recordVerb} removed,{' '}
-            <code className="text-xs">skills -g update</code> reinstalls{' '}
-            {copy.pronoun}.
+            {hasRemovableRecords ? (
+              <>
+                The skills CLI still tracks {copy.subject} no longer installed.
+                Until the {copy.recordNoun} {copy.recordVerb} removed,{' '}
+                <code className="text-xs">skills -g update</code> reinstalls{' '}
+                {copy.pronoun}.
+              </>
+            ) : (
+              <>
+                Nothing here can be removed automatically. Until these records
+                are sorted out,{' '}
+                <code className="text-xs">skills -g update</code> keeps
+                reinstalling the skills behind them.
+              </>
+            )}
           </DialogDescription>
         </DialogHeader>
 
-        <ScrollArea className="max-h-48 rounded-md border border-border">
-          <ul className="p-3 space-y-1 text-sm">
-            {consentedNames.map((name) => (
-              <li
-                key={name}
-                className="font-mono text-xs text-muted-foreground"
-              >
-                {name}
-              </li>
-            ))}
-          </ul>
-        </ScrollArea>
+        {hasRemovableRecords ? (
+          <ScrollArea className="max-h-48 rounded-md border border-border">
+            <ul className="p-3 space-y-1 text-sm">
+              {consentedNames.map((name) => (
+                <li
+                  key={name}
+                  className="font-mono text-xs text-muted-foreground"
+                >
+                  {name}
+                </li>
+              ))}
+            </ul>
+          </ScrollArea>
+        ) : null}
+
+        {unprunableEntries.length > 0 ? (
+          <section className="rounded-md border border-border bg-muted/40 p-3">
+            <h3 className="text-xs font-medium text-foreground">
+              {describeUnprunableSection(unprunableEntries.length)}
+            </h3>
+            {/* Capped like the removable list above: a lock can collide on
+                many names at once, and two lines each would push the footer
+                off screen. */}
+            <ScrollArea className="mt-2 max-h-40">
+              <ul className="space-y-2 pr-3">
+                {unprunableEntries.map((entry) => (
+                  <li key={entry.name} className="text-xs">
+                    <span className="font-mono text-foreground">
+                      {entry.name}
+                    </span>
+                    <p className="text-muted-foreground">
+                      {describeUnprunableReason(entry.reason)}
+                    </p>
+                  </li>
+                ))}
+              </ul>
+            </ScrollArea>
+          </section>
+        ) : null}
 
         <DialogFooter>
           <Button variant="outline" onClick={handleClose} disabled={isPruning}>
-            Cancel
+            {/* Not "Close": that is already the corner X's accessible name, and
+                two controls answering to it makes the footer ambiguous to a
+                screen reader walking the dialog. */}
+            {hasRemovableRecords ? 'Cancel' : 'Got it'}
           </Button>
-          <Button onClick={handlePrune} disabled={isPruning}>
-            {isPruning ? (
-              <>
-                <Loader2 className="h-4 w-4 animate-spin mr-2" />
-                Pruning...
-              </>
-            ) : (
-              copy.confirmLabel
-            )}
-          </Button>
+          {hasRemovableRecords ? (
+            <Button onClick={handlePrune} disabled={isPruning}>
+              {isPruning ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                  Pruning...
+                </>
+              ) : (
+                copy.confirmLabel
+              )}
+            </Button>
+          ) : null}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/renderer/src/components/dashboard/LockPruneDialog.tsx
+++ b/src/renderer/src/components/dashboard/LockPruneDialog.tsx
@@ -60,11 +60,21 @@ export const LockPruneDialog = function LockPruneDialog(): React.ReactElement {
   // Every count-dependent phrase comes from one call, so the sentence, the
   // pronoun and the button label cannot disagree about how many records there
   // are. Tested directly in `lockPruneCopy.test.ts`, without rendering.
-  const copy = describeLockPruneTarget(consentedNames.length)
+  // A scan landing while the dialog is open can move a consented name into the
+  // blocked list — an agent copy appearing mid-dialog does exactly that. Left
+  // alone, the same record would sit in the delete list AND in the section
+  // explaining it cannot be deleted. Filtering only ever removes names from
+  // what the button sends, so the consent snapshot still holds: the user can
+  // never have more deleted than they read.
+  const blockedNames = new Set(unprunableEntries.map((entry) => entry.name))
+  const removableNames = consentedNames.filter(
+    (name) => !blockedNames.has(name),
+  )
+  const copy = describeLockPruneTarget(removableNames.length)
   // The dialog is reachable with nothing to remove: a user whose stale records
   // are ALL blocked still needs to reach the explanation. Without this the
   // whole body would read "0 skills" behind a "Remove 0 records" button.
-  const hasRemovableRecords = consentedNames.length > 0
+  const hasRemovableRecords = removableNames.length > 0
 
   const handleClose = (): void => {
     if (!isPruning) dispatch(closeLockPruneDialog())
@@ -73,7 +83,7 @@ export const LockPruneDialog = function LockPruneDialog(): React.ReactElement {
   const handlePrune = async (): Promise<void> => {
     let result: PruneLockEntriesResult
     try {
-      result = await dispatch(pruneStaleLockEntries(consentedNames)).unwrap()
+      result = await dispatch(pruneStaleLockEntries(removableNames)).unwrap()
     } catch (error) {
       // A rejected thunk (IPC down, zod refusing an arg, main-process throw)
       // used to escape this handler unhandled: the dialog stayed open with no
@@ -90,7 +100,7 @@ export const LockPruneDialog = function LockPruneDialog(): React.ReactElement {
     // that survived will show up in the widget again on the next scan.
     if (result.failed.length > 0) {
       toast.error(
-        `Could not remove ${result.failed.length} of ${consentedNames.length} ${pluralize(consentedNames.length, 'record')}.`,
+        `Could not remove ${result.failed.length} of ${removableNames.length} ${pluralize(removableNames.length, 'record')}.`,
       )
     } else if (result.pruned.length === 0) {
       // Nothing failed, but nothing went either — main revalidated every name
@@ -146,7 +156,7 @@ export const LockPruneDialog = function LockPruneDialog(): React.ReactElement {
         {hasRemovableRecords ? (
           <ScrollArea className="max-h-48 rounded-md border border-border">
             <ul className="p-3 space-y-1 text-sm">
-              {consentedNames.map((name) => (
+              {removableNames.map((name) => (
                 <li
                   key={name}
                   className="font-mono text-xs text-muted-foreground"

--- a/src/renderer/src/components/dashboard/lockPruneCopy.test.ts
+++ b/src/renderer/src/components/dashboard/lockPruneCopy.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'vitest'
 
-import { describeLockPruneTarget } from './lockPruneCopy'
+import {
+  describeLockPruneTarget,
+  describeUnprunableReason,
+  describeUnprunableSection,
+} from './lockPruneCopy'
 
 describe('describeLockPruneTarget', () => {
   test('reads as one skill throughout when a single record is up for deletion', () => {
@@ -54,5 +58,59 @@ describe('describeLockPruneTarget', () => {
       pronoun: 'them',
       confirmLabel: 'Remove 0 records',
     })
+  })
+})
+
+describe('describeUnprunableReason', () => {
+  test('tells a user with a name collision that removing either record is the risk', () => {
+    // Arrange
+    const reason = 'name-collision' as const
+
+    // Act
+    const explanation = describeUnprunableReason(reason)
+
+    // Assert
+    expect(explanation).toBe(
+      'Another lock record maps to the same folder, so removing either one could remove the wrong record.',
+    )
+  })
+
+  test('warns that an agent-held folder would be deleted with the record', () => {
+    // Arrange
+    // This is the one the user most needs stated plainly: the CLI would rm -rf
+    // real files under ~/.claude/skills, not just drop a lock entry.
+    const reason = 'agent-copy' as const
+
+    // Act
+    const explanation = describeUnprunableReason(reason)
+
+    // Assert
+    expect(explanation).toBe(
+      'An agent holds a real folder under this name, not a link — removing the record would delete that folder with it.',
+    )
+  })
+})
+
+describe('describeUnprunableSection', () => {
+  test('agrees with its verb for a single blocked record', () => {
+    // Arrange
+    const count = 1
+
+    // Act
+    const heading = describeUnprunableSection(count)
+
+    // Assert
+    expect(heading).toBe('1 record needs attention first')
+  })
+
+  test('agrees with its verb for several blocked records', () => {
+    // Arrange
+    const count = 4
+
+    // Act
+    const heading = describeUnprunableSection(count)
+
+    // Assert
+    expect(heading).toBe('4 records need attention first')
   })
 })

--- a/src/renderer/src/components/dashboard/lockPruneCopy.test.ts
+++ b/src/renderer/src/components/dashboard/lockPruneCopy.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test } from 'vitest'
 
+import type { SkillName, UnprunableLockEntry } from '@/shared/types'
+
 import {
   describeLockPruneTarget,
   describeUnprunableReason,
   describeUnprunableSection,
+  selectRemovableNames,
 } from './lockPruneCopy'
 
 describe('describeLockPruneTarget', () => {
@@ -112,5 +115,63 @@ describe('describeUnprunableSection', () => {
 
     // Assert
     expect(heading).toBe('4 records need attention first')
+  })
+})
+
+describe('selectRemovableNames', () => {
+  test('drops a consented name the scan blocked while the dialog was open', () => {
+    // Arrange — the record the user read is still in the snapshot, but a scan
+    // has since found an agent copy behind it.
+    const consentedNames = ['plain-stale', 'agent-copy-skill'] as SkillName[]
+    const unprunableEntries: UnprunableLockEntry[] = [
+      { name: 'agent-copy-skill', reason: 'agent-copy' },
+    ]
+
+    // Act
+    const removable = selectRemovableNames(consentedNames, unprunableEntries)
+
+    // Assert
+    expect(removable).toEqual(['plain-stale'])
+  })
+
+  test('sends every consented name when the scan blocked none of them', () => {
+    // Arrange
+    const consentedNames = ['one', 'two'] as SkillName[]
+
+    // Act
+    const removable = selectRemovableNames(consentedNames, [])
+
+    // Assert
+    expect(removable).toEqual(['one', 'two'])
+  })
+
+  test('sends nothing when every consented name turned out to be blocked', () => {
+    // Arrange — the dialog still has to render, as pure explanation.
+    const consentedNames = ['collided', 'agent-copy-skill'] as SkillName[]
+    const unprunableEntries: UnprunableLockEntry[] = [
+      { name: 'collided', reason: 'name-collision' },
+      { name: 'agent-copy-skill', reason: 'agent-copy' },
+    ]
+
+    // Act
+    const removable = selectRemovableNames(consentedNames, unprunableEntries)
+
+    // Assert
+    expect(removable).toEqual([])
+  })
+
+  test('ignores a blocked record that was never in the consent snapshot', () => {
+    // Arrange — the scan reports the whole lock; the dialog only ever deletes
+    // what the user actually read.
+    const consentedNames = ['plain-stale'] as SkillName[]
+    const unprunableEntries: UnprunableLockEntry[] = [
+      { name: 'never-shown', reason: 'agent-copy' },
+    ]
+
+    // Act
+    const removable = selectRemovableNames(consentedNames, unprunableEntries)
+
+    // Assert
+    expect(removable).toEqual(['plain-stale'])
   })
 })

--- a/src/renderer/src/components/dashboard/lockPruneCopy.ts
+++ b/src/renderer/src/components/dashboard/lockPruneCopy.ts
@@ -1,5 +1,9 @@
 import { pluralize } from '@/renderer/src/utils/pluralize'
-import type { UnprunableReason } from '@/shared/types'
+import type {
+  SkillName,
+  UnprunableLockEntry,
+  UnprunableReason,
+} from '@/shared/types'
 
 /**
  * The count-dependent wording the prune dialog renders, resolved once so the
@@ -37,6 +41,26 @@ export function describeLockPruneTarget(count: number): LockPruneCopy {
     pronoun: isSingular ? 'it' : 'them',
     confirmLabel: `Remove ${count} ${pluralize(count, 'record')}`,
   }
+}
+
+/**
+ * Drop the names a scan has since blocked from the list the user consented to,
+ * so the prune request can never contain a record the dialog is simultaneously
+ * explaining it cannot touch; called on each render of {@link LockPruneDialog}.
+ *
+ * Filtering only ever removes names, so the consent snapshot still holds: the
+ * user can never have more deleted than they read.
+ * @param consentedNames - The snapshot taken when the dialog opened.
+ * @param unprunableEntries - What the newest scan reports as blocked.
+ * @returns The subset still safe to send to the prune.
+ * @example selectRemovableNames(['a', 'b'], [{ name: 'b', reason: 'agent-copy' }]) // => ['a']
+ */
+export function selectRemovableNames(
+  consentedNames: readonly SkillName[],
+  unprunableEntries: readonly UnprunableLockEntry[],
+): SkillName[] {
+  const blockedNames = new Set(unprunableEntries.map((entry) => entry.name))
+  return consentedNames.filter((name) => !blockedNames.has(name))
 }
 
 /**

--- a/src/renderer/src/components/dashboard/lockPruneCopy.ts
+++ b/src/renderer/src/components/dashboard/lockPruneCopy.ts
@@ -1,4 +1,5 @@
 import { pluralize } from '@/renderer/src/utils/pluralize'
+import type { UnprunableReason } from '@/shared/types'
 
 /**
  * The count-dependent wording the prune dialog renders, resolved once so the
@@ -36,4 +37,34 @@ export function describeLockPruneTarget(count: number): LockPruneCopy {
     pronoun: isSingular ? 'it' : 'them',
     confirmLabel: `Remove ${count} ${pluralize(count, 'record')}`,
   }
+}
+
+/**
+ * One sentence explaining why a stale record cannot be pruned, shown beside its
+ * name in {@link LockPruneDialog}. Exhaustive over {@link UnprunableReason} with
+ * no default arm on purpose: a new reason should fail the build here rather than
+ * render a blocked record with nothing said about it.
+ * @param reason - What the scan found blocking the prune.
+ * @returns Plain-language explanation ending in a period.
+ * @example describeUnprunableReason('agent-copy') // => 'An agent holds a real folder…'
+ */
+export function describeUnprunableReason(reason: UnprunableReason): string {
+  switch (reason) {
+    case 'name-collision':
+      return 'Another lock record maps to the same folder, so removing either one could remove the wrong record.'
+    case 'agent-copy':
+      return 'An agent holds a real folder under this name, not a link — removing the record would delete that folder with it.'
+  }
+}
+
+/**
+ * Heading for the blocked-records section, agreeing with its own count.
+ * Separate from {@link describeLockPruneTarget} because the two counts are
+ * independent: a dialog can have three removable records and one blocked.
+ * @param count - How many records are blocked.
+ * @returns Heading text.
+ * @example describeUnprunableSection(1) // => '1 record needs attention first'
+ */
+export function describeUnprunableSection(count: number): string {
+  return `${count} ${pluralize(count, 'record')} ${count === 1 ? 'needs' : 'need'} attention first`
 }

--- a/src/renderer/src/components/dashboard/widgets/HealthWidget.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/widgets/HealthWidget.browser.test.tsx
@@ -1,6 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { Provider } from 'react-redux'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, test } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import '@/renderer/src/styles/globals.css'
@@ -48,6 +48,8 @@ function makeSkill(symlinks: SymlinkInfo[]): Skill {
  * Renders HealthWidget with real skills/skillLock/ui reducers so button clicks update Redux normally.
  * @param skills - Skill inventory to seed through the fetchSkills.fulfilled reducer.
  * @param staleLockNames - Stale skill-lock records to seed; empty means a clean lock.
+ * @param scanStatus - `unavailable` seeds a scan that could not read the lock.
+ * @param unprunable - Stale records the scan refused to offer for deletion.
  * @returns Browser screen and store.
  * @example
  * const { screen } = await renderHealthWidget([makeSkill([makeSymlink('broken')])])
@@ -56,6 +58,7 @@ async function renderHealthWidget(
   skills: Skill[],
   staleLockNames: string[] = [],
   scanStatus: 'ok' | 'unavailable' = 'ok',
+  unprunable: { name: string; reason: 'name-collision' | 'agent-copy' }[] = [],
 ) {
   const [
     { default: skillsReducer, fetchSkills },
@@ -82,7 +85,7 @@ async function renderHealthWidget(
   store.dispatch(
     fetchStaleLockEntries.fulfilled(
       scanStatus === 'ok'
-        ? { status: 'ok', names: staleLockNames }
+        ? { status: 'ok', names: staleLockNames, unprunable }
         : { status: 'unavailable' },
       'req-lock',
       undefined,
@@ -274,5 +277,59 @@ describe('HealthWidget stale skill-lock records', () => {
     expect(
       screen.getByRole('button', { name: 'Prune lock' }).query(),
     ).toBeNull()
+  })
+
+  test('counts blocked lock records so an all-blocked lock never reports Healthy', async () => {
+    // Arrange
+    // These records disagree with disk exactly as much as prunable ones do.
+    // Leaving them out of the count showed "Healthy" while `skills -g update`
+    // kept resurrecting the skills behind them.
+    const skills = [makeSkill([makeSymlink('valid')])]
+
+    // Act
+    const { screen } = await renderHealthWidget(skills, [], 'ok', [
+      { name: 'ambiguous', reason: 'name-collision' },
+      { name: 'Ambiguous', reason: 'name-collision' },
+    ])
+
+    // Assert
+    await expect
+      .element(screen.getByText('lock', { exact: true }))
+      .toBeVisible()
+    await expect.element(screen.getByText('2', { exact: true })).toBeVisible()
+    expect(screen.getByText('Healthy').query()).toBeNull()
+  })
+
+  test('offers Review lock rather than Prune lock when nothing can be removed', async () => {
+    // Arrange
+    // The dialog behind this button has no delete to offer, so promising a
+    // prune would misdescribe what clicking it does.
+    const skills = [makeSkill([makeSymlink('valid')])]
+
+    // Act
+    const { screen, store } = await renderHealthWidget(skills, [], 'ok', [
+      { name: 'agent-owned', reason: 'agent-copy' },
+    ])
+    await screen.getByRole('button', { name: 'Review lock' }).click()
+
+    // Assert
+    expect(store.getState().ui.lockPruneDialogOpen).toBe(true)
+  })
+
+  test('still says Prune lock while at least one record can be removed', async () => {
+    // Arrange
+    // The discriminating case for the label: a mixed lock keeps the
+    // destructive verb, because the button really does open a delete.
+    const skills = [makeSkill([makeSymlink('valid')])]
+
+    // Act
+    const { screen } = await renderHealthWidget(skills, ['removable'], 'ok', [
+      { name: 'agent-owned', reason: 'agent-copy' },
+    ])
+
+    // Assert
+    await expect
+      .element(screen.getByRole('button', { name: 'Prune lock' }))
+      .toBeVisible()
   })
 })

--- a/src/renderer/src/components/dashboard/widgets/HealthWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/HealthWidget.tsx
@@ -3,7 +3,10 @@ import React from 'react'
 
 import { Button } from '@/renderer/src/components/ui/button'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
-import { selectStaleLockEntryCount } from '@/renderer/src/redux/slices/skillLockSlice'
+import {
+  selectLockRecordsNeedingAttention,
+  selectStaleLockEntryCount,
+} from '@/renderer/src/redux/slices/skillLockSlice'
 import { selectSkillsItems } from '@/renderer/src/redux/slices/skillsSlice'
 import {
   openLockPruneDialog,
@@ -128,9 +131,13 @@ export const HealthWidget = function HealthWidget(): React.ReactElement {
   const skills = useAppSelector(selectSkillsItems)
   const totals = tallySymlinks(skills)
   const percentLabel = healthPercentLabel(totals)
-  const staleLockCount = useAppSelector(selectStaleLockEntryCount)
+  const prunableLockCount = useAppSelector(selectStaleLockEntryCount)
+  // Counts blocked records too. They disagree with disk exactly as much as the
+  // prunable ones do, and leaving them out reported a healthy lock while
+  // `skills -g update` kept resurrecting the skills behind them.
+  const lockCount = useAppSelector(selectLockRecordsNeedingAttention)
   const hasBrokenLinks = totals.broken > 0
-  const hasStaleLockEntries = staleLockCount > 0
+  const hasStaleLockEntries = lockCount > 0
   const hasManualReviewOnly =
     !hasBrokenLinks && !hasStaleLockEntries && totals.inaccessible > 0
   const isHealthy =
@@ -176,16 +183,16 @@ export const HealthWidget = function HealthWidget(): React.ReactElement {
               <span className="text-muted-foreground">manual</span>
             </span>
           ) : null}
-          {staleLockCount > 0 ? (
+          {lockCount > 0 ? (
             <span className="inline-flex items-center gap-1 text-foreground">
               <FileWarning className="h-3 w-3" aria-hidden="true" />
-              <span className="tabular-nums">{staleLockCount}</span>
+              <span className="tabular-nums">{lockCount}</span>
               <span className="text-muted-foreground">lock</span>
             </span>
           ) : null}
           {totals.broken === 0 &&
           totals.inaccessible === 0 &&
-          staleLockCount === 0 ? (
+          lockCount === 0 ? (
             <span className="inline-flex items-center gap-1 text-muted-foreground">
               <AlertCircle className="h-3 w-3" aria-hidden="true" />
               <span className="tabular-nums">0</span>
@@ -217,7 +224,9 @@ export const HealthWidget = function HealthWidget(): React.ReactElement {
             className="h-8 min-h-8 px-2 text-[11px]"
           >
             <FileWarning className="h-3.5 w-3.5" aria-hidden="true" />
-            Prune lock
+            {/* Nothing to prune means the dialog is pure explanation, and a
+                button promising a delete would be lying about what it opens. */}
+            {prunableLockCount > 0 ? 'Prune lock' : 'Review lock'}
           </Button>
         ) : null}
         {hasManualReviewOnly ? (

--- a/src/renderer/src/redux/slices/skillLockSlice.test.ts
+++ b/src/renderer/src/redux/slices/skillLockSlice.test.ts
@@ -6,8 +6,10 @@ import skillLockReducer, {
   pruneStaleLockEntries,
   selectConsentedLockEntryNames,
   selectIsPruningLockEntries,
+  selectLockRecordsNeedingAttention,
   selectStaleLockEntryCount,
   selectStaleLockEntryNames,
+  selectUnprunableLockEntries,
 } from './skillLockSlice'
 import { closeLockPruneDialog, openLockPruneDialog } from './uiSlice'
 
@@ -35,7 +37,7 @@ describe('skillLockSlice', () => {
     store.dispatch(fetchStaleLockEntries.pending('req-1', undefined))
     store.dispatch(
       fetchStaleLockEntries.fulfilled(
-        { status: 'ok', names: ['old-skill', 'another-skill'] },
+        { status: 'ok', names: ['old-skill', 'another-skill'], unprunable: [] },
         'req-1',
         undefined,
       ),
@@ -57,7 +59,7 @@ describe('skillLockSlice', () => {
     store.dispatch(fetchStaleLockEntries.pending('req-1', undefined))
     store.dispatch(
       fetchStaleLockEntries.fulfilled(
-        { status: 'ok', names: ['old-skill'] },
+        { status: 'ok', names: ['old-skill'], unprunable: [] },
         'req-1',
         undefined,
       ),
@@ -100,7 +102,7 @@ describe('skillLockSlice', () => {
     store.dispatch(fetchStaleLockEntries.pending('req-1', undefined))
     store.dispatch(
       fetchStaleLockEntries.fulfilled(
-        { status: 'ok', names: ['pruned-ok', 'stubborn'] },
+        { status: 'ok', names: ['pruned-ok', 'stubborn'], unprunable: [] },
         'req-1',
         undefined,
       ),
@@ -162,7 +164,7 @@ describe('skillLockSlice', () => {
     store.dispatch(fetchStaleLockEntries.pending('req-fresh', undefined))
     store.dispatch(
       fetchStaleLockEntries.fulfilled(
-        { status: 'ok', names: ['current-truth'] },
+        { status: 'ok', names: ['current-truth'], unprunable: [] },
         'req-fresh',
         undefined,
       ),
@@ -171,7 +173,7 @@ describe('skillLockSlice', () => {
     // Act
     store.dispatch(
       fetchStaleLockEntries.fulfilled(
-        { status: 'ok', names: ['long-gone', 'also-gone'] },
+        { status: 'ok', names: ['long-gone', 'also-gone'], unprunable: [] },
         'req-slow',
         undefined,
       ),
@@ -192,7 +194,7 @@ describe('skillLockSlice', () => {
     store.dispatch(fetchStaleLockEntries.pending('req-fresh', undefined))
     store.dispatch(
       fetchStaleLockEntries.fulfilled(
-        { status: 'ok', names: ['current-truth'] },
+        { status: 'ok', names: ['current-truth'], unprunable: [] },
         'req-fresh',
         undefined,
       ),
@@ -220,7 +222,7 @@ describe('skillLockSlice', () => {
     store.dispatch(fetchStaleLockEntries.pending('req-mid-prune', undefined))
     store.dispatch(
       fetchStaleLockEntries.fulfilled(
-        { status: 'ok', names: ['old-skill', 'newly-stale'] },
+        { status: 'ok', names: ['old-skill', 'newly-stale'], unprunable: [] },
         'req-mid-prune',
         undefined,
       ),
@@ -280,7 +282,7 @@ describe('skillLockSlice', () => {
     store.dispatch(fetchStaleLockEntries.pending('req-1', undefined))
     store.dispatch(
       fetchStaleLockEntries.fulfilled(
-        { status: 'ok', names: ['old-skill'] },
+        { status: 'ok', names: ['old-skill'], unprunable: [] },
         'req-1',
         undefined,
       ),
@@ -291,7 +293,7 @@ describe('skillLockSlice', () => {
     store.dispatch(fetchStaleLockEntries.pending('req-2', undefined))
     store.dispatch(
       fetchStaleLockEntries.fulfilled(
-        { status: 'ok', names: ['old-skill', 'just-appeared'] },
+        { status: 'ok', names: ['old-skill', 'just-appeared'], unprunable: [] },
         'req-2',
         undefined,
       ),
@@ -318,7 +320,7 @@ describe('skillLockSlice', () => {
     store.dispatch(fetchStaleLockEntries.pending('req-scan', undefined))
     store.dispatch(
       fetchStaleLockEntries.fulfilled(
-        { status: 'ok', names: ['old-skill', 'newly-found'] },
+        { status: 'ok', names: ['old-skill', 'newly-found'], unprunable: [] },
         'req-scan',
         undefined,
       ),
@@ -335,7 +337,7 @@ describe('skillLockSlice', () => {
     store.dispatch(fetchStaleLockEntries.pending('req-scan', undefined))
     store.dispatch(
       fetchStaleLockEntries.fulfilled(
-        { status: 'ok', names: ['old-skill', 'newly-found'] },
+        { status: 'ok', names: ['old-skill', 'newly-found'], unprunable: [] },
         'req-scan',
         undefined,
       ),
@@ -407,7 +409,7 @@ describe('skillLockSlice', () => {
     store.dispatch(fetchStaleLockEntries.pending('req-1', undefined))
     store.dispatch(
       fetchStaleLockEntries.fulfilled(
-        { status: 'ok', names: ['old-skill'] },
+        { status: 'ok', names: ['old-skill'], unprunable: [] },
         'req-1',
         undefined,
       ),
@@ -417,7 +419,7 @@ describe('skillLockSlice', () => {
     store.dispatch(fetchStaleLockEntries.pending('req-2', undefined))
     store.dispatch(
       fetchStaleLockEntries.fulfilled(
-        { status: 'ok', names: ['different-skill'] },
+        { status: 'ok', names: ['different-skill'], unprunable: [] },
         'req-2',
         undefined,
       ),
@@ -451,7 +453,7 @@ describe('skillLockSlice', () => {
     // Act
     store.dispatch(
       fetchStaleLockEntries.fulfilled(
-        { status: 'ok', names: ['old-skill'] },
+        { status: 'ok', names: ['old-skill'], unprunable: [] },
         'req-before-prune',
         undefined,
       ),
@@ -459,5 +461,131 @@ describe('skillLockSlice', () => {
 
     // Assert
     expect(selectStaleLockEntryNames(readState(store))).toEqual([])
+  })
+  test('keeps a blocked record out of the list the confirm button would delete', async () => {
+    // Arrange
+    // `staleNames` is what the dialog snapshots and sends to main. A record the
+    // scan already refused belongs in the explanation, never in that request.
+    const store = createTestStore()
+
+    // Act
+    store.dispatch(fetchStaleLockEntries.pending('req-1', undefined))
+    store.dispatch(
+      fetchStaleLockEntries.fulfilled(
+        {
+          status: 'ok',
+          names: ['removable'],
+          unprunable: [{ name: 'agent-owned', reason: 'agent-copy' }],
+        },
+        'req-1',
+        undefined,
+      ),
+    )
+    store.dispatch(openLockPruneDialog())
+
+    // Assert
+    expect(selectConsentedLockEntryNames(readState(store))).toEqual([
+      'removable',
+    ])
+    expect(selectUnprunableLockEntries(readState(store))).toEqual([
+      { name: 'agent-owned', reason: 'agent-copy' },
+    ])
+  })
+
+  test('counts blocked records as needing attention so an all-blocked lock never reads as healthy', async () => {
+    // Arrange
+    // With nothing prunable the old count was 0, the widget said "Healthy", and
+    // `skills -g update` went on resurrecting both skills every run.
+    const store = createTestStore()
+
+    // Act
+    store.dispatch(fetchStaleLockEntries.pending('req-1', undefined))
+    store.dispatch(
+      fetchStaleLockEntries.fulfilled(
+        {
+          status: 'ok',
+          names: [],
+          unprunable: [
+            { name: 'ambiguous', reason: 'name-collision' },
+            { name: 'Ambiguous', reason: 'name-collision' },
+          ],
+        },
+        'req-1',
+        undefined,
+      ),
+    )
+
+    // Assert
+    expect(selectStaleLockEntryCount(readState(store))).toBe(0)
+    expect(selectLockRecordsNeedingAttention(readState(store))).toBe(2)
+  })
+
+  test('drops the blocked list when a later scan cannot read the lock', async () => {
+    // Arrange
+    // An unavailable scan read nothing, so it has no more standing to name a
+    // blocked record than a stale one. Leaving the reasons up would explain a
+    // state we can no longer see.
+    const store = createTestStore()
+    store.dispatch(fetchStaleLockEntries.pending('req-1', undefined))
+    store.dispatch(
+      fetchStaleLockEntries.fulfilled(
+        {
+          status: 'ok',
+          names: [],
+          unprunable: [{ name: 'agent-owned', reason: 'agent-copy' }],
+        },
+        'req-1',
+        undefined,
+      ),
+    )
+
+    // Act
+    store.dispatch(fetchStaleLockEntries.pending('req-2', undefined))
+    store.dispatch(
+      fetchStaleLockEntries.fulfilled(
+        { status: 'unavailable' },
+        'req-2',
+        undefined,
+      ),
+    )
+
+    // Assert
+    expect(selectUnprunableLockEntries(readState(store))).toEqual([])
+    expect(selectLockRecordsNeedingAttention(readState(store))).toBe(0)
+  })
+
+  test('leaves the blocked list alone when a prune reports failures', async () => {
+    // Arrange
+    // Only a scan re-derives these reasons from disk. A prune result overwriting
+    // them would erase the explanation the moment the user tried anything else.
+    const store = createTestStore()
+    store.dispatch(fetchStaleLockEntries.pending('req-1', undefined))
+    store.dispatch(
+      fetchStaleLockEntries.fulfilled(
+        {
+          status: 'ok',
+          names: ['removable'],
+          unprunable: [{ name: 'agent-owned', reason: 'agent-copy' }],
+        },
+        'req-1',
+        undefined,
+      ),
+    )
+
+    // Act
+    store.dispatch(pruneStaleLockEntries.pending('prune-1', ['removable']))
+    store.dispatch(
+      pruneStaleLockEntries.fulfilled(
+        { pruned: [], skipped: [], failed: ['removable'] },
+        'prune-1',
+        ['removable'],
+      ),
+    )
+
+    // Assert
+    expect(selectUnprunableLockEntries(readState(store))).toEqual([
+      { name: 'agent-owned', reason: 'agent-copy' },
+    ])
+    expect(selectLockRecordsNeedingAttention(readState(store))).toBe(2)
   })
 })

--- a/src/renderer/src/redux/slices/skillLockSlice.ts
+++ b/src/renderer/src/redux/slices/skillLockSlice.ts
@@ -2,7 +2,7 @@ import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 
 import { openLockPruneDialog } from '@/renderer/src/redux/slices/uiSlice'
 import type { RootState } from '@/renderer/src/redux/store'
-import type { SkillName } from '@/shared/types'
+import type { SkillName, UnprunableLockEntry } from '@/shared/types'
 
 // ============================================================================
 // State shape
@@ -21,6 +21,14 @@ import type { SkillName } from '@/shared/types'
 interface SkillLockState {
   /** Raw lock keys reported stale by the last scan. */
   staleNames: SkillName[]
+  /**
+   * Stale records the last scan refused to offer for deletion, each with why.
+   * Held apart from {@link SkillLockState.staleNames} because the difference is
+   * what the user can do next: those are behind a button, these are behind an
+   * explanation. A prune never touches this list, so it is replaced only by a
+   * scan — the one thing that re-derives both reasons from disk.
+   */
+  unprunableEntries: UnprunableLockEntry[]
   /** `idle` before the first scan; `unavailable` when main could not compare. */
   status: 'idle' | 'ok' | 'unavailable'
   /**
@@ -61,6 +69,7 @@ interface SkillLockState {
 
 const initialState: SkillLockState = {
   staleNames: [],
+  unprunableEntries: [],
   status: 'idle',
   scanRequestId: null,
   pruneRequestId: null,
@@ -115,12 +124,14 @@ const skillLockSlice = createSlice({
         if (action.payload.status === 'ok') {
           state.status = 'ok'
           state.staleNames = action.payload.names
+          state.unprunableEntries = action.payload.unprunable
           return
         }
         // Main could not compare the two sides. Drop the count rather than
         // showing a stale one next to a "prune" button.
         state.status = 'unavailable'
         state.staleNames = []
+        state.unprunableEntries = []
       })
       .addCase(fetchStaleLockEntries.rejected, (state, action) => {
         if (action.meta.requestId !== state.scanRequestId) return
@@ -130,6 +141,7 @@ const skillLockSlice = createSlice({
         state.staleNamesSupersededByScan = true
         state.status = 'unavailable'
         state.staleNames = []
+        state.unprunableEntries = []
       })
       .addCase(pruneStaleLockEntries.pending, (state, action) => {
         state.scanRequestId = null
@@ -206,3 +218,32 @@ export const selectIsPruningLockEntries = (state: RootState): boolean =>
  */
 export const selectConsentedLockEntryNames = (state: RootState): SkillName[] =>
   state.skillLock.consentedNames
+
+/**
+ * Stale records the scan refused to offer for deletion, with the reason each
+ * one is blocked. Empty while the scan is unavailable, for the same reason
+ * {@link selectStaleLockEntryCount} reports zero there: a scan that read
+ * nothing cannot name a blocked record any more than it can name a stale one.
+ * @param state - Root Redux state.
+ * @returns Blocked lock records and why.
+ * @example useAppSelector(selectUnprunableLockEntries) // => [{ name: 'a', reason: 'agent-copy' }]
+ */
+export const selectUnprunableLockEntries = (
+  state: RootState,
+): UnprunableLockEntry[] =>
+  state.skillLock.status === 'ok' ? state.skillLock.unprunableEntries : []
+
+/**
+ * Every lock record that disagrees with disk, prunable or not. Drives the
+ * widget's count and its CTA: a user whose records are ALL blocked still has to
+ * be able to reach the explanation, and a count that omitted them would report
+ * a healthy lock while `skills -g update` kept resurrecting deleted skills.
+ * @param state - Root Redux state.
+ * @returns Total stale record count.
+ * @example useAppSelector(selectLockRecordsNeedingAttention) // => 3
+ */
+export const selectLockRecordsNeedingAttention = (state: RootState): number =>
+  state.skillLock.status === 'ok'
+    ? state.skillLock.staleNames.length +
+      state.skillLock.unprunableEntries.length
+    : 0

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1422,15 +1422,53 @@ export interface SyncExecuteResult {
 }
 
 /**
+ * Why a stale lock record cannot be pruned, even though its skill is gone.
+ *
+ * Both values name a state the user can act on themselves, which is the whole
+ * point of separating them from a plain failure: a record that merely `failed`
+ * is worth retrying, one that is `unprunable` is not.
+ * - `name-collision`: another lock key sanitizes to the same source directory,
+ *   so "does this skill still exist" no longer answers anything about either
+ *   record, and upstream `removeSkillFromLock` is last-write-wins over the
+ *   sanitized name — delegating would delete the wrong one.
+ * - `agent-copy`: some agent holds a REAL directory (not a symlink) under this
+ *   name, and `skills remove --global` would recursively delete it out of every
+ *   agent directory, including `~/.claude/skills` and `~/.cursor/skills`.
+ */
+export type UnprunableReason = 'name-collision' | 'agent-copy'
+
+/**
+ * A lock record that is stale but blocked from pruning, with the reason.
+ * @example { name: 'old-skill', reason: 'agent-copy' }
+ */
+export interface UnprunableLockEntry {
+  /** Raw lock key, exactly as the CLI stores it. */
+  name: SkillName
+  /** What blocks the prune. */
+  reason: UnprunableReason
+}
+
+/**
  * Result of scanning the skills CLI lock for records whose skill is gone.
  * `unavailable` means one side of the comparison could not be read (the lock,
  * or `~/.agents/skills` itself). It is deliberately NOT "0 stale": with half
  * the picture missing, every surviving record would look deletable.
- * @example { status: 'ok', names: ['old-skill'] }
+ *
+ * `unprunable` deliberately exists only on the `ok` arm. An unavailable scan
+ * read nothing, so it has no more standing to name a blocked record than it has
+ * to name a stale one — do NOT add the field to the failure arm.
+ * @example { status: 'ok', names: ['old-skill'], unprunable: [] }
  * @example { status: 'unavailable' }
  */
 export type StaleLockScanResult =
-  { status: 'ok'; names: SkillName[] } | { status: 'unavailable' }
+  | {
+      status: 'ok'
+      /** Records safe to delegate to `skills remove` right now. */
+      names: SkillName[]
+      /** Records that are stale but blocked, each with why. */
+      unprunable: UnprunableLockEntry[]
+    }
+  | { status: 'unavailable' }
 
 /**
  * IPC argument for `skills:lock:prune` — the exact stale lock records the user


### PR DESCRIPTION
Addresses the stale-lock cluster in `TODOS.md`: the P2 name-collision entry, the manual-recovery P3 sub-item, and the explanation half of the P1 agent-directory-copies entry.

## The severity raise found while tracing this

**A shipped feature had a permanent-brick path, and this PR closes it.** Both source-backed writers of the `.manual-recovery` marker (`skillLockService.ts:1123`, `:1182`) run BEFORE the manifest exists. So `readTrashedSourceDirNames` hit ENOENT on a parseable tombstone id, which it treats as "one of our own entries caught mid-write" and answers `unavailable` for the whole scan. `startupCleanup` deliberately never sweeps a marked entry, so that state was permanent: **one stuck trash entry killed the stale-lock feature outright and failed every prune closed, with no way back.** This was filed as a P3 follow-up. It is not one.

The fix checks the marker before the manifest and returns `null` for a marked entry — terminal, so it is neither a mid-write signal nor a live undo window.

## What else changes

The scan used to silently drop records it could not offer. Two kinds:

- **name-collision** — two lock keys sanitize to one directory name, so removing either could remove the wrong record. `buildUniqueDirNameIndex` already deletes every collided name, so the collided set is `keys.filter(k => !byDirName.has(sanitizeName(k)))` — one line, no extra I/O.
- **agent-copy** — an agent holds a real directory (not a symlink) under the name, and `skills remove --global` would recursively delete it out of every agent directory, `~/.claude/skills` and `~/.cursor/skills` included. The prune already refused these into `failed`; the scan now says so *before* the user clicks a button that could only report a failure. It probes the already-proven-stale list only, never the whole lock, so the common case is zero extra `lstat`.

Both now surface as `unprunable` on the scan result, render in the dialog with a plain-language reason, and count toward the widget's "needs review" — an all-blocked lock used to report Healthy while `skills -g update` kept resurrecting the skills behind it. The prune's own checks are untouched and remain the TOCTOU backstop.

## Details worth a reviewer's eye

- **`unprunable` exists only on the `ok` arm** of `StaleLockScanResult`, on purpose. An unavailable scan read nothing, so it has no standing to name a blocked record.
- **The dialog is now reachable with nothing to remove.** A user whose records are all blocked still needs the explanation, so the delete button and its list render only when something is removable, and the footer reads "Got it" — not "Close", which is already the corner X's accessible name.
- **`removableNames` filters the consent snapshot against the live blocked list.** A scan landing mid-dialog could otherwise put one record in the delete list and in the "cannot be deleted" section at once. Filtering only narrows what the button sends, so consent still holds.
- **`LockPruneBanner` deliberately stays on the prunable count** while the widget uses the wider one. Every sentence in the banner promises a prune; announcing a blocked record there would offer a button that can only say no. Commented at the selector and pinned by a test.
- **Blocked records sort by code unit, not `localeCompare`.** ICU ordered `lock-prune:dup` before `lock-prune/dup` under Electron and the opposite under the node test lane — not something a result shape should depend on.
- **`MANUAL_RECOVERY_MARKER` moved to `main/constants.ts`** to break an import cycle: `trashService` already imports `skillLockService`.
- **`HealthWidget.browser.test.tsx` now imports both `it` and `test`.** New tests use `test` per CLAUDE.md; the 13 existing `it` blocks were left alone rather than churned.

## Test plan

- `pnpm validate` — 194 files, 2523 tests passed
- `pnpm test:coverage` — 94.88 stmts / 85.05 branch / 96.82 funcs / 99.26 lines, all above thresholds
- `npx tsc -p e2e/tsconfig.json --noEmit` — clean (`e2e/types.d.ts` is hand-mirrored; root typecheck cannot catch omissions there)
- `pnpm test:e2e` — 84 passed
- Mutation-tested: marker check removed, agent-copy probe forced false, collisions dropped, `hideCloseButton` removed, blocked section not rendered, `removableNames` filter reverted, banner switched to the wide selector. Each caught by exactly the intended test, none by an unrelated one.

## Still open, deliberately

`TODOS.md` P1 "decide how prune should treat skills with real agent-directory copies" stays open. This PR explains the dead end; choosing the way out (narrow `--agent`, or stop delegating and own the lock format) is an architecture call, not a bug fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - ロックのプルーン時に、名前の衝突やエージェント側のコピーなど、削除できない項目を理由付きで表示します。
  - 削除可能な項目と削除できない項目を分けて確認できます。
  - 削除可能な項目がない場合は、削除操作を実行せず案内を表示します。
  - ヘルス表示が削除できないロックも考慮し、必要に応じて「Review lock」を表示します。

- **改善**
  - プルーン処理中はダイアログを閉じられないようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->