### PR TITLE
fix(dashboard): stop hiding Manual review, and use one noun for lock records

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1273,11 +1273,49 @@ its own copy of the check as the TOCTOU backstop.
 REMAINING: the record still cannot be pruned at all. That needs the delegation
 decision below, which is an architecture call, not a UI one.
 
-**Fix direction:** either narrow the delegation (pass `--agent` restricted to
-universal-source agents), or stop delegating and edit the lock directly,
+**Fix direction:** ~~either narrow the delegation (pass `--agent` restricted to
+universal-source agents), or~~ stop delegating and edit the lock directly,
 accepting ownership of the lock format. See
 `docs/adr/0001-prune-the-skill-lock-at-trash-eviction.md`
 (corrected 2026-09-06).
+
+**The `--agent` branch is closed — it provably cannot work.** Read from the
+pinned bundle (`skills@1.5.23`, `dist/cli.mjs`, `removeCommand`), not inferred:
+
+```js
+let targetAgents
+if (options.agent && options.agent.length > 0) targetAgents = options.agent
+else targetAgents = Object.keys(agents)
+// ...
+const remainingAgents = (await detectInstalledAgents()).filter(
+  (a) => !targetAgents.includes(a),
+)
+let isStillUsed = false
+for (const agentKey of remainingAgents)
+  if (
+    await lstat(
+      getInstallPath(skillName, agentKey, { global: isGlobal, cwd }),
+    ).catch(() => null)
+  ) {
+    isStillUsed = true
+    break
+  }
+// ...
+if (!isStillUsed) await removeSkillFromLock(skillName)
+```
+
+Narrowing `--agent` to universal-source agents puts the agent holding the real
+copy into `remainingAgents`. Its install path exists, so `isStillUsed` is true,
+so `removeSkillFromLock` is never called and the lock record survives — exactly
+the state the fix was meant to clear. Narrowing the flag changes which
+directories get deleted; it cannot change whether the lock entry goes.
+
+**So the only branch left is owning the lock format**, which ADR 0001 rejected
+because the lock carries a `"version"` field and a parser means tracking the CLI
+forever. Nothing found here overturns that reasoning — this evidence only
+removes the alternative to it. That leaves a genuine architecture decision with
+no good option, which is a call for a human to make, not one to settle quietly
+inside a cleanup pass. **Still open, now with one branch eliminated.**
 
 **Depends on / blocked by:** Nothing.
 
@@ -1436,18 +1474,35 @@ scan false-negative, not an unprunable state — see there.
 - ~~`SUPPORTED_LOCK_VERSION` guards `version < 3` with no upper bound.~~
   FIXED: a higher version now reports `unavailable`, reusing the existing
   three-valued status channel.
-- `HealthWidget`'s `hasManualReviewOnly` now requires `!hasStaleLockEntries`,
+- ~~`HealthWidget`'s `hasManualReviewOnly` now requires `!hasStaleLockEntries`,
   so the "Manual review" affordance disappears whenever a stale lock coexists
   with inaccessible links; and the two CTAs can co-occur in a widget footer
