### PR TITLE
fix(dashboard): stop stat numbers overlapping in a narrow widget

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -624,11 +624,16 @@ web breakpoints.
 Rules:
 
 - Keep the main three-region model: sidebar, content, Inspector.
-- Panels must remain usable at narrow widths through truncation, scrolling, or
-  progressive disclosure.
+- Panels must remain usable at narrow widths through truncation, wrapping,
+  scrolling, or progressive disclosure.
 - Text must not overlap icons, counters, badges, or adjacent actions.
 - Use stable dimensions for toolbar buttons, counters, tabs, and widgets.
 - Avoid viewport-scaled fonts.
+- Reflow _inside_ a dashboard widget with a container query (`@container` plus
+  `@min-[<rem>]:`), never a viewport breakpoint. The user resizes widgets in the
+  grid and again with the panel splitter, so widget width is decoupled from
+  window width: one 800px window can hand the same widget 112px or 238px. A
+  `md:` rule reads a number the widget never sees.
 
 ## Do and Don't
 

--- a/src/renderer/src/components/dashboard/widgets/HealthWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/HealthWidget.tsx
@@ -166,13 +166,17 @@ export const HealthWidget = function HealthWidget(): React.ReactElement {
         manualReview={totals.inaccessible}
       />
 
-      <div className="flex items-center justify-between text-xs">
+      {/* Wraps rather than clipping: at the 6-col grid's `w: 2`-`w: 3` sizes in
+          a narrow panel this row is ~111px wide, and a non-wrapping legend put
+          "cleanup" and "manual" outside the shell's `overflow-hidden`, hiding
+          two of the three counts with no scrollbar or affordance to find them. */}
+      <div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-1 text-xs">
         <span className="inline-flex items-center gap-1 text-success">
           <CheckCircle className="h-3 w-3" aria-hidden="true" />
           <span className="tabular-nums">{totals.valid}</span>
           <span className="text-muted-foreground">valid</span>
         </span>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
           {totals.broken > 0 ? (
             <span className="inline-flex items-center gap-1 text-amber-400">
               <AlertCircle className="h-3 w-3" aria-hidden="true" />

--- a/src/renderer/src/components/dashboard/widgets/StatsWidget.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/widgets/StatsWidget.browser.test.tsx
@@ -1,6 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { Provider } from 'react-redux'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import '@/renderer/src/styles/globals.css'
@@ -76,7 +76,7 @@ async function renderStats(skills: Skill[], agents: Agent[]) {
 }
 
 describe('StatsWidget', () => {
-  it('counts only symlinked skills as Linked and only on-disk agents as active', async () => {
+  test('counts only symlinked skills as Linked and only on-disk agents as active', async () => {
     // Arrange: 3 skills where 2 carry valid symlinks and 1 is unlinked (count 0),
     // plus 4 agents where exactly 1 has its skills dir on disk and 3 do not. The
     // resulting numbers (Skills 3, Linked 2, Agents 1) are deliberately distinct

--- a/src/renderer/src/components/dashboard/widgets/StatsWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/StatsWidget.tsx
@@ -39,6 +39,18 @@ function countActiveAgents(
 // ----------------------------------------------------------------------------
 // Tile — a single stat cell. Extracted because all three rows share this
 // layout; keeping it inline would duplicate the icon+number+label markup.
+//
+// Two forms, switched by the container query in {@link StatsWidget}:
+//   - wide  (>= 12rem): icon over number over label, three tiles side by side
+//   - narrow (< 12rem): icon + number + label on one line, three tiles stacked
+//
+// The narrow form exists because the widget lives in a resizable
+// `react-grid-layout` cell inside a resizable panel: at an 800px window with
+// the default `w: 3` size it is only 112px wide, which leaves 36px per tile
+// while the number alone renders 46px. The stacked-tile form overflowed into
+// its neighbours and rendered "227" "222" "50" as an unreadable "22250" —
+// the one thing DESIGN.md's responsive section forbids outright ("Text must
+// not overlap icons, counters, badges, or adjacent actions").
 // ----------------------------------------------------------------------------
 
 interface StatTileProps {
@@ -56,12 +68,20 @@ const StatTile = function StatTile({
   accentClass,
 }: StatTileProps): React.ReactElement {
   return (
-    <div className="flex-1 min-w-0 flex flex-col items-center justify-center gap-1 px-2">
-      <Icon className={`h-4 w-4 ${accentClass}`} aria-hidden="true" />
-      <span className={`text-2xl font-semibold tabular-nums ${accentClass}`}>
+    // `overflow-hidden` is the hard guarantee behind the container query: even
+    // at a width no breakpoint anticipated, content clips at the tile edge
+    // instead of spilling onto the neighbouring stat.
+    <div className="flex-1 min-w-0 overflow-hidden flex items-center gap-1.5 @min-[12rem]:flex-col @min-[12rem]:justify-center @min-[12rem]:gap-1 @min-[12rem]:px-2">
+      <Icon
+        className={`h-3.5 w-3.5 shrink-0 @min-[12rem]:h-4 @min-[12rem]:w-4 ${accentClass}`}
+        aria-hidden="true"
+      />
+      <span
+        className={`text-base font-semibold tabular-nums @min-[12rem]:text-2xl ${accentClass}`}
+      >
         {value}
       </span>
-      <span className="text-[11px] text-muted-foreground uppercase tracking-wide">
+      <span className="text-[11px] text-muted-foreground uppercase tracking-wide truncate">
         {label}
       </span>
     </div>
@@ -85,29 +105,47 @@ export const StatsWidget = function StatsWidget(): React.ReactElement {
   const activeAgents = countActiveAgents(agents)
 
   return (
-    <div className="h-full w-full flex items-stretch">
-      <StatTile
-        icon={BarChart3}
-        label="Skills"
-        value={totalSkills}
-        accentClass="text-foreground"
-      />
+    // `@container` (not a viewport breakpoint) because the widget is resizable
+    // in the grid *and* sits in a resizable panel, so its width is decoupled
+    // from `innerWidth` — an 800px window can hold this widget at 112px or
+    // 238px depending only on the user's own layout.
+    //
+    // 12rem = 192px is the measured floor for the side-by-side form: three
+    // tiles need 46px for the number plus 16px of `px-2`, so 3 x 62px plus the
+    // two 1px dividers = 188px.
+    <div className="@container h-full w-full">
+      <div className="h-full w-full flex flex-col justify-center gap-1 px-1 @min-[12rem]:flex-row @min-[12rem]:gap-0 @min-[12rem]:px-0">
+        <StatTile
+          icon={BarChart3}
+          label="Skills"
+          value={totalSkills}
+          accentClass="text-foreground"
+        />
 
-      <div className="w-px bg-border" aria-hidden="true" />
-      <StatTile
-        icon={Link2}
-        label="Linked"
-        value={linkedSkills}
-        accentClass="text-success"
-      />
+        {/* Dividers only separate side-by-side tiles; stacked rows read as a
+            list and a rule between each would crowd a 90px-tall body. */}
+        <div
+          className="hidden @min-[12rem]:block w-px bg-border"
+          aria-hidden="true"
+        />
+        <StatTile
+          icon={Link2}
+          label="Linked"
+          value={linkedSkills}
+          accentClass="text-success"
+        />
 
-      <div className="w-px bg-border" aria-hidden="true" />
-      <StatTile
-        icon={Users}
-        label="Agents"
-        value={activeAgents}
-        accentClass="text-emerald-400"
-      />
+        <div
+          className="hidden @min-[12rem]:block w-px bg-border"
+          aria-hidden="true"
+        />
+        <StatTile
+          icon={Users}
+          label="Agents"
+          value={activeAgents}
+          accentClass="text-emerald-400"
+        />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Problem

At the Overview tab's default `w: 3` of the 6-column grid in an **800x600** window, the Skill Stats widget body is **112px**. Three side-by-side tiles left 36px each while the number alone renders at 46px, so `227` `222` `50` painted over each other as an unreadable **"22250"** — the overlap [`DESIGN.md`'s responsive section](../blob/main/DESIGN.md) forbids outright.

Measured before the fix (`getBoundingClientRect`, live app):

| span | x-range | collides with |
|---|---|---|
| `"227"` | 545-591 | `"222"` (582-628) |
| `"SKILLS"` | 549-587 | `"LINKED"` (584-626) |

Symlink Health had the sibling bug: at ~111px its legend row was wider than the body, and `WidgetShell`'s `overflow-hidden` swallowed **"cleanup"** and **"manual"** — two of the three counts invisible with no scrollbar or affordance to find them.

## Fix

**`StatsWidget`** reflows to a compact `icon · number · label` row per stat below **12rem**, keeping the existing three-across form above it.

The breakpoint is a **container query, not `md:`**. The user resizes widgets in the grid *and* again with the panel splitter, so widget width is decoupled from window width — the same 800px window can hand this widget 112px or 238px. A viewport rule reads a number the widget never sees. `overflow-hidden` on the tile is the hard guarantee behind the query: at any width no breakpoint anticipated, content clips at the tile edge instead of spilling onto its neighbour.

12rem = 192px is the measured floor for the side-by-side form: three tiles need 46px for the number plus 16px of `px-2`, so 3 x 62px plus the two 1px dividers = 188px.

**`HealthWidget`**'s legend now wraps.

**`DESIGN.md`** gains the container-query rule this surfaced, plus `wrapping` in the list of sanctioned narrow-width strategies.

## Trade-off to know about

Wrapping the Health legend introduces **29px of vertical scroll** in that widget body (`clientHeight` 170 vs `scrollHeight` 199), which pushes the redundant "Manual review" status line below the fold. This is strictly better than the status quo: DESIGN.md sanctions scrolling as a narrow-width strategy, the primary **"Scan issues"** action stays fully visible at rest (y 515-547 against a widget bottom of 558), and all three counts become reachable instead of two being invisible with no affordance at all.

## Test plan

- `pnpm validate` — green (198 files, 2617 tests)
- `pnpm test:e2e` — green (86 passed)
- Live `playwright-cli` `getBoundingClientRect` scan, per `.react-grid-item`, of span-pair intersections plus an "escapes the widget box" check:
  - **800x600** — Welcome (231px), Skill Stats (112px), Symlink Health (111px), Agent Coverage (231px): all `overlaps: []`, `escapes: []`
  - **1400x900** — widget 254px, three-across form intact (`"227"` 869-915 at h32 = `text-2xl`, `"222"` 953-999, `"50"` 1045-1076), `overlaps: []`

## Coverage gap (deliberate)

No automated layout regression test ships with this. Tailwind utilities do **not** apply in the `*.browser.test.tsx` vitest lane — a probe reported `containerType: "normal"` on the `@container` element and 18px line boxes (default 16px font) instead of `text-[11px]`, verified after clearing `node_modules/.vite` and `node_modules/.vitest`. Both the old and new markup render as plain stacked blocks there, so **any** Tailwind-driven layout assertion in that lane passes on both and proves nothing. The e2e suite is the only lane with real CSS, but nothing in `e2e/` resizes the window today, and adding that capability is out of scope for a layout fix. The verification here is the live measurement above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ダッシュボードの統計ウィジェットが、パネル幅に応じて自動的にレイアウトを調整するようになりました。
  - 狭い表示幅では統計項目をコンパクトに縦並びで表示し、内容のはみ出しを防ぎます。
  - ヘルスウィジェットの凡例が、狭い幅でも折り返して表示されるようになりました。

- **ドキュメント**
  - ウィジェットのレスポンシブ表示に関する設計ガイドを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->