### PR TITLE
fix: address persistence warning review feedback

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1226,7 +1226,7 @@ Deferred items captured during planning. Pick up when scope and bandwidth allow.
 
 **Finding:** `createStorageMiddleware` defaults to `createSafeLocalStorage()`, whose `setItem` catches its own throw and only `console.error`s (`dist/index.mjs:147-155`), and which returns `createNoopStorage()` outright when `localStorage` is unavailable (`:132-135`). The middleware's `onError(error, 'save')` hook is therefore unreachable for a failed write — `saveToStorage`'s try/catch never fires because the adapter never rethrows. Locked skills, bookmarks, theme and dashboard layout all stop persisting with nothing on screen to say so.
 
-**Fix:** `createReportingLocalStorage` (`src/renderer/src/redux/reportingLocalStorage.ts`) is passed as the middleware's `storage` option and reports the first rejected write through a non-expiring `toast.error`, latched in memory so the debounced repeat does not spam. Reads and removes keep the lenient behavior of the default adapter.
+**Fix:** `createReportingLocalStorage` (`src/renderer/src/redux/reportingLocalStorage.ts`) is passed as the middleware's `storage` option. Rejected writes are retried until `warnPersistedStateNotSaved()` successfully delivers the non-expiring `toast.error`; only the first successfully delivered rejection is latched and reported, so debounced repeats do not spam. Reads and removes keep the lenient behavior of the default adapter.
 
 ## skill-lock prune eng-review follow-ups (2026-09-06)
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -1220,13 +1220,13 @@ Deferred items captured during planning. Pick up when scope and bandwidth allow.
 
 **Why deferred:** User explicitly chose "manual lock only" — deferred until there is evidence of demand.
 
-### P3. Protection state persistence failure in private browsing
+### ~~P3. Protection state persistence failure in private browsing~~
 
-**Context:** `redux-persist` writes to `localStorage`. Private/incognito mode and certain browser-based Electron sandboxes can silently cap or reject localStorage writes. Protected skills would be lost on app restart.
+**Status:** FIXED (PR F). Was: deferred as a private-mode-only edge case. Two corrections to the original entry: this repo does not use `redux-persist` (it uses `@laststance/redux-storage-middleware`), and the trigger is not specific to private browsing — any rejected `localStorage.setItem`, `QuotaExceededError` included, loses the same state just as silently.
 
-**Fix direction:** Detect localStorage write failure in `redux-persist`'s storage adapter and show a one-time warning: "Skill lock list could not be saved — it will be lost when the app closes."
+**Finding:** `createStorageMiddleware` defaults to `createSafeLocalStorage()`, whose `setItem` catches its own throw and only `console.error`s (`dist/index.mjs:147-155`), and which returns `createNoopStorage()` outright when `localStorage` is unavailable (`:132-135`). The middleware's `onError(error, 'save')` hook is therefore unreachable for a failed write — `saveToStorage`'s try/catch never fires because the adapter never rethrows. Locked skills, bookmarks, theme and dashboard layout all stop persisting with nothing on screen to say so.
 
-**Why deferred:** Electron with a real user profile almost always has a working localStorage. Private mode is not a primary Electron use case.
+**Fix:** `createReportingLocalStorage` (`src/renderer/src/redux/reportingLocalStorage.ts`) is passed as the middleware's `storage` option and reports the first rejected write through a non-expiring `toast.error`, latched in memory so the debounced repeat does not spam. Reads and removes keep the lenient behavior of the default adapter.
 
 ## skill-lock prune eng-review follow-ups (2026-09-06)
 

--- a/src/renderer/src/redux/reportingLocalStorage.test.ts
+++ b/src/renderer/src/redux/reportingLocalStorage.test.ts
@@ -29,7 +29,7 @@ describe('createReportingLocalStorage', () => {
       },
       removeItem: () => {},
     })
-    const onWriteFailure = vi.fn()
+    const onWriteFailure = vi.fn(() => true)
     const storage = createReportingLocalStorage(onWriteFailure)
 
     // Act
@@ -51,7 +51,7 @@ describe('createReportingLocalStorage', () => {
       },
       removeItem: () => {},
     })
-    const onWriteFailure = vi.fn()
+    const onWriteFailure = vi.fn(() => true)
     const storage = createReportingLocalStorage(onWriteFailure)
 
     // Act
@@ -71,7 +71,7 @@ describe('createReportingLocalStorage', () => {
       setItem: () => {},
       removeItem: () => {},
     })
-    const onWriteFailure = vi.fn()
+    const onWriteFailure = vi.fn(() => true)
     const storage = createReportingLocalStorage(onWriteFailure)
 
     // Act