-  with no wrap at minimum widget size.
-- Feature copy uses four nouns for one concept ("deleted skills", "records",
+  with no wrap at minimum widget size.~~ FIXED, and wider than filed. The flag
+  also required `!hasBrokenLinks`, which hid the label for the same reason in a
+  second state — neither CTA resolves an inaccessible link ("Scan issues" opens
+  the broken-link cleanup, "Prune lock" touches lock records), so suppressing
+  the label whenever one of them rendered left those links with nothing pointing
+  at them. It is now `hasManualReview = totals.inaccessible > 0`, which cannot
+  collide with `isHealthy` (that requires `inaccessible === 0`). The footer got
+  `flex-wrap`. One existing test asserted `getByText('manual')` non-exact and
+  began matching the footer label too; it is now `{ exact: true }`, matching the
+  sibling assertion that already was.
+- ~~Feature copy uses four nouns for one concept ("deleted skills", "records",
   "stale records", "skills that are no longer installed") against the internal
-  `StaleLockEntry` naming. Pick one.
+  `StaleLockEntry` naming. Pick one.~~ FIXED. The rule picked: **"record" is the
+  only countable noun**, and "skill" appears solely to say what a record points
+  at, never with a number. So the banner reads "still tracks 3 records for
+  skills you deleted" and the dialog "still tracks 3 records for skills that are
+  no longer installed"; the "stale" qualifier left the success toast, which the
+  button label already established. Both counts now agree with `recordNoun`
+  because they come from the same `describeLockPruneTarget` call.
 - ~~`PruneLockEntriesResult.skipped` has no reader in the renderer.~~ Not true
   as filed: `LockPruneDialog.tsx` reads it for the "Kept N records" toast on the
   nothing-pruned branch.
-- Dead JSDoc link `{@link skillLockService}` at `skillsCliService.ts:210`
-  (the line number in the original filing has drifted; the link itself is real).
+- ~~Dead JSDoc link `{@link skillLockService}` at `skillsCliService.ts:210`
+  (the line number in the original filing has drifted; the link itself is real).~~
+  FIXED: it now links `{@link pruneLockEntries}`, which is the actual caller and
+  a symbol a reader can reach.
 - No E2E reaches the npx-unavailable prune path. `e2e/spec/skill-lock-prune.e2e.ts`
   (added by /qa on `feat/prune-stale-skill-lock-entries`, 2026-09-06) covers
   every guard plus one real `npx skills remove`, but the branch where the CLI

--- a/docs/adr/0001-prune-the-skill-lock-at-trash-eviction.md
+++ b/docs/adr/0001-prune-the-skill-lock-at-trash-eviction.md
@@ -63,8 +63,23 @@ recursively deleted, with no tombstone and no undo.
 one is a symlink or absent (`holdsRealAgentDirectory`). Refused names are
 reported as failures rather than silently skipped. The consequence is that a
 user holding a real agent-directory copy under a pruned name gets a permanent
-"cannot prune" state; narrowing the delegation or writing the lock directly is
-the open follow-up.
+"cannot prune" state; writing the lock directly is the open follow-up.
+
+**Narrowing the delegation was the other candidate. It is ruled out
+(2026-09-06).** Passing `--agent` restricted to the universal-source agents
+would keep `rm` away from `~/.claude/skills`, but it cannot clear the lock
+record, which is the whole point of the prune. In `removeCommand`, `--agent`
+sets `targetAgents`, and everything installed but not targeted becomes
+`remainingAgents`; if any of those still holds an install path for the name,
+`isStillUsed` is set and both the canonical-path delete **and**
+`removeSkillFromLock(skillName)` are skipped. The real agent directory that
+forced the narrowing is exactly what makes `isStillUsed` true. So the narrowed
+call would delete less and still leave the record behind.
+
+That leaves owning the lock format as the only remaining option, which this ADR
+rejects above for reasons that still hold. The decision is therefore open by
+design rather than by omission: both branches have a real cost, and choosing
+between them is a product call.
 
 The CLI exits 0 even when every removal failed: `remove.ts` logs the failures
 and falls through to its normal outro without calling `process.exit(1)`. Success

--- a/src/main/services/skillsCliService.ts
+++ b/src/main/services/skillsCliService.ts
@@ -207,7 +207,7 @@ class SkillsCliService extends EventEmitter {
 
   /**
    * Remove skills from the global lock using `npx skills remove <names...>`.
-   * Called by {@link skillLockService} to prune records whose skill is already
+   * Called by {@link pruneLockEntries} to prune records whose skill is already
    * gone from disk; the CLI owns the lock format, so the app never writes it.
    *
    * Deliberately passes no `onOutput` callback: `parseProgressFromOutput`

--- a/src/renderer/src/components/dashboard/LockPruneBanner.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/LockPruneBanner.browser.test.tsx
@@ -102,7 +102,9 @@ describe('LockPruneBanner', () => {
 
     // Assert
     await expect
-      .element(screen.getByText(/still tracks 1 deleted skill,/))
+      .element(
+        screen.getByText(/still tracks 1 record for a skill you deleted,/),
+      )
       .toBeVisible()
   })
 

--- a/src/renderer/src/components/dashboard/LockPruneBanner.tsx
+++ b/src/renderer/src/components/dashboard/LockPruneBanner.tsx
@@ -39,11 +39,12 @@ export const LockPruneBanner =
           aria-hidden="true"
         />
         <p className="flex-1 text-xs text-foreground">
-          The skills CLI still tracks {staleCount} deleted{' '}
-          {pluralize(staleCount, 'skill')}, so{' '}
+          The skills CLI still tracks {staleCount}{' '}
+          {pluralize(staleCount, 'record')} for{' '}
+          {staleCount === 1 ? 'a skill' : 'skills'} you deleted, so{' '}
           <code className="text-[11px]">skills -g update</code> brings{' '}
-          {staleCount === 1 ? 'it' : 'them'} back. You can prune those records
-          here now.
+          {staleCount === 1 ? 'it' : 'them'} back. You can prune{' '}
+          {staleCount === 1 ? 'it' : 'them'} here now.
         </p>
         <Button
           type="button"

--- a/src/renderer/src/components/dashboard/LockPruneBanner.tsx
+++ b/src/renderer/src/components/dashboard/LockPruneBanner.tsx
@@ -9,7 +9,8 @@ import {
 } from '@/renderer/src/redux/slices/dashboardSlice'
 import { selectStaleLockEntryCount } from '@/renderer/src/redux/slices/skillLockSlice'
 import { openLockPruneDialog } from '@/renderer/src/redux/slices/uiSlice'
-import { pluralize } from '@/renderer/src/utils/pluralize'
+
+import { describeLockPruneTarget } from './lockPruneCopy'
 
 /**
  * One-time announcement that the app can now prune the skills CLI lock.
@@ -28,6 +29,9 @@ export const LockPruneBanner =
     // hand the user a button that can only tell them no. The widget is the
     // surface that reports those, and it says "Review lock" instead.
     const staleCount = useAppSelector(selectStaleLockEntryCount)
+    // Same call the dialog makes, so the banner's subject clause and pronouns
+    // cannot drift from the ones behind the button it opens.
+    const copy = describeLockPruneTarget(staleCount)
     const isDismissed = useAppSelector(selectLockPruneBannerDismissed)
 
     if (isDismissed || staleCount === 0) return null
@@ -39,12 +43,9 @@ export const LockPruneBanner =
           aria-hidden="true"
         />
         <p className="flex-1 text-xs text-foreground">
-          The skills CLI still tracks {staleCount}{' '}
-          {pluralize(staleCount, 'record')} for{' '}
-          {staleCount === 1 ? 'a skill' : 'skills'} you deleted, so{' '}
+          The skills CLI still tracks {copy.subject} you deleted, so{' '}
           <code className="text-[11px]">skills -g update</code> brings{' '}
-          {staleCount === 1 ? 'it' : 'them'} back. You can prune{' '}
-          {staleCount === 1 ? 'it' : 'them'} here now.
+          {copy.pronoun} back. You can prune {copy.pronoun} here now.
         </p>
         <Button
           type="button"

--- a/src/renderer/src/components/dashboard/LockPruneDialog.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/LockPruneDialog.browser.test.tsx
@@ -219,7 +219,7 @@ describe('LockPruneDialog', () => {
   test('does not claim success when main pruned nothing and kept every record', async () => {
     // Arrange — main revalidates each name before deleting. If the skill came
     // back on disk or is still inside its undo window, nothing is removed and
-    // nothing failed. "Removed 0 stale records" would claim work never done.
+    // nothing failed. "Removed 0 records" would claim work never done.
     mockPruneLockEntries.mockResolvedValue({
       pruned: [],
       skipped: ['came-back'],
@@ -264,7 +264,7 @@ describe('LockPruneDialog', () => {
     // Assert
     await vi.waitFor(() => {
       expect(mockToastSuccess).toHaveBeenCalledWith(
-        'Removed 1 stale record from the skill lock.',
+        'Removed 1 record from the skill lock.',
       )
     })
     expect(mockToastInfo).not.toHaveBeenCalled()

--- a/src/renderer/src/components/dashboard/LockPruneDialog.tsx
+++ b/src/renderer/src/components/dashboard/LockPruneDialog.tsx
@@ -111,7 +111,7 @@ export const LockPruneDialog = function LockPruneDialog(): React.ReactElement {
       )
     } else {
       toast.success(
-        `Removed ${result.pruned.length} stale ${pluralize(result.pruned.length, 'record')} from the skill lock.`,
+        `Removed ${result.pruned.length} ${pluralize(result.pruned.length, 'record')} from the skill lock.`,
       )
     }
 
@@ -134,8 +134,9 @@ export const LockPruneDialog = function LockPruneDialog(): React.ReactElement {
           <DialogDescription>
             {hasRemovableRecords ? (
               <>
-                The skills CLI still tracks {copy.subject} no longer installed.
-                Until the {copy.recordNoun} {copy.recordVerb} removed,{' '}
+                The skills CLI still tracks {copy.subject} that{' '}
+                {copy.recordVerb} no longer installed. Until the{' '}
+                {copy.recordNoun} {copy.recordVerb} removed,{' '}
                 <code className="text-xs">skills -g update</code> reinstalls{' '}
                 {copy.pronoun}.
               </>

--- a/src/renderer/src/components/dashboard/lockPruneCopy.test.ts
+++ b/src/renderer/src/components/dashboard/lockPruneCopy.test.ts
@@ -19,7 +19,7 @@ describe('describeLockPruneTarget', () => {
 
     // Assert
     expect(copy).toEqual({
-      subject: 'a skill that is',
+      subject: '1 record for a skill',
       recordNoun: 'record',
       recordVerb: 'is',
       pronoun: 'it',
@@ -36,7 +36,7 @@ describe('describeLockPruneTarget', () => {
 
     // Assert
     expect(copy).toEqual({
-      subject: '3 skills that are',
+      subject: '3 records for skills',
       recordNoun: 'records',
       recordVerb: 'are',
       pronoun: 'them',
@@ -47,7 +47,7 @@ describe('describeLockPruneTarget', () => {
   test('stays plural at zero so an empty dialog never reads as one skill', () => {
     // Arrange
     // The dialog opens on whatever the scan found; a race can leave it empty,
-    // and "a skill that is no longer installed" would then be a lie.
+    // and "1 record for a skill" would then be a lie.
     const count = 0
 
     // Act
@@ -55,7 +55,7 @@ describe('describeLockPruneTarget', () => {
 
     // Assert
     expect(copy).toEqual({
-      subject: '0 skills that are',
+      subject: '0 records for skills',
       recordNoun: 'records',
       recordVerb: 'are',
       pronoun: 'them',

--- a/src/renderer/src/components/dashboard/lockPruneCopy.test.ts
+++ b/src/renderer/src/components/dashboard/lockPruneCopy.test.ts
@@ -10,7 +10,7 @@ import {
 } from './lockPruneCopy'
 
 describe('describeLockPruneTarget', () => {
-  test('reads as one skill throughout when a single record is up for deletion', () => {
+  test('keeps every word singular when exactly one record is up for deletion', () => {
     // Arrange
     const count = 1
 
@@ -44,7 +44,7 @@ describe('describeLockPruneTarget', () => {
     })
   })
 
-  test('stays plural at zero so an empty dialog never reads as one skill', () => {
+  test('stays plural at zero so an empty dialog never reads as a single record', () => {
     // Arrange
     // The dialog opens on whatever the scan found; a race can leave it empty,
     // and "1 record for a skill" would then be a lie.

--- a/src/renderer/src/components/dashboard/lockPruneCopy.ts
+++ b/src/renderer/src/components/dashboard/lockPruneCopy.ts
@@ -11,7 +11,11 @@ import type {
  * records are in play.
  */
 export interface LockPruneCopy {
-  /** Subject clause: what the CLI still tracks. */
+  /**
+   * Subject clause: what the CLI still tracks. Counts RECORDS, never skills —
+   * one noun is countable across this feature so the dialog, the banner and the
+   * widget cannot appear to disagree about how many things are wrong.
+   */
   subject: string
   /** Singular or plural noun for a lock record. */
   recordNoun: string
@@ -30,12 +34,14 @@ export interface LockPruneCopy {
  * @param count - How many lock records the dialog is asking about.
  * @returns The wording for that count.
  * @example describeLockPruneTarget(1).confirmLabel // => 'Remove 1 record'
- * @example describeLockPruneTarget(3).subject // => '3 skills that are'
+ * @example describeLockPruneTarget(3).subject // => '3 records for skills'
  */
 export function describeLockPruneTarget(count: number): LockPruneCopy {
   const isSingular = count === 1
   return {
-    subject: isSingular ? 'a skill that is' : `${count} skills that are`,
+    subject: isSingular
+      ? '1 record for a skill'
+      : `${count} records for skills`,
     recordNoun: pluralize(count, 'record'),
     recordVerb: isSingular ? 'is' : 'are',
     pronoun: isSingular ? 'it' : 'them',

--- a/src/renderer/src/components/dashboard/widgets/HealthWidget.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/widgets/HealthWidget.browser.test.tsx
@@ -170,7 +170,11 @@ describe('HealthWidget', () => {
 
     // Assert
     await expect.element(screen.getByText('cleanup')).toBeVisible()
-    await expect.element(screen.getByText('manual')).toBeVisible()
+    // Exact: the footer's "Manual review" label now also renders in this state,
+    // and a substring match would resolve to both.
+    await expect
+      .element(screen.getByText('manual', { exact: true }))
+      .toBeVisible()
     await expect
       .element(
         screen.getByRole('img', {
@@ -178,6 +182,39 @@ describe('HealthWidget', () => {
         }),
       )
       .toBeInTheDocument()
+    await expect
+      .element(screen.getByRole('button', { name: 'Scan issues' }))
+      .toBeVisible()
+  })
+
+  test('still flags manual review when a stale lock record coexists with it', async () => {
+    // Arrange — the case that hid the label: an unreadable link plus a lock
+    // record. Neither CTA in the footer resolves an inaccessible link, so
+    // dropping the label left that link with nothing pointing at it.
+    const skills = [makeSkill([makeSymlink('inaccessible')])]
+
+    // Act
+    const { screen } = await renderHealthWidget(skills, ['old-skill'])
+
+    // Assert
+    await expect.element(screen.getByText('Manual review')).toBeVisible()
+    await expect
+      .element(screen.getByRole('button', { name: 'Prune lock' }))
+      .toBeVisible()
+  })
+
+  test('still flags manual review when broken links coexist with it', async () => {
+    // Arrange — same bug on the other flag: "Scan issues" opens the broken-link
+    // cleanup, which never touches an inaccessible link.
+    const skills = [
+      makeSkill([makeSymlink('broken'), makeSymlink('inaccessible')]),
+    ]
+
+    // Act
+    const { screen } = await renderHealthWidget(skills)
+
+    // Assert
+    await expect.element(screen.getByText('Manual review')).toBeVisible()
     await expect
       .element(screen.getByRole('button', { name: 'Scan issues' }))
       .toBeVisible()

--- a/src/renderer/src/components/dashboard/widgets/HealthWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/HealthWidget.tsx
@@ -138,8 +138,12 @@ export const HealthWidget = function HealthWidget(): React.ReactElement {
   const lockCount = useAppSelector(selectLockRecordsNeedingAttention)
   const hasBrokenLinks = totals.broken > 0
   const hasStaleLockEntries = lockCount > 0
-  const hasManualReviewOnly =
-    !hasBrokenLinks && !hasStaleLockEntries && totals.inaccessible > 0
+  // Inaccessible links are what "manual review" means, and nothing else in this
+  // footer resolves them: "Scan issues" opens the broken-link cleanup and
+  // "Prune lock" touches lock records. Gating this on the absence of those two
+  // hid the label exactly when the widget was busiest, so a user with a broken
+  // link AND an unreadable one was never told about the second.
+  const hasManualReview = totals.inaccessible > 0
   const isHealthy =
     !hasBrokenLinks && !hasStaleLockEntries && totals.inaccessible === 0
 
@@ -201,7 +205,7 @@ export const HealthWidget = function HealthWidget(): React.ReactElement {
           ) : null}
         </div>
       </div>
-      <div className="min-h-8 mt-auto flex items-center justify-end gap-1.5">
+      <div className="min-h-8 mt-auto flex flex-wrap items-center justify-end gap-1.5">
         {hasBrokenLinks ? (
           <Button
             type="button"
@@ -229,7 +233,7 @@ export const HealthWidget = function HealthWidget(): React.ReactElement {
             {prunableLockCount > 0 ? 'Prune lock' : 'Review lock'}
           </Button>
         ) : null}
-        {hasManualReviewOnly ? (
+        {hasManualReview ? (
           <span className="text-[11px] text-amber-400">Manual review</span>
         ) : null}
         {isHealthy ? (


### PR DESCRIPTION
Three of the smaller items from the skill-lock prune review, plus one architecture finding recorded rather than acted on.

## The bug worth reading

`hasManualReviewOnly` suppressed the "Manual review" label whenever a stale lock **or** a broken link was also present. Nothing else in that footer resolves an inaccessible link — "Scan issues" opens the broken-link cleanup, "Prune lock" touches lock records — so **the label vanished exactly when the widget was busiest**, and a user with both a broken link and an unreadable one was never told about the second.

It is now `hasManualReview = totals.inaccessible > 0`. That cannot collide with `isHealthy`, which requires `inaccessible === 0`.

Filed as only the stale-lock half. The broken-link half is the same bug from the same expression and is fixed with it.

## Also in here

- **Footer wrap.** Two CTAs plus the label overflowed at minimum widget size; the footer now has `flex-wrap`.
- **One noun.** The feature used four for one concept. The rule: **"record" is the only countable noun**, and "skill" says what a record points at, never with a number. Banner reads "still tracks 3 records for skills you deleted"; dialog "still tracks 3 records for skills that are no longer installed". The "stale" qualifier leaves the success toast, which the button label already established.
- **Dead JSDoc link.** `skillsCliService`'s `{@link skillLockService}` named a module that is not a symbol there. Now `{@link pruneLockEntries}`, the real caller.
- **Banner shares the dialog's copy source** (found by the OCR delegate pass on this branch). Unifying the noun had left the banner hand-rolling its own `pluralize`, its own "a skill"/"skills" branch, and the same pronoun ternary twice in one sentence — all of which `describeLockPruneTarget` already returns.

## One P1 stays open, deliberately

`P1. Decide how prune should treat skills with real agent-directory copies` proposed two branches. **One is now provably dead**, read from the pinned `skills@1.5.23` bundle rather than inferred:

```js
if (options.agent && options.agent.length > 0) targetAgents = options.agent;
const remainingAgents = (await detectInstalledAgents())
  .filter((a) => !targetAgents.includes(a));
// any remaining agent holding an install path:
if (...) { isStillUsed = true; break }
if (!isStillUsed) await removeSkillFromLock(skillName);
```

Narrowing `--agent` to universal-source agents puts the agent holding the real copy into `remainingAgents`, which sets `isStillUsed`, which skips `removeSkillFromLock`. The record survives — the exact state the fix was meant to clear. Narrowing changes which directories get deleted; it cannot change whether the lock entry goes.

That leaves owning the lock format, which ADR 0001 rejects on grounds this evidence does not overturn. Both remaining options carry a real cost, so the item stays **open with one branch eliminated** — recorded in `TODOS.md` and `docs/adr/0001`, not decided here.

## Test Plan

- [x] `pnpm validate` — 194 files, 2530 tests, green
- [x] `pnpm test:e2e` — 84 passed
- [x] `pnpm test:coverage` — 94.89 / 85.09 / 96.83 / 99.26, all above thresholds
- [x] Two new regression tests pin the label in both states that used to hide it
- [x] One existing assertion used `getByText('manual')` non-exact and began matching the new footer label; now `{ exact: true }`, matching the sibling assertion that already was

## Security Checklist

- [x] This change does not widen renderer access to Node.js, Electron, or direct filesystem APIs. Renderer-only edits are a boolean condition, a Tailwind class, and copy strings; no preload surface, no IPC channel, no `fs` reach.
- [x] New IPC or filesystem behavior validates untrusted renderer input in the main process. N/A — this PR adds no IPC and no filesystem behavior; the only main-process edit is a JSDoc `{@link}` target.
- [x] Dependency, workflow, or release changes preserve least-privilege permissions and pinned third-party Actions. N/A — no dependency, workflow, or release files touched.
- [x] Security-sensitive behavior is documented or linked from `SECURITY.md` when relevant. N/A — no security-sensitive behavior changes. The `agent-copy` refusal that protects `~/.claude/skills` is untouched; this PR only renames the noun it is described with.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - ダッシュボードで、壊れたリンク・アクセス不能なリンク・古いロック記録がある場合も「Manual review」を適切に表示。
  - フッターのボタン領域が画面幅に応じて折り返されるよう改善。
  - ロックのプルーニング画面・通知で、対象を「record」として正確に表示し、単数・複数形にも対応。
  - プルーニング件数の表示を、実際に処理可能・削除されたレコード数に統一。

- **ドキュメント**
  - ロック記録のプルーニング方針と未解決の設計判断を明確化。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
