### PR TITLE
refactor(types): name the types MainContent re-derived, move Radix casts to the seam

### DIFF
--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -70,11 +70,13 @@ import { useRenderEffect } from '@/renderer/src/hooks/useRenderEffect'
 import { cn } from '@/renderer/src/lib/utils'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
 import {
+  type RepoFacetOption,
   selectBulkSelectableVisibleSkillNames,
   selectFilteredSkillCount,
   selectRepoFacetOptions,
   selectSelectedVisibleNames,
   selectSourceFilterViewModel,
+  type SourceFilterViewModel,
 } from '@/renderer/src/redux/selectors'
 import { setPreviewSkill } from '@/renderer/src/redux/slices/marketplaceSlice'
 import { selectProtectedNamesSet } from '@/renderer/src/redux/slices/protectSlice'
@@ -140,7 +142,8 @@ import type {
   TombstoneId,
 } from '@/shared/types'
 
-const SKILL_TYPE_FILTER_OPTIONS: {
+/** One row of the skill-type include menu: the filter it selects plus its presentation. */
+interface SkillTypeFilterOption {
   value: SkillTypeFilter
   label: string
   /** Colored dot class to match skill type visual indicators */
@@ -151,7 +154,9 @@ const SKILL_TYPE_FILTER_OPTIONS: {
    * filter is discoverable without docs. @see issue #203
    */
   hint?: string
-}[] = [
+}
+
+const SKILL_TYPE_FILTER_OPTIONS: SkillTypeFilterOption[] = [
   { value: 'all', label: 'All' },
   { value: 'symlinked', label: 'Symlinked', dotClass: 'bg-success' },
   { value: 'local', label: 'Local', dotClass: 'bg-emerald-400' },
@@ -168,12 +173,8 @@ const SKILL_TYPE_FILTER_OPTIONS: {
 const EXCLUDABLE_SKILL_TYPE_FILTER_OPTIONS = SKILL_TYPE_FILTER_OPTIONS.filter(
   (
     option,
-  ): option is {
-    value: ExcludableSkillTypeFilter
-    label: string
-    dotClass?: string
-    hint?: string
-  } => option.value !== 'all',
+  ): option is SkillTypeFilterOption & { value: ExcludableSkillTypeFilter } =>
+    option.value !== 'all',
 )
 
 /**
@@ -194,9 +195,6 @@ function getUnavailableExcludeReason(
   return includeFilter === excludeFilter ? 'Already included' : 'Not in view'
 }
 
-type SourceFilterViewModel = ReturnType<typeof selectSourceFilterViewModel>
-type RepoFacetOptions = ReturnType<typeof selectRepoFacetOptions>
-type BulkDeleteTargetSummary = ReturnType<typeof getBulkDeleteTargetSummary>
 type ExcludedSkillTypeToggleHandlers = Record<
   ExcludableSkillTypeFilter,
   () => void
@@ -775,16 +773,16 @@ function useBulkConfirmActions(
 
 interface MainContentEventHandlerOptions {
   bulkSelectMode: boolean
-  repoFacetOptions: RepoFacetOptions
+  repoFacetOptions: RepoFacetOption[]
 }
 
 interface MainContentEventHandlers {
   handleClearFilter: () => void
   handleClearSourceFilter: () => void
-  handleTabChange: (value: string) => void
+  handleTabChange: (value: ActiveTab) => void
   handleToggleSortOrder: () => void
   handleToggleBulkSelectMode: () => void
-  handleSkillTypeFilterChange: (value: string) => void
+  handleSkillTypeFilterChange: (value: SkillTypeFilter) => void
   handleToggleSource: (source: RepositoryId) => void
   handleSelectShowAllRepos: (event: Event) => void
   handleSelectAllRepos: (event: Event) => void
@@ -815,8 +813,8 @@ function useMainContentEventHandlers({
     dispatch(clearSelectedSources())
   }
 
-  const handleTabChange = (value: string): void => {
-    dispatch(setActiveTab(value as ActiveTab))
+  const handleTabChange = (value: ActiveTab): void => {
+    dispatch(setActiveTab(value))
     dispatch(setPreviewSkill(null))
   }
 
@@ -834,8 +832,8 @@ function useMainContentEventHandlers({
     dispatch(enterBulkSelectMode())
   }
 
-  const handleSkillTypeFilterChange = (value: string): void => {
-    dispatch(setSkillTypeFilter(value as SkillTypeFilter))
+  const handleSkillTypeFilterChange = (value: SkillTypeFilter): void => {
+    dispatch(setSkillTypeFilter(value))
   }
 
   const handleToggleSource = (source: RepositoryId): void => {
@@ -1215,7 +1213,12 @@ export const MainContent = function MainContent(): React.ReactElement {
     >
       <Tabs
         value={activeTab}
-        onValueChange={handleTabChange}
+        // Radix types `onValueChange` as `(value: string) => void`, so under
+        // `strictFunctionTypes` the narrower handler cannot be passed directly.
+        // The assertion holds by construction rather than by luck: `Tabs` is
+        // controlled, and its only Triggers are `installed` (InstalledTabLabel)
+        // and `marketplace` below, so Radix has no other value to echo back.
+        onValueChange={(value) => handleTabChange(value as ActiveTab)}
         className="h-full flex flex-col"
       >
         <div className="p-4 border-b border-border">
@@ -1340,7 +1343,7 @@ interface InstalledToolbarProps {
   onToggleSource: (source: RepositoryId) => void
   onKeepDropdownOpen: (event: Event) => void
   onToggleBulkSelectMode: () => void
-  onSkillTypeFilterChange: (value: string) => void
+  onSkillTypeFilterChange: (value: SkillTypeFilter) => void
   onSelectClearExcludedSkillTypeFilters: (event: Event) => void
 }
 
@@ -1587,7 +1590,7 @@ interface SkillTypeFilterMenuProps {
   availableExcludeTypes: ExcludableSkillTypeFilter[]
   skillTypeTriggerLabel: string
   excludedSkillTypeToggleHandlers: ExcludedSkillTypeToggleHandlers
-  onSkillTypeFilterChange: (value: string) => void
+  onSkillTypeFilterChange: (value: SkillTypeFilter) => void
   onKeepDropdownOpen: (event: Event) => void
   onSelectClearExcludedSkillTypeFilters: (event: Event) => void
 }
@@ -1636,7 +1639,14 @@ const SkillTypeFilterMenu = function SkillTypeFilterMenu({
         <DropdownMenuLabel>Include</DropdownMenuLabel>
         <DropdownMenuRadioGroup
           value={skillTypeFilter}
-          onValueChange={onSkillTypeFilterChange}
+          // Same Radix `(value: string) => void` seam as the tab bar. Sound
+          // because every RadioItem below draws its value from
+          // {@link SKILL_TYPE_FILTER_OPTIONS}, typed
+          // {@link SkillTypeFilterOption}[] -- Radix only echoes an item's own
+          // value, so nothing outside the union can arrive here.
+          onValueChange={(value) =>
+            onSkillTypeFilterChange(value as SkillTypeFilter)
+          }
         >
           {SKILL_TYPE_FILTER_OPTIONS.map((option) => (
             <DropdownMenuRadioItem
@@ -1771,7 +1781,7 @@ const InstalledFilterPills = function InstalledFilterPills({
 
 interface BulkConfirmDialogProps {
   bulkConfirm: BulkConfirmState | null
-  bulkDeleteTargetSummary: BulkDeleteTargetSummary
+  bulkDeleteTargetSummary: PartitionedGlobalDeleteTargets | null
   isPrimaryDisabled: boolean
   onCancel: () => void
   onConfirm: () => void

--- a/src/renderer/src/redux/selectors.ts
+++ b/src/renderer/src/redux/selectors.ts
@@ -37,7 +37,7 @@ import type {
   SkillTypeFilter,
 } from './slices/uiSlice'
 
-interface RepoFacetOption {
+export interface RepoFacetOption {
   source: RepositoryId
   count: SkillCount
 }
@@ -366,7 +366,7 @@ interface SourceFilterRow {
  *   include filter (drives the "N local skills hidden" hint); 0 when inactive.
  *   Ignores the search query.
  */
-interface SourceFilterViewModel {
+export interface SourceFilterViewModel {
   selectedSources: RepositoryId[]
   validRepoIds: RepositoryId[]
   dropdownRows: SourceFilterRow[]


### PR DESCRIPTION
## Summary

A colorful-type pass over `MainContent.tsx`'s two colorless boundaries. Type-only — no runtime behavior changes.

### 1. The `as ActiveTab` / `as SkillTypeFilter` cast seam

`handleTabChange` and `handleSkillTypeFilterChange` accepted a bare `string` and re-asserted the domain union inside the body. The consequence wasn't the cast itself but its blast radius: **three prop declarations** between the JSX and Redux (`MainContentEventHandlers`, `InstalledToolbarProps`, `SkillTypeFilterMenuProps`) all advertised `string`, ~800 lines from the component that made the narrower type true.

Those now carry `ActiveTab` / `SkillTypeFilter` end to end, and both handlers dispatch with no cast.

**Why the casts are not gone entirely — please don't re-flag this in a later audit.** Radix declares

```ts
onValueChange?: (value: string) => void;   // @radix-ui/react-tabs/dist/index.d.ts:15
```

as a *property* with a function type. `tsconfig.json` sets `"strict": true`, so `strictFunctionTypes` is on and parameter positions are contravariant — `(value: ActiveTab) => void` is not assignable to `(value: string) => void`. `tsc` confirms it; after this change the only two errors in the tree were exactly those two seams.

The alternative, a runtime narrowing guard, was **rejected deliberately** on two independent grounds:

- **It would be dead code.** `Tabs` is controlled (`value={activeTab}`) over a closed two-Trigger set (`installed`, `marketplace`), and every `DropdownMenuRadioItem` draws its value from `SKILL_TYPE_FILTER_OPTIONS`, which is typed `SkillTypeFilterOption[]`. Radix only ever echoes back an item's own value, so the else-branch is unreachable — the same unreachable branch #312 just deleted.
- **It's out of contract.** A colorful-type pass is compile-time only and must not change runtime behavior.

So the cast **moves to the JSX boundary**, on the line adjacent to the Triggers that make it sound, with the reasoning inline. Same number of assertions as before (one per seam), but now every declaration between the boundary and Redux is domain-typed, and the justification is visible where a reader can check it.

### 2. Three `ReturnType<typeof selector>` aliases deleted

`SourceFilterViewModel` and `RepoFacetOption` already existed as named interfaces in `selectors.ts`, and both selectors already carried explicit return annotations (`): SourceFilterViewModel =>`, `): RepoFacetOption[] =>`). They were merely unexported, so `MainContent` re-derived them through `ReturnType<>`. Exported both; deleted all three aliases.

`BulkDeleteTargetSummary` was pure indirection: `getBulkDeleteTargetSummary` returns `PartitionedGlobalDeleteTargets | null`, and that type was **already imported** at the top of the file.

### 3. `SkillTypeFilterOption` named once

The option-list element type was anonymous, and its shape was retyped **verbatim** inside the `EXCLUDABLE_SKILL_TYPE_FILTER_OPTIONS` type predicate — two copies that could drift. Named once; the predicate now intersects it with the narrowed `value`.

## Test plan

| Gate | Result |
| --- | --- |
| `pnpm validate` | exit 0 — 194 files / 2533 tests; lint, typecheck, dead-code, dupes, health, storybook all pass |
| `pnpm test:coverage` | 94.91 stmt / 85.16 branch / 96.84 func / 99.27 line — all above CI floors (94.5 / 84.5 / 96.0 / 99.2) |
| `pnpm test:e2e` | 84 passed |
| `npx tsc -p e2e/tsconfig.json --noEmit` | clean (not covered by `pnpm validate`) |

Function coverage moved 96.83 → 96.84, which confirms the two new seam arrows are exercised by the existing suite rather than adding uncovered functions.

`fallow:dead-code` passes with the two new exports because both are imported by `MainContent` in the same commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * フィルターやタブ操作の入力型を明確化し、選択時の不正な値を防止しました。
  * リポジトリやスキル種別のフィルター情報を、他の画面機能でも利用しやすくしました。
  * 一括削除確認画面で、削除対象の概要が正しく表示されるように改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->