### PR TITLE
fix(protect): follow skill renames instead of silently unlocking

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1204,13 +1204,15 @@ Deferred items captured during planning. Pick up when scope and bandwidth allow.
 
 ## Skill deletion protection follow-ups (2026-06-16)
 
-### P2. Skill rename silently drops its lock
+### ~~P2. Skill rename silently drops its lock~~
 
-**Context:** `addProtection` / `removeProtection` store skill names. If a skill is renamed (source directory renamed on disk), the locked name is orphaned — the renamed skill appears unlocked. This is identical behavior to bookmarks, which have the same limitation.
+**Status:** FIXED (PR K). Two corrections to the original entry. First, "renamed on disk" understated the trigger: `Skill.name` is `SKILL.md` frontmatter `name:` falling back to the directory name (`metadataParser.ts:25`), so editing that one frontmatter line renames the skill just as effectively as `mv` does, and neither touches the directory's inode. Second, the deferral rested on "same accepted trade-off as bookmarks" — a false analogy. `BookmarkedSkill` (`shared/types.ts`) points at a remote `repo`/`url` and has no local path, so no stable local identity exists for it; `protect.items` names a local directory whose `Skill.filesystemIdentity` the scan already captures on every source row. Bookmarks genuinely cannot do this; locks always could.
 
-**Fix direction:** On skill rename, migrate the old name to the new name in `protect.items`. Requires a rename event in the scan result or a diffing pass after each fetch.
+**Finding:** locks were stored as bare names. A rename stranded the lock on a name nothing resolves to, and the renamed row came back unlocked — one unconfirmed bulk delete away from being gone, which is exactly what the lock exists to prevent.
 
-**Why deferred:** Skill rename is rare and the failure is silent-unlock (not silent-delete). The user discovers it naturally on their next interaction with the row. Same accepted trade-off as bookmarks.
+**Fix:** `protect.items` is now `ProtectedSkill[]` — `{ name, identity?: { dev, ino } }`. `ProtectButton` records the identity at lock time, and a `fetchSkills.fulfilled` handler in `protectSlice` follows any inode whose name changed and backfills identities for locks that have none (mirroring the same-action prune already in `uiSlice`). Reconciling against each scan rather than a rename event is deliberate: a rename made while the app is closed emits no event, and that is the common case. The `dev`+`ino` pair is narrower than the repo's `FilesystemEntryIdentity` on purpose — `ctimeMs`, which the destructive-delete guards compare to reject reused-inode replacements, is bumped by `rename(2)` itself. `PERSIST_STATE_VERSION` 4 → 5 wraps existing names; it cannot invent an inode, so upgraded locks stay identity-less until the first scan.
+
+**Known ceiling:** a recycled inode can move a lock onto a different skill. The failure direction is over-protection (an extra confirmation), never a silent unlock, and macOS/APFS does not reuse inode numbers in practice.
 
 ### P3. isLocal auto-protect
 

