### PR TITLE
fix(trash): fsync trash writes so a power cut cannot tear a manifest

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -79,7 +79,12 @@ reviews:
     - path: '**/*.test.ts'
       instructions: |
         Tests use Vitest. Review for:
-        - Main process tests: mock `fs/promises` with `vi.mock('fs/promises')`.
+        - Main process tests: mock the fs module with the SAME specifier the module
+          under test imports — `vi.mock('node:fs/promises')` for a module importing
+          `node:fs/promises`, `vi.mock('fs/promises')` for one importing `fs/promises`.
+          Vitest normalises the two, so a mismatch still intercepts today, but the
+          test's interception then rides on resolver aliasing instead of on the
+          specifier it names.
         - Renderer tests: stub `window.electron` via `vi.stubGlobal`.
         - Pure helper tests: no mocking needed — test input/output directly.
         - Prefer testing extracted pure functions over React component rendering (no RTL in this project).
@@ -112,7 +117,8 @@ code_generation:
     path_instructions:
       - path: 'src/main/**/*.ts'
         instructions: |
-          Use Vitest. Mock `fs/promises` and `path` modules.
+          Use Vitest. Mock the fs and `path` modules, matching the specifier the
+          module under test imports (`node:fs/promises` vs `fs/promises`).
           For symlink-related tests, mock both `lstat` and `readlink`.
           Use `vi.mock()` at module level, `vi.mocked()` for type-safe assertions.
       - path: 'src/renderer/**/*.ts'

--- a/TODOS.md
+++ b/TODOS.md
@@ -1414,24 +1414,47 @@ a reviewer would have to hold at the same time.
 
 **Depends on / blocked by:** Nothing.
 
-### P3. Trash writes are not fsynced, so a power cut can still tear a manifest
+### ~~P3. Trash writes are not fsynced, so a power cut can still tear a manifest~~
 
-`fs.writeFile` returns once the bytes are in the page cache. The publish rename
-is a journalled metadata op, so a power cut (not a process kill — a kill leaves
-the page cache intact) can land the renamed directory while losing the
-`manifest.json` contents inside it, producing a tombstone-named entry the app
-cannot restore.
+FIXED. `fs.writeFile` and `fs.rename` return once the change is in the page
+cache, so a power cut (not a process kill -- a kill leaves the page cache
+intact) could land a renamed tombstone while losing the `manifest.json`
+contents inside it. Both trash write sites now flush.
 
-MITIGATED, not fixed: `startupCleanup` now keeps such an entry instead of
-sweeping it, so the consequence is a stray directory rather than a deleted
-skill. The likelihood is untouched.
+`writeManifestThenPublish` does three flushes, none redundant: the manifest's
+bytes, `stagingDir` (the directory entry that _names_ the manifest), then
+`TRASH_DIR` after the publish rename. Dropping the middle one leaves a power
+cut able to land the tombstone with the manifest dirent missing from inside
+it -- the entry the rename promises, holding nothing that says what it holds.
 
