### PR TITLE
fix(trash): publish trash entries atomically so a kill cannot destroy a skill

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1361,18 +1361,47 @@ That is a feature, not a follow-up to this entry.
 
 **Depends on / blocked by:** Nothing.
 
-### P2. `moveToTrash` writes `manifest.json` after moving the source in
+### ~~P2. `moveToTrash` writes `manifest.json` after moving the source in~~
 
-`trashService.ts:1112-1150` renames the source into the entry and only then
-writes the manifest, so an entry can briefly exist that nothing can describe.
-The scan side is now defended (an entry whose name parses as a tombstone id but
-has no manifest is treated as unreadable, not foreign), but the underlying
-ordering still means a crash in that window leaves an entry no code can
-interpret and `startupCleanup` will sweep.
+FIXED: the source-backed path now assembles the entry under
+`.staging-<entryName>` (`STAGED_ENTRY_PREFIX`) and publishes it with one
+`fs.rename`. Until that rename lands nothing parses the directory as a
+tombstone — `tombstoneIdSchema` and `startupCleanup`'s name parse both require
+a leading `\d+`, which the prefix breaks — so a kill in the window leaves the
+source parked in the trash instead of swept away. No reader changed.
 
-**Fix direction:** write the manifest before moving the source in, or stage it
-under a temp name. The existing rollback arms depend on today's order, so this
-needs care — that is why review did not touch it.
+Writing the manifest first was considered and rejected: it swaps this window
+for a worse one, an entry claiming a skill is trashed while the source is still
+live, and `evict` would prune that skill's lock key.
+
+Two consequences worth knowing:
+
+- **Nothing may ever sweep a `.staging-` entry.** It can hold the user's only
+  copy of a skill. A leaked one is a bounded disk leak in a crash-only path;
+  that is the deliberate trade.
+- **`readTrashedSourceDirNames` was left alone on purpose.** A staged entry now
+  falls through to "foreign" instead of `unavailable`, but a staged window is
+  not a live undo window: no tombstone id has reached the renderer yet.
+  Teaching the scan to recognise `.staging-` would make one leaked directory
+  brick stale-lock detection permanently, which is strictly worse. Its
+  ENOENT-on-parseable-tombstone branch stays live for entries written by the
+  pre-staging build and for manifests deleted after the fact; the comment there
+  was retargeted to say so.
+
+**Depends on / blocked by:** Nothing.
+
+### P2. `moveLocalOnlyToTrash` has the same manifest-after-move ordering
+
+`trashService.ts:1241-1470` moves each agent's real folder into
+`<entryDir>/local-copies/<agentId>` and only then writes the manifest, so a
+kill in that window leaves a tombstone-named entry with no manifest — the same
+sweep-the-only-copy exposure the source-backed path just closed.
+
+**Fix direction:** same as above, build under `STAGED_ENTRY_PREFIX` and publish
+with one rename. Kept out of that PR because four of its failure arms embed
+`${entryDir}` in user-facing "stranded in ..." messages, so staging means
+rewriting every message against a maybe-published path — a second state machine
+a reviewer would have to hold at the same time.
 
 **Depends on / blocked by:** Nothing.
 
@@ -1445,8 +1474,9 @@ scan false-negative, not an unprunable state — see there.
 - ~~Manual-recovery trash entries keep their lock record alive forever:
   `readTrashedSourceDirNames` counts them as "still restorable" although their
   restore already failed permanently.~~ FIXED, and it was worse than filed. Both
-  source-backed writers of the `.manual-recovery` marker run BEFORE the manifest
-  exists (`trashService.ts` source-move failure, and manifest-write rollback), so
+  source-backed writers of the `.manual-recovery` marker fire on paths that never
+  wrote a manifest (`trashService.ts` source-move failure, and the publish
+  rollback), so
   the entry read as ENOENT on a parseable tombstone id — which
   `readTrashedSourceDirNames` treats as "one of our entries caught mid-write" and
   answers `unavailable` for the whole scan. `startupCleanup` deliberately never

--- a/TODOS.md
+++ b/TODOS.md
@@ -1368,7 +1368,10 @@ FIXED: the source-backed path now assembles the entry under
 `fs.rename`. Until that rename lands nothing parses the directory as a
 tombstone — `tombstoneIdSchema` and `startupCleanup`'s name parse both require
 a leading `\d+`, which the prefix breaks — so a kill in the window leaves the
-source parked in the trash instead of swept away. No reader changed.
+source parked in the trash instead of swept away. One reader changed:
+`startupCleanup` now also refuses to sweep a published entry that still holds a
+`source/` or `local-copies/` payload but whose manifest will not parse (see the
+fsync entry below for why that state is still reachable).
 
 Writing the manifest first was considered and rejected: it swaps this window
 for a worse one, an entry claiming a skill is trashed while the source is still
@@ -1402,6 +1405,27 @@ with one rename. Kept out of that PR because four of its failure arms embed
 `${entryDir}` in user-facing "stranded in ..." messages, so staging means
 rewriting every message against a maybe-published path — a second state machine
 a reviewer would have to hold at the same time.
+
+**Depends on / blocked by:** Nothing.
+
+### P3. Trash writes are not fsynced, so a power cut can still tear a manifest
+
+`fs.writeFile` returns once the bytes are in the page cache. The publish rename
+is a journalled metadata op, so a power cut (not a process kill — a kill leaves
+the page cache intact) can land the renamed directory while losing the
+`manifest.json` contents inside it, producing a tombstone-named entry the app
+cannot restore.
+
+MITIGATED, not fixed: `startupCleanup` now keeps such an entry instead of
+sweeping it, so the consequence is a stray directory rather than a deleted
+skill. The likelihood is untouched.
+
+**Fix direction:** fsync the manifest before the publish rename and fsync
+`TRASH_DIR` after it. Deliberately not done in PR #311: durability ordering is
+a policy for every write in the trash and lock paths, not one call site, and
+doing it here alone would imply a guarantee the neighbouring writes do not
+make. It also means writing the manifest through a `FileHandle`, which moves
+the write off the module-level `fs.writeFile` the durability suite observes.
 
 **Depends on / blocked by:** Nothing.
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -1435,6 +1435,33 @@ the write off the module-level `fs.writeFile` the durability suite observes.
 
 **Depends on / blocked by:** Nothing.
 
+### P3. A bookkeeping name that is a directory reads as empty to the sweep guard
+
+`hasTrashEntryPayload` decides "this entry still holds user data" by name:
+anything that is not `manifest.json` or `.manual-recovery` counts as payload.
+That direction is deliberate (a payload directory added later is protected
+without anyone widening a list), but it leaves the inverse corner open. An
+entry whose only content is a _directory_ named `manifest.json` lists as all
+bookkeeping, so `classifyEntryForSweep` returns `'sweep'` and `evict` removes
+it recursively.
+
+NOT REACHED BY THE APP, and deliberately left open in PR #311. Every write to
+that path is `fs.writeFile`, so no code path and no torn write can produce a
+directory there — a truncated write yields a short file, never a directory
+inode. Reaching it needs a user hand-creating the directory, and in that case
+the swept content is something the app never wrote and `restore` could never
+restore, because restore needs a parseable manifest at exactly that path. Any
+entry that also holds real payload (`source`, `local-copies`) is already kept.
+
+**Fix direction:** `fs.readdir(entryDir, { withFileTypes: true })` and treat a
+bookkeeping name as bookkeeping only when `isFile()`. Blocked on the shared
+`readdirSpy` in `trashService.durability.test.ts`, which narrows `readdir` to
+one argument on purpose ("Single-arg on purpose") and is routed through by
+seven tests — widening it means working around the `typeof actual.readdir`
+overload set.
+
+**Depends on / blocked by:** Nothing.
+
 ### P2. A kill landing mid-write can still truncate the lock
 
 Upstream writes `.skill-lock.json` with a plain `writeFile` (no temp+rename)

--- a/TODOS.md
+++ b/TODOS.md
@@ -1454,13 +1454,16 @@ restore, because restore needs a parseable manifest at exactly that path. Any
 entry that also holds real payload (`source`, `local-copies`) is already kept.
 
 **Fix direction:** `fs.readdir(entryDir, { withFileTypes: true })` and treat a
-bookkeeping name as bookkeeping only when `isFile()`. Blocked on the shared
-`readdirSpy` in `trashService.durability.test.ts`, which narrows `readdir` to
-one argument on purpose ("Single-arg on purpose") and is routed through by
-seven tests — widening it means working around the `typeof actual.readdir`
-overload set.
+bookkeeping name as bookkeeping only when `isFile()`. The production change is
+two lines; the cost is all in the test harness.
 
-**Depends on / blocked by:** Nothing.
+**Depends on / blocked by:** No other TODO, but it cannot land without first
+widening the shared `readdirSpy` in `trashService.durability.test.ts`. That spy
+narrows `readdir` to one argument on purpose ("Single-arg on purpose") and is
+routed through by seven tests, so forwarding an options argument means working
+around the `typeof actual.readdir` overload set — the spy cannot be annotated
+with it, because `readdir` is an overload set and `Promise<string[]>` is not
+assignable to `Promise<NonSharedBuffer[]>`.
 
 ### P2. A kill landing mid-write can still truncate the lock
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -1397,8 +1397,14 @@ Two consequences worth knowing:
 
 `trashService.ts:1241-1470` moves each agent's real folder into
 `<entryDir>/local-copies/<agentId>` and only then writes the manifest, so a