--- a/e2e/spec/delete-hidden-agents.e2e.ts
+++ b/e2e/spec/delete-hidden-agents.e2e.ts
@@ -154,7 +154,7 @@ test('hidden folder deletion keeps protected slots, visible agents, and shared s
   const folders = await stageHiddenFolders(isolatedHome, appWindow)
   await dispatchAction(appWindow, {
     type: 'protect/addProtection',
-    payload: folders.protectedName,
+    payload: { name: folders.protectedName },
   })
   await appWindow.getByRole('button', { name: 'Hidden agent actions' }).click()
   await appWindow

--- a/e2e/spec/regression.e2e.ts
+++ b/e2e/spec/regression.e2e.ts
@@ -1038,7 +1038,7 @@ test('protected cards explain why Delete is unavailable while unlocked cards rem
   await refreshSkillsState(appWindow)
   await dispatchAction(appWindow, {
     type: 'protect/addProtection',
-    payload: 'analyze-app',
+    payload: { name: 'analyze-app' },
   })
 
   // Act — isolate the protected row just as a user narrows a long skill list.

--- a/src/renderer/src/components/layout/MainContent.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.browser.test.tsx
@@ -2831,7 +2831,7 @@ describe('MainContent toolbar primary action guards', () => {
     store.dispatch(fetchSkills.fulfilled([protectedSkill], 'req-protected'))
     store.dispatch(enterBulkSelectMode())
     store.dispatch(toggleSelection(skillName))
-    store.dispatch(addProtection(skillName))
+    store.dispatch(addProtection({ name: skillName }))
 
     // Act
     await screen.getByRole('button', { name: 'Open bulk confirm' }).click()

--- a/src/renderer/src/components/sidebar/AgentDeleteDialog.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/AgentDeleteDialog.browser.test.tsx
@@ -185,7 +185,7 @@ describe('AgentDeleteDialog confirm action', () => {
     const { addProtection } =
       await import('@/renderer/src/redux/slices/protectSlice')
     store.dispatch(fetchSkills.fulfilled([protectedSkill], 'skills-request'))
-    store.dispatch(addProtection('protected-task'))
+    store.dispatch(addProtection({ name: 'protected-task' }))
 
     // Act
     await screen.getByRole('button', { name: /^Delete$/i }).click()

--- a/src/renderer/src/components/sidebar/AgentFoldersMenu.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/AgentFoldersMenu.browser.test.tsx
@@ -285,7 +285,7 @@ describe('Hidden agent folder deletion', () => {
       isOrphan: false,
     }
     store.dispatch(fetchSkills.fulfilled([protectedSkill], 'protected-skills'))
-    store.dispatch(addProtection('protected-task'))
+    store.dispatch(addProtection({ name: 'protected-task' }))
     mockRemoveAllFromAgent.mockResolvedValue({
       success: true,
       removedCount: 1,

--- a/src/renderer/src/components/skills/SkillItem.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillItem.browser.test.tsx
@@ -1103,6 +1103,21 @@ describe('SkillItem protection', () => {
     ])
   })
 
+  test('locks a row the scan captured no identity for without inventing one', async () => {
+    // Arrange — agent-linked symlinks and orphans reach the list with no
+    // `filesystemIdentity`; only `scanSourceSkills` records one.
+    const { screen, store } = await renderSkillItem(
+      makeSkill({ name: 'task', filesystemIdentity: undefined }),
+    )
+
+    // Act
+    await screen.getByRole('button', { name: /^Lock task$/i }).click()
+
+    // Assert — a name-only lock, exactly as before v5. Writing a placeholder
+    // inode here would bind the lock to a directory that was never scanned.
+    expect(store.getState().protect.items).toEqual([{ name: 'task' }])
+  })
+
   it('labels a protected skill and offers an Unlock action', async () => {
     // Arrange — dispatch addProtection before rendering so ProtectButton
     // receives isProtected=true and renders the Lock icon.

--- a/src/renderer/src/components/skills/SkillItem.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillItem.browser.test.tsx
@@ -1089,6 +1089,20 @@ describe('SkillItem protection', () => {
       .toBeInTheDocument()
   })
 
+  test('records the skill directory behind the lock so a later rename keeps it locked', async () => {
+    // Arrange — the row carries the identity `scanSourceSkills` captured.
+    const { screen, store } = await renderSkillItem(makeSkill({ name: 'task' }))
+
+    // Act
+    await screen.getByRole('button', { name: /^Lock task$/i }).click()
+
+    // Assert — locking by name alone is what stranded the lock on rename;
+    // the inode is captured now, not left to the next scan.
+    expect(store.getState().protect.items).toEqual([
+      { name: 'task', identity: { dev: 1, ino: 2 } },
+    ])
+  })
+
   it('labels a protected skill and offers an Unlock action', async () => {
     // Arrange — dispatch addProtection before rendering so ProtectButton
     // receives isProtected=true and renders the Lock icon.
@@ -1097,7 +1111,7 @@ describe('SkillItem protection', () => {
       await import('@/renderer/src/redux/slices/protectSlice')
 
     // Act
-    store.dispatch(addProtection('task'))
+    store.dispatch(addProtection({ name: 'task' }))
 
     // Assert — text makes protection scannable while the lock remains actionable.
     await expect
@@ -1115,7 +1129,7 @@ describe('SkillItem protection', () => {
       await import('@/renderer/src/redux/slices/protectSlice')
 
     // Act — protect the skill so the destructive action becomes unavailable.
-    store.dispatch(addProtection('task'))
+    store.dispatch(addProtection({ name: 'task' }))
 
     // Assert — keep the stable action slot visible, expose its ARIA state, and name why.
     const deleteButton = screen.getByRole('button', {
@@ -1130,7 +1144,7 @@ describe('SkillItem protection', () => {
     const { screen, store } = await renderSkillItem(makeSkill({ name: 'task' }))
     const { addProtection, removeProtection } =
       await import('@/renderer/src/redux/slices/protectSlice')
-    store.dispatch(addProtection('task'))
+    store.dispatch(addProtection({ name: 'task' }))
 
     // Act
     store.dispatch(removeProtection('task'))
@@ -1166,7 +1180,7 @@ describe('SkillItem protection', () => {
 
     // Act
     store.dispatch(selectAgent('cursor'))
-    store.dispatch(addProtection('task'))
+    store.dispatch(addProtection({ name: 'task' }))
 
     // Assert
     await expect
@@ -1202,7 +1216,7 @@ describe('SkillItem protection', () => {
 
     // Act
     store.dispatch(selectAgent('cursor'))
-    store.dispatch(addProtection('task'))
+    store.dispatch(addProtection({ name: 'task' }))
 
     // Assert
     await expect
@@ -1237,7 +1251,7 @@ describe('SkillItem protection', () => {
     const { addProtection, removeProtection } =
       await import('@/renderer/src/redux/slices/protectSlice')
     store.dispatch(selectAgent('cursor'))
-    store.dispatch(addProtection('task'))
+    store.dispatch(addProtection({ name: 'task' }))
 
     // Act
     store.dispatch(removeProtection('task'))

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -90,6 +90,12 @@ declare global {
 
 interface ProtectButtonProps {
   skillName: SkillName
+  /**
+   * Scan-time identity of the skill directory, stored with the lock so a later
+   * rename can be followed. `undefined` for rows the scan had none for (agent-only
+   * links, orphans) — those locks stay name-only, exactly as before.
+   */
+  identity: Skill['filesystemIdentity']
   /** Whether the bookmark button is visible (affects horizontal positioning). */
   showBookmark: boolean
   /** Whether an X button (unlink or delete) is visible (affects positioning). */
@@ -99,13 +105,14 @@ interface ProtectButtonProps {
 /**
  * Lock / unlock toggle shown on every skill row. Manages its own Redux state
  * so the parent SkillItem only needs `isProtected` for status and action guards.
- * @param props - Skill name, bookmark visibility, and X-button visibility for positioning.
+ * @param props - Skill name, its filesystem identity, and the sibling-button flags used for positioning.
  * @returns Tooltip-wrapped lock icon button that dispatches protect actions.
  * @example
- * <ProtectButton skillName="task" showBookmark={true} hasXButton={false} />
+ * <ProtectButton skillName="task" identity={skill.filesystemIdentity} showBookmark={true} hasXButton={false} />
  */
 const ProtectButton = function ProtectButton({
   skillName,
+  identity,
   showBookmark,
   hasXButton,
 }: ProtectButtonProps): React.ReactElement {
@@ -117,7 +124,15 @@ const ProtectButton = function ProtectButton({
   const handleToggle = (e: React.MouseEvent): void => {
     e.stopPropagation()
     dispatch(
-      isProtected ? removeProtection(skillName) : addProtection(skillName),
+      isProtected
+        ? removeProtection(skillName)
+        : // Recorded at lock time, not left to the next scan: the identity the
+          // user is locking is the one on screen right now, and a rename before
+          // the next `fetchSkills` would otherwise slip through unfollowed.
+          addProtection({
+            name: skillName,
+            identity: identity && { dev: identity.dev, ino: identity.ino },
+          }),
     )
   }
 
@@ -684,6 +699,7 @@ export const SkillItem = function SkillItem({
             protectButton={
               <ProtectButton
                 skillName={skill.name}
+                identity={skill.filesystemIdentity}
                 showBookmark={showBookmark}
                 hasXButton={showUnlinkButtonBase || showDeleteButtonBase}
               />

--- a/src/renderer/src/redux/migrations.test.ts
+++ b/src/renderer/src/redux/migrations.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, test } from 'vitest'
 
 import { WIDGET_REGISTRY } from '@/renderer/src/components/dashboard/widgets/registry'
 import { COLOR_PRESET_CHROMA, PERSIST_STATE_VERSION } from '@/shared/constants'
@@ -33,6 +33,22 @@ type LegacyTheme = ThemeState & {
  *
  * @vitest-environment happy-dom
  */
+
+/**
+ * A theme slice already on the current schema — used by the v4 → v5 tests to
+ * prove the protect migration never touches its neighbours.
+ * @returns Current-schema ThemeState fixture
+ * @example makeCurrentTheme() // => { hue: 195, chroma: ..., mode: 'dark', ... }
+ */
+function makeCurrentTheme() {
+  return {
+    hue: 195,
+    chroma: COLOR_PRESET_CHROMA,
+    mode: 'dark' as const,
+    modePreference: 'dark' as const,
+    preset: 'cyan' as const,
+  }
+}
 
 describe('migrateState — v0 → v1 correctness', () => {
   it('keeps a known preset in full color when the legacy presetType is missing', () => {
@@ -714,6 +730,76 @@ describe('V4_WIDGET_MIN_SIZES drift guard', () => {
         `WIDGET_REGISTRY['${type}'].minSize is missing — bump migrations or registry`,
       ).toEqual(min)
     }
+  })
+})
+
+describe('migrateState — v4 → v5 protect lock records', () => {
+  /**
+   * v4 persisted bare skill names, so renaming a skill stranded its lock on a
+   * name nothing resolves to and the renamed row came back unlocked — one
+   * unconfirmed bulk delete away from being gone. v5 stores records that also
+   * carry the directory inode. The migration cannot invent one (`lstat` output
+   * was never persisted), so it only wraps the names and `protectSlice`
+   * backfills identities on the first scan.
+   */
+  test('carries every v4 lock forward so nothing is unlocked by the upgrade', () => {
+    // Arrange
+    const state = { protect: { items: ['task', 'browse'] } }
+
+    // Act
+    migrateState(state, 4)
+
+    // Assert
+    expect(state.protect).toEqual({
+      items: [{ name: 'task' }, { name: 'browse' }],
+    })
+  })
+
+  test('leaves an install that never locked anything alone', () => {
+    // Arrange
+    const state = { theme: makeCurrentTheme() }
+
+    // Act & Assert
+    expect(() => migrateState(state, 4)).not.toThrow()
+    expect(state.theme).toEqual(makeCurrentTheme())
+  })
+
+  test('drops a malformed protect slice instead of wiping the whole persisted store', () => {
+    // Arrange — a throwing migrate() makes the storage middleware removeItem
+    // the entire key, costing the user their theme, bookmarks and dashboard.
+    const state = {
+      protect: { items: 'not-a-list' },
+      theme: makeCurrentTheme(),
+    }
+
+    // Act
+    expect(() => migrateState(state, 4)).not.toThrow()
+
+    // Assert — only the unreadable slice is gone; everything else survives.
+    expect(state.protect).toBeUndefined()
+    expect(state.theme).toEqual(makeCurrentTheme())
+  })
+
+  test('drops a non-object protect slot rather than wrapping garbage into a lock', () => {
+    // Arrange
+    const state = { protect: null }
+
+    // Act
+    expect(() => migrateState(state, 4)).not.toThrow()
+
+    // Assert
+    expect(state.protect).toBeUndefined()
+  })
+
+  test('skips lock entries that are not names, since they could never match a skill', () => {
+    // Arrange — half-written or tampered storage.
+    const state = { protect: { items: ['task', 42, null, { name: 'browse' }] } }
+
+    // Act
+    migrateState(state, 4)
+
+    // Assert
+    expect(state.protect).toEqual({ items: [{ name: 'task' }] })
   })
 })
 

--- a/src/renderer/src/redux/migrations.ts
+++ b/src/renderer/src/redux/migrations.ts
@@ -8,6 +8,7 @@ import {
   THEME_PRESETS,
 } from '@/shared/constants'
 
+import type { ProtectedSkill } from './slices/protectSlice'
 import type { ThemeState } from './slices/themeSlice'
 
 /**
@@ -24,7 +25,11 @@ import type { ThemeState } from './slices/themeSlice'
 export interface MigratableState {
   theme?: ThemeState
   dashboard?: unknown
-  /** New in v4+: protect slice starts from initialState on first load, no migration needed. */
+  /**
+   * Locked skill names in v4 and earlier, {@link ProtectedSkill} records from
+   * v5. Typed `unknown` because {@link migrateV4ToV5} reads the legacy array
+   * shape before writing the current one.
+   */
   protect?: unknown
 }
 
@@ -223,6 +228,42 @@ function migrateV3ToV4(state: MigratableState): void {
 }
 
 /**
+ * v4 → v5 migration for the protect slice. v4 persisted bare skill names, so a
+ * rename left the lock pointing at a name nothing resolves to and the renamed
+ * skill came back unlocked. v5 stores {@link ProtectedSkill} records that also
+ * carry the directory inode. No inode can be invented for an existing payload
+ * — `lstat` results are not persisted — so every upgraded lock ships without
+ * one and `protectSlice` backfills it on the first scan.
+ *
+ * Never throws on a malformed payload: `migrate()` rejecting makes
+ * `@laststance/redux-storage-middleware` `removeItem` the whole key, which
+ * would cost the user their theme, bookmarks and dashboard as well. A `protect`
+ * slot that is not an array of names is dropped so the reducer's initialState
+ * takes over — same defensive style as {@link migrateV0ToV1}.
+ */
+function migrateV4ToV5(state: MigratableState): void {
+  if (!state.protect || typeof state.protect !== 'object') {
+    delete state.protect
+    return
+  }
+  const legacy = state.protect as { items?: unknown }
+  if (!Array.isArray(legacy.items)) {
+    delete state.protect
+    return
+  }
+  state.protect = {
+    // Non-string entries (tampered or half-written storage) are dropped rather
+    // than wrapped — a `{ name: 42 }` lock would never match a scanned row and
+    // would sit in the list forever.
+    items: legacy.items
+      .filter(
+        (name): name is ProtectedSkill['name'] => typeof name === 'string',
+      )
+      .map((name): ProtectedSkill => ({ name })),
+  }
+}
+
+/**
  * Chain migrations up to `PERSIST_STATE_VERSION`. Each `case` must advance
  * `current` to the next schema version; unknown sources throw so bumping
  * `PERSIST_STATE_VERSION` without adding a migration fails loudly in tests
@@ -254,6 +295,10 @@ export function migrateState<T extends MigratableState>(
       case 3:
         migrateV3ToV4(state)
         current = 4
+        break
+      case 4:
+        migrateV4ToV5(state)
+        current = 5
         break
       default:
         throw new Error(

--- a/src/renderer/src/redux/migrations.ts
+++ b/src/renderer/src/redux/migrations.ts
@@ -256,9 +256,7 @@ function migrateV4ToV5(state: MigratableState): void {
     // than wrapped — a `{ name: 42 }` lock would never match a scanned row and
     // would sit in the list forever.
     items: legacy.items
-      .filter(
-        (name): name is ProtectedSkill['name'] => typeof name === 'string',
-      )
+      .filter((name) => typeof name === 'string')
       .map((name): ProtectedSkill => ({ name })),
   }
 }

--- a/src/renderer/src/redux/selectors.test.ts
+++ b/src/renderer/src/redux/selectors.test.ts
@@ -126,7 +126,9 @@ function buildState(overrides: {
       items: overrides.bookmarks ?? [],
     },
     protect: {
-      items: overrides.protectedSkillNames ?? [],
+      // `protect.items` holds ProtectedSkill records; these fixtures only care
+      // about the name, so the identity the rename reconciler uses is omitted.
+      items: (overrides.protectedSkillNames ?? []).map((name) => ({ name })),
     },
   }
 }

--- a/src/renderer/src/redux/slices/agentsSlice.ts
+++ b/src/renderer/src/redux/slices/agentsSlice.ts
@@ -4,6 +4,8 @@ import { createSlice, createAsyncThunk } from '@reduxjs/toolkit'
 import type { RootState } from '@/renderer/src/redux/store'
 import type { AbsolutePath, Agent } from '@/shared/types'
 
+import { selectProtectedNamesSet } from './protectSlice'
+
 /**
  * Redux state for the Agents feature area.
  * Tracks the list of discovered agents and the agent currently queued
@@ -48,7 +50,7 @@ export function collectProtectedAgentSlotPaths(
   state: RootState,
   agent: Agent,
 ): AbsolutePath[] {
-  const protectedNames = new Set(state.protect.items)
+  const protectedNames = selectProtectedNamesSet(state)
 
   return state.skills.items
     .filter((skill) => protectedNames.has(skill.name))

--- a/src/renderer/src/redux/slices/protectSlice.test.ts
+++ b/src/renderer/src/redux/slices/protectSlice.test.ts
@@ -256,12 +256,59 @@ describe('protectSlice rename reconciliation', () => {
       fetchSkills.fulfilled([makeScannedSkill('browse', 10)], 'scan-1'),
     )
 
-    // Assert — inode 10 follows its rename onto "browse"; the lock on the
-    // vanished inode 20 keeps its stale name rather than being dropped, since
-    // the skill may only have been moved away temporarily.
+    // Assert — inode 10 follows its rename onto "browse" and the lock on the
+    // vanished inode 20 is dropped rather than shadowing it. Keeping both
+    // would let Unlock silently take an entry the list can never show, and
+    // keeping the stale one un-renamed would re-lock "browse" on the next scan.
     expect(store.getState().protect.items).toEqual([
       { name: 'browse', identity: { dev: 1, ino: 10 } },
-      { name: 'browse', identity: { dev: 1, ino: 20 } },
+    ])
+  })
+
+  test('resolves a rename onto a locked name the same way whichever lock was added first', async () => {
+    // Arrange — the same collision as above, locks added in the other order.
+    const { addProtection } = await import('./protectSlice')
+    const { fetchSkills } = await import('./skillsSlice')
+    const store = await createTestStore()
+    store.dispatch(
+      addProtection({ name: 'browse', identity: { dev: 1, ino: 20 } }),
+    )
+    store.dispatch(
+      addProtection({ name: 'task', identity: { dev: 1, ino: 10 } }),
+    )
+
+    // Act
+    store.dispatch(
+      fetchSkills.fulfilled([makeScannedSkill('browse', 10)], 'scan-1'),
+    )
+
+    // Assert — insertion order is an accident of when the user clicked Lock;
+    // settling the scanned inode first keeps the outcome the same either way.
+    expect(store.getState().protect.items).toEqual([
+      { name: 'browse', identity: { dev: 1, ino: 10 } },
+    ])
+  })
+
+  test('collapses a pre-scan lock onto the renamed skill it turned out to name', async () => {
+    // Arrange — "foo" locked with its inode, plus a name-only lock on "bar";
+    // while closed, "foo" was renamed to "bar", so both now mean one skill.
+    const { addProtection } = await import('./protectSlice')
+    const { fetchSkills } = await import('./skillsSlice')
+    const store = await createTestStore()
+    store.dispatch(
+      addProtection({ name: 'foo', identity: { dev: 1, ino: 10 } }),
+    )
+    store.dispatch(addProtection({ name: 'bar' }))
+
+    // Act
+    store.dispatch(
+      fetchSkills.fulfilled([makeScannedSkill('bar', 10)], 'scan-1'),
+    )
+
+    // Assert — one skill, one lock. Two entries sharing an inode would both
+    // chase the same name on every later rename.
+    expect(store.getState().protect.items).toEqual([
+      { name: 'bar', identity: { dev: 1, ino: 10 } },
     ])
   })
 

--- a/src/renderer/src/redux/slices/protectSlice.test.ts
+++ b/src/renderer/src/redux/slices/protectSlice.test.ts
@@ -208,9 +208,39 @@ describe('protectSlice rename reconciliation', () => {
     ])
   })
 
-  test('does not collapse two locks into one when a rename lands on an already-locked name', async () => {
+  test('follows a chain of renames that swap names within one scan', async () => {
+    // Arrange — both locked; while closed the user renamed "task" to "browse"
+    // and the old "browse" to "write", so one scan carries the whole chain.
+    const { addProtection } = await import('./protectSlice')
+    const { fetchSkills } = await import('./skillsSlice')
+    const store = await createTestStore()
+    store.dispatch(
+      addProtection({ name: 'task', identity: { dev: 1, ino: 10 } }),
+    )
+    store.dispatch(
+      addProtection({ name: 'browse', identity: { dev: 1, ino: 20 } }),
+    )
+
+    // Act
+    store.dispatch(
+      fetchSkills.fulfilled(
+        [makeScannedSkill('browse', 10), makeScannedSkill('write', 20)],
+        'scan-1',
+      ),
+    )
+
+    // Assert — treating "browse" as taken because a lock started there would
+    // strand inode 10 on "task" and leave the real "browse" deletable.
+    expect(store.getState().protect.items).toEqual([
+      { name: 'browse', identity: { dev: 1, ino: 10 } },
+      { name: 'write', identity: { dev: 1, ino: 20 } },
+    ])
+  })
+
+  test('does not point two locks at the same name when a rename lands on a locked one', async () => {
     // Arrange — both locked; while closed, "browse" was deleted and "task"
-    // renamed into its place, so one inode now answers to a locked name.
+    // renamed into its place, so one inode now answers to a locked name and
+    // inode 20 is gone from the scan entirely.
     const { addProtection } = await import('./protectSlice')
     const { fetchSkills } = await import('./skillsSlice')
     const store = await createTestStore()
@@ -226,10 +256,11 @@ describe('protectSlice rename reconciliation', () => {
       fetchSkills.fulfilled([makeScannedSkill('browse', 10)], 'scan-1'),
     )
 
-    // Assert — "browse" stays protected exactly once; unlocking it must not
-    // take a second, invisible entry with it.
+    // Assert — inode 10 follows its rename onto "browse"; the lock on the
+    // vanished inode 20 keeps its stale name rather than being dropped, since
+    // the skill may only have been moved away temporarily.
     expect(store.getState().protect.items).toEqual([
-      { name: 'task', identity: { dev: 1, ino: 10 } },
+      { name: 'browse', identity: { dev: 1, ino: 10 } },
       { name: 'browse', identity: { dev: 1, ino: 20 } },
     ])
   })

--- a/src/renderer/src/redux/slices/protectSlice.test.ts
+++ b/src/renderer/src/redux/slices/protectSlice.test.ts
@@ -1,5 +1,35 @@
 import { configureStore } from '@reduxjs/toolkit'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, test } from 'vitest'
+
+import type { Skill } from '@/shared/types'
+
+/**
+ * Build a source-skill row the way `scanSourceSkills` does: named, and carrying
+ * the `lstat` identity of its directory.
+ * @param name - Name the row shows in the list.
+ * @param ino - Inode of the skill directory; `dev` is fixed since one machine has one source volume.
+ * @returns Complete Skill object
+ * @example makeScannedSkill('task', 10)
+ */
+function makeScannedSkill(name: Skill['name'], ino: number): Skill {
+  return {
+    name,
+    description: 'scanned',
+    path: `/home/user/.agents/skills/${name}`,
+    filesystemIdentity: {
+      kind: 'directory',
+      dev: 1,
+      ino,
+      size: 96,
+      ctimeMs: 100,
+      mtimeMs: 100,
+    },
+    symlinkCount: 0,
+    symlinks: [],
+    isSource: true,
+    isOrphan: false,
+  }
+}
 
 async function createTestStore() {
   const { default: protectReducer } = await import('./protectSlice')
@@ -7,7 +37,7 @@ async function createTestStore() {
 }
 
 describe('protectSlice', () => {
-  it('starts with an empty protected list', async () => {
+  test('starts with an empty protected list', async () => {
     // Arrange
     const store = await createTestStore()
 
@@ -18,50 +48,50 @@ describe('protectSlice', () => {
     expect(items).toEqual([])
   })
 
-  it('locking a skill adds its name to the protected list', async () => {
+  test('locking a skill adds its name to the protected list', async () => {
     // Arrange
     const { addProtection } = await import('./protectSlice')
     const store = await createTestStore()
 
     // Act
-    store.dispatch(addProtection('task'))
+    store.dispatch(addProtection({ name: 'task' }))
 
     // Assert
-    expect(store.getState().protect.items).toEqual(['task'])
+    expect(store.getState().protect.items).toEqual([{ name: 'task' }])
   })
 
-  it('locking the same skill twice keeps only one entry', async () => {
+  test('locking the same skill twice keeps only one entry', async () => {
     // Arrange
     const { addProtection } = await import('./protectSlice')
     const store = await createTestStore()
 
     // Act
-    store.dispatch(addProtection('task'))
-    store.dispatch(addProtection('task'))
+    store.dispatch(addProtection({ name: 'task' }))
+    store.dispatch(addProtection({ name: 'task' }))
 
     // Assert
     expect(store.getState().protect.items).toHaveLength(1)
   })
 
-  it('locks two distinct skills as separate entries', async () => {
+  test('locks two distinct skills as separate entries', async () => {
     // Arrange
     const { addProtection } = await import('./protectSlice')
     const store = await createTestStore()
 
     // Act
-    store.dispatch(addProtection('task'))
-    store.dispatch(addProtection('browse'))
+    store.dispatch(addProtection({ name: 'task' }))
+    store.dispatch(addProtection({ name: 'browse' }))
 
     // Assert
     expect(store.getState().protect.items).toHaveLength(2)
   })
 
-  it('unlocking a skill removes only that skill and leaves the rest protected', async () => {
+  test('unlocking a skill removes only that skill and leaves the rest protected', async () => {
     // Arrange
     const { addProtection, removeProtection } = await import('./protectSlice')
     const store = await createTestStore()
-    store.dispatch(addProtection('task'))
-    store.dispatch(addProtection('browse'))
+    store.dispatch(addProtection({ name: 'task' }))
+    store.dispatch(addProtection({ name: 'browse' }))
 
     // Act
     store.dispatch(removeProtection('task'))
@@ -69,14 +99,14 @@ describe('protectSlice', () => {
     // Assert
     const items = store.getState().protect.items
     expect(items).toHaveLength(1)
-    expect(items[0]).toBe('browse')
+    expect(items[0]).toEqual({ name: 'browse' })
   })
 
-  it('leaves the list unchanged when unlocking a name that was never locked', async () => {
+  test('leaves the list unchanged when unlocking a name that was never locked', async () => {
     // Arrange
     const { addProtection, removeProtection } = await import('./protectSlice')
     const store = await createTestStore()
-    store.dispatch(addProtection('task'))
+    store.dispatch(addProtection({ name: 'task' }))
 
     // Act
     store.dispatch(removeProtection('nonexistent'))
@@ -85,11 +115,11 @@ describe('protectSlice', () => {
     expect(store.getState().protect.items).toHaveLength(1)
   })
 
-  it('reports a skill as protected only when it is in the protected list', async () => {
+  test('reports a skill as protected only when it is in the protected list', async () => {
     // Arrange
     const { addProtection, selectIsProtected } = await import('./protectSlice')
     const store = await createTestStore()
-    store.dispatch(addProtection('task'))
+    store.dispatch(addProtection({ name: 'task' }))
 
     // Act
     const isTaskProtected = selectIsProtected(store.getState(), 'task')
@@ -100,13 +130,13 @@ describe('protectSlice', () => {
     expect(isOtherProtected).toBe(false)
   })
 
-  it('selectProtectedNamesSet returns a Set containing all locked skill names', async () => {
+  test('selectProtectedNamesSet returns a Set containing all locked skill names', async () => {
     // Arrange
     const { addProtection, selectProtectedNamesSet } =
       await import('./protectSlice')
     const store = await createTestStore()
-    store.dispatch(addProtection('task'))
-    store.dispatch(addProtection('browse'))
+    store.dispatch(addProtection({ name: 'task' }))
+    store.dispatch(addProtection({ name: 'browse' }))
 
     // Act
     const set = selectProtectedNamesSet(store.getState())
@@ -115,5 +145,112 @@ describe('protectSlice', () => {
     expect(set.has('task')).toBe(true)
     expect(set.has('browse')).toBe(true)
     expect(set.has('other')).toBe(false)
+  })
+})
+
+describe('protectSlice rename reconciliation', () => {
+  test('keeps a skill locked after it is renamed while the app is closed', async () => {
+    // Arrange — locked while the directory was still called "task".
+    const { addProtection } = await import('./protectSlice')
+    const { fetchSkills } = await import('./skillsSlice')
+    const store = await createTestStore()
+    store.dispatch(
+      addProtection({ name: 'task', identity: { dev: 1, ino: 10 } }),
+    )
+
+    // Act — next scan finds the same inode under a new name.
+    store.dispatch(
+      fetchSkills.fulfilled([makeScannedSkill('todo', 10)], 'scan-1'),
+    )
+
+    // Assert — the lock followed the rename instead of stranding on "task".
+    expect(store.getState().protect.items).toEqual([
+      { name: 'todo', identity: { dev: 1, ino: 10 } },
+    ])
+  })
+
+  test('records the inode of a lock taken before any scan so a later rename is followed', async () => {
+    // Arrange — a v4-migrated lock, or one taken on a row with no identity.
+    const { addProtection } = await import('./protectSlice')
+    const { fetchSkills } = await import('./skillsSlice')
+    const store = await createTestStore()
+    store.dispatch(addProtection({ name: 'task' }))
+
+    // Act
+    store.dispatch(
+      fetchSkills.fulfilled([makeScannedSkill('task', 10)], 'scan-1'),
+    )
+
+    // Assert
+    expect(store.getState().protect.items).toEqual([
+      { name: 'task', identity: { dev: 1, ino: 10 } },
+    ])
+  })
+
+  test('keeps a lock whose skill is missing from the scan instead of dropping it', async () => {
+    // Arrange — an external drive with the skill on it is unplugged.
+    const { addProtection } = await import('./protectSlice')
+    const { fetchSkills } = await import('./skillsSlice')
+    const store = await createTestStore()
+    store.dispatch(
+      addProtection({ name: 'task', identity: { dev: 1, ino: 10 } }),
+    )
+
+    // Act
+    store.dispatch(
+      fetchSkills.fulfilled([makeScannedSkill('browse', 20)], 'scan-1'),
+    )
+
+    // Assert — silently unlocking on a transient empty scan is the bug this
+    // whole feature exists to prevent.
+    expect(store.getState().protect.items).toEqual([
+      { name: 'task', identity: { dev: 1, ino: 10 } },
+    ])
+  })
+
+  test('does not collapse two locks into one when a rename lands on an already-locked name', async () => {
+    // Arrange — both locked; while closed, "browse" was deleted and "task"
+    // renamed into its place, so one inode now answers to a locked name.
+    const { addProtection } = await import('./protectSlice')
+    const { fetchSkills } = await import('./skillsSlice')
+    const store = await createTestStore()
+    store.dispatch(
+      addProtection({ name: 'task', identity: { dev: 1, ino: 10 } }),
+    )
+    store.dispatch(
+      addProtection({ name: 'browse', identity: { dev: 1, ino: 20 } }),
+    )
+
+    // Act
+    store.dispatch(
+      fetchSkills.fulfilled([makeScannedSkill('browse', 10)], 'scan-1'),
+    )
+
+    // Assert — "browse" stays protected exactly once; unlocking it must not
+    // take a second, invisible entry with it.
+    expect(store.getState().protect.items).toEqual([
+      { name: 'task', identity: { dev: 1, ino: 10 } },
+      { name: 'browse', identity: { dev: 1, ino: 20 } },
+    ])
+  })
+
+  test('reuses the memoized protected-name set when a scan renames nothing', async () => {
+    // Arrange
+    const { addProtection, selectProtectedNamesSet } =
+      await import('./protectSlice')
+    const { fetchSkills } = await import('./skillsSlice')
+    const store = await createTestStore()
+    store.dispatch(
+      addProtection({ name: 'task', identity: { dev: 1, ino: 10 } }),
+    )
+    const before = selectProtectedNamesSet(store.getState())
+
+    // Act
+    store.dispatch(
+      fetchSkills.fulfilled([makeScannedSkill('task', 10)], 'scan-1'),
+    )
+
+    // Assert — a rebuilt Set on every scan would re-render the whole list.
+    expect(selectProtectedNamesSet(store.getState())).toBe(before)
   })
 })

--- a/src/renderer/src/redux/slices/protectSlice.ts
+++ b/src/renderer/src/redux/slices/protectSlice.ts
@@ -2,21 +2,52 @@ import type { PayloadAction } from '@reduxjs/toolkit'
 import { createSelector, createSlice } from '@reduxjs/toolkit'
 
 import type { RootState } from '@/renderer/src/redux/store'
-import type { SkillName } from '@/shared/types'
+import type { FilesystemEntryIdentity, SkillName } from '@/shared/types'
+
+import { fetchSkills } from './skillsSlice'
+
+/**
+ * A locked skill, remembered by the name on screen AND by the directory that
+ * name pointed at, so an out-of-app rename does not silently unlock it.
+ * @example { name: 'task', identity: { dev: 16777233, ino: 12345 } }
+ */
+export interface ProtectedSkill {
+  /** Name currently shown in the list — `SKILL.md` frontmatter `name:`, else the directory name. */
+  name: SkillName
+  /**
+   * Deliberately narrower than {@link FilesystemEntryIdentity}: only `dev` +
+   * `ino` survive a rename. `ctimeMs`, which the destructive-delete guards
+   * compare to reject reused-inode replacements, is bumped by `rename(2)`
+   * itself, so including it would reject exactly the case this field exists
+   * to catch. The residual cost is a recycled inode moving a lock onto a
+   * different skill — over-protection, never a silent unlock.
+   * Absent for locks persisted before v5 and for rows the scan has no
+   * identity for (agent-only links, orphans); backfilled on the next scan.
+   */
+  identity?: Pick<FilesystemEntryIdentity, 'dev' | 'ino'>
+}
 
 /**
  * Redux state for the per-skill protection feature.
- * Persisted to localStorage via redux-persist so locked skills survive app restarts.
- * Protection is a fat-finger guard only — it lives in the renderer and can be bypassed
- * by clearing app data. Do not treat it as a security control.
+ * Persisted to localStorage via `@laststance/redux-storage-middleware` so
+ * locked skills survive app restarts. Protection is a fat-finger guard only —
+ * it lives in the renderer and can be bypassed by clearing app data. Do not
+ * treat it as a security control.
  */
 interface ProtectState {
-  /** Skill names that the user has locked (insertion order, no duplicates). */
-  items: SkillName[]
+  /** Skills the user has locked (insertion order, no duplicate names). */
+  items: ProtectedSkill[]
 }
 
 const initialState: ProtectState = {
   items: [],
+}
+
+/** Map key that pairs `dev` with `ino` — neither alone identifies a directory. */
+function inodeKey(
+  identity: Pick<FilesystemEntryIdentity, 'dev' | 'ino'>,
+): string {
+  return `${identity.dev}:${identity.ino}`
 }
 
 const protectSlice = createSlice({
@@ -24,13 +55,13 @@ const protectSlice = createSlice({
   initialState,
   reducers: {
     /**
-     * Lock a skill by name. Ignores duplicates.
-     * @param action.payload - Skill name to protect
+     * Lock a skill. Ignores duplicates by name.
+     * @param action.payload - Skill name plus, when the scan captured one, the inode behind it.
      * @example
-     * dispatch(addProtection('task'))
+     * dispatch(addProtection({ name: 'task', identity: { dev: 16777233, ino: 12345 } }))
      */
-    addProtection: (state, action: PayloadAction<SkillName>) => {
-      if (!state.items.includes(action.payload)) {
+    addProtection: (state, action: PayloadAction<ProtectedSkill>) => {
+      if (!state.items.some((item) => item.name === action.payload.name)) {
         state.items.push(action.payload)
       }
     },
@@ -41,8 +72,56 @@ const protectSlice = createSlice({
      * dispatch(removeProtection('task'))
      */
     removeProtection: (state, action: PayloadAction<SkillName>) => {
-      state.items = state.items.filter((name) => name !== action.payload)
+      state.items = state.items.filter((item) => item.name !== action.payload)
     },
+  },
+  extraReducers: (builder) => {
+    // ── Follow renames, and backfill identities the lock was saved without ──
+    // Renaming a skill changes `Skill.name` two ways — renaming the directory
+    // (when SKILL.md has no `name:`) or editing that frontmatter field — and
+    // both leave the directory's inode untouched. Without this the lock keeps
+    // pointing at a name nothing resolves to and the renamed row comes back
+    // unlocked, so the next bulk delete takes it with no confirmation.
+    //
+    // Reconciling here rather than on a rename event is deliberate: a rename
+    // made while the app is closed emits no event, and that is the common
+    // case. `fetchSkills` runs on mount and after every mutation, so the
+    // comparison is against whatever the disk actually holds now.
+    //
+    // Mirrors the `fetchSkills.fulfilled` prune in uiSlice — same action, same
+    // "reconcile persisted references against the fresh inventory" shape.
+    builder.addCase(fetchSkills.fulfilled, (state, action) => {
+      const nameByInode = new Map<string, SkillName>()
+      const identityByName = new Map<SkillName, FilesystemEntryIdentity>()
+      for (const skill of action.payload) {
+        if (!skill.filesystemIdentity) continue
+        nameByInode.set(inodeKey(skill.filesystemIdentity), skill.name)
+        identityByName.set(skill.name, skill.filesystemIdentity)
+      }
+      // Names already locked, read before any rewrite: a rename whose target
+      // is locked too needs no rewrite (the target is already protected), and
+      // rewriting anyway would leave two entries the user can only unlock as
+      // a pair.
+      const lockedNames = new Set(state.items.map((item) => item.name))
+
+      for (const item of state.items) {
+        if (item.identity) {
+          const currentName = nameByInode.get(inodeKey(item.identity))
+          // Assign only on a real change so `items` keeps its reference and
+          // the memoized selectors below do not rebuild on every scan.
+          if (currentName && !lockedNames.has(currentName)) {
+            item.name = currentName
+          }
+          continue
+        }
+        // Pre-v5 lock, or one taken on a row the scan had no identity for.
+        // Bind it now so the NEXT rename is followed; a name that matches
+        // nothing is left alone, because dropping it would unlock a skill the
+        // user may only have temporarily moved away.
+        const scanned = identityByName.get(item.name)
+        if (scanned) item.identity = { dev: scanned.dev, ino: scanned.ino }
+      }
+    })
   },
 })
 
@@ -52,10 +131,10 @@ export const { addProtection, removeProtection } = protectSlice.actions
 type ProtectSelectorState = Pick<RootState, 'protect'>
 
 /**
- * Select all protected skill names (internal — used by createSelector below).
- * @returns SkillName[]
+ * Select all protected skills (internal — used by createSelector below).
+ * @returns ProtectedSkill[]
  */
-const selectProtectedItems = (state: ProtectSelectorState): SkillName[] =>
+const selectProtectedItems = (state: ProtectSelectorState): ProtectedSkill[] =>
   state.protect.items
 
 /**
@@ -67,7 +146,7 @@ const selectProtectedItems = (state: ProtectSelectorState): SkillName[] =>
  */
 export const selectProtectedNamesSet = createSelector(
   [selectProtectedItems],
-  (items) => new Set(items) as ReadonlySet<SkillName>,
+  (items) => new Set(items.map((item) => item.name)) as ReadonlySet<SkillName>,
 )
 
 /**

--- a/src/renderer/src/redux/slices/protectSlice.ts
+++ b/src/renderer/src/redux/slices/protectSlice.ts
@@ -98,22 +98,24 @@ const protectSlice = createSlice({
         nameByInode.set(inodeKey(skill.filesystemIdentity), skill.name)
         identityByName.set(skill.name, skill.filesystemIdentity)
       }
-      // Names already locked, read before any rewrite: a rename whose target
-      // is locked too needs no rewrite (the target is already protected), and
-      // rewriting anyway would leave two entries the user can only unlock as
-      // a pair.
-      const lockedNames = new Set(state.items.map((item) => item.name))
+      // Names this pass has already handed out. Filled as each lock settles,
+      // never snapshotted up front: one scan can carry a chain (`task`→`browse`
+      // while `browse`→`write`), and against a snapshot every link after the
+      // first reads as taken, so the chain stalls and the name that really is
+      // on disk ends up unprotected. Against the running set a name only
+      // counts as taken once some lock actually keeps it.
+      const claimed = new Set<SkillName>()
 
       for (const item of state.items) {
         if (item.identity) {
           const currentName = nameByInode.get(inodeKey(item.identity))
-          // `lockedNames` holds this item's own name too, so an unchanged name
-          // short-circuits here as well: nothing is written, `items` keeps its
-          // reference, and the memoized selectors below do not rebuild on a
-          // scan that renamed nothing.
-          if (currentName && !lockedNames.has(currentName)) {
+          // Assigning the name it already has is not a change — Immer skips
+          // identical writes — so `items` keeps its reference and the memoized
+          // selector below does not rebuild on a scan that renamed nothing.
+          if (currentName && !claimed.has(currentName)) {
             item.name = currentName
           }
+          claimed.add(item.name)
           continue
         }
         // Pre-v5 lock, or one taken on a row the scan had no identity for.
@@ -122,6 +124,7 @@ const protectSlice = createSlice({
         // user may only have temporarily moved away.
         const scanned = identityByName.get(item.name)
         if (scanned) item.identity = { dev: scanned.dev, ino: scanned.ino }
+        claimed.add(item.name)
       }
     })
   },

--- a/src/renderer/src/redux/slices/protectSlice.ts
+++ b/src/renderer/src/redux/slices/protectSlice.ts
@@ -107,8 +107,10 @@ const protectSlice = createSlice({
       for (const item of state.items) {
         if (item.identity) {
           const currentName = nameByInode.get(inodeKey(item.identity))
-          // Assign only on a real change so `items` keeps its reference and
-          // the memoized selectors below do not rebuild on every scan.
+          // `lockedNames` holds this item's own name too, so an unchanged name
+          // short-circuits here as well: nothing is written, `items` keeps its
+          // reference, and the memoized selectors below do not rebuild on a
+          // scan that renamed nothing.
           if (currentName && !lockedNames.has(currentName)) {
             item.name = currentName
           }

--- a/src/renderer/src/redux/slices/protectSlice.ts
+++ b/src/renderer/src/redux/slices/protectSlice.ts
@@ -98,34 +98,51 @@ const protectSlice = createSlice({
         nameByInode.set(inodeKey(skill.filesystemIdentity), skill.name)
         identityByName.set(skill.name, skill.filesystemIdentity)
       }
-      // Names this pass has already handed out. Filled as each lock settles,
-      // never snapshotted up front: one scan can carry a chain (`task`→`browse`
-      // while `browse`→`write`), and against a snapshot every link after the
-      // first reads as taken, so the chain stalls and the name that really is
-      // on disk ends up unprotected. Against the running set a name only
-      // counts as taken once some lock actually keeps it.
+      // Pass 1 — locks whose directory this scan actually found. The scan is
+      // authoritative about the name a surviving inode answers to, so these
+      // names are taken first. One scan maps each inode to one name and skill
+      // names are unique, so they never collide with each other, and settling
+      // them up front is what makes the result independent of the order locks
+      // happen to sit in. Doing it in one running pass instead let a chain
+      // (`task`→`browse` while `browse`→`write`) resolve or stall purely on
+      // that order.
       const claimed = new Set<SkillName>()
-
       for (const item of state.items) {
-        if (item.identity) {
-          const currentName = nameByInode.get(inodeKey(item.identity))
-          // Assigning the name it already has is not a change — Immer skips
-          // identical writes — so `items` keeps its reference and the memoized
-          // selector below does not rebuild on a scan that renamed nothing.
-          if (currentName && !claimed.has(currentName)) {
-            item.name = currentName
-          }
-          claimed.add(item.name)
-          continue
+        const currentName =
+          item.identity && nameByInode.get(inodeKey(item.identity))
+        if (!currentName) continue
+        // Assigning the name it already has is not a change — Immer skips
+        // identical writes — so `items` keeps its reference and the memoized
+        // selector below does not rebuild on a scan that renamed nothing.
+        item.name = currentName
+        claimed.add(currentName)
+      }
+
+      // Pass 2 — the rest: locks the scan has no directory for, and pre-v5
+      // locks that never had one.
+      const kept = state.items.filter((item) => {
+        if (item.identity && nameByInode.has(inodeKey(item.identity))) {
+          return true
         }
         // Pre-v5 lock, or one taken on a row the scan had no identity for.
-        // Bind it now so the NEXT rename is followed; a name that matches
-        // nothing is left alone, because dropping it would unlock a skill the
-        // user may only have temporarily moved away.
-        const scanned = identityByName.get(item.name)
-        if (scanned) item.identity = { dev: scanned.dev, ino: scanned.ino }
+        // Bind it now so the NEXT rename is followed.
+        if (!item.identity) {
+          const scanned = identityByName.get(item.name)
+          if (scanned) item.identity = { dev: scanned.dev, ino: scanned.ino }
+        }
+        // A name that matches nothing is kept, because dropping it would
+        // unlock a skill the user may only have temporarily moved away. It is
+        // dropped only when pass 1 handed that name to a live directory: the
+        // shadow entry is unreachable from the UI, `removeProtection` would
+        // silently take it along with the real lock, and leaving it would
+        // re-lock the skill on the next scan after the user unlocked it.
+        if (claimed.has(item.name)) return false
         claimed.add(item.name)
-      }
+        return true
+      })
+      // Reassign only when something was dropped, so a scan that changed
+      // nothing leaves `items` referentially stable for the memoized selector.
+      if (kept.length !== state.items.length) state.items = kept
     })
   },
 })

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -31,8 +31,12 @@ export const PERSIST_STORAGE_KEY = 'skills-desktop-state'
  *    Health widget's `minSize.h` grew 2 → 3 so its action row ("Scan issues")
  *    no longer clips against the card's bottom edge. Same mechanism and
  *    rationale as v1 → v2 (see `clampPersistedWidgetSizes`).
+ *  - v4 → v5: `protect.items` went from `SkillName[]` to `ProtectedSkill[]`,
+ *    so a lock can remember the inode behind the name and survive a rename.
+ *    The migration wraps each persisted name; it cannot invent an inode, so
+ *    upgraded locks carry no identity until the first scan backfills them.
  */
-export const PERSIST_STATE_VERSION = 4
+export const PERSIST_STATE_VERSION = 5
 
 /**
  * Chroma value applied to OKLCH tokens for fully-saturated (color) presets.


### PR DESCRIPTION
## Problem

`protect.items` stored bare skill names. Rename a skill and the lock stays pinned to a name nothing resolves to — the renamed row comes back **unlocked**, one unconfirmed bulk delete away from being gone. That is precisely the outcome the lock exists to prevent, and nothing on screen says it happened.

Two corrections to the TODO that filed this:

1. **"renamed on disk" understated the trigger.** `Skill.name` is `SKILL.md` frontmatter `name:` falling back to the directory name (`metadataParser.ts:25`), so editing that one frontmatter line renames the skill just as effectively as `mv` does. Neither touches the directory's inode.
2. **"Same accepted trade-off as bookmarks" is a false analogy.** `BookmarkedSkill` points at a remote `repo`/`url` and has no local path, so no stable local identity exists for it. `protect.items` names a *local* directory, and `Skill.filesystemIdentity` is already captured on every source row by `scanSourceSkills`. Bookmarks genuinely cannot do this; locks always could. Bookmarks are deliberately **out of scope** here.

## Fix

`protect.items` becomes `ProtectedSkill[]`:

```ts
interface ProtectedSkill {
  name: SkillName
  identity?: Pick<FilesystemEntryIdentity, 'dev' | 'ino'>
}
```

- **`ProtectButton` records the identity at lock time**, so a rename before the next scan is still followed.
- **`protectSlice` reconciles on `fetchSkills.fulfilled`**: any persisted inode whose scanned name changed has its lock renamed; locks with no identity get one backfilled. Reconciling per *scan* rather than per rename *event* is deliberate — a rename made while the app is closed emits no event, and that is the common case. This mirrors the `fetchSkills.fulfilled` prune already living in `uiSlice` (same action, same "reconcile persisted references against the fresh inventory" shape). No import cycle: `skillsSlice` does not import `protectSlice`.
- **`PERSIST_STATE_VERSION` 4 → 5** wraps persisted names. It cannot invent an inode (`lstat` output was never persisted), so upgraded locks ship identity-less and are backfilled by the first scan — a deliberately two-state field.

### Why `dev` + `ino` and not the whole `FilesystemEntryIdentity`

The repo's destructive-delete guards compare `ctimeMs` to reject reused-inode same-path replacements (`shared/types.ts:56`). This check is narrower **on purpose**: `rename(2)` bumps `ctimeMs` itself, so including it would reject exactly the case this field exists to catch. Documented in the `ProtectedSkill` docstring so the narrowing does not read as an oversight.

**Known ceiling:** a recycled inode can move a lock onto a different skill. The failure direction is over-protection (one extra confirmation), never a silent unlock, and APFS does not reuse inode numbers in practice.

### The migration must not throw

A throwing `migrate()` makes `@laststance/redux-storage-middleware` `removeItem` the **whole key** — the user loses theme, bookmarks and dashboard along with their locks. `migrateV4ToV5` drops an unreadable `protect` slot so the reducer's `initialState` takes over, matching the defensive style `migrateV0ToV1` already uses. Covered by tests.

## Also in this PR

- `collectProtectedAgentSlotPaths` (`agentsSlice.ts`) rebuilt its own `Set` from `state.protect.items`; it now reads through `selectProtectedNamesSet`. It was the only consumer bypassing the selectors, so the shape change would otherwise have been a silent behavior break.
- Two false doc references corrected: the `ProtectState` docstring claimed persistence "via redux-persist" (this repo uses `@laststance/redux-storage-middleware`), and `MigratableState.protect` claimed "no migration needed".

## Test plan

`pnpm validate` — **198 files / 2605 tests, exit 0** (re-run on the final tree).
`pnpm test:e2e -g` on the two specs that regressed — 2 passed.

## Review rounds

**Round 1 — chained renames stalled.** The set of already-taken names was
snapshotted before any rewrite. One scan carrying `task`→`browse` while
`browse`→`write` stopped at the first link: `browse` read as taken because a
lock started there, inode 10 stayed stranded on `task`, and the `browse` that
really was on disk came back deletable. The same snapshot was documented as
preventing two locks from rewriting onto one name; it did not, and two locks
sharing an inode both took the new name (reproduced by hand before fixing).

**Round 1 — two e2e specs dispatched the pre-v5 payload.**
`delete-hidden-agents` and `regression` passed `payload: '<name>'`, which the
new reducer reads as a nameless lock. `e2e/` compiles under its own tsconfig,
so `pnpm typecheck` never saw them and both tests failed on CI.

**Round 2 — the fix was order-dependent.** Filling the name set as each lock
settled resolved the chain but made the answer depend on the order locks
happened to sit in. With `task@10` and `browse@20` locked and a scan returning
only `browse@10`, `task` first gives two `browse` entries; `browse` first
leaves inode 10 stranded on `task`. Same inputs, two answers.

Now two passes. Pass 1 settles every lock whose directory the scan actually
found: the scan is authoritative about the name a surviving inode answers to,
one scan maps each inode to one name, and skill names are unique, so these
never collide with each other and never depend on iteration order. Pass 2
handles the rest — binding an inode to a pre-v5 lock, and keeping a lock whose
directory is simply absent, since the skill may only have been moved away
temporarily.

**Why the shadow is dropped rather than reserved.** A lock is dropped in
exactly one case: pass 1 handed its name to a live directory. The review
suggested reserving that name for the unresolved lock instead, which is worse.
Reserving leaves inode 10 stranded on `task`; the user then unlocks `browse`,
that entry goes, and on the next scan `task@10` finds `browse` free and renames
onto it — the skill silently re-locks itself right after being unlocked. That
is visible and confusing. The duplicate it replaces was only invisible, and
`removeProtection` would have taken it along with the real lock without saying
so.

Verified across both insertion orders for every case, plus 2- and 3-cycle name
swaps: each reverse-order pair yields the identical inode→name mapping.

**Known limit (deliberate).** A lock whose directory is absent *and* whose name
a live skill has taken over is dropped. Narrow, and the alternative above is
worse.

Tests added across the rounds: the chain; the reverse insertion order of the
collision; a name-only pre-v5 lock collapsing onto the renamed skill it turned
out to name; and locking a row the scan captured no identity for (the codecov
partial on `handleToggle`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 保護したスキルの名前を変更しても、保護状態が維持されるようになりました。
  - ファイルシステム上の識別情報を利用し、名前変更を正確に追跡します。
  - 対応するスキルが見つからない場合も、保護設定を保持します。

- **改善**
  - 既存の保護設定を新しい形式へ自動移行します。
  - 初回スキャン前の設定を保持し、スキャン後に識別情報を補完します。
  - 保護対象の重複登録を整理します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