-**Fix direction:** fsync the manifest before the publish rename and fsync
-`TRASH_DIR` after it. Deliberately not done in PR #311: durability ordering is
-a policy for every write in the trash and lock paths, not one call site, and
-doing it here alone would imply a guarantee the neighbouring writes do not
-make. It also means writing the manifest through a `FileHandle`, which moves
-the write off the module-level `fs.writeFile` the durability suite observes.
+`markManualRecoveryEntry` flushes too, and its loss mode is the worse of the
+two: if the marker bytes vanish while the rename lands, the entry is a
+tombstone-named directory with a manifest that still parses, so
+`classifyEntryForSweep` answers `'sweep'` and `startupCleanup` evicts the only
+copy the marker existed to protect. A torn manifest merely downgrades the
+entry to `'unreadable-manifest'`, which is kept.
+
+**The deferral reason was empirically wrong, not merely outgrown.** This was
+held back from PR #311 because "durability ordering is a policy for every write
+in the trash and lock paths, not one call site." Checked: `skillLockService`
+performs **zero** writes -- the skills CLI owns `.skill-lock.json`, this app
+only reads it (and says so at `skillLockService.ts:49,68`). So the policy
+surface is two `fs.writeFile` calls, both covered here, and there is no
+neighbouring write left to imply a weaker guarantee than.
+
+`fsyncPath` (`src/main/utils/fsyncPath.ts`) opens read-only, which POSIX
+allows for `fsync` and is what lets one helper cover files and directories.
+It never throws: a failed flush means the bytes are still cached and the
+caller's operation genuinely succeeded, so propagating it would roll back a
+delete that worked.
+
+The manifest write stays on the module-level `fs.writeFile` on purpose.
+Rewriting it through a `FileHandle` would stop
+`trashService.durability.test.ts`'s `writeFileSpy` matching
+`path.endsWith('manifest.json')`, silently defanging `onManifestWrite` and
+`failManifestWrite` into vacuous passes rather than failing loudly. Verified by
+breaking the spy's match: two tests fail. One extra `open` is the cheaper side
+of that trade.
 
 **Depends on / blocked by:** Nothing.
 

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -16,6 +16,7 @@ import {
 import { manifestSchema } from '@/main/ipc/ipc-schemas'
 import { errorCode, isMissingPathError } from '@/main/utils/errorCode'
 import { extractErrorMessage } from '@/main/utils/errors'
+import { fsyncPath } from '@/main/utils/fsyncPath'
 import { UNDO_WINDOW_MS } from '@/shared/constants'
 import { tombstoneId } from '@/shared/types'
 import type {
@@ -338,6 +339,14 @@ async function markManualRecoveryEntry(
   const body = `manual recovery required\nreason: ${reason}\nmarkedAt: ${new Date().toISOString()}\n`
   try {
     await fs.writeFile(markerPath, body, 'utf-8')
+    // Flushed before the caller's publish rename, and the marker matters more
+    // than the manifest does: losing these bytes while the rename lands leaves
+    // a tombstone-named dir whose manifest still parses, so
+    // {@link classifyEntryForSweep} answers 'sweep' and startup cleanup evicts
+    // the only copy the marker existed to protect. A torn manifest only
+    // downgrades the entry to 'unreadable-manifest', which is kept.
+    await fsyncPath(markerPath)
+    await fsyncPath(entryDir)
   } catch (error) {
     console.warn('trashService: failed to mark manual recovery entry', {
       entryDir,
@@ -369,6 +378,9 @@ async function publishManualRecoveryEntry(
   await markManualRecoveryEntry(stagingDir, reason)
   try {
     await fs.rename(stagingDir, entryDir)
+    // The rename is a metadata change in TRASH_DIR, so TRASH_DIR is what has
+    // to be flushed for the published name to survive a power cut.
+    await fsyncPath(TRASH_DIR)
     return entryDir
   } catch (publishError) {
     // Recoverable either way: the caller reports whichever path we return.
@@ -383,10 +395,12 @@ async function publishManualRecoveryEntry(
 }
 
 /**
- * Persist a trash manifest, then publish the staged entry with one atomic
- * rename. Both trash paths call it as their last forward step; a rejection
- * means the entry never became a tombstone, so the caller's catch owns the
- * rollback and the staged dir is still whole when it runs.
+ * Persist a trash manifest durably, then publish the staged entry with one
+ * atomic rename. Both trash paths call it as their last forward step; a
+ * rejection means the entry never became a tombstone, so the caller's catch
+ * owns the rollback and the staged dir is still whole when it runs. The
+ * flushes make the tombstone survive a power cut, not just a process kill:
+ * a kill leaves the page cache intact, a power cut does not.
  * @param manifest - v2 manifest for either trash kind.
  * @param stagingDir - Half-built entry under {@link STAGED_ENTRY_PREFIX}.
  * @param entryDir - Tombstone-named path to publish it as.
@@ -403,9 +417,17 @@ async function writeManifestThenPublish(
   // free to write it where the publish leaves it behind.
   const manifestPath = join(stagingDir, 'manifest.json')
   await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf-8')
+  // Three flushes, none of them redundant: the file's bytes, the directory
+  // entry that names it, and the parent that names the published entry. Skip
+  // the middle one and a power cut can land the tombstone with the manifest
+  // dirent missing from inside it -- the entry the rename promises, holding
+  // nothing that says what it holds.
+  await fsyncPath(manifestPath)
+  await fsyncPath(stagingDir)
   // Rename is atomic, so a failure here leaves the staged entry intact rather
   // than a half-published tombstone.
   await fs.rename(stagingDir, entryDir)
+  await fsyncPath(TRASH_DIR)
 }
 
 /**

--- a/src/main/utils/fsyncPath.test.ts
+++ b/src/main/utils/fsyncPath.test.ts
@@ -1,0 +1,165 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+/**
+ * Arms the mocked `fs.open` per test. Hoisted so the `vi.mock` factory can
+ * close over it; left null so every other test runs against the real handle.
+ */
+const openHooks = vi.hoisted(() => ({
+  /** Replaces the opened handle, to observe `sync`/`close` or fail the flush. */
+  handleOverride: null as null | {
+    sync: () => Promise<void>
+    close: () => Promise<void>
+  },
+  /** Every path handed to `fs.open`, so a real flush can be proven to happen. */
+  openedPaths: [] as string[],
+}))
+
+vi.mock('node:fs/promises', async () => {
+  const actual =
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+    await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+  const openSpy: typeof actual.open = async (path, ...rest) => {
+    openHooks.openedPaths.push(String(path))
+    if (openHooks.handleOverride) {
+      // The only cast in this file, and unavoidable: a stub standing in for a
+      // FileHandle would otherwise have to implement every member of it, none
+      // of which fsyncPath touches beyond sync and close.
+      return openHooks.handleOverride as unknown as Awaited<
+        ReturnType<typeof actual.open>
+      >
+    }
+    return actual.open(path, ...rest)
+  }
+  return { ...actual, default: actual, open: openSpy }
+})
+
+const { fsyncPath } = await import('./fsyncPath')
+
+describe('fsyncPath', () => {
+  afterEach(() => {
+    openHooks.handleOverride = null
+    openHooks.openedPaths = []
+    vi.restoreAllMocks()
+  })
+
+  test('flushes the file to stable storage instead of leaving it in the page cache', async () => {
+    // Arrange
+    const workDir = await mkdtemp(join(tmpdir(), 'fsync-file-'))
+    const manifestPath = join(workDir, 'manifest.json')
+    await writeFile(manifestPath, '{"schemaVersion":2}', 'utf-8')
+    const syncSpy = vi.fn(async () => {})
+    const closeSpy = vi.fn(async () => {})
+    openHooks.handleOverride = { sync: syncSpy, close: closeSpy }
+
+    // Act
+    await fsyncPath(manifestPath)
+
+    // Assert
+    expect(syncSpy).toHaveBeenCalledTimes(1)
+    expect(closeSpy).toHaveBeenCalledTimes(1)
+    await rm(workDir, { recursive: true, force: true })
+  })
+
+  test('flushes a directory too, so a published rename survives a power cut', async () => {
+    // Arrange
+    const trashDir = await mkdtemp(join(tmpdir(), 'fsync-dir-'))
+    await writeFile(join(trashDir, 'manifest.json'), '{}', 'utf-8')
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    // Act
+    await fsyncPath(trashDir)
+
+    // Assert
+    // No override here on purpose: this is the one test that proves the real
+    // platform accepts `open(dir, 'r')` + `sync()`, which is what lets one
+    // helper cover both the manifest and the directory that names it.
+    expect(openHooks.openedPaths).toEqual([trashDir])
+    expect(warnSpy).not.toHaveBeenCalled()
+    expect(await readFile(join(trashDir, 'manifest.json'), 'utf-8')).toBe('{}')
+    await rm(trashDir, { recursive: true, force: true })
+  })
+
+  test('returns quietly when the path cannot be opened, so a failed flush never rolls back a delete that worked', async () => {
+    // Arrange
+    const workDir = await mkdtemp(join(tmpdir(), 'fsync-missing-'))
+    const missingPath = join(workDir, 'never-created.json')
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    // Act
+    const outcome = await fsyncPath(missingPath).then(
+      () => 'resolved',
+      () => 'rejected',
+    )
+
+    // Assert
+    expect(outcome).toBe('resolved')
+    expect(warnSpy).toHaveBeenCalledWith('fsyncPath: flush failed', {
+      path: missingPath,
+      code: 'ENOENT',
+      message: expect.stringContaining('ENOENT'),
+    })
+    await rm(workDir, { recursive: true, force: true })
+  })
+
+  test('returns quietly when the flush itself is refused, not just the open', async () => {
+    // Arrange
+    const workDir = await mkdtemp(join(tmpdir(), 'fsync-refused-'))
+    const manifestPath = join(workDir, 'manifest.json')
+    await writeFile(manifestPath, '{}', 'utf-8')
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const closeSpy = vi.fn(async () => {})
+    openHooks.handleOverride = {
+      sync: async () => {
+        throw Object.assign(new Error('flush refused'), { code: 'EIO' })
+      },
+      close: closeSpy,
+    }
+
+    // Act
+    const outcome = await fsyncPath(manifestPath).then(
+      () => 'resolved',
+      () => 'rejected',
+    )
+
+    // Assert
+    expect(outcome).toBe('resolved')
+    expect(warnSpy).toHaveBeenCalledWith('fsyncPath: flush failed', {
+      path: manifestPath,
+      code: 'EIO',
+      message: 'flush refused',
+    })
+    // Still closed: a handle leaked on the error path outlives the process.
+    expect(closeSpy).toHaveBeenCalledTimes(1)
+    await rm(workDir, { recursive: true, force: true })
+  })
+
+  test('still returns when the handle cannot even be closed, so a stuck fd cannot fail a delete', async () => {
+    // Arrange
+    const workDir = await mkdtemp(join(tmpdir(), 'fsync-unclosable-'))
+    const manifestPath = join(workDir, 'manifest.json')
+    await writeFile(manifestPath, '{}', 'utf-8')
+    const syncSpy = vi.fn(async () => {})
+    openHooks.handleOverride = {
+      sync: syncSpy,
+      close: async () => {
+        throw Object.assign(new Error('close refused'), { code: 'EIO' })
+      },
+    }
+
+    // Act
+    const outcome = await fsyncPath(manifestPath).then(
+      () => 'resolved',
+      () => 'rejected',
+    )
+
+    // Assert
+    expect(outcome).toBe('resolved')
+    // The flush is what the caller depends on; it landed before the close failed.
+    expect(syncSpy).toHaveBeenCalledTimes(1)
+    await rm(workDir, { recursive: true, force: true })
+  })
+})

--- a/src/main/utils/fsyncPath.ts
+++ b/src/main/utils/fsyncPath.ts
@@ -1,0 +1,40 @@
+import * as fs from 'node:fs/promises'
+
+import { errorCode } from '@/main/utils/errorCode'
+import { extractErrorMessage } from '@/main/utils/errors'
+
+/**
+ * Flush one file or directory to stable storage so a power cut cannot lose it.
+ * Exists because `fs.writeFile` and `fs.rename` return once the change is in
+ * the page cache; trash publishes call it between their write and their rename
+ * so a torn manifest cannot outlive the tombstone that promises it.
+ * Never throws: an fsync rejection means the bytes are still cached and the
+ * caller's operation genuinely succeeded, so propagating it would roll back a
+ * delete that worked. Opened read-only — POSIX `fsync` needs a valid fd, not a
+ * writable one, which is also what lets one helper cover directories.
+ * ponytail: POSIX-only ceiling -- Windows refuses to open a directory, where
+ * this degrades to a logged warning and the file flushes still land. Upgrade
+ * to a platform branch if the app ever ships beyond macOS.
+ * @param path - Absolute file or directory path to flush.
+ * @returns Promise that resolves after the flush, or after logging its failure.
+ * @example await fsyncPath(join(entryDir, 'manifest.json'))
+ */
+export async function fsyncPath(path: string): Promise<void> {
+  let handle: fs.FileHandle | undefined
+  try {
+    handle = await fs.open(path, 'r')
+    await handle.sync()
+  } catch (error) {
+    console.warn('fsyncPath: flush failed', {
+      path,
+      code: errorCode(error),
+      message: extractErrorMessage(error),
+    })
+  } finally {
+    // Closing is its own failure mode: the flush may have landed even when the
+    // handle cannot be released, and leaking an fd is worse than a warning.
+    await handle?.close().catch(() => {
+      // best-effort close
+    })
+  }
+}


### PR DESCRIPTION
## Summary

`fs.writeFile` and `fs.rename` return once the change is in the page cache. A process kill leaves that cache intact, so the staging work in #311 and #315 already covers it — but a **power cut** does not, and could land a renamed tombstone while losing the `manifest.json` contents inside it.

Both trash write sites now flush through a new `fsyncPath` util.

Closes TODO P3 ("Trash writes are not fsynced").

## The deferral reason was empirically wrong, not merely outgrown

This was held back from #311 because durability is "a policy for every write in the trash and lock paths, not one call site, and doing it here alone would imply a guarantee the neighbouring writes do not make."

Checked: **`skillLockService` performs zero writes.** The skills CLI owns `.skill-lock.json`; this app only reads it, and says so at `skillLockService.ts:49` and `:68`. So the whole policy surface is two `fs.writeFile` calls in `trashService.ts`, both covered here. There is no neighbouring write left to imply a weaker guarantee than.

## Changes

### `writeManifestThenPublish` — three flushes, none redundant

```
writeFile(manifest) → fsync(manifestPath) → fsync(stagingDir) → rename → fsync(TRASH_DIR)
```

The manifest's bytes, then the directory entry that *names* it, then the parent that names the published entry. Drop the middle one and a power cut can land the tombstone with the manifest dirent missing from inside it — the entry the rename promises, holding nothing that says what it holds. (Ordering *between* the first two is immaterial — both must simply precede the rename — but sequential reads as a durability ladder, and two fsyncs on the same filesystem gain nothing from `Promise.all`.)

### `markManualRecoveryEntry` — in scope, and the worse loss mode of the two

Not named by the TODO, but it is the other write in the trash path, and its failure is more severe than the manifest's: lose the marker bytes while the rename lands and the entry is a tombstone-named directory whose manifest **still parses**, so `classifyEntryForSweep` answers `'sweep'` and `startupCleanup` evicts the only copy the marker existed to protect. A torn manifest merely downgrades the entry to `'unreadable-manifest'`, which is kept. Skipping it would reproduce the exact inconsistency the TODO warned about.

### `publishManualRecoveryEntry` — `fsync(TRASH_DIR)` after its rename

These two are the only renames whose destination parent is `TRASH_DIR`; the others (`:503`, `:1398`) land inside `stagingDir`.

### `src/main/utils/fsyncPath.ts` (new)

Opens read-only, which POSIX allows for `fsync` and is what lets one helper cover files *and* directories. **It never throws**: a failed flush means the bytes are still in the page cache and the caller's operation genuinely succeeded, so propagating it would roll back a delete that worked. The POSIX-only ceiling is marked with a `ponytail:` comment — on Windows a directory open is refused and this degrades to a logged warning while the file flushes still land. The app is macOS-only today.

## Why the manifest write stays on `fs.writeFile`

The obvious implementation is `open(path,'w')` → `writeFile` → `sync()`, one handle instead of two opens. It is the wrong trade here.

`trashService.durability.test.ts` mocks `node:fs/promises` and matches `path.endsWith('manifest.json')` to drive two hooks: `onManifestWrite` (an observation point *inside* the build window) and `failManifestWrite` (the publish-rollback arm). Moving the write onto a `FileHandle` stops that spy matching — which does not fail those tests, it **defangs them into vacuous passes**.

Verified rather than assumed: breaking the spy's match to `never-matches.json` fails two tests (`hides the half-built entry from every tombstone reader…`, `publishes a stranded entry under its tombstone name…`). They are load-bearing, and they still fire. One extra `open` is the cheaper side of that trade.

## Test plan

Five tests in `src/main/utils/fsyncPath.test.ts`, **all five proven non-vacuous** by neutering only the util to `async () => {}` — all five fail.

- `flushes the file to stable storage instead of leaving it in the page cache` — asserts `sync()` and `close()` each fire once.
- `flushes a directory too, so a published rename survives a power cut` — deliberately runs against the **real** filesystem with no handle override, asserting the opened path. This is the one test that proves the platform actually accepts `open(dir,'r')` + `sync()`, which is what lets one helper cover both.
- `returns quietly when the path cannot be opened…` and `…when the flush itself is refused, not just the open` — the never-throws contract, on both failure points, each asserting the exact warn payload.
- `still returns when the handle cannot even be closed, so a stuck fd cannot fail a delete` — added after coverage showed the best-effort close arrow uncovered; covering it beat ignoring it.

An earlier draft of the directory test **was vacuous** (a no-op util passed it, since it only asserted "no warning + file still readable"). Caught by the same revert-only-the-production-change check, then fixed to observe the real open.

## Review disposition

One finding, round 1: *"unify the mock specifier to `fs/promises` per the repo convention."* Fixed at the root instead (`a0a7ecf`) — **the rule was stale, not the test.**

The literal suggestion has two halves and the production half is wrong: it also asks `fsyncPath.ts` to import bare `fs/promises`, but its only consumer (`trashService.ts`) imports `node:fs/promises`, and production in `src/main` is 27 `node:` vs 10 bare.

The convention *as practiced* is the opposite of the yaml line. All nine main-process test files that mock fs mirror the specifier their module under test imports — the six bare ones test bare-importing services, the three `node:` ones (`folder.integration.test.ts`, `trashService.durability.test.ts`, this file) test `node:`-importing modules. Changing only this file would add a fourth deviation rather than produce consistency.

And the mismatch is not purely stylistic: swapping this file to `vi.mock('fs/promises')` keeps all five tests green, so Vitest *does* normalise the two specifiers. That is precisely why mirroring matters — with a mismatch the interception rides on resolver aliasing rather than on the specifier the test names, and if that ever changes the mock silently stops intercepting and the suite goes vacuous. These tests are built to fail loudly instead.

So `.coderabbit.yaml:82` and `:115` now state the real invariant. That stops the finding recurring on every future `node:`-importing module.

Gates on `cdd158e`:

- `pnpm validate` exit 0 — 196 files, 2558 tests.
- `pnpm test:e2e` — 84 passed.
- `pnpm test:coverage` exit 0 — 94.96 stmt / 85.29 branch / 96.81 func / 99.27 line. `trashService.ts` at 555/555 lines, 60/60 functions, 168/168 branches; `fsyncPath.ts` fully covered.

## Not in this PR

Durability for writes *outside* the trash path. There are none in this app's main process — the only other candidate, `.skill-lock.json`, is written by the skills CLI, not by us.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ゴミ箱への変更をより確実に保存するよう改善しました。
  * 電源断が発生した場合でも、ゴミ箱の状態や復旧情報が失われにくくなりました。
  * ファイルシステムの同期に失敗した場合も、警告を記録して処理を継続できるようになりました。

* **テスト**
  * ファイル・ディレクトリの保存処理と、同期やクローズの失敗時の動作を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->