-kill in that window leaves a tombstone-named entry with no manifest — the same
-sweep-the-only-copy exposure the source-backed path just closed.
+kill in that window leaves a tombstone-named entry with no manifest.
+
+NARROWED by PR #311: the data-loss half is already closed. `local-copies` is
+not a bookkeeping name, so `classifyEntryForSweep` sees a payload, returns
+`'unreadable-manifest'`, and `startupCleanup` keeps the entry. What remains is
+that the entry is unrestorable through the app — the user has to find
+`<entryDir>/local-copies/<agentId>` and move it back by hand, with no UI
+telling them it is there.
 
 **Fix direction:** same as above, build under `STAGED_ENTRY_PREFIX` and publish
 with one rename. Kept out of that PR because four of its failure arms embed

--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -28,6 +28,16 @@ export const TRASH_DIR = join(homedir(), '.agents', '.trash')
 export const MANUAL_RECOVERY_MARKER = '.manual-recovery'
 
 /**
+ * Basename prefix a trash entry wears while it is still being assembled.
+ * `moveToTrash` builds the entry under this name and publishes it with one
+ * atomic rename, so a kill mid-move leaves a directory that no reader treats
+ * as a tombstone: {@link tombstoneIdSchema} and startup cleanup's name parse
+ * both require a leading `\d+`, which this prefix breaks. Nothing sweeps a
+ * staged name — it can hold the user's only copy of a skill.
+ */
+export const STAGED_ENTRY_PREFIX = '.staging-'
+
+/**
  * Supported AI agents with their full skills directory paths.
  *
  * Built from `scanDir` (always required on AGENT_DEFINITIONS). For most

--- a/src/main/services/skillLockService.test.ts
+++ b/src/main/services/skillLockService.test.ts
@@ -108,7 +108,7 @@ async function makeTombstone(dirName: string): Promise<void> {
 /**
  * Stage a trash entry that failed its automatic restore, exactly as
  * `trashService` leaves one: the marker is written while no manifest exists,
- * because both source-backed writers run before the manifest is created.
+ * because both source-backed writers fire on paths that never wrote one.
  * @param dirName - Basename of the source directory the entry was staged from.
  * @param withManifest - Also write a valid manifest (a shape today's writers never produce).
  * @example await makeManualRecoveryEntry('stuck-skill')
@@ -410,11 +410,11 @@ describe('scanStaleLockEntries', () => {
 
   test('keeps scanning when a trash entry was left for manual recovery with no manifest', async () => {
     // Arrange
-    // Both source-backed writers of the marker run BEFORE the manifest exists,
-    // so the entry reads as ENOENT. Without the marker check that looks like one
-    // of our own entries caught mid-write and takes the whole scan to
-    // `unavailable` — permanently, because startup cleanup never sweeps a marked
-    // entry. The feature would be dead for that user with no way back.
+    // Both source-backed writers of the marker fire on paths that never wrote a
+    // manifest, so the entry reads as ENOENT. Without the marker check that looks
+    // like one of our own entries with a lost manifest and takes the whole scan
+    // to `unavailable` — permanently, because startup cleanup never sweeps a
+    // marked entry. The feature would be dead for that user with no way back.
     const { scanStaleLockEntries } = await serviceModule
     await writeLock(['stuck-skill'])
     await makeManualRecoveryEntry('stuck-skill')
@@ -505,11 +505,12 @@ describe('scanStaleLockEntries', () => {
     })
   })
 
-  test('treats a trash entry still being staged as unreadable rather than foreign', async () => {
+  test('treats a manifest-less tombstone as unreadable rather than foreign', async () => {
     // Arrange
-    // `moveToTrash` renames the source in BEFORE writing manifest.json, so one
-    // of our own entries caught in that window has no manifest. Reading that as
-    // a foreign file would report a skill whose undo is still live as stale.
+    // A published entry normally always carries its manifest, but one written by
+    // the pre-staging build — or one whose manifest was deleted after the fact —
+    // does not. Reading that as a foreign file would report a skill whose undo is
+    // still live as stale.
     const { scanStaleLockEntries } = await serviceModule
     await writeLock(['mid-staging'])
     await mkdir(join(trashDir, '1700000000000-mid-staging-bbbbbbbb'), {

--- a/src/main/services/skillLockService.ts
+++ b/src/main/services/skillLockService.ts
@@ -194,8 +194,9 @@ type TrashReadResult =
 
 /**
  * True when a trash entry carries the terminal manual-recovery marker.
- * Read by {@link readTrashedSourceDirNames} before the manifest, because both
- * source-backed writers of the marker run BEFORE the manifest exists.
+ * Read by {@link readTrashedSourceDirNames} before the manifest, because a
+ * marked entry can legitimately have none — both source-backed writers of the
+ * marker fire on paths where the manifest was never written.
  * @param entryDir - Trash entry directory under `TRASH_DIR`.
  * @returns true only on proof the marker is there.
  * @example await isManualRecoveryEntry('/Users/me/.agents/.trash/2026-...') // => false
@@ -247,10 +248,11 @@ async function readTrashedSourceDirNames(): Promise<TrashReadResult> {
       const entryDir = join(TRASH_DIR, entryName)
       // Checked BEFORE the manifest, and it is load-bearing. Both source-backed
       // writers of this marker (`trashService` at the source-move failure and
-      // at the manifest-write rollback) run while no manifest exists yet, so
-      // without this the ENOENT below reads as "one of our entries caught
-      // mid-write" and takes the whole scan to `unavailable` — permanently,
-      // since `startupCleanup` deliberately never sweeps a marked entry.
+      // at the entry-publish rollback) fire on paths where the manifest was
+      // never written, so without this the ENOENT below reads as "one of our
+      // own entries with a lost manifest" and takes the whole scan to
+      // `unavailable` — permanently, since `startupCleanup` deliberately never
+      // sweeps a marked entry.
       //
       // Returning null also stops the entry counting as "still restorable":
       // its automatic restore already failed for good, so holding the lock
@@ -267,10 +269,15 @@ async function readTrashedSourceDirNames(): Promise<TrashReadResult> {
         // the lock record for a skill still inside its undo window.
         //
         // A MISSING manifest is only benign when the entry is not ours.
-        // `moveToTrash` renames the source in BEFORE writing the manifest, so
-        // one of our own entries caught in that window reads as ENOENT here —
-        // and treating it as foreign would drop a skill whose undo is live.
-        // Only our entries carry a parseable tombstone id as their name.
+        // `moveToTrash` now builds each entry under a staged name and publishes
+        // it with one rename, so a published entry always carries its manifest.
+        // Two cases still reach here: an entry written by the pre-staging build
+        // that was killed mid-move, and one whose manifest was deleted or
+        // truncated after the fact. Both may still hold a skill whose undo is
+        // live, and treating them as foreign would drop it.
+        // Only our entries carry a parseable tombstone id as their name; a
+        // half-built `.staging-` entry deliberately does not, because a leaked
+        // one would otherwise take this scan to `unavailable` for good.
         if (
           isMissingPathError(error) &&
           tombstoneIdSchema.safeParse(entryName).success

--- a/src/main/services/trashService.durability.test.ts
+++ b/src/main/services/trashService.durability.test.ts
@@ -3,10 +3,22 @@ import { lstat, mkdir, readdir, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, join } from 'node:path'
 
-import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from 'vitest'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+  vi,
+} from 'vitest'
 
 import { tombstoneIdSchema } from '@/main/ipc/ipc-schemas'
-import type { AbsolutePath, FilesystemEntryIdentity, SkillName } from '@/shared/types'
+import type {
+  AbsolutePath,
+  FilesystemEntryIdentity,
+  SkillName,
+} from '@/shared/types'
 
 import { filesystemIdentityFromStats } from './filesystemIdentity'
 
@@ -15,7 +27,9 @@ import { filesystemIdentityFromStats } from './filesystemIdentity'
 // home before `trashService`'s top-level `TRASH_DIR` is computed, and
 // `validatePath` resolves through `realpathSync`, so an uncanonicalized
 // `/var/folders/...` would read as an escape from its own declared base.
-const sharedHome = realpathSync(mkdtempSync(join(tmpdir(), 'skills-trash-dur-')))
+const sharedHome = realpathSync(
+  mkdtempSync(join(tmpdir(), 'skills-trash-dur-')),
+)
 const sharedSourceDir = join(sharedHome, '.agents', 'skills')
 const sharedTrashDir = join(sharedHome, '.agents', '.trash')
 const sharedAgentCursor = join(sharedHome, '.cursor', 'skills')
@@ -30,10 +44,14 @@ const fsHooks = vi.hoisted(() => ({
   onManifestWrite: null as null | (() => Promise<void>),
   /** Rejects that write when set, to drive the publish-rollback arm. */
   failManifestWrite: false,
-  /** Absolute destination whose `fs.cp` must fail, to strand the source. */
-  failCopyToDestination: null as null | string,
+  /** Decides which `fs.cp` destinations must fail, to strand the source. */
+  failCopyWhen: null as null | ((destination: string) => boolean),
   /** Rejects the publish rename when set, to drive its fallback arm. */
   failPublishRename: false,
