### PR TITLE
fix(skills): put the card overlay buttons on the DESIGN.md icon scale

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -598,6 +598,10 @@ finger-target minimum does not apply. The floor is WCAG 2.5.8 AA: 24x24 CSS px
   a bulk-select checkbox wrapper can keep a 44px (`min-h-11 min-w-11`) target:
   the glyph stays small, nothing reads as chunky, and the larger target is pure
   ergonomics. This is the ONLY sanctioned use of 44px on a control.
+- **A reservation voids that exception.** `opacity-0` does not set
+  `pointer-events: none`, so a gutter that keeps a neighbouring control
+  clickable must clear the hidden box — and that reservation is a layout cost.
+  Such a control returns to the scale above (see `getCardContentPaddingClass`).
 - Dense row controls may show a smaller glyph inside a 24px-or-larger target. An
   invisible `after:-inset-*` halo can extend the comfortable click area, but
   never over a row that is itself clickable: `opacity-0` controls stay

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -138,9 +138,9 @@ const ProtectButton = function ProtectButton({
 
   const rightClass =
     showBookmark && hasXButton
-      ? 'right-22'
+      ? 'right-14'
       : hasXButton || showBookmark
-        ? 'right-11'
+        ? 'right-7'
         : 'right-0'
 
   return (
@@ -152,7 +152,7 @@ const ProtectButton = function ProtectButton({
           aria-label={isProtected ? `Unlock ${skillName}` : `Lock ${skillName}`}
           data-testid={`skill-protect-${skillName}`}
           className={cn(
-            'absolute top-1.5 min-h-11 min-w-11 flex items-center justify-center rounded-md z-10 transition-opacity focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+            'absolute top-3.5 size-7 flex items-center justify-center rounded-md z-10 transition-opacity focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
             rightClass,
             isProtected
               ? 'text-foreground'
@@ -721,8 +721,8 @@ export const SkillItem = function SkillItem({
               'p-4',
               // Reserve right space for the absolute-positioned X/bookmark
               // overlays so the always-visible "+ Add" control never slides
-              // under them on hover. Bookmark + X stack to 88px, so that case
-              // needs pr-24 (96px), not the single-button pr-14 (56px).
+              // under them. Bookmark + X stack to 56px, so that case needs
+              // pr-15 (60px), not the single-button pr-8 (32px).
               getCardContentPaddingClass({
                 showProtect: true,
                 showBookmark,
@@ -836,7 +836,7 @@ const SkillItemOverlayActions = function SkillItemOverlayActions({
       }
       data-testid={`skill-delete-${skill.name}`}
       className={cn(
-        'absolute top-1.5 right-0 min-h-11 min-w-11 flex items-center justify-center rounded-md z-10 transition-opacity focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+        'absolute top-3.5 right-0 size-7 flex items-center justify-center rounded-md z-10 transition-opacity focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
         isProtected
           ? 'cursor-not-allowed text-muted-foreground opacity-40'
           : 'text-muted-foreground opacity-0 hover:bg-destructive/10 hover:text-destructive group-hover:opacity-100 focus-visible:opacity-100',
@@ -859,7 +859,7 @@ const SkillItemOverlayActions = function SkillItemOverlayActions({
                   ? `Delete ${skill.name} from ${selectedAgentName}`
                   : `Unlink ${skill.name} from ${selectedAgentName}`
               }
-              className="absolute top-1.5 right-0 min-h-11 min-w-11 flex items-center justify-center rounded-md hover:bg-destructive/10 text-muted-foreground hover:text-destructive z-10 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              className="absolute top-3.5 right-0 size-7 flex items-center justify-center rounded-md hover:bg-destructive/10 text-muted-foreground hover:text-destructive z-10 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
             >
               <X className="h-3.5 w-3.5" />
             </button>
@@ -899,8 +899,8 @@ const SkillItemOverlayActions = function SkillItemOverlayActions({
                   : `Bookmark ${skill.name}`
               }
               className={cn(
-                'absolute top-1.5 min-h-11 min-w-11 flex items-center justify-center rounded-md z-10 transition-opacity focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
-                showUnlinkButton || showDeleteButton ? 'right-11' : 'right-0',
+                'absolute top-3.5 size-7 flex items-center justify-center rounded-md z-10 transition-opacity focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+                showUnlinkButton || showDeleteButton ? 'right-7' : 'right-0',
                 isBookmarked
                   ? 'text-primary'
                   : 'text-muted-foreground hover:text-foreground opacity-40 group-hover:opacity-100 focus-visible:opacity-100',

--- a/src/renderer/src/components/skills/skillItemHelpers.test.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.test.ts
@@ -707,8 +707,8 @@ describe('getCardContentPaddingClass', () => {
     // Act
     const paddingClass = getCardContentPaddingClass(flags)
 
-    // Assert — pr-24 (96px) clears the 88px stack with an 8px gap.
-    expect(paddingClass).toBe('pr-24')
+    // Assert — pr-15 (60px) clears the 56px stack with a 4px gap.
+    expect(paddingClass).toBe('pr-15')
   })
 
   it('reserves the wide gutter when a bookmark stacks with the unlink button in agent view', () => {
@@ -724,7 +724,7 @@ describe('getCardContentPaddingClass', () => {
     const paddingClass = getCardContentPaddingClass(flags)
 
     // Assert
-    expect(paddingClass).toBe('pr-24')
+    expect(paddingClass).toBe('pr-15')
   })
 
   it('reserves a single-button gutter when only the bookmark shows', () => {
@@ -740,8 +740,8 @@ describe('getCardContentPaddingClass', () => {
     // Act
     const paddingClass = getCardContentPaddingClass(flags)
 
-    // Assert — pr-14 (56px) clears one 44px button.
-    expect(paddingClass).toBe('pr-14')
+    // Assert — pr-8 (32px) clears one 28px button with a 4px gap.
+    expect(paddingClass).toBe('pr-8')
   })
 
   it('reserves a single-button gutter when only an X button shows (non-bookmarkable skill)', () => {
@@ -757,7 +757,7 @@ describe('getCardContentPaddingClass', () => {
     const paddingClass = getCardContentPaddingClass(flags)
 
     // Assert
-    expect(paddingClass).toBe('pr-14')
+    expect(paddingClass).toBe('pr-8')
   })
 
   it('uses normal padding when no overlay buttons render', () => {
@@ -789,8 +789,8 @@ describe('getCardContentPaddingClass', () => {
     // Act
     const paddingClass = getCardContentPaddingClass(flags)
 
-    // Assert — pr-36 (144px) clears the full three-button 132px stack.
-    expect(paddingClass).toBe('pr-36')
+    // Assert — pr-22 (88px) clears the full three-button 84px stack.
+    expect(paddingClass).toBe('pr-22')
   })
 
   it('reserves the widest gutter when lock, bookmark, and unlink all show', () => {
@@ -806,7 +806,7 @@ describe('getCardContentPaddingClass', () => {
     const paddingClass = getCardContentPaddingClass(flags)
 
     // Assert
-    expect(paddingClass).toBe('pr-36')
+    expect(paddingClass).toBe('pr-22')
   })
 
   it('reserves the two-button gutter when lock and bookmark show without an X', () => {
@@ -822,8 +822,8 @@ describe('getCardContentPaddingClass', () => {
     // Act
     const paddingClass = getCardContentPaddingClass(flags)
 
-    // Assert — pr-24 (96px) clears the 88px two-button stack.
-    expect(paddingClass).toBe('pr-24')
+    // Assert — pr-15 (60px) clears the 56px two-button stack.
+    expect(paddingClass).toBe('pr-15')
   })
 
   it('reserves the two-button gutter when lock and an X show without a bookmark', () => {
@@ -839,7 +839,7 @@ describe('getCardContentPaddingClass', () => {
     const paddingClass = getCardContentPaddingClass(flags)
 
     // Assert
-    expect(paddingClass).toBe('pr-24')
+    expect(paddingClass).toBe('pr-15')
   })
 
   it('reserves a single-button gutter when only the lock button shows', () => {
@@ -855,7 +855,7 @@ describe('getCardContentPaddingClass', () => {
     // Act
     const paddingClass = getCardContentPaddingClass(flags)
 
-    // Assert — pr-14 (56px) clears a single 44px button.
-    expect(paddingClass).toBe('pr-14')
+    // Assert — pr-8 (32px) clears a single 28px button.
+    expect(paddingClass).toBe('pr-8')
   })
 })

--- a/src/renderer/src/components/skills/skillItemHelpers.ts
+++ b/src/renderer/src/components/skills/skillItemHelpers.ts
@@ -155,23 +155,33 @@ export function getSkillItemVisibility(
  * Exists because the action buttons (lock + bookmark + X) are `absolute`-positioned
  * overlays out of the content flow, so the body needs a manual right gutter to
  * keep its always-visible title-row controls (the "+ Add" button) from sliding
- * under those overlays on hover.
+ * under those overlays.
  *
- * Button positions (each 44px wide):
+ * The gutter reserves for the X even though it rests at `opacity-0`: hiding a
+ * button that way does not set `pointer-events: none`, so it keeps eating
+ * clicks at rest (DESIGN.md, Target sizing). Its box therefore does carry a
+ * layout cost, which is why it is on the same 28px scale as the other two
+ * rather than taking the 44px invisible-hit-area exception.
+ *
+ * Button positions (each 28px wide — the DESIGN.md `icon` token; the previous
+ * 44px boxes reserved 144px around three 14px glyphs, squeezing the card
+ * description to 70px at an 800px window):
  * - X (delete/unlink): right-0
- * - bookmark: right-11 when X shows, else right-0
- * - lock: right-22 when both X and bookmark show, else adjusts left
+ * - bookmark: right-7 when X shows, else right-0
+ * - lock: right-14 when both X and bookmark show, else adjusts left
+ *
+ * Each returned value is the occupied stack (28px per slot) plus 4px of gap.
  *
  * @param flags - Which overlay buttons render (from `getSkillItemVisibility` + `canBookmarkSkill`)
  * @returns
- * - `'pr-36'` (144px): lock AND bookmark AND an X button all show → clear the 132px stack
- * - `'pr-24'` (96px): two of the three overlay slots occupied
- * - `'pr-14'` (56px): exactly one overlay slot occupied
+ * - `'pr-22'` (88px): lock AND bookmark AND an X button all show → clear the 84px stack
+ * - `'pr-15'` (60px): two of the three overlay slots occupied → clear 56px
+ * - `'pr-8'` (32px): exactly one overlay slot occupied → clear 28px
  * - `'pr-4'` (16px): no overlay buttons → normal card padding
  * @example
- * getCardContentPaddingClass({ showProtect: true, showBookmark: true, showUnlinkButton: false, showDeleteButton: true }) // => 'pr-36'
- * getCardContentPaddingClass({ showProtect: false, showBookmark: true, showUnlinkButton: false, showDeleteButton: true }) // => 'pr-24'
- * getCardContentPaddingClass({ showProtect: false, showBookmark: true, showUnlinkButton: false, showDeleteButton: false }) // => 'pr-14'
+ * getCardContentPaddingClass({ showProtect: true, showBookmark: true, showUnlinkButton: false, showDeleteButton: true }) // => 'pr-22'
+ * getCardContentPaddingClass({ showProtect: false, showBookmark: true, showUnlinkButton: false, showDeleteButton: true }) // => 'pr-15'
+ * getCardContentPaddingClass({ showProtect: false, showBookmark: true, showUnlinkButton: false, showDeleteButton: false }) // => 'pr-8'
  * getCardContentPaddingClass({ showProtect: false, showBookmark: false, showUnlinkButton: false, showDeleteButton: false }) // => 'pr-4'
  */
 export function getCardContentPaddingClass(flags: {
@@ -179,7 +189,7 @@ export function getCardContentPaddingClass(flags: {
   showBookmark: boolean
   showUnlinkButton: boolean
   showDeleteButton: boolean
-}): 'pr-36' | 'pr-24' | 'pr-14' | 'pr-4' {
+}): 'pr-22' | 'pr-15' | 'pr-8' | 'pr-4' {
   const { showProtect, showBookmark, showUnlinkButton, showDeleteButton } =
     flags
   const hasXButton = showUnlinkButton || showDeleteButton
@@ -187,8 +197,8 @@ export function getCardContentPaddingClass(flags: {
   const overlayCount = [showProtect, showBookmark, hasXButton].filter(
     Boolean,
   ).length
-  if (overlayCount >= 3) return 'pr-36'
-  if (overlayCount === 2) return 'pr-24'
-  if (overlayCount === 1) return 'pr-14'
+  if (overlayCount >= 3) return 'pr-22'
+  if (overlayCount === 2) return 'pr-15'
+  if (overlayCount === 1) return 'pr-8'
   return 'pr-4'
 }


### PR DESCRIPTION
## Summary

- Skill-card overlay buttons (lock / bookmark / delete-unlink) drop from 44px boxes to `size-7` (28px, the DESIGN.md `icon` token).
- `getCardContentPaddingClass` reserves the real stack width instead of a 44px-per-slot gutter: `pr-22` / `pr-15` / `pr-8` / `pr-4`.
- `top-1.5` becomes `top-3.5` so the smaller boxes stay vertically centred on the title row.
- DESIGN.md gains the rule that a *reservation* voids the invisible-hit-area exception, because `opacity-0` does not set `pointer-events: none`.

## Problem

The lock, bookmark and delete overlays on a skill card were `min-h-11 min-w-11` — 44px boxes around 14px glyphs.

Lock and bookmark rest at `opacity-40`, i.e. **always-visible controls**, so `DESIGN.md:592-595` applies directly:

> A **visible, always-on control sets real layout** — its box, and any space reserved for it … follows the button scale above. **Never reserve 44px around a 16px glyph; that is wasted width on a pointer-driven app, and width is scarce in the center list.**

The cost was measurable. At **800x600** the card is 232px wide, the three buttons stacked to **133px**, `getCardContentPaddingClass` reserved **144px** (`pr-36`), and the card body was left with **70px**:

| element | before | after |
|---|---|---|
| description `<p>` `clientWidth` | **70px** | **126px** |
| skill name element | rendered nothing | **55px** |
| overlay box | 44x44 | 28x28 |
| gutter | 144px (`pr-36`) for a 133px stack | 88px (`pr-22`) for an 84px stack |

## Fix

All three overlays go to `size-7` (28px, the DESIGN.md `icon` token). Stack 84px, gutter 88px, 4px of breathing room to the always-visible "+ Add" button.

New `getCardContentPaddingClass` values — each is the occupied stack (28px per slot) plus a 4px gap:

| slots | before | after |
|---|---|---|
| 3 | `pr-36` (144px) | `pr-22` (88px) |
| 2 | `pr-24` (96px) | `pr-15` (60px) |
| 1 | `pr-14` (56px) | `pr-8` (32px) |
| 0 | `pr-4` (16px) | `pr-4` (16px) |

### Why the hover-only delete shrinks too

`DESIGN.md:596-599` exempts an invisible hit area because it *"carries no resting box and no layout cost"*. That premise does not hold here: `opacity-0` does not set `pointer-events: none`, and the button measures **`pointerEvents: "auto"`** at rest. The gutter therefore has to clear its box to keep "+ Add" clickable — which is exactly a layout cost. `DESIGN.md:602-604` already says the same thing in prose about `opacity-0` halos stealing row clicks.

DESIGN.md gains that rule so the next reviewer inherits it rather than re-deriving it.

### Vertical re-centering

A 44px box at `top-1.5` (6px) happened to centre on the title row. A 28px box at the same offset floats **8px high** (`cy 21` vs the "+ Add" button's `cy 29`). `top-1.5` becomes `top-3.5`, re-measured at **`cy 29` for all three overlays against "+ Add"'s `cy 29` — a 0px delta**.

### Deliberately unchanged

- **`SkillItem.tsx:966`** (bulk-select checkbox wrapper) keeps its 44px target. It is DESIGN.md's *named* invisible-hit-area exception and nothing reserves space for it.
- **`AgentItem.tsx:158`** keeps `min-h-11`. That is a full-width sidebar **row**'s min-height — a density concept that costs no horizontal width, not an icon-button box.

## Test Plan

- [x] `pnpm validate` — green
- [x] `pnpm test:e2e` — green (86 passed)
- Live `playwright-cli` `getBoundingClientRect` scan of all 8 visible cards at **800x600**: every overlay `28x28` at `cy 29`, `pr-22` applied, `collideWithAdd: []`, description `126`. The three offset tokens land on exact 28px steps — delete `relRight 1`, bookmark `relRight 29`, lock `relRight 57` — which verifies `right-0`, `right-7` **and** `right-14` in a single card.
- Re-verified at **1400x900**: card 532px, same 4px gap, `cy 29` throughout, description 426px. No regression in the wide case.
- `skillItemHelpers.test.ts` assertions and their geometry comments updated to the new values.

## Security Checklist

- [x] This change does not widen renderer access to Node.js, Electron, or direct filesystem APIs. — Tailwind class strings only; no `fs`, no `require`, no preload surface touched.
- [x] New IPC or filesystem behavior validates untrusted renderer input in the main process. — N/A: no IPC channel, handler, or payload shape is added or changed.
- [x] Dependency, workflow, or release changes preserve least-privilege permissions and pinned third-party Actions. — N/A: no dependency, workflow, or release file is touched (4 files: 1 doc, 3 renderer).
- [x] Security-sensitive behavior is documented or linked from `SECURITY.md` when relevant. — N/A: no security-sensitive behavior changes. The DESIGN.md addition is an accessibility/target-sizing rule, not a security control.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - スキルカード上の保護・削除・解除・ブックマークボタンをコンパクトに調整しました。
  - 複数の操作ボタンがカード内に収まりやすくなり、コンテンツの表示領域が広がりました。
  - ボタンの縦位置と横方向の配置を見直し、カード上で操作しやすいレイアウトに整えました。

- **ドキュメント**
  - 非表示コントロールとアクセシビリティ上のクリック領域に関する設計方針を明確化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