@@ -91,7 +91,7 @@ describe('createReportingLocalStorage', () => {
         throw new Error('SecurityError: storage is disabled')
       },
     })
-    const onWriteFailure = vi.fn()
+    const onWriteFailure = vi.fn(() => true)
     const storage = createReportingLocalStorage(onWriteFailure)
 
     // Act
@@ -99,6 +99,31 @@ describe('createReportingLocalStorage', () => {
 
     // Assert
     expect(onWriteFailure).toHaveBeenCalledTimes(0)
+  })
+
+  test('keeps the warning unspent when the hydration write fails before any toast surface exists', () => {
+    // Arrange — the middleware writes once, undebounced, during hydration; a
+    // warning published then reaches nobody, so the adapter must try again.
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => {
+        throw new DOMException('quota', 'QuotaExceededError')
+      },
+      removeItem: () => {},
+    })
+    const onWriteFailure = vi
+      .fn<(error: unknown) => boolean>()
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true)
+    const storage = createReportingLocalStorage(onWriteFailure)
+
+    // Act — the hydration migration write, then the first debounced save.
+    storage.setItem('skills-desktop-state', '{"theme":{"mode":"dark"}}')
+    storage.setItem('skills-desktop-state', '{"protect":{"items":["a"]}}')
+    storage.setItem('skills-desktop-state', '{"protect":{"items":["a","b"]}}')
+
+    // Assert — retried after the undelivered attempt, then latched.
+    expect(onWriteFailure).toHaveBeenCalledTimes(2)
   })
 
   test('warns again in a fresh app run after the previous run already warned', () => {
@@ -110,8 +135,8 @@ describe('createReportingLocalStorage', () => {
       },
       removeItem: () => {},
     })
-    const firstRun = vi.fn()
-    const secondRun = vi.fn()
+    const firstRun = vi.fn(() => true)
+    const secondRun = vi.fn(() => true)
 
     // Act
     createReportingLocalStorage(firstRun).setItem('skills-desktop-state', '{}')

--- a/src/renderer/src/redux/reportingLocalStorage.test.ts
+++ b/src/renderer/src/redux/reportingLocalStorage.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { createReportingLocalStorage } from './reportingLocalStorage'
+
+/**
+ * Guards the only signal a user gets that their locked skills, bookmarks and
+ * theme have stopped persisting. The library's own adapter swallows a rejected
+ * write into a console line, so a regression here restores the exact silence
+ * this adapter exists to break.
+ */
+describe('createReportingLocalStorage', () => {
+  beforeEach(() => {
+    // The adapter console.errors every rejected write; silence it so a failing
+    // assertion is not buried under expected noise.
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  test('warns the user once no matter how many debounced saves localStorage rejects', () => {
+    // Arrange
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => {
+        throw new DOMException('quota', 'QuotaExceededError')
+      },
+      removeItem: () => {},
+    })
+    const onWriteFailure = vi.fn()
+    const storage = createReportingLocalStorage(onWriteFailure)
+
+    // Act
+    storage.setItem('skills-desktop-state', '{"protect":{"items":["a"]}}')
+    storage.setItem('skills-desktop-state', '{"protect":{"items":["a","b"]}}')
+    storage.setItem('skills-desktop-state', '{"protect":{"items":[]}}')
+
+    // Assert
+    expect(onWriteFailure).toHaveBeenCalledTimes(1)
+  })
+
+  test('stays silent while localStorage accepts the persisted state', () => {
+    // Arrange
+    const written: Record<string, string> = {}
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => written[key] ?? null,
+      setItem: (key: string, value: string) => {
+        written[key] = value
+      },
+      removeItem: () => {},
+    })
+    const onWriteFailure = vi.fn()
+    const storage = createReportingLocalStorage(onWriteFailure)
+
+    // Act
+    storage.setItem('skills-desktop-state', '{"theme":{"mode":"dark"}}')
+
+    // Assert
+    expect(written['skills-desktop-state']).toBe('{"theme":{"mode":"dark"}}')
+    expect(onWriteFailure).toHaveBeenCalledTimes(0)
+  })
+
+  test('boots from initial state instead of throwing when localStorage cannot be read', () => {
+    // Arrange
+    vi.stubGlobal('localStorage', {
+      getItem: () => {
+        throw new Error('SecurityError: storage is disabled')
+      },
+      setItem: () => {},
+      removeItem: () => {},
+    })
+    const onWriteFailure = vi.fn()
+    const storage = createReportingLocalStorage(onWriteFailure)
+
+    // Act
+    const loaded = storage.getItem('skills-desktop-state')
+
+    // Assert
+    expect(loaded).toBe(null)
+    expect(onWriteFailure).toHaveBeenCalledTimes(0)
+  })
+
+  test('does not warn about lost data when clearing persisted state fails', () => {
+    // Arrange
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {
+        throw new Error('SecurityError: storage is disabled')
+      },
+    })
+    const onWriteFailure = vi.fn()
+    const storage = createReportingLocalStorage(onWriteFailure)
+
+    // Act
+    storage.removeItem('skills-desktop-state')
+
+    // Assert
+    expect(onWriteFailure).toHaveBeenCalledTimes(0)
+  })
+
+  test('warns again in a fresh app run after the previous run already warned', () => {
+    // Arrange
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => {
+        throw new DOMException('quota', 'QuotaExceededError')
+      },
+      removeItem: () => {},
+    })
+    const firstRun = vi.fn()
+    const secondRun = vi.fn()
+
+    // Act
+    createReportingLocalStorage(firstRun).setItem('skills-desktop-state', '{}')
+    createReportingLocalStorage(secondRun).setItem('skills-desktop-state', '{}')
+
+    // Assert
+    expect(firstRun).toHaveBeenCalledTimes(1)
+    expect(secondRun).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/redux/reportingLocalStorage.ts
+++ b/src/renderer/src/redux/reportingLocalStorage.ts
@@ -7,17 +7,20 @@ import type { SyncStorage } from '@laststance/redux-storage-middleware'
  * when `localStorage` is unavailable, so a user whose locked skills, bookmarks
  * and theme have stopped persisting learns about it only after a restart.
  * Built once by the store and handed to `createStorageMiddleware`.
