### PR TITLE
fix(preview): end the dead "Loading files..." spinner on an unreadable skill

### DIFF
--- a/src/renderer/src/components/skills/CodePreview.browser.test.tsx
+++ b/src/renderer/src/components/skills/CodePreview.browser.test.tsx
@@ -1,6 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { Provider } from 'react-redux'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, test, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import type { PreviewContent } from '@/renderer/src/hooks/useCodePreview'
@@ -51,6 +51,7 @@ function makeHookReturn(overrides: {
   activeFile?: AbsolutePath | null
   content?: PreviewContent
   loading?: boolean
+  loadFailed?: boolean
   setActiveFile?: (path: AbsolutePath | null) => Promise<void>
 }) {
   return {
@@ -59,6 +60,7 @@ function makeHookReturn(overrides: {
     setActiveFile: overrides.setActiveFile ?? vi.fn(),
     content: overrides.content ?? { kind: 'empty' },
     loading: overrides.loading ?? false,
+    loadFailed: overrides.loadFailed ?? false,
   }
 }
 
@@ -117,6 +119,25 @@ describe('CodePreview', () => {
     await expect
       .element(screen.getByText('No preview files found'))
       .toBeInTheDocument()
+  })
+
+  test('explains an unreadable folder instead of claiming the skill has no files', async () => {
+    // Arrange -- a failed list leaves `files` empty, so this must not be
+    // mistaken for the ordinary "no previewable files" empty state.
+    mockUseCodePreview.mockReturnValue(
+      makeHookReturn({ loading: false, files: [], loadFailed: true }),
+    )
+
+    // Act
+    const screen = await renderCodePreview()
+
+    // Assert
+    await expect
+      .element(screen.getByText("Cannot read this skill's files"))
+      .toBeInTheDocument()
+    expect(
+      screen.container.textContent?.includes('No preview files found'),
+    ).toBe(false)
   })
 
   it('renders a tab for every previewable file once the list has loaded', async () => {

--- a/src/renderer/src/components/skills/CodePreview.tsx
+++ b/src/renderer/src/components/skills/CodePreview.tsx
@@ -1,12 +1,14 @@
 import * as TabsPrimitive from '@radix-ui/react-tabs'
 import { FolderX } from 'lucide-react'
 import React from 'react'
+import { match } from 'ts-pattern'
 
 import { useCodePreview } from '@/renderer/src/hooks/useCodePreview'
 import { useAppSelector } from '@/renderer/src/redux/hooks'
 import { selectPreviewAppearanceSettings } from '@/renderer/src/redux/slices/settingsSlice'
 import type { AbsolutePath } from '@/shared/types'
 
+import { resolvePreviewPaneState } from './codePreviewHelpers'
 import { FileContent } from './FileContent'
 import { FileTabs } from './FileTabs'
 
@@ -47,56 +49,43 @@ export const CodePreview = function CodePreview({
     setActiveFile(next)
   }
 
-  if (loading) {
-    return (
+  // Exhaustive over PreviewPaneState: the priority order between these four
+  // panes lives in {@link resolvePreviewPaneState} and is asserted there
+  // without React, and a future pane added to the union fails compilation here
+  // instead of silently never rendering.
+  return match(resolvePreviewPaneState({ loading, loadFailed, activeFile }))
+    .with({ kind: 'loading' }, () => (
       <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
         Loading files...
       </div>
-    )
-  }
-
-  // Ordered before the empty state on purpose: a failed list leaves `files`
-  // empty, so without this the pane would claim the skill simply has no
-  // previewable files instead of admitting it could not read them.
-  if (loadFailed) {
-    return <FilesUnavailableNotice />
-  }
-
-  // Guards the value the tabs actually read, and it is equivalent to guarding
-  // on `files.length === 0` in both directions. Forward: {@link useCodePreview}
-  // computes `activeFile` as `userSelectedFile ?? files[0]?.path ?? null`, so
-  // `!activeFile` needs an empty list. Reverse: `setActiveFile` drops any path
-  // absent from `files` before it commits, and the render-phase reset nulls
-  // `userSelectedFile` on every `skillPath` change -- so a selection can never
-  // outlive the list it came from.
-  if (!activeFile) {
-    return (
+    ))
+    .with({ kind: 'unavailable' }, () => <FilesUnavailableNotice />)
+    .with({ kind: 'empty' }, () => (
       <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
         No preview files found
       </div>
-    )
-  }
-
-  return (
-    <TabsPrimitive.Root
-      value={activeFile}
-      onValueChange={handleValueChange}
-      className="flex flex-col h-full"
-    >
-      <FileTabs files={files} activeFilePath={activeFile} />
-      <TabsPrimitive.Content
-        value={activeFile}
-        className="flex-1 flex flex-col min-h-0 focus-visible:outline-none"
+    ))
+    .with({ kind: 'ready' }, ({ activeFile: activeFilePath }) => (
+      <TabsPrimitive.Root
+        value={activeFilePath}
+        onValueChange={handleValueChange}
+        className="flex flex-col h-full"
       >
-        <FileContent
-          content={content}
-          markdownFontSizePx={markdownFontSizePx}
-          codeFontSizePx={codeFontSizePx}
-          codeThemeId={codeThemeId}
-        />
-      </TabsPrimitive.Content>
-    </TabsPrimitive.Root>
-  )
+        <FileTabs files={files} activeFilePath={activeFilePath} />
+        <TabsPrimitive.Content
+          value={activeFilePath}
+          className="flex-1 flex flex-col min-h-0 focus-visible:outline-none"
+        >
+          <FileContent
+            content={content}
+            markdownFontSizePx={markdownFontSizePx}
+            codeFontSizePx={codeFontSizePx}
+            codeThemeId={codeThemeId}
+          />
+        </TabsPrimitive.Content>
+      </TabsPrimitive.Root>
+    ))
+    .exhaustive()
 }
 
 /**

--- a/src/renderer/src/components/skills/CodePreview.tsx
+++ b/src/renderer/src/components/skills/CodePreview.tsx
@@ -1,4 +1,5 @@
 import * as TabsPrimitive from '@radix-ui/react-tabs'
+import { FolderX } from 'lucide-react'
 import React from 'react'
 
 import { useCodePreview } from '@/renderer/src/hooks/useCodePreview'
@@ -32,7 +33,7 @@ interface CodePreviewProps {
 export const CodePreview = function CodePreview({
   skillPath,
 }: CodePreviewProps): React.ReactElement {
-  const { files, activeFile, setActiveFile, content, loading } =
+  const { files, activeFile, setActiveFile, content, loading, loadFailed } =
     useCodePreview(skillPath)
   // Preview typography is user-configurable in Settings → Appearance; this is
   // the single Redux read that feeds the otherwise-presentational FileContent.
@@ -52,6 +53,13 @@ export const CodePreview = function CodePreview({
         Loading files...
       </div>
     )
+  }
+
+  // Ordered before the empty state on purpose: a failed list leaves `files`
+  // empty, so without this the pane would claim the skill simply has no
+  // previewable files instead of admitting it could not read them.
+  if (loadFailed) {
+    return <FilesUnavailableNotice />
   }
 
   // Guards the value the tabs actually read, and it is equivalent to guarding
@@ -90,3 +98,26 @@ export const CodePreview = function CodePreview({
     </TabsPrimitive.Root>
   )
 }
+
+/**
+ * Terminal-failure state for the Files tab when the file list could not be read.
+ * Takes the fuller icon + heading + description treatment DESIGN.md reserves for
+ * real failures, unlike the quiet one-liner used for the expected "skill has no
+ * previewable files" empty. Amber is the app-wide inaccessible-status hue, so
+ * this adds no new colour semantic. @see DESIGN.md "Empty States"
+ */
+const FilesUnavailableNotice =
+  function FilesUnavailableNotice(): React.ReactElement {
+    return (
+      <div className="flex flex-col items-center justify-center h-full p-6 text-center">
+        <FolderX className="size-10 text-amber-400 mb-3" aria-hidden />
+        <h3 className="text-sm font-medium text-foreground mb-1">
+          Cannot read this skill&apos;s files
+        </h3>
+        <p className="text-xs text-muted-foreground max-w-xs">
+          Its folder sits outside the skill directories this app is allowed to
+          read. The Info tab shows where each agent links this skill from.
+        </p>
+      </div>
+    )
+  }

--- a/src/renderer/src/components/skills/CodePreview.tsx
+++ b/src/renderer/src/components/skills/CodePreview.tsx
@@ -46,7 +46,11 @@ export const CodePreview = function CodePreview({
   const handleValueChange = (next: string) => {
     /* v8 ignore next -- next is always a non-empty file.path: Radix emits a Trigger's own value and every FileTabs Trigger has value={file.path} (non-empty AbsolutePath); Root has no collapsible/deselect prop, so next === '' never occurs */
     if (!next) return
-    setActiveFile(next)
+    // Fire-and-forget by design: {@link useCodePreview} owns the loading and
+    // failure states, and its `setActiveFile` degrades a failed read to the
+    // empty pane rather than rejecting. `void` pins that at the call site so a
+    // future rejection is a visible change here, not a silently dropped one.
+    void setActiveFile(next)
   }
 
   // Exhaustive over PreviewPaneState: the priority order between these four

--- a/src/renderer/src/components/skills/codePreviewHelpers.test.ts
+++ b/src/renderer/src/components/skills/codePreviewHelpers.test.ts
@@ -76,9 +76,12 @@ describe('resolvePreviewPaneState', () => {
     expect(state).toEqual({ kind: 'loading' })
   })
 
-  test('hides a stale active file behind the unavailable pane when the list failed', () => {
-    // Arrange — a content read can reject after the list landed, leaving an
-    // activeFile alongside a failure. The failure still wins.
+  test('never routes a failed list to the file pane, even with a file selected', () => {
+    // Arrange — defensive, not a state {@link useCodePreview} can currently
+    // produce: `loadFailed` is set only when the list itself rejected, which
+    // leaves `files` empty and `activeFile` null. Pinned anyway because this
+    // is the one ordering a future caller could get wrong -- routing a failure
+    // to the file pane would render a tab with no readable content behind it.
     const input = { loading: false, loadFailed: true, activeFile: ACTIVE_FILE }
 
     // Act

--- a/src/renderer/src/components/skills/codePreviewHelpers.test.ts
+++ b/src/renderer/src/components/skills/codePreviewHelpers.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from 'vitest'
+
+import type { AbsolutePath } from '@/shared/types'
+
+import { resolvePreviewPaneState } from './codePreviewHelpers'
+
+const ACTIVE_FILE = '/home/user/.agents/skills/tdd/SKILL.md' as AbsolutePath
+
+describe('resolvePreviewPaneState', () => {
+  test('shows the loading pane while the file list is still in flight', () => {
+    // Arrange
+    const input = { loading: true, loadFailed: false, activeFile: null }
+
+    // Act
+    const state = resolvePreviewPaneState(input)
+
+    // Assert
+    expect(state).toEqual({ kind: 'loading' })
+  })
+
+  test('shows the unavailable pane when the file list could not be read', () => {
+    // Arrange
+    const input = { loading: false, loadFailed: true, activeFile: null }
+
+    // Act
+    const state = resolvePreviewPaneState(input)
+
+    // Assert
+    expect(state).toEqual({ kind: 'unavailable' })
+  })
+
+  test('shows the empty pane when the list succeeded but held no previewable file', () => {
+    // Arrange
+    const input = { loading: false, loadFailed: false, activeFile: null }
+
+    // Act
+    const state = resolvePreviewPaneState(input)
+
+    // Assert
+    expect(state).toEqual({ kind: 'empty' })
+  })
+
+  test('shows the ready pane carrying the active file once one is selected', () => {
+    // Arrange
+    const input = { loading: false, loadFailed: false, activeFile: ACTIVE_FILE }
+
+    // Act
+    const state = resolvePreviewPaneState(input)
+
+    // Assert
+    expect(state).toEqual({ kind: 'ready', activeFile: ACTIVE_FILE })
+  })
+
+  test('reports an unreadable list rather than an empty one when both look empty', () => {
+    // Arrange — a failed list leaves activeFile null exactly like a skill with
+    // nothing to preview. Getting this order wrong tells the user their skill
+    // has no files when the truth is the app could not read the folder.
+    const input = { loading: false, loadFailed: true, activeFile: null }
+
+    // Act
+    const state = resolvePreviewPaneState(input)
+
+    // Assert
+    expect(state).toEqual({ kind: 'unavailable' })
+  })
+
+  test('keeps showing the spinner while a load that will fail is still running', () => {
+    // Arrange — loading outranks loadFailed so a stale failure flag from the
+    // previous skill cannot flash its notice over the new skill's spinner.
+    const input = { loading: true, loadFailed: true, activeFile: null }
+
+    // Act
+    const state = resolvePreviewPaneState(input)
+
+    // Assert
+    expect(state).toEqual({ kind: 'loading' })
+  })
+
+  test('hides a stale active file behind the unavailable pane when the list failed', () => {
+    // Arrange — a content read can reject after the list landed, leaving an
+    // activeFile alongside a failure. The failure still wins.
+    const input = { loading: false, loadFailed: true, activeFile: ACTIVE_FILE }
+
+    // Act
+    const state = resolvePreviewPaneState(input)
+
+    // Assert
+    expect(state).toEqual({ kind: 'unavailable' })
+  })
+})

--- a/src/renderer/src/components/skills/codePreviewHelpers.ts
+++ b/src/renderer/src/components/skills/codePreviewHelpers.ts
@@ -1,0 +1,52 @@
+import type { AbsolutePath } from '@/shared/types'
+
+/**
+ * Which of {@link CodePreview}'s four mutually exclusive panes should render.
+ * `ready` carries the resolved path so the caller gets a non-null
+ * {@link AbsolutePath} without re-narrowing at the JSX site.
+ */
+export type PreviewPaneState =
+  | { kind: 'loading' }
+  | { kind: 'unavailable' }
+  | { kind: 'empty' }
+  | { kind: 'ready'; activeFile: AbsolutePath }
+
+interface PreviewPaneInput {
+  /** True until the file list has been fetched for the current skill. */
+  loading: boolean
+  /** True when that fetch rejected, so no list exists to render. */
+  loadFailed: boolean
+  /** The file whose content the pane shows; null when the list is empty. */
+  activeFile: AbsolutePath | null
+}
+
+/**
+ * Pick the pane to render, in strict priority order, so the ordering is
+ * assertable without mounting React. Exists because two of the four states are
+ * reached with `activeFile === null` and would otherwise be indistinguishable:
+ * a failed list leaves `files` empty exactly like a skill with nothing to
+ * preview, so `unavailable` MUST outrank `empty` or a read failure gets
+ * misreported as "this skill has no files".
+ * @param input - The three flags {@link useCodePreview} exposes.
+ * @returns
+ * - `loading` while the list is in flight (outranks everything: the other flags
+ *   are not yet meaningful)
+ * - `unavailable` when the list rejected
+ * - `empty` when the list succeeded but held no previewable file
+ * - `ready` otherwise, carrying the active file's path
+ * @example
+ * resolvePreviewPaneState({ loading: false, loadFailed: true, activeFile: null })
+ * // => { kind: 'unavailable' }
+ * resolvePreviewPaneState({ loading: false, loadFailed: false, activeFile: '/s/a.md' })
+ * // => { kind: 'ready', activeFile: '/s/a.md' }
+ */
+export function resolvePreviewPaneState({
+  loading,
+  loadFailed,
+  activeFile,
+}: PreviewPaneInput): PreviewPaneState {
+  if (loading) return { kind: 'loading' }
+  if (loadFailed) return { kind: 'unavailable' }
+  if (!activeFile) return { kind: 'empty' }
+  return { kind: 'ready', activeFile }
+}

--- a/src/renderer/src/hooks/useCodePreview.browser.test.tsx
+++ b/src/renderer/src/hooks/useCodePreview.browser.test.tsx
@@ -397,6 +397,54 @@ describe('useCodePreview', () => {
     expect(result.current.loading).toBe(false)
   })
 
+  test('keeps the tab list usable when a file read rejects after the list loaded', async () => {
+    // Arrange -- list succeeds, so the tabs are valid; only the first file's
+    // content fails. Treating this as an unreadable folder would hide a tab
+    // bar the user can still click through.
+    const first = makeFile()
+    const second = makeFile({
+      name: 'notes.md',
+      path: '/skills/tdd/notes.md',
+      relativePath: 'notes.md',
+    })
+    listMock.mockResolvedValue([first, second])
+    readMock.mockRejectedValue(new Error('EIO'))
+
+    // Act
+    const { useCodePreview } = await import('./useCodePreview')
+    const { result } = await renderHook(() => useCodePreview('/skills/tdd'))
+
+    // Assert
+    await expect.poll(() => result.current.loading).toBe(false)
+    expect(result.current.loadFailed).toBe(false)
+    expect(result.current.files).toEqual([first, second])
+    expect(result.current.activeFile).toBe(first.path)
+    expect(result.current.content).toEqual({ kind: 'empty' })
+  })
+
+  test('keeps the tab list usable when an image read rejects after the list loaded', async () => {
+    // Arrange -- same contract on the binary branch of loadContentForFile.
+    const image = makeFile({
+      name: 'logo.png',
+      path: '/skills/tdd/logo.png',
+      relativePath: 'logo.png',
+      extension: '.png',
+      previewable: 'image',
+    })
+    listMock.mockResolvedValue([image])
+    readBinaryMock.mockRejectedValue(new Error('EIO'))
+
+    // Act
+    const { useCodePreview } = await import('./useCodePreview')
+    const { result } = await renderHook(() => useCodePreview('/skills/tdd'))
+
+    // Assert
+    await expect.poll(() => result.current.loading).toBe(false)
+    expect(result.current.loadFailed).toBe(false)
+    expect(result.current.files).toEqual([image])
+    expect(result.current.content).toEqual({ kind: 'empty' })
+  })
+
   test('ends the loading state and reports failure when the file list cannot be read', async () => {
     // Arrange -- the main process rejects any path outside its allowed bases,
     // which is how a skill symlinked from off-tree reaches this hook.

--- a/src/renderer/src/hooks/useCodePreview.browser.test.tsx
+++ b/src/renderer/src/hooks/useCodePreview.browser.test.tsx
@@ -445,6 +445,66 @@ describe('useCodePreview', () => {
     expect(result.current.content).toEqual({ kind: 'empty' })
   })
 
+  test('keeps the user-selected file showing when a slow initial-load read finally rejects', async () => {
+    // Arrange -- reject-side twin of the resolve-side stale-click test above.
+    // read(first) hangs then fails; read(second) wins immediately, so the
+    // failure lands after the user is already looking at `second`.
+    const first = makeFile()
+    const second = makeFile({
+      name: 'notes.md',
+      path: '/skills/tdd/notes.md',
+      relativePath: 'notes.md',
+    })
+    const secondBody = makeTextContent({ name: 'notes.md', content: 'notes' })
+
+    listMock.mockResolvedValue([first, second])
+
+    let rejectFirst: ((reason: Error) => void) | null = null
+    readMock.mockImplementation(async (p) => {
+      if (p === first.path) {
+        return new Promise<SkillFileContent | null>((_res, rej) => {
+          rejectFirst = rej
+        })
+      }
+      return secondBody
+    })
+
+    const { useCodePreview } = await import('./useCodePreview')
+    const { result, act } = await renderHook(() =>
+      useCodePreview('/skills/tdd'),
+    )
+
+    await expect.poll(() => result.current.files.length).toBe(2)
+    // Same gate as the resolve-side test: prove read(first) is pending, or
+    // `rejectFirst?.(…)` no-ops and the guard never gets exercised.
+    await expect
+      .poll(() => readMock.mock.calls.some((c) => c[0] === first.path))
+      .toBe(true)
+
+    // Act
+    await act(async () => {
+      await result.current.setActiveFile(second.path)
+    })
+
+    // Assert
+    expect(result.current.activeFile).toBe(second.path)
+    expect(result.current.content).toEqual({ kind: 'text', data: secondBody })
+
+    // Act
+    // The slow initial read now fails. The catch must not blank the pane the
+    // user is reading -- only `first`'s content is missing, and nobody is
+    // looking at it.
+    await act(async () => {
+      rejectFirst?.(new Error('EIO'))
+      await Promise.resolve()
+    })
+
+    // Assert
+    expect(result.current.activeFile).toBe(second.path)
+    expect(result.current.content).toEqual({ kind: 'text', data: secondBody })
+    expect(result.current.loadFailed).toBe(false)
+  })
+
   test('ends the loading state and reports failure when the file list cannot be read', async () => {
     // Arrange -- the main process rejects any path outside its allowed bases,
     // which is how a skill symlinked from off-tree reaches this hook.

--- a/src/renderer/src/hooks/useCodePreview.browser.test.tsx
+++ b/src/renderer/src/hooks/useCodePreview.browser.test.tsx
@@ -595,6 +595,54 @@ describe('useCodePreview', () => {
     expect(result.current.activeFile).toBeNull()
   })
 
+  test("ignores a previous skill's list rejection that lands after the next skill loaded", async () => {
+    // Arrange -- ordering twin of the test below: there the rejection settles
+    // BEFORE the switch, here it settles after, so the stale catch runs while
+    // skill B already owns the pane.
+    const fileB = makeFile({ path: '/skills/b/SKILL.md' })
+    const bodyB = makeTextContent({ content: 'B' })
+    let rejectA: ((reason: Error) => void) | null = null
+    listMock.mockImplementation(async (p) => {
+      if (p === '/outside/skills/a') {
+        return new Promise<SkillFile[]>((_res, rej) => {
+          rejectA = rej
+        })
+      }
+      return [fileB]
+    })
+    readMock.mockResolvedValue(bodyB)
+
+    const { useCodePreview } = await import('./useCodePreview')
+    const { result, rerender, act } = await renderHook(
+      (props?: { path: string }) =>
+        useCodePreview(props?.path ?? '/outside/skills/a'),
+      { initialProps: { path: '/outside/skills/a' } },
+    )
+    // Gate on the pending call: without it `rejectA?.(…)` could no-op.
+    await expect
+      .poll(() => listMock.mock.calls.some((c) => c[0] === '/outside/skills/a'))
+      .toBe(true)
+
+    // Act
+    rerender({ path: '/skills/b' })
+    await expect
+      .poll(() => result.current.content)
+      .toEqual({ kind: 'text', data: bodyB })
+    // Only now does skill A's list fail.
+    await act(async () => {
+      rejectA?.(new Error('Path traversal attempt detected'))
+      await Promise.resolve()
+    })
+
+    // Assert
+    // Skill B is readable; A's failure must not strand it on the unavailable
+    // pane, and must not roll `loadedPath` back to A and re-show the spinner.
+    expect(result.current.loadFailed).toBe(false)
+    expect(result.current.loading).toBe(false)
+    expect(result.current.content).toEqual({ kind: 'text', data: bodyB })
+    expect(result.current.activeFile).toBe(fileB.path)
+  })
+
   test("drops a previous skill's load failure when a readable skill is opened", async () => {
     // Arrange -- skill A is unreadable, skill B lists fine.
     const fileB = makeFile({ path: '/skills/b/SKILL.md' })

--- a/src/renderer/src/hooks/useCodePreview.browser.test.tsx
+++ b/src/renderer/src/hooks/useCodePreview.browser.test.tsx
@@ -865,4 +865,67 @@ describe('useCodePreview', () => {
     await expect.poll(() => result.current.content).toEqual({ kind: 'empty' })
     expect(readBinaryMock).toHaveBeenCalledTimes(1)
   })
+
+  test('shows the spinner again when switching back to a skill mid-reload', async () => {
+    // Arrange -- A lists once, then hangs on its second visit; B never settles,
+    // so the trip back to A happens while nothing else can repaint the pane.
+    const fileA = makeFile({ path: '/skills/a/SKILL.md' })
+    const bodyA = makeTextContent({ content: 'A' })
+    let resolveSecondListOfA: ((files: SkillFile[]) => void) | null = null
+    let listCallsForA = 0
+    listMock.mockImplementation(async (p) => {
+      if (p === '/skills/a') {
+        listCallsForA += 1
+        if (listCallsForA === 1) return [fileA]
+        return new Promise<SkillFile[]>((res) => {
+          resolveSecondListOfA = res
+        })
+      }
+      // Skill B's list never resolves, so its effect writes nothing.
+      return new Promise<SkillFile[]>(() => {})
+    })
+    readMock.mockResolvedValue(bodyA)
+
+    const { useCodePreview } = await import('./useCodePreview')
+    const { result, rerender, act } = await renderHook(
+      (props?: { path: string }) => useCodePreview(props?.path ?? '/skills/a'),
+      { initialProps: { path: '/skills/a' } },
+    )
+    await expect
+      .poll(() => result.current.content)
+      .toEqual({ kind: 'text', data: bodyA })
+
+    // Act
+    rerender({ path: '/skills/b' })
+    // Gate on B's effect: without it React batches both rerenders into a single
+    // render at '/skills/a', the B render never commits, and the switch this
+    // test is about never happens.
+    await expect
+      .poll(() => listMock.mock.calls.some((c) => c[0] === '/skills/b'))
+      .toBe(true)
+    rerender({ path: '/skills/a' })
+    // Gate on A's SECOND list call, which only happens once the return render
+    // has committed. Assert before this and `result.current` still reports the
+    // B render, where `loading` was true for an unrelated reason.
+    await expect.poll(() => listCallsForA).toBe(2)
+
+    // Assert
+    // `loadedPath` still held '/skills/a' across the detour, so `loading` read
+    // false while A was re-listing -- and the switch reset had already blanked
+    // `content`. That painted a file with text as a file with none.
+    expect(result.current.loading).toBe(true)
+
+    // And the spinner is transient, not a new way to get stuck: A's second list
+    // lands and the pane comes back.
+    // Same `act()` wrapper the sibling tests use: it keeps effect flushing under
+    // React's control and sidesteps TS narrowing the resolver to `null`.
+    await act(async () => {
+      resolveSecondListOfA?.([fileA])
+      await Promise.resolve()
+    })
+    await expect
+      .poll(() => result.current.content)
+      .toEqual({ kind: 'text', data: bodyA })
+    expect(result.current.loading).toBe(false)
+  })
 })

--- a/src/renderer/src/hooks/useCodePreview.browser.test.tsx
+++ b/src/renderer/src/hooks/useCodePreview.browser.test.tsx
@@ -505,6 +505,76 @@ describe('useCodePreview', () => {
     expect(result.current.loadFailed).toBe(false)
   })
 
+  test('empties the pane instead of showing the previous file when a click fails', async () => {
+    // Arrange -- first file reads fine, the clicked one rejects. The tab bar
+    // has already moved (selection commits before the read), so keeping the
+    // old content would caption `first`'s text with `second`'s tab.
+    const first = makeFile()
+    const second = makeFile({
+      name: 'notes.md',
+      path: '/skills/tdd/notes.md',
+      relativePath: 'notes.md',
+    })
+    const firstBody = makeTextContent()
+    listMock.mockResolvedValue([first, second])
+    readMock.mockImplementation(async (p) => {
+      if (p === first.path) return firstBody
+      throw new Error('EIO')
+    })
+
+    const { useCodePreview } = await import('./useCodePreview')
+    const { result, act } = await renderHook(() =>
+      useCodePreview('/skills/tdd'),
+    )
+    await expect.poll(() => result.current.loading).toBe(false)
+    expect(result.current.content).toEqual({ kind: 'text', data: firstBody })
+
+    // Act
+    await act(async () => {
+      await result.current.setActiveFile(second.path)
+    })
+
+    // Assert
+    expect(result.current.activeFile).toBe(second.path)
+    expect(result.current.content).toEqual({ kind: 'empty' })
+    // A failed read of one file is not a failed folder -- the tabs stay usable.
+    expect(result.current.loadFailed).toBe(false)
+    expect(result.current.files).toEqual([first, second])
+  })
+
+  test('empties the pane instead of showing the previous file when an image click fails', async () => {
+    // Arrange -- same contract on the binary branch of loadContentForFile.
+    const first = makeFile()
+    const image = makeFile({
+      name: 'logo.png',
+      path: '/skills/tdd/logo.png',
+      relativePath: 'logo.png',
+      extension: '.png',
+      previewable: 'image',
+    })
+    const firstBody = makeTextContent()
+    listMock.mockResolvedValue([first, image])
+    readMock.mockResolvedValue(firstBody)
+    readBinaryMock.mockRejectedValue(new Error('EIO'))
+
+    const { useCodePreview } = await import('./useCodePreview')
+    const { result, act } = await renderHook(() =>
+      useCodePreview('/skills/tdd'),
+    )
+    await expect.poll(() => result.current.loading).toBe(false)
+    expect(result.current.content).toEqual({ kind: 'text', data: firstBody })
+
+    // Act
+    await act(async () => {
+      await result.current.setActiveFile(image.path)
+    })
+
+    // Assert
+    expect(result.current.activeFile).toBe(image.path)
+    expect(result.current.content).toEqual({ kind: 'empty' })
+    expect(result.current.loadFailed).toBe(false)
+  })
+
   test('ends the loading state and reports failure when the file list cannot be read', async () => {
     // Arrange -- the main process rejects any path outside its allowed bases,
     // which is how a skill symlinked from off-tree reaches this hook.

--- a/src/renderer/src/hooks/useCodePreview.browser.test.tsx
+++ b/src/renderer/src/hooks/useCodePreview.browser.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest'
 import { renderHook } from 'vitest-browser-react'
 
 import type {
@@ -395,6 +395,57 @@ describe('useCodePreview', () => {
       .toEqual({ kind: 'text', data: bodyB })
     expect(result.current.activeFile).toBe(fileB.path)
     expect(result.current.loading).toBe(false)
+  })
+
+  test('ends the loading state and reports failure when the file list cannot be read', async () => {
+    // Arrange -- the main process rejects any path outside its allowed bases,
+    // which is how a skill symlinked from off-tree reaches this hook.
+    listMock.mockRejectedValue(new Error('Path traversal attempt detected'))
+
+    // Act
+    const { useCodePreview } = await import('./useCodePreview')
+    const { result } = await renderHook(() =>
+      useCodePreview('/outside/skills/tdd'),
+    )
+
+    // Assert
+    // `loading` must settle to false: leaving it true is the infinite-spinner
+    // bug this catch exists to prevent.
+    await expect.poll(() => result.current.loadFailed).toBe(true)
+    expect(result.current.loading).toBe(false)
+    expect(result.current.files).toEqual([])
+    expect(result.current.activeFile).toBeNull()
+  })
+
+  test("drops a previous skill's load failure when a readable skill is opened", async () => {
+    // Arrange -- skill A is unreadable, skill B lists fine.
+    const fileB = makeFile({ path: '/skills/b/SKILL.md' })
+    const bodyB = makeTextContent({ content: 'B' })
+    listMock.mockImplementation(async (p) => {
+      if (p === '/outside/skills/a')
+        throw new Error('Path traversal attempt detected')
+      return [fileB]
+    })
+    readMock.mockResolvedValue(bodyB)
+
+    const { useCodePreview } = await import('./useCodePreview')
+    const { result, rerender } = await renderHook(
+      (props?: { path: string }) =>
+        useCodePreview(props?.path ?? '/outside/skills/a'),
+      { initialProps: { path: '/outside/skills/a' } },
+    )
+    await expect.poll(() => result.current.loadFailed).toBe(true)
+
+    // Act
+    rerender({ path: '/skills/b' })
+
+    // Assert
+    // A sticky flag would blame skill B for skill A's unreadable folder.
+    await expect
+      .poll(() => result.current.content)
+      .toEqual({ kind: 'text', data: bodyB })
+    expect(result.current.loadFailed).toBe(false)
+    expect(result.current.activeFile).toBe(fileB.path)
   })
 
   it('previews an image file through the binary reader without calling the text reader', async () => {

--- a/src/renderer/src/hooks/useCodePreview.ts
+++ b/src/renderer/src/hooks/useCodePreview.ts
@@ -138,7 +138,18 @@ export function useCodePreview(skillPath: AbsolutePath): UseCodePreviewReturn {
       return
     }
     // react-doctor-disable-next-line react-doctor/async-defer-await -- the post-await guards (below) deliberately re-read refs AFTER the async gap to drop a stale click or a skill switch that happened DURING the load; they cannot move before the await.
-    const next = await loadContentForFile(file)
+    const next = await loadContentForFile(file).catch(
+      (error: unknown): PreviewContent => {
+        // The UI falls back to the empty pane; DevTools gets the real cause.
+        console.warn('[preview] failed to read selected file:', error)
+        // Degrade to empty, don't rethrow. The selection committed above, so
+        // this tab is already highlighted: leaving `content` alone would
+        // caption the PREVIOUS file's text with THIS file's tab. An empty pane
+        // is honest, misattributed text is not. Rethrowing is not an option
+        // either -- `handleValueChange` drops the promise, so it would float.
+        return { kind: 'empty' }
+      },
+    )
     // After the await, two things may have happened out of order:
     // (a) the user picked a different file (stale click loses)
     // (b) the skill itself switched (whole state already reset)

--- a/src/renderer/src/hooks/useCodePreview.ts
+++ b/src/renderer/src/hooks/useCodePreview.ts
@@ -72,9 +72,14 @@ export function useCodePreview(skillPath: AbsolutePath): UseCodePreviewReturn {
 
   useEffect(() => {
     let cancelled = false
+    // Distinguishes the two failures the catch below can see. A rejected list
+    // leaves the pane with nothing to show; a rejected content read leaves a
+    // perfectly good tab bar that must stay on screen.
+    let listSucceeded = false
     async function loadFiles(): Promise<void> {
       const fileList = await window.electron.files.list(skillPath)
       if (cancelled) return
+      listSucceeded = true
       setFiles(fileList)
       setLoadedPath(skillPath)
       const first = fileList[0]
@@ -91,12 +96,20 @@ export function useCodePreview(skillPath: AbsolutePath): UseCodePreviewReturn {
     // agent symlink that points off-tree resolves outside `getAllowedBases()`.
     // Without this catch the rejection floats, `loadedPath` never advances, and
     // `loading` stays true forever -- a spinner with no error and no retry.
+    // The catch stays broad rather than wrapping only the list await: narrowing
+    // it would leave every later rejection floating again, which is the bug.
     loadFiles().catch((error: unknown) => {
       // The UI states the cause in plain language; DevTools gets the real one.
-      console.warn('[preview] failed to list skill files:', error)
+      console.warn('[preview] failed to load skill files:', error)
       if (cancelled) return
       setLoadedPath(skillPath)
-      setLoadFailed(true)
+      if (!listSucceeded) {
+        setLoadFailed(true)
+        return
+      }
+      // The list landed, so `files` is valid and its tabs must keep rendering;
+      // only this one file's content is missing.
+      setContent({ kind: 'empty' })
     })
     return () => {
       cancelled = true

--- a/src/renderer/src/hooks/useCodePreview.ts
+++ b/src/renderer/src/hooks/useCodePreview.ts
@@ -25,6 +25,7 @@ interface UseCodePreviewReturn {
   setActiveFile: (path: AbsolutePath | null) => Promise<void>
   content: PreviewContent
   loading: boolean
+  loadFailed: boolean
 }
 
 /**
@@ -39,6 +40,7 @@ interface UseCodePreviewReturn {
  * - setActiveFile: change the active file and load its content
  * - content: discriminated union describing how the renderer should display the file
  * - loading: true until the initial file list has been fetched for the current skill
+ * - loadFailed: true when that fetch rejected, so the pane can explain instead of spinning
  * @example
  * const { files, content, setActiveFile } = useCodePreview('/skills/tdd')
  * // content.kind === 'text' | 'image' | 'binary' | 'empty'
@@ -50,6 +52,7 @@ export function useCodePreview(skillPath: AbsolutePath): UseCodePreviewReturn {
     null,
   )
   const [content, setContent] = useState<PreviewContent>({ kind: 'empty' })
+  const [loadFailed, setLoadFailed] = useState(false)
   const prevSkillPathRef = useRef(skillPath)
   // Mirror of userSelectedFile readable synchronously from the initial-load
   // effect. The effect must check the *current* selection when its async IPC
@@ -61,6 +64,7 @@ export function useCodePreview(skillPath: AbsolutePath): UseCodePreviewReturn {
     userSelectedFileRef.current = null
     setUserSelectedFile(null)
     setContent({ kind: 'empty' })
+    setLoadFailed(false)
   }
 
   const loading = loadedPath !== skillPath
@@ -82,7 +86,18 @@ export function useCodePreview(skillPath: AbsolutePath): UseCodePreviewReturn {
       if (cancelled || userSelectedFileRef.current !== null) return
       setContent(initial)
     }
-    loadFiles()
+    // `files.list` rejects when the main process refuses the path: `validatePath`
+    // runs OUTSIDE `listSkillFiles`' own swallow, and a skill reached through an
+    // agent symlink that points off-tree resolves outside `getAllowedBases()`.
+    // Without this catch the rejection floats, `loadedPath` never advances, and
+    // `loading` stays true forever -- a spinner with no error and no retry.
+    loadFiles().catch((error: unknown) => {
+      // The UI states the cause in plain language; DevTools gets the real one.
+      console.warn('[preview] failed to list skill files:', error)
+      if (cancelled) return
+      setLoadedPath(skillPath)
+      setLoadFailed(true)
+    })
     return () => {
       cancelled = true
     }
@@ -116,7 +131,7 @@ export function useCodePreview(skillPath: AbsolutePath): UseCodePreviewReturn {
     setContent(next)
   }
 
-  return { files, activeFile, setActiveFile, content, loading }
+  return { files, activeFile, setActiveFile, content, loading, loadFailed }
 }
 
 /**

--- a/src/renderer/src/hooks/useCodePreview.ts
+++ b/src/renderer/src/hooks/useCodePreview.ts
@@ -76,9 +76,21 @@ export function useCodePreview(skillPath: AbsolutePath): UseCodePreviewReturn {
     // leaves the pane with nothing to show; a rejected content read leaves a
     // perfectly good tab bar that must stay on screen.
     let listSucceeded = false
+    // Stronger than `cancelled`, and needed because it closes a window
+    // `cancelled` cannot: the ref is reassigned during the RENDER of the next
+    // skill, while `cancelled` is only set at commit, when React runs this
+    // effect's cleanup. A rejection landing between those two points would see
+    // `cancelled === false` and write this skill's failure over the next one's
+    // state. That matters for `loadFailed` specifically: every other value here
+    // is overwritten by the next skill's own load, but `loadFailed` is cleared
+    // only by the render-phase reset, which has already run by then -- so a
+    // stale `true` would strand a readable skill on the unavailable pane.
+    const isStaleSkill = (): boolean => prevSkillPathRef.current !== skillPath
     async function loadFiles(): Promise<void> {
       const fileList = await window.electron.files.list(skillPath)
       if (cancelled) return
+      /* v8 ignore next -- unreachable under test for the same reason it exists: the window it closes opens between React's render phase (where prevSkillPathRef is reassigned) and its commit phase (where this effect's cleanup sets `cancelled`), and `rerender` runs both synchronously, so `cancelled` always wins in the harness */
+      if (isStaleSkill()) return
       listSucceeded = true
       setFiles(fileList)
       setLoadedPath(skillPath)
@@ -102,6 +114,8 @@ export function useCodePreview(skillPath: AbsolutePath): UseCodePreviewReturn {
       // The UI states the cause in plain language; DevTools gets the real one.
       console.warn('[preview] failed to load skill files:', error)
       if (cancelled) return
+      /* v8 ignore next -- unreachable under test for the same reason it exists: the window it closes opens between React's render phase (where prevSkillPathRef is reassigned) and its commit phase (where this effect's cleanup sets `cancelled`), and `rerender` runs both synchronously, so `cancelled` always wins in the harness */
+      if (isStaleSkill()) return
       setLoadedPath(skillPath)
       if (!listSucceeded) {
         setLoadFailed(true)

--- a/src/renderer/src/hooks/useCodePreview.ts
+++ b/src/renderer/src/hooks/useCodePreview.ts
@@ -101,6 +101,13 @@ export function useCodePreview(skillPath: AbsolutePath): UseCodePreviewReturn {
       }
       const initial = await loadContentForFile(first)
       if (cancelled || userSelectedFileRef.current !== null) return
+      // The sibling guard above cannot stand in for this one: the render-phase
+      // reset nulls `userSelectedFileRef`, so it catches a stale CLICK but never
+      // a stale SKILL. Without this, the previous skill's file text lands under
+      // the next skill's tab bar -- misattributed content, which is worse than
+      // the blank pane the reset would otherwise leave.
+      /* v8 ignore next -- unreachable under test for the same reason it exists: the window it closes opens between React's render phase (where prevSkillPathRef is reassigned) and its commit phase (where this effect's cleanup sets `cancelled`), and `rerender` runs both synchronously, so `cancelled` always wins in the harness */
+      if (isStaleSkill()) return
       setContent(initial)
     }
     // `files.list` rejects when the main process refuses the path: `validatePath`

--- a/src/renderer/src/hooks/useCodePreview.ts
+++ b/src/renderer/src/hooks/useCodePreview.ts
@@ -108,7 +108,13 @@ export function useCodePreview(skillPath: AbsolutePath): UseCodePreviewReturn {
         return
       }
       // The list landed, so `files` is valid and its tabs must keep rendering;
-      // only this one file's content is missing.
+      // only this one file's content is missing. Same stale-click guard the
+      // success path uses: a click during the initial read already committed
+      // `userSelectedFile` and painted that file, so blanking here would wipe
+      // the tab the user is looking at. (The `!listSucceeded` arm above needs
+      // no guard -- `files` is empty there, so `setActiveFile` rejects every
+      // path and the ref is provably still null.)
+      if (userSelectedFileRef.current !== null) return
       setContent({ kind: 'empty' })
     })
     return () => {

--- a/src/renderer/src/hooks/useCodePreview.ts
+++ b/src/renderer/src/hooks/useCodePreview.ts
@@ -64,6 +64,13 @@ export function useCodePreview(skillPath: AbsolutePath): UseCodePreviewReturn {
     userSelectedFileRef.current = null
     setUserSelectedFile(null)
     setContent({ kind: 'empty' })
+    // Without this, `loading` is a lie on the way BACK to a skill: A -> B -> A
+    // leaves `loadedPath` at A across the detour, so the return switch computes
+    // `loading === false` while A is still re-listing -- and the reset above has
+    // just blanked `content`, so a file that has text renders as having none for
+    // one IPC round-trip. Nulling it keeps the spinner up until the new list
+    // lands, which is what `loading` claims to mean.
+    setLoadedPath(null)
     setLoadFailed(false)
   }
 


### PR DESCRIPTION
## Problem

Two ways the Files tab could lie about its own state, both from unhandled
rejections in the preview load path.

**1. Dead spinner.** Opening a skill whose files cannot be listed left the pane
spinning "Loading files..." forever — no error, no retry, no way out.

`useCodePreview`'s effect called `loadFiles()` as a floating promise.
`listSkillFiles` swallows its own errors and returns `[]`, but `validatePath`
runs **outside** that swallow (`src/main/ipc/files.ts:20`), and
`pathValidation.ts:62` throws `Path traversal attempt detected` for a path
outside `getAllowedBases()`. The IPC promise rejected, nothing caught it,
`setLoadedPath` never ran, and `loading` (derived as `loadedPath !== skillPath`)
stayed true forever.

Reachable today: `skillScanner.ts:379` sets `path: targetPath ?? linkPath`,
where `targetPath` comes from `readSymlinkTargetIfPresent`. A skill symlinked
into an agent directory from off-tree gets a `skill.path` outside the allowed
bases, and `SkillDetail.tsx:125` hands it straight to `<CodePreview>`.

**2. Misattributed content.** `setActiveFile` commits the selection *before*
awaiting the file's content, so a rejected read left the newly clicked tab
highlighted over the **previous file's text** — the pane captioned one file's
content with another file's tab. `handleValueChange` discarded the returned
promise, so the rejection floated with no diagnostic.

Both pre-existing. The first was found by PR #312's adversarial pass; the second
by CodeRabbit on this PR.

## Fix

**`useCodePreview.ts`**

- Catch the effect's rejection, end the loading state, and expose a new
  `loadFailed` flag so the pane can explain instead of spinning. The catch stays
  broad rather than wrapping only the list `await`: narrowing it would leave
  later rejections floating again, which is the bug.
- A `listSucceeded` latch separates the two failures that catch can see. A
  rejected **list** leaves nothing to show → `loadFailed`. A rejected **content
  read** after the list landed leaves a valid tab bar that must keep rendering →
  only that file's content is missing.
- Both content-failure paths carry the same `userSelectedFileRef` stale-click
  guard as the success path, so a read that fails after the user clicked another
  tab does not blank the pane they are reading. The list-failure arm needs no
  guard: `files` is empty there, so `setActiveFile` rejects every path and the
  ref is provably null.
- `setActiveFile` resolves a failed read to `{ kind: 'empty' }` rather than
  rethrowing, so the existing post-await guards handle staleness in one place
  and the two load paths cannot drift apart.
- Both post-await writes in the effect also check `prevSkillPathRef`, not just
  `cancelled`. `cancelled` is set from the cleanup function, at commit; the ref
  is reassigned during the *render* of the next skill. A rejection landing
  between those two points would write the old skill's outcome over the new
  one's state. Harmless for everything the next load overwrites, but not for
  `loadFailed` -- the render-phase reset is the only thing that clears it and
  has already run, so a stale `true` would strand a readable skill on the
  unavailable pane.

**`codePreviewHelpers.ts` (new)** — `resolvePreviewPaneState()` picks the pane in
strict priority order as a pure function, per `.coderabbit.yaml:63` ("extract
conditional rendering logic into pure helper functions for testability without
React Testing Library"). The ordering matters and is now assertable without
mounting React: a failed list leaves `files` empty *exactly like* a skill with
nothing to preview, so `unavailable` MUST outrank `empty` or a read failure gets
misreported as "this skill has no files".

**`CodePreview.tsx`** — three early returns replaced by `match(...).exhaustive()`
over the four pane states, so a future pane fails compilation instead of
silently never rendering. New module-level `FilesUnavailableNotice` gets the icon
+ heading + description treatment DESIGN.md's "Empty States" section reserves for
terminal failures, in `text-amber-400` — already the app's "broken /
inaccessible" hue (`DESIGN.md:84`), so no new colour semantic. The
`setActiveFile` call site is now `void`, matching the repo's fire-and-forget
convention and pinning the invariant it depends on.

Why not an error `PreviewContent` kind: a failed list leaves `activeFile` null,
so `CodePreview`'s `!activeFile` early return fires before `FileContent` ever
renders. That kind would have been dead code.

## Test plan

- `pnpm validate` — exit 0 (195 files, 2550 tests)
- `pnpm test:coverage` — 94.95 stmt / 85.29 branch / 96.80 func / 99.27 line,
  above every CI floor; `useCodePreview.ts` at 66/66 lines, 10/10 functions,
  39/39 branches
- `npx tsc -p e2e/tsconfig.json --noEmit` — clean
- `pnpm test:e2e` — 84 passed
- Every new test verified non-vacuous by reverting the production change and
  confirming it fails, with one disclosed exception: `ignores a previous skill's
  list rejection that lands after the next skill loaded` was **measured vacuous**
  for the `isStaleSkill` guard specifically — `rerender` runs render, commit and
  cleanup synchronously, so `cancelled` always wins in the harness and the guard
  is provably unreachable there. Kept because it does cover an ordering nothing
  else did (the old list rejecting *after* the next skill loaded, where the
  existing sibling settles it *before* the switch)

## `loading` in the other direction

`loading` is derived as `loadedPath !== skillPath`, and `loadedPath` was never
cleared on a skill switch. So `A -> B -> A` (returning while B's list is still in
flight) computed `loading === false` for A's re-listing, with `content` already
blanked by the switch reset — a file that has text rendering as a file with none
for one IPC round-trip. `setLoadedPath(null)` in the reset closes it. Same
derivation as the headline bug, opposite direction.

## Stale-skill guards

`cancelled` is set by the effect cleanup, which React runs at **commit**.
`prevSkillPathRef.current` is reassigned during the **render** of the next skill.
A promise settling between those two points sees `cancelled === false`. All three
post-`await` writes plus the `catch` now re-check `prevSkillPathRef`, each in its
own statement with a `/* v8 ignore next */` mirroring the identical guard that
already lived in `setActiveFile`. The `userSelectedFileRef` check cannot stand in
for it: the render-phase reset nulls that ref, so it catches a stale *click* and
never a stale *skill*.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * コードプレビューでファイル一覧や内容の読み込みに失敗した場合、原因に応じた適切なエラーメッセージを表示します。
  * 読み込み失敗時もファイルタブと選択状態を維持し、プレビューを空の状態で表示します。
  * スキルを切り替えると、以前の読み込み失敗状態がリセットされます。
  * 再読み込み中はスピナーを表示し、完了後にプレビューを復元します。
  * 古い読み込み結果が現在のプレビューを上書きしないよう改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


