### PR TITLE
fix(theme): follow theme changes in an already-open Settings window

### DIFF
--- a/.storybook/storybook-utils.tsx
+++ b/.storybook/storybook-utils.tsx
@@ -555,6 +555,10 @@ export function installStorybookElectronMock(): void {
       },
       onChanged: () => cleanup,
     },
+    theme: {
+      broadcast: async () => undefined,
+      onChanged: () => cleanup,
+    },
     activity: {
       list: async () => [],
       onChanged: () => cleanup,

--- a/TODOS.md
+++ b/TODOS.md
@@ -6,11 +6,33 @@ Deferred items captured during planning. Pick up when scope and bandwidth allow.
 
 ### P2. Open Settings should follow theme changes in the main window
 
-**Status:** Deferred; the theme synchronization code is unchanged by the opacity feature.
+**Status:** FIXED.
 
 **Finding:** Switching the main window from Dark to Light leaves an already-open Settings window in Dark until reload. This makes two windows from the same app look inconsistent.
 
-**Fix direction:** Synchronize theme changes to open Settings windows and cover the two-window interaction in Electron E2E.
+**Fix:** Theme lives in renderer Redux (persisted to localStorage), not in
+`settings.json`, so it had no main-process owner to broadcast from. The window
+that changes the theme now publishes its resolved `ThemeState` over
+`theme:broadcast`; main relays it as `theme:changed` and every window adopts it
+with a `syncTheme` action. `syncTheme` is deliberately excluded from the
+listener that publishes, so adopting a broadcast never re-publishes and the two
+windows cannot bounce state at each other. Covered by
+`e2e/spec/settings-window-theme-sync.e2e.ts` (mode switch and accent preset,
+both across the two real windows).
+
+**Fixed alongside it:** the OS-appearance ("Auto") subscription and the new
+cross-window subscription were both installed from the
+`ACTION_HYDRATE_COMPLETE` handler, and the storage middleware does not dispatch
+that action when localStorage is still empty. On a first launch neither
+subscription existed, so "Auto" silently stopped following macOS Appearance
+until the app had been restarted once. Both now install from `store.ts` at
+store creation.
+
+**Known ceiling:** a broadcast is a one-shot event, so a window that is mid-load
+when another window changes the theme misses it and keeps the palette it read
+from localStorage at boot. The window that changed the theme has already
+persisted the new state by then, so this only bites if the two overlap within
+the few hundred ms before the second window's store evaluates.
 
 ### P2. Main-window cards should fit the minimum desktop width
 

--- a/e2e/spec/settings-window-theme-sync.e2e.ts
+++ b/e2e/spec/settings-window-theme-sync.e2e.ts
@@ -1,0 +1,90 @@
+import { mkdtempSync, realpathSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { Page } from '@playwright/test'
+
+import { test, expect } from '../fixtures/electron-app'
+
+/**
+ * The Settings window is a second BrowserWindow with its own renderer process
+ * and its own store, so it reads the persisted theme once at boot. Before the
+ * `theme:changed` broadcast existed, switching the main window Dark -> Light
+ * left it stranded in the old palette until it was closed and reopened: two
+ * windows of one app, visibly disagreeing.
+ *
+ * Only an Electron E2E can cover this — the two stores live in separate
+ * processes, so a single-renderer test can never observe the crossing.
+ */
+const themeSyncTest = test.extend<{ settingsWindow: Page }>({
+  // eslint-disable-next-line no-empty-pattern
+  isolatedHome: async ({}, use) => {
+    const isolatedHome = realpathSync.native(
+      mkdtempSync(join(tmpdir(), 'skills-desktop-e2e-theme-sync-')),
+    )
+    try {
+      await use(isolatedHome)
+    } finally {
+      rmSync(isolatedHome, { recursive: true, force: true })
+    }
+  },
+  settingsWindow: async ({ electronApp, appWindow }, use) => {
+    const settingsWindowPromise = electronApp.waitForEvent('window')
+    await appWindow.getByRole('button', { name: 'Open settings' }).click()
+    const settingsWindow = await settingsWindowPromise
+    await settingsWindow.waitForLoadState('domcontentloaded')
+    // A broadcast is a one-shot event: publishing before this window has
+    // subscribed would be missed and the test would fail for the wrong
+    // reason. The subscription is installed when `store.ts` evaluates, which
+    // is a prerequisite of React rendering anything, so waiting for real
+    // Settings content is a sufficient signal.
+    await settingsWindow
+      .getByRole('button', { name: 'Appearance', exact: true })
+      .waitFor()
+    await use(settingsWindow)
+  },
+})
+
+themeSyncTest(
+  'repaints an open Settings window when the main window switches to Light',
+  async ({ appWindow, settingsWindow }) => {
+    // Arrange — both windows start on the default neutral-dark palette.
+    await expect(settingsWindow.locator('html')).toHaveClass(/dark/)
+
+    // Act — switch the main window to Light through the real dropdown.
+    await appWindow
+      .getByRole('button', { name: 'Theme and color options' })
+      .click()
+    await appWindow.getByRole('radio', { name: 'Light mode' }).click()
+
+    // Assert — the already-open Settings window follows, no reopen required.
+    await expect(settingsWindow.locator('html')).toHaveClass(/light/)
+    await expect(settingsWindow.locator('html')).not.toHaveClass(/dark/)
+    await expect(appWindow.locator('html')).toHaveClass(/light/)
+  },
+)
+
+themeSyncTest(
+  'carries an accent preset across to the open Settings window',
+  async ({ appWindow, settingsWindow }) => {
+    // Arrange — a neutral preset leaves chroma at 0 in both windows.
+    await expect(settingsWindow.locator('html')).toHaveCSS(
+      '--theme-chroma',
+      '0',
+    )
+
+    // Act — pick Cyan in the main window.
+    await appWindow
+      .getByRole('button', { name: 'Theme and color options' })
+      .click()
+    await appWindow.getByRole('button', { name: 'Select Cyan theme' }).click()
+
+    // Assert — hue and chroma both cross, so the Settings window renders the
+    // same accent rather than a half-applied palette.
+    await expect(settingsWindow.locator('html')).toHaveCSS('--theme-hue', '195')
+    await expect(settingsWindow.locator('html')).toHaveCSS(
+      '--theme-chroma',
+      '0.16',
+    )
+  },
+)

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -11,6 +11,7 @@ import { registerSkillsHandlers } from './skills'
 import { registerSkillsCliHandlers } from './skillsCli'
 import { registerSourceHandlers } from './source'
 import { registerSyncHandlers } from './sync'
+import { registerThemeHandlers } from './theme'
 import { registerUpdateHandlers } from './update'
 import { registerWindowHandlers } from './window'
 
@@ -32,6 +33,7 @@ export function registerAllHandlers(): void {
   registerActivityHandlers()
   registerShellHandlers()
   registerSettingsHandlers()
+  registerThemeHandlers()
   registerFolderHandlers()
   registerWindowHandlers()
 }

--- a/src/main/ipc/ipc-schemas.test.ts
+++ b/src/main/ipc/ipc-schemas.test.ts
@@ -880,4 +880,18 @@ describe('theme:broadcast', () => {
     // Assert
     expect(result.success).toBe(false)
   })
+
+  it('blocks a key the theme contract does not declare', () => {
+    // Strict rather than stripping: an extra key means the broadcasting
+    // renderer and this schema have drifted, and a relay that fails loudly
+    // beats one that quietly drops a field the receiving reducer expects.
+    // Arrange
+    const schema = IPC_ARG_SCHEMAS['theme:broadcast']
+
+    // Act
+    const result = schema!.safeParse([{ ...validTheme, accent: 'neon' }])
+
+    // Assert
+    expect(result.success).toBe(false)
+  })
 })

--- a/src/main/ipc/ipc-schemas.test.ts
+++ b/src/main/ipc/ipc-schemas.test.ts
@@ -822,3 +822,62 @@ describe('settings:set lockstep with SettingsSchema', () => {
     )
   })
 })