- * @param onWriteFailure - Called at most once per app run, on the first rejected write.
+ * @param reportWriteFailure - Called on every rejected write until it returns `true`, i.e. until the warning actually reached the user.
  * @returns A {@link SyncStorage} adapter that reads and removes exactly as leniently as the default one.
  * @example
- * createReportingLocalStorage(() => toast.error('Settings could not be saved'))
+ * createReportingLocalStorage(() => { toast.error('Settings could not be saved'); return true })
  */
 export function createReportingLocalStorage(
-  onWriteFailure: (error: unknown) => void,
+  reportWriteFailure: (error: unknown) => boolean,
 ): SyncStorage {
-  // In-memory latch, deliberately not persisted: saves are debounced (300ms by
-  // default) and repeat on every state change, so without it a broken
-  // localStorage would fire one warning per edit for the whole session.
+  // Latched on DELIVERY, not on failure, and deliberately not persisted. Saves
+  // are debounced (300ms by default) and repeat on every state change, so a
+  // per-failure latch would fire one warning per edit — but the middleware also
+  // performs one UNDEBOUNCED write while hydrating (the persist-version
+  // migration), long before React has mounted a toast surface. Spending the
+  // latch there would swallow the only warning the user ever gets.
   let reported = false
 
   return {
@@ -37,16 +40,20 @@ export function createReportingLocalStorage(
         globalThis.localStorage.setItem(key, value)
       } catch (error) {
         // Private mode, a disabled storage partition and a quota overflow all
-        // surface here as a throwing `setItem`, so the write path is the only
-        // trigger needed. A construction-time availability probe would fire
-        // before the Toaster subscribes and the warning would be dropped.
+        // surface here — either as a throwing `setItem` or as a `localStorage`
+        // that is not there to call — so the write path is the only trigger
+        // needed. A construction-time availability probe would run before any
+        // toast surface exists and the warning would be dropped.
+        //
+        // Logged on every rejection, unlike the user-facing warning: the
+        // console line is the diagnostic trail, and matches what the library's
+        // own adapter does today.
         console.error(
           '[redux] persisting app state to localStorage failed',
           error,
         )
         if (reported) return
-        reported = true
-        onWriteFailure(error)
+        reported = reportWriteFailure(error)
       }
     },
     removeItem: (key) => {

--- a/src/renderer/src/redux/reportingLocalStorage.ts
+++ b/src/renderer/src/redux/reportingLocalStorage.ts
@@ -1,0 +1,61 @@
+import type { SyncStorage } from '@laststance/redux-storage-middleware'
+
+/**
+ * Wrap `localStorage` so a rejected persist write is reported once instead of vanishing.
+ * Exists because the middleware's own adapter swallows every `setItem` throw
+ * (`createSafeStorage`, `dist/index.mjs:147-155`) and degrades to a no-op store
+ * when `localStorage` is unavailable, so a user whose locked skills, bookmarks
+ * and theme have stopped persisting learns about it only after a restart.
+ * Built once by the store and handed to `createStorageMiddleware`.
+ * @param onWriteFailure - Called at most once per app run, on the first rejected write.
+ * @returns A {@link SyncStorage} adapter that reads and removes exactly as leniently as the default one.
+ * @example
+ * createReportingLocalStorage(() => toast.error('Settings could not be saved'))
+ */
+export function createReportingLocalStorage(
+  onWriteFailure: (error: unknown) => void,
+): SyncStorage {
+  // In-memory latch, deliberately not persisted: saves are debounced (300ms by
+  // default) and repeat on every state change, so without it a broken
+  // localStorage would fire one warning per edit for the whole session.
+  let reported = false
+
+  return {
+    getItem: (key) => {
+      try {
+        return globalThis.localStorage.getItem(key)
+      } catch {
+        // Same degradation the default adapter already has: an unreadable
+        // store is indistinguishable from an empty one and the app boots on
+        // initialState. Not reported — nothing has been lost yet, and the next
+        // write reports for real if storage is genuinely broken.
+        return null
+      }
+    },
+    setItem: (key, value) => {
+      try {
+        globalThis.localStorage.setItem(key, value)
+      } catch (error) {
+        // Private mode, a disabled storage partition and a quota overflow all
+        // surface here as a throwing `setItem`, so the write path is the only
+        // trigger needed. A construction-time availability probe would fire
+        // before the Toaster subscribes and the warning would be dropped.
+        console.error(
+          '[redux] persisting app state to localStorage failed',
+          error,
+        )
+        if (reported) return
+        reported = true
+        onWriteFailure(error)
+      }
+    },
+    removeItem: (key) => {
+      try {
+        globalThis.localStorage.removeItem(key)
+      } catch {
+        // A failed remove leaves stale state behind, not lost state, so there
+        // is nothing to warn the user about.
+      }
+    },
+  }
+}

--- a/src/renderer/src/redux/store.ts
+++ b/src/renderer/src/redux/store.ts
@@ -54,14 +54,24 @@ type RootReducerState = ReturnType<typeof rootReducer>
 
 /**
  * Tell the user their persisted state is not reaching disk, once per app run.
- * Fires from {@link createReportingLocalStorage} the first time a debounced
- * save is rejected — private mode, a disabled storage partition, or a full
- * quota — because until then the failure is a console line nobody reads.
- * The copy names every persisted slice, not just locks: `slices` below covers
- * theme and bookmarks too, and all of them reset together.
- * @example warnPersistedStateNotSaved() // => a non-expiring error toast
+ * Fires from {@link createReportingLocalStorage} when a save is rejected —
+ * private mode, a disabled storage partition, or a full quota — because until
+ * then the failure is a console line nobody reads. The copy names every
+ * persisted slice, not just locks: `slices` below covers theme, bookmarks and
+ * dashboard too, and all of them reset together.
+ * @returns `true` once the toast has been published, so the adapter can latch; `false` while hydration is still running and nothing would be shown
+ * @example warnPersistedStateNotSaved() // => true, and a non-expiring error toast
  */
-function warnPersistedStateNotSaved(): void {
+function warnPersistedStateNotSaved(): boolean {
+  // The one undebounced write is the persist-version migration inside
+  // `rehydrate`, a microtask after this module evaluates — before React has
+  // rendered the Toaster, where a published toast is dropped on the floor.
+  // Reporting "not delivered" leaves the warning unspent for the next save,
+  // which is debounced by 300ms and therefore always lands after mount.
+  // Hydration that fails outright never flips this, but it also stops every
+  // save (`saveHandler` is gated on the hydrated state), so nothing goes unreported.
+  if (!storageApi.hasHydrated()) return false
+
   toast.error('Settings could not be saved', {
     description:
       'Locked skills, bookmarks and theme will reset when the app closes — local storage rejected the write.',
@@ -70,19 +80,23 @@ function warnPersistedStateNotSaved(): void {
     duration: Infinity,
     closeButton: true,
   })
+  return true
 }
 
-const { middleware: storageMiddleware, reducer } =
-  createStorageMiddleware<RootReducerState>({
-    rootReducer,
-    key: PERSIST_STORAGE_KEY,
-    slices: ['theme', 'bookmarks', 'protect', 'dashboard'],
-    version: PERSIST_STATE_VERSION,
-    migrate: migrateState,
-    // Replaces the library default, which console.errors a rejected write and
-    // returns a silent no-op store when localStorage is unavailable.
-    storage: createReportingLocalStorage(warnPersistedStateNotSaved),
-  })
+const {
+  middleware: storageMiddleware,
+  reducer,
+  api: storageApi,
+} = createStorageMiddleware<RootReducerState>({
+  rootReducer,
+  key: PERSIST_STORAGE_KEY,
+  slices: ['theme', 'bookmarks', 'protect', 'dashboard'],
+  version: PERSIST_STATE_VERSION,
+  migrate: migrateState,
+  // Replaces the library default, which console.errors a rejected write and
+  // returns a silent no-op store when localStorage is unavailable.
+  storage: createReportingLocalStorage(warnPersistedStateNotSaved),
+})
 
 export const store = configureStore({
   reducer,

--- a/src/renderer/src/redux/store.ts
+++ b/src/renderer/src/redux/store.ts
@@ -74,7 +74,7 @@ function warnPersistedStateNotSaved(): boolean {
 
   toast.error('Settings could not be saved', {
     description:
-      'Locked skills, bookmarks and theme will reset when the app closes — local storage rejected the write.',
+      'Locked skills, bookmarks, theme and dashboard will reset when the app closes — local storage rejected the write.',
     // Non-expiring with an explicit close button: this is the one warning the
     // user gets, and a 4-second auto-dismiss can be missed entirely.
     duration: Infinity,

--- a/src/renderer/src/redux/store.ts
+++ b/src/renderer/src/redux/store.ts
@@ -1,11 +1,13 @@
 import { createStorageMiddleware } from '@laststance/redux-storage-middleware'
 import { combineReducers, configureStore } from '@reduxjs/toolkit'
 import { setupListeners } from '@reduxjs/toolkit/query'
+import { toast } from 'sonner'
 
 import { PERSIST_STATE_VERSION, PERSIST_STORAGE_KEY } from '@/shared/constants'
 
 import { listenerMiddleware } from './listener'
 import { migrateState } from './migrations'
+import { createReportingLocalStorage } from './reportingLocalStorage'
 import activityReducer from './slices/activitySlice'
 import agentsReducer from './slices/agentsSlice'
 import bookmarkReducer from './slices/bookmarkSlice'
@@ -50,6 +52,26 @@ const rootReducer = combineReducers({
 
 type RootReducerState = ReturnType<typeof rootReducer>
 
+/**
+ * Tell the user their persisted state is not reaching disk, once per app run.
+ * Fires from {@link createReportingLocalStorage} the first time a debounced
+ * save is rejected — private mode, a disabled storage partition, or a full
+ * quota — because until then the failure is a console line nobody reads.
+ * The copy names every persisted slice, not just locks: `slices` below covers
+ * theme and bookmarks too, and all of them reset together.
+ * @example warnPersistedStateNotSaved() // => a non-expiring error toast
+ */
+function warnPersistedStateNotSaved(): void {
+  toast.error('Settings could not be saved', {
+    description:
+      'Locked skills, bookmarks and theme will reset when the app closes — local storage rejected the write.',
+    // Non-expiring with an explicit close button: this is the one warning the
+    // user gets, and a 4-second auto-dismiss can be missed entirely.
+    duration: Infinity,
+    closeButton: true,
+  })
+}
+
 const { middleware: storageMiddleware, reducer } =
   createStorageMiddleware<RootReducerState>({
     rootReducer,
@@ -57,6 +79,9 @@ const { middleware: storageMiddleware, reducer } =
     slices: ['theme', 'bookmarks', 'protect', 'dashboard'],
     version: PERSIST_STATE_VERSION,
     migrate: migrateState,
+    // Replaces the library default, which console.errors a rejected write and
+    // returns a silent no-op store when localStorage is unavailable.
+    storage: createReportingLocalStorage(warnPersistedStateNotSaved),
   })
 
 export const store = configureStore({


### PR DESCRIPTION
Follow-up fixes for #319.

This addresses the two actionable review comments:
- include dashboard state in the persisted-state warning, since it is persisted alongside locks, bookmarks, and theme;
- document that rejected writes are retried until `warnPersistedStateNotSaved()` successfully delivers the warning, and only the first delivered rejection is latched.

Validation:
- `pnpm test -- src/renderer/src/redux/reportingLocalStorage.test.ts src/renderer/src/redux/store.test.ts --run` (198 files, 2590 tests passed)
- `pnpm typecheck`
- `pnpm exec eslint src/renderer/src/redux/store.ts src/renderer/src/redux/reportingLocalStorage.ts`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - プライベートブラウジングを含む、localStorageへの保存が拒否された場合に、設定や保護状態が保存されなかったことをエラー通知でお知らせするようになりました。
  - 通知が正常に表示されるまで再試行し、同一セッション中の重複通知を防止します。
  - 保存以外の読み取り・削除エラーでは、従来どおりアプリの動作を妨げません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->