### PR TITLE
fix(lock): restore .skill-lock.json when a killed CLI leaves it torn

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1521,10 +1521,17 @@ fix direction said. Two reasons, both discovered while implementing it:
 - The signal is not needed. `execCli` was the privileged place only because it
   is where a kill is observable (`proc.on('close')` does not even capture
   `signal` today). A cause-independent predicate is strictly safer: restore
-  only when the lock **parsed before and does not parse now**. That covers a
-  kill, a crash, and a power cut alike, and it can never undo a legitimate
-  write, because a legitimately emptied lock is still valid JSON
-  (`{version, skills:{}}`).
+  only when the lock **parsed before and does not parse now**. That covers the
+  CLI child dying by any cause -- SIGTERM from `cancel()`, SIGKILL after the
+  grace window, or a crash -- and it can never undo a legitimate write, because
+  a legitimately emptied lock is still valid JSON (`{version, skills:{}}`).
+
+  NOT covered: a power cut or a crash of the Electron process itself. The
+  snapshot is in memory and the repair runs from a `finally`, so if the parent
+  dies there is nothing left to repair with; on the next launch the torn lock
+  reads as `untrusted` and is left alone. Surviving that would need the
+  snapshot on disk, which is a bigger change than the exposure warrants -- the
+  CLI is the only thing this app kills on purpose.
 
 `runLockWrite` is also the one chokepoint every lock writer already routes
 through -- install via `ipc/skillsCli.ts:37`, prune via

--- a/TODOS.md
+++ b/TODOS.md
@@ -1488,7 +1488,9 @@ around the `typeof actual.readdir` overload set — the spy cannot be annotated
 with it, because `readdir` is an overload set and `Promise<string[]>` is not
 assignable to `Promise<NonSharedBuffer[]>`.
 
-### P2. A kill landing mid-write can still truncate the lock
+### ~~P2. A kill landing mid-write can still truncate the lock~~
+
+FIXED. All three exposures are closed.
 
 Upstream writes `.skill-lock.json` with a plain `writeFile` (no temp+rename)
 and reads a truncated file as an EMPTY lock, so any signal landing between the
@@ -1511,9 +1513,41 @@ involved. `cancel()` SIGTERMs an already-spawned install at a moment the user
 picks, and `install` keeps the 60s ceiling by design. The mutex cannot help
 here — the damage is a single interrupted write.
 
-**Fix direction:** snapshot the lock bytes before any lock-writing spawn and
-restore them when the child is killed rather than exiting cleanly. Fix at
-`execCli`, not in the prune path.
+FIXED at `runLockWrite` (`skillLockService.ts:75`), NOT at `execCli` as the
+fix direction said. Two reasons, both discovered while implementing it:
+
+- `skillLockService.ts:21` already imports `skillsCliService`, so importing
+  `getSkillLockPath` back into `skillsCliService` would be a circular import.
+- The signal is not needed. `execCli` was the privileged place only because it
+  is where a kill is observable (`proc.on('close')` does not even capture
+  `signal` today). A cause-independent predicate is strictly safer: restore
+  only when the lock **parsed before and does not parse now**. That covers a
+  kill, a crash, and a power cut alike, and it can never undo a legitimate
+  write, because a legitimately emptied lock is still valid JSON
+  (`{version, skills:{}}`).
+
+`runLockWrite` is also the one chokepoint every lock writer already routes
+through -- install via `ipc/skillsCli.ts:37`, prune via
+`skillLockService.ts:542` -- so nothing can write the lock outside the repair.
+
+Three details worth keeping:
+
+- The predicate is a raw `JSON.parse`, deliberately **not**
+  `readSkillLockKeys`. That helper reports `version > SUPPORTED_LOCK_VERSION`
+  as `unavailable` (`skillLockService.ts:152`), so a lock a newer CLI wrote
+  would be classified as damage and clobbered with our stale snapshot -- new
+  data loss introduced by the repair.
+- Snapshot-absent means `unlink`, not "do nothing". A killed FIRST install
+  leaves a 0-byte file, which is worse than no file: `readSkillLockKeys` maps
+  missing to `{ok, keys:[]}` but unparseable to `unavailable`, so the leftover
+  would permanently degrade every prune scan.
+- The repair writes through temp+rename+`fsyncPath`, the atomicity the CLI's
+  own writer lacks. Recovering from a torn write with another torn-able write
+  would leave the same hole one level down.
+
+A snapshot that cannot be read (EACCES) logs and lets the install proceed:
+blocking it on a permissions quirk trades a rare corruption for a common
+outage.
 
 **Depends on / blocked by:** Nothing.
 