+
+describe('theme:broadcast', () => {
+  const validTheme = {
+    hue: 195,
+    chroma: 0.16,
+    mode: 'dark' as const,
+    modePreference: 'system' as const,
+    preset: 'cyan',
+  }
+
+  it('relays a resolved theme that names a real preset', () => {
+    // Arrange
+    const schema = IPC_ARG_SCHEMAS['theme:broadcast']
+
+    // Act
+    const result = schema!.safeParse([validTheme])
+
+    // Assert
+    expect(result.success).toBe(true)
+  })
+
+  it('blocks a preset name that is not in THEME_PRESETS', () => {
+    // Every window dispatches this payload straight into its theme reducer.
+    // An unknown key would land on the reducer's stale-preset fallback and
+    // silently reset the palette in a window the user never touched.
+    // Arrange
+    const schema = IPC_ARG_SCHEMAS['theme:broadcast']
+
+    // Act
+    const result = schema!.safeParse([{ ...validTheme, preset: 'mono-dark' }])
+
+    // Assert
+    expect(result.success).toBe(false)
+  })
+
+  it('blocks an out-of-range hue before it is written to a style property', () => {
+    // `applyThemeToDOM` writes `hue` verbatim into `--theme-hue`, so the
+    // OKLCH range is the only thing constraining it.
+    // Arrange
+    const schema = IPC_ARG_SCHEMAS['theme:broadcast']
+
+    // Act
+    const result = schema!.safeParse([{ ...validTheme, hue: 9999 }])
+
+    // Assert
+    expect(result.success).toBe(false)
+  })
+
+  it('blocks a mode outside light and dark', () => {
+    // Arrange
+    const schema = IPC_ARG_SCHEMAS['theme:broadcast']
+
+    // Act
+    const result = schema!.safeParse([{ ...validTheme, mode: 'sepia' }])
+
+    // Assert
+    expect(result.success).toBe(false)
+  })
+})

--- a/src/main/ipc/ipc-schemas.ts
+++ b/src/main/ipc/ipc-schemas.ts
@@ -1,6 +1,11 @@
 import { z } from 'zod'
 
-import { AGENT_IDS, CODE_THEME_IDS, TERMINAL_APP_IDS } from '@/shared/constants'
+import {
+  AGENT_IDS,
+  CODE_THEME_IDS,
+  TERMINAL_APP_IDS,
+  THEME_PRESETS,
+} from '@/shared/constants'
 import type { IpcInvokeChannel } from '@/shared/ipc-contract'
 import {
   CODE_FONT_SIZE_SCHEMA,
@@ -425,6 +430,24 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
       // settings:set. A bare boolean has no constraint that can drift, so
       // there's nothing to keep in lockstep beyond the type itself.
       autoDownloadUpdates: z.boolean().optional(),
+    }),
+  ]),
+
+  // Cross-window theme relay. Main re-broadcasts this payload to every open
+  // window, where it is dispatched straight into Redux and projected onto
+  // `<html>` as CSS custom properties — so it must be validated here rather
+  // than trusted because it came from "our own" renderer. `preset` is pinned
+  // to the THEME_PRESETS keys so an unknown name cannot reach the reducer's
+  // stale-key fallback, and hue/chroma are bounded to the OKLCH ranges
+  // globals.css actually consumes: an out-of-range number would otherwise be
+  // written verbatim into a style property.
+  'theme:broadcast': z.tuple([
+    z.object({
+      hue: z.number().min(0).max(360),
+      chroma: z.number().min(0).max(1),
+      mode: z.enum(['light', 'dark']),
+      modePreference: z.enum(['light', 'dark', 'system']),
+      preset: z.enum(Object.keys(THEME_PRESETS) as [string, ...string[]]),
     }),
   ]),
 