+  /** Forces the source move into the trash to report a cross-device rename. */
+  failCrossDeviceMove: false,
+  /** Absolute entry directory whose `fs.readdir` must fail, to blind the sweep. */
+  failReaddirFor: null as null | string,
 }))
 
 vi.mock('node:os', async () => {
@@ -70,10 +88,20 @@ vi.mock('node:fs/promises', async () => {
     return actual.writeFile(path, ...rest)
   }
   const copySpy: typeof actual.cp = async (source, destination, ...rest) => {
-    if (destination === fsHooks.failCopyToDestination) {
+    if (fsHooks.failCopyWhen?.(String(destination)) === true) {
       throw Object.assign(new Error('copy refused'), { code: 'EACCES' })
     }
     return actual.cp(source, destination, ...rest)
+  }
+  // Single-arg on purpose: `trashService` only ever lists TRASH_DIR and one
+  // entry directory, both without options, so the overload set adds nothing.
+  const readdirSpy = async (
+    path: Parameters<typeof actual.readdir>[0],
+  ): Promise<string[]> => {
+    if (String(path) === fsHooks.failReaddirFor) {
+      throw Object.assign(new Error('listing refused'), { code: 'EACCES' })
+    }
+    return actual.readdir(path)
   }
   // Scoped to the publish rename by its destination shape: the same `rename`
   // moves the source into the staged entry, and failing that would abort long
@@ -85,6 +113,16 @@ vi.mock('node:fs/promises', async () => {
     ) {
       throw Object.assign(new Error('publish refused'), { code: 'EACCES' })
     }
+    // Only the move into the trash goes cross-device; the sibling stage rename
+    // stays in the source dir, which is what the EXDEV fallback relies on.
+    if (
+      fsHooks.failCrossDeviceMove &&
+      String(destination).startsWith(sharedTrashDir)
+    ) {
+      throw Object.assign(new Error('cross-device move refused'), {
+        code: 'EXDEV',
+      })
+    }
     return actual.rename(source, destination)
   }
   return {
@@ -92,6 +130,7 @@ vi.mock('node:fs/promises', async () => {
     default: actual,
     writeFile: writeFileSpy,
     cp: copySpy,
+    readdir: readdirSpy,
     rename: renameSpy,
   }
 })
@@ -139,8 +178,10 @@ describe('moveToTrash durability across a kill', () => {
     __clearEvictTimersForTests()
     fsHooks.onManifestWrite = null
     fsHooks.failManifestWrite = false
-    fsHooks.failCopyToDestination = null
+    fsHooks.failCopyWhen = null
     fsHooks.failPublishRename = false
+    fsHooks.failCrossDeviceMove = false
+    fsHooks.failReaddirFor = null
     await rm(sharedTrashDir, { recursive: true, force: true })
     await rm(sharedSourceDir, { recursive: true, force: true })
     await rm(sharedAgentCursor, { recursive: true, force: true })
@@ -170,11 +211,7 @@ describe('moveToTrash durability across a kill', () => {
     }
 
     // Act
-    const result = await moveToTrash(
-      skillName,
-      sourcePath,
-      reviewedIdentity,
-    )
+    const result = await moveToTrash(skillName, sourcePath, reviewedIdentity)
 
     // Assert
     expect(
@@ -222,7 +259,7 @@ describe('moveToTrash durability across a kill', () => {
     const reviewedIdentity = await reviewedIdentityFor(sourcePath)
     fsHooks.onManifestWrite = async () => {}
     fsHooks.failManifestWrite = true
-    fsHooks.failCopyToDestination = sourcePath
+    fsHooks.failCopyWhen = (destination) => destination === sourcePath
 
     // Act
     const moveError = await moveToTrash(
@@ -249,6 +286,88 @@ describe('moveToTrash durability across a kill', () => {
     })
   })
 
+  test('names the folder beside the original path when nothing ever reached the trash entry', async () => {
+    // Arrange
+    // Cross-device delete whose copy into the entry fails and whose restore
+    // fails too. The reviewed folder is parked next to where it used to live,
+    // and the trash entry holds nothing — so pointing the user at the entry
+    // would send them to an empty path during a data-loss incident.
+    const { moveToTrash } = await trashServicePromise
+    const skillName: SkillName = 'stranded-beside-original'
+    const sourcePath = await makeSourceSkill(skillName)
+    const reviewedIdentity = await reviewedIdentityFor(sourcePath)
+    fsHooks.failCrossDeviceMove = true
+    fsHooks.failCopyWhen = (destination) =>
+      destination === sourcePath || destination.endsWith('/source')
+
+    // Act
+    const moveError = await moveToTrash(
+      skillName,
+      sourcePath,
+      reviewedIdentity,
+    ).catch((error: unknown) => error)
+
+    // Assert
+    expect(existsSync(sourcePath)).toBe(false)
+    const siblingStageNames = (await readdir(sharedSourceDir)).filter((name) =>
+      name.startsWith(`.${skillName}.trash-source-`),
+    )
+    expect(siblingStageNames).toHaveLength(1)
+    const siblingStageDir = join(sharedSourceDir, siblingStageNames[0])
+    expect(existsSync(join(siblingStageDir, 'SKILL.md'))).toBe(true)
+    // Nothing publishable was built, so the staged entry is dropped rather
+    // than left behind as an empty tombstone the sweep must then protect.
+    expect(await readdir(sharedTrashDir)).toEqual([])
+    expect(moveError).toMatchObject({
+      message: expect.stringContaining(
+        `source preserved in ${siblingStageDir}`,
+      ),
+    })
+  })
+
+  test('keeps a published entry whose manifest did not survive the crash, because its source is the only copy', async () => {
+    // Arrange
+    // The publish rename is atomic, but the manifest bytes it publishes are
+    // not: a power cut can land the directory entry and lose the file
+    // contents. `restore` cannot read this entry, so sweeping it would be a
+    // permanent delete rather than an expiry.
+    const { startupCleanup } = await trashServicePromise
+    const entryDir = join(
+      sharedTrashDir,
+      '1700000000000-torn-manifest-aaaaaaaa',
+    )
+    const strandedSkillFile = join(entryDir, 'source', 'SKILL.md')
+    await mkdir(join(entryDir, 'source'), { recursive: true })
+    await writeFile(strandedSkillFile, '# torn-manifest\n', 'utf-8')
+    await writeFile(
+      join(entryDir, 'manifest.json'),
+      '{"schemaVersion":2,"kind":"source-',
+      'utf-8',
+    )
+
+    // Act
+    await startupCleanup()
+
+    // Assert
+    expect(existsSync(strandedSkillFile)).toBe(true)
+  })
+
+  test('keeps an entry it cannot even list, because a failed check is not proof the entry is empty', async () => {
+    // Arrange
+    // No manifest and no listing. Guessing "empty" here costs the user their
+    // skill; guessing "occupied" costs a stray directory under ~/.agents.
+    const { startupCleanup } = await trashServicePromise
+    const entryDir = join(sharedTrashDir, '1700000000000-unlistable-bbbbbbbb')
+    await mkdir(entryDir, { recursive: true })
+    fsHooks.failReaddirFor = entryDir
+
+    // Act
+    await startupCleanup()
+
+    // Assert
+    expect(existsSync(entryDir)).toBe(true)
+  })
+
   test('still points the user at the stranded copy when even publishing it fails', async () => {
     // Arrange
     // Last resort: the source could not go back and the entry could not be
@@ -264,7 +383,7 @@ describe('moveToTrash durability across a kill', () => {
       .mockImplementation(() => {})
     fsHooks.onManifestWrite = async () => {}
     fsHooks.failManifestWrite = true
-    fsHooks.failCopyToDestination = sourcePath
+    fsHooks.failCopyWhen = (destination) => destination === sourcePath
     fsHooks.failPublishRename = true
 
     // Act

--- a/src/main/services/trashService.durability.test.ts
+++ b/src/main/services/trashService.durability.test.ts
@@ -1,0 +1,289 @@
+import { existsSync, mkdtempSync, realpathSync } from 'node:fs'
+import { lstat, mkdir, readdir, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { basename, join } from 'node:path'
+
+import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from 'vitest'
+
+import { tombstoneIdSchema } from '@/main/ipc/ipc-schemas'
+import type { AbsolutePath, FilesystemEntryIdentity, SkillName } from '@/shared/types'
+
+import { filesystemIdentityFromStats } from './filesystemIdentity'
+
+// Same module-load stamping + realpath canonicalization as
+// `trashService.integration.test.ts`: the mock factory has to capture a defined
+// home before `trashService`'s top-level `TRASH_DIR` is computed, and
+// `validatePath` resolves through `realpathSync`, so an uncanonicalized
+// `/var/folders/...` would read as an escape from its own declared base.
+const sharedHome = realpathSync(mkdtempSync(join(tmpdir(), 'skills-trash-dur-')))
+const sharedSourceDir = join(sharedHome, '.agents', 'skills')
+const sharedTrashDir = join(sharedHome, '.agents', '.trash')
+const sharedAgentCursor = join(sharedHome, '.cursor', 'skills')
+
+/**
+ * Hooks the mocked `node:fs/promises` reads on every call. Hoisted so the
+ * `vi.mock` factory can close over them, and armed per-test so setup writes in
+ * Arrange never trip an observer meant for Act.
+ */
+const fsHooks = vi.hoisted(() => ({
+  /** Runs just before each `manifest.json` write, inside the build window. */
+  onManifestWrite: null as null | (() => Promise<void>),
+  /** Rejects that write when set, to drive the publish-rollback arm. */
+  failManifestWrite: false,
+  /** Absolute destination whose `fs.cp` must fail, to strand the source. */
+  failCopyToDestination: null as null | string,
+  /** Rejects the publish rename when set, to drive its fallback arm. */
+  failPublishRename: false,
+}))
+
+vi.mock('node:os', async () => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const actual = await vi.importActual<typeof import('node:os')>('node:os')
+  return { ...actual, homedir: () => sharedHome }
+})
+
+// `../constants` reaches home through the bare `'os'` specifier, so the AGENTS
+// table needs its own mock or agent paths still point at the real `~`.
+vi.mock('os', async () => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const actual = await vi.importActual<typeof import('os')>('os')
+  return { ...actual, homedir: () => sharedHome }
+})
+
+// Everything delegates to the real filesystem; the wrappers only add an
+// observation point inside `moveToTrash`'s build window and two opt-in
+// failures. A durability claim about a crash window cannot be checked from
+// outside that window.
+vi.mock('node:fs/promises', async () => {
+  const actual =
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+    await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+  const writeFileSpy: typeof actual.writeFile = async (path, ...rest) => {
+    if (String(path).endsWith('manifest.json') && fsHooks.onManifestWrite) {
+      await fsHooks.onManifestWrite()
+      if (fsHooks.failManifestWrite) {
+        throw Object.assign(new Error('manifest write refused'), {
+          code: 'EACCES',
+        })
+      }
+    }
+    return actual.writeFile(path, ...rest)
+  }
+  const copySpy: typeof actual.cp = async (source, destination, ...rest) => {
+    if (destination === fsHooks.failCopyToDestination) {
+      throw Object.assign(new Error('copy refused'), { code: 'EACCES' })
+    }
+    return actual.cp(source, destination, ...rest)
+  }
+  // Scoped to the publish rename by its destination shape: the same `rename`
+  // moves the source into the staged entry, and failing that would abort long
+  // before the arm under test.
+  const renameSpy: typeof actual.rename = async (source, destination) => {
+    if (
+      fsHooks.failPublishRename &&
+      tombstoneIdSchema.safeParse(basename(String(destination))).success
+    ) {
+      throw Object.assign(new Error('publish refused'), { code: 'EACCES' })
+    }
+    return actual.rename(source, destination)
+  }
+  return {
+    ...actual,
+    default: actual,
+    writeFile: writeFileSpy,
+    cp: copySpy,
+    rename: renameSpy,
+  }
+})
+
+// Imported AFTER the mocks so its module-level TRASH_DIR resolves under tmp.
+const trashServicePromise = import('./trashService')
+
+/**
+ * Create a source skill with SKILL.md so `moveToTrash` has a real dir to move.
+ * @param skillName - Directory basename under the source dir.
+ * @returns Absolute path to the created skill directory.
+ * @example await makeSourceSkill('theme-generator')
+ */
+async function makeSourceSkill(skillName: string): Promise<AbsolutePath> {
+  const skillPath = join(sharedSourceDir, skillName)
+  await mkdir(skillPath, { recursive: true })
+  await writeFile(join(skillPath, 'SKILL.md'), `# ${skillName}\n`, 'utf-8')
+  return skillPath
+}
+
+/**
+ * Capture the reviewed identity the destructive IPC would have carried.
+ * @param path - Path about to be deleted.
+ * @returns Serializable identity for the reviewed directory.
+ * @example await reviewedIdentityFor('/tmp/home/.agents/skills/theme-generator')
+ */
+async function reviewedIdentityFor(
+  path: AbsolutePath,
+): Promise<FilesystemEntryIdentity> {
+  return filesystemIdentityFromStats(await lstat(path))
+}
+
+describe('moveToTrash durability across a kill', () => {
+  beforeAll(async () => {
+    await mkdir(sharedSourceDir, { recursive: true })
+    await mkdir(sharedAgentCursor, { recursive: true })
+  })
+
+  afterAll(async () => {
+    await rm(sharedHome, { recursive: true, force: true })
+  })
+
+  afterEach(async () => {
+    const { __clearEvictTimersForTests } = await trashServicePromise
+    __clearEvictTimersForTests()
+    fsHooks.onManifestWrite = null
+    fsHooks.failManifestWrite = false
+    fsHooks.failCopyToDestination = null
+    fsHooks.failPublishRename = false
+    await rm(sharedTrashDir, { recursive: true, force: true })
+    await rm(sharedSourceDir, { recursive: true, force: true })
+    await rm(sharedAgentCursor, { recursive: true, force: true })
+    await mkdir(sharedSourceDir, { recursive: true })
+    await mkdir(sharedAgentCursor, { recursive: true })
+  })
+
+  test('hides the half-built entry from every tombstone reader while the source is already inside it', async () => {
+    // Arrange
+    // This is the crash window: the source has left ~/.agents/skills and the
+    // manifest is not written yet. If anything in the trash parses as a
+    // tombstone at this instant, a kill here hands startupCleanup a manifestless
+    // entry to sweep and the skill is gone for good.
+    const { moveToTrash } = await trashServicePromise
+    const skillName: SkillName = 'killed-mid-move'
+    const sourcePath = await makeSourceSkill(skillName)
+    await symlink(sourcePath, join(sharedAgentCursor, skillName))
+    const reviewedIdentity = await reviewedIdentityFor(sourcePath)
+
+    let namesInTrashDuringBuild: string[] = []
+    let skillFileWasAlreadyInTrash = false
+    fsHooks.onManifestWrite = async () => {
+      namesInTrashDuringBuild = await readdir(sharedTrashDir)
+      skillFileWasAlreadyInTrash = namesInTrashDuringBuild.some((entryName) =>
+        existsSync(join(sharedTrashDir, entryName, 'source', 'SKILL.md')),
+      )
+    }
+
+    // Act
+    const result = await moveToTrash(
+      skillName,
+      sourcePath,
+      reviewedIdentity,
+    )
+
+    // Assert
+    expect(
+      namesInTrashDuringBuild.filter(
+        (entryName) => tombstoneIdSchema.safeParse(entryName).success,
+      ),
+    ).toEqual([])
+    // Guards against a vacuous pass: the window is only interesting once the
+    // user's data is actually in there.
+    expect(skillFileWasAlreadyInTrash).toBe(true)
+    expect(result.kind).toBe('tombstoned')
+    expect(await readdir(sharedTrashDir)).toEqual([
+      result.kind === 'tombstoned' ? result.tombstoneId : '',
+    ])
+  })
+
+  test('leaves a half-built entry on disk at startup instead of sweeping the only copy of the skill', async () => {
+    // Arrange
+    // Exactly what a kill in the window above leaves behind. Nothing may ever
+    // sweep it: the folder inside is the user's only copy of that skill.
+    const { startupCleanup } = await trashServicePromise
+    const stagedEntryDir = join(
+      sharedTrashDir,
+      '.staging-1700000000000-killed-skill-aaaaaaaa',
+    )
+    const strandedSkillFile = join(stagedEntryDir, 'source', 'SKILL.md')
+    await mkdir(join(stagedEntryDir, 'source'), { recursive: true })
+    await writeFile(strandedSkillFile, '# killed-skill\n', 'utf-8')
+
+    // Act
+    await startupCleanup()
+
+    // Assert
+    expect(existsSync(strandedSkillFile)).toBe(true)
+  })
+
+  test('publishes a stranded entry under its tombstone name so manual recovery can still find it', async () => {
+    // Arrange
+    // Manifest write fails, and putting the source back fails too, so the copy
+    // in the trash is all that is left. It has to end up under a name the
+    // marker readers scan, not under the staged name they ignore.
+    const { moveToTrash, TrashError } = await trashServicePromise
+    const skillName: SkillName = 'stranded-skill'
+    const sourcePath = await makeSourceSkill(skillName)
+    const reviewedIdentity = await reviewedIdentityFor(sourcePath)
+    fsHooks.onManifestWrite = async () => {}
+    fsHooks.failManifestWrite = true
+    fsHooks.failCopyToDestination = sourcePath
+
+    // Act
+    const moveError = await moveToTrash(
+      skillName,
+      sourcePath,
+      reviewedIdentity,
+    ).catch((error: unknown) => error)
+
+    // Assert
+    expect(moveError).toBeInstanceOf(TrashError)
+    const publishedEntryNames = await readdir(sharedTrashDir)
+    expect(
+      publishedEntryNames.filter(
+        (entryName) => tombstoneIdSchema.safeParse(entryName).success,
+      ),
+    ).toHaveLength(1)
+    const publishedEntryDir = join(sharedTrashDir, publishedEntryNames[0])
+    expect(existsSync(join(publishedEntryDir, 'source', 'SKILL.md'))).toBe(true)
+    expect(existsSync(join(publishedEntryDir, '.manual-recovery'))).toBe(true)
+    expect(moveError).toMatchObject({
+      message: expect.stringContaining(
+        `source is stranded in ${join(publishedEntryDir, 'source')}`,
+      ),
+    })
+  })
+
+  test('still points the user at the stranded copy when even publishing it fails', async () => {
+    // Arrange
+    // Last resort: the source could not go back and the entry could not be
+    // published either. The copy is still on disk under the staged name, which
+    // nothing sweeps — so the error has to name that path rather than a
+    // tombstone path that was never created.
+    const { moveToTrash } = await trashServicePromise
+    const skillName: SkillName = 'unpublishable-skill'
+    const sourcePath = await makeSourceSkill(skillName)
+    const reviewedIdentity = await reviewedIdentityFor(sourcePath)
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+    fsHooks.onManifestWrite = async () => {}
+    fsHooks.failManifestWrite = true
+    fsHooks.failCopyToDestination = sourcePath
+    fsHooks.failPublishRename = true
+
+    // Act
+    const moveError = await moveToTrash(
+      skillName,
+      sourcePath,
+      reviewedIdentity,
+    ).catch((error: unknown) => error)
+    consoleErrorSpy.mockRestore()
+
+    // Assert
+    const stagedEntryNames = await readdir(sharedTrashDir)
+    expect(stagedEntryNames).toHaveLength(1)
+    const stagedEntryDir = join(sharedTrashDir, stagedEntryNames[0])
+    expect(existsSync(join(stagedEntryDir, 'source', 'SKILL.md'))).toBe(true)
+    expect(moveError).toMatchObject({
+      message: expect.stringContaining(
+        `source is stranded in ${join(stagedEntryDir, 'source')}`,
+      ),
+    })
+  })
+})

--- a/src/main/services/trashService.orphanRace.test.ts
+++ b/src/main/services/trashService.orphanRace.test.ts
@@ -683,14 +683,19 @@ describe('trashService orphan cleanup guarded commit', () => {
     const { __getTrashDirForTests, moveToTrash } =
       await import('./trashService')
 
-    // Act / Assert
-    await expect(
-      moveToTrash(
+    // Act
+    let surfacedError: unknown
+    try {
+      await moveToTrash(
         skillName,
         sourcePath,
         await reviewedIdentityForPath(sourcePath),
-      ),
-    ).rejects.toThrow(/source copy preserved/i)
+      )
+    } catch (error) {
+      surfacedError = error
+    }
+
+    // Assert
     expect((await lstat(sourcePath)).isDirectory()).toBe(true)
     expect((await lstat(linkPath)).isSymbolicLink()).toBe(true)
     const trashEntries = await readdir(__getTrashDirForTests())
@@ -700,6 +705,14 @@ describe('trashService orphan cleanup guarded commit', () => {
     await expect(
       lstat(join(entryDir, '.manual-recovery')),
     ).resolves.toBeDefined()
+    // The hint has to name where the copy actually landed. The entry is built
+    // under a staged name and published with a rename, so a message built
+    // before the publish would send the user to a path that no longer exists.
+    expect(surfacedError).toMatchObject({
+      message: expect.stringContaining(
+        `source copy preserved in ${join(entryDir, 'source')}`,
+      ),
+    })
   })
 
   it('does not overwrite a replacement during manifest rollback restore', async () => {
@@ -2708,7 +2721,7 @@ describe('trashService orphan cleanup guarded commit', () => {
         sourcePath as never,
         await reviewedIdentityForPath(sourcePath),
       ),
-    ).rejects.toThrow(/Failed to write trash manifest/i)
+    ).rejects.toThrow(/Failed to finalize trash entry/i)
     // Source restored to its original location.
     expect(await readFile(join(sourcePath, 'SKILL.md'), 'utf-8')).toContain(
       skillName,

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -10,6 +10,7 @@ import {
   AGENTS,
   MANUAL_RECOVERY_MARKER,
   SOURCE_DIR,
+  STAGED_ENTRY_PREFIX,
   TRASH_DIR,
 } from '@/main/constants'
 import { manifestSchema } from '@/main/ipc/ipc-schemas'
@@ -347,6 +348,41 @@ async function markManualRecoveryEntry(
 }
 
 /**
+ * Publish a staged entry that holds the user's only remaining copy: mark it
+ * terminal, then rename it under its real tombstone name. Runs on the two
+ * source-backed failure arms, because {@link hasManualRecoveryMarker} and
+ * {@link isManualRecoveryEntry} only ever look at published entry names.
+ * @param stagingDir - Half-built entry under {@link STAGED_ENTRY_PREFIX}.
+ * @param entryDir - Tombstone-named path to publish it as.
+ * @param reason - Human-readable recovery reason for operators and tests.
+ * @returns
+ * - `entryDir` once the entry is published
+ * - `stagingDir` when the rename failed — the data is still there, just not
+ *   under a name the marker readers scan, and nothing sweeps staged names
+ * @example await publishManualRecoveryEntry(stagingDir, entryDir, 'source rollback failed')
+ */
+async function publishManualRecoveryEntry(
+  stagingDir: AbsolutePath,
+  entryDir: AbsolutePath,
+  reason: string,
+): Promise<AbsolutePath> {
+  await markManualRecoveryEntry(stagingDir, reason)
+  try {
+    await fs.rename(stagingDir, entryDir)
+    return entryDir
+  } catch (publishError) {
+    // Recoverable either way: the caller reports whichever path we return.
+    console.error('trashService: failed to publish manual recovery entry', {
+      stagingDir,
+      entryDir,
+      code: errorCode(publishError),
+      message: extractErrorMessage(publishError),
+    })
+    return stagingDir
+  }
+}
+
+/**
  * Check whether startup cleanup must leave a trash entry for manual recovery.
  * @param entryDir - Trash entry directory under TRASH_DIR.
  * @returns true when the marker exists or cannot be checked safely.
@@ -412,7 +448,12 @@ interface SourceMoveFailure {
  * Move a source folder into a trash entry while preserving staged EXDEV recovery copies.
  * @param sourcePath - Reviewed skill source directory to move.
  * @param entrySourceDir - Destination `<entryDir>/source` directory.
- * @returns null on success, otherwise a failure object describing cleanup safety.
+ * @returns
+ * - `null` once the source sits inside the entry
+ * - a failure object otherwise; its `preserveEntryDirForManualRecovery` tells
+ *   the caller the entry now holds the user's only copy. The caller, not this
+ *   function, appends the "preserved in <path>" hint — only it knows where the
+ *   publish rename left the data.
  * @example await moveSourceIntoTrashEntry('/Users/me/.agents/skills/x', '/Users/me/.agents/.trash/id/source')
  */
 async function moveSourceIntoTrashEntry(
@@ -488,13 +529,10 @@ async function moveSourceIntoTrashEntry(
             preserveEntryDirForManualRecovery = true
           }
         }
-        const recoveryHint = preserveEntryDirForManualRecovery
-          ? `; source copy preserved in ${entrySourceDir}`
-          : ''
         return {
           preserveEntryDirForManualRecovery,
           error: new TrashError(
-            `Failed to move source to trash (cross-device): ${extractErrorMessage(fallbackError)}${recoveryHint}`,
+            `Failed to move source to trash (cross-device): ${extractErrorMessage(fallbackError)}`,
             errorCode(fallbackError),
           ),
         }
@@ -1100,18 +1138,22 @@ async function moveSourceBackedToTrash(
 
   const entryName = buildEntryName(skillName)
   const entryDir = join(TRASH_DIR, entryName)
-  const entrySourceDir = join(entryDir, 'source')
-  const manifestPath = join(entryDir, 'manifest.json')
+  // Everything below is assembled under a staged name and published with one
+  // rename at the end. A kill before that rename leaves a directory no reader
+  // parses as a tombstone, so the source waits there instead of being swept.
+  const stagingDir = join(TRASH_DIR, `${STAGED_ENTRY_PREFIX}${entryName}`)
+  const entrySourceDir = join(stagingDir, 'source')
+  const manifestPath = join(stagingDir, 'manifest.json')
 
   // Walk agents, collect + remove symlinks. Abort on non-ENOENT unlink failure.
   const { recordedSymlinks, cascadeAgentIds } =
     await removeSourceBackedAgentSymlinks(skillName, sourcePath)
 
-  // Atomically move source → trash entry. On EXDEV, copy + remove.
+  // Atomically move source → staged entry. On EXDEV, copy + remove.
   // If the move fails, the symlinks we already unlinked would otherwise be
   // lost. Best-effort re-create them before re-throwing so the user is not
   // left with a half-deleted skill (source still on disk but agents unlinked).
-  await fs.mkdir(entryDir, { recursive: true })
+  await fs.mkdir(stagingDir, { recursive: true })
   const sourceMoveFailure = await moveSourceIntoTrashEntry(
     sourcePath,
     entrySourceDir,
@@ -1119,26 +1161,35 @@ async function moveSourceBackedToTrash(
   )
   if (sourceMoveFailure !== null) {
     // Rollback symlinks, but never delete an entry that now holds the recovery
-    // copy created by the EXDEV fallback.
+    // copy created by the EXDEV fallback — publish that one instead, since the
+    // marker readers only ever scan published entry names.
     await rollbackRemovedSymlinks(recordedSymlinks)
     if (sourceMoveFailure.preserveEntryDirForManualRecovery) {
-      await markManualRecoveryEntry(
+      const recoveryDir = await publishManualRecoveryEntry(
+        stagingDir,
         entryDir,
         'source EXDEV fallback copied to trash but removing original failed',
       )
-    } else {
-      /* v8 ignore next 3 -- best-effort cleanup: any fs.rm rejection (EPERM/EBUSY/EACCES — force only suppresses ENOENT) is intentionally swallowed by .catch, and no suite stages a writable-but-unremovable dir, so this recovery arm is unreachable under test */
-      await fs.rm(entryDir, { recursive: true, force: true }).catch(() => {
-        // entryDir cleanup is best-effort — caller already has the real error.
-      })
+      // Built here, not inside the move: the publish lands under either name,
+      // and a data-loss message pointing at a path that does not exist is
+      // worse than one with no path at all.
+      throw new TrashError(
+        `${sourceMoveFailure.error.message}; source copy preserved in ${join(recoveryDir, 'source')}`,
+        sourceMoveFailure.error.code,
+      )
     }
+    /* v8 ignore next 3 -- best-effort cleanup: any fs.rm rejection (EPERM/EBUSY/EACCES — force only suppresses ENOENT) is intentionally swallowed by .catch, and no suite stages a writable-but-unremovable dir, so this recovery arm is unreachable under test */
+    await fs.rm(stagingDir, { recursive: true, force: true }).catch(() => {
+      // Staged cleanup is best-effort — caller already has the real error.
+    })
     throw sourceMoveFailure.error
   }
 
-  // Write manifest. If this fails after the source was already moved in, we
-  // are in a state with no manifest, no evict timer, and removed symlinks —
-  // restore would be impossible. Roll back (source → original path, re-create
-  // symlinks, drop trash entry) before surfacing the error to the caller.
+  // Write the manifest, then publish. Both run against the staged entry, so a
+  // kill at any point up to the rename leaves the source parked under a name
+  // startupCleanup skips and `restore` never sees — recoverable, never swept.
+  // A *failure* still rolls back (source → original path, re-create symlinks,
+  // drop the staged entry) rather than leaving the user half-deleted.
   const manifest = {
     schemaVersion: 2 as const,
     kind: 'source-backed' as const,
@@ -1149,9 +1200,12 @@ async function moveSourceBackedToTrash(
   }
   try {
     await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf-8')
-  } catch (manifestWriteError) {
-    const manifestWriteCode = errorCode(manifestWriteError)
-    const manifestWriteMessage = extractErrorMessage(manifestWriteError)
+    // The publish. Rename is atomic, so on failure the staged entry is still
+    // whole and the rollback below applies to it unchanged.
+    await fs.rename(stagingDir, entryDir)
+  } catch (entryPublishError) {
+    const entryPublishCode = errorCode(entryPublishError)
+    const entryPublishMessage = extractErrorMessage(entryPublishError)
 
     // Step 1: restore the source back without clobbering a recreated slot.
     let restoreSourceFailed = false
@@ -1160,7 +1214,7 @@ async function moveSourceBackedToTrash(
     } catch (restoreError) {
       restoreSourceFailed = true
       console.error(
-        'trashService: manifest write rollback — failed to restore source',
+        'trashService: entry publish rollback — failed to restore source',
         {
           skillName,
           entryName,
@@ -1174,27 +1228,31 @@ async function moveSourceBackedToTrash(
     await rollbackRemovedSymlinks(recordedSymlinks)
 
     // Step 3: drop only fully rolled-back entries. If source restore failed,
-    // entrySourceDir is the manual recovery path and must survive this error.
+    // entrySourceDir is the manual recovery path and must survive this error —
+    // publish it so the marker readers can find it under a tombstone name.
+    let strandedSourceDir = entrySourceDir
     if (!restoreSourceFailed) {
       /* v8 ignore next 3 -- best-effort cleanup: any fs.rm rejection (EPERM/EBUSY/EACCES — force only suppresses ENOENT) is intentionally swallowed by .catch, and no suite stages a writable-but-unremovable dir, so this recovery arm is unreachable under test */
-      await fs.rm(entryDir, { recursive: true, force: true }).catch(() => {
-        // entry cleanup is best-effort — caller already has the real error.
+      await fs.rm(stagingDir, { recursive: true, force: true }).catch(() => {
+        // Staged cleanup is best-effort — caller already has the real error.
       })
     } else {
-      await markManualRecoveryEntry(
+      const recoveryDir = await publishManualRecoveryEntry(
+        stagingDir,
         entryDir,
         'source manifest rollback failed to restore original path',
       )
+      strandedSourceDir = join(recoveryDir, 'source')
     }
 
     // If we couldn't put the source back the user is in a broken state. Flag
     // it in the thrown error so the caller surfaces "manual recovery" to the UI.
     const prefix = restoreSourceFailed
-      ? `Failed to write trash manifest; source is stranded in ${entrySourceDir}`
-      : 'Failed to write trash manifest'
+      ? `Failed to finalize trash entry; source is stranded in ${strandedSourceDir}`
+      : 'Failed to finalize trash entry'
     throw new TrashError(
-      `${prefix}: ${manifestWriteMessage}`,
-      manifestWriteCode,
+      `${prefix}: ${entryPublishMessage}`,
+      entryPublishCode,
     )
   }
 

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -447,14 +447,14 @@ interface SourceMoveFailure {
 /**
  * Move a source folder into a trash entry while preserving staged EXDEV recovery copies.
  * @param sourcePath - Reviewed skill source directory to move.
- * @param entrySourceDir - Destination `<entryDir>/source` directory.
+ * @param entrySourceDir - Destination `<stagingDir>/source` directory.
  * @returns
  * - `null` once the source sits inside the entry
  * - a failure object otherwise; its `preserveEntryDirForManualRecovery` tells
  *   the caller the entry now holds the user's only copy. The caller, not this
  *   function, appends the "preserved in <path>" hint — only it knows where the
  *   publish rename left the data.
- * @example await moveSourceIntoTrashEntry('/Users/me/.agents/skills/x', '/Users/me/.agents/.trash/id/source')
+ * @example await moveSourceIntoTrashEntry('/Users/me/.agents/skills/x', '/Users/me/.agents/.trash/.staging-id/source')
  */
 async function moveSourceIntoTrashEntry(
   sourcePath: AbsolutePath,
@@ -1240,7 +1240,7 @@ async function moveSourceBackedToTrash(
       const recoveryDir = await publishManualRecoveryEntry(
         stagingDir,
         entryDir,
-        'source manifest rollback failed to restore original path',
+        'source entry publish rollback failed to restore original path',
       )
       strandedSourceDir = join(recoveryDir, 'source')
     }

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -439,9 +439,22 @@ function coerceTrashError(error: unknown, messagePrefix: string): TrashError {
       )
 }
 
+/**
+ * Where a failed source move left the user's only copy, and why it is stuck there.
+ * Carries the location rather than a flag: the caller turns this into a
+ * "preserved in <path>" hint, and a hint naming the wrong directory sends the
+ * user hunting an empty path during a data-loss incident.
+ */
+type ManualRecoveryLocation =
+  /** Inside `<stagingDir>/source`, so publishing the entry keeps it findable. */
+  | { reason: string; inEntry: true }
+  /** Beside the original path, so the staged entry holds nothing worth publishing. */
+  | { reason: string; strandedAt: AbsolutePath }
+
 interface SourceMoveFailure {
   error: TrashError
-  preserveEntryDirForManualRecovery: boolean
+  /** Absent when the original is back where it started — nothing to preserve. */
+  manualRecovery?: ManualRecoveryLocation
 }
 
 /**
@@ -450,10 +463,9 @@ interface SourceMoveFailure {
  * @param entrySourceDir - Destination `<stagingDir>/source` directory.
  * @returns
  * - `null` once the source sits inside the entry
- * - a failure object otherwise; its `preserveEntryDirForManualRecovery` tells
- *   the caller the entry now holds the user's only copy. The caller, not this
- *   function, appends the "preserved in <path>" hint — only it knows where the
- *   publish rename left the data.
+ * - a failure object otherwise; its {@link ManualRecoveryLocation} names where
+ *   the user's only copy ended up. The caller, not this function, appends the
+ *   "preserved in <path>" hint — only it knows where the publish rename landed.
  * @example await moveSourceIntoTrashEntry('/Users/me/.agents/skills/x', '/Users/me/.agents/.trash/.staging-id/source')
  */
 async function moveSourceIntoTrashEntry(
@@ -474,7 +486,11 @@ async function moveSourceIntoTrashEntry(
         await moveDirectoryNoOverwrite(entrySourceDir, sourcePath)
       } catch {
         return {
-          preserveEntryDirForManualRecovery: true,
+          manualRecovery: {
+            reason:
+              'staged source validation failed and restoring the original path failed',
+            inEntry: true,
+          },
           error: coerceTrashError(
             identityError,
             'Failed to validate staged source',
@@ -482,7 +498,6 @@ async function moveSourceIntoTrashEntry(
         }
       }
       return {
-        preserveEntryDirForManualRecovery: false,
         error: coerceTrashError(
           identityError,
           'Failed to validate staged source',
@@ -494,7 +509,7 @@ async function moveSourceIntoTrashEntry(
     const code = errorCode(error)
 
     if (code === 'EXDEV') {
-      let preserveEntryDirForManualRecovery = false
+      let manualRecovery: ManualRecoveryLocation | undefined
       const siblingStagePath = buildSiblingStagePath(sourcePath, 'trash-source')
       try {
         // Cross-device fallback still starts with a same-directory rename, so
@@ -509,7 +524,6 @@ async function moveSourceIntoTrashEntry(
         } catch (identityError) {
           await moveDirectoryNoOverwrite(siblingStagePath, sourcePath)
           return {
-            preserveEntryDirForManualRecovery: false,
             error: coerceTrashError(
               identityError,
               'Failed to validate staged source',
@@ -517,7 +531,11 @@ async function moveSourceIntoTrashEntry(
           }
         }
         await copyDirectoryNoOverwrite(siblingStagePath, entrySourceDir)
-        preserveEntryDirForManualRecovery = true
+        manualRecovery = {
+          reason:
+            'source EXDEV fallback copied to trash but removing original failed',
+          inEntry: true,
+        }
         await fs.rm(siblingStagePath, { recursive: true, force: true })
         return null
       } catch (fallbackError) {
@@ -526,11 +544,18 @@ async function moveSourceIntoTrashEntry(
           await moveDirectoryNoOverwrite(siblingStagePath, sourcePath)
         } catch (restoreError) {
           if (errorCode(restoreError) !== 'ENOENT') {
-            preserveEntryDirForManualRecovery = true
+            // The sibling stage is the sole copy only when the copy into the
+            // entry never ran, so `??=` leaves a completed entry copy in
+            // place — that one is published, and the better thing to name.
+            manualRecovery ??= {
+              reason:
+                'reviewed source staged beside its original path and could not be restored',
+              strandedAt: siblingStagePath,
+            }
           }
         }
         return {
-          preserveEntryDirForManualRecovery,
+          manualRecovery,
           error: new TrashError(
             `Failed to move source to trash (cross-device): ${extractErrorMessage(fallbackError)}`,
             errorCode(fallbackError),
@@ -541,13 +566,11 @@ async function moveSourceIntoTrashEntry(
 
     if (code === 'ENOENT') {
       return {
-        preserveEntryDirForManualRecovery: false,
         error: new TrashError('Skill not found (already deleted?)', code),
       }
     }
 
     return {
-      preserveEntryDirForManualRecovery: false,
       error: new TrashError(
         `Failed to move source to trash: ${extractErrorMessage(error)}`,
         code,
@@ -1160,19 +1183,20 @@ async function moveSourceBackedToTrash(
     reviewedIdentity,
   )
   if (sourceMoveFailure !== null) {
-    // Rollback symlinks, but never delete an entry that now holds the recovery
-    // copy created by the EXDEV fallback — publish that one instead, since the
-    // marker readers only ever scan published entry names.
+    // Rollback symlinks, but never delete an entry that now holds the only
+    // surviving copy. Which path the hint names is decided here, not inside the
+    // move: only this side knows where the publish rename landed, and a
+    // data-loss message pointing at an empty path is worse than no path at all.
     await rollbackRemovedSymlinks(recordedSymlinks)
-    if (sourceMoveFailure.preserveEntryDirForManualRecovery) {
+    const { manualRecovery } = sourceMoveFailure
+    if (manualRecovery !== undefined && 'inEntry' in manualRecovery) {
+      // The copy sits in the staged entry, so publish it — marker readers only
+      // ever scan published entry names.
       const recoveryDir = await publishManualRecoveryEntry(
         stagingDir,
         entryDir,
-        'source EXDEV fallback copied to trash but removing original failed',
+        manualRecovery.reason,
       )
-      // Built here, not inside the move: the publish lands under either name,
-      // and a data-loss message pointing at a path that does not exist is
-      // worse than one with no path at all.
       throw new TrashError(
         `${sourceMoveFailure.error.message}; source copy preserved in ${join(recoveryDir, 'source')}`,
         sourceMoveFailure.error.code,
@@ -1182,6 +1206,14 @@ async function moveSourceBackedToTrash(
     await fs.rm(stagingDir, { recursive: true, force: true }).catch(() => {
       // Staged cleanup is best-effort — caller already has the real error.
     })
+    if (manualRecovery !== undefined) {
+      // Nothing publishable was ever built: the reviewed source is parked
+      // beside its original path, so that is the path the user needs.
+      throw new TrashError(
+        `${sourceMoveFailure.error.message}; source preserved in ${manualRecovery.strandedAt}`,
+        sourceMoveFailure.error.code,
+      )
+    }
     throw sourceMoveFailure.error
   }
 
@@ -1250,10 +1282,7 @@ async function moveSourceBackedToTrash(
     const prefix = restoreSourceFailed
       ? `Failed to finalize trash entry; source is stranded in ${strandedSourceDir}`
       : 'Failed to finalize trash entry'
-    throw new TrashError(
-      `${prefix}: ${entryPublishMessage}`,
-      entryPublishCode,
-    )
+    throw new TrashError(`${prefix}: ${entryPublishMessage}`, entryPublishCode)
   }
 
   const id = tombstoneId(entryName)
@@ -1909,6 +1938,60 @@ async function finalizeRestore(
 }
 
 /**
+ * The only names inside a trash entry that are not user data. Listed this way
+ * round on purpose: a payload directory added later (`source`, `local-copies`,
+ * whatever comes next) is protected without anyone remembering to widen a list.
+ */
+const TRASH_ENTRY_BOOKKEEPING_NAMES = ['manifest.json', MANUAL_RECOVERY_MARKER]
+
+/**
+ * Check whether a trash entry still holds skill data, for {@link classifyEntryForSweep}.
+ * @param entryDir - Trash entry directory under TRASH_DIR.
+ * @returns true when anything but bookkeeping is inside, or it cannot be listed.
+ * @example await hasTrashEntryPayload('/Users/me/.agents/.trash/1729-task-abc12345')
+ */
+async function hasTrashEntryPayload(entryDir: AbsolutePath): Promise<boolean> {
+  try {
+    const names = await fs.readdir(entryDir)
+    return names.some((name) => !TRASH_ENTRY_BOOKKEEPING_NAMES.includes(name))
+  } catch {
+    // Cannot list it, so cannot prove it is empty — same posture as
+    // {@link hasManualRecoveryMarker}: an unreadable check keeps the entry.
+    return true
+  }
+}
+
+/**
+ * Decide whether {@link startupCleanup} may sweep one orphan trash entry.
+ * Both skips guard the same thing — a directory that may hold the user's only
+ * copy — so they share one pass and keep the plan loop to a single await.
+ * @param entryDir - Trash entry directory under TRASH_DIR.
+ * @returns `'sweep'`, or the reason the entry has to stay.
+ * @example await classifyEntryForSweep('/Users/me/.agents/.trash/1729-task-abc12345') // 'sweep'
+ */
+async function classifyEntryForSweep(
+  entryDir: AbsolutePath,
+): Promise<'sweep' | 'manual-recovery' | 'unreadable-manifest'> {
+  if (await hasManualRecoveryMarker(entryDir)) return 'manual-recovery'
+  try {
+    const parsedJson: unknown = JSON.parse(
+      await fs.readFile(join(entryDir, 'manifest.json'), 'utf-8'),
+    )
+    manifestSchema.parse(parsedJson)
+    return 'sweep'
+  } catch {
+    // Without a readable manifest {@link restore} can never bring the entry
+    // back, so sweeping it is a permanent delete rather than an expiry. A
+    // manifest written just before the publish rename is not guaranteed to
+    // have reached stable storage, so treat the payload as the user's only
+    // copy and keep it for manual recovery.
+    return (await hasTrashEntryPayload(entryDir))
+      ? 'unreadable-manifest'
+      : 'sweep'
+  }
+}
+
+/**
  * Sweep every orphan trash entry on `app.whenReady`.
  *
  * The undo window is a session concept: the Redux undoToast that paired with a
@@ -1917,7 +2000,8 @@ async function finalizeRestore(
  * here its lock record is treated as still-wanted, so a skill the user deleted
  * yesterday keeps coming back on `skills -g update`.
  *
- * Entries flagged for manual recovery are skipped — those hold the only
+ * Entries flagged for manual recovery are skipped, as are entries still
+ * holding content behind an unreadable manifest — both may be the only
  * surviving copy of user data. Removal goes through {@link evict} so the
  * lock-prune hook covers both deletion exits, not just the in-session timer.
  * Runs with concurrency bound 4 so a storm of orphans doesn't stall startup.
@@ -1942,15 +2026,21 @@ export async function startupCleanup(): Promise<void> {
 
   const toSweep: TombstoneId[] = []
   let manualRecoverySkippedCount = 0
+  let unreadableManifestSkippedCount = 0
   for (const entryName of entries) {
     if (parseDeletedAtFromEntryName(entryName) === null) {
       // Unparseable name = foreign file; do not touch.
       continue
     }
     const entryDir = join(TRASH_DIR, entryName)
-    // react-doctor-disable-next-line react-doctor/async-await-in-loop -- marker reads only build the toSweep plan and mutate manualRecoverySkippedCount; the actual eviction runs via a concurrency-4 pool below.
-    if (await hasManualRecoveryMarker(entryDir)) {
+    // react-doctor-disable-next-line react-doctor/async-await-in-loop -- the classify reads only build the toSweep plan and mutate the skip counters; the actual eviction runs via a concurrency-4 pool below.
+    const disposition = await classifyEntryForSweep(entryDir)
+    if (disposition === 'manual-recovery') {
       manualRecoverySkippedCount++
+      continue
+    }
+    if (disposition === 'unreadable-manifest') {
+      unreadableManifestSkippedCount++
       continue
     }
     toSweep.push(tombstoneId(entryName))
@@ -1975,6 +2065,7 @@ export async function startupCleanup(): Promise<void> {
   console.info('trashService: startupCleanup', {
     sweptCount: toSweep.length,
     manualRecoverySkippedCount,
+    unreadableManifestSkippedCount,
     totalEntries: entries.length,
     durationMs: Date.now() - startTime,
   })

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -446,10 +446,10 @@ function coerceTrashError(error: unknown, messagePrefix: string): TrashError {
  * user hunting an empty path during a data-loss incident.
  */
 type ManualRecoveryLocation =
-  /** Inside `<stagingDir>/source`, so publishing the entry keeps it findable. */
-  | { reason: string; inEntry: true }
-  /** Beside the original path, so the staged entry holds nothing worth publishing. */
-  | { reason: string; strandedAt: AbsolutePath }
+  /** Inside `<stagingDir>/source`; `reason` becomes the published marker's text. */
+  | { inEntry: true; reason: string }
+  /** Beside the original path — nothing is published, so no marker to write. */
+  | { strandedAt: AbsolutePath }
 
 interface SourceMoveFailure {
   error: TrashError
@@ -547,11 +547,7 @@ async function moveSourceIntoTrashEntry(
             // The sibling stage is the sole copy only when the copy into the
             // entry never ran, so `??=` leaves a completed entry copy in
             // place — that one is published, and the better thing to name.
-            manualRecovery ??= {
-              reason:
-                'reviewed source staged beside its original path and could not be restored',
-              strandedAt: siblingStagePath,
-            }
+            manualRecovery ??= { strandedAt: siblingStagePath }
           }
         }
         return {


### PR DESCRIPTION
## Summary

Fixes the TODOS P2 **"`moveToTrash` writes `manifest.json` after moving the source in"**.

`moveSourceBackedToTrash` used to `mkdir` the entry under its real tombstone
name, `rename` the user's skill into it, and only then write `manifest.json`.
Kill the app anywhere in that window and the trash held a directory that
`startupCleanup` parses as a tombstone but that carries no manifest — so the
24h sweep deletes it, taking the user's only copy of the skill with it.

**The fix (staging + atomic publish):** the entry is assembled at
`<TRASH_DIR>/.staging-<entryName>` and published with a single
`fs.rename(stagingDir, entryDir)` placed inside the same `try` as the manifest
write. Until that rename lands, nothing on disk parses as a tombstone — both
`tombstoneIdSchema` (`/^\d+-[^/\\]+-[a-f0-9]{8}$/`) and startup cleanup's own
name parse (`/^\d+$/` on the pre-dash prefix) reject a leading `.staging-`.
A kill at any point in the window leaves the skill parked in the trash instead
of swept.

**One reader changed, and only in `trashService.ts` itself.**
`grep -ran "TRASH_DIR" src/main src/preload` returns four hits: the definition
in `constants.ts`, two doc-comment mentions (`ipc-schemas.ts`, `ipc/skills.ts`),
and exactly one real reader outside `trashService.ts` —
`skillLockService.ts`'s `readTrashedSourceDirNames`, which already ignores any
name that is not a parseable tombstone id and is untouched here. Inside
`trashService.ts`, `startupCleanup` gained the sweep guard described below.

### `startupCleanup` no longer sweeps an entry it cannot read

`fs.writeFile` returns once the bytes are in the page cache. A *kill* keeps
those bytes (the OS still has them), so the staging fix above is complete for
the threat in the title. A *power cut* is different: the publish rename is a
journalled metadata op and can land while the manifest contents do not,
producing a tombstone-named entry whose manifest will not parse. `restore`
cannot bring that entry back, so the startup sweep would be a permanent delete
rather than an expiry.

`startupCleanup` now classifies each entry once: manual-recovery marker,
unreadable manifest with content still inside, or sweepable. The content check
is written as "anything that is not `manifest.json` or `.manual-recovery`", so
a payload directory added later is protected without anyone remembering to
widen a list. An entry with nothing left in it is still swept — the guard
refuses to delete data, not to delete directories.

**`evict()` is deliberately untouched.** Correcting what an earlier review
reply on this PR said: its three callers are the two TTL timers and
`startupCleanup`, all inside `trashService.ts` — no IPC channel reaches it, so
there is no user-initiated "delete permanently" among them. The reason to guard
only one caller is sharper than caller count anyway. `fs.writeFile` returns
with the bytes in the page cache, so within the process that wrote it the
manifest always reads back intact, and a TTL timer only ever exists for an
entry that same process created. `startupCleanup` is the only caller that meets
an entry written by a *previous* process — which is exactly the window a power
cut opens. Guarding it is not a partial fix.

### Recovery hints name where the data actually is

`SourceMoveFailure` used to carry a `preserveEntryDirForManualRecovery`
boolean. That is not enough information: on the EXDEV path, the copy into the
trash entry can fail *before* it ever runs, leaving the reviewed source parked
beside its original path as `.<name>.trash-source-<hex>` while the staged entry
holds nothing at all. The caller was publishing that empty entry and telling
the user their copy was at `<entry>/source`.

It now carries a `ManualRecoveryLocation` union — `inEntry` or
`strandedAt: <path>` — so "preserve without saying where" is not
representable. `inEntry` publishes and names the published path; `strandedAt`
drops the staged entry and names the sibling stage. The same-device
validation-and-restore failure also gets its own reason string instead of
borrowing the EXDEV one.

### Manual-recovery arms

The two arms that deliberately keep the entry (EXDEV fallback copied but the
original could not be removed; manifest rollback failed to restore the source)
now go through `publishManualRecoveryEntry`: mark, then rename, returning
whichever path the data actually ended up at. `hasManualRecoveryMarker` and
`isManualRecoveryEntry` only ever scan *published* names, so an unpublished
marked entry would be invisible to them.

The user-facing "your copy is at ..." hint is now built by the caller, not
inside `moveSourceIntoTrashEntry` — only the caller knows whether the publish
rename landed, and a data-loss message pointing at a path that does not exist
is worse than one with no path at all.

### Deliberately not done

- **`readTrashedSourceDirNames` is NOT taught about `.staging-`.** A single
  leaked staging dir would then return `unavailable` forever and permanently
  brick stale-lock detection — strictly worse than the narrow race it closes.
  A staged window is also not a live undo window: no tombstone id has reached
  the renderer yet.
- **`startupCleanup` does NOT sweep `.staging-` entries.** A leaked one can
  hold the user's only copy of a skill; sweeping it recreates the exact bug
  being fixed here.
- **`moveLocalOnlyToTrash` has the same ordering** and is filed as its own
  TODOS P2 rather than folded in. Its *data-loss* half is already closed here:
  `local-copies` is not a bookkeeping name, so the sweep guard keeps a
  manifest-less local-only entry instead of deleting it. What remains is that
  such an entry is unrestorable through the app, and its four failure arms
  embed `${entryDir}` in user-facing "stranded in ..." messages — so staging it
  needs its own message audit.
- **No `fsync`.** Filed as TODOS P3. Durability ordering is a policy for every
  write in the trash and lock paths, not one call site; fsyncing only the
  manifest would imply a guarantee its neighbours do not make. The sweep guard
  above makes the *consequence* safe regardless of cause, which is the half
  that actually prevents the deletion.

## Test plan

- [x] `pnpm validate` — 195 files / 2537 tests, lint + typecheck + dead-code + dupes + health + storybook all green
- [x] `pnpm test:coverage` — 94.91 stmts / 85.1 branch / 96.83 funcs / 99.27 lines, all above the CI thresholds (94.5 / 84.5 / 96.0 / 99.2); `trashService.ts` has no uncovered line this PR introduced
- [x] `pnpm test:e2e` — 84 passed
- [x] **Mutation proof for the ordering fix:** setting `STAGED_ENTRY_PREFIX = ''` makes `trashService.durability.test.ts` test 1 fail with the exact tombstone name the old ordering exposed
- [x] **Mutation proof for the recovery path:** rebuilding the hint from the staged path makes the EXDEV test fail on the published-path assertion
- [x] **Mutation proof for the stranded-sibling arm:** switching it to `{ inEntry: true, reason: '...' }` makes the new sibling test fail on both the empty-trash assertion and the hint (the bare `{ inEntry: true }` no longer type-checks — `reason` is marker text the `inEntry` arm requires)
- [x] **Mutation proof for the sweep guard:** returning `'sweep'` on an unreadable manifest fails the torn-manifest test; inverting the bookkeeping check fails the existing integration sweep test

### New tests — `src/main/services/trashService.durability.test.ts`

1. `hides the half-built entry from every tombstone reader while the source is already inside it` — the discriminator: hooks the manifest write, snapshots the trash dir mid-build, asserts no name parses as a tombstone while the skill is already inside
2. `leaves a half-built entry on disk at startup instead of sweeping the only copy of the skill` — hand-plants a `.staging-` entry, runs `startupCleanup()`, asserts survival
3. `publishes a stranded entry under its tombstone name so manual recovery can still find it`
4. `still points the user at the stranded copy when even publishing it fails`
5. `names the folder beside the original path when nothing ever reached the trash entry` — cross-device delete whose copy and restore both fail; asserts the trash is left empty and the error names the sibling stage
6. `keeps a published entry whose manifest did not survive the crash, because its source is the only copy`
7. `keeps an entry it cannot even list, because a failed check is not proof the entry is empty`

### Reviewer note

The durability test mocks `node:fs/promises`, not the bare `fs/promises` that
`.coderabbit.yaml` suggests. Both `trashService.ts` and `skillLockService.ts`
import the `node:`-prefixed specifier, so a bare `vi.mock('fs/promises')` would
be a no-op here.

## Security Checklist

- [x] This change does not widen renderer access to Node.js, Electron, or direct filesystem APIs — it is main-process only, and no IPC surface, preload binding, or channel contract changed.
- [x] New IPC or filesystem behavior validates untrusted renderer input in the main process — no new IPC. The reviewed-identity checks (`assertStagedReviewedDirectory`) that gate the destructive move are unchanged; the staged path is derived from the same validated `entryName`, never from renderer input.
- [x] Dependency, workflow, or release changes preserve least-privilege permissions and pinned third-party Actions — none touched.
- [x] Security-sensitive behavior is documented or linked from `SECURITY.md` when relevant — this is a data-durability fix, not an access-control change; the reasoning lives in TODOS.md and in the code comments.

One deliberate trade worth naming: `startupCleanup` now retains entries it
cannot parse, so an unreadable entry persists rather than being reclaimed. That
is bounded (a directory under `~/.agents/.trash` the user can delete) and is
the conservative side of a data-loss decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * ゴミ箱への移動中の項目が、通常のゴミ箱項目として表示・削除されにくくなりました。
  * マニフェストの書き込みや移動に失敗した場合も、データを保持し、手動復旧に必要な保存先を示すよう改善しました。
  * 起動時のクリーンアップで、マニフェストを読み取れない項目にデータが残っている場合は削除しないようになりました。
  * エラーメッセージに、確認が必要な保存先を含めるよう改善しました。

* **テスト**
  * ゴミ箱移動、クリーンアップ、復旧処理に関する耐久性テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