--- a/src/main/services/skillLockService.test.ts
+++ b/src/main/services/skillLockService.test.ts
@@ -1,5 +1,13 @@
 import { mkdtempSync, realpathSync } from 'node:fs'
-import { mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises'
+import {
+  access,
+  chmod,
+  mkdir,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -168,8 +176,12 @@ beforeEach(async () => {
   delete process.env.XDG_STATE_HOME
 })
 
-afterEach(() => {
+afterEach(async () => {
   delete process.env.XDG_STATE_HOME
+  // One test drops write permission on `.agents` to make the lock repair fail.
+  // Restoring it here rather than in that test keeps a failure there from
+  // poisoning every test after it: `rm -rf` cannot empty a 0o500 directory.
+  await chmod(join(sharedHome, '.agents'), 0o700).catch(() => {})
 })
 
 // `sharedHome` is created once at module load and every test writes inside it,
@@ -1034,5 +1046,137 @@ describe('runLockWrite', () => {
     // Assert
     await expect(failed).rejects.toThrow('install exploded')
     await expect(afterFailure).resolves.toBe('still running')
+  })
+
+  test('restores the install records a cancelled install truncated out of the lock', async () => {
+    // Arrange
+    // `cancel()` SIGTERMs the CLI between its `O_TRUNC` open and its write, and
+    // a zero-length lock reads as an empty one: every install record gone.
+    const { runLockWrite } = await serviceModule
+    await writeLock(['tdd-workflow', 'code-review'])
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    // Act
+    await runLockWrite(async () => {
+      await writeFile(lockPath, '', 'utf-8')
+    })
+
+    // Assert
+    expect(await readLockKeys()).toEqual(['tdd-workflow', 'code-review'])
+    // The repair itself is temp+rename, so it must leave nothing behind.
+    await expect(access(`${lockPath}.recovering`)).rejects.toThrow()
+    consoleWarn.mockRestore()
+  })
+
+  test('leaves a lock the user legitimately emptied alone', async () => {
+    // Arrange
+    // Removing the last skill is a real write, and its result is valid JSON.
+    const { runLockWrite } = await serviceModule
+    await writeLock(['tdd-workflow'])
+
+    // Act
+    await runLockWrite(async () => {
+      await writeFile(lockPath, '{"version":3,"skills":{}}', 'utf-8')
+    })
+
+    // Assert
+    expect(await readLockKeys()).toEqual([])
+  })
+
+  test('keeps a lock a newer CLI wrote instead of reverting it to the snapshot', async () => {
+    // Arrange
+    // A lock at a version this app does not support still parses, so it is a
+    // successful write and not damage — judging it by `readSkillLockKeys`
+    // would classify it as unavailable and clobber it with our stale copy.
+    const { runLockWrite } = await serviceModule
+    await writeLock(['old-skill'])
+
+    // Act
+    await runLockWrite(async () => {
+      await writeFile(
+        lockPath,
+        '{"version":99,"skills":{"installed-by-newer-cli":{}}}',
+        'utf-8',
+      )
+    })
+
+    // Assert
+    expect(await readLockKeys()).toEqual(['installed-by-newer-cli'])
+  })
+
+  test('deletes the zero-byte lock a cancelled first install leaves behind', async () => {
+    // Arrange
+    // No lock exists yet, so there are no bytes to put back — and a leftover
+    // unparseable file is worse than none: a missing lock reads as empty, an
+    // unparseable one reads as unavailable and blocks every prune scan.
+    const { runLockWrite } = await serviceModule
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    // Act
+    await runLockWrite(async () => {
+      await writeFile(lockPath, '', 'utf-8')
+    })
+
+    // Assert
+    await expect(access(lockPath)).rejects.toThrow()
+    consoleWarn.mockRestore()
+  })
+
+  test('leaves an already-corrupt lock exactly as it found it', async () => {
+    // Arrange
+    // Nothing here knows what the good bytes were, so writing anything back
+    // would be inventing them.
+    const { runLockWrite } = await serviceModule
+    await mkdir(join(sharedHome, '.agents'), { recursive: true })
+    await writeFile(lockPath, 'corrupt before we ever ran', 'utf-8')
+
+    // Act
+    await runLockWrite(async () => undefined)
+
+    // Assert
+    expect(await readFile(lockPath, 'utf-8')).toBe('corrupt before we ever ran')
+  })
+
+  test('reports a repair it could not perform instead of failing the install', async () => {
+    // Arrange
+    // The repair writes a temp file next to the lock, so a directory the app
+    // cannot write to is where it runs out of options.
+    const { runLockWrite } = await serviceModule
+    const agentsDir = join(sharedHome, '.agents')
+    await writeLock(['tdd-workflow'])
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // Act
+    const ran = await runLockWrite(async () => {
+      await writeFile(lockPath, '', 'utf-8')
+      await chmod(agentsDir, 0o500)
+      return 'install ran'
+    })
+
+    // Assert
+    expect(ran).toBe('install ran')
+    expect(consoleError).toHaveBeenCalledWith(
+      'skillLockService: torn lock could not be restored',
+      expect.objectContaining({ code: 'EACCES' }),
+    )
+    consoleError.mockRestore()
+  })
+
+  test('still runs the install when the lock cannot be snapshotted', async () => {
+    // Arrange
+    // Blocking an install on a permissions quirk trades a rare corruption for
+    // a common outage.
+    const { runLockWrite } = await serviceModule
+    await writeLock(['tdd-workflow'])
+    await chmod(lockPath, 0o000)
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    // Act
+    const ran = await runLockWrite(async () => 'install ran')
+
+    // Assert
+    expect(ran).toBe('install ran')
+    await chmod(lockPath, 0o644)
+    consoleWarn.mockRestore()
   })
 })

--- a/src/main/services/skillLockService.test.ts
+++ b/src/main/services/skillLockService.test.ts
@@ -1176,6 +1176,12 @@ describe('runLockWrite', () => {
 
     // Assert
     expect(ran).toBe('install ran')
+    // Also pins that the snapshot really failed: `chmod` does not deny for
+    // root, and without this the test would pass having proven nothing.
+    expect(consoleWarn).toHaveBeenCalledWith(
+      'skillLockService: lock snapshot failed',
+      expect.objectContaining({ code: 'EACCES' }),
+    )
     await chmod(lockPath, 0o644)
     consoleWarn.mockRestore()
   })

--- a/src/main/services/skillLockService.test.ts
+++ b/src/main/services/skillLockService.test.ts
@@ -1156,7 +1156,7 @@ describe('runLockWrite', () => {
     // Assert
     expect(ran).toBe('install ran')
     expect(consoleError).toHaveBeenCalledWith(
-      'skillLockService: torn lock could not be restored',
+      'skillLockService: torn lock could not be repaired',
       expect.objectContaining({ code: 'EACCES' }),
     )
     consoleError.mockRestore()

--- a/src/main/services/skillLockService.ts
+++ b/src/main/services/skillLockService.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs/promises'
 import { homedir } from 'node:os'
-import { basename, join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
 
 import { z } from 'zod'
 
@@ -8,6 +8,7 @@ import { MANUAL_RECOVERY_MARKER, SOURCE_DIR, TRASH_DIR } from '@/main/constants'
 import { manifestSchema, tombstoneIdSchema } from '@/main/ipc/ipc-schemas'
 import { errorCode, isMissingPathError } from '@/main/utils/errorCode'
 import { extractErrorMessage } from '@/main/utils/errors'
+import { fsyncPath } from '@/main/utils/fsyncPath'
 import { AGENT_DEFINITIONS } from '@/shared/constants'
 import type {
   AbsolutePath,
@@ -64,16 +65,30 @@ let pruneFlushTimer: NodeJS.Timeout | null = null
 let lockWriteChain: Promise<unknown> = Promise.resolve()
 
 /**
- * Serialize anything that causes the skills CLI to rewrite the global lock.
+ * Serialize anything that causes the skills CLI to rewrite the global lock, and
+ * undo the write when it leaves the file torn.
  * `writeSkillLock` in the CLI is a plain `writeFile` with no temp+rename, and
  * a half-written lock parses as an EMPTY lock, silently dropping every skill
- * the user installed. One chain is cheaper than making the CLI atomic.
+ * the user installed. One chain is cheaper than making the CLI atomic; the
+ * chain alone cannot help when {@link SkillsCliService.cancel} SIGTERMs the only writer there
+ * is, which is what {@link restoreLockIfTorn} is for.
  * @param operation - Work to run once no other lock write is in flight.
  * @returns Whatever `operation` resolves to.
  * @example await runLockWrite(() => skillsCliService.install(options))
  */
 export async function runLockWrite<T>(operation: () => Promise<T>): Promise<T> {
-  const run = lockWriteChain.then(operation, operation)
+  /** Snapshots INSIDE the chain: at queue time it would predate the write ahead of us. */
+  const guarded = async (): Promise<T> => {
+    const snapshot = await snapshotLock()
+    try {
+      return await operation()
+    } finally {
+      // `finally`, not the success path: a killed CLI is as likely to reject as
+      // to resolve with `success: false`, and both leave the same torn file.
+      await restoreLockIfTorn(snapshot)
+    }
+  }
+  const run = lockWriteChain.then(guarded, guarded)
   // Swallow rejections on the CHAIN only; `run` still rejects for the caller.
   lockWriteChain = run.catch(() => undefined)
   return run
@@ -92,6 +107,104 @@ export function getSkillLockPath(): AbsolutePath {
     return join(xdgStateHome, 'skills', LOCK_FILE)
   }
   return join(homedir(), '.agents', LOCK_FILE)
+}
+
+/**
+ * Pre-operation state of the lock, held so a killed CLI cannot leave it torn.
+ * `untrusted` covers both "already unparseable" and "could not be read at all":
+ * in neither case do we hold bytes worth putting back.
+ */
+type LockSnapshot =
+  | { status: 'intact'; bytes: string }
+  | { status: 'absent' }
+  | { status: 'untrusted' }
+
+/**
+ * Capture the lock exactly as it stands before an operation that may be killed.
+ * Never throws: a snapshot we cannot take only costs the restore, and blocking
+ * an install on a permissions quirk trades a rare corruption for a common outage.
+ * @returns The bytes to put back, `absent` when no lock exists yet, or `untrusted`.
+ * @example await snapshotLock() // => { status: 'absent' }
+ */
+async function snapshotLock(): Promise<LockSnapshot> {
+  let bytes: string
+  try {
+    bytes = await fs.readFile(getSkillLockPath(), 'utf-8')
+  } catch (error) {
+    // No lock yet is the normal state of a fresh install, not a failed read.
+    if (isMissingPathError(error)) return { status: 'absent' }
+    console.warn('skillLockService: lock snapshot failed', {
+      code: errorCode(error),
+      message: extractErrorMessage(error),
+    })
+    return { status: 'untrusted' }
+  }
+  try {
+    // Raw parse, deliberately NOT {@link readSkillLockKeys}: that reports a lock
+    // written by a NEWER CLI as unavailable, and treating that as damage here
+    // would clobber a legitimate write with our stale copy.
+    JSON.parse(bytes)
+  } catch {
+    return { status: 'untrusted' }
+  }
+  return { status: 'intact', bytes }
+}
+
+/**
+ * Put the pre-operation lock back when the operation left the file unparseable.
+ * {@link SkillsCliService.cancel} SIGTERMs an already-spawned install at a moment the user picks,
+ * and the CLI writes the lock with no temp+rename, so a signal landing between
+ * the `O_TRUNC` open and the write loses every install record — a truncated
+ * lock reads as an EMPTY one. Repairs damage only: a legitimately emptied lock
+ * is still valid JSON (`{version, skills:{}}`), so this can never undo a real write.
+ * @param snapshot - What {@link snapshotLock} saw before the operation ran.
+ * @returns Promise that resolves once the lock is repaired, or left alone.
+ * @example await restoreLockIfTorn({ status: 'absent' })
+ */
+async function restoreLockIfTorn(snapshot: LockSnapshot): Promise<void> {
+  if (snapshot.status === 'untrusted') return
+  const lockPath = getSkillLockPath()
+  let current: string
+  try {
+    current = await fs.readFile(lockPath, 'utf-8')
+  } catch {
+    // Missing is the state a fresh install starts from, and a lock we cannot
+    // read is not something a blind overwrite can improve.
+    return
+  }
+  try {
+    JSON.parse(current)
+    return
+  } catch {
+    // Unparseable is exactly the truncated-write signature. Fall through.
+  }
+
+  if (snapshot.status === 'absent') {
+    // A killed FIRST install leaves a 0-byte file, which is WORSE than no file:
+    // {@link readSkillLockKeys} maps missing to an empty lock but unparseable to
+    // `unavailable`, so the leftover permanently degrades every prune scan.
+    await fs.rm(lockPath, { force: true }).catch(() => {
+      // best-effort: the warning below still names the file
+    })
+    console.warn('skillLockService: removed a torn lock left by a killed write')
+    return
+  }
+
+  try {
+    // Temp+rename, the atomicity the CLI's own writer lacks: a second kill
+    // during THIS write would otherwise re-tear the file we came to repair.
+    const recoveryPath = `${lockPath}.recovering`
+    await fs.writeFile(recoveryPath, snapshot.bytes, 'utf-8')
+    await fsyncPath(recoveryPath)
+    await fs.rename(recoveryPath, lockPath)
+    await fsyncPath(dirname(lockPath))
+    console.warn('skillLockService: restored a torn lock from its snapshot')
+  } catch (error) {
+    console.error('skillLockService: torn lock could not be restored', {
+      code: errorCode(error),
+      message: extractErrorMessage(error),
+    })
+  }
 }
 
 /**

--- a/src/main/services/skillLockService.ts
+++ b/src/main/services/skillLockService.ts
@@ -70,8 +70,8 @@ let lockWriteChain: Promise<unknown> = Promise.resolve()
  * `writeSkillLock` in the CLI is a plain `writeFile` with no temp+rename, and
  * a half-written lock parses as an EMPTY lock, silently dropping every skill
  * the user installed. One chain is cheaper than making the CLI atomic; the
- * chain alone cannot help when {@link SkillsCliService.cancel} SIGTERMs the only writer there
- * is, which is what {@link restoreLockIfTorn} is for.
+ * chain alone cannot help when {@link SkillsCliService.cancel} SIGTERMs the
+ * only writer there is, which is what {@link restoreLockIfTorn} is for.
  * @param operation - Work to run once no other lock write is in flight.
  * @returns Whatever `operation` resolves to.
  * @example await runLockWrite(() => skillsCliService.install(options))
@@ -152,11 +152,13 @@ async function snapshotLock(): Promise<LockSnapshot> {
 
 /**
  * Put the pre-operation lock back when the operation left the file unparseable.
- * {@link SkillsCliService.cancel} SIGTERMs an already-spawned install at a moment the user picks,
- * and the CLI writes the lock with no temp+rename, so a signal landing between
- * the `O_TRUNC` open and the write loses every install record — a truncated
- * lock reads as an EMPTY one. Repairs damage only: a legitimately emptied lock
- * is still valid JSON (`{version, skills:{}}`), so this can never undo a real write.
+ * {@link SkillsCliService.cancel} SIGTERMs an already-spawned install at a
+ * moment the user picks, and the CLI writes the lock with no temp+rename, so a
+ * signal landing between the `O_TRUNC` open and the write loses every install
+ * record — a truncated lock reads as an EMPTY one. Repairs damage only: a
+ * legitimately emptied lock is still valid JSON (`{version, skills:{}}`), so
+ * this can never undo a real write. Never throws, because it is awaited from a
+ * `finally` where a rejection would mask the operation's own error.
  * @param snapshot - What {@link snapshotLock} saw before the operation ran.
  * @returns Promise that resolves once the lock is repaired, or left alone.
  * @example await restoreLockIfTorn({ status: 'absent' })
@@ -179,18 +181,16 @@ async function restoreLockIfTorn(snapshot: LockSnapshot): Promise<void> {
     // Unparseable is exactly the truncated-write signature. Fall through.
   }
 
-  if (snapshot.status === 'absent') {
-    // A killed FIRST install leaves a 0-byte file, which is WORSE than no file:
-    // {@link readSkillLockKeys} maps missing to an empty lock but unparseable to
-    // `unavailable`, so the leftover permanently degrades every prune scan.
-    await fs.rm(lockPath, { force: true }).catch(() => {
-      // best-effort: the warning below still names the file
-    })
-    console.warn('skillLockService: removed a torn lock left by a killed write')
-    return
-  }
-
   try {
+    if (snapshot.status === 'absent') {
+      // A killed FIRST install leaves a 0-byte file, which is WORSE than no
+      // file: {@link readSkillLockKeys} maps missing to an empty lock but
+      // unparseable to `unavailable`, so the leftover would permanently
+      // degrade every prune scan.
+      await fs.rm(lockPath, { force: true })
+      console.warn('skillLockService: removed a torn lock a killed write left')
+      return
+    }
     // Temp+rename, the atomicity the CLI's own writer lacks: a second kill
     // during THIS write would otherwise re-tear the file we came to repair.
     const recoveryPath = `${lockPath}.recovering`
@@ -200,7 +200,7 @@ async function restoreLockIfTorn(snapshot: LockSnapshot): Promise<void> {
     await fsyncPath(dirname(lockPath))
     console.warn('skillLockService: restored a torn lock from its snapshot')
   } catch (error) {
-    console.error('skillLockService: torn lock could not be restored', {
+    console.error('skillLockService: torn lock could not be repaired', {
       code: errorCode(error),
       message: extractErrorMessage(error),
     })


### PR DESCRIPTION
Closes the last of the three exposures in TODOS `P2. A kill landing mid-write can still truncate the lock`.

## Problem

The skills CLI writes `.skill-lock.json` with a plain `writeFile` (no temp+rename) and reads a truncated file as an **empty** lock. `SkillsCliService.cancel()` SIGTERMs an already-spawned install at a moment the user picks, so a signal landing between the `O_TRUNC` open and the write loses every install record.

PR #306 closed two of three exposures (the concurrency race, and the timeout firing during the write). The remaining one is a kill with no second writer involved — the mutex cannot help, because the damage is a single interrupted write.

## Fix

`runLockWrite` (`src/main/services/skillLockService.ts:75`) snapshots the lock before running the operation and puts the snapshot back when the operation leaves the file unparseable.

## Why `runLockWrite` and not `execCli`, which is what the TODO said

Two reasons, both found while implementing it:

1. **`execCli` would be a circular import.** `skillLockService.ts:21` already imports `skillsCliService`, so pulling `getSkillLockPath` the other way cycles. Landing it at `execCli` would mean first moving `getSkillLockPath` + `LOCK_FILE` out into a util.
2. **The kill signal is not needed.** `execCli` was privileged only because it is where a kill is observable (`proc.on('close')` does not even capture `signal` today). A cause-independent predicate is strictly safer: restore only when the lock **parsed before and does not parse now**. That covers the CLI child dying by any cause — SIGTERM from `cancel()`, SIGKILL after the grace window, or a crash — and it can never undo a legitimate write, because a legitimately emptied lock is still valid JSON (`{version, skills:{}}`).

**Not covered, and corrected after review:** a power cut, or a crash of the Electron process itself. The snapshot is in memory and the repair runs from a `finally`, so if the parent dies there is nothing left to repair with; on the next launch the torn lock reads as `untrusted` and is left alone. The first commit message still claims otherwise; `15d28ac` fixes TODOS.md and this body.

`runLockWrite` is also the one chokepoint every lock writer already routes through — install via `ipc/skillsCli.ts:37`, prune via `skillLockService.ts:542`. Verified there is no fourth writer that escapes it.

## Three decisions worth reviewing

- **The predicate is a raw `JSON.parse`, deliberately not `readSkillLockKeys`.** That helper reports `version > SUPPORTED_LOCK_VERSION` as `unavailable` (`skillLockService.ts:152`), so a lock written by a *newer* CLI would be classified as damage and clobbered with our stale snapshot — new data loss introduced by the repair. Pinned by the test `keeps a lock a newer CLI wrote instead of reverting it to the snapshot`.
- **Snapshot-absent means `unlink`, not "do nothing".** A killed *first* install leaves a 0-byte file, which is worse than no file: `readSkillLockKeys` maps missing to `{ok, keys: []}` but unparseable to `unavailable`, so the leftover would permanently degrade every prune scan.
- **The repair writes through temp+rename+`fsyncPath`** (the helper from #316), the atomicity the CLI's own writer lacks. Recovering from a torn write with another torn-able write would leave the same hole one level down.

A snapshot that cannot be read (EACCES) logs and lets the install proceed: blocking an install on a permissions quirk trades a rare corruption for a common outage.

## Scope note

The guard wraps every `runLockWrite` caller, including the two read-only ones (`resolveLockKeyForDirectory`, `scanStaleLockEntries`). Cost is one extra `readFile` on those paths; the benefit is that any future lock writer inherits the repair without having to remember it.

## Test plan

7 new tests in `skillLockService.test.ts`, on a real temp filesystem (no fs mock):

| Test | Pins |
|---|---|
| restores the install records a cancelled install truncated out of the lock | the repair itself, and that no `.recovering` temp file leaks |
| leaves a lock the user legitimately emptied alone | a valid empty lock is a real write, not damage |
| keeps a lock a newer CLI wrote instead of reverting it to the snapshot | raw `JSON.parse` rather than `readSkillLockKeys` |
| deletes the zero-byte lock a cancelled first install leaves behind | snapshot-absent → unlink |
| leaves an already-corrupt lock exactly as it found it | `untrusted` snapshot never invents bytes |
| reports a repair it could not perform instead of failing the install | the repair never propagates its own failure |
| still runs the install when the lock cannot be snapshotted | EACCES does not block the spawn |

**All 7 proven non-vacuous** by mutating only production code and confirming the right ones fail:

- restore removed entirely → the 2 repair tests fail.
- restore made unconditional → the 2 "leave it alone" tests fail (plus 5 pre-existing prune tests, which confirms the guard also sits on real prune writes).
- `untrusted` treated as `absent` → `leaves an already-corrupt lock` fails.
- repair failure swallowed → `reports a repair it could not perform` fails.
- snapshot rethrows instead of logging → `still runs the install when the lock cannot be snapshotted` fails.

Gates:

- `pnpm validate` exit 0 — 196 files, 2565 tests
- `pnpm test:coverage` exit 0 — 94.96 stmt / 85.31 branch / 96.76 func / 99.26 line
- `pnpm test:e2e` — 84 passed
- Every new line in `skillLockService.ts` is covered (verified against `coverage-final.json`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - ロックファイルの書き込み中に破損が発生した場合、以前の有効な状態へ自動的に復元できるようになりました。
  - 初回セットアップ時の空または破損したロックファイルを適切に処理し、インストールを継続できるようになりました。
  - 正当な空のロックや未対応バージョンのロックファイルを誤って上書きしないよう改善しました。
  - 復元や状態確認に失敗した場合でも状況を記録し、処理を継続します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