--- a/src/main/ipc/ipc-schemas.ts
+++ b/src/main/ipc/ipc-schemas.ts
@@ -5,6 +5,7 @@ import {
   CODE_THEME_IDS,
   TERMINAL_APP_IDS,
   THEME_PRESETS,
+  type ThemePresetName,
 } from '@/shared/constants'
 import type { IpcInvokeChannel } from '@/shared/ipc-contract'
 import {
@@ -16,6 +17,7 @@ import {
   WINDOW_BACKGROUND_BLUR_RADIUS_SCHEMA,
   WINDOW_OPACITY_MODE_SCHEMA,
 } from '@/shared/settings'
+import { MODE_PREFERENCES, THEME_MODES } from '@/shared/theme'
 
 /**
  * Zod schemas for runtime validation of IPC invoke arguments.
@@ -442,12 +444,19 @@ export const IPC_ARG_SCHEMAS: Partial<Record<IpcInvokeChannel, z.ZodTuple>> = {
   // globals.css actually consumes: an out-of-range number would otherwise be
   // written verbatim into a style property.
   'theme:broadcast': z.tuple([
-    z.object({
+    // Strict, like `settings:set`: an unknown key means the sender and this
+    // schema have drifted, and failing the relay is louder than silently
+    // stripping the field on its way to the reducer.
+    z.strictObject({
       hue: z.number().min(0).max(360),
       chroma: z.number().min(0).max(1),
-      mode: z.enum(['light', 'dark']),
-      modePreference: z.enum(['light', 'dark', 'system']),
-      preset: z.enum(Object.keys(THEME_PRESETS) as [string, ...string[]]),
+      mode: z.enum(THEME_MODES),
+      modePreference: z.enum(MODE_PREFERENCES),
+      // `Object.keys` widens to `string[]`; `z.enum` needs a non-empty tuple.
+      // Same cast the two renderer call sites already use for this table.
+      preset: z.enum(
+        Object.keys(THEME_PRESETS) as [ThemePresetName, ...ThemePresetName[]],
+      ),
     }),
   ]),
 

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -17,6 +17,8 @@ import { broadcastTypedEvent } from './typedSend'
  *                            and broadcasts `settings:changed` so every
  *                            open window converges (no stale state across
  *                            the main window and Settings window).
+ *  - `theme:broadcast`       re-emits a renderer's resolved theme as
+ *                            `theme:changed` to every window.
  *
  * The broadcast is what eliminates the dual-Redux race we'd see if
  * persistence lived in localStorage and both windows wrote to the same
@@ -63,5 +65,16 @@ export function registerSettingsHandlers(): void {
       broadcastTypedEvent(IPC_CHANNELS.SETTINGS_CHANGED, next)
     }
     return next
+  })
+
+  // Theme has no main-process owner: it lives in renderer Redux and is
+  // persisted to localStorage, so main is a pure relay here rather than the
+  // source of truth it is for settings. The sender is deliberately included
+  // in the fan-out — the receiving listener dispatches `syncTheme`, which the
+  // broadcasting listener does not match, so the echo dies in one hop and we
+  // reuse `broadcastTypedEvent` instead of re-implementing its
+  // destroyed-window guard just to skip one window.
+  typedHandle(IPC_CHANNELS.THEME_BROADCAST, (_event, theme) => {
+    broadcastTypedEvent(IPC_CHANNELS.THEME_CHANGED, theme)
   })
 }

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -17,8 +17,6 @@ import { broadcastTypedEvent } from './typedSend'
  *                            and broadcasts `settings:changed` so every
  *                            open window converges (no stale state across
  *                            the main window and Settings window).
- *  - `theme:broadcast`       re-emits a renderer's resolved theme as
- *                            `theme:changed` to every window.
  *
  * The broadcast is what eliminates the dual-Redux race we'd see if
  * persistence lived in localStorage and both windows wrote to the same
@@ -65,16 +63,5 @@ export function registerSettingsHandlers(): void {
       broadcastTypedEvent(IPC_CHANNELS.SETTINGS_CHANGED, next)
     }
     return next
-  })
-
-  // Theme has no main-process owner: it lives in renderer Redux and is
-  // persisted to localStorage, so main is a pure relay here rather than the
-  // source of truth it is for settings. The sender is deliberately included
-  // in the fan-out — the receiving listener dispatches `syncTheme`, which the
-  // broadcasting listener does not match, so the echo dies in one hop and we
-  // reuse `broadcastTypedEvent` instead of re-implementing its
-  // destroyed-window guard just to skip one window.
-  typedHandle(IPC_CHANNELS.THEME_BROADCAST, (_event, theme) => {
-    broadcastTypedEvent(IPC_CHANNELS.THEME_CHANGED, theme)
   })
 }

--- a/src/main/ipc/theme.ts
+++ b/src/main/ipc/theme.ts
@@ -1,0 +1,29 @@
+import { broadcastTypedEvent } from '@/main/ipc/typedSend'
+import { IPC_CHANNELS } from '@/shared/ipc-channels'
+
+import { typedHandle } from './typedHandle'
+
+/**
+ * Wires the cross-window theme relay:
+ *  - `theme:broadcast`  re-emits a renderer's resolved theme as
+ *                       `theme:changed` to every open window.
+ *
+ * Unlike settings, main is a pure relay here rather than the source of truth:
+ * theme lives in renderer Redux and is persisted to localStorage, so there is
+ * no main-process copy to update. The relay exists because each BrowserWindow
+ * is its own renderer process with its own store, and the Settings window
+ * would otherwise keep the palette it read at boot.
+ *
+ * The sender is deliberately left in the fan-out. The receiving listener
+ * dispatches `syncTheme`, which the broadcasting listener does not match, so
+ * the echo dies in one hop — cheaper than re-implementing
+ * {@link broadcastTypedEvent}'s destroyed-window guard just to skip one window.
+ *
+ * The payload is validated against `IPC_ARG_SCHEMAS['theme:broadcast']` inside
+ * {@link typedHandle} before it is fanned out.
+ */
+export function registerThemeHandlers(): void {
+  typedHandle(IPC_CHANNELS.THEME_BROADCAST, (_event, theme) => {
+    broadcastTypedEvent(IPC_CHANNELS.THEME_CHANGED, theme)
+  })
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3,6 +3,7 @@ import { contextBridge } from 'electron'
 import type { ActivityEvent, ActivityListOptions } from '@/shared/activityLog'
 import { IPC_CHANNELS } from '@/shared/ipc-channels'
 import type { Settings, SettingsPatch } from '@/shared/settings'
+import type { ThemeState } from '@/shared/theme'
 import type {
   AbsolutePath,
   ClearOrphanSymlinksOptions,
@@ -154,6 +155,16 @@ contextBridge.exposeInMainWorld('electron', {
     get: async () => typedInvoke('settings:get'),
     set: async (partial: SettingsPatch) => typedInvoke('settings:set', partial),
     onChanged: createIpcListener<Settings>(IPC_CHANNELS.SETTINGS_CHANGED),
+  },
+  // Theme — unlike settings, the source of truth is renderer Redux (persisted
+  // to localStorage), so main only relays. `broadcast` publishes the window's
+  // resolved theme; `onChanged` lets every other window adopt it, which is
+  // what keeps an open Settings window from being stranded in the old palette
+  // when the main window switches Dark <-> Light.
+  theme: {
+    broadcast: async (state: ThemeState) =>
+      typedInvoke('theme:broadcast', state),
+    onChanged: createIpcListener<ThemeState>(IPC_CHANNELS.THEME_CHANGED),
   },
   // Activity timeline — append-only event log owned by main (userData/
   // activity-log.json). Renderer hydrates via `activity:list` and converges

--- a/src/renderer/settings/index.html
+++ b/src/renderer/settings/index.html
@@ -8,9 +8,10 @@
       // Theme pre-hydration bootstrap. Mirrors src/renderer/index.html so the
       // Settings window picks up the user's persisted theme (mode + preset)
       // before React mounts, avoiding a neutral-dark flash. Settings does NOT
-      // expose theme controls, so we only READ from localStorage; live updates
-      // from the main window are not propagated here (theme changes require
-      // closing and reopening Settings).
+      // expose theme controls, so we only READ from localStorage here; once
+      // React mounts, live changes from the main window arrive over the
+      // `theme:changed` broadcast (see installThemeBroadcastListener in
+      // src/renderer/src/redux/listener.ts).
       //
       // Magic literals duplicated from constants.ts; bootstrap.test.ts
       // guards against drift:

--- a/src/renderer/src/redux/listener.test.ts
+++ b/src/renderer/src/redux/listener.test.ts
@@ -584,7 +584,7 @@ describe('theme listener — cross-window sync', () => {
     expect(document.documentElement.classList.contains('dark')).toBe(false)
   })
 
-  test('subscribes to the other window only once even if hydration completes twice', async () => {
+  test('subscribes to the other window only once even if the installer runs twice', async () => {
     // Arrange
     let subscriptions = 0
     Object.defineProperty(window, 'electron', {

--- a/src/renderer/src/redux/listener.test.ts
+++ b/src/renderer/src/redux/listener.test.ts
@@ -1,6 +1,6 @@
 import { ACTION_HYDRATE_COMPLETE } from '@laststance/redux-storage-middleware'
 import { configureStore } from '@reduxjs/toolkit'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, test, vi } from 'vitest'
 
 /**
  * Integration tests for the theme DOM side effect in listener.ts. The listener
@@ -9,9 +9,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
  * reacting to Redux state. Tests run in happy-dom so we can assert against a
  * real `document.documentElement`.
  *
- * Matcher coverage: setTheme, setModePreference, ACTION_HYDRATE_COMPLETE. If
- * a future reducer is added that mutates theme state, extending the matcher
- * in listener.ts requires a new test here.
+ * Matcher coverage: setTheme, setModePreference, syncTheme,
+ * ACTION_HYDRATE_COMPLETE. If a future reducer is added that mutates theme
+ * state, extending the matcher in listener.ts requires a new test here.
  *
  * @vitest-environment happy-dom
  */
@@ -25,13 +25,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
  * a no-op.
  */
 async function createThemedStore() {
-  const { listenerMiddleware } = await import('./listener')
+  const { installThemeSubscriptions, listenerMiddleware } =
+    await import('./listener')
   const { default: themeReducer } = await import('./slices/themeSlice')
-  return configureStore({
+  const store = configureStore({
     reducer: { theme: themeReducer },
     middleware: (getDefault) =>
       getDefault().prepend(listenerMiddleware.middleware),
   })
+  // Mirrors store.ts: the window-level subscriptions are installed at store
+  // creation, NOT from the hydration handler — the storage middleware skips
+  // ACTION_HYDRATE_COMPLETE entirely when localStorage is still empty.
+  installThemeSubscriptions(store)
+  return store
 }
 
 beforeEach(() => {
@@ -47,6 +53,11 @@ beforeEach(() => {
   root.style.removeProperty('--theme-hue')
   root.style.removeProperty('--theme-chroma')
   root.classList.remove('dark', 'light', 'tone-tinted')
+
+  // Drop any preload bridge a cross-window test installed — happy-dom keeps
+  // one `window` for the whole file, so a leftover stub would make the
+  // "no bridge" test pass for the wrong reason.
+  Reflect.deleteProperty(window, 'electron')
 })
 
 describe('theme listener — applyThemeToDOM', () => {
@@ -302,15 +313,14 @@ describe('theme listener — applyThemeToDOM', () => {
     expect(store.getState().theme.modePreference).toBe('system')
   })
 
-  it('subscribes to OS appearance only once even if hydration completes twice', async () => {
-    // Idempotency guard for the OS-appearance subscription: ACTION_HYDRATE_COMPLETE
-    // should fire once per session, but a hot-module-reload replay (or any future
-    // code path that re-dispatches it) must NOT stack a second
+  it('subscribes to OS appearance only once even if the installer runs twice', async () => {
+    // Idempotency guard for the OS-appearance subscription: `store.ts` installs
+    // once, but a hot-module-reload replay must NOT stack a second
     // `prefers-color-scheme` change listener. Without the
-    // `systemThemeListenerInstalled` short-circuit, every replayed hydrate would
-    // add another subscription, so one OS flip would re-resolve the theme N times
-    // and leak listeners. The guard makes the second hydrate a no-op for
-    // subscription setup, which we observe by counting matchMedia calls.
+    // `systemThemeListenerInstalled` short-circuit, every replay would add
+    // another subscription, so one OS flip would re-resolve the theme N times
+    // and leak listeners. The guard makes the second install a no-op, which we
+    // observe by counting matchMedia calls.
 
     // Arrange — a matchMedia spy installed before importing the listener so the
     // first hydrate wires its change handler against our stub.
@@ -333,13 +343,13 @@ describe('theme listener — applyThemeToDOM', () => {
     })
 
     const store = await createThemedStore()
+    const { installThemeSubscriptions } = await import('./listener')
 
-    // Act — hydrate twice on the SAME store (same module instance, so the
-    // module-level installed flag persists between the two dispatches).
-    store.dispatch({ type: ACTION_HYDRATE_COMPLETE })
-    store.dispatch({ type: ACTION_HYDRATE_COMPLETE })
+    // Act — install a second time on the SAME module instance, so the
+    // module-level installed flag persists between the two calls.
+    installThemeSubscriptions(store)
 
-    // Assert — only the first hydrate subscribed; the second hit the guard.
+    // Assert — only the first install subscribed; the second hit the guard.
     expect(osAppearanceSubscriptions).toBe(1)
     expect(matchMediaStub).toHaveBeenCalledTimes(1)
   })
@@ -409,6 +419,8 @@ describe('theme listener — applyThemeToDOM', () => {
     })
 
     try {
+      // Act (part 1) — creating the store runs the installer, which must
+      // early-return on the missing matchMedia rather than calling it.
       const store = await createThemedStore()
       const { setTheme } = await import('./slices/themeSlice')
       store.dispatch(setTheme('blue'))
@@ -417,8 +429,7 @@ describe('theme listener — applyThemeToDOM', () => {
       root.style.removeProperty('--theme-chroma')
       root.classList.remove('dark', 'light')
 
-      // Act — hydration completes; installSystemThemeListener must early-return
-      // on the missing matchMedia rather than calling window.matchMedia(...).
+      // Act (part 2) — hydration still repaints without throwing.
       expect(() =>
         store.dispatch({ type: ACTION_HYDRATE_COMPLETE }),
       ).not.toThrow()
@@ -473,5 +484,168 @@ describe('theme listener — applyThemeToDOM', () => {
     expect(store.getState().theme.preset).toBe('neutral-light')
 
     setPropertySpy.mockRestore()
+  })
+})
+
+describe('theme listener — cross-window sync', () => {
+  /**
+   * Install a stub preload bridge and hand back the pieces the tests drive:
+   * `broadcast` records what this window published, and `emitChanged` plays
+   * the other window's broadcast back in.
+   */
+  function stubThemeBridge() {
+    const broadcast = vi.fn().mockResolvedValue(undefined)
+    let received: ((state: unknown) => void) | null = null
+    Object.defineProperty(window, 'electron', {
+      configurable: true,
+      writable: true,
+      value: {
+        theme: {
+          broadcast,
+          onChanged: (callback: (state: unknown) => void) => {
+            received = callback
+            return () => {}
+          },
+        },
+      },
+    })
+    return {
+      broadcast,
+      emitChanged: (state: unknown) => received?.(state),
+    }
+  }
+
+  test('publishes the resolved theme so the Settings window can follow a mode switch', async () => {
+    // Arrange
+    const { broadcast } = stubThemeBridge()
+    const store = await createThemedStore()
+    const { setModePreference } = await import('./slices/themeSlice')
+
+    // Act
+    store.dispatch(setModePreference('light'))
+
+    // Assert — the whole resolved state travels, not just the preset name:
+    // the receiving window must not re-resolve `mode` against its own
+    // matchMedia.
+    expect(broadcast).toHaveBeenCalledWith({
+      hue: 0,
+      chroma: 0,
+      mode: 'light',
+      modePreference: 'light',
+      preset: 'neutral-light',
+    })
+  })
+
+  test('adopts a theme published by the other window without echoing it back', async () => {
+    // Regression guard for an infinite cross-window bounce: if adopting a
+    // broadcast re-published it, the two windows would relay the same state
+    // to each other forever.
+
+    // Arrange
+    const { broadcast, emitChanged } = stubThemeBridge()
+    const store = await createThemedStore()
+
+    // Act — the other window switched to Cyan.
+    emitChanged({
+      hue: 195,
+      chroma: 0.16,
+      mode: 'dark',
+      modePreference: 'dark',
+      preset: 'cyan',
+    })
+
+    // Assert
+    expect(store.getState().theme.preset).toBe('cyan')
+    expect(broadcast).not.toHaveBeenCalled()
+  })
+
+  test('repaints <html> when the other window switches from Dark to Light', async () => {
+    // The bug this whole path exists for: an open Settings window used to
+    // stay Dark until it was closed and reopened.
+
+    // Arrange
+    const { emitChanged } = stubThemeBridge()
+    const store = await createThemedStore()
+    // A returning user: hydration repaints the persisted dark palette first.
+    store.dispatch({ type: ACTION_HYDRATE_COMPLETE })
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+
+    // Act
+    emitChanged({
+      hue: 0,
+      chroma: 0,
+      mode: 'light',
+      modePreference: 'light',
+      preset: 'neutral-light',
+    })
+
+    // Assert
+    expect(document.documentElement.classList.contains('light')).toBe(true)
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+  })
+
+  test('subscribes to the other window only once even if hydration completes twice', async () => {
+    // Arrange
+    let subscriptions = 0
+    Object.defineProperty(window, 'electron', {
+      configurable: true,
+      writable: true,
+      value: {
+        theme: {
+          broadcast: vi.fn().mockResolvedValue(undefined),
+          onChanged: () => {
+            subscriptions += 1
+            return () => {}
+          },
+        },
+      },
+    })
+    const store = await createThemedStore()
+    const { installThemeSubscriptions } = await import('./listener')
+
+    // Act
+    installThemeSubscriptions(store)
+
+    // Assert
+    expect(subscriptions).toBe(1)
+  })
+
+  test('still paints the theme when no preload bridge is present', async () => {
+    // The node test lane and Storybook both render this store without
+    // `window.electron`; theme must keep working rather than throw.
+
+    // Arrange — `beforeEach` already removed any stub bridge.
+    const store = await createThemedStore()
+    const { setTheme } = await import('./slices/themeSlice')
+
+    // Act
+    store.dispatch(setTheme('neutral-light'))
+
+    // Assert
+    expect(document.documentElement.classList.contains('light')).toBe(true)
+  })
+
+  test('still follows the other window on a first launch, before anything is persisted', async () => {
+    // Regression guard for the trigger these subscriptions used to hang off:
+    // the storage middleware short-circuits without dispatching
+    // ACTION_HYDRATE_COMPLETE when localStorage holds nothing, so installing
+    // on hydration left a fresh profile with no cross-window sync at all.
+
+    // Arrange — a store that never sees a hydrate action.
+    const { emitChanged } = stubThemeBridge()
+    const store = await createThemedStore()
+
+    // Act
+    emitChanged({
+      hue: 0,
+      chroma: 0,
+      mode: 'light',
+      modePreference: 'light',
+      preset: 'neutral-light',
+    })
+
+    // Assert
+    expect(store.getState().theme.mode).toBe('light')
+    expect(document.documentElement.classList.contains('light')).toBe(true)
   })
 })

--- a/src/renderer/src/redux/listener.ts
+++ b/src/renderer/src/redux/listener.ts
@@ -28,14 +28,14 @@ type ListenerEffectApi = Parameters<
 >[1]
 
 /**
- * The two members the window-level theme subscriptions need. Satisfied by both
- * the Redux store and a listener effect's api, so {@link installThemeSubscriptions}
- * can be called from either without importing `RootState` (which would close a
- * cycle back through `store.ts`).
+ * The narrowest api the window-level theme subscriptions need: dispatch, and
+ * a read of the one slice they consult. Typed structurally rather than as
+ * `RootState` so `listener.ts` does not close an import cycle back through
+ * `store.ts`, and narrowly enough that no `as` cast is needed at the read.
  */
 interface ThemeSubscriptionApi {
   dispatch: ListenerEffectApi['dispatch']
-  getState: () => unknown
+  getState: () => { theme: ThemeState }
 }
 
 // Type for state accessed in listeners (avoids circular RootState import)
@@ -105,7 +105,7 @@ function installSystemThemeListener(api: ThemeSubscriptionApi): void {
   const systemQuery = window.matchMedia('(prefers-color-scheme: dark)')
   systemQuery.addEventListener('change', () => {
     // Explicit light/dark must stay sticky; only the "Auto" path reacts.
-    const { theme } = api.getState() as ListenerState
+    const { theme } = api.getState()
     if (theme.modePreference === 'system') {
       api.dispatch(setModePreference('system'))
     }

--- a/src/renderer/src/redux/listener.ts
+++ b/src/renderer/src/redux/listener.ts
@@ -12,7 +12,7 @@ import type { AgentId } from '@/shared/types'
 import { setSettings } from './slices/settingsSlice'
 import { fetchStaleLockEntries } from './slices/skillLockSlice'
 import { clearSelection } from './slices/skillsSlice'
-import { setModePreference, setTheme } from './slices/themeSlice'
+import { setModePreference, setTheme, syncTheme } from './slices/themeSlice'
 import type { ThemeState } from './slices/themeSlice'
 import {
   fetchSyncPreview,
@@ -26,6 +26,17 @@ export const listenerMiddleware = createListenerMiddleware()
 type ListenerEffectApi = Parameters<
   Parameters<typeof listenerMiddleware.startListening>[0]['effect']
 >[1]
+
+/**
+ * The two members the window-level theme subscriptions need. Satisfied by both
+ * the Redux store and a listener effect's api, so {@link installThemeSubscriptions}
+ * can be called from either without importing `RootState` (which would close a
+ * cycle back through `store.ts`).
+ */
+interface ThemeSubscriptionApi {
+  dispatch: ListenerEffectApi['dispatch']
+  getState: () => unknown
+}
 
 // Type for state accessed in listeners (avoids circular RootState import)
 interface ListenerState {
@@ -65,9 +76,9 @@ function applyThemeToDOM(state: ThemeState): void {
 
 /**
  * Tracks whether the `prefers-color-scheme` listener has been installed.
- * `ACTION_HYDRATE_COMPLETE` should only fire once per session, but a
- * conservative guard keeps the subscription idempotent if a future
- * code path replays the action (e.g. during hot module reload).
+ * {@link installThemeSubscriptions} runs once per store, but a conservative
+ * guard keeps the subscription idempotent if the module is re-evaluated
+ * (e.g. during hot module reload).
  */
 let systemThemeListenerInstalled = false
 
@@ -83,7 +94,7 @@ let systemThemeListenerInstalled = false
  * doesn't always implement matchMedia) so the listener stays safe to
  * import everywhere.
  */
-function installSystemThemeListener(listenerApi: ListenerEffectApi): void {
+function installSystemThemeListener(api: ThemeSubscriptionApi): void {
   if (systemThemeListenerInstalled) return
   if (
     typeof window === 'undefined' ||
@@ -94,39 +105,105 @@ function installSystemThemeListener(listenerApi: ListenerEffectApi): void {
   const systemQuery = window.matchMedia('(prefers-color-scheme: dark)')
   systemQuery.addEventListener('change', () => {
     // Explicit light/dark must stay sticky; only the "Auto" path reacts.
-    const { theme } = listenerApi.getState() as ListenerState
+    const { theme } = api.getState() as ListenerState
     if (theme.modePreference === 'system') {
-      listenerApi.dispatch(setModePreference('system'))
+      api.dispatch(setModePreference('system'))
     }
   })
   systemThemeListenerInstalled = true
 }
 
 /**
+ * Tracks whether the cross-window `theme:changed` subscription is installed.
+ * Same idempotence guard as {@link systemThemeListenerInstalled}, and for the
+ * same reason: one install per store, and a module re-evaluation must not
+ * stack duplicate subscriptions.
+ */
+let themeBroadcastListenerInstalled = false
+
+/**
+ * Adopt theme changes made in the app's other window.
+ *
+ * Installed from `store.ts` so BOTH renderer entry points get it for free —
+ * the main window and the Settings window load different HTML but the same
+ * store module. Without this, switching the main window Dark -> Light left an
+ * already open Settings window in the old palette until it was closed and
+ * reopened: two windows of one app, visibly disagreeing.
+ *
+ * `window.electron` is absent in the vitest node lane, so the guard keeps
+ * `listener.ts` safe to import headlessly, exactly like the matchMedia guard
+ * above.
+ */
+function installThemeBroadcastListener(api: ThemeSubscriptionApi): void {
+  if (themeBroadcastListenerInstalled) return
+  if (typeof window === 'undefined' || !window.electron?.theme) return
+  window.electron.theme.onChanged((nextTheme) => {
+    api.dispatch(syncTheme(nextTheme))
+  })
+  themeBroadcastListenerInstalled = true
+}
+
+/**
+ * Install the two window-level theme subscriptions: OS appearance changes and
+ * the other window's `theme:changed` broadcast.
+ *
+ * Called once from `store.ts` at store creation rather than from the
+ * `ACTION_HYDRATE_COMPLETE` handler, because that action is NOT dispatched
+ * when localStorage holds nothing yet — the storage middleware short-circuits
+ * on `persisted === null`. Hanging these off hydration meant a first launch
+ * (or any launch after the user cleared storage) got neither subscription:
+ * "Auto" silently stopped following macOS Appearance, and an open Settings
+ * window would not follow the main window's palette.
+ *
+ * Both installers are individually idempotent, so a hot-module-reload replay
+ * of this call cannot stack duplicate subscriptions.
+ *
+ * @param api - The Redux store, or any `{ dispatch, getState }` pair.
+ * @example
+ * export const store = configureStore({ ... })
+ * installThemeSubscriptions(store)
+ */
+export function installThemeSubscriptions(api: ThemeSubscriptionApi): void {
+  installSystemThemeListener(api)
+  installThemeBroadcastListener(api)
+}
+
+/**
  * Theme initialization listener
  * Applies persisted theme from localStorage after hydration completes.
  * This ensures the correct theme is shown after storage-middleware loads
- * state, and installs the system-theme subscription so future OS flips
- * propagate when the user is on "Auto".
+ * state. The window-level subscriptions are NOT installed here — see
+ * {@link installThemeSubscriptions} for why hydration is the wrong trigger.
  */
 listenerMiddleware.startListening({
   type: ACTION_HYDRATE_COMPLETE,
   effect: (_action, listenerApi) => {
     const state = listenerApi.getState() as ListenerState
     applyThemeToDOM(state.theme)
-    installSystemThemeListener(listenerApi)
   },
 })
 
 /**
  * Theme switching side effect
- * Listens to all theme-related actions and applies CSS changes
+ * Listens to all theme-related actions and applies CSS changes, then tells
+ * the app's other window to adopt the same palette.
+ *
+ * `syncTheme` is matched for the DOM write but NOT for the broadcast: it is
+ * how a window ADOPTS someone else's theme, so re-publishing it would bounce
+ * the same state between windows forever. Keeping the two concerns in one
+ * listener (rather than two overlapping matchers) makes that asymmetry the
+ * single visible line it is.
  */
 listenerMiddleware.startListening({
-  matcher: isAnyOf(setTheme, setModePreference),
-  effect: (_action, listenerApi) => {
+  matcher: isAnyOf(setTheme, setModePreference, syncTheme),
+  effect: (action, listenerApi) => {
     const state = listenerApi.getState() as ListenerState
     applyThemeToDOM(state.theme)
+    if (syncTheme.match(action)) return
+    // Fire-and-forget: a failed relay costs the other window one stale
+    // palette until its next theme change, which is strictly better than
+    // an unhandled rejection tearing through the middleware.
+    void window.electron?.theme?.broadcast(state.theme).catch(() => {})
   },
 })
 

--- a/src/renderer/src/redux/slices/themeSlice.test.ts
+++ b/src/renderer/src/redux/slices/themeSlice.test.ts
@@ -1,5 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest'
 
 import { COLOR_PRESET_CHROMA, TINTED_NEUTRAL_CHROMA } from '@/shared/constants'
 
@@ -323,5 +323,37 @@ describe('themeSlice', () => {
     expect(state.preset).toBe('neutral-dark')
     expect(state.chroma).toBe(0)
     expect(state.mode).toBe('dark')
+  })
+  test("adopts the other window's theme wholesale rather than re-deriving it", async () => {
+    // The Settings window is a second renderer process with its own store, so
+    // it takes the sender's ALREADY-RESOLVED state. Re-deriving `mode` from
+    // the preset would run the receiver's own matchMedia, which is not what
+    // the user just picked in the main window.
+
+    // Arrange — this window is on a saturated cyan dark theme.
+    const { setTheme, syncTheme } = await import('./themeSlice')
+    const store = await createTestStore()
+    store.dispatch(setTheme('cyan'))
+
+    // Act — the other window switched to plain light.
+    store.dispatch(
+      syncTheme({
+        hue: 0,
+        chroma: 0,
+        mode: 'light',
+        modePreference: 'system',
+        preset: 'neutral-light',
+      }),
+    )
+
+    // Assert — every field crosses, including `modePreference: 'system'`,
+    // which no preset name could have implied.
+    expect(store.getState().theme).toEqual({
+      hue: 0,
+      chroma: 0,
+      mode: 'light',
+      modePreference: 'system',
+      preset: 'neutral-light',
+    })
   })
 })

--- a/src/renderer/src/redux/slices/themeSlice.ts
+++ b/src/renderer/src/redux/slices/themeSlice.ts
@@ -3,53 +3,14 @@ import { createSlice } from '@reduxjs/toolkit'
 
 import type { ThemePresetName } from '@/shared/constants'
 import { THEME_PRESETS } from '@/shared/constants'
+import type { ModePreference, ThemeState } from '@/shared/theme'
 
 /**
- * User-facing palette mode choice.
- * - 'light' / 'dark' are sticky: the user pinned the palette and we never
- *   auto-flip it regardless of OS appearance changes.
- * - 'system' follows prefers-color-scheme: the listener middleware keeps
- *   state.mode in sync with the OS as long as this preference is active.
- *
- * Persisted alongside `mode` so the resolved value can survive cold starts
- * (read by the pre-hydration bootstrap script) while the preference
- * survives OS theme changes.
+ * {@link ThemeState} and {@link ModePreference} live in `shared/` because the
+ * `theme:changed` broadcast carries them across the IPC boundary. Re-exported
+ * here so existing slice consumers keep one import site.
  */
-export type ModePreference = 'light' | 'dark' | 'system'
-
-/**
- * Shape persisted in localStorage via `@laststance/redux-storage-middleware`.
- * `hue` x `chroma` together project to OKLCH coordinates on `<html>`:
- *   --theme-hue:    state.hue    (angle, ignored when chroma === 0)
- *   --theme-chroma: state.chroma (0 = grayscale ramp, 0.16 = saturated ramp)
- * Mode is tracked independently so users can flip dark/light without losing
- * their color preset. `preset` is the authoritative key; `hue`/`chroma`/`mode`
- * are derived snapshots kept in state so the DOM listener can apply them in
- * one pass without re-looking-up the preset table.
- *
- * `mode` is the resolved palette (what `<html>` actually wears) and
- * `modePreference` is the user's choice. They differ only when the user
- * picked "system" - in which case `mode` mirrors the OS while
- * `modePreference` stays `'system'` so the next OS flip can be honored.
- */
-export interface ThemeState {
-  /** OKLCH hue angle (0-360). No visual effect when `chroma === 0`. @example 195 */
-  hue: number
-  /**
-   * OKLCH chroma scalar driving the entire token ramp. Only two values are
-   * ever persisted: `0` (neutral / shadcn) and `COLOR_PRESET_CHROMA` (color preset).
-   */
-  chroma: number
-  /** Light vs dark palette selector. Applied as `.light` / `.dark` on `<html>`. */
-  mode: 'light' | 'dark'
-  /**
-   * User's explicit mode choice. Persisted so the "Auto" affordance survives
-   * reloads and the resolver can re-apply OS appearance after hydration.
-   */
-  modePreference: ModePreference
-  /** Authoritative preset key. Drives ThemeSelector's aria-pressed state. */
-  preset: ThemePresetName
-}
+export type { ModePreference, ThemeState } from '@/shared/theme'
 
 const initialState: ThemeState = {
   hue: 0,
@@ -173,8 +134,28 @@ const themeSlice = createSlice({
       const partner = partnerForMode(state.preset, resolved)
       if (partner) state.preset = partner
     },
+
+    /**
+     * Adopt a resolved {@link ThemeState} broadcast by another window.
+     *
+     * Exists because the Settings window is a second BrowserWindow with its
+     * own renderer process and its own store: it reads the persisted theme
+     * once at boot, so a Dark -> Light switch in the main window used to
+     * leave it stranded in the old palette until reopened.
+     *
+     * A whole-object replace, deliberately - the same idempotent shape as
+     * `setSettings`. Re-deriving from `preset` instead would re-run
+     * `resolveMode` against the RECEIVER's `matchMedia`, and a distinct
+     * action is what keeps the broadcast from echoing: the listener that
+     * emits `theme:broadcast` matches only the two user-driven actions, so
+     * adopting a broadcast never re-broadcasts.
+     *
+     * @example
+     * dispatch(syncTheme({ hue: 0, chroma: 0, mode: 'light', modePreference: 'light', preset: 'neutral-light' }))
+     */
+    syncTheme: (_state, action: PayloadAction<ThemeState>) => action.payload,
   },
 })
 
-export const { setTheme, setModePreference } = themeSlice.actions
+export const { setTheme, setModePreference, syncTheme } = themeSlice.actions
 export default themeSlice.reducer

--- a/src/renderer/src/redux/store.ts
+++ b/src/renderer/src/redux/store.ts
@@ -5,7 +5,7 @@ import { toast } from 'sonner'
 
 import { PERSIST_STATE_VERSION, PERSIST_STORAGE_KEY } from '@/shared/constants'
 
-import { listenerMiddleware } from './listener'
+import { installThemeSubscriptions, listenerMiddleware } from './listener'
 import { migrateState } from './migrations'
 import { createReportingLocalStorage } from './reportingLocalStorage'
 import activityReducer from './slices/activitySlice'
@@ -107,6 +107,12 @@ export const store = configureStore({
 })
 
 setupListeners(store.dispatch)
+
+// Window-level theme subscriptions (OS appearance + the other window's
+// broadcast). Installed here rather than from the hydration listener because
+// the storage middleware does not dispatch ACTION_HYDRATE_COMPLETE when
+// localStorage is still empty, so a first launch would get neither.
+installThemeSubscriptions(store)
 
 export type RootState = ReturnType<typeof store.getState>
 export type AppDispatch = typeof store.dispatch

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -3,6 +3,7 @@ import type {
   ActivityListOptions,
 } from '../../../shared/activityLog'
 import type { Settings, SettingsPatch } from '../../../shared/settings'
+import type { ThemeState } from '../../../shared/theme'
 import type {
   AbsolutePath,
   Skill,
@@ -160,6 +161,10 @@ declare global {
         get: () => Promise<Settings>
         set: (partial: SettingsPatch) => Promise<Settings>
         onChanged: (callback: (settings: Settings) => void) => () => void
+      }
+      theme: {
+        broadcast: (state: ThemeState) => Promise<void>
+        onChanged: (callback: (state: ThemeState) => void) => () => void
       }
       activity: {
         list: (options?: ActivityListOptions) => Promise<ActivityEvent[]>

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -73,6 +73,12 @@ export const IPC_CHANNELS = {
   SETTINGS_SET: 'settings:set',
   SETTINGS_CHANGED: 'settings:changed',
 
+  // Theme (cross-window). Theme lives in renderer Redux + localStorage, not
+  // in settings.json, so it has no main-process owner to broadcast from —
+  // the window that changed it asks main to fan the resolved state out.
+  THEME_BROADCAST: 'theme:broadcast',
+  THEME_CHANGED: 'theme:changed',
+
   // Activity timeline (dashboard) — append-only event log persisted under
   // userData. `list` hydrates the widget on mount; `changed` broadcasts the
   // new log after each recorded add/remove/sync.

--- a/src/shared/ipc-contract.test.ts
+++ b/src/shared/ipc-contract.test.ts
@@ -43,6 +43,7 @@ describe('IPC contract alignment', () => {
       [IPC_CHANNELS.SETTINGS_OPEN]: true,
       [IPC_CHANNELS.SETTINGS_GET]: true,
       [IPC_CHANNELS.SETTINGS_SET]: true,
+      [IPC_CHANNELS.THEME_BROADCAST]: true,
       [IPC_CHANNELS.ACTIVITY_LIST]: true,
       [IPC_CHANNELS.FOLDER_REVEAL_IN_FINDER]: true,
       [IPC_CHANNELS.FOLDER_OPEN_IN_TERMINAL]: true,
@@ -58,7 +59,7 @@ describe('IPC contract alignment', () => {
     // The `satisfies` clause above is a structural guard; this length check is
     // the trip-wire that forces a human PR diff when a channel is added.
     // Assert
-    expect(invokeChannelKeys).toHaveLength(39)
+    expect(invokeChannelKeys).toHaveLength(40)
   })
 
   it('forces a review by tripping when a push-event channel is added or removed', () => {
@@ -74,6 +75,7 @@ describe('IPC contract alignment', () => {
       [IPC_CHANNELS.UPDATE_DOWNLOADED]: true,
       [IPC_CHANNELS.UPDATE_ERROR]: true,
       [IPC_CHANNELS.SETTINGS_CHANGED]: true,
+      [IPC_CHANNELS.THEME_CHANGED]: true,
       [IPC_CHANNELS.ACTIVITY_CHANGED]: true,
     } as const satisfies Record<keyof IpcEventContract, true>
 
@@ -82,6 +84,6 @@ describe('IPC contract alignment', () => {
 
     // Runtime assertion: mapping covers exactly the contract keys
     // Assert
-    expect(eventChannelKeys).toHaveLength(10)
+    expect(eventChannelKeys).toHaveLength(11)
   })
 })

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -1,5 +1,6 @@
 import type { ActivityEvent, ActivityListOptions } from './activityLog'
 import type { Settings, SettingsPatch } from './settings'
+import type { ThemeState } from './theme'
 import type {
   AbsolutePath,
   Agent,
@@ -151,6 +152,7 @@ export interface IpcInvokeContract {
   'settings:open': { args: []; result: void }
   'settings:get': { args: []; result: Settings }
   'settings:set': { args: [SettingsPatch]; result: Settings }
+  'theme:broadcast': { args: [ThemeState]; result: void }
   'activity:list': {
     // Always 1-arg (possibly `undefined`) to match the Zod tuple schema, like
     // `sync:preview`: preload forwards the options arg even when it is
@@ -192,6 +194,7 @@ export interface IpcEventContract {
   'update:downloaded': UpdateInfo
   'update:error': UpdateErrorPayload
   'settings:changed': Settings
+  'theme:changed': ThemeState
   'activity:changed': ActivityEvent[]
 }
 

--- a/src/shared/theme.ts
+++ b/src/shared/theme.ts
@@ -1,6 +1,23 @@
 import type { ThemePresetName } from './constants'
 
 /**
+ * Every palette `<html>` can actually wear. Declared as a value, not just a
+ * union, so `src/main/ipc/ipc-schemas.ts` can build the `theme:broadcast`
+ * `z.enum` from it — adding a mode then updates the IPC validator with it
+ * instead of leaving the two lists to drift apart silently.
+ */
+export const THEME_MODES = ['light', 'dark'] as const
+
+/** Resolved palette selector. @example 'dark' */
+export type ThemeMode = (typeof THEME_MODES)[number]
+
+/**
+ * Every value {@link ModePreference} accepts. Same single-source-of-truth
+ * reason as {@link THEME_MODES}: the IPC schema derives its enum from here.
+ */
+export const MODE_PREFERENCES = ['light', 'dark', 'system'] as const
+
+/**
  * User-facing palette mode choice.
  * - 'light' / 'dark' are sticky: the user pinned the palette and we never
  *   auto-flip it regardless of OS appearance changes.
@@ -12,7 +29,7 @@ import type { ThemePresetName } from './constants'
  * (read by the pre-hydration bootstrap script) while the preference
  * survives OS theme changes.
  */
-export type ModePreference = 'light' | 'dark' | 'system'
+export type ModePreference = (typeof MODE_PREFERENCES)[number]
 
 /**
  * Shape persisted in localStorage via `@laststance/redux-storage-middleware`,
@@ -48,7 +65,7 @@ export interface ThemeState {
    */
   chroma: number
   /** Light vs dark palette selector. Applied as `.light` / `.dark` on `<html>`. */
-  mode: 'light' | 'dark'
+  mode: ThemeMode
   /**
    * User's explicit mode choice. Persisted so the "Auto" affordance survives
    * reloads and the resolver can re-apply OS appearance after hydration.

--- a/src/shared/theme.ts
+++ b/src/shared/theme.ts
@@ -1,0 +1,59 @@
+import type { ThemePresetName } from './constants'
+
+/**
+ * User-facing palette mode choice.
+ * - 'light' / 'dark' are sticky: the user pinned the palette and we never
+ *   auto-flip it regardless of OS appearance changes.
+ * - 'system' follows prefers-color-scheme: the listener middleware keeps
+ *   {@link ThemeState.mode} in sync with the OS as long as this preference
+ *   is active.
+ *
+ * Persisted alongside `mode` so the resolved value can survive cold starts
+ * (read by the pre-hydration bootstrap script) while the preference
+ * survives OS theme changes.
+ */
+export type ModePreference = 'light' | 'dark' | 'system'
+
+/**
+ * Shape persisted in localStorage via `@laststance/redux-storage-middleware`,
+ * and the payload of the `theme:changed` broadcast that keeps the Settings
+ * window's palette aligned with the main window's.
+ *
+ * `hue` x `chroma` together project to OKLCH coordinates on `<html>`:
+ *   --theme-hue:    state.hue    (angle, ignored when chroma === 0)
+ *   --theme-chroma: state.chroma (0 = grayscale ramp, 0.16 = saturated ramp)
+ * Mode is tracked independently so users can flip dark/light without losing
+ * their color preset. `preset` is the authoritative key; `hue`/`chroma`/`mode`
+ * are derived snapshots kept in state so the DOM listener can apply them in
+ * one pass without re-looking-up the preset table.
+ *
+ * `mode` is the resolved palette (what `<html>` actually wears) and
+ * `modePreference` is the user's choice. They differ only when the user
+ * picked "system" - in which case `mode` mirrors the OS while
+ * `modePreference` stays `'system'` so the next OS flip can be honored.
+ *
+ * Lives in `shared/` rather than the slice because it crosses the IPC
+ * boundary: `src/shared/ipc-contract.ts` types the broadcast with it, and a
+ * contract reaching into the renderer would invert the layering.
+ *
+ * @example
+ * { hue: 195, chroma: 0.16, mode: 'dark', modePreference: 'system', preset: 'cyan' }
+ */
+export interface ThemeState {
+  /** OKLCH hue angle (0-360). No visual effect when `chroma === 0`. @example 195 */
+  hue: number
+  /**
+   * OKLCH chroma scalar driving the entire token ramp. Only two values are
+   * ever persisted: `0` (neutral / shadcn) and `COLOR_PRESET_CHROMA` (color preset).
+   */
+  chroma: number
+  /** Light vs dark palette selector. Applied as `.light` / `.dark` on `<html>`. */
+  mode: 'light' | 'dark'
+  /**
+   * User's explicit mode choice. Persisted so the "Auto" affordance survives
+   * reloads and the resolver can re-apply OS appearance after hydration.
+   */
+  modePreference: ModePreference
+  /** Authoritative preset key. Drives ThemeSelector's aria-pressed state. */
+  preset: ThemePresetName
+}


### PR DESCRIPTION
## What

An already-open Settings window now follows theme changes made in the main
window. Closes the `P2. Open Settings should follow theme changes in the main
window` entry in `TODOS.md`.

## Why it was broken

The Settings window is a second `BrowserWindow` with its own renderer process
and its own store. It reads the persisted theme once, from the pre-hydration
bootstrap in `src/renderer/settings/index.html`, and nothing updated it after
that — `settings/index.html` even documented the limitation as permanent
("theme changes require closing and reopening Settings"). Switching the main
window Dark → Light left two windows of one app visibly disagreeing.

Theme is not part of `settings.json`. It lives in renderer Redux and is
persisted to localStorage, so unlike every other cross-window value it has no
main-process owner to broadcast from.

## The fix

The window that changes the theme publishes its resolved `ThemeState` over a
new `theme:broadcast` invoke channel; main relays it as `theme:changed` to
every window, and each one adopts it with a new `syncTheme` action.

Three things this gets right that the obvious version does not:

- **The whole resolved state travels**, not just the preset name. `mode` is
  derived from `modePreference` through `resolveMode`, which reads
  `matchMedia` — re-deriving it in the receiver would answer with the
  *receiver's* OS query rather than what the user just picked.
- **`syncTheme` is excluded from the listener that publishes.** Adopting a
  broadcast therefore never re-publishes, so the two windows cannot relay the
  same state to each other forever. That asymmetry is one line and is covered
  by a regression test.
- **Main is a pure relay here**, not the source of truth it is for settings.
  The sender is deliberately left in the fan-out: the echo dies in one hop
  because of the point above, which is cheaper than re-implementing
  `broadcastTypedEvent`'s destroyed-window guard just to skip one window.

`ThemeState` and `ModePreference` moved to `src/shared/theme.ts` because they
now cross the IPC boundary; `themeSlice` re-exports them so existing consumers
keep one import site.

## Adjacent bug fixed in the same commit

Both this subscription and the existing OS-appearance ("Auto") subscription
were installed from the `ACTION_HYDRATE_COMPLETE` handler. The storage
middleware short-circuits on `persisted === null` and never dispatches that
action when localStorage is still empty:

```js
const persisted = loadFromStorage()
if (persisted === null) {
  hydrationState = "hydrated"
  hydratedState = null
  return          // <- no ACTION_HYDRATE_COMPLETE
}
```

So on a **first launch** neither subscription existed: "Auto" silently stopped
following macOS Appearance until the app had been restarted once. Found while
verifying this PR's e2e — the fresh-HOME fixture never dispatched hydrate, so
the new sync did not work either. Both now install from `store.ts` at store
creation, which is the one place that runs in both windows regardless of what
localStorage holds.

## Known ceiling

A broadcast is a one-shot event, so a window that is mid-load when another
window changes the theme misses it and keeps the palette it read at boot. The
window that changed it has already persisted the new state by then, so this
only bites if the two overlap within the few hundred ms before the second
window's store evaluates.

## Review pass (open-code-review, 12/12 files)

Two findings, both fixed in `224f130`:

- **`theme:broadcast` had no `IPC_ARG_SCHEMAS` entry** — the only invoke
  channel carrying a payload that reached its handler unvalidated. Main fans
  that payload out to every window, where it is dispatched straight into Redux
  and written onto `<html>` as CSS custom properties. `preset` is now pinned to
  the `THEME_PRESETS` keys (an unknown name would otherwise land on the
  reducer's stale-key fallback and silently reset the palette in a window the
  user never touched) and hue/chroma are bounded to the OKLCH ranges
  `globals.css` consumes. Four boundary tests added.
- **The relay lived in `registerSettingsHandlers()`**, whose name no longer
  covered it. Moved to `src/main/ipc/theme.ts`, matching the one-domain-per-file
  layout of the rest of `src/main/ipc/`.

Also narrowed `ThemeSubscriptionApi.getState` from `() => unknown` to the one
slice it reads, which drops an `as` cast.

## CodeRabbit round 1 (`224f130`)

Three findings, two fixed and one declined.

**Fixed** — `THEME_MODES` and `MODE_PREFERENCES` now live in `src/shared/theme.ts`
as const arrays with `ThemeMode` / `ModePreference` derived from them, and the
`theme:broadcast` Zod enums build from the same arrays. The mode values were
previously written twice with nothing keeping them in sync. The schema also
moved from `z.object` to `z.strictObject`, matching `settings:set` (the only
other channel taking a free-form object): an unknown key now fails the relay
instead of being stripped on the way to the receiving reducer. `preset` casts to
`ThemePresetName` rather than `string`.

**Fixed** — a listener test whose name claimed hydration completed twice when the
test actually runs the installer twice.

**Declined — main-process theme snapshot API.** The finding's stated ordering is
inverted: `installThemeSubscriptions(store)` runs synchronously at `store.ts:115`,
while the storage middleware schedules its localStorage read with
`Promise.resolve().then(() => api.rehydrate())`, so the subscription is
registered *before* the read, not after. The gap that does exist is the one
already documented under **Known ceiling** — a window still loading its bundle
misses the one-shot `webContents.send`. A snapshot channel would cost a new
invoke channel across seven files and put renderer-owned state in main,
inverting this PR's layering rationale (theme has no main-process owner, which
is why the relay is stateless). It self-heals on the next theme change.

## Test plan

- `pnpm validate` — **198 files / 2617 tests, exit 0**, on the exact committed
  tree (`git diff HEAD --stat` empty after lint-staged).
- `pnpm test:e2e` — **86 passed**, including two new two-window specs in
  `e2e/spec/settings-window-theme-sync.e2e.ts`: a Dark → Light mode switch and
  an accent-preset change, both asserted on the real second window. Only an
  Electron e2e can cover this — the two stores are in separate processes, so a
  single-renderer test can never observe the crossing.
- New unit coverage in `listener.test.ts`: publishes the resolved state;
  adopts without echoing; repaints `<html>`; installs once; works with no
  preload bridge; and works on a first launch with no hydrate action.
- New reducer test in `themeSlice.test.ts` for the wholesale adopt.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * メインウィンドウで変更したテーマが、開いているSettingsウィンドウへ自動同期されるようになりました。
  * ライト／ダークモード、アクセントカラー、プリセットの変更がウィンドウ間で反映されます。
  * OSの外観設定変更にも各ウィンドウが追従します。

* **テスト**
  * テーマ同期、色設定の反映、無効なテーマ値の検証に関するテストを追加しました。

* **ドキュメント**
  * Settingsのテーマ同期に関する説明と対応状況を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
