### PR TITLE
fix(trash): stage local-only trash entries and publish them atomically

### DIFF
--- a/src/main/services/trashService.orphanRace.test.ts
+++ b/src/main/services/trashService.orphanRace.test.ts
@@ -874,6 +874,87 @@ describe('trashService orphan cleanup guarded commit', () => {
     ).resolves.toBeDefined()
   })
 
+  test("names the folder's real location when an EXDEV copy fails and the restore fails too", async () => {
+    // Arrange
+    // The cross-device copy INTO the trash fails, and putting the original back
+    // fails too -- so the user's whole folder is parked beside its old slot
+    // under a bookkeeping name. Nothing else in this flow reports that path, so
+    // the thrown error is the only thing standing between them and a folder
+    // they cannot find.
+    const skillName = 'local-exdev-restore-fails'
+    const claudeSkillsDir = join(tempHome, '.claude', 'skills')
+    const localPath = join(claudeSkillsDir, skillName)
+    await mkdir(localPath, { recursive: true })
+    await writeFile(join(localPath, 'SKILL.md'), `# ${skillName}\n`, 'utf-8')
+    vi.doMock('node:fs/promises', async () => {
+      const actual =
+        await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
+      return {
+        ...actual,
+        rename: async (oldPath: string, newPath: string): Promise<void> => {
+          // Only the move into the trash is cross-device; the sibling-stage
+          // rename inside the agent dir still works.
+          if (oldPath === localPath && newPath.includes('/.agents/.trash/')) {
+            const error = new Error(
+              'forced cross-device local move',
+            ) as NodeJS.ErrnoException
+            error.code = 'EXDEV'
+            throw error
+          }
+          return actual.rename(oldPath, newPath)
+        },
+        cp: async (
+          source: string,
+          destination: string,
+          options?: Parameters<typeof actual.cp>[2],
+        ): Promise<void> => {
+          // Fail the copy into the trash entry, then fail the restore back to
+          // the agent slot -- both legs of the EXDEV fallback.
+          if (destination.includes('/.agents/.trash/')) {
+            const error = new Error(
+              'forced cross-device copy failure',
+            ) as NodeJS.ErrnoException
+            error.code = 'ENOSPC'
+            throw error
+          }
+          if (destination === localPath) {
+            const error = new Error(
+              'forced restore failure',
+            ) as NodeJS.ErrnoException
+            error.code = 'EACCES'
+            throw error
+          }
+          return actual.cp(source, destination, options)
+        },
+      }
+    })
+    const { __getTrashDirForTests, moveToTrash } =
+      await import('./trashService')
+
+    // Act
+    const moveError = await moveToTrash(
+      skillName,
+      localPath,
+      await reviewedIdentityForPath(localPath),
+    ).catch((error: unknown) => error)
+
+    // Assert
+    const moveErrorMessage = moveError instanceof Error ? moveError.message : ''
+    // The copy never reached the trash, so claiming a staged copy would send
+    // the user to an entry that holds nothing.
+    expect(moveErrorMessage).not.toMatch(/staged copy preserved/i)
+    const strandedPathMatch = /original folder left at (\S+)/.exec(
+      moveErrorMessage,
+    )
+    const strandedOriginalPath = strandedPathMatch?.[1] ?? ''
+    expect(
+      await readFile(join(strandedOriginalPath, 'SKILL.md'), 'utf-8'),
+    ).toContain(skillName)
+    // Nothing was published: the staged entry held no copy, so a tombstone
+    // would be an empty promise of recovery.
+    expect(await readdir(__getTrashDirForTests())).toEqual([])
+  })
+
   it('rejects deleting a reviewed path that contains a null byte in its basename', async () => {
     // Arrange
     // A reviewed source path whose basename carries a NUL byte passes the

--- a/src/main/services/trashService.orphanRace.test.ts
+++ b/src/main/services/trashService.orphanRace.test.ts
@@ -15,9 +15,9 @@ import {
 import type * as NodeFsPromises from 'node:fs/promises'
 import type * as NodeOs from 'node:os'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest'
 
 import type { FilesystemEntryIdentity } from '@/shared/types'
 
@@ -1577,13 +1577,79 @@ describe('trashService orphan cleanup guarded commit', () => {
         localPath,
         await reviewedIdentityForPath(localPath),
       ),
-    ).rejects.toThrow(/Failed to write trash manifest/i)
+    ).rejects.toThrow(/Failed to finalize trash entry/i)
     // The staged folder was restored to its original agent slot.
     expect(await readFile(join(localPath, 'SKILL.md'), 'utf-8')).toContain(
       skillName,
     )
     // All copies restored → trash entry removed.
     await expect(readdir(__getTrashDirForTests())).resolves.toEqual([])
+  })
+
+  test('assembles local copies under a staged name and publishes them with one rename', async () => {
+    // Arrange
+    // Snapshot TRASH_DIR at the instant the manifest is written -- the last
+    // moment before the entry is published. Nothing tombstone-shaped may exist
+    // yet, or a crash right here would leave readers a half-built entry.
+    const skillName = 'local-staged-publish'
+    const claudeSkillsDir = join(tempHome, '.claude', 'skills')
+    const localPath = join(claudeSkillsDir, skillName)
+    await mkdir(localPath, { recursive: true })
+    await writeFile(join(localPath, 'SKILL.md'), `# ${skillName}\n`, 'utf-8')
+    let entryNameDuringWrite = ''
+    let trashDirDuringWrite: string[] = []
+    vi.doMock('node:fs/promises', async () => {
+      const actual =
+        await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
+      return {
+        ...actual,
+        writeFile: async (
+          path: string,
+          data: Parameters<typeof actual.writeFile>[1],
+          options?: Parameters<typeof actual.writeFile>[2],
+        ): Promise<void> => {
+          if (path.endsWith('/manifest.json')) {
+            // <TRASH_DIR>/<entry>/manifest.json — one dirname to the entry,
+            // a second to TRASH_DIR itself.
+            entryNameDuringWrite = basename(dirname(path))
+            trashDirDuringWrite = await actual.readdir(dirname(dirname(path)))
+          }
+          return actual.writeFile(path, data, options)
+        },
+      }
+    })
+    const { __getTrashDirForTests, moveToTrash } =
+      await import('./trashService')
+
+    // Act
+    const result = await moveToTrash(
+      skillName,
+      localPath,
+      await reviewedIdentityForPath(localPath),
+    )
+
+    // Assert
+    // Mid-flight the copies sit under a name no tombstone reader parses, and
+    // it is the ONLY thing in the trash dir — no tombstone-named sibling.
+    expect(entryNameDuringWrite).toMatch(/^\.staging-/)
+    expect(trashDirDuringWrite).toEqual([entryNameDuringWrite])
+    // One rename then makes the whole entry visible under its tombstone name.
+    const publishedEntries = await readdir(__getTrashDirForTests())
+    expect(publishedEntries).toHaveLength(1)
+    expect(publishedEntries[0]).not.toMatch(/^\.staging-/)
+    expect(result.kind).toBe('tombstoned')
+    expect(
+      await readFile(
+        join(
+          __getTrashDirForTests(),
+          publishedEntries[0],
+          'local-copies',
+          'claude-code',
+          'SKILL.md',
+        ),
+        'utf-8',
+      ),
+    ).toContain(skillName)
   })
 
   it('strands a local copy for manual recovery when manifest rollback cannot restore it', async () => {
@@ -1637,14 +1703,17 @@ describe('trashService orphan cleanup guarded commit', () => {
     const { __getTrashDirForTests, moveToTrash } =
       await import('./trashService')
 
-    // Act / Assert
-    await expect(
-      moveToTrash(
-        skillName,
-        localPath,
-        await reviewedIdentityForPath(localPath),
-      ),
-    ).rejects.toThrow(/stranded in/i)
+    // Act
+    const strandError = await moveToTrash(
+      skillName,
+      localPath,
+      await reviewedIdentityForPath(localPath),
+    ).catch((error: unknown) => error)
+
+    // Assert
+    const strandedMessage =
+      strandError instanceof Error ? strandError.message : ''
+    expect(strandedMessage).toMatch(/stranded in/i)
     expect(
       warnSpy.mock.calls.some(
         ([message]) => message === 'trashService: rollback local copy failed',
@@ -1652,6 +1721,7 @@ describe('trashService orphan cleanup guarded commit', () => {
     ).toBe(true)
     const trashEntries = await readdir(__getTrashDirForTests())
     expect(trashEntries).toHaveLength(1)
+    expect(trashEntries[0]).not.toMatch(/^\.staging-/)
     const entryDir = join(__getTrashDirForTests(), trashEntries[0])
     await expect(
       lstat(join(entryDir, '.manual-recovery')),
@@ -1659,6 +1729,20 @@ describe('trashService orphan cleanup guarded commit', () => {
     await expect(
       lstat(join(entryDir, 'local-copies', 'claude-code')),
     ).resolves.toBeDefined()
+    // The path in the message is the one the user has to open to get their only
+    // surviving copy back, so it must name where the data LANDED -- not the
+    // pre-publish staging dir it was assembled under, which no longer exists.
+    const strandedPathMatch = /stranded in (.+) \(agents: /.exec(
+      strandedMessage,
+    )
+    const strandedLocalCopiesDir = strandedPathMatch?.[1] ?? ''
+    expect(strandedLocalCopiesDir).toBe(join(entryDir, 'local-copies'))
+    expect(
+      await readFile(
+        join(strandedLocalCopiesDir, 'claude-code', 'SKILL.md'),
+        'utf-8',
+      ),
+    ).toContain(skillName)
     warnSpy.mockRestore()
   })
 

--- a/src/main/services/trashService.orphanRace.test.ts
+++ b/src/main/services/trashService.orphanRace.test.ts
@@ -955,6 +955,75 @@ describe('trashService orphan cleanup guarded commit', () => {
     expect(await readdir(__getTrashDirForTests())).toEqual([])
   })
 
+  test('claims no recovery location when the folder never left its agent slot', async () => {
+    // Arrange
+    // The move into the trash reports EXDEV, and the sibling-stage rename that
+    // the fallback opens with fails too -- so the folder never moved and is
+    // still exactly where the user left it. Naming a recovery path here would
+    // send them hunting a directory that was never created.
+    const skillName = 'local-exdev-never-staged'
+    const claudeSkillsDir = join(tempHome, '.claude', 'skills')
+    const localPath = join(claudeSkillsDir, skillName)
+    await mkdir(localPath, { recursive: true })
+    await writeFile(join(localPath, 'SKILL.md'), `# ${skillName}\n`, 'utf-8')
+    vi.doMock('node:fs/promises', async () => {
+      const actual =
+        await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
+      return {
+        ...actual,
+        rename: async (oldPath: string, newPath: string): Promise<void> => {
+          if (oldPath !== localPath) return actual.rename(oldPath, newPath)
+          if (newPath.includes('/.agents/.trash/')) {
+            const error = new Error(
+              'forced cross-device local move',
+            ) as NodeJS.ErrnoException
+            error.code = 'EXDEV'
+            throw error
+          }
+          // The sibling-stage rename inside the agent dir fails as well.
+          const error = new Error(
+            'forced sibling stage failure',
+          ) as NodeJS.ErrnoException
+          error.code = 'EACCES'
+          throw error
+        },
+        lstat: async (path: string): Promise<Stats> => {
+          // An agent dir the process cannot search answers EACCES for a missing
+          // child instead of ENOENT -- so "does the sibling stage exist?"
+          // cannot be read off this errno, which is the point of the test.
+          if (path.includes(`.${skillName}.trash-local-`)) {
+            const error = new Error(
+              'forced sibling stage lstat failure',
+            ) as NodeJS.ErrnoException
+            error.code = 'EACCES'
+            throw error
+          }
+          return actual.lstat(path)
+        },
+      }
+    })
+    const { __getTrashDirForTests, moveToTrash } =
+      await import('./trashService')
+
+    // Act
+    const moveError = await moveToTrash(
+      skillName,
+      localPath,
+      await reviewedIdentityForPath(localPath),
+    ).catch((error: unknown) => error)
+
+    // Assert
+    const moveErrorMessage = moveError instanceof Error ? moveError.message : ''
+    expect(moveErrorMessage).toMatch(/failed to move local copy/i)
+    expect(moveErrorMessage).not.toMatch(/original folder left at/i)
+    expect(moveErrorMessage).not.toMatch(/staged copy preserved/i)
+    // The folder is untouched in the slot the user already knows about.
+    expect(await readFile(join(localPath, 'SKILL.md'), 'utf-8')).toContain(
+      skillName,
+    )
+    expect(await readdir(__getTrashDirForTests())).toEqual([])
+  })
+
   it('rejects deleting a reviewed path that contains a null byte in its basename', async () => {
     // Arrange
     // A reviewed source path whose basename carries a NUL byte passes the
@@ -3892,15 +3961,15 @@ describe('trashService orphan cleanup guarded commit', () => {
     // Arrange
     // Local-only mirror of the source case: EXDEV forces the sibling-stage + copy
     // fallback for an agent-local copy. The copy fails (no staged copy created) and
-    // the sibling restore probe finds it already gone (ENOENT). The surfaced fatal
-    // error must NOT claim a staged copy was preserved.
+    // the restore back to the agent slot finds it already gone (ENOENT). The
+    // surfaced fatal error must NOT claim a staged copy was preserved, and must
+    // not name a recovery path either -- nothing is parked at the sibling.
     const skillName = 'local-exdev-sibling-gone'
     const claudeSkillsDir = join(tempHome, '.claude', 'skills')
     const localPath = join(claudeSkillsDir, skillName)
     await mkdir(localPath, { recursive: true })
     await writeFile(join(localPath, 'SKILL.md'), `# ${skillName}\n`, 'utf-8')
     const siblingStageMarker = `.${skillName}.trash-local-claude-code-`
-    let siblingLstatCalls = 0
     vi.doMock('node:fs/promises', async () => {
       const actual =
         await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
@@ -3916,36 +3985,26 @@ describe('trashService orphan cleanup guarded commit', () => {
           }
           return actual.rename(oldPath, newPath)
         },
-        lstat: async (
-          path: string,
-          options?: Parameters<typeof actual.lstat>[1],
-        ): Promise<Awaited<ReturnType<typeof actual.lstat>>> => {
-          if (path.includes(siblingStageMarker)) {
-            siblingLstatCalls += 1
-            // 1st lstat = identity recheck (must pass); 2nd = restore probe → ENOENT.
-            if (siblingLstatCalls >= 2) {
-              const error = new Error(
-                'sibling already gone',
-              ) as NodeJS.ErrnoException
-              error.code = 'ENOENT'
-              throw error
-            }
-          }
-          return actual.lstat(path, options)
-        },
         cp: async (
           source: string,
           destination: string,
           options?: Parameters<typeof actual.cp>[2],
         ): Promise<void> => {
-          if (
-            source.includes(siblingStageMarker) &&
-            destination.includes('/.agents/.trash/')
-          ) {
+          if (source.includes(siblingStageMarker)) {
+            // Copy into the trash entry fails outright...
+            if (destination.includes('/.agents/.trash/')) {
+              const error = new Error(
+                'forced cross-device copy failure',
+              ) as NodeJS.ErrnoException
+              error.code = 'EACCES'
+              throw error
+            }
+            // ...and the restore back to the agent slot finds the staged folder
+            // already gone, which is what ENOENT from the copy means.
             const error = new Error(
-              'forced cross-device copy failure',
+              'sibling already gone',
             ) as NodeJS.ErrnoException
-            error.code = 'EACCES'
+            error.code = 'ENOENT'
             throw error
           }
           return actual.cp(source, destination, options)
@@ -3973,9 +4032,12 @@ describe('trashService orphan cleanup guarded commit', () => {
     expect((surfacedError as Error).message).not.toMatch(
       /staged copy preserved/,
     )
+    expect((surfacedError as Error).message).not.toMatch(
+      /original folder left at/,
+    )
     // Unrecoverable branch: the local copy was staged out and the ENOENT restore
-    // probe leaves nothing to bring back, so it is gone from its original path —
-    // exactly why the error honestly omits a staged-copy hint.
+    // leaves nothing to bring back, so it is gone from its original path —
+    // exactly why the error honestly omits both hints.
     expect(existsSync(localPath)).toBe(false)
   })
 })

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -1413,10 +1413,15 @@ async function moveLocalOnlyToTrash(
             `trash-local-${copy.agentId}`,
           )
           let stagedCopyCreated = false
+          // Whether the folder ever left its agent slot. The catch below needs
+          // this to tell "still exactly where the user left it" apart from
+          // "parked under a bookkeeping name", and only the forward path knows.
+          let siblingStageCreated = false
           try {
             // Rename inside the original agent dir first; this binds the copy
             // to the reviewed identity before non-atomic cross-device copy.
             await fs.rename(copy.linkPath, siblingStagePath)
+            siblingStageCreated = true
             try {
               await assertStagedReviewedDirectory(
                 siblingStagePath,
@@ -1440,16 +1445,27 @@ async function moveLocalOnlyToTrash(
             await fs.rm(siblingStagePath, { recursive: true, force: true })
             return { kind: 'moved' as const }
           } catch (fallbackError) {
-            // Set only when the restore back to the agent dir failed, which
-            // parks the user's whole folder beside its old slot under a
-            // bookkeeping name nothing else in this flow reports.
+            // Set only when the folder actually left its slot AND could not be
+            // put back -- that is the one case where it sits beside its old
+            // home under a bookkeeping name nothing else in this flow reports.
+            // Reading it off the forward flag rather than off lstat's errno
+            // matters: when the sibling rename is what failed, the folder never
+            // moved, and lstat on a nonexistent child of an unsearchable agent
+            // dir answers EACCES, not ENOENT -- which would name a path that
+            // was never created while the folder sat untouched at linkPath.
             let strandedOriginalPath: AbsolutePath | null = null
-            try {
-              await fs.lstat(siblingStagePath)
-              await moveDirectoryNoOverwrite(siblingStagePath, copy.linkPath)
-            } catch (restoreError) {
-              if (errorCode(restoreError) !== 'ENOENT') {
-                strandedOriginalPath = siblingStagePath
+            if (siblingStageCreated) {
+              try {
+                await moveDirectoryNoOverwrite(siblingStagePath, copy.linkPath)
+              } catch (restoreError) {
+                // ENOENT means the staged folder is gone too, so there is
+                // nothing parked to send anyone to. Any other failure means it
+                // is still sitting there under the bookkeeping name. Reading
+                // this off the restore itself rather than a separate lstat
+                // probe closes the window where the answer changes in between.
+                if (errorCode(restoreError) !== 'ENOENT') {
+                  strandedOriginalPath = siblingStagePath
+                }
               }
             }
             // Two survivors, tracked apart on purpose: folding the failed

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -383,6 +383,30 @@ async function publishManualRecoveryEntry(
 }
 
 /**
+ * Persist a trash manifest, then publish the staged entry with one atomic
+ * rename. Both trash paths call it as their last forward step; a rejection
+ * means the entry never became a tombstone, so the caller's catch owns the
+ * rollback and the staged dir is still whole when it runs.
+ * @param manifestPath - `manifest.json` inside {@link stagingDir}.
+ * @param manifest - v2 manifest for either trash kind.
+ * @param stagingDir - Half-built entry under {@link STAGED_ENTRY_PREFIX}.
+ * @param entryDir - Tombstone-named path to publish it as.
+ * @returns Nothing. Throws the underlying fs error from either step.
+ * @example await writeManifestThenPublish(manifestPath, manifest, stagingDir, entryDir)
+ */
+async function writeManifestThenPublish(
+  manifestPath: AbsolutePath,
+  manifest: z.infer<typeof manifestSchema>,
+  stagingDir: AbsolutePath,
+  entryDir: AbsolutePath,
+): Promise<void> {
+  await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf-8')
+  // Rename is atomic, so a failure here leaves the staged entry intact rather
+  // than a half-published tombstone.
+  await fs.rename(stagingDir, entryDir)
+}
+
+/**
  * Check whether startup cleanup must leave a trash entry for manual recovery.
  * @param entryDir - Trash entry directory under TRASH_DIR.
  * @returns true when the marker exists or cannot be checked safely.
@@ -613,19 +637,20 @@ async function rollbackRemovedSymlinks(
  * Returns the subset of copies that could NOT be restored. The caller MUST
  * use this list to decide whether the staged trash entry is still the only
  * surviving copy of the data: if any restore failed, the staged folder under
- * `<entryDir>/local-copies/<agentId>/` is the user's only remaining copy and
- * the entryDir MUST NOT be deleted.
- * @param entryDir - Trash entry root (contains `local-copies/<agentId>/`)
+ * `<entryRoot>/local-copies/<agentId>/` is the user's only remaining copy and
+ * `entryRoot` MUST NOT be deleted — publish it for manual recovery instead.
+ * @param entryRoot - Entry root holding `local-copies/<agentId>/`. Always the
+ * pre-publish staging dir today; the callers all run before the publish rename.
  * @param copies - Local copies that were moved during the failing forward pass
  * @returns The copies whose restore failed (empty array means full success)
  */
 async function rollbackMovedLocalCopies(
-  entryDir: AbsolutePath,
+  entryRoot: AbsolutePath,
   copies: RecordedLocalCopy[],
 ): Promise<RecordedLocalCopy[]> {
   const unrestoredCopies: RecordedLocalCopy[] = []
   for (const copy of copies) {
-    const stagedPath = join(entryDir, 'local-copies', copy.agentId)
+    const stagedPath = join(entryRoot, 'local-copies', copy.agentId)
     try {
       // react-doctor-disable-next-line react-doctor/async-await-in-loop -- intra-iteration dependent (mkdir parent then move into it); best-effort rollback accumulating unrestoredCopies, order- and fd-sensitive.
       await fs.mkdir(dirname(copy.linkPath), { recursive: true })
@@ -1227,10 +1252,7 @@ async function moveSourceBackedToTrash(
     symlinks: recordedSymlinks,
   }
   try {
-    await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf-8')
-    // The publish. Rename is atomic, so on failure the staged entry is still
-    // whole and the rollback below applies to it unchanged.
-    await fs.rename(stagingDir, entryDir)
+    await writeManifestThenPublish(manifestPath, manifest, stagingDir, entryDir)
   } catch (entryPublishError) {
     const entryPublishCode = errorCode(entryPublishError)
     const entryPublishMessage = extractErrorMessage(entryPublishError)
@@ -1308,13 +1330,15 @@ async function moveSourceBackedToTrash(
  * Local-only path of `moveToTrash`. The skill exists only as real folders
  * inside one or more agent dirs (no `~/.agents/skills/<name>` source).
  *
- * Lifecycle:
- * 1. `mkdir(<entryDir>/local-copies)` to host the staged folders.
- * 2. For each `RecordedLocalCopy`, `fs.rename(linkPath → <entryDir>/local-copies/<agentId>)`.
+ * Lifecycle (staged then published, mirroring {@link moveSourceBackedToTrash}):
+ * 1. `mkdir(<stagingDir>/local-copies)` to host the staged folders.
+ * 2. For each `RecordedLocalCopy`, `fs.rename(linkPath → <stagingDir>/local-copies/<agentId>)`.
  *    On EXDEV: cp + rm fallback. On per-copy failure: rollback (rename already-moved
  *    copies back to their linkPaths) before throwing.
- * 3. Write v2 local-only manifest. On manifest-write failure: rollback all moved
- *    copies and drop the entry dir.
+ * 3. Write v2 local-only manifest, then `fs.rename(stagingDir → entryDir)` in the
+ *    SAME try. Either the entry publishes whole or nothing parses as a tombstone.
+ *    On failure: rollback all moved copies and drop the staged dir; if rollback
+ *    could not restore them all, publish the staged dir for manual recovery.
  * 4. Schedule TTL evict timer.
  *
  * `cascadeAgents` is the list of agents whose local copies were moved;
@@ -1331,12 +1355,17 @@ async function moveLocalOnlyToTrash(
 
   const entryName = buildEntryName(skillName)
   const entryDir = join(TRASH_DIR, entryName)
-  const localCopiesRoot = join(entryDir, 'local-copies')
-  const manifestPath = join(entryDir, 'manifest.json')
+  // Same staged-then-published shape as the source-backed twin: everything is
+  // assembled under a name no reader parses as a tombstone, then one rename
+  // publishes it. A kill before that rename leaves the copies waiting there
+  // instead of half an entry the sweep would act on.
+  const stagingDir = join(TRASH_DIR, `${STAGED_ENTRY_PREFIX}${entryName}`)
+  const localCopiesRoot = join(stagingDir, 'local-copies')
+  const manifestPath = join(stagingDir, 'manifest.json')
 
   await fs.mkdir(localCopiesRoot, { recursive: true })
 
-  // Move each agent's real folder into <entryDir>/local-copies/<agentId>/.
+  // Move each agent's real folder into <stagingDir>/local-copies/<agentId>/.
   // Track successfully-moved copies so a mid-loop failure can be rolled back.
   const moved: RecordedLocalCopy[] = []
   for (const copy of localCopies) {
@@ -1344,13 +1373,16 @@ async function moveLocalOnlyToTrash(
     /* v8 ignore start -- defense-in-depth: the sole caller moveToTrash always supplies a non-null filesystemIdentity, so this optional-field guard is unreachable via any public entry point */
     if (!copy.filesystemIdentity) {
       // react-doctor-disable-next-line react-doctor/async-await-in-loop -- sequential move loop accumulates the moved array and must rename already-moved copies back in order on failure (also an unreachable v8-ignored guard).
-      const unrestoredCopies = await rollbackMovedLocalCopies(entryDir, moved)
+      const unrestoredCopies = await rollbackMovedLocalCopies(stagingDir, moved)
       if (unrestoredCopies.length === 0) {
-        await fs.rm(entryDir, { recursive: true, force: true }).catch(() => {
+        await fs.rm(stagingDir, { recursive: true, force: true }).catch(() => {
           // best-effort cleanup
         })
       } else {
-        await markManualRecoveryEntry(
+        // Return discarded on purpose: this arm's throw names no path, so the
+        // published location has no reader to hand it to.
+        await publishManualRecoveryEntry(
+          stagingDir,
           entryDir,
           'local-only rollback left staged copies in trash',
         )
@@ -1442,23 +1474,29 @@ async function moveLocalOnlyToTrash(
         }))
 
       if (recoveryOutcome.kind === 'fatal') {
-        const unrestoredCopies = await rollbackMovedLocalCopies(entryDir, moved)
+        const unrestoredCopies = await rollbackMovedLocalCopies(
+          stagingDir,
+          moved,
+        )
         if (
           unrestoredCopies.length === 0 &&
           !recoveryOutcome.preserveEntryDir
         ) {
           // All copies restored — safe to drop the staged entry dir.
           /* v8 ignore next 3 -- best-effort cleanup: any fs.rm rejection (EPERM/EBUSY/EACCES — force only suppresses ENOENT) is intentionally swallowed by .catch, and no suite stages a writable-but-unremovable dir, so this recovery arm is unreachable under test */
-          await fs.rm(entryDir, { recursive: true, force: true }).catch(() => {
-            // best-effort cleanup
-          })
+          await fs
+            .rm(stagingDir, { recursive: true, force: true })
+            .catch(() => {
+              // best-effort cleanup
+            })
           throw recoveryOutcome.error
         }
         // One or more copies could not be restored. The staged folder under
-        // <entryDir>/local-copies/<agentId>/ is the ONLY remaining copy of
-        // the user's data. Preserve entryDir and surface a recovery hint so
-        // the caller (and ultimately the UI) can guide the user to it.
-        await markManualRecoveryEntry(
+        // local-copies/<agentId>/ is the ONLY remaining copy of the user's
+        // data, so publish it under the tombstone name the marker readers scan
+        // and report whichever path it actually landed at.
+        const recoveryDir = await publishManualRecoveryEntry(
+          stagingDir,
           entryDir,
           'local-only EXDEV fallback or rollback left staged copies in trash',
         )
@@ -1471,7 +1509,7 @@ async function moveLocalOnlyToTrash(
           ]),
         ).join(', ')
         throw new TrashError(
-          `${recoveryOutcome.error.message}; local copy/copies stranded in ${entryDir}/local-copies (agents: ${strandedAgents})`,
+          `${recoveryOutcome.error.message}; local copy/copies stranded in ${join(recoveryDir, 'local-copies')} (agents: ${strandedAgents})`,
           recoveryOutcome.error.code,
         )
       }
@@ -1485,7 +1523,7 @@ async function moveLocalOnlyToTrash(
   if (moved.length === 0) {
     // Every copy raced away — nothing to tombstone.
     /* v8 ignore next 3 -- best-effort cleanup: any fs.rm rejection (EPERM/EBUSY/EACCES — force only suppresses ENOENT) is intentionally swallowed by .catch, and no suite stages a writable-but-unremovable dir, so this recovery arm is unreachable under test */
-    await fs.rm(entryDir, { recursive: true, force: true }).catch(() => {
+    await fs.rm(stagingDir, { recursive: true, force: true }).catch(() => {
       // best-effort cleanup
     })
     throw new TrashError('Skill not found (already deleted?)', 'ENOENT')
@@ -1499,27 +1537,28 @@ async function moveLocalOnlyToTrash(
     localCopies: moved.map(({ agentId, linkPath }) => ({ agentId, linkPath })),
   }
   try {
-    await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf-8')
-  } catch (manifestWriteError) {
-    const manifestWriteCode = errorCode(manifestWriteError)
-    const manifestWriteMessage = extractErrorMessage(manifestWriteError)
+    await writeManifestThenPublish(manifestPath, manifest, stagingDir, entryDir)
+  } catch (entryPublishError) {
+    const entryPublishCode = errorCode(entryPublishError)
+    const entryPublishMessage = extractErrorMessage(entryPublishError)
 
-    const unrestoredCopies = await rollbackMovedLocalCopies(entryDir, moved)
+    const unrestoredCopies = await rollbackMovedLocalCopies(stagingDir, moved)
     if (unrestoredCopies.length === 0) {
       // All copies restored — safe to drop the staged entry dir.
       /* v8 ignore next 3 -- best-effort cleanup: any fs.rm rejection (EPERM/EBUSY/EACCES — force only suppresses ENOENT) is intentionally swallowed by .catch, and no suite stages a writable-but-unremovable dir, so this recovery arm is unreachable under test */
-      await fs.rm(entryDir, { recursive: true, force: true }).catch(() => {
+      await fs.rm(stagingDir, { recursive: true, force: true }).catch(() => {
         // best-effort cleanup
       })
       throw new TrashError(
-        `Failed to write trash manifest: ${manifestWriteMessage}`,
-        manifestWriteCode,
+        `Failed to finalize trash entry: ${entryPublishMessage}`,
+        entryPublishCode,
       )
     }
-    // Manifest write failed AND rollback could not restore every copy. The
-    // staged folder is the ONLY remaining copy of the user's data — keep
-    // entryDir intact so they can recover manually from local-copies/.
-    await markManualRecoveryEntry(
+    // Publish failed AND rollback could not restore every copy. The staged
+    // folder is the ONLY remaining copy of the user's data, so publish it under
+    // the tombstone name the marker readers scan and report where it landed.
+    const recoveryDir = await publishManualRecoveryEntry(
+      stagingDir,
       entryDir,
       'local-only manifest rollback left staged copies in trash',
     )
@@ -1527,8 +1566,8 @@ async function moveLocalOnlyToTrash(
       .map((copy) => copy.agentId)
       .join(', ')
     throw new TrashError(
-      `Failed to write trash manifest: ${manifestWriteMessage}; ${unrestoredCopies.length} local copy/copies stranded in ${entryDir}/local-copies (agents: ${strandedAgents})`,
-      manifestWriteCode,
+      `Failed to finalize trash entry: ${entryPublishMessage}; ${unrestoredCopies.length} local copy/copies stranded in ${join(recoveryDir, 'local-copies')} (agents: ${strandedAgents})`,
+      entryPublishCode,
     )
   }
 

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -387,19 +387,21 @@ async function publishManualRecoveryEntry(
  * rename. Both trash paths call it as their last forward step; a rejection
  * means the entry never became a tombstone, so the caller's catch owns the
  * rollback and the staged dir is still whole when it runs.
- * @param manifestPath - `manifest.json` inside {@link stagingDir}.
  * @param manifest - v2 manifest for either trash kind.
  * @param stagingDir - Half-built entry under {@link STAGED_ENTRY_PREFIX}.
  * @param entryDir - Tombstone-named path to publish it as.
  * @returns Nothing. Throws the underlying fs error from either step.
- * @example await writeManifestThenPublish(manifestPath, manifest, stagingDir, entryDir)
+ * @example await writeManifestThenPublish(manifest, stagingDir, entryDir)
  */
 async function writeManifestThenPublish(
-  manifestPath: AbsolutePath,
   manifest: z.infer<typeof manifestSchema>,
   stagingDir: AbsolutePath,
   entryDir: AbsolutePath,
 ): Promise<void> {
+  // Derived, never passed in: the manifest has to land inside the very dir the
+  // next line renames away, and a caller free to pass its own path is a caller
+  // free to write it where the publish leaves it behind.
+  const manifestPath = join(stagingDir, 'manifest.json')
   await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf-8')
   // Rename is atomic, so a failure here leaves the staged entry intact rather
   // than a half-published tombstone.
@@ -1187,7 +1189,6 @@ async function moveSourceBackedToTrash(
   // parses as a tombstone, so the source waits there instead of being swept.
   const stagingDir = join(TRASH_DIR, `${STAGED_ENTRY_PREFIX}${entryName}`)
   const entrySourceDir = join(stagingDir, 'source')
-  const manifestPath = join(stagingDir, 'manifest.json')
 
   // Walk agents, collect + remove symlinks. Abort on non-ENOENT unlink failure.
   const { recordedSymlinks, cascadeAgentIds } =
@@ -1252,7 +1253,7 @@ async function moveSourceBackedToTrash(
     symlinks: recordedSymlinks,
   }
   try {
-    await writeManifestThenPublish(manifestPath, manifest, stagingDir, entryDir)
+    await writeManifestThenPublish(manifest, stagingDir, entryDir)
   } catch (entryPublishError) {
     const entryPublishCode = errorCode(entryPublishError)
     const entryPublishMessage = extractErrorMessage(entryPublishError)
@@ -1361,7 +1362,6 @@ async function moveLocalOnlyToTrash(
   // instead of half an entry the sweep would act on.
   const stagingDir = join(TRASH_DIR, `${STAGED_ENTRY_PREFIX}${entryName}`)
   const localCopiesRoot = join(stagingDir, 'local-copies')
-  const manifestPath = join(stagingDir, 'manifest.json')
 
   await fs.mkdir(localCopiesRoot, { recursive: true })
 
@@ -1427,7 +1427,7 @@ async function moveLocalOnlyToTrash(
               await moveDirectoryNoOverwrite(siblingStagePath, copy.linkPath)
               return {
                 kind: 'fatal' as const,
-                preserveEntryDir: false,
+                preserveStagedEntry: false,
                 strandedAgentId: copy.agentId,
                 error: coerceTrashError(
                   identityError,
@@ -1448,12 +1448,17 @@ async function moveLocalOnlyToTrash(
                 stagedCopyCreated = true
               }
             }
+            // No path here on purpose. A non-empty hint implies
+            // preserveStagedEntry, which routes every caller through the publish
+            // rename below -- so naming stagedPath would name a directory that
+            // no longer exists by the time the caller wraps this message with
+            // the one it does still live in.
             const recoveryHint = stagedCopyCreated
-              ? `; staged copy preserved in ${stagedPath}`
+              ? '; staged copy preserved in trash for manual recovery'
               : ''
             return {
               kind: 'fatal' as const,
-              preserveEntryDir: stagedCopyCreated,
+              preserveStagedEntry: stagedCopyCreated,
               strandedAgentId: copy.agentId,
               error: new TrashError(
                 `Failed to move local copy (cross-device, agent=${copy.agentId}): ${extractErrorMessage(fallbackError)}${recoveryHint}`,
@@ -1465,7 +1470,7 @@ async function moveLocalOnlyToTrash(
         .with('ENOENT', async () => ({ kind: 'race-skip' as const }))
         .otherwise(async () => ({
           kind: 'fatal' as const,
-          preserveEntryDir: false,
+          preserveStagedEntry: false,
           strandedAgentId: copy.agentId,
           error: new TrashError(
             `Failed to move local copy (agent=${copy.agentId}): ${extractErrorMessage(error)}`,
@@ -1480,7 +1485,7 @@ async function moveLocalOnlyToTrash(
         )
         if (
           unrestoredCopies.length === 0 &&
-          !recoveryOutcome.preserveEntryDir
+          !recoveryOutcome.preserveStagedEntry
         ) {
           // All copies restored — safe to drop the staged entry dir.
           /* v8 ignore next 3 -- best-effort cleanup: any fs.rm rejection (EPERM/EBUSY/EACCES — force only suppresses ENOENT) is intentionally swallowed by .catch, and no suite stages a writable-but-unremovable dir, so this recovery arm is unreachable under test */
@@ -1503,7 +1508,7 @@ async function moveLocalOnlyToTrash(
         const strandedAgents = Array.from(
           new Set([
             ...unrestoredCopies.map((copy) => copy.agentId),
-            ...(recoveryOutcome.preserveEntryDir
+            ...(recoveryOutcome.preserveStagedEntry
               ? [recoveryOutcome.strandedAgentId]
               : []),
           ]),
@@ -1537,7 +1542,7 @@ async function moveLocalOnlyToTrash(
     localCopies: moved.map(({ agentId, linkPath }) => ({ agentId, linkPath })),
   }
   try {
-    await writeManifestThenPublish(manifestPath, manifest, stagingDir, entryDir)
+    await writeManifestThenPublish(manifest, stagingDir, entryDir)
   } catch (entryPublishError) {
     const entryPublishCode = errorCode(entryPublishError)
     const entryPublishMessage = extractErrorMessage(entryPublishError)

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -1440,28 +1440,41 @@ async function moveLocalOnlyToTrash(
             await fs.rm(siblingStagePath, { recursive: true, force: true })
             return { kind: 'moved' as const }
           } catch (fallbackError) {
+            // Set only when the restore back to the agent dir failed, which
+            // parks the user's whole folder beside its old slot under a
+            // bookkeeping name nothing else in this flow reports.
+            let strandedOriginalPath: AbsolutePath | null = null
             try {
               await fs.lstat(siblingStagePath)
               await moveDirectoryNoOverwrite(siblingStagePath, copy.linkPath)
             } catch (restoreError) {
               if (errorCode(restoreError) !== 'ENOENT') {
-                stagedCopyCreated = true
+                strandedOriginalPath = siblingStagePath
               }
             }
-            // No path here on purpose. A non-empty hint implies
-            // preserveStagedEntry, which routes every caller through the publish
-            // rename below -- so naming stagedPath would name a directory that
-            // no longer exists by the time the caller wraps this message with
-            // the one it does still live in.
-            const recoveryHint = stagedCopyCreated
+            // Two survivors, tracked apart on purpose: folding the failed
+            // restore back into `stagedCopyCreated` would claim a copy reached
+            // the staged entry when the copy step is exactly what failed, and
+            // send the user to an empty trash entry while their folder sat at
+            // siblingStagePath unnamed.
+            //
+            // The staged hint carries no path -- only the caller knows where
+            // the publish rename landed, and it appends that. The stranded
+            // original is publish-independent, so its path is named here, the
+            // same split {@link ManualRecoveryLocation} draws for the
+            // source-backed twin.
+            const stagedCopyHint = stagedCopyCreated
               ? '; staged copy preserved in trash for manual recovery'
+              : ''
+            const strandedOriginalHint = strandedOriginalPath
+              ? `; original folder left at ${strandedOriginalPath}`
               : ''
             return {
               kind: 'fatal' as const,
               preserveStagedEntry: stagedCopyCreated,
               strandedAgentId: copy.agentId,
               error: new TrashError(
-                `Failed to move local copy (cross-device, agent=${copy.agentId}): ${extractErrorMessage(fallbackError)}${recoveryHint}`,
+                `Failed to move local copy (cross-device, agent=${copy.agentId}): ${extractErrorMessage(fallbackError)}${stagedCopyHint}${strandedOriginalHint}`,
                 errorCode(fallbackError),
               ),
             }


### PR DESCRIPTION
## Summary

`moveLocalOnlyToTrash` assembled the trash entry **directly under its tombstone name** and never renamed anything, so a crash mid-flight left a half-built entry under a name the startup sweep reads as real. This mirrors the source-backed twin (`moveSourceBackedToTrash`, shipped in #311): build everything under `.staging-<entryName>`, then publish with one atomic rename.

Review then surfaced a second, worse bug on the same code path — a cross-device failure sent the user to an *empty* trash entry while their only copy sat unreported under a bookkeeping name. Both are fixed here; see "Recovery reporting" below.

Closes TODO #11.

### Why staging matters more here than for the source-backed path

For local-only deletes there is **no source directory by definition**, so the staged folder is the user's *only* copy. Verified the sweep is safe with it: `parseDeletedAtFromEntryName` takes the substring before the first dash and requires `/^\d+$/`, so `.staging-…` yields prefix `.staging` → `null` → `startupCleanup` hits its `continue` ("unparseable name = foreign file; do not touch"). A crash now parks the only copy where nothing acts on it.

### The TODO's stated blocker dissolves

The TODO feared the four failure arms embedding `${entryDir}` would need "a second state machine" to know whether the entry had been published. They do not: **every one of those arms runs before the publish rename**, and `publishManualRecoveryEntry` already returns whichever path the data actually landed at. The stranded-copy messages now report that returned path, so a user following the error opens the directory their data is really in.

### Recovery reporting (the higher-severity half)

The EXDEV fallback tracked two different facts in one boolean. `stagedCopyCreated` meant both "a copy reached the staged entry" **and** "the restore of `siblingStagePath` failed" — reachable precisely when the copy step is what threw. The message then claimed a staged copy existed when none did, pointing the user at an empty trash entry during a data-loss incident while the real folder sat at `<agentDir>/.<skill>.trash-local-<agentId>-<hex>`, named nowhere.

Now tracked apart, with the same split `ManualRecoveryLocation` already draws for the source-backed twin: `strandedAgentId`-style locations are publish-independent so the producer names the path, `inEntry` locations are publish-dependent so only the caller can. Two independent hints, either, both, or neither.

Whether the folder ever left its agent slot is read off a **forward-path flag** (`siblingStageCreated`), not off an `lstat` errno. `lstat` on a missing child of a directory the process cannot search answers **EACCES, not ENOENT** — the same permission failure that would have failed the preceding rename, so the two co-occur, and the errno reading would name a path that was never created while the folder sat untouched at `linkPath`. Reading it forward also closes the check-then-act window.

## Changes

- `moveLocalOnlyToTrash`: `localCopiesRoot` / `manifestPath` rebase onto `stagingDir`; 3× `rollbackMovedLocalCopies(stagingDir, …)`; 4× `fs.rm(stagingDir, …)`; 3× `markManualRecoveryEntry(entryDir, …)` → `publishManualRecoveryEntry(stagingDir, entryDir, …)`
- Extract `writeManifestThenPublish` so both trash paths share one manifest-write-then-rename step. This also clears the `fallow:dupes` clone group the parity created, and makes the pending fsync TODO (#12) a one-function change instead of two.
- EXDEV fallback: split `stagedCopyCreated` into a staged-copy hint and a `strandedOriginalPath` hint; add `siblingStageCreated` and drop the `lstat` probe.
- `preserveEntryDir` → `preserveStagedEntry` (5 sites) — the flag has meant "keep the staging dir" since the publish moved.
- Rename the thrown message `Failed to write trash manifest` → `Failed to finalize trash entry`, matching the source-backed path.
- `rollbackMovedLocalCopies`' first param `entryDir` → `entryRoot`: every caller passes the pre-publish staging dir.

## Test plan

Four tests, each proven non-vacuous by reverting **only** the production change:

- **`assembles local copies under a staged name and publishes them with one rename`** snapshots `TRASH_DIR` at the instant the manifest is written (the last moment before publish) and asserts nothing tombstone-shaped exists yet. Without the fix: `expected '1788723448216-local-staged-publish-d9…' to match /^\.staging-/`.
- **`strands a local copy for manual recovery when manifest rollback cannot restore it`** now extracts the path out of the thrown message, asserts it equals the published `<entry>/local-copies`, and reads the surviving `SKILL.md` from it. Previously `/stranded in/i` matched any path, including one that did not exist.
- **`names the folder's real location when an EXDEV copy fails and the restore fails too`** asserts the message does **not** claim a staged copy, extracts `original folder left at <path>`, reads `SKILL.md` back out of it, and asserts the trash dir is empty.
- **`claims no recovery location when the folder never left its agent slot`** mocks `lstat` to throw EACCES for the sibling-stage name, reproducing the unsearchable-agent-dir case. It asserts neither hint appears and `SKILL.md` is still at `localPath`. My first draft of this test was vacuous — an unmocked `lstat` honestly returned ENOENT and masked the exact errno case the test claims to cover.

Gates on `947bcfe`:

- `pnpm validate` exit 0 — 195 files, 2553 tests.
- `pnpm test:e2e` — 84 passed.
- `pnpm test:coverage` — 94.95 stmt / 85.29 branch / 96.80 func / 99.27 line; `trashService.ts` at 549/549 lines, 60/60 functions, 168/168 branches.

## Review dispositions

Findings verified against real code rather than obeyed. Three were declined with reasons:

- **`fs.rm` with `{ recursive: true }` needs user confirmation** (`.coderabbit.yaml:45`) — skipped. The rule targets agent-initiated deletion; this is user-initiated deletion whose confirmation happens in the UI, and the identical call already ships on `main` at `:1202` / `:1264`. Nothing new is deleted here.
- **`vi.doMock` vs module-level `vi.mock`** — skipped as out of scope. The file's existing suites all use the same style; converting one test would make it the odd one out. Offered separately as a repo-wide PR if the convention is worth enforcing.
- Two findings were fixed **differently than suggested**, recorded in the commit messages. For the EXDEV conflation, the suggestion was "move the real copy into `stagingDir` or report its real path" — moving it means a second cross-device copy on a path reached *because* a cross-device copy failed (most plausibly ENOSPC), so the path is reported instead. For the `lstat` finding, the probe was dropped rather than repaired.

One defect in this PR was found by a self-review pass, not by a reviewer: `recoveryHint` named `stagedPath`, which was true before this PR (nothing renamed `stagingDir`) and false after it. Fixed in `c14a14d`.

## Not in this PR

- The fsync policy (TODO #12) ships next, on top of the `writeManifestThenPublish` seam this adds.
- **`.staging-` directories have no recovery path.** `startupCleanup` skips any name `parseDeletedAtFromEntryName` can't parse, so a leaked staging dir is never swept *and* never restorable. Pre-existing — `main` already produces this shape at `trashService.ts:1163` (source-backed, #311); this PR adds a second producer. The un-parseable name is deliberate (`skillLockService.ts:279-281`), and auto-promoting it to a tombstone name would let the sweep evict the user's only copy. The *reporting* half is worth doing repo-wide, separately.
- **Latent invariant:** after a partial rollback the published manual-recovery entry's `manifest.json` still lists already-restored copies. Unreachable today (this arm throws, so no `tombstoneId` ever exists, and there is no trash-listing IPC). If a trash browser is ever added, narrow the manifest to `unrestoredCopies` before the entry becomes reachable.
- This PR makes a previously-invisible stranded path **visible** (`<agentDir>/.<skill>.trash-local-<agentId>-<hex>`) without adding cleanup for it — `startupCleanup` only sweeps `TRASH_DIR`. Strictly better than silently abandoning it, but it is a new named-but-unreclaimed path and is tracked as deferred, not fixed.
