### PR TITLE
fix(scan): keep source skills we could not probe instead of hiding them

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1246,7 +1246,8 @@ This is the source-directory counterpart of the already-fixed P1 "Inaccessible s
 `valid | not-a-skill | unreadable`, applying the repo's settled rule that only
 `ENOENT`/`ENOTDIR` prove absence. `listValidSourceSkillDirs` became
 `listSourceSkillDirs`, returning `{ status: 'listed', entries } | { status:
-'unreadable', code }`; kept entries carry `isUnreadable`. The three surfaces:
+'unreadable' }` and logging the failing code once at the catch site; kept
+entries carry `isUnreadable`. The three surfaces:
 
 - A source skill whose `SKILL.md` cannot be probed **stays in the list** with an
   amber `unreadable` badge, mirroring the existing `orphan` badge.
@@ -1267,10 +1268,13 @@ in `syncService.ts`): creating agent symlinks for a directory we cannot confirm
 is a skill is an action on a guess. That is a behaviour statement now, not the
 side effect of a swallowed error.
 
-**NOT covered:** the outer `catch` in `getSourceStats` still returns zeros with
-no flag. It fires only when `stat(SOURCE_DIR)` or the recursive size walk
-rejects, which an `EACCES` on the directory does not cause (`readdir` fails
-first and is now classified). Left alone as a separate pre-existing swallow.
+The outer `catch` in `getSourceStats` is **gone**, not deferred. It was first
+written off as unreachable on the reasoning that `readdir` fails before `stat`
+does — true when only the source directory itself is unreadable, false when its
+**parent** is not traversable, where `stat(SOURCE_DIR)` rejects too and the
+shared catch threw away the `unreadable` fact to return an honest-looking
+"0 skills". `stat` is now settled with `.catch(() => null)`, which leaves all
+three reads total and makes `getSourceStats` unable to throw.
 
 ## skill-lock prune /review follow-ups (2026-09-06)
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -1230,9 +1230,9 @@ Deferred items captured during planning. Pick up when scope and bandwidth allow.
 
 ## skill-lock prune eng-review follow-ups (2026-09-06)
 
-### P2. Inaccessible source skills must not vanish silently from the list
+### ~~P2. Inaccessible source skills must not vanish silently from the list~~
 
-**Status:** Deferred; the prune feature guards its own destructive path separately (it uses a dedicated ENOENT/ENOTDIR existence check per lock key, not the shared validator), so this is an independent pre-existing bug.
+**Status:** FIXED (PR E). Was: deferred; the prune feature guards its own destructive path separately (it uses a dedicated ENOENT/ENOTDIR existence check per lock key, not the shared validator), so this was an independent pre-existing bug.
 
 **Finding:** `isValidSkillDir` (`src/main/services/skillValidation.ts:15-22`) ends in `catch { return false }`, so `EACCES`, `EIO`, and `ELOOP` on a skill's `SKILL.md` are all reported as "not a valid skill directory". `listValidSourceSkillDirs` then drops the entry, and the skill disappears from the list with nothing shown to explain why. The same swallow exists one level up in `dirScanner.ts:45-47`, where any `readdir` failure returns `[]` — indistinguishable from "no skills installed".
 
@@ -1241,6 +1241,36 @@ This is the source-directory counterpart of the already-fixed P1 "Inaccessible s
 **Fix direction:** Make both `isValidSkillDir` and `listValidSourceSkillDirs` distinguish "succeeded and absent" from "could not determine". Keep today's degrade-to-empty behavior at the four production call sites (`skillScanner.ts:284`, `skillScanner.ts:606`, `syncService.ts:78`, `syncService.ts:145`) but write it explicitly, and surface an indeterminate result in the UI rather than rendering it as absence. `dirScanner.ts` has no test file today, so the change needs one.
 
 **Depends on / blocked by:** Nothing. Fully independent of the prune work.
+
+**What shipped:** `probeSkillDir` in `skillValidation.ts` returns
+`valid | not-a-skill | unreadable`, applying the repo's settled rule that only
+`ENOENT`/`ENOTDIR` prove absence. `listValidSourceSkillDirs` became
+`listSourceSkillDirs`, returning `{ status: 'listed', entries } | { status:
+'unreadable', code }`; kept entries carry `isUnreadable`. The three surfaces:
+
+- A source skill whose `SKILL.md` cannot be probed **stays in the list** with an
+  amber `unreadable` badge, mirroring the existing `orphan` badge.
+- A source directory that cannot be read shows "Folder could not be read" in
+  `SourceCard` instead of "0 skills", which was the actual lie.
+- `getSourceStats.skillCount` counts what the list renders (unreadable rows
+  included) so the sidebar and the list cannot disagree.
+
+`isValidSkillDir` kept its exact boolean behaviour and became a one-line wrapper.
+That was deliberate: its other four callers (`ipc/skills.ts:167`, `:716`,
+`skillScanner.ts:486`, `trashService.ts:275`) are all guards in front of a
+destructive or fanning-out action, and for them an unreadable probe must stay
+fail-closed. Widening the shared function would have forced "fail-closed" to be
+re-stated at each of those sites instead of inherited.
+
+Sync deliberately does NOT fan out an unreadable skill (`syncableSourceSkills`
+in `syncService.ts`): creating agent symlinks for a directory we cannot confirm
+is a skill is an action on a guess. That is a behaviour statement now, not the
+side effect of a swallowed error.
+
+**NOT covered:** the outer `catch` in `getSourceStats` still returns zeros with
+no flag. It fires only when `stat(SOURCE_DIR)` or the recursive size walk
+rejects, which an `EACCES` on the directory does not cause (`readdir` fails
+first and is now classified). Left alone as a separate pre-existing swallow.
 
 ## skill-lock prune /review follow-ups (2026-09-06)
 

--- a/src/main/services/dirScanner.test.ts
+++ b/src/main/services/dirScanner.test.ts
@@ -1,0 +1,208 @@
+import { join } from 'node:path'
+
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const SOURCE_DIR = '/mock/source/skills'
+
+const readdirMock = vi.fn()
+const statMock = vi.fn()
+
+vi.mock('fs/promises', () => ({
+  readdir: readdirMock,
+  stat: statMock,
+}))
+
+vi.mock('../constants', () => ({
+  SOURCE_DIR: '/mock/source/skills',
+}))
+
+/**
+ * Build an fs error carrying a real Node `code`, which is what the probe branches on.
+ * @param code - Node-style errno code.
+ * @returns Error object with the requested code attached.
+ * @example createFsError('EACCES')
+ */
+function createFsError(code: string): Error & { code: string } {
+  return Object.assign(new Error(`${code}: mock failure`), { code })
+}
+
+/**
+ * Build a Dirent-like entry for the readdir mock.
+ * @param name - Entry name as it appears under the source directory.
+ * @param isDirectory - Whether readdir should report the entry as a directory.
+ * @returns Dirent-compatible object consumed by the source listing.
+ * @example createDirent('tdd-workflow', true)
+ */
+function createDirent(
+  name: string,
+  isDirectory: boolean,
+): { name: string; isDirectory: () => boolean } {
+  return { name, isDirectory: () => isDirectory }
+}
+
+/**
+ * Stats stub whose `isFile()` answer drives the SKILL.md probe.
+ * @param isFile - Whether SKILL.md should look like a regular file.
+ * @returns fs.Stats-compatible object.
+ * @example createStats(true).isFile() // => true
+ */
+function createStats(isFile: boolean): { isFile: () => boolean } {
+  return { isFile: () => isFile }
+}
+
+describe('listSourceSkillDirs', () => {
+  beforeEach(() => {
+    readdirMock.mockReset()
+    statMock.mockReset()
+  })
+
+  test('keeps a skill whose SKILL.md cannot be read so a permissions problem does not look like a deletion', async () => {
+    // Arrange: one source directory whose SKILL.md probe is refused by the OS.
+    readdirMock.mockResolvedValue([createDirent('locked-skill', true)])
+    statMock.mockRejectedValue(createFsError('EACCES'))
+    const { listSourceSkillDirs } = await import('./dirScanner')
+
+    // Act
+    const listing = await listSourceSkillDirs()
+
+    // Assert: the skill is still listed, flagged so the UI can say why.
+    expect(listing).toEqual({
+      status: 'listed',
+      entries: [
+        {
+          name: 'locked-skill',
+          path: join(SOURCE_DIR, 'locked-skill'),
+          isUnreadable: true,
+        },
+      ],
+    })
+  })
+
+  test('lists a readable skill without the unreadable flag', async () => {
+    // Arrange: SKILL.md exists as a regular file.
+    readdirMock.mockResolvedValue([createDirent('tdd-workflow', true)])
+    statMock.mockResolvedValue(createStats(true))
+    const { listSourceSkillDirs } = await import('./dirScanner')
+
+    // Act
+    const listing = await listSourceSkillDirs()
+
+    // Assert
+    expect(listing).toEqual({
+      status: 'listed',
+      entries: [
+        {
+          name: 'tdd-workflow',
+          path: join(SOURCE_DIR, 'tdd-workflow'),
+          isUnreadable: false,
+        },
+      ],
+    })
+  })
+
+  test('drops a directory that has no SKILL.md at all', async () => {
+    // Arrange: the probe succeeds in proving SKILL.md cannot exist.
+    readdirMock.mockResolvedValue([createDirent('not-a-skill', true)])
+    statMock.mockRejectedValue(createFsError('ENOENT'))
+    const { listSourceSkillDirs } = await import('./dirScanner')
+
+    // Act
+    const listing = await listSourceSkillDirs()
+
+    // Assert: a folder without SKILL.md is not a skill and must not be offered.
+    expect(listing).toEqual({ status: 'listed', entries: [] })
+  })
+
+  test('drops a directory whose SKILL.md is a directory rather than a file', async () => {
+    // Arrange: stat resolves, but the entry is not a regular file.
+    readdirMock.mockResolvedValue([createDirent('skill-md-is-a-dir', true)])
+    statMock.mockResolvedValue(createStats(false))
+    const { listSourceSkillDirs } = await import('./dirScanner')
+
+    // Act
+    const listing = await listSourceSkillDirs()
+
+    // Assert
+    expect(listing).toEqual({ status: 'listed', entries: [] })
+  })
+
+  test('reports an unreadable source directory instead of reporting no skills installed', async () => {
+    // Arrange: ~/.agents/skills exists but the process may not open it.
+    readdirMock.mockRejectedValue(createFsError('EACCES'))
+    const { listSourceSkillDirs } = await import('./dirScanner')
+
+    // Act
+    const listing = await listSourceSkillDirs()
+
+    // Assert: the caller can tell "could not look" from "nothing there".
+    expect(listing).toEqual({ status: 'unreadable', code: 'EACCES' })
+  })
+
+  test('reports an empty list when the source directory does not exist yet', async () => {
+    // Arrange: a fresh install before the first `skills add`.
+    readdirMock.mockRejectedValue(createFsError('ENOENT'))
+    const { listSourceSkillDirs } = await import('./dirScanner')
+
+    // Act
+    const listing = await listSourceSkillDirs()
+
+    // Assert: a missing source directory is a real empty state, not a failure.
+    expect(listing).toEqual({ status: 'listed', entries: [] })
+  })
+
+  test('skips hidden entries and files so .git and .DS_Store never become skills', async () => {
+    // Arrange: one hidden directory, one regular file, one real skill.
+    readdirMock.mockResolvedValue([
+      createDirent('.git', true),
+      createDirent('README.md', false),
+      createDirent('tdd-workflow', true),
+    ])
+    statMock.mockResolvedValue(createStats(true))
+    const { listSourceSkillDirs } = await import('./dirScanner')
+
+    // Act
+    const listing = await listSourceSkillDirs()
+
+    // Assert
+    expect(listing).toEqual({
+      status: 'listed',
+      entries: [
+        {
+          name: 'tdd-workflow',
+          path: join(SOURCE_DIR, 'tdd-workflow'),
+          isUnreadable: false,
+        },
+      ],
+    })
+  })
+})
+
+describe('isValidSkillDir', () => {
+  beforeEach(() => {
+    statMock.mockReset()
+  })
+
+  test('refuses a directory whose SKILL.md could not be probed so destructive guards stay fail-closed', async () => {
+    // Arrange: the probe is refused, so validity is unknown.
+    statMock.mockRejectedValue(createFsError('EACCES'))
+    const { isValidSkillDir } = await import('./skillValidation')
+
+    // Act
+    const isValid = await isValidSkillDir(join(SOURCE_DIR, 'locked-skill'))
+
+    // Assert: unknown must never read as "yes, delete/copy it".
+    expect(isValid).toBe(false)
+  })
+
+  test('accepts a directory whose SKILL.md is a regular file', async () => {
+    // Arrange
+    statMock.mockResolvedValue(createStats(true))
+    const { isValidSkillDir } = await import('./skillValidation')
+
+    // Act
+    const isValid = await isValidSkillDir(join(SOURCE_DIR, 'tdd-workflow'))
+
+    // Assert
+    expect(isValid).toBe(true)
+  })
+})

--- a/src/main/services/dirScanner.test.ts
+++ b/src/main/services/dirScanner.test.ts
@@ -129,25 +129,36 @@ describe('listSourceSkillDirs', () => {
   test('reports an unreadable source directory instead of reporting no skills installed', async () => {
     // Arrange: ~/.agents/skills exists but the process may not open it.
     readdirMock.mockRejectedValue(createFsError('EACCES'))
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const { listSourceSkillDirs } = await import('./dirScanner')
 
     // Act
     const listing = await listSourceSkillDirs()
 
-    // Assert: the caller can tell "could not look" from "nothing there".
-    expect(listing).toEqual({ status: 'unreadable', code: 'EACCES' })
+    // Assert: the caller can tell "could not look" from "nothing there", and
+    // the reason reaches the log rather than being swallowed as it was before.
+    expect(listing).toEqual({ status: 'unreadable' })
+    expect(warnSpy).toHaveBeenCalledWith(
+      'dirScanner: source skills directory could not be read',
+      expect.objectContaining({ code: 'EACCES' }),
+    )
+    warnSpy.mockRestore()
   })
 
   test('reports an empty list when the source directory does not exist yet', async () => {
     // Arrange: a fresh install before the first `skills add`.
     readdirMock.mockRejectedValue(createFsError('ENOENT'))
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const { listSourceSkillDirs } = await import('./dirScanner')
 
     // Act
     const listing = await listSourceSkillDirs()
 
-    // Assert: a missing source directory is a real empty state, not a failure.
+    // Assert: a missing source directory is a real empty state, not a failure,
+    // so it must not spend a warning on the normal first-run path either.
     expect(listing).toEqual({ status: 'listed', entries: [] })
+    expect(warnSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
   })
 
   test('skips hidden entries and files so .git and .DS_Store never become skills', async () => {

--- a/src/main/services/dirScanner.ts
+++ b/src/main/services/dirScanner.ts
@@ -2,48 +2,72 @@ import { readdir } from 'fs/promises'
 import { join } from 'path'
 
 import { SOURCE_DIR } from '@/main/constants'
+import { errorCode, isMissingPathError } from '@/main/utils/errorCode'
 import type { AbsolutePath, SkillName } from '@/shared/types'
 
-import { isValidSkillDir } from './skillValidation'
+import { probeSkillDir } from './skillValidation'
 
 /**
- * Entry representing a valid skill directory on disk.
- * @example { name: 'tdd-workflow', path: '/Users/me/.agents/skills/tdd-workflow' }
+ * Entry representing a skill directory on disk that the scan is keeping.
+ * @example { name: 'tdd-workflow', path: '/Users/me/.agents/skills/tdd-workflow', isUnreadable: false }
  */
 export interface SkillDirEntry {
   /** Directory name, matches the skill's identifier. @example "tdd-workflow" */
   name: SkillName
   /** Absolute path to the skill directory on disk. */
   path: AbsolutePath
+  /**
+   * `true` when `SKILL.md` could not be probed, so the app cannot confirm this
+   * is a real skill. The entry is still listed — dropping it would make a
+   * permissions problem look like the user deleting the skill.
+   */
+  isUnreadable: boolean
 }
 
 /**
- * List all valid skill directories under ~/.agents/skills/.
- * Filters out hidden entries (e.g. .git, .DS_Store) and directories
- * without a SKILL.md file. Used by skillScanner and syncService
- * to avoid duplicating the readdir + filter + validate pattern.
- * @returns Array of { name, path } for each valid skill directory
- * @example
- * listValidSourceSkillDirs()
- * // => [{ name: 'theme-generator', path: '/Users/x/.agents/skills/theme-generator' }]
+ * Outcome of listing `~/.agents/skills/`, separating an empty folder from one we could not open.
+ * `unreadable` exists because the previous `catch { return [] }` reported an
+ * `EACCES` on the source directory as "no skills installed".
+ * @example { status: 'unreadable', code: 'EACCES' }
  */
-export async function listValidSourceSkillDirs(): Promise<SkillDirEntry[]> {
-  try {
-    const entries = await readdir(SOURCE_DIR, { withFileTypes: true })
-    const dirs = entries.filter(
-      (e) => e.isDirectory() && !e.name.startsWith('.'),
-    )
+export type SourceSkillDirListing =
+  | { status: 'listed'; entries: SkillDirEntry[] }
+  | { status: 'unreadable'; code: string | undefined }
 
-    const results: SkillDirEntry[] = []
-    for (const dir of dirs) {
-      const skillPath = join(SOURCE_DIR, dir.name)
-      // react-doctor-disable-next-line react-doctor/async-await-in-loop -- isValidSkillDir probe per entry building the valid-dirs list; bounded local-fs reads kept sequential to stay fd-bounded.
-      if (await isValidSkillDir(skillPath)) {
-        results.push({ name: dir.name, path: skillPath })
-      }
-    }
-    return results
-  } catch {
-    return []
+/**
+ * List the skill directories under ~/.agents/skills/, keeping unprovable entries instead of dropping them.
+ * Filters out hidden entries (e.g. .git, .DS_Store) and directories the probe
+ * proved are not skills. Used by skillScanner and syncService to avoid
+ * duplicating the readdir + filter + probe pattern.
+ * @returns `listed` with one entry per kept directory, or `unreadable` when the source directory itself could not be read
+ * @example
+ * await listSourceSkillDirs()
+ * // => { status: 'listed', entries: [{ name: 'theme-generator', path: '/Users/x/.agents/skills/theme-generator', isUnreadable: false }] }
+ */
+export async function listSourceSkillDirs(): Promise<SourceSkillDirListing> {
+  let entries
+  try {
+    entries = await readdir(SOURCE_DIR, { withFileTypes: true })
+  } catch (error) {
+    // A source directory that does not exist yet is a real empty state — a
+    // fresh install before the first `skills add`. Anything else is a failed look.
+    if (isMissingPathError(error)) return { status: 'listed', entries: [] }
+    return { status: 'unreadable', code: errorCode(error) }
   }
+
+  const dirs = entries.filter((e) => e.isDirectory() && !e.name.startsWith('.'))
+
+  const results: SkillDirEntry[] = []
+  for (const dir of dirs) {
+    const skillPath = join(SOURCE_DIR, dir.name)
+    // react-doctor-disable-next-line react-doctor/async-await-in-loop -- probeSkillDir per entry building the kept-dirs list; bounded local-fs reads kept sequential to stay fd-bounded.
+    const probe = await probeSkillDir(skillPath)
+    if (probe === 'not-a-skill') continue
+    results.push({
+      name: dir.name,
+      path: skillPath,
+      isUnreadable: probe === 'unreadable',
+    })
+  }
+  return { status: 'listed', entries: results }
 }

--- a/src/main/services/dirScanner.ts
+++ b/src/main/services/dirScanner.ts
@@ -19,9 +19,10 @@ export interface SkillDirEntry {
   /** Absolute path to the skill directory on disk. */
   path: AbsolutePath
   /**
-   * `true` when `SKILL.md` could not be probed, so the app cannot confirm this
-   * is a real skill. The entry is still listed — dropping it would make a
-   * permissions problem look like the user deleting the skill.
+   * `true` when `SKILL.md` could not be `stat`ed, so the app could not look at
+   * it at all. The entry is still listed — dropping it would make a permissions
+   * problem look like the user deleting the skill. A `SKILL.md` that stats fine
+   * reads as readable here even if its contents are not; the probe never opens it.
    */
   isUnreadable: boolean
 }

--- a/src/main/services/dirScanner.ts
+++ b/src/main/services/dirScanner.ts
@@ -1,8 +1,10 @@
+import type { Dirent } from 'fs'
 import { readdir } from 'fs/promises'
 import { join } from 'path'
 
 import { SOURCE_DIR } from '@/main/constants'
 import { errorCode, isMissingPathError } from '@/main/utils/errorCode'
+import { extractErrorMessage } from '@/main/utils/errors'
 import type { AbsolutePath, SkillName } from '@/shared/types'
 
 import { probeSkillDir } from './skillValidation'
@@ -28,11 +30,10 @@ export interface SkillDirEntry {
  * Outcome of listing `~/.agents/skills/`, separating an empty folder from one we could not open.
  * `unreadable` exists because the previous `catch { return [] }` reported an
  * `EACCES` on the source directory as "no skills installed".
- * @example { status: 'unreadable', code: 'EACCES' }
+ * @example { status: 'unreadable' }
  */
 export type SourceSkillDirListing =
-  | { status: 'listed'; entries: SkillDirEntry[] }
-  | { status: 'unreadable'; code: string | undefined }
+  { status: 'listed'; entries: SkillDirEntry[] } | { status: 'unreadable' }
 
 /**
  * List the skill directories under ~/.agents/skills/, keeping unprovable entries instead of dropping them.
@@ -45,14 +46,20 @@ export type SourceSkillDirListing =
  * // => { status: 'listed', entries: [{ name: 'theme-generator', path: '/Users/x/.agents/skills/theme-generator', isUnreadable: false }] }
  */
 export async function listSourceSkillDirs(): Promise<SourceSkillDirListing> {
-  let entries
+  let entries: Dirent[]
   try {
     entries = await readdir(SOURCE_DIR, { withFileTypes: true })
   } catch (error) {
     // A source directory that does not exist yet is a real empty state — a
     // fresh install before the first `skills add`. Anything else is a failed look.
     if (isMissingPathError(error)) return { status: 'listed', entries: [] }
-    return { status: 'unreadable', code: errorCode(error) }
+    // The whole point of this TODO is that the failure stopped being silent,
+    // so it is logged here as well as surfaced through `SourceStats`.
+    console.warn('dirScanner: source skills directory could not be read', {
+      code: errorCode(error),
+      message: extractErrorMessage(error),
+    })
+    return { status: 'unreadable' }
   }
 
   const dirs = entries.filter((e) => e.isDirectory() && !e.name.startsWith('.'))

--- a/src/main/services/skillScanner.test.ts
+++ b/src/main/services/skillScanner.test.ts
@@ -846,6 +846,50 @@ describe('scanSkills orphan symlink surfacing (issue #127)', () => {
     expect(stats.skillCount).toBe(1)
   })
 
+  test('lists no source skills when the source directory itself cannot be opened', async () => {
+    // Arrange: ~/.agents/skills exists but EACCES on open, and one agent still
+    // has a real local skill folder so an empty result cannot be a false pass.
+    readdirMock.mockImplementation(async (path: string) => {
+      if (path === '/mock/source/skills') {
+        throw createFsError(`EACCES: ${path}`, 'EACCES')
+      }
+      if (path === '/mock/agents/codex/skills') {
+        return [
+          createDirent('local-only', {
+            isDirectory: true,
+            isSymbolicLink: false,
+          }),
+        ]
+      }
+      return []
+    })
+    statMock.mockImplementation(async (path: string) => {
+      if (path === '/mock/agents/codex/skills/local-only/SKILL.md') {
+        return { isFile: () => true }
+      }
+      throw createFsError(`ENOENT: ${path}`, 'ENOENT')
+    })
+    lstatMock.mockImplementation(async (path: string) => {
+      if (path === '/mock/agents/codex/skills/local-only') {
+        return createDirectoryStats(path.length)
+      }
+      throw createFsError(`ENOENT: ${path}`, 'ENOENT')
+    })
+
+    const { scanSkills } = await import('./skillScanner')
+
+    // Act
+    const skills = await scanSkills()
+
+    // Assert: the scan degrades to zero source skills rather than throwing —
+    // `SourceStats.isUnreadable` is what tells the user the list is a placeholder.
+    expect(skills.filter((skill) => skill.isSource)).toHaveLength(0)
+    expect(skills).toHaveLength(1)
+    expect(skills[0]).toEqual(
+      expect.objectContaining({ name: 'local-only', isSource: false }),
+    )
+  })
+
   it('merges orphan broken slots into a same-named local skill (regression for #127 follow-up)', async () => {
     // Arrange: Cursor has a real folder named "frontend-design" → local skill.
     // Codex has a broken symlink with the same name → source missing, orphan.

--- a/src/main/services/skillScanner.test.ts
+++ b/src/main/services/skillScanner.test.ts
@@ -813,6 +813,28 @@ describe('scanSkills orphan symlink surfacing (issue #127)', () => {
     expect(stats.skillCount).toBe(0)
   })
 
+  test('keeps the unreadable flag when the source directory cannot be stat-ed either', async () => {
+    // Arrange: SOURCE_DIR's parent is not traversable, so BOTH readdir and
+    // stat fail with EACCES — the case where a shared catch would have dropped
+    // the unreadable fact and rendered an honest-looking "0 skills".
+    readdirMock.mockImplementation(async (path: string) => {
+      throw createFsError(`EACCES: ${path}`, 'EACCES')
+    })
+    statMock.mockImplementation(async (path: string) => {
+      throw createFsError(`EACCES: ${path}`, 'EACCES')
+    })
+
+    const { getSourceStats } = await import('./skillScanner')
+
+    // Act
+    const stats = await getSourceStats()
+
+    // Assert: the warning survives, and the placeholder fields stay valid.
+    expect(stats.isUnreadable).toBe(true)
+    expect(stats.skillCount).toBe(0)
+    expect(stats.totalSize).toBe('0 B')
+    expect(typeof stats.lastModified).toBe('string')
+  })
   test('leaves the unreadable flag off the stats for a source directory it could read', async () => {
     // Arrange: one real source skill.
     readdirMock.mockImplementation(async (path: string) => {

--- a/src/main/services/skillScanner.test.ts
+++ b/src/main/services/skillScanner.test.ts
@@ -319,34 +319,6 @@ describe('scanSkills local skill aggregation', () => {
     // Assert: the SKILL.md-less directory is excluded from the inventory.
     expect(skills).toHaveLength(0)
   })
-
-  it('skips directories without SKILL.md when listing valid source skills', async () => {
-    // Arrange: SOURCE_DIR holds one real folder "no-skill-md" that contains no
-    // SKILL.md file, so isValidSkillDir returns false for it. The source-dir
-    // lister must drop such a directory — a folder without SKILL.md is not a
-    // skill and must never be reported as an installable source.
-    readdirMock.mockImplementation(async (path: string) => {
-      if (path === '/mock/source/skills') {
-        return [
-          createDirent('no-skill-md', {
-            isDirectory: true,
-            isSymbolicLink: false,
-          }),
-        ]
-      }
-      return []
-    })
-    // No SKILL.md exists, so the stat probe for "no-skill-md/SKILL.md" throws
-    // ENOENT and isValidSkillDir resolves false for the candidate directory.
-    statMock.mockRejectedValue(new Error('ENOENT'))
-    const { listValidSourceSkillDirs } = await import('./dirScanner')
-
-    // Act
-    const sourceSkillDirs = await listValidSourceSkillDirs()
-
-    // Assert: the SKILL.md-less directory yields an empty source-skill list.
-    expect(sourceSkillDirs).toEqual([])
-  })
 })
 
 describe('scanSkills agent-only linked symlink surfacing', () => {
@@ -756,6 +728,122 @@ describe('scanSkills orphan symlink surfacing (issue #127)', () => {
       path: '/mock/source/skills/live-source',
       isSource: true,
     })
+  })
+
+  test('keeps a source skill whose SKILL.md could not be read and flags it for the list', async () => {
+    // Arrange: one readable source skill, one whose SKILL.md probe is refused.
+    readdirMock.mockImplementation(async (path: string) => {
+      if (path === '/mock/source/skills') {
+        return [
+          createDirent('readable-source', {
+            isDirectory: true,
+            isSymbolicLink: false,
+          }),
+          createDirent('locked-source', {
+            isDirectory: true,
+            isSymbolicLink: false,
+          }),
+        ]
+      }
+      return []
+    })
+    statMock.mockImplementation(async (path: string) => {
+      if (path === '/mock/source/skills/readable-source/SKILL.md') {
+        return { isFile: () => true }
+      }
+      if (path === '/mock/source/skills/locked-source/SKILL.md') {
+        throw createFsError(`EACCES: ${path}`, 'EACCES')
+      }
+      throw createFsError(`ENOENT: ${path}`, 'ENOENT')
+    })
+    lstatMock.mockImplementation(async (path: string) => {
+      if (
+        path === '/mock/source/skills/readable-source' ||
+        path === '/mock/source/skills/locked-source'
+      ) {
+        return createDirectoryStats(path.length)
+      }
+      throw createFsError(`ENOENT: ${path}`, 'ENOENT')
+    })
+
+    const { scanSkills } = await import('./skillScanner')
+
+    // Act
+    const skills = await scanSkills()
+
+    // Assert: the locked skill stays in the inventory carrying the doubt, so a
+    // permissions problem cannot look like the user having deleted it.
+    expect(skills).toHaveLength(2)
+    expect(skills).toContainEqual(
+      expect.objectContaining({
+        name: 'locked-source',
+        isSource: true,
+        isUnreadable: true,
+      }),
+    )
+    expect(skills).toContainEqual(
+      expect.objectContaining({
+        name: 'readable-source',
+        isSource: true,
+        isUnreadable: false,
+      }),
+    )
+  })
+
+  test('reports an unreadable source directory in the stats instead of a zero skill count', async () => {
+    // Arrange: ~/.agents/skills exists but cannot be opened.
+    readdirMock.mockImplementation(async (path: string) => {
+      if (path === '/mock/source/skills') {
+        throw createFsError(`EACCES: ${path}`, 'EACCES')
+      }
+      return []
+    })
+    statMock.mockResolvedValue({
+      isFile: () => false,
+      mtime: new Date('2026-04-10T08:00:00.000Z'),
+    })
+
+    const { getSourceStats } = await import('./skillScanner')
+
+    // Act
+    const stats = await getSourceStats()
+
+    // Assert: the sidebar needs to know the count is a placeholder, not a fact.
+    expect(stats.isUnreadable).toBe(true)
+    expect(stats.skillCount).toBe(0)
+  })
+
+  test('leaves the unreadable flag off the stats for a source directory it could read', async () => {
+    // Arrange: one real source skill.
+    readdirMock.mockImplementation(async (path: string) => {
+      if (path === '/mock/source/skills') {
+        return [
+          createDirent('readable-source', {
+            isDirectory: true,
+            isSymbolicLink: false,
+          }),
+        ]
+      }
+      return []
+    })
+    statMock.mockImplementation(async (path: string) => {
+      if (path === '/mock/source/skills/readable-source/SKILL.md') {
+        return { isFile: () => true }
+      }
+      return {
+        isFile: () => false,
+        mtime: new Date('2026-04-10T08:00:00.000Z'),
+      }
+    })
+
+    const { getSourceStats } = await import('./skillScanner')
+
+    // Act
+    const stats = await getSourceStats()
+
+    // Assert: a healthy folder must never render the permissions warning.
+    expect(stats.isUnreadable).toBe(false)
+    expect(stats.skillCount).toBe(1)
   })
 
   it('merges orphan broken slots into a same-named local skill (regression for #127 follow-up)', async () => {

--- a/src/main/services/skillScanner.ts
+++ b/src/main/services/skillScanner.ts
@@ -605,33 +605,30 @@ export async function getSkill(skillName: SkillName): Promise<Skill | null> {
  * // => { path: '~/.agents/skills', skillCount: 5, totalSize: '2.3 MB' }
  */
 export async function getSourceStats(): Promise<SourceStats> {
-  try {
-    // Independent reads of SOURCE_DIR (dir list + stat + recursive size). Only
-    // stat() can reject; the other two are total, so Promise.all surfaces the
-    // exact same error to the outer catch as the sequential version did.
-    const [listing, stats, totalBytes] = await Promise.all([
-      listSourceSkillDirs(),
-      stat(SOURCE_DIR),
-      calculateDirectorySize(SOURCE_DIR),
-    ])
+  // Three independent reads of SOURCE_DIR. `listSourceSkillDirs` and
+  // `calculateDirectorySize` both swallow their own failures, and `stat` is
+  // settled here rather than allowed to reject the whole batch: when
+  // SOURCE_DIR's parent is not traversable BOTH the listing and the stat fail,
+  // and a shared catch would have thrown away the `unreadable` fact and
+  // rendered the folder as an honest-looking "0 skills" — the exact lie this
+  // function exists to stop telling.
+  const [listing, stats, totalBytes] = await Promise.all([
+    listSourceSkillDirs(),
+    stat(SOURCE_DIR).catch(() => null),
+    calculateDirectorySize(SOURCE_DIR),
+  ])
 
-    return {
-      path: SOURCE_DIR,
-      // Counts what the list renders, unreadable rows included, so the sidebar
-      // count and the list cannot disagree.
-      skillCount: listing.status === 'listed' ? listing.entries.length : 0,
-      totalSize: formatBytes(totalBytes),
-      lastModified: stats.mtime.toISOString(),
-      // The one place a "0 skills" reading is a lie gets to say so.
-      isUnreadable: listing.status === 'unreadable',
-    }
-  } catch {
-    return {
-      path: SOURCE_DIR,
-      skillCount: 0,
-      totalSize: '0 B',
-      lastModified: new Date().toISOString(),
-    }
+  return {
+    path: SOURCE_DIR,
+    // Counts what the list renders, unreadable rows included, so the sidebar
+    // count and the list cannot disagree.
+    skillCount: listing.status === 'listed' ? listing.entries.length : 0,
+    totalSize: formatBytes(totalBytes),
+    // No consumer renders this today; "now" keeps the field a valid
+    // `IsoTimestamp` without widening the type for an unread value.
+    lastModified: (stats?.mtime ?? new Date()).toISOString(),
+    // The one place a "0 skills" reading is a lie gets to say so.
+    isUnreadable: listing.status === 'unreadable',
   }
 }
 

--- a/src/main/services/skillScanner.ts
+++ b/src/main/services/skillScanner.ts
@@ -17,7 +17,7 @@ import type {
   SymlinkStatus,
 } from '@/shared/types'
 
-import { listValidSourceSkillDirs } from './dirScanner'
+import { listSourceSkillDirs } from './dirScanner'
 import { filesystemIdentityFromStats } from './filesystemIdentity'
 import { parseSkillMetadata } from './metadataParser'
 import { getSkillLockPath } from './skillLockService'
@@ -281,10 +281,14 @@ export async function scanSkills(): Promise<Skill[]> {
  * @returns Array of source skills
  */
 async function scanSourceSkills(): Promise<Skill[]> {
-  const validDirs = await listValidSourceSkillDirs()
+  const listing = await listSourceSkillDirs()
+  // Degrade to an empty source list when the directory itself could not be
+  // read, exactly as the old swallow did — but the emptiness is now stated
+  // here, and `SourceStats.isUnreadable` is what tells the user about it.
+  const sourceDirs = listing.status === 'listed' ? listing.entries : []
 
   const skills = await Promise.all(
-    validDirs.map(async (dir): Promise<Skill | null> => {
+    sourceDirs.map(async (dir): Promise<Skill | null> => {
       try {
         const [metadata, symlinks, stats] = await Promise.all([
           parseSkillMetadata(dir.path),
@@ -301,6 +305,9 @@ async function scanSourceSkills(): Promise<Skill[]> {
           symlinks,
           isSource: true,
           isOrphan: false,
+          // Kept in the list on purpose: `SKILL.md` could not be probed, so the
+          // row carries the doubt instead of disappearing like a deleted skill.
+          isUnreadable: dir.isUnreadable,
         }
       } catch (error) {
         // Race: another process deleted the source dir after readdir/stat but
@@ -602,17 +609,21 @@ export async function getSourceStats(): Promise<SourceStats> {
     // Independent reads of SOURCE_DIR (dir list + stat + recursive size). Only
     // stat() can reject; the other two are total, so Promise.all surfaces the
     // exact same error to the outer catch as the sequential version did.
-    const [validDirs, stats, totalBytes] = await Promise.all([
-      listValidSourceSkillDirs(),
+    const [listing, stats, totalBytes] = await Promise.all([
+      listSourceSkillDirs(),
       stat(SOURCE_DIR),
       calculateDirectorySize(SOURCE_DIR),
     ])
 
     return {
       path: SOURCE_DIR,
-      skillCount: validDirs.length,
+      // Counts what the list renders, unreadable rows included, so the sidebar
+      // count and the list cannot disagree.
+      skillCount: listing.status === 'listed' ? listing.entries.length : 0,
       totalSize: formatBytes(totalBytes),
       lastModified: stats.mtime.toISOString(),
+      // The one place a "0 skills" reading is a lie gets to say so.
+      isUnreadable: listing.status === 'unreadable',
     }
   } catch {
     return {

--- a/src/main/services/skillValidation.ts
+++ b/src/main/services/skillValidation.ts
@@ -1,22 +1,55 @@
 import { stat } from 'fs/promises'
 import { join } from 'path'
 
+import { isMissingPathError } from '@/main/utils/errorCode'
 import type { AbsolutePath } from '@/shared/types'
+
+/**
+ * What a `SKILL.md` probe actually established about a candidate directory.
+ * `unreadable` is deliberately NOT folded into `not-a-skill`: `EACCES`, `EIO`,
+ * and `ELOOP` mean we could not look, which is a different fact from looking
+ * and finding nothing, and the list must not render the two the same way.
+ * @example 'unreadable'
+ */
+export type SkillDirProbe = 'valid' | 'not-a-skill' | 'unreadable'
+
+/**
+ * Probe a directory for a readable `SKILL.md`, keeping "could not determine" apart from "definitely not a skill".
+ * Exists because {@link isValidSkillDir} collapses both into `false`, which made
+ * a permissions problem on one skill look exactly like the user deleting it.
+ * Called per candidate directory by {@link listSourceSkillDirs}.
+ * @param dirPath - Absolute path to the candidate skill directory.
+ * @returns
+ * - `valid`: `SKILL.md` exists and is a regular file
+ * - `not-a-skill`: the probe succeeded and `SKILL.md` is absent or not a file
+ * - `unreadable`: the probe itself failed, so validity is unknown
+ * @example
+ * await probeSkillDir('/Users/me/.agents/skills/tdd-workflow') // => 'valid'
+ */
+export async function probeSkillDir(
+  dirPath: AbsolutePath,
+): Promise<SkillDirProbe> {
+  try {
+    const stats = await stat(join(dirPath, 'SKILL.md'))
+    return stats.isFile() ? 'valid' : 'not-a-skill'
+  } catch (error) {
+    // Same rule the repo already settled on for symlink targets: only ENOENT
+    // and ENOTDIR prove the path cannot exist. Everything else is a failed look.
+    return isMissingPathError(error) ? 'not-a-skill' : 'unreadable'
+  }
+}
 
 /**
  * Check if a directory is a valid skill directory (contains SKILL.md as a regular file).
  * Uses stat().isFile() instead of access() to verify the entry is actually a file,
  * not a directory or other filesystem object with the same name.
+ * Fail-closed on purpose: every caller is a guard in front of a destructive or
+ * fanning-out action, so an unreadable probe must read as "not a skill".
  * @param dirPath - Absolute path to the directory to check
  * @returns true if SKILL.md exists as a regular file in the directory
  * @example
  * await isValidSkillDir('/path/to/my-skill') // true if SKILL.md is a file
  */
 export async function isValidSkillDir(dirPath: AbsolutePath): Promise<boolean> {
-  try {
-    const stats = await stat(join(dirPath, 'SKILL.md'))
-    return stats.isFile()
-  } catch {
-    return false
-  }
+  return (await probeSkillDir(dirPath)) === 'valid'
 }

--- a/src/main/services/skillValidation.ts
+++ b/src/main/services/skillValidation.ts
@@ -14,13 +14,13 @@ import type { AbsolutePath } from '@/shared/types'
 export type SkillDirProbe = 'valid' | 'not-a-skill' | 'unreadable'
 
 /**
- * Probe a directory for a readable `SKILL.md`, keeping "could not determine" apart from "definitely not a skill".
+ * Probe a directory for a `SKILL.md` entry, keeping "could not determine" apart from "definitely not a skill".
  * Exists because {@link isValidSkillDir} collapses both into `false`, which made
  * a permissions problem on one skill look exactly like the user deleting it.
  * Called per candidate directory by {@link listSourceSkillDirs}.
  * @param dirPath - Absolute path to the candidate skill directory.
  * @returns
- * - `valid`: `SKILL.md` exists and is a regular file
+ * - `valid`: `SKILL.md` exists and is a regular file (its contents are NOT read)
  * - `not-a-skill`: the probe succeeded and `SKILL.md` is absent or not a file
  * - `unreadable`: the probe itself failed, so validity is unknown
  * @example

--- a/src/main/services/syncService.test.ts
+++ b/src/main/services/syncService.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path'
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, test, vi } from 'vitest'
 
 /**
  * Create a mock Stats-like object for lstat results.
@@ -71,6 +71,54 @@ describe('syncPreview', () => {
     expect(result.toCreate).toBe(0)
     expect(result.alreadySynced).toBe(0)
     expect(result.conflicts).toHaveLength(0)
+  })
+
+  test('refuses to fan out a source skill whose SKILL.md could not be read', async () => {
+    // Arrange: one readable skill, one whose SKILL.md probe is refused by the OS.
+    readdirMock.mockImplementation(async (dir: string) => {
+      if (dir === '/mock/source/skills') {
+        return [
+          { name: 'readable-skill', isDirectory: () => true },
+          { name: 'locked-skill', isDirectory: () => true },
+        ]
+      }
+      return []
+    })
+    statMock.mockImplementation(async (path: string) => {
+      if (path === join('/mock/source/skills', 'locked-skill', 'SKILL.md')) {
+        throw Object.assign(new Error('EACCES: denied'), { code: 'EACCES' })
+      }
+      return { isFile: () => true }
+    })
+    lstatMock.mockRejectedValue(new Error('ENOENT'))
+    const { syncPreview } = await import('./syncService')
+
+    // Act
+    const result = await syncPreview()
+
+    // Assert: creating symlinks for a directory we cannot confirm is a skill is
+    // a fan-out on a guess, so sync stays on the one skill it could verify.
+    expect(result.totalSkills).toBe(1)
+    expect(result.toCreate).toBe(2) // 1 verifiable skill x 2 agents
+  })
+
+  test('syncs nothing when the source directory itself could not be read', async () => {
+    // Arrange: ~/.agents/skills exists but cannot be opened.
+    readdirMock.mockImplementation(async (dir: string) => {
+      if (dir === '/mock/source/skills') {
+        throw Object.assign(new Error('EACCES: denied'), { code: 'EACCES' })
+      }
+      return []
+    })
+    lstatMock.mockRejectedValue(new Error('ENOENT'))
+    const { syncPreview } = await import('./syncService')
+
+    // Act
+    const result = await syncPreview()
+
+    // Assert: same degrade-to-empty the old swallow produced, now on purpose.
+    expect(result.totalSkills).toBe(0)
+    expect(result.toCreate).toBe(0)
   })
 
   it('reports an existing symlink in every agent as already synced', async () => {

--- a/src/main/services/syncService.ts
+++ b/src/main/services/syncService.ts
@@ -17,8 +17,11 @@ import type {
   SyncResultItem,
 } from '@/shared/types'
 
-import { listSourceSkillDirs } from './dirScanner'
-import type { SkillDirEntry, SourceSkillDirListing } from './dirScanner'
+import {
+  listSourceSkillDirs,
+  type SkillDirEntry,
+  type SourceSkillDirListing,
+} from './dirScanner'
 
 /** Agent-on-disk row used internally by syncPreview/syncExecute. */
 type ExistingAgent = { id: AgentId; name: AgentName; path: AbsolutePath }
@@ -50,6 +53,14 @@ async function getExistingAgents(): Promise<ExistingAgent[]> {
  * short-circuit with empty results rather than silently no-op'ing across all
  * agents (defends against typos in the agentId arg).
  */
+function filterAgentsByOption<TAgent extends { id: AgentId }>(
+  agents: TAgent[],
+  agentId: AgentId | undefined,
+): TAgent[] {
+  if (!agentId) return agents
+  return agents.filter((a) => a.id === agentId)
+}
+
 /**
  * Pick the source skills sync is allowed to fan out, written explicitly rather than inherited from a swallowed error.
  * An unreadable source directory degrades to "sync nothing" exactly as the old
@@ -58,19 +69,11 @@ async function getExistingAgents(): Promise<ExistingAgent[]> {
  * confirm is a skill is a fan-out we should not perform on a guess.
  * @param listing - What {@link listSourceSkillDirs} saw under `~/.agents/skills/`.
  * @returns The entries sync may link, possibly empty.
- * @example syncableSourceSkills({ status: 'unreadable', code: 'EACCES' }) // => []
+ * @example syncableSourceSkills({ status: 'unreadable' }) // => []
  */
 function syncableSourceSkills(listing: SourceSkillDirListing): SkillDirEntry[] {
   if (listing.status === 'unreadable') return []
   return listing.entries.filter((entry) => !entry.isUnreadable)
-}
-
-function filterAgentsByOption<TAgent extends { id: AgentId }>(
-  agents: TAgent[],
-  agentId: AgentId | undefined,
-): TAgent[] {
-  if (!agentId) return agents
-  return agents.filter((a) => a.id === agentId)
 }
 
 /**

--- a/src/main/services/syncService.ts
+++ b/src/main/services/syncService.ts
@@ -65,8 +65,10 @@ function filterAgentsByOption<TAgent extends { id: AgentId }>(
  * Pick the source skills sync is allowed to fan out, written explicitly rather than inherited from a swallowed error.
  * An unreadable source directory degrades to "sync nothing" exactly as the old
  * `catch { return [] }` did; an individual skill whose `SKILL.md` could not be
- * probed is skipped because creating agent symlinks for a directory we cannot
- * confirm is a skill is a fan-out we should not perform on a guess.
+ * `stat`ed is skipped because fanning symlinks out to a directory we could not
+ * even look at is a guess. A `SKILL.md` that stats fine but whose contents are
+ * unreadable is still linked on purpose: the probe never reads it, and a
+ * symlink stays correct once the permission bit is fixed.
  * @param listing - What {@link listSourceSkillDirs} saw under `~/.agents/skills/`.
  * @returns The entries sync may link, possibly empty.
  * @example syncableSourceSkills({ status: 'unreadable' }) // => []

--- a/src/main/services/syncService.ts
+++ b/src/main/services/syncService.ts
@@ -17,7 +17,8 @@ import type {
   SyncResultItem,
 } from '@/shared/types'
 
-import { listValidSourceSkillDirs } from './dirScanner'
+import { listSourceSkillDirs } from './dirScanner'
+import type { SkillDirEntry, SourceSkillDirListing } from './dirScanner'
 
 /** Agent-on-disk row used internally by syncPreview/syncExecute. */
 type ExistingAgent = { id: AgentId; name: AgentName; path: AbsolutePath }
@@ -49,6 +50,21 @@ async function getExistingAgents(): Promise<ExistingAgent[]> {
  * short-circuit with empty results rather than silently no-op'ing across all
  * agents (defends against typos in the agentId arg).
  */
+/**
+ * Pick the source skills sync is allowed to fan out, written explicitly rather than inherited from a swallowed error.
+ * An unreadable source directory degrades to "sync nothing" exactly as the old
+ * `catch { return [] }` did; an individual skill whose `SKILL.md` could not be
+ * probed is skipped because creating agent symlinks for a directory we cannot
+ * confirm is a skill is a fan-out we should not perform on a guess.
+ * @param listing - What {@link listSourceSkillDirs} saw under `~/.agents/skills/`.
+ * @returns The entries sync may link, possibly empty.
+ * @example syncableSourceSkills({ status: 'unreadable', code: 'EACCES' }) // => []
+ */
+function syncableSourceSkills(listing: SourceSkillDirListing): SkillDirEntry[] {
+  if (listing.status === 'unreadable') return []
+  return listing.entries.filter((entry) => !entry.isUnreadable)
+}
+
 function filterAgentsByOption<TAgent extends { id: AgentId }>(
   agents: TAgent[],
   agentId: AgentId | undefined,
@@ -74,10 +90,11 @@ export async function syncPreview(
 ): Promise<SyncPreviewResult> {
   // Independent reads (source skills + on-disk agents); both helpers are total
   // (never reject), so parallelizing is behavior-identical aside from speed.
-  const [skills, allAgents] = await Promise.all([
-    listValidSourceSkillDirs(),
+  const [listing, allAgents] = await Promise.all([
+    listSourceSkillDirs(),
     getExistingAgents(),
   ])
+  const skills = syncableSourceSkills(listing)
   const agents = filterAgentsByOption(allAgents, options?.agentId)
 
   let toCreate = 0
@@ -141,10 +158,11 @@ export async function syncExecute(
 
   // Independent reads (source skills + on-disk agents); both helpers are total
   // (never reject), so parallelizing is behavior-identical aside from speed.
-  const [skills, allAgents] = await Promise.all([
-    listValidSourceSkillDirs(),
+  const [listing, allAgents] = await Promise.all([
+    listSourceSkillDirs(),
     getExistingAgents(),
   ])
+  const skills = syncableSourceSkills(listing)
   const agents = filterAgentsByOption(allAgents, agentId)
 
   let created = 0

--- a/src/renderer/src/components/sidebar/SourceCard.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/SourceCard.browser.test.tsx
@@ -1,6 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { Provider } from 'react-redux'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import type { SyncPreviewResult } from '@/shared/types'
@@ -340,5 +340,43 @@ describe('Sidebar → SourceCard sync', () => {
     await vi.waitFor(() => {
       expect(toastError).toHaveBeenCalledWith('Failed to preview sync')
     })
+  })
+})
+
+describe('Sidebar → SourceCard unreadable source folder', () => {
+  test('explains a source folder it could not open instead of reporting zero skills', async () => {
+    // Arrange: the main process could not readdir ~/.agents/skills.
+    mockSourceGetStats.mockResolvedValue({
+      path: '/Users/test/.agents/skills',
+      skillCount: 0,
+      totalSize: '0 B',
+      isUnreadable: true,
+    })
+
+    // Act
+    const { screen } = await renderSourceCard()
+
+    // Assert: "0 skills" would send the user reinstalling skills they still have.
+    await expect
+      .element(
+        screen.getByText('Folder could not be read — check its permissions'),
+      )
+      .toBeInTheDocument()
+    expect(screen.getByText('0 skills').query()).toBeNull()
+  })
+
+  test('shows the skill count for a source folder it could read', async () => {
+    // Arrange: the default stats stub reports a readable folder.
+
+    // Act
+    const { screen } = await renderSourceCard()
+
+    // Assert: the warning must not replace the count on a healthy folder.
+    await expect.element(screen.getByText('2 skills')).toBeInTheDocument()
+    expect(
+      screen
+        .getByText('Folder could not be read — check its permissions')
+        .query(),
+    ).toBeNull()
   })
 })

--- a/src/renderer/src/components/sidebar/SourceCard.tsx
+++ b/src/renderer/src/components/sidebar/SourceCard.tsx
@@ -215,12 +215,19 @@ export const SourceCard = function SourceCard(): React.ReactElement {
           </div>
           <div className="hover:text-primary transition-colors">
             <p className="text-sm font-medium truncate">~/.agents/skills</p>
-            {sourceStats && (
-              <div className="flex gap-4 mt-2 text-xs text-muted-foreground">
-                <span>{sourceStats.skillCount} skills</span>
-                <span>{sourceStats.totalSize}</span>
-              </div>
-            )}
+            {sourceStats &&
+              (sourceStats.isUnreadable ? (
+                // A folder we could not open must never be reported as "0 skills" —
+                // that reads as "you have no skills" and sends users reinstalling.
+                <div className="mt-2 text-xs text-amber-300">
+                  Folder could not be read — check its permissions
+                </div>
+              ) : (
+                <div className="flex gap-4 mt-2 text-xs text-muted-foreground">
+                  <span>{sourceStats.skillCount} skills</span>
+                  <span>{sourceStats.totalSize}</span>
+                </div>
+              ))}
           </div>
         </CardContent>
       </Card>

--- a/src/renderer/src/components/sidebar/SourceCard.tsx
+++ b/src/renderer/src/components/sidebar/SourceCard.tsx
@@ -219,7 +219,10 @@ export const SourceCard = function SourceCard(): React.ReactElement {
               (sourceStats.isUnreadable ? (
                 // A folder we could not open must never be reported as "0 skills" —
                 // that reads as "you have no skills" and sends users reinstalling.
-                <div className="mt-2 text-xs text-amber-300">
+                // `text-amber-400` is DESIGN.md's needs-review status-text hue;
+                // the `text-amber-300` exception is only for badge text sitting
+                // on an amber tint, and this notice has no background.
+                <div className="mt-2 text-xs text-amber-400">
                   Folder could not be read — check its permissions
                 </div>
               ) : (

--- a/src/renderer/src/components/skills/SkillItem.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillItem.browser.test.tsx
@@ -1,6 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { Provider } from 'react-redux'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
@@ -1248,5 +1248,37 @@ describe('SkillItem protection', () => {
         screen.getByRole('button', { name: /^Unlink task from agent$/i }),
       )
       .toBeInTheDocument()
+  })
+})
+
+describe('SkillItem unreadable badge', () => {
+  test('marks a source skill whose SKILL.md could not be read instead of hiding the row', async () => {
+    // Arrange: the scan kept the row and flagged it, rather than dropping it.
+    const unreadableSkill = makeSkill({ isUnreadable: true })
+
+    // Act
+    const { screen } = await renderSkillItem(unreadableSkill)
+
+    // Assert: the row is present AND says why it could not be confirmed, so a
+    // permissions problem never reads as the skill having been deleted.
+    await expect
+      .element(screen.getByTestId('skill-unreadable-badge-task'))
+      .toBeInTheDocument()
+    await expect
+      .element(
+        screen.getByLabelText('Unreadable skill — SKILL.md could not be read'),
+      )
+      .toBeInTheDocument()
+  })
+
+  test('leaves a skill with a readable SKILL.md unbadged', async () => {
+    // Arrange
+    const readableSkill = makeSkill()
+
+    // Act
+    const { screen } = await renderSkillItem(readableSkill)
+
+    // Assert: the amber warning must not appear on every healthy row.
+    expect(screen.getByTestId('skill-unreadable-badge-task').query()).toBeNull()
   })
 })

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -280,6 +280,14 @@ const GlobalStatusBadges = function GlobalStatusBadges({
   )
 }
 
+/**
+ * Shared amber pill styling for the three "this row needs a look" markers
+ * (inaccessible link, orphan, unreadable). One string so the badges cannot
+ * drift apart visually when one of them is restyled.
+ */
+const AMBER_STATUS_BADGE_CLASS =
+  'inline-flex items-center rounded-md border border-amber-400/50 bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-amber-300 shrink-0'
+
 interface SkillTitleRowProps {
   skill: Skill
   isLinked: boolean
@@ -340,7 +348,7 @@ const SkillTitleRow = function SkillTitleRow({
           <span
             // react-doctor-disable-next-line react-doctor/prefer-tag-over-role -- composed "inaccessible" text status badge collapsed to one labelled graphic via role="img"+aria-label. <img> needs a src and cannot contain the badge text.
             role="img"
-            className="inline-flex items-center rounded-md border border-amber-400/50 bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-amber-300 shrink-0"
+            className={AMBER_STATUS_BADGE_CLASS}
             aria-label="Inaccessible link - manual review required"
             title="Target cannot be verified - review this link before removing it"
           >
@@ -352,7 +360,7 @@ const SkillTitleRow = function SkillTitleRow({
             // react-doctor-disable-next-line react-doctor/prefer-tag-over-role -- composed "orphan" text status badge collapsed to one labelled graphic via role="img"+aria-label. <img> needs a src and cannot contain the badge text.
             role="img"
             data-testid={`skill-orphan-badge-${skill.name}`}
-            className="inline-flex items-center rounded-md border border-amber-400/50 bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-amber-300 shrink-0"
+            className={AMBER_STATUS_BADGE_CLASS}
             aria-label="Orphan skill — source directory is missing"
             title="Source directory is missing — use Cleanup to remove the dangling symlinks"
           >
@@ -364,7 +372,7 @@ const SkillTitleRow = function SkillTitleRow({
             // react-doctor-disable-next-line react-doctor/prefer-tag-over-role -- composed "unreadable" text status badge collapsed to one labelled graphic via role="img"+aria-label. <img> needs a src and cannot contain the badge text.
             role="img"
             data-testid={`skill-unreadable-badge-${skill.name}`}
-            className="inline-flex items-center rounded-md border border-amber-400/50 bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-amber-300 shrink-0"
+            className={AMBER_STATUS_BADGE_CLASS}
             aria-label="Unreadable skill — SKILL.md could not be read"
             title="SKILL.md could not be read, so this folder cannot be confirmed as a skill — check its permissions"
           >
@@ -657,15 +665,11 @@ export const SkillItem = function SkillItem({
             !didPartialFail &&
               isInaccessibleSkill &&
               'border-l-2 border-l-amber-400/60',
-            // Orphan accent — mutually exclusive with linked/local rows by
-            // definition, so the order below is purely for the partial-fail override.
+            // Orphan and unreadable share one amber "needs a look" accent. Orphan
+            // is mutually exclusive with linked/local rows by definition, so the
+            // order here is purely for the partial-fail override.
             !didPartialFail &&
-              skill.isOrphan &&
-              'border-l-2 border-l-amber-400/60',
-            // Unreadable accent — same amber "needs a look" treatment as orphan,
-            // so the row that kept its place still reads as unresolved.
-            !didPartialFail &&
-              skill.isUnreadable &&
+              (skill.isOrphan || skill.isUnreadable) &&
               'border-l-2 border-l-amber-400/60',
             // In-flight fade while the row is part of an active bulk op.
             isInFlight && 'opacity-50 duration-150',

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -359,6 +359,18 @@ const SkillTitleRow = function SkillTitleRow({
             orphan
           </span>
         )}
+        {skill.isUnreadable && (
+          <span
+            // react-doctor-disable-next-line react-doctor/prefer-tag-over-role -- composed "unreadable" text status badge collapsed to one labelled graphic via role="img"+aria-label. <img> needs a src and cannot contain the badge text.
+            role="img"
+            data-testid={`skill-unreadable-badge-${skill.name}`}
+            className="inline-flex items-center rounded-md border border-amber-400/50 bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-amber-300 shrink-0"
+            aria-label="Unreadable skill — SKILL.md could not be read"
+            title="SKILL.md could not be read, so this folder cannot be confirmed as a skill — check its permissions"
+          >
+            unreadable
+          </span>
+        )}
       </h3>
       {(showAddButton || showGStackBadge) && (
         <div className="flex shrink-0 items-center gap-1">
@@ -649,6 +661,11 @@ export const SkillItem = function SkillItem({
             // definition, so the order below is purely for the partial-fail override.
             !didPartialFail &&
               skill.isOrphan &&
+              'border-l-2 border-l-amber-400/60',
+            // Unreadable accent — same amber "needs a look" treatment as orphan,
+            // so the row that kept its place still reads as unresolved.
+            !didPartialFail &&
+              skill.isUnreadable &&
               'border-l-2 border-l-amber-400/60',
             // In-flight fade while the row is part of an active bulk op.
             isInFlight && 'opacity-50 duration-150',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -301,6 +301,14 @@ export interface Skill {
    * to gate delete/unlink buttons (see issue #127, cleanup flow #71).
    */
   isOrphan: boolean
+  /**
+   * `true` when the skill's `SKILL.md` could not be probed (`EACCES`, `EIO`,
+   * `ELOOP` — anything but `ENOENT`/`ENOTDIR`), so the app cannot confirm the
+   * directory is a real skill. The row is rendered anyway: dropping it made a
+   * permissions problem look exactly like the user deleting the skill.
+   * Set by `scanSourceSkills()` in `src/main/services/skillScanner.ts`.
+   */
+  isUnreadable?: boolean
   /** Short source identifier in owner/repo format. @example "vercel-labs/skills" */
   source?: RepositoryId
   /** Full URL to the source repository. @example "https://github.com/vercel-labs/skills.git" */
@@ -492,6 +500,13 @@ export interface SourceStats {
   totalSize: HumanFileSize
   /** ISO 8601 last-modified timestamp. @example "2026-04-10T08:00:00.000Z" */
   lastModified: IsoTimestamp
+  /**
+   * `true` when `~/.agents/skills/` itself could not be read, which makes the
+   * `skillCount: 0` above a placeholder rather than a fact. The sidebar shows
+   * the failure instead of the count so an unreadable folder is never
+   * presented as an empty one.
+   */
+  isUnreadable?: boolean
 }
 
 /**


### PR DESCRIPTION
Closes TODO **P2. Inaccessible source skills must not vanish silently from the list**.

## The bug

Two swallows made a filesystem problem look like the user having deleted things.

1. `isValidSkillDir` ended in `catch { return false }`, so `EACCES` / `EIO` / `ELOOP` on a skill's `SKILL.md` read as "not a valid skill directory". `listValidSourceSkillDirs` dropped the entry and **the skill disappeared from the list with nothing shown to explain why**.
2. One level up, any `readdir` failure on `~/.agents/skills/` returned `[]` — **indistinguishable from "no skills installed"**. The sidebar then said "0 skills", which is the reading most likely to send someone reinstalling skills they still have.

This is the source-directory counterpart of the already-fixed P1 *"Inaccessible symlink targets must not be treated as cleanup-ready broken links"*. The repo settled the rule there: only `ENOENT` and `ENOTDIR` prove a path cannot exist. This applies the same rule one directory up.

## The fix

`probeSkillDir` (`skillValidation.ts`) returns `valid | not-a-skill | unreadable`. `listValidSourceSkillDirs` became `listSourceSkillDirs`, returning `{ status: 'listed', entries } | { status: 'unreadable' }`; kept entries carry `isUnreadable`, and the unreadable case is logged with its errno rather than swallowed.

Three surfaces:

- **A source skill whose `SKILL.md` cannot be probed stays in the list**, behind an amber `unreadable` badge that mirrors the existing `orphan` badge (same border accent, same `role="img"` + `aria-label` shape).
- **An unreadable source directory says so** in `SourceCard` — "Folder could not be read — check its permissions" — instead of rendering "0 skills".
- `getSourceStats.skillCount` counts what the list renders, unreadable rows included, so the sidebar and the list cannot disagree.

## Two decisions worth reviewing

**`isValidSkillDir` kept its exact boolean behaviour** and became a one-line wrapper over `probeSkillDir`. Its other four callers — `ipc/skills.ts:167`, `ipc/skills.ts:716`, `skillScanner.ts:486`, `trashService.ts:275` — are all guards in front of a destructive or fanning-out action, and for them an unreadable probe must stay fail-closed. Widening the shared function would have forced "fail-closed" to be re-stated at each of those four sites instead of inherited from one place. A test pins that fail-closed behaviour so a future refactor cannot quietly open it.

**Sync deliberately does not fan out an unreadable skill** (`syncableSourceSkills` in `syncService.ts`). Creating agent symlinks for a directory we cannot confirm is a skill is an action on a guess. That is now a stated behaviour with a test, rather than the accidental side effect of a swallowed error. The degrade-to-empty on an unreadable source directory is preserved at all four production call sites, but written explicitly at each.

## Not covered

The outer `catch` in `getSourceStats` still returns zeros with no flag. It fires only if `stat(SOURCE_DIR)` or the recursive size walk rejects, which an `EACCES` on the directory does not cause (`readdir` fails first and is now classified). Left alone as a separate pre-existing swallow rather than widened on a guess.

## Review passes already run

`/open-code-review-delegate` ran before this reached CodeRabbit and found five things, all fixed in `0f55d36`:

1. **Real defect:** inserting `syncableSourceSkills` between `filterAgentsByOption`'s JSDoc and its declaration orphaned that doc — the guard function lost its documentation and the block attached to the wrong symbol.
2. **Dead code:** `SourceSkillDirListing` carried a `code` field no caller read. Removed; the errno now goes to `console.warn` instead, which suits a TODO about a failure being *silent* better than an unread field did.
3. `let entries` was an evolving `let`; annotated `Dirent[]`.
4. Two `import` statements from the same module folded into one.
5. **Duplicate code:** the amber pill `className` was copy-pasted three times (inaccessible, orphan, unreadable). Extracted to `AMBER_STATUS_BADGE_CLASS`, and the two identical border-accent branches merged into one condition.

## Test plan

- `pnpm validate` — exit 0, **197 files / 2582 tests** (re-run after the commit, since lint-staged reformats)
- `pnpm test:e2e` — **84 passed**
- Coverage, re-measured on the current HEAD `b9fc2cc` (not on the first commit): `dirScanner.ts`, `skillValidation.ts`, `syncService.ts`, **and `skillScanner.ts`** each have **0 uncovered statements and 0 partial branches** (verified by reading `coverage-final.json`'s `statementMap`/`s` and `branchMap`/`b`, not the summary table). The first measurement predated the OCR commit and missed one gap — see M13.
- **New file** `dirScanner.test.ts` (9 tests) — the TODO noted `dirScanner.ts` had no test file.
- **12 production-only mutations run, each killed by the intended test** — including *over-eager* mutations for the guard tests, which a removal mutation cannot catch:
  - M1 `unreadable` collapses back to `not-a-skill` → kills the two "keeps a skill…" tests
  - M2 every probe failure becomes `unreadable` → kills "drops a directory that has no SKILL.md"
  - M3 `readdir` failure always degrades to empty → kills both unreadable-directory tests
  - M4 a missing source dir reports as unreadable → kills "reports an empty list when the source directory does not exist yet"
  - M5 sync stops filtering unreadable skills → kills "refuses to fan out…"
  - M6 `isValidSkillDir` accepts an unprovable dir → kills the fail-closed test
  - M7 / M8 scanner and stats hardcode `isUnreadable: false` → kill the corresponding flag tests
  - M9 / M10 badge never / always renders → kill both `SkillItem` tests
  - M11 / M12 `SourceCard` always / never shows the notice → kill both `SourceCard` tests
  - M13 `listSourceSkillDirs` rethrows on `EACCES` instead of returning `{ status: 'unreadable' }` → kills the new `scanSkills` degradation test
  - M14 drop the `.catch(() => null)` on `stat(SOURCE_DIR)` → kills the new both-EACCES `getSourceStats` test

The third commit exists because of M13. Re-running coverage introspection on the post-OCR HEAD showed `scanSourceSkills`'s `listing.status === 'listed' ? listing.entries : []` had **0 hits on the failure arm** — the feature's own degradation path was never exercised through `scanSkills`. One test now covers it, and asserts the agent-local skills survive so an empty result cannot be a false pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 読み取り不能なソースフォルダーやスキルを一覧に保持し、状態を表示するようになりました。
  - ソースフォルダーには権限警告、スキルには未読バッジと説明を表示します。
  - 読み取り不能な項目は同期対象から除外されます。

- **バグ修正**
  - 読み取り不能な項目を「0件」や一覧からの欠落として誤表示しないよう改善しました。
  - 一覧の表示件数と統計情報が一致するよう改善しました。
  - 読み取り不能なフォルダーでは、正確でないスキル数や容量を表示しないようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## Review round 2 (CodeRabbit, `f7fceb6`)

**Fixed — `getSourceStats` dropped the unreadable flag when `stat` also failed.** The outer `catch` had been written off as unreachable because `readdir` fails before `stat` does. That holds when the source directory itself is mode `000` (`stat` only needs `x` on the *parent*), and it does **not** hold when `~/.agents` is not traversable: both reject, `Promise.all` rejects, and the catch returned zeros with no flag — the honest-looking "0 skills" this PR exists to stop showing. `stat` is now settled with `.catch(() => null)`; `listSourceSkillDirs` and `calculateDirectorySize` were already total, so the `try`/`catch` is **deleted** rather than left as unreachable code and `getSourceStats` can no longer throw. New test covers both-EACCES; M14 proves it non-vacuous. `TODOS.md` entry #8 corrected — it had recorded this as a deferred pre-existing swallow.

**Fixed — `SourceCard` notice now `text-amber-400`** per DESIGN.md:84 (needs-review *status text*). No tint background added: DESIGN.md:86 scopes fills to badges and chips, and this is a full-width sentence.

**Declined — `SkillItem`'s `text-amber-300`.** DESIGN.md:92 names it as the explicit exception ("badge text on a denser amber tint"), it sits on `bg-amber-500/15`, and it is the pre-existing styling of the `inaccessible` and `orphan` badges that an earlier review pass asked be unified into one `AMBER_STATUS_BADGE_CLASS`.