### PR TITLE
refactor(types): brand 29 plain domain aliases with `Brand<T, B>`

### DIFF
--- a/.storybook/fixtures.ts
+++ b/.storybook/fixtures.ts
@@ -2,6 +2,19 @@ import { DEFAULT_SETTINGS, type Settings } from '@/shared/settings'
 import {
   repositoryId,
   semanticVersion,
+  toAgentCount,
+  toFileExtension,
+  toFileName,
+  toFileSizeBytes,
+  toHttpUrl,
+  toHumanFileSize,
+  toInstallCount,
+  toIsoTimestamp,
+  toLineCount,
+  toPosixRelativePath,
+  toSkillCount,
+  toSkillRank,
+  toSymlinkCount,
   tombstoneId,
   type Agent,
   type BookmarkedSkill,
@@ -30,32 +43,32 @@ export const storyAgents: Agent[] = [
     name: 'Claude Code',
     path: '/Users/raphtalia/.claude/skills',
     exists: true,
-    skillCount: 8,
-    localSkillCount: 1,
+    skillCount: toSkillCount(8),
+    localSkillCount: toSkillCount(1),
   },
   {
     id: 'cursor',
     name: 'Cursor',
     path: '/Users/raphtalia/.cursor/skills',
     exists: true,
-    skillCount: 6,
-    localSkillCount: 0,
+    skillCount: toSkillCount(6),
+    localSkillCount: toSkillCount(0),
   },
   {
     id: 'codex',
     name: 'Codex',
     path: '/Users/raphtalia/.codex/skills',
     exists: true,
-    skillCount: 5,
-    localSkillCount: 2,
+    skillCount: toSkillCount(5),
+    localSkillCount: toSkillCount(2),
   },
   {
     id: 'gemini-cli',
     name: 'Gemini CLI',
     path: '/Users/raphtalia/.gemini/skills',
     exists: false,
-    skillCount: 0,
-    localSkillCount: 0,
+    skillCount: toSkillCount(0),
+    localSkillCount: toSkillCount(0),
   },
 ]
 
@@ -72,11 +85,11 @@ export const storySkills: Skill[] = [
     description:
       'Designer-eye QA for spacing, hierarchy, interaction polish, and screenshots.',
     path: '/Users/raphtalia/.agents/skills/design-review',
-    symlinkCount: 3,
+    symlinkCount: toSymlinkCount(3),
     isSource: true,
     isOrphan: false,
     source: repositoryId('laststance/gstack'),
-    sourceUrl: 'https://github.com/laststance/gstack',
+    sourceUrl: toHttpUrl('https://github.com/laststance/gstack'),
     symlinks: [
       {
         agentId: 'claude-code',
@@ -109,11 +122,11 @@ export const storySkills: Skill[] = [
     description:
       'Runs Electron UI verification through Playwright and the debug port.',
     path: '/Users/raphtalia/.agents/skills/qa-electron',
-    symlinkCount: 2,
+    symlinkCount: toSymlinkCount(2),
     isSource: true,
     isOrphan: false,
     source: repositoryId('laststance/gstack'),
-    sourceUrl: 'https://github.com/laststance/gstack',
+    sourceUrl: toHttpUrl('https://github.com/laststance/gstack'),
     symlinks: [
       {
         agentId: 'claude-code',
@@ -144,7 +157,7 @@ export const storySkills: Skill[] = [
     name: 'open-to-dia',
     description: 'Local macOS launcher skill for opening current URLs in Dia.',
     path: '/Users/raphtalia/.codex/skills/open-to-dia',
-    symlinkCount: 0,
+    symlinkCount: toSymlinkCount(0),
     isSource: false,
     isOrphan: false,
     symlinks: [
@@ -161,7 +174,7 @@ export const storySkills: Skill[] = [
     name: 'retired-skill',
     description: 'Source folder removed; remaining links need cleanup.',
     path: '/Users/raphtalia/.agents/skills/retired-skill',
-    symlinkCount: 0,
+    symlinkCount: toSymlinkCount(0),
     isSource: false,
     isOrphan: true,
     symlinks: [
@@ -194,32 +207,32 @@ export const storySkills: Skill[] = [
  */
 export const storyMarketplaceSkills: SkillSearchResult[] = [
   {
-    rank: 1,
+    rank: toSkillRank(1),
     name: 'task',
     repo: repositoryId('vercel-labs/skills'),
-    url: 'https://skills.sh/task',
-    installCount: 2480,
+    url: toHttpUrl('https://skills.sh/task'),
+    installCount: toInstallCount(2480),
   },
   {
-    rank: 2,
+    rank: toSkillRank(2),
     name: 'browser-use',
     repo: repositoryId('browser-use/skills'),
-    url: 'https://skills.sh/browser-use',
-    installCount: 1630,
+    url: toHttpUrl('https://skills.sh/browser-use'),
+    installCount: toInstallCount(1630),
   },
   {
-    rank: 3,
+    rank: toSkillRank(3),
     name: 'code-review',
     repo: repositoryId('laststance/gstack'),
-    url: 'https://skills.sh/code-review',
-    installCount: 820,
+    url: toHttpUrl('https://skills.sh/code-review'),
+    installCount: toInstallCount(820),
   },
   {
-    rank: 4,
+    rank: toSkillRank(4),
     name: 'azure-ai',
     repo: repositoryId('microsoft/azure-skills'),
-    url: 'https://skills.sh/azure-ai',
-    installCount: 312,
+    url: toHttpUrl('https://skills.sh/azure-ai'),
+    installCount: toInstallCount(312),
   },
 ]
 
@@ -227,53 +240,53 @@ export const storyBookmarks: BookmarkedSkill[] = [
   {
     name: 'task',
     repo: repositoryId('vercel-labs/skills'),
-    url: 'https://skills.sh/task',
-    bookmarkedAt: now,
+    url: toHttpUrl('https://skills.sh/task'),
+    bookmarkedAt: toIsoTimestamp(now),
   },
   {
     name: 'browser-use',
     repo: repositoryId('browser-use/skills'),
-    url: 'https://skills.sh/browser-use',
-    bookmarkedAt: now,
+    url: toHttpUrl('https://skills.sh/browser-use'),
+    bookmarkedAt: toIsoTimestamp(now),
   },
 ]
 
 export const storySourceStats: SourceStats = {
   path: '/Users/raphtalia/.agents/skills',
-  skillCount: storySkills.length,
-  totalSize: '4.8 MB',
-  lastModified: now,
+  skillCount: toSkillCount(storySkills.length),
+  totalSize: toHumanFileSize('4.8 MB'),
+  lastModified: toIsoTimestamp(now),
 }
 
 export const storySkillFiles: SkillFile[] = [
   {
-    name: 'SKILL.md',
+    name: toFileName('SKILL.md'),
     path: '/Users/raphtalia/.agents/skills/design-review/SKILL.md',
-    relativePath: 'SKILL.md',
-    extension: '.md',
-    size: 2048,
+    relativePath: toPosixRelativePath('SKILL.md'),
+    extension: toFileExtension('.md'),
+    size: toFileSizeBytes(2048),
     previewable: 'text',
   },
   {
-    name: 'qa.md',
+    name: toFileName('qa.md'),
     path: '/Users/raphtalia/.agents/skills/design-review/references/qa.md',
-    relativePath: 'references/qa.md',
-    extension: '.md',
-    size: 1024,
+    relativePath: toPosixRelativePath('references/qa.md'),
+    extension: toFileExtension('.md'),
+    size: toFileSizeBytes(1024),
     previewable: 'text',
   },
   {
-    name: 'diagram.png',
+    name: toFileName('diagram.png'),
     path: '/Users/raphtalia/.agents/skills/design-review/assets/diagram.png',
-    relativePath: 'assets/diagram.png',
-    extension: '.png',
-    size: 9280,
+    relativePath: toPosixRelativePath('assets/diagram.png'),
+    extension: toFileExtension('.png'),
+    size: toFileSizeBytes(9280),
     previewable: 'image',
   },
 ]
 
 export const storySkillFileContent: SkillFileContent = {
-  name: 'SKILL.md',
+  name: toFileName('SKILL.md'),
   content: [
     '---',
     'name: design-review',
@@ -286,15 +299,15 @@ export const storySkillFileContent: SkillFileContent = {
     '2. Mark hierarchy and spacing issues.',
     '3. Fix source and verify with screenshots.',
   ].join('\n'),
-  extension: '.md',
-  lineCount: 10,
+  extension: toFileExtension('.md'),
+  lineCount: toLineCount(10),
 }
 
 export const storySyncPreview: SyncPreviewResult = {
-  totalSkills: 4,
-  totalAgents: 3,
-  toCreate: 3,
-  alreadySynced: 8,
+  totalSkills: toSkillCount(4),
+  totalAgents: toAgentCount(3),
+  toCreate: toSymlinkCount(3),
+  alreadySynced: toSymlinkCount(8),
   conflicts: [
     {
       skillName: 'qa-electron',
@@ -307,9 +320,9 @@ export const storySyncPreview: SyncPreviewResult = {
 
 export const storySyncResult: SyncExecuteResult = {
   success: false,
-  created: 2,
-  replaced: 1,
-  skipped: 7,
+  created: toSymlinkCount(2),
+  replaced: toSymlinkCount(1),
+  skipped: toSymlinkCount(7),
   errors: [
     {
       path: '/Users/raphtalia/.cursor/skills/retired-skill',

--- a/.storybook/stories/Dashboard.stories.tsx
+++ b/.storybook/stories/Dashboard.stories.tsx
@@ -25,6 +25,12 @@ import { WhatsNewWidget } from '@/renderer/src/components/dashboard/widgets/What
 
 import { storyMarketplaceSkills } from '../fixtures'
 import { StoryCard, StoryGrid } from '../storybook-utils'
+import {
+  toGridColumnSpan,
+  toGridColumnStart,
+  toGridRowSpan,
+  toGridRowStart,
+} from '@/renderer/src/components/dashboard/types'
 
 const meta = {
   title: 'Dashboard/Components',
@@ -41,19 +47,19 @@ type Story = StoryObj<typeof meta>
 const welcomeInstance: WidgetInstance = {
   id: 'storybook-welcome' as never,
   type: 'welcome',
-  x: 0,
-  y: 0,
-  w: 6,
-  h: 3,
+  x: toGridColumnStart(0),
+  y: toGridRowStart(0),
+  w: toGridColumnSpan(6),
+  h: toGridRowSpan(3),
 }
 
 const statsInstance: WidgetInstance = {
   id: 'storybook-stats' as never,
   type: 'stats',
-  x: 0,
-  y: 0,
-  w: 3,
-  h: 2,
+  x: toGridColumnStart(0),
+  y: toGridRowStart(0),
+  w: toGridColumnSpan(3),
+  h: toGridRowSpan(2),
 }
 
 export const CanvasAndControls: Story = {

--- a/.storybook/stories/Marketplace.stories.tsx
+++ b/.storybook/stories/Marketplace.stories.tsx
@@ -13,6 +13,7 @@ import { SkillsMarketplace } from '@/renderer/src/components/marketplace/SkillsM
 
 import { storyMarketplaceSkills } from '../fixtures'
 import { StoryCard, StoryGrid } from '../storybook-utils'
+import { toProgressPercent } from '@/shared/types'
 
 const meta = {
   title: 'Marketplace/Components',
@@ -105,7 +106,7 @@ export const LoadingAndInstallStates: Story = {
           installProgress: {
             phase: 'installing',
             message: 'Linking skill into selected agents',
-            percent: 72,
+            percent: toProgressPercent(72),
           },
         },
       },

--- a/.storybook/stories/Primitives.stories.tsx
+++ b/.storybook/stories/Primitives.stories.tsx
@@ -52,6 +52,7 @@ import {
 
 import { storySkills } from '../fixtures'
 import { StoryCard, StoryGrid } from '../storybook-utils'
+import { toSymlinkCount } from '@/shared/types'
 
 const meta = {
   title: 'Primitives/Components',
@@ -210,10 +211,14 @@ export const FeedbackAndStatus: Story = {
         <div className="flex flex-wrap gap-2">
           <StatusBadge
             status="valid"
-            count={3}
+            count={toSymlinkCount(3)}
             agentNames={['Claude Code', 'Cursor', 'Codex']}
           />
-          <StatusBadge status="broken" count={1} agentNames={['Cursor']} />
+          <StatusBadge
+            status="broken"
+            count={toSymlinkCount(1)}
+            agentNames={['Cursor']}
+          />
           <StatusBadge status="missing" />
         </div>
       </StoryCard>

--- a/.storybook/stories/Skills.stories.tsx
+++ b/.storybook/stories/Skills.stories.tsx
@@ -23,6 +23,7 @@ import {
   storyTombstoneIds,
 } from '../fixtures'
 import { StoryCard, StoryGrid } from '../storybook-utils'
+import { toFileName, toFileSizeBytes, toIsoTimestamp } from '@/shared/types'
 
 const meta = {
   title: 'Skills/Components',
@@ -43,8 +44,8 @@ const textPreview: PreviewContent = {
 
 const binaryPreview: PreviewContent = {
   kind: 'binary',
-  fileName: 'archive.zip',
-  size: 420_000,
+  fileName: toFileName('archive.zip'),
+  size: toFileSizeBytes(420_000),
 }
 
 export const SkillRowsAndSearch: Story = {
@@ -135,7 +136,9 @@ export const FilePreviewStates: Story = {
           skillNames={[storySkills[0]!.name, storySkills[1]!.name]}
           tombstoneIds={storyTombstoneIds}
           // react-doctor-disable-next-line react-doctor/rendering-hydration-mismatch-time -- Storybook story renders client-only with no SSR hydration boundary; Date.now() here is intentional fixture data (15s expiry) and cannot mismatch.
-          expiresAt={new Date(Date.now() + 15_000).toISOString()}
+          expiresAt={toIsoTimestamp(
+            new Date(Date.now() + 15_000).toISOString(),
+          )}
           summary="Deleted 2 skills. 5 symlinks removed."
           onUndo={() => undefined}
           toastId="storybook-undo-toast"

--- a/.storybook/storybook-utils.tsx
+++ b/.storybook/storybook-utils.tsx
@@ -36,6 +36,18 @@ import {
   storySyncResult,
   storyTombstoneIds,
 } from './fixtures'
+import {
+  toAgentCount,
+  toDataUrl,
+  toFileName,
+  toFileSizeBytes,
+  toMimeType,
+  toPixelHeight,
+  toPixelWidth,
+  toSkillCount,
+  toSymlinkCount,
+  toUnixTimestampMs,
+} from '@/shared/types'
 
 const rootReducer = combineReducers({
   theme: themeReducer,
@@ -313,19 +325,19 @@ function createDefaultStoryState(): StoryRootState {
       leaderboard: {
         'all-time': {
           skills: storyMarketplaceSkills,
-          lastFetched: Date.now(),
+          lastFetched: toUnixTimestampMs(Date.now()),
           filter: 'all-time',
           status: 'idle',
         },
         trending: {
           skills: storyMarketplaceSkills,
-          lastFetched: Date.now(),
+          lastFetched: toUnixTimestampMs(Date.now()),
           filter: 'trending',
           status: 'idle',
         },
         hot: {
           skills: storyMarketplaceSkills,
-          lastFetched: Date.now(),
+          lastFetched: toUnixTimestampMs(Date.now()),
           filter: 'hot',
           status: 'idle',
         },
@@ -396,7 +408,7 @@ export function installStorybookElectronMock(): void {
         skillName: storySkills[0]?.name ?? 'design-review',
         outcome: 'deleted',
         tombstoneId: storyTombstoneIds[0]!,
-        symlinksRemoved: 3,
+        symlinksRemoved: toSymlinkCount(3),
         cascadeAgents: ['claude-code', 'cursor'],
       },
     ],
@@ -411,13 +423,13 @@ export function installStorybookElectronMock(): void {
   }
   const createSymlinksResult: CreateSymlinksResult = {
     success: true,
-    created: 1,
+    created: toSymlinkCount(1),
     failures: [],
   }
   const restoreResult: RestoreDeletedSkillResult = {
     outcome: 'restored',
-    symlinksRestored: 3,
-    symlinksSkipped: 0,
+    symlinksRestored: toSymlinkCount(3),
+    symlinksSkipped: toSymlinkCount(0),
   }
 
   window.electron = {
@@ -455,14 +467,21 @@ export function installStorybookElectronMock(): void {
     skills: {
       getAll: async () => storySkills,
       unlinkFromAgent: async () => ({ success: true }),
-      removeAllFromAgent: async () => ({ success: true, removedCount: 4 }),
+      removeAllFromAgent: async () => ({
+        success: true,
+        removedCount: toSkillCount(4),
+      }),
       deleteSkill: async () => ({
         success: true,
-        symlinksRemoved: 3,
+        symlinksRemoved: toSymlinkCount(3),
         cascadeAgents: ['claude-code', 'cursor'],
       }),
       createSymlinks: async () => createSymlinksResult,
-      copyToAgents: async () => ({ success: true, copied: 1, failures: [] }),
+      copyToAgents: async () => ({
+        success: true,
+        copied: toAgentCount(1),
+        failures: [],
+      }),
       deleteSkills: async () => deleteResult,
       clearOrphanSymlinks: async (options) => ({
         // Echo the requested rows 1:1 so stories reflect exactly what was
@@ -470,7 +489,7 @@ export function installStorybookElectronMock(): void {
         items: options.items.map((item) => ({
           skillName: item.skillName,
           outcome: 'orphan-cleared' as const,
-          symlinksRemoved: item.agents.length,
+          symlinksRemoved: toSymlinkCount(item.agents.length),
           cascadeAgents: item.agents.map((agent) => agent.agentId),
         })),
       }),
@@ -507,11 +526,12 @@ export function installStorybookElectronMock(): void {
       list: async () => storySkillFiles,
       read: async () => storySkillFileContent,
       readBinary: async () => ({
-        name: 'diagram.png',
-        dataUrl:
+        name: toFileName('diagram.png'),
+        dataUrl: toDataUrl(
           'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 180"><rect width="320" height="180" fill="%230b1118"/><path d="M40 120h240" stroke="%2322d3ee" stroke-width="10" stroke-linecap="round"/><circle cx="82" cy="90" r="28" fill="%2334d399"/><circle cx="160" cy="72" r="28" fill="%2322d3ee"/><circle cx="238" cy="90" r="28" fill="%23f59e0b"/></svg>',
-        mimeType: 'image/svg+xml',
-        size: 9280,
+        ),
+        mimeType: toMimeType('image/svg+xml'),
+        size: toFileSizeBytes(9280),
       }),
     },
     update: {
@@ -568,7 +588,10 @@ export function installStorybookElectronMock(): void {
       openInTerminal: async () => ({ ok: true }),
     },
     window: {
-      getMainBounds: async () => ({ width: 1200, height: 800 }),
+      getMainBounds: async () => ({
+        width: toPixelWidth(1200),
+        height: toPixelHeight(800),
+      }),
     },
   }
 

--- a/e2e/helpers/iron-rule.ts
+++ b/e2e/helpers/iron-rule.ts
@@ -1,7 +1,5 @@
 import { expect } from '@playwright/test'
 
-import type { RemoveAllFromAgentResult } from '@/shared/types'
-
 /**
  * Assert the structured IRON RULE refusal triplet returned by
  * `removeAllFromAgent` when `isSharedAgentPath` short-circuits the handler:
@@ -12,11 +10,20 @@ import type { RemoveAllFromAgentResult } from '@/shared/types'
  * would each silently pass on a copy drift unless every match string was
  * audited.
  *
+ * Takes the structured-clone shape rather than `RemoveAllFromAgentResult`
+ * itself: `page.evaluate` round-trips the value out of the renderer, which
+ * erases the `SkillCount` brand on `removedCount`. Mirrors how
+ * `E2EFilesystemIdentity` is redeclared in the specs for the same reason.
+ *
  * @example
  * const result = await appWindow.evaluate(...)
  * expectIronRuleRefusal(result)
  */
-export function expectIronRuleRefusal(result: RemoveAllFromAgentResult): void {
+export function expectIronRuleRefusal(result: {
+  success: boolean
+  removedCount: number
+  error?: string
+}): void {
   expect(result.success).toBe(false)
   expect(result.removedCount).toBe(0)
   expect(result.error).toMatch(/Refusing to delete a shared skills folder/)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -11,6 +11,7 @@ import {
 
 import { MACOS_TRAFFIC_LIGHT_POSITION_PX } from '@/shared/constants'
 import { isAllowedSkillsUrl } from '@/shared/marketplaceUrlPolicy'
+import { toPixelHeight, toPixelWidth } from '@/shared/types'
 
 import { registerAllHandlers } from './ipc/handlers'
 import { getMainWindow, setMainWindow } from './services/mainWindowState'
@@ -80,8 +81,8 @@ app.on('second-instance', () => {
  * preference the app maximizes on `ready-to-show` so users keep the original
  * "fills the screen" behavior on first launch.
  */
-const DEFAULT_LAUNCH_WIDTH = 1200
-const DEFAULT_LAUNCH_HEIGHT = 800
+const DEFAULT_LAUNCH_WIDTH = toPixelWidth(1200)
+const DEFAULT_LAUNCH_HEIGHT = toPixelHeight(800)
 
 function createWindow(): void {
   const settings = getSettings()
@@ -92,7 +93,12 @@ function createWindow(): void {
   // one (clamping happens *before* the BrowserWindow is constructed because
   // Electron applies `width`/`height` literally — there's no built-in clamp).
   const persistedWindowSize = settings.windowSize
-  const primaryWorkArea = screen.getPrimaryDisplay().workAreaSize
+  const { width: workAreaWidth, height: workAreaHeight } =
+    screen.getPrimaryDisplay().workAreaSize
+  const primaryWorkArea = {
+    width: toPixelWidth(workAreaWidth),
+    height: toPixelHeight(workAreaHeight),
+  }
   const hasCustomSize = persistedWindowSize !== undefined
   const launchSize = hasCustomSize
     ? clampSizeToWorkArea(persistedWindowSize, primaryWorkArea)

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -46,6 +46,13 @@ import type {
   FilesystemEntryIdentity,
   SkillName,
 } from '@/shared/types'
+import {
+  toAgentCount,
+  toBatchItemCount,
+  toBatchItemIndex,
+  toSkillCount,
+  toSymlinkCount,
+} from '@/shared/types'
 
 import { recordActivityEvents } from './activity'
 import { typedHandle } from './typedHandle'
@@ -637,7 +644,7 @@ async function clearReviewedOrphanRecord(item: {
     return {
       skillName: item.skillName,
       outcome: 'orphan-cleared',
-      symlinksRemoved: cascadeAgents.length,
+      symlinksRemoved: toSymlinkCount(cascadeAgents.length),
       cascadeAgents,
     }
   } catch (error) {
@@ -649,7 +656,10 @@ async function clearReviewedOrphanRecord(item: {
       outcome: 'error',
       error: code ? { message, code } : { message },
       ...(cascadeAgents.length > 0
-        ? { symlinksRemoved: cascadeAgents.length, cascadeAgents }
+        ? {
+            symlinksRemoved: toSymlinkCount(cascadeAgents.length),
+            cascadeAgents,
+          }
         : {}),
     }
   }
@@ -765,7 +775,7 @@ export function registerSkillsHandlers(): void {
       if (!agent) {
         return {
           success: false,
-          removedCount: 0,
+          removedCount: toSkillCount(0),
           error: 'Agent not found',
         }
       }
@@ -789,7 +799,7 @@ export function registerSkillsHandlers(): void {
       if (isSharedAgentPath(derivedAgentPath)) {
         return {
           success: false,
-          removedCount: 0,
+          removedCount: toSkillCount(0),
           error:
             'Refusing to delete a shared skills folder. This directory is used by the Universal source and/or multiple agents — deleting it would cascade beyond the selected agent.',
         }
@@ -802,14 +812,14 @@ export function registerSkillsHandlers(): void {
         stats = await fs.lstat(derivedAgentPath)
       } catch (error) {
         if (errorCode(error) === 'ENOENT') {
-          return { success: true, removedCount: 0 }
+          return { success: true, removedCount: toSkillCount(0) }
         }
         throw error
       }
       if (!stats.isDirectory() || stats.isSymbolicLink()) {
         return {
           success: false,
-          removedCount: 0,
+          removedCount: toSkillCount(0),
           error: 'Reviewed agent skills path is no longer a real directory.',
         }
       }
@@ -818,7 +828,7 @@ export function registerSkillsHandlers(): void {
       if (!isReviewedEntryUnchanged(stats, options.filesystemIdentity)) {
         return {
           success: false,
-          removedCount: 0,
+          removedCount: toSkillCount(0),
           error: 'Reviewed agent skills folder changed since review.',
         }
       }
@@ -866,8 +876,8 @@ export function registerSkillsHandlers(): void {
 
         return {
           success: true,
-          removedCount,
-          preservedCount: protectedExistingPaths.size,
+          removedCount: toSkillCount(removedCount),
+          preservedCount: toSkillCount(protectedExistingPaths.size),
         }
       }
 
@@ -882,11 +892,11 @@ export function registerSkillsHandlers(): void {
         },
       )
 
-      return { success: true, removedCount: entries.length }
+      return { success: true, removedCount: toSkillCount(entries.length) }
     } catch (error) {
       return {
         success: false,
-        removedCount: 0,
+        removedCount: toSkillCount(0),
         error: extractErrorMessage(error),
       }
     }
@@ -929,7 +939,7 @@ export function registerSkillsHandlers(): void {
     } catch (error) {
       return {
         success: false,
-        symlinksRemoved: 0,
+        symlinksRemoved: toSymlinkCount(0),
         cascadeAgents: [],
         error:
           error instanceof TrashError
@@ -972,7 +982,7 @@ export function registerSkillsHandlers(): void {
             skillName,
             outcome: 'deleted',
             tombstoneId: moveResult.tombstoneId,
-            symlinksRemoved: moveResult.symlinksRemoved,
+            symlinksRemoved: toSymlinkCount(moveResult.symlinksRemoved),
             cascadeAgents: moveResult.cascadeAgents,
           })
         } catch (error) {
@@ -986,8 +996,8 @@ export function registerSkillsHandlers(): void {
 
         if (emitProgress) {
           typedSend(event.sender, IPC_CHANNELS.SKILLS_DELETE_PROGRESS, {
-            current: itemIndex + 1,
-            total,
+            current: toBatchItemIndex(itemIndex + 1),
+            total: toBatchItemCount(total),
           })
         }
       }
@@ -1178,7 +1188,11 @@ export function registerSkillsHandlers(): void {
       })),
     )
 
-    return { success: failures.length === 0, created, failures }
+    return {
+      success: failures.length === 0,
+      created: toSymlinkCount(created),
+      failures,
+    }
   })
 
   /**
@@ -1239,7 +1253,7 @@ export function registerSkillsHandlers(): void {
       if (detectionOutcome.kind === 'invalid') {
         return {
           success: false,
-          copied: 0,
+          copied: toAgentCount(0),
           failures: targetAgentIds.map((id) => ({
             agentId: id,
             error: 'Source is neither a symlink nor a directory',
@@ -1253,7 +1267,7 @@ export function registerSkillsHandlers(): void {
     } catch (error) {
       return {
         success: false,
-        copied: 0,
+        copied: toAgentCount(0),
         failures: targetAgentIds.map((id) => ({
           agentId: id,
           error: extractErrorMessage(error, 'Cannot access source skill'),
@@ -1316,6 +1330,10 @@ export function registerSkillsHandlers(): void {
       })),
     )
 
-    return { success: failures.length === 0, copied, failures }
+    return {
+      success: failures.length === 0,
+      copied: toAgentCount(copied),
+      failures,
+    }
   })
 }

--- a/src/main/ipc/window.ts
+++ b/src/main/ipc/window.ts
@@ -1,5 +1,6 @@
 import { getMainWindow } from '@/main/services/mainWindowState'
 import { IPC_CHANNELS } from '@/shared/ipc-channels'
+import { toPixelHeight, toPixelWidth } from '@/shared/types'
 
 import { typedHandle } from './typedHandle'
 
@@ -18,6 +19,9 @@ export function registerWindowHandlers(): void {
     const mainWindow = getMainWindow()
     if (mainWindow === null) return null
     const bounds = mainWindow.getContentBounds()
-    return { width: bounds.width, height: bounds.height }
+    return {
+      width: toPixelWidth(bounds.width),
+      height: toPixelHeight(bounds.height),
+    }
   })
 }

--- a/src/main/services/agentScanner.ts
+++ b/src/main/services/agentScanner.ts
@@ -3,6 +3,7 @@ import { join } from 'path'
 
 import { AGENTS } from '@/main/constants'
 import type { AbsolutePath, Agent, SkillCount } from '@/shared/types'
+import { toSkillCount } from '@/shared/types'
 
 import { getEmptyAgentFolder } from './emptyAgentFolderService'
 import { filesystemIdentityFromStats } from './filesystemIdentity'
@@ -43,7 +44,7 @@ export async function scanAgents(): Promise<Agent[]> {
             countAgentSkills(agent.path),
             countLocalSkills(agent.path),
           ])
-        : [0, 0]
+        : [toSkillCount(0), toSkillCount(0)]
       const filesystemIdentity = exists
         ? await lstat(agent.path)
             .then((stats) => filesystemIdentityFromStats(stats))
@@ -108,9 +109,9 @@ async function countAgentSkills(agentPath: AbsolutePath): Promise<SkillCount> {
       }),
     )
 
-    return validityChecks.filter(Boolean).length
+    return toSkillCount(validityChecks.filter(Boolean).length)
   } catch {
-    return 0
+    return toSkillCount(0)
   }
 }
 
@@ -143,8 +144,8 @@ async function countLocalSkills(agentPath: AbsolutePath): Promise<SkillCount> {
       }),
     )
 
-    return validChecks.filter(Boolean).length
+    return toSkillCount(validChecks.filter(Boolean).length)
   } catch {
-    return 0
+    return toSkillCount(0)
   }
 }

--- a/src/main/services/fileReader.ts
+++ b/src/main/services/fileReader.ts
@@ -19,6 +19,15 @@ import type {
   SkillFile,
   SkillFileContent,
 } from '@/shared/types'
+import {
+  toDataUrl,
+  toFileExtension,
+  toFileName,
+  toFileSizeBytes,
+  toLineCount,
+  toMimeType,
+  toPosixRelativePath,
+} from '@/shared/types'
 
 /**
  * Recursively list previewable files in a skill directory.
@@ -137,11 +146,11 @@ async function buildFileEntry(
   if (kind === 'image' && size > MAX_IMAGE_FILE_BYTES) previewable = 'binary'
 
   return {
-    name: entry.name,
+    name: toFileName(entry.name),
     path: fullPath,
     relativePath: toPosixRelative(rootPath, fullPath),
-    extension: getNormalizedExtension(entry.name),
-    size,
+    extension: toFileExtension(getNormalizedExtension(entry.name)),
+    size: toFileSizeBytes(size),
     previewable,
   }
 }
@@ -157,7 +166,7 @@ function toPosixRelative(
   full: AbsolutePath,
 ): PosixRelativePath {
   const rel = full.slice(root.length).replace(/^[/\\]+/, '')
-  return rel.split(/[/\\]+/).join('/')
+  return toPosixRelativePath(rel.split(/[/\\]+/).join('/'))
 }
 
 /**
@@ -181,10 +190,10 @@ export async function readSkillFile(
     const name = basename(filePath)
 
     return {
-      name,
+      name: toFileName(name),
       content,
-      extension: getNormalizedExtension(name),
-      lineCount: content.split('\n').length,
+      extension: toFileExtension(getNormalizedExtension(name)),
+      lineCount: toLineCount(content.split('\n').length),
     }
   } catch {
     return null
@@ -214,7 +223,12 @@ export async function readBinaryFile(
     const buffer = await readFile(filePath)
     const dataUrl = `data:${mimeType};base64,${buffer.toString('base64')}`
 
-    return { name, dataUrl, mimeType, size }
+    return {
+      name: toFileName(name),
+      dataUrl: toDataUrl(dataUrl),
+      mimeType: toMimeType(mimeType),
+      size: toFileSizeBytes(size),
+    }
   } catch {
     return null
   }

--- a/src/main/services/filesystemIdentity.test.ts
+++ b/src/main/services/filesystemIdentity.test.ts
@@ -3,6 +3,7 @@ import type { Stats } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
 import type { FilesystemEntryIdentity } from '@/shared/types'
+import { toFileSizeBytes } from '@/shared/types'
 
 import {
   filesystemIdentityFromStats,
@@ -23,7 +24,7 @@ describe('filesystem identity guards for destructive deletes', () => {
     kind: 'directory',
     dev: 16777233,
     ino: 99,
-    size: 96,
+    size: toFileSizeBytes(96),
     ctimeMs: 1_000,
     mtimeMs: 2_000,
   }
@@ -36,7 +37,7 @@ describe('filesystem identity guards for destructive deletes', () => {
         kind: 'directory',
         dev: 16777233,
         ino: 99,
-        size: 96,
+        size: toFileSizeBytes(96),
         ctimeMs: 1_500,
         mtimeMs: 2_000,
       }
@@ -57,7 +58,7 @@ describe('filesystem identity guards for destructive deletes', () => {
         kind: 'directory',
         dev: 16777233,
         ino: 99,
-        size: 96,
+        size: toFileSizeBytes(96),
         ctimeMs: 1_000,
         mtimeMs: 2_000,
       }
@@ -78,7 +79,7 @@ describe('filesystem identity guards for destructive deletes', () => {
         kind: 'directory',
         dev: 16777233,
         ino: 100,
-        size: 96,
+        size: toFileSizeBytes(96),
         ctimeMs: 1_000,
         mtimeMs: 2_000,
       }
@@ -99,7 +100,7 @@ describe('filesystem identity guards for destructive deletes', () => {
         kind: 'symlink',
         dev: 16777233,
         ino: 99,
-        size: 96,
+        size: toFileSizeBytes(96),
         ctimeMs: 1_000,
         mtimeMs: 2_000,
       }
@@ -121,7 +122,7 @@ describe('filesystem identity guards for destructive deletes', () => {
         kind: 'directory',
         dev: 0,
         ino: 0,
-        size: 96,
+        size: toFileSizeBytes(96),
         ctimeMs: 1_000,
         mtimeMs: 2_000,
       }
@@ -129,7 +130,7 @@ describe('filesystem identity guards for destructive deletes', () => {
         kind: 'directory',
         dev: 0,
         ino: 0,
-        size: 96,
+        size: toFileSizeBytes(96),
         ctimeMs: 1_500,
         mtimeMs: 2_000,
       }
@@ -153,7 +154,7 @@ describe('filesystem identity guards for destructive deletes', () => {
         kind: 'directory',
         dev: 16777233,
         ino: 99,
-        size: 96,
+        size: toFileSizeBytes(96),
         ctimeMs: 1_500,
         mtimeMs: 2_000,
       }
@@ -174,7 +175,7 @@ describe('filesystem identity guards for destructive deletes', () => {
         kind: 'directory',
         dev: 16777233,
         ino: 100,
-        size: 96,
+        size: toFileSizeBytes(96),
         ctimeMs: 1_000,
         mtimeMs: 2_000,
       }
@@ -196,7 +197,7 @@ describe('filesystem identity guards for destructive deletes', () => {
         kind: 'directory',
         dev: 0,
         ino: 0,
-        size: 96,
+        size: toFileSizeBytes(96),
         ctimeMs: 1_000,
         mtimeMs: 2_000,
       }
@@ -204,7 +205,7 @@ describe('filesystem identity guards for destructive deletes', () => {
         kind: 'directory',
         dev: 0,
         ino: 0,
-        size: 96,
+        size: toFileSizeBytes(96),
         ctimeMs: 1_000,
         mtimeMs: 2_000,
       }

--- a/src/main/services/filesystemIdentity.ts
+++ b/src/main/services/filesystemIdentity.ts
@@ -1,6 +1,7 @@
 import type { Stats } from 'node:fs'
 
 import type { FilesystemEntryIdentity } from '@/shared/types'
+import { toFileSizeBytes } from '@/shared/types'
 
 /**
  * Convert Node fs.Stats into the small identity payload reviewed by destructive UI.
@@ -21,7 +22,7 @@ export function filesystemIdentityFromStats(
           : 'other',
     dev: stats.dev,
     ino: stats.ino,
-    size: stats.size,
+    size: toFileSizeBytes(stats.size),
     ctimeMs: stats.ctimeMs,
     mtimeMs: stats.mtimeMs,
   }

--- a/src/main/services/leaderboardService.ts
+++ b/src/main/services/leaderboardService.ts
@@ -1,5 +1,10 @@
 import { REPO_PATTERN, SKILL_NAME_PATTERN } from '@/main/utils/skillIdentifiers'
-import { repositoryId } from '@/shared/types'
+import {
+  repositoryId,
+  toHttpUrl,
+  toInstallCount,
+  toSkillRank,
+} from '@/shared/types'
 import type {
   InstallCount,
   RankingFilter,
@@ -35,15 +40,15 @@ const MAX_RESULTS = 50
 export function parseFormattedCount(text: string): InstallCount {
   const trimmed = text.trim().replace(/,/g, '')
   const match = trimmed.match(/^(\d+(?:\.\d+)?)\s*([KMB])?$/i)
-  if (!match) return 0
+  if (!match) return toInstallCount(0)
 
   const num = parseFloat(match[1])
   const suffix = match[2]?.toUpperCase()
 
-  if (suffix === 'K') return Math.round(num * 1_000)
-  if (suffix === 'M') return Math.round(num * 1_000_000)
-  if (suffix === 'B') return Math.round(num * 1_000_000_000)
-  return Math.round(num)
+  if (suffix === 'K') return toInstallCount(Math.round(num * 1_000))
+  if (suffix === 'M') return toInstallCount(Math.round(num * 1_000_000))
+  if (suffix === 'B') return toInstallCount(Math.round(num * 1_000_000_000))
+  return toInstallCount(Math.round(num))
 }
 
 /**
@@ -114,11 +119,11 @@ export function parseLeaderboardHtml(html: string): SkillSearchResult[] {
     }
 
     results.push({
-      rank: rank++,
+      rank: toSkillRank(rank++),
       name,
       repo: repositoryId(repo),
-      url: `https://skills.sh/${repo}/${skillSlug}`,
-      installCount,
+      url: toHttpUrl(`https://skills.sh/${repo}/${skillSlug}`),
+      installCount: toInstallCount(installCount),
     })
   }
 

--- a/src/main/services/settings.test.ts
+++ b/src/main/services/settings.test.ts
@@ -14,6 +14,7 @@ import {
 } from 'vitest'
 
 import { DEFAULT_SETTINGS, type Settings } from '@/shared/settings'
+import { toPixelHeight, toPixelWidth } from '@/shared/types'
 
 import type * as SettingsModule from './settings'
 import { areSettingsEqual } from './settings'
@@ -96,10 +97,13 @@ describe('areSettingsEqual', () => {
   it('treats matching window dimensions as unchanged even when Zod produced a fresh object reference', () => {
     // Arrange: Zod parse produces a fresh object on every call, so the
     // references differ even when the width/height values match.
-    const saved = { ...baseSettings, windowSize: { width: 1200, height: 800 } }
+    const saved = {
+      ...baseSettings,
+      windowSize: { width: toPixelWidth(1200), height: toPixelHeight(800) },
+    }
     const incoming = {
       ...baseSettings,
-      windowSize: { width: 1200, height: 800 },
+      windowSize: { width: toPixelWidth(1200), height: toPixelHeight(800) },
     }
 
     // Act
@@ -111,10 +115,13 @@ describe('areSettingsEqual', () => {
 
   it('detects a changed window width so the resized dimensions get persisted', () => {
     // Arrange
-    const saved = { ...baseSettings, windowSize: { width: 1200, height: 800 } }
+    const saved = {
+      ...baseSettings,
+      windowSize: { width: toPixelWidth(1200), height: toPixelHeight(800) },
+    }
     const incoming = {
       ...baseSettings,
-      windowSize: { width: 1201, height: 800 },
+      windowSize: { width: toPixelWidth(1201), height: toPixelHeight(800) },
     }
 
     // Act
@@ -126,10 +133,13 @@ describe('areSettingsEqual', () => {
 
   it('detects a changed window height so the resized dimensions get persisted', () => {
     // Arrange
-    const saved = { ...baseSettings, windowSize: { width: 1200, height: 800 } }
+    const saved = {
+      ...baseSettings,
+      windowSize: { width: toPixelWidth(1200), height: toPixelHeight(800) },
+    }
     const incoming = {
       ...baseSettings,
-      windowSize: { width: 1200, height: 801 },
+      windowSize: { width: toPixelWidth(1200), height: toPixelHeight(801) },
     }
 
     // Act
@@ -143,7 +153,7 @@ describe('areSettingsEqual', () => {
     // Arrange
     const withSize = {
       ...baseSettings,
-      windowSize: { width: 1200, height: 800 },
+      windowSize: { width: toPixelWidth(1200), height: toPixelHeight(800) },
     }
     const withoutSize = { ...baseSettings, windowSize: undefined }
 
@@ -163,7 +173,7 @@ describe('areSettingsEqual', () => {
     const withoutKey = { ...baseSettings }
     const withKey = {
       ...baseSettings,
-      windowSize: { width: 1200, height: 800 },
+      windowSize: { width: toPixelWidth(1200), height: toPixelHeight(800) },
     }
 
     // Act
@@ -520,7 +530,9 @@ describe('settings persistence', () => {
 
       // Act / Assert
       await expect(
-        saveSettings({ windowSize: { width: 10, height: 800 } }),
+        saveSettings({
+          windowSize: { width: toPixelWidth(10), height: toPixelHeight(800) },
+        }),
       ).rejects.toThrow()
     })
   })

--- a/src/main/services/skillScanner.ts
+++ b/src/main/services/skillScanner.ts
@@ -4,7 +4,14 @@ import { basename, join } from 'path'
 import { AGENTS, SOURCE_DIR } from '@/main/constants'
 import { isMissingPathError } from '@/main/utils/errorCode'
 import { formatBytes } from '@/shared/fileTypes'
-import { repositoryId } from '@/shared/types'
+import {
+  repositoryId,
+  toFileSizeBytes,
+  toHumanFileSize,
+  toIsoTimestamp,
+  toSkillCount,
+  toSymlinkCount,
+} from '@/shared/types'
 import type {
   AbsolutePath,
   FileSizeBytes,
@@ -384,7 +391,7 @@ async function scanAgentLinkedSymlinks(
           metadata?.description ??
           'Inaccessible symlink — target cannot be verified',
         path: targetPath ?? linkPath,
-        symlinkCount: 0,
+        symlinkCount: toSymlinkCount(0),
         symlinks: createMissingSymlinkSlots(name),
         isSource: false,
         isOrphan: false,
@@ -446,7 +453,7 @@ async function scanOrphanSymlinks(
         name,
         description: 'Orphan symlink — source skill no longer exists',
         path: linkPath,
-        symlinkCount: 0,
+        symlinkCount: toSymlinkCount(0),
         symlinks: createMissingSymlinkSlots(name),
         isSource: false,
         isOrphan: true,
@@ -546,7 +553,7 @@ async function scanAllLocalSkills(): Promise<Skill[]> {
         description: metadata.description,
         path: skillPath,
         filesystemIdentity,
-        symlinkCount: 0, // Local skills have 0 symlinks
+        symlinkCount: toSymlinkCount(0), // Local skills have 0 symlinks
         symlinks: createMissingSymlinkSlots(dirName),
         isSource: false,
         isOrphan: false,
@@ -622,11 +629,13 @@ export async function getSourceStats(): Promise<SourceStats> {
     path: SOURCE_DIR,
     // Counts what the list renders, unreadable rows included, so the sidebar
     // count and the list cannot disagree.
-    skillCount: listing.status === 'listed' ? listing.entries.length : 0,
-    totalSize: formatBytes(totalBytes),
+    skillCount: toSkillCount(
+      listing.status === 'listed' ? listing.entries.length : 0,
+    ),
+    totalSize: toHumanFileSize(formatBytes(totalBytes)),
     // No consumer renders this today; "now" keeps the field a valid
     // `IsoTimestamp` without widening the type for an unread value.
-    lastModified: (stats?.mtime ?? new Date()).toISOString(),
+    lastModified: toIsoTimestamp((stats?.mtime ?? new Date()).toISOString()),
     // The one place a "0 skills" reading is a lie gets to say so.
     isUnreadable: listing.status === 'unreadable',
   }
@@ -659,5 +668,5 @@ async function calculateDirectorySize(
     // Ignore errors
   }
 
-  return total
+  return toFileSizeBytes(total)
 }

--- a/src/main/services/skillsCliService.test.ts
+++ b/src/main/services/skillsCliService.test.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from 'events'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { SKILLS_CLI_VERSION } from '@/shared/constants'
-import { repositoryId } from '@/shared/types'
+import { repositoryId, toSearchQuery } from '@/shared/types'
 import type { InstallProgress } from '@/shared/types'
 
 /**
@@ -83,8 +83,8 @@ describe('skillsCliService.cancel', () => {
     const first = simulateCli({ autoClose: false })
     const second = simulateCli({ autoClose: false })
     const { skillsCliService } = await import('./skillsCliService')
-    const searchA = skillsCliService.search('a')
-    const searchB = skillsCliService.search('b')
+    const searchA = skillsCliService.search(toSearchQuery('a'))
+    const searchB = skillsCliService.search(toSearchQuery('b'))
 
     // Act
     skillsCliService.cancel()
@@ -107,7 +107,7 @@ describe('skillsCliService.cancel', () => {
     const search = simulateCli({ autoClose: false })
     const prune = simulateCli({ autoClose: false })
     const { skillsCliService } = await import('./skillsCliService')
-    const searching = skillsCliService.search('a')
+    const searching = skillsCliService.search(toSearchQuery('a'))
     const pruning = skillsCliService.removeSkills(['old-skill'])
 
     // Act
@@ -160,7 +160,7 @@ describe('skillsCliService.execCli environment', () => {
     const { skillsCliService } = await import('./skillsCliService')
 
     // Act
-    await skillsCliService.search('find-skills')
+    await skillsCliService.search(toSearchQuery('find-skills'))
 
     // Assert
     expect(spawnMock).toHaveBeenCalledWith(
@@ -187,7 +187,7 @@ describe('skillsCliService.execCli environment', () => {
     const { skillsCliService } = await import('./skillsCliService')
 
     // Act — search must not crash on the missing PATH and still resolve.
-    const results = await skillsCliService.search('find-skills')
+    const results = await skillsCliService.search(toSearchQuery('find-skills'))
 
     // Assert — the spawned env PATH contains the toolchain fallbacks and never
     // leaks the literal string 'undefined' from a missing inherited PATH.
@@ -225,7 +225,7 @@ describe('skillsCliService.search', () => {
     const { skillsCliService } = await import('./skillsCliService')
 
     // Act
-    const results = await skillsCliService.search('react')
+    const results = await skillsCliService.search(toSearchQuery('react'))
 
     // Assert
     expect(results).toEqual([
@@ -257,7 +257,7 @@ describe('skillsCliService.search', () => {
     const { skillsCliService } = await import('./skillsCliService')
 
     // Act
-    const results = await skillsCliService.search('react')
+    const results = await skillsCliService.search(toSearchQuery('react'))
 
     // Assert
     expect(results).toEqual([
@@ -286,7 +286,7 @@ describe('skillsCliService.search', () => {
     const { skillsCliService } = await import('./skillsCliService')
 
     // Act
-    const results = await skillsCliService.search('skills')
+    const results = await skillsCliService.search(toSearchQuery('skills'))
 
     // Assert — the URL-less row falls back to the constructed skills.sh link.
     expect(results).toEqual([
@@ -458,7 +458,7 @@ describe('skillsCliService.search failure handling', () => {
     const { skillsCliService } = await import('./skillsCliService')
 
     // Act
-    const results = await skillsCliService.search('react')
+    const results = await skillsCliService.search(toSearchQuery('react'))
 
     // Assert
     expect(results).toEqual([])
@@ -478,7 +478,7 @@ describe('skillsCliService.search failure handling', () => {
     const { skillsCliService } = await import('./skillsCliService')
 
     // Act
-    const results = await skillsCliService.search('skill')
+    const results = await skillsCliService.search(toSearchQuery('skill'))
 
     // Assert — only the well-formed row survives, ranked first.
     expect(results).toEqual([
@@ -621,7 +621,7 @@ describe('skillsCliService.execCli error and timeout paths', () => {
     const { skillsCliService } = await import('./skillsCliService')
 
     // Act
-    const searchPromise = skillsCliService.search('react')
+    const searchPromise = skillsCliService.search(toSearchQuery('react'))
     fake.emit('error', new Error('spawn npx ENOENT'))
     const results = await searchPromise
 
@@ -637,7 +637,7 @@ describe('skillsCliService.execCli error and timeout paths', () => {
     const { skillsCliService } = await import('./skillsCliService')
 
     // Act
-    const searchPromise = skillsCliService.search('react')
+    const searchPromise = skillsCliService.search(toSearchQuery('react'))
     fake.emit('error', new Error('spawn npx ENOENT'))
     fake.emit('close', 0)
     const results = await searchPromise
@@ -657,7 +657,7 @@ describe('skillsCliService.execCli error and timeout paths', () => {
     const { skillsCliService } = await import('./skillsCliService')
 
     // Act
-    const searchPromise = skillsCliService.search('react')
+    const searchPromise = skillsCliService.search(toSearchQuery('react'))
     await vi.advanceTimersByTimeAsync(PAST_SPAWN_TIMEOUT_MS)
     // The kill only asks; the result waits for the child to actually go.
     fake.emit('close', null)

--- a/src/main/services/skillsCliService.ts
+++ b/src/main/services/skillsCliService.ts
@@ -8,7 +8,7 @@ import { match, P } from 'ts-pattern'
 import { parseFormattedCount } from '@/main/services/leaderboardService'
 import { REPO_PATTERN, SKILL_NAME_PATTERN } from '@/main/utils/skillIdentifiers'
 import { AGENT_DEFINITIONS, SKILLS_CLI_VERSION } from '@/shared/constants'
-import { repositoryId } from '@/shared/types'
+import { repositoryId, toHttpUrl, toSkillRank } from '@/shared/types'
 import type {
   SkillSearchResult,
   InstallOptions,
@@ -434,10 +434,10 @@ class SkillsCliService extends EventEmitter {
         const urlMatch = urlLine?.match(/^[└├]\s*(https?:\/\/[^\s]+)$/)
 
         const searchResult: SkillSearchResult = {
-          rank: rank++,
+          rank: toSkillRank(rank++),
           name,
           repo: repositoryId(repo),
-          url: urlMatch?.[1] || `https://skills.sh/${repo}/${name}`,
+          url: toHttpUrl(urlMatch?.[1] || `https://skills.sh/${repo}/${name}`),
         }
         // Older CLI output omits telemetry, so only attach the field when seen.
         if (installCountText) {

--- a/src/main/services/symlinkChecker.ts
+++ b/src/main/services/symlinkChecker.ts
@@ -13,6 +13,7 @@ import type {
   SymlinkInfo,
   SymlinkStatus,
 } from '@/shared/types'
+import { toSymlinkCount } from '@/shared/types'
 
 import { filesystemIdentityFromStats } from './filesystemIdentity'
 
@@ -279,5 +280,5 @@ async function resolveSymlinkTarget(
  * // => 1
  */
 export function countValidSymlinks(symlinks: SymlinkInfo[]): SymlinkCount {
-  return symlinks.filter((s) => s.status === 'valid').length
+  return toSymlinkCount(symlinks.filter((s) => s.status === 'valid').length)
 }

--- a/src/main/services/syncService.ts
+++ b/src/main/services/syncService.ts
@@ -16,6 +16,7 @@ import type {
   SyncPreviewResult,
   SyncResultItem,
 } from '@/shared/types'
+import { toAgentCount, toSkillCount, toSymlinkCount } from '@/shared/types'
 
 import {
   listSourceSkillDirs,
@@ -133,10 +134,10 @@ export async function syncPreview(
   }
 
   return {
-    totalSkills: skills.length,
-    totalAgents: agents.length,
-    toCreate,
-    alreadySynced,
+    totalSkills: toSkillCount(skills.length),
+    totalAgents: toAgentCount(agents.length),
+    toCreate: toSymlinkCount(toCreate),
+    alreadySynced: toSymlinkCount(alreadySynced),
     conflicts,
     ...(options?.agentId ? { forAgent: options.agentId } : {}),
   }
@@ -248,9 +249,9 @@ export async function syncExecute(
 
   return {
     success: errors.length === 0,
-    created,
-    replaced,
-    skipped,
+    created: toSymlinkCount(created),
+    replaced: toSymlinkCount(replaced),
+    skipped: toSymlinkCount(skipped),
     errors,
     details,
   }

--- a/src/main/services/trashService.integration.test.ts
+++ b/src/main/services/trashService.integration.test.ts
@@ -27,6 +27,7 @@ import type {
   FilesystemEntryIdentity,
   SkillName,
 } from '@/shared/types'
+import { toFileSizeBytes } from '@/shared/types'
 
 import { filesystemIdentityFromStats } from './filesystemIdentity'
 import type { MoveToTrashResult } from './trashService'
@@ -35,7 +36,7 @@ const missingDirectoryIdentity: FilesystemEntryIdentity = {
   kind: 'directory',
   dev: 1,
   ino: 1,
-  size: 96,
+  size: toFileSizeBytes(96),
   ctimeMs: 1,
   mtimeMs: 1,
 }

--- a/src/main/services/trashService.orphanRace.test.ts
+++ b/src/main/services/trashService.orphanRace.test.ts
@@ -20,6 +20,7 @@ import { basename, dirname, join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest'
 
 import type { FilesystemEntryIdentity } from '@/shared/types'
+import { toFileSizeBytes } from '@/shared/types'
 
 import { filesystemIdentityFromStats } from './filesystemIdentity'
 
@@ -43,7 +44,7 @@ const missingDirectoryIdentityForOrphanTests: FilesystemEntryIdentity = {
   kind: 'directory',
   dev: 1,
   ino: 1,
-  size: 96,
+  size: toFileSizeBytes(96),
   ctimeMs: 1,
   mtimeMs: 1,
 }

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -18,7 +18,7 @@ import { errorCode, isMissingPathError } from '@/main/utils/errorCode'
 import { extractErrorMessage } from '@/main/utils/errors'
 import { fsyncPath } from '@/main/utils/fsyncPath'
 import { UNDO_WINDOW_MS } from '@/shared/constants'
-import { tombstoneId } from '@/shared/types'
+import { toSymlinkCount, toUnixTimestampMs, tombstoneId } from '@/shared/types'
 import type {
   AbsolutePath,
   AgentId,
@@ -1345,7 +1345,7 @@ async function moveSourceBackedToTrash(
     kind: 'tombstoned',
     tombstoneId: id,
     cascadeAgents: cascadeAgentIds,
-    symlinksRemoved: recordedSymlinks.length,
+    symlinksRemoved: toSymlinkCount(recordedSymlinks.length),
   }
 }
 
@@ -1644,7 +1644,7 @@ async function moveLocalOnlyToTrash(
     kind: 'tombstoned',
     tombstoneId: id,
     cascadeAgents: moved.map((c) => c.agentId),
-    symlinksRemoved: moved.length,
+    symlinksRemoved: toSymlinkCount(moved.length),
   }
 }
 
@@ -1913,8 +1913,8 @@ async function restoreSourceBacked(
 
   return {
     outcome: 'restored',
-    symlinksRestored,
-    symlinksSkipped,
+    symlinksRestored: toSymlinkCount(symlinksRestored),
+    symlinksSkipped: toSymlinkCount(symlinksSkipped),
   }
 }
 
@@ -1984,8 +1984,8 @@ async function restoreLocalOnly(
     )
     return {
       outcome: 'restored',
-      symlinksRestored,
-      symlinksSkipped,
+      symlinksRestored: toSymlinkCount(symlinksRestored),
+      symlinksSkipped: toSymlinkCount(symlinksSkipped),
     }
   }
 
@@ -1993,8 +1993,8 @@ async function restoreLocalOnly(
 
   return {
     outcome: 'restored',
-    symlinksRestored,
-    symlinksSkipped,
+    symlinksRestored: toSymlinkCount(symlinksRestored),
+    symlinksSkipped: toSymlinkCount(symlinksSkipped),
   }
 }
 
@@ -2178,7 +2178,7 @@ function parseDeletedAtFromEntryName(
   if (!/^\d+$/.test(prefix)) return null
   const parsed = Number.parseInt(prefix, 10)
   /* v8 ignore next -- the `: null` arm needs Number.parseInt(prefix) to be non-finite, which requires a 309+ digit prefix; such a name exceeds the 255-byte filesystem NAME_MAX, so fs.readdir in startupCleanup (the sole caller) can never surface it. parseInt of any \d+ name short enough to exist on disk is always finite. */
-  return Number.isFinite(parsed) ? parsed : null
+  return Number.isFinite(parsed) ? toUnixTimestampMs(parsed) : null
 }
 
 /**

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -2,7 +2,12 @@ import { autoUpdater } from 'electron-updater'
 
 import { IPC_CHANNELS } from '@/shared/ipc-channels'
 import type { Settings } from '@/shared/settings'
-import { semanticVersion } from '@/shared/types'
+import {
+  semanticVersion,
+  toByteCount,
+  toBytesPerSecond,
+  toProgressPercent,
+} from '@/shared/types'
 
 import { broadcastTypedEvent as broadcastEvent } from './ipc/typedSend'
 import { getSettings } from './services/settings'
@@ -77,10 +82,10 @@ function registerUpdaterEventHandlers(): void {
   autoUpdater.on('download-progress', (progress) => {
     console.log(`Download progress: ${progress.percent.toFixed(1)}%`)
     broadcastEvent(IPC_CHANNELS.UPDATE_PROGRESS, {
-      percent: progress.percent,
-      bytesPerSecond: progress.bytesPerSecond,
-      total: progress.total,
-      transferred: progress.transferred,
+      percent: toProgressPercent(progress.percent),
+      bytesPerSecond: toBytesPerSecond(progress.bytesPerSecond),
+      total: toByteCount(progress.total),
+      transferred: toByteCount(progress.transferred),
     })
   })
 

--- a/src/main/utils/clampSizeToWorkArea.test.ts
+++ b/src/main/utils/clampSizeToWorkArea.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, it } from 'vitest'
 
+import { toPixelHeight, toPixelWidth } from '@/shared/types'
+
 import { clampSizeToWorkArea } from './clampSizeToWorkArea'
 
 describe('clampSizeToWorkArea', () => {
   it('keeps a smaller window at its desired size so it is not needlessly shrunk', () => {
     // Arrange
-    const desiredSize = { width: 1000, height: 700 }
-    const workArea = { width: 1440, height: 900 }
+    const desiredSize = {
+      width: toPixelWidth(1000),
+      height: toPixelHeight(700),
+    }
+    const workArea = { width: toPixelWidth(1440), height: toPixelHeight(900) }
 
     // Act
     const result = clampSizeToWorkArea(desiredSize, workArea)
@@ -17,8 +22,11 @@ describe('clampSizeToWorkArea', () => {
 
   it('shrinks an over-wide window to the work-area width so it cannot overflow off-screen', () => {
     // Arrange
-    const desiredSize = { width: 3000, height: 700 }
-    const workArea = { width: 1440, height: 900 }
+    const desiredSize = {
+      width: toPixelWidth(3000),
+      height: toPixelHeight(700),
+    }
+    const workArea = { width: toPixelWidth(1440), height: toPixelHeight(900) }
 
     // Act
     const result = clampSizeToWorkArea(desiredSize, workArea)
@@ -29,8 +37,11 @@ describe('clampSizeToWorkArea', () => {
 
   it('shrinks an over-tall window to the work-area height so it cannot overflow off-screen', () => {
     // Arrange
-    const desiredSize = { width: 1000, height: 2000 }
-    const workArea = { width: 1440, height: 900 }
+    const desiredSize = {
+      width: toPixelWidth(1000),
+      height: toPixelHeight(2000),
+    }
+    const workArea = { width: toPixelWidth(1440), height: toPixelHeight(900) }
 
     // Act
     const result = clampSizeToWorkArea(desiredSize, workArea)
@@ -41,8 +52,11 @@ describe('clampSizeToWorkArea', () => {
 
   it('clamps width and height separately so an oversized window fills but never exceeds the work area', () => {
     // Arrange
-    const desiredSize = { width: 3000, height: 2000 }
-    const workArea = { width: 1440, height: 900 }
+    const desiredSize = {
+      width: toPixelWidth(3000),
+      height: toPixelHeight(2000),
+    }
+    const workArea = { width: toPixelWidth(1440), height: toPixelHeight(900) }
 
     // Act
     const result = clampSizeToWorkArea(desiredSize, workArea)
@@ -53,8 +67,11 @@ describe('clampSizeToWorkArea', () => {
 
   it('leaves a window that exactly matches the work area unchanged', () => {
     // Arrange
-    const desiredSize = { width: 1440, height: 900 }
-    const workArea = { width: 1440, height: 900 }
+    const desiredSize = {
+      width: toPixelWidth(1440),
+      height: toPixelHeight(900),
+    }
+    const workArea = { width: toPixelWidth(1440), height: toPixelHeight(900) }
 
     // Act
     const result = clampSizeToWorkArea(desiredSize, workArea)

--- a/src/main/utils/clampSizeToWorkArea.ts
+++ b/src/main/utils/clampSizeToWorkArea.ts
@@ -1,4 +1,5 @@
 import type { PixelHeight, PixelWidth } from '@/shared/types'
+import { toPixelHeight, toPixelWidth } from '@/shared/types'
 
 /**
  * Clamp a desired window size to a display's usable work area.
@@ -29,7 +30,7 @@ export function clampSizeToWorkArea(
   workArea: { width: PixelWidth; height: PixelHeight },
 ): { width: PixelWidth; height: PixelHeight } {
   return {
-    width: Math.min(desired.width, workArea.width),
-    height: Math.min(desired.height, workArea.height),
+    width: toPixelWidth(Math.min(desired.width, workArea.width)),
+    height: toPixelHeight(Math.min(desired.height, workArea.height)),
   }
 }

--- a/src/renderer/settings/SettingsApp.browser.test.tsx
+++ b/src/renderer/settings/SettingsApp.browser.test.tsx
@@ -6,6 +6,7 @@ import { render } from 'vitest-browser-react'
 import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
 import { DEFAULT_SETTINGS } from '@/shared/settings'
 import type { Agent } from '@/shared/types'
+import { toSkillCount } from '@/shared/types'
 
 const mockSettingsGet = vi.fn()
 const mockSettingsSet = vi.fn()
@@ -25,8 +26,8 @@ const FIXTURE_AGENTS: Agent[] = [
     name: 'Claude Code',
     path: '/Users/test/.claude/skills',
     exists: true,
-    skillCount: 3,
-    localSkillCount: 0,
+    skillCount: toSkillCount(3),
+    localSkillCount: toSkillCount(0),
   },
 ]
 

--- a/src/renderer/settings/sections/Agents.browser.test.tsx
+++ b/src/renderer/settings/sections/Agents.browser.test.tsx
@@ -6,6 +6,7 @@ import { render } from 'vitest-browser-react'
 import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
 import { DEFAULT_SETTINGS } from '@/shared/settings'
 import type { Agent, AgentId } from '@/shared/types'
+import { toSkillCount } from '@/shared/types'
 
 const mockSettingsSet = vi.fn()
 const mockAgentsGetAll = vi.fn()
@@ -20,16 +21,16 @@ const FIXTURE_AGENTS: Agent[] = [
     name: 'Claude Code',
     path: '/Users/test/.claude/skills',
     exists: true,
-    skillCount: 3,
-    localSkillCount: 0,
+    skillCount: toSkillCount(3),
+    localSkillCount: toSkillCount(0),
   },
   {
     id: 'cursor',
     name: 'Cursor',
     path: '/Users/test/.cursor/skills',
     exists: true,
-    skillCount: 1,
-    localSkillCount: 0,
+    skillCount: toSkillCount(1),
+    localSkillCount: toSkillCount(0),
   },
 ]
 
@@ -233,8 +234,8 @@ describe('Settings → Agents', () => {
       name: 'Codex',
       path: '/Users/test/.codex/skills',
       exists: false,
-      skillCount: 0,
-      localSkillCount: 0,
+      skillCount: toSkillCount(0),
+      localSkillCount: toSkillCount(0),
     }
     const { screen } = await renderAgents(
       [],

--- a/src/renderer/settings/sections/General.browser.test.tsx
+++ b/src/renderer/settings/sections/General.browser.test.tsx
@@ -8,6 +8,7 @@ import type {
   CliCommandOperationResult,
   CliCommandStatus,
 } from '@/shared/types'
+import { toPixelHeight, toPixelWidth } from '@/shared/types'
 
 const mockSettingsSet = vi.fn()
 const mockWindowGetMainBounds = vi.fn()
@@ -87,7 +88,7 @@ async function createStore(
  * untouched — callers control whether the mount probe resolves or rejects.
  * @param overrides - Settings fields to merge over `DEFAULT_SETTINGS`.
  * @returns The vitest-browser render screen.
- * @example await renderGeneralRaw({ windowSize: { width: 1000, height: 700 } })
+ * @example await renderGeneralRaw({ windowSize: { width: toPixelWidth(1000), height: toPixelHeight(700) } })
  */
 async function renderGeneralRaw(overrides?: Partial<Settings>) {
   const store = await createStore(overrides)
@@ -316,7 +317,7 @@ describe('Settings → General startup window size', () => {
       .poll(() => mockSettingsSet.mock.calls.length)
       .toBeGreaterThanOrEqual(1)
     expect(mockSettingsSet).toHaveBeenLastCalledWith({
-      windowSize: { width: 1200, height: 800 },
+      windowSize: { width: toPixelWidth(1200), height: toPixelHeight(800) },
     })
   })
 
@@ -399,7 +400,7 @@ describe('Settings → General startup window size', () => {
   it('clears the persisted size when "Reset to default" is clicked', async () => {
     // Arrange
     const screen = await renderGeneral(notInstalledStatus, {
-      windowSize: { width: 1000, height: 700 },
+      windowSize: { width: toPixelWidth(1000), height: toPixelHeight(700) },
     })
 
     // Act

--- a/src/renderer/src/components/UpdateToast.browser.test.tsx
+++ b/src/renderer/src/components/UpdateToast.browser.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import type { RootState } from '@/renderer/src/redux/store'
-import { semanticVersion } from '@/shared/types'
+import { semanticVersion, toProgressPercent } from '@/shared/types'
 
 /**
  * Browser-mode tests for the auto-update toast. Runs in Chromium so the
@@ -68,7 +68,7 @@ async function renderToast(
               ? null
               : semanticVersion(overrides.version),
         releaseNotes: null,
-        progress: overrides.progress ?? 0,
+        progress: toProgressPercent(overrides.progress ?? 0),
         error: overrides.error ?? null,
         dismissed: overrides.dismissed ?? false,
       } satisfies RootState['update'],

--- a/src/renderer/src/components/dashboard/DashboardCanvas.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/DashboardCanvas.browser.test.tsx
@@ -5,6 +5,14 @@ import { render } from 'vitest-browser-react'
 
 import '@/renderer/src/styles/globals.css'
 
+import {
+  toDashboardPageName,
+  toGridColumnSpan,
+  toGridColumnStart,
+  toGridRowSpan,
+  toGridRowStart,
+} from '@/renderer/src/components/dashboard/types'
+
 import type { DashboardPage, WidgetInstance, WidgetType } from './types'
 import { newDashboardPageId, newWidgetInstanceId } from './utils/ids'
 
@@ -20,7 +28,7 @@ import { newDashboardPageId, newWidgetInstanceId } from './utils/ids'
 function makePage(name: string, widgets: WidgetInstance[]): DashboardPage {
   return {
     id: newDashboardPageId(),
-    name,
+    name: toDashboardPageName(name),
     widgets,
   }
 }
@@ -42,10 +50,10 @@ function makeWidget(
   return {
     id: newWidgetInstanceId(),
     type,
-    x: placement.x ?? 0,
-    y: placement.y ?? 0,
-    w: placement.w ?? 6,
-    h: placement.h ?? 3,
+    x: toGridColumnStart(placement.x ?? 0),
+    y: toGridRowStart(placement.y ?? 0),
+    w: toGridColumnSpan(placement.w ?? 6),
+    h: toGridRowSpan(placement.h ?? 3),
   }
 }
 
@@ -177,7 +185,12 @@ describe('DashboardCanvas', () => {
     // Grid Layout's vertical compactor pulls it up to y=0 on mount, which fires
     // onLayoutChange and must be written back to the store.
     const page = makePage('Overview', [
-      makeWidget('welcome', { x: 0, y: 5, w: 6, h: 3 }),
+      makeWidget('welcome', {
+        x: toGridColumnStart(0),
+        y: toGridRowStart(5),
+        w: toGridColumnSpan(6),
+        h: toGridRowSpan(3),
+      }),
     ])
 
     // Act
@@ -195,7 +208,7 @@ describe('DashboardCanvas', () => {
     const removedType = 'legacy-removed-widget' as WidgetType
     const page = makePage('Overview', [
       makeWidget(removedType),
-      makeWidget('welcome', { y: 3 }),
+      makeWidget('welcome', { y: toGridRowStart(3) }),
     ])
 
     // Act

--- a/src/renderer/src/components/dashboard/DashboardCanvas.tsx
+++ b/src/renderer/src/components/dashboard/DashboardCanvas.tsx
@@ -4,6 +4,12 @@ import ReactGridLayout, {
   type Layout,
 } from 'react-grid-layout'
 
+import {
+  toGridColumnSpan,
+  toGridColumnStart,
+  toGridRowSpan,
+  toGridRowStart,
+} from '@/renderer/src/components/dashboard/types'
 import { useCycleEffect } from '@/renderer/src/hooks/useCycleEffect'
 import { useInitialEffect } from '@/renderer/src/hooks/useInitialEffect'
 import { useAppDispatch, useAppSelector } from '@/renderer/src/redux/hooks'
@@ -112,8 +118,8 @@ const DashboardGrid = function DashboardGrid({
     const def = getWidgetDefinition(widget.type)
     return {
       i: widget.id,
-      x: widget.x,
-      y: widget.y,
+      x: toGridColumnStart(widget.x),
+      y: toGridRowStart(widget.y),
       w: widget.w,
       h: widget.h,
       minW: def?.minSize.w ?? 1,
@@ -127,10 +133,10 @@ const DashboardGrid = function DashboardGrid({
         pageId,
         layout: next.map((item) => ({
           i: item.i,
-          x: item.x,
-          y: item.y,
-          w: item.w,
-          h: item.h,
+          x: toGridColumnStart(item.x),
+          y: toGridRowStart(item.y),
+          w: toGridColumnSpan(item.w),
+          h: toGridRowSpan(item.h),
         })),
       }),
     )

--- a/src/renderer/src/components/dashboard/DashboardEditToolbar.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/DashboardEditToolbar.browser.test.tsx
@@ -5,6 +5,8 @@ import { render } from 'vitest-browser-react'
 
 import '@/renderer/src/styles/globals.css'
 
+import { toDashboardPageName } from '@/renderer/src/components/dashboard/types'
+
 import type { DashboardPage } from './types'
 import { newDashboardPageId } from './utils/ids'
 
@@ -44,7 +46,11 @@ async function renderToolbar(
   ])
 
   const pages = options.pages ?? [
-    { id: newDashboardPageId(), name: 'My Layout', widgets: [] },
+    {
+      id: newDashboardPageId(),
+      name: toDashboardPageName('My Layout'),
+      widgets: [],
+    },
   ]
 
   const store = configureStore({
@@ -147,7 +153,13 @@ describe('DashboardEditToolbar', () => {
   it('appends a new blank page when the Page button is clicked', async () => {
     // Arrange: a single starting page.
     const { screen, store } = await renderToolbar({
-      pages: [{ id: newDashboardPageId(), name: 'Overview', widgets: [] }],
+      pages: [
+        {
+          id: newDashboardPageId(),
+          name: toDashboardPageName('Overview'),
+          widgets: [],
+        },
+      ],
       isEditMode: true,
     })
 
@@ -163,7 +175,11 @@ describe('DashboardEditToolbar', () => {
     vi.spyOn(window, 'confirm').mockReturnValue(true)
     const { screen, store } = await renderToolbar({
       pages: [
-        { id: newDashboardPageId(), name: 'My Custom Page', widgets: [] },
+        {
+          id: newDashboardPageId(),
+          name: toDashboardPageName('My Custom Page'),
+          widgets: [],
+        },
       ],
       isEditMode: true,
     })
@@ -185,7 +201,11 @@ describe('DashboardEditToolbar', () => {
     vi.spyOn(window, 'confirm').mockReturnValue(false)
     const { screen, store } = await renderToolbar({
       pages: [
-        { id: newDashboardPageId(), name: 'My Custom Page', widgets: [] },
+        {
+          id: newDashboardPageId(),
+          name: toDashboardPageName('My Custom Page'),
+          widgets: [],
+        },
       ],
       isEditMode: true,
     })

--- a/src/renderer/src/components/dashboard/DashboardPageTabs.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/DashboardPageTabs.browser.test.tsx
@@ -5,6 +5,8 @@ import { render } from 'vitest-browser-react'
 
 import '@/renderer/src/styles/globals.css'
 
+import { toDashboardPageName } from '@/renderer/src/components/dashboard/types'
+
 import type { DashboardPage } from './types'
 import { newDashboardPageId } from './utils/ids'
 
@@ -18,7 +20,7 @@ import { newDashboardPageId } from './utils/ids'
 function makePage(name: string): DashboardPage {
   return {
     id: newDashboardPageId(),
-    name,
+    name: toDashboardPageName(name),
     widgets: [],
   }
 }

--- a/src/renderer/src/components/dashboard/DashboardPageTabs.tsx
+++ b/src/renderer/src/components/dashboard/DashboardPageTabs.tsx
@@ -2,6 +2,7 @@ import { MoreHorizontal, Pencil, Plus, Trash2 } from 'lucide-react'
 import React, { useRef, useState } from 'react'
 import { match } from 'ts-pattern'
 
+import { toDashboardPageName } from '@/renderer/src/components/dashboard/types'
 import { DestructiveConfirmDialog } from '@/renderer/src/components/shared/DestructiveConfirmDialog'
 import {
   DropdownMenu,
@@ -204,7 +205,9 @@ const PageTab = function PageTab({
   const commitRename = (): void => {
     const trimmedName = draftName.trim()
     if (trimmedName.length > 0 && trimmedName !== page.name) {
-      dispatch(renamePage({ pageId: page.id, name: trimmedName }))
+      dispatch(
+        renamePage({ pageId: page.id, name: toDashboardPageName(trimmedName) }),
+      )
     }
     onFinishRename()
   }
@@ -237,7 +240,9 @@ const PageTab = function PageTab({
         ref={renameInputRef}
         type="text"
         value={draftName}
-        onChange={(event) => setDraftName(event.target.value)}
+        onChange={(event) =>
+          setDraftName(toDashboardPageName(event.target.value))
+        }
         onBlur={commitRename}
         onKeyDown={(event) => {
           if (event.key === 'Enter') {

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
@@ -5,6 +5,7 @@ import { render } from 'vitest-browser-react'
 
 import '@/renderer/src/styles/globals.css'
 import type { Agent, Skill, SkillName, SymlinkInfo } from '@/shared/types'
+import { toSkillCount, toSymlinkCount } from '@/shared/types'
 
 const mockGetSkills = vi.fn()
 const mockGetAgents = vi.fn()
@@ -32,16 +33,16 @@ const TEST_AGENTS: Agent[] = [
     name: 'Cursor',
     path: '/Users/test/.cursor/skills',
     exists: true,
-    skillCount: 0,
-    localSkillCount: 0,
+    skillCount: toSkillCount(0),
+    localSkillCount: toSkillCount(0),
   },
   {
     id: 'codex',
     name: 'Codex',
     path: '/Users/test/.codex/skills',
     exists: true,
-    skillCount: 0,
-    localSkillCount: 0,
+    skillCount: toSkillCount(0),
+    localSkillCount: toSkillCount(0),
   },
 ]
 
@@ -90,7 +91,7 @@ function makeSkillWithBrokenSlot(
     name: skillName,
     description: `${skillName} description`,
     path: `/Users/test/.agents/skills/${skillName}`,
-    symlinkCount: 0,
+    symlinkCount: toSymlinkCount(0),
     symlinks: [makeBrokenSlot(skillName, agentId, symlinkOverrides)],
     isSource: true,
     isOrphan: false,
@@ -112,7 +113,7 @@ function makeSkillWithBrokenSlots(
   return {
     ...makeSkillWithBrokenSlot(skillName, agentIds[0] ?? 'cursor'),
     symlinks: agentIds.map((agentId) => makeBrokenSlot(skillName, agentId)),
-    symlinkCount: agentIds.length,
+    symlinkCount: toSymlinkCount(agentIds.length),
   }
 }
 

--- a/src/renderer/src/components/dashboard/WidgetPicker.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/WidgetPicker.browser.test.tsx
@@ -3,6 +3,8 @@ import { Provider } from 'react-redux'
 import { describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
+import { toDashboardPageName } from '@/renderer/src/components/dashboard/types'
+
 import '@/renderer/src/styles/globals.css'
 
 /**
@@ -42,7 +44,7 @@ async function renderPicker(
     },
   })
   // One empty page so the clicked widget is placed via the common add path.
-  store.dispatch(addPage({ name: 'Test Page' }))
+  store.dispatch(addPage({ name: toDashboardPageName('Test Page') }))
   // Simulate a returning user who already dismissed the Welcome card.
   if (options.welcomeDismissed) store.dispatch(dismissWelcome())
 

--- a/src/renderer/src/components/dashboard/WidgetPicker.tsx
+++ b/src/renderer/src/components/dashboard/WidgetPicker.tsx
@@ -1,6 +1,12 @@
 import React, { useRef } from 'react'
 
 import {
+  toGridColumnSpan,
+  toGridColumnStart,
+  toGridRowSpan,
+  toGridRowStart,
+} from '@/renderer/src/components/dashboard/types'
+import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -120,10 +126,10 @@ export const WidgetPicker = function WidgetPicker({
   const previewInstance = {
     id: PREVIEW_INSTANCE_ID,
     type: previewType,
-    x: 0,
-    y: 0,
-    w: previewDefinition?.defaultSize.w ?? 1,
-    h: previewDefinition?.defaultSize.h ?? 1,
+    x: toGridColumnStart(0),
+    y: toGridRowStart(0),
+    w: previewDefinition?.defaultSize.w ?? toGridColumnSpan(1),
+    h: previewDefinition?.defaultSize.h ?? toGridRowSpan(1),
   }
 
   // Plain handler: each row already creates a new arrow in `.map()`, so

--- a/src/renderer/src/components/dashboard/WidgetShell.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/WidgetShell.browser.test.tsx
@@ -5,6 +5,14 @@ import { render } from 'vitest-browser-react'
 
 import '@/renderer/src/styles/globals.css'
 
+import {
+  toDashboardPageName,
+  toGridColumnSpan,
+  toGridColumnStart,
+  toGridRowSpan,
+  toGridRowStart,
+} from '@/renderer/src/components/dashboard/types'
+
 import type { DashboardPage, WidgetDefinition, WidgetInstance } from './types'
 import { newDashboardPageId, newWidgetInstanceId } from './utils/ids'
 
@@ -15,7 +23,14 @@ import { newDashboardPageId, newWidgetInstanceId } from './utils/ids'
  * @returns A WidgetInstance for preloaded dashboard state.
  */
 function makeWidget(id: WidgetInstance['id']): WidgetInstance {
-  return { id, type: 'welcome', x: 0, y: 0, w: 6, h: 3 }
+  return {
+    id,
+    type: 'welcome',
+    x: toGridColumnStart(0),
+    y: toGridRowStart(0),
+    w: toGridColumnSpan(6),
+    h: toGridRowSpan(3),
+  }
 }
 
 /**
@@ -29,8 +44,8 @@ const fakeDefinition: WidgetDefinition = {
   icon: ({ className }: { className?: string }) => (
     <span data-testid="fake-icon" className={className} />
   ),
-  defaultSize: { w: 6, h: 3 },
-  minSize: { w: 2, h: 2 },
+  defaultSize: { w: toGridColumnSpan(6), h: toGridRowSpan(3) },
+  minSize: { w: toGridColumnSpan(2), h: toGridRowSpan(2) },
   Component: ({ instance }: { instance: WidgetInstance }) => (
     <div data-testid="fake-body">{instance.type}</div>
   ),
@@ -60,7 +75,7 @@ async function renderShell(
   const extraWidgets = (options.extraWidgetIds ?? []).map(makeWidget)
   const page: DashboardPage = {
     id: newDashboardPageId(),
-    name: 'Test Page',
+    name: toDashboardPageName('Test Page'),
     widgets: [shellWidget, ...extraWidgets],
   }
 
@@ -128,7 +143,7 @@ describe('WidgetShell', () => {
     const shellWidget = makeWidget(newWidgetInstanceId())
     const page: DashboardPage = {
       id: newDashboardPageId(),
-      name: 'Test Page',
+      name: toDashboardPageName('Test Page'),
       widgets: [shellWidget, makeWidget(newWidgetInstanceId())],
     }
     const store = configureStore({

--- a/src/renderer/src/components/dashboard/types.ts
+++ b/src/renderer/src/components/dashboard/types.ts
@@ -43,7 +43,15 @@ export type DashboardPageId = Brand<string, 'DashboardPageId'>
  * @description Human-readable tab name shown in the dashboard page strip.
  * @example "Overview"
  */
-export type DashboardPageName = string
+export type DashboardPageName = Brand<string, 'DashboardPageName'>
+
+/**
+ * Construct a {@link DashboardPageName} from a raw string at a trust boundary
+ * (a page-rename input or the preset builder).
+ * @example toDashboardPageName('x')
+ */
+export const toDashboardPageName = (value: string): DashboardPageName =>
+  value as DashboardPageName
 
 // ============================================================================
 // Placement
@@ -56,25 +64,57 @@ export type DashboardPageName = string
  * @description Zero-based grid column where a widget begins.
  * @example 3
  */
-export type GridColumnStart = number
+export type GridColumnStart = Brand<number, 'GridColumnStart'>
+
+/**
+ * Construct a {@link GridColumnStart} from a raw number at a trust boundary
+ * (a react-grid-layout callback or persisted state).
+ * @example toGridColumnStart(1)
+ */
+export const toGridColumnStart = (value: number): GridColumnStart =>
+  value as GridColumnStart
 
 /**
  * @description Zero-based grid row where a widget begins.
  * @example 6
  */
-export type GridRowStart = number
+export type GridRowStart = Brand<number, 'GridRowStart'>
+
+/**
+ * Construct a {@link GridRowStart} from a raw number at a trust boundary
+ * (a react-grid-layout callback or persisted state).
+ * @example toGridRowStart(1)
+ */
+export const toGridRowStart = (value: number): GridRowStart =>
+  value as GridRowStart
 
 /**
  * @description Width of a widget measured in dashboard grid columns.
  * @example 6
  */
-export type GridColumnSpan = number
+export type GridColumnSpan = Brand<number, 'GridColumnSpan'>
+
+/**
+ * Construct a {@link GridColumnSpan} from a raw number at a trust boundary
+ * (a react-grid-layout callback or the size table).
+ * @example toGridColumnSpan(1)
+ */
+export const toGridColumnSpan = (value: number): GridColumnSpan =>
+  value as GridColumnSpan
 
 /**
  * @description Height of a widget measured in dashboard grid rows.
  * @example 3
  */
-export type GridRowSpan = number
+export type GridRowSpan = Brand<number, 'GridRowSpan'>
+
+/**
+ * Construct a {@link GridRowSpan} from a raw number at a trust boundary
+ * (a react-grid-layout callback or the size table).
+ * @example toGridRowSpan(1)
+ */
+export const toGridRowSpan = (value: number): GridRowSpan =>
+  value as GridRowSpan
 
 /**
  * A single placed widget on a page.

--- a/src/renderer/src/components/dashboard/types.ts
+++ b/src/renderer/src/components/dashboard/types.ts
@@ -48,7 +48,7 @@ export type DashboardPageName = Brand<string, 'DashboardPageName'>
 /**
  * Construct a {@link DashboardPageName} from a raw string at a trust boundary
  * (a page-rename input or the preset builder).
- * @example toDashboardPageName('x')
+ * @example toDashboardPageName('Overview')
  */
 export const toDashboardPageName = (value: string): DashboardPageName =>
   value as DashboardPageName
@@ -69,7 +69,7 @@ export type GridColumnStart = Brand<number, 'GridColumnStart'>
 /**
  * Construct a {@link GridColumnStart} from a raw number at a trust boundary
  * (a react-grid-layout callback or persisted state).
- * @example toGridColumnStart(1)
+ * @example toGridColumnStart(3)
  */
 export const toGridColumnStart = (value: number): GridColumnStart =>
   value as GridColumnStart
@@ -83,7 +83,7 @@ export type GridRowStart = Brand<number, 'GridRowStart'>
 /**
  * Construct a {@link GridRowStart} from a raw number at a trust boundary
  * (a react-grid-layout callback or persisted state).
- * @example toGridRowStart(1)
+ * @example toGridRowStart(6)
  */
 export const toGridRowStart = (value: number): GridRowStart =>
   value as GridRowStart
@@ -97,7 +97,7 @@ export type GridColumnSpan = Brand<number, 'GridColumnSpan'>
 /**
  * Construct a {@link GridColumnSpan} from a raw number at a trust boundary
  * (a react-grid-layout callback or the size table).
- * @example toGridColumnSpan(1)
+ * @example toGridColumnSpan(6)
  */
 export const toGridColumnSpan = (value: number): GridColumnSpan =>
   value as GridColumnSpan
@@ -111,7 +111,7 @@ export type GridRowSpan = Brand<number, 'GridRowSpan'>
 /**
  * Construct a {@link GridRowSpan} from a raw number at a trust boundary
  * (a react-grid-layout callback or the size table).
- * @example toGridRowSpan(1)
+ * @example toGridRowSpan(3)
  */
 export const toGridRowSpan = (value: number): GridRowSpan =>
   value as GridRowSpan

--- a/src/renderer/src/components/dashboard/utils/buildSymlinkCleanupPlan.test.ts
+++ b/src/renderer/src/components/dashboard/utils/buildSymlinkCleanupPlan.test.ts
@@ -9,6 +9,7 @@ import type {
   SymlinkInfo,
   SymlinkStatus,
 } from '@/shared/types'
+import { toSymlinkCount } from '@/shared/types'
 
 import {
   buildSymlinkCleanupPlan,
@@ -57,8 +58,9 @@ function makeSkill(overrides: Partial<Skill> = {}): Skill {
     name,
     description: `${name} description`,
     path: overrides.path ?? `/Users/test/.agents/skills/${name}`,
-    symlinkCount: symlinks.filter((symlink) => symlink.status === 'valid')
-      .length,
+    symlinkCount: toSymlinkCount(
+      symlinks.filter((symlink) => symlink.status === 'valid').length,
+    ),
     symlinks,
     isSource: overrides.isSource ?? true,
     isOrphan: overrides.isOrphan ?? false,

--- a/src/renderer/src/components/dashboard/utils/buildSymlinkCleanupPlan.ts
+++ b/src/renderer/src/components/dashboard/utils/buildSymlinkCleanupPlan.ts
@@ -11,6 +11,12 @@ import type {
   SymlinkCount,
   SymlinkInfo,
 } from '@/shared/types'
+import {
+  toAgentCount,
+  toIsoTimestamp,
+  toSkillCount,
+  toSymlinkCount,
+} from '@/shared/types'
 
 /**
  * @description Stable review-row identifier generated for Symlink Health cleanup selection.
@@ -187,7 +193,7 @@ export function buildSymlinkCleanupPlan(
           linkPath: symlink.linkPath,
           targetPath: symlink.targetPath,
         })),
-        symlinkCount: cleanupEligibleBrokenSlots.length,
+        symlinkCount: toSymlinkCount(cleanupEligibleBrokenSlots.length),
       })
       for (const symlink of cleanupEligibleBrokenSlots) {
         affectedAgentIds.add(symlink.agentId)
@@ -223,17 +229,16 @@ export function buildSymlinkCleanupPlan(
   )
 
   return {
-    generatedAt: new Date().toISOString(),
+    generatedAt: toIsoTimestamp(new Date().toISOString()),
     orphanRecords,
     brokenSlotsByAgent,
     totals: {
-      orphanRecords: orphanRecords.length,
-      orphanSymlinks: orphanRecords.reduce(
-        (total, item) => total + item.symlinkCount,
-        0,
+      orphanRecords: toSkillCount(orphanRecords.length),
+      orphanSymlinks: toSymlinkCount(
+        orphanRecords.reduce((total, item) => total + item.symlinkCount, 0),
       ),
-      brokenSlots,
-      affectedAgents: affectedAgentIds.size,
+      brokenSlots: toSymlinkCount(brokenSlots),
+      affectedAgents: toAgentCount(affectedAgentIds.size),
     },
   }
 }

--- a/src/renderer/src/components/dashboard/utils/findEmptySpot.test.ts
+++ b/src/renderer/src/components/dashboard/utils/findEmptySpot.test.ts
@@ -5,6 +5,12 @@ import type {
   WidgetInstanceId,
   WidgetType,
 } from '@/renderer/src/components/dashboard/types'
+import {
+  toGridColumnSpan,
+  toGridColumnStart,
+  toGridRowSpan,
+  toGridRowStart,
+} from '@/renderer/src/components/dashboard/types'
 
 import { findEmptySpot } from './findEmptySpot'
 
@@ -21,7 +27,10 @@ function buildWidget(
   return {
     id: `w_test_${position.x}_${position.y}` as WidgetInstanceId,
     type,
-    ...position,
+    x: toGridColumnStart(position.x),
+    y: toGridRowStart(position.y),
+    w: toGridColumnSpan(position.w),
+    h: toGridRowSpan(position.h),
   }
 }
 
@@ -31,7 +40,10 @@ describe('findEmptySpot', () => {
     const noWidgets: WidgetInstance[] = []
 
     // Act
-    const spot = findEmptySpot(noWidgets, { w: 6, h: 2 })
+    const spot = findEmptySpot(noWidgets, {
+      w: toGridColumnSpan(6),
+      h: toGridRowSpan(2),
+    })
 
     // Assert
     expect(spot).toEqual({ x: 0, y: 0 })
@@ -42,7 +54,10 @@ describe('findEmptySpot', () => {
     const widgets = [buildWidget({ x: 0, y: 0, w: 6, h: 2 })]
 
     // Act
-    const spot = findEmptySpot(widgets, { w: 6, h: 2 })
+    const spot = findEmptySpot(widgets, {
+      w: toGridColumnSpan(6),
+      h: toGridRowSpan(2),
+    })
 
     // Assert
     expect(spot).toEqual({ x: 0, y: 2 })
@@ -53,7 +68,10 @@ describe('findEmptySpot', () => {
     const widgets = [buildWidget({ x: 0, y: 0, w: 3, h: 2 })]
 
     // Act
-    const spot = findEmptySpot(widgets, { w: 3, h: 2 })
+    const spot = findEmptySpot(widgets, {
+      w: toGridColumnSpan(3),
+      h: toGridRowSpan(2),
+    })
 
     // Assert
     expect(spot).toEqual({ x: 3, y: 0 })
@@ -69,7 +87,10 @@ describe('findEmptySpot', () => {
     ]
 
     // Act
-    const spot = findEmptySpot(widgets, { w: 3, h: 1 })
+    const spot = findEmptySpot(widgets, {
+      w: toGridColumnSpan(3),
+      h: toGridRowSpan(1),
+    })
 
     // Assert
     expect(spot).toBeNull()
@@ -80,7 +101,10 @@ describe('findEmptySpot', () => {
     const noWidgets: WidgetInstance[] = []
 
     // Act
-    const spot = findEmptySpot(noWidgets, { w: 7, h: 1 })
+    const spot = findEmptySpot(noWidgets, {
+      w: toGridColumnSpan(7),
+      h: toGridRowSpan(1),
+    })
 
     // Assert
     expect(spot).toBeNull()
@@ -93,7 +117,10 @@ describe('findEmptySpot', () => {
     const widgets = [buildWidget({ x: 0, y: 0, w: 6, h: 40 })]
 
     // Act
-    const spot = findEmptySpot(widgets, { w: 6, h: 1 })
+    const spot = findEmptySpot(widgets, {
+      w: toGridColumnSpan(6),
+      h: toGridRowSpan(1),
+    })
 
     // Assert
     expect(spot).toBeNull()

--- a/src/renderer/src/components/dashboard/utils/findEmptySpot.ts
+++ b/src/renderer/src/components/dashboard/utils/findEmptySpot.ts
@@ -4,6 +4,10 @@ import type {
   WidgetInstance,
   WidgetSize,
 } from '@/renderer/src/components/dashboard/types'
+import {
+  toGridColumnStart,
+  toGridRowStart,
+} from '@/renderer/src/components/dashboard/types'
 
 import {
   GRID_COLS,
@@ -49,8 +53,15 @@ export function findEmptySpot(
 
   for (let originY = 0; originY < MAX_GRID_ROWS_SEARCH; originY++) {
     for (let originX = 0; originX <= GRID_COLS - size.w; originX++) {
-      if (fitsAt(occupied, originX, originY, size)) {
-        return { x: originX, y: originY }
+      if (
+        fitsAt(
+          occupied,
+          toGridColumnStart(originX),
+          toGridRowStart(originY),
+          size,
+        )
+      ) {
+        return { x: toGridColumnStart(originX), y: toGridRowStart(originY) }
       }
     }
   }

--- a/src/renderer/src/components/dashboard/utils/nextPageName.test.ts
+++ b/src/renderer/src/components/dashboard/utils/nextPageName.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { DashboardPage } from '@/renderer/src/components/dashboard/types'
+import { toDashboardPageName } from '@/renderer/src/components/dashboard/types'
 
 import { newDashboardPageId } from './ids'
 import { nextPageName } from './nextPageName'
@@ -15,7 +16,7 @@ import { nextPageName } from './nextPageName'
 function makePage(name: string): DashboardPage {
   return {
     id: newDashboardPageId(),
-    name,
+    name: toDashboardPageName(name),
     widgets: [],
   }
 }

--- a/src/renderer/src/components/dashboard/utils/nextPageName.ts
+++ b/src/renderer/src/components/dashboard/utils/nextPageName.ts
@@ -2,6 +2,7 @@ import type {
   DashboardPage,
   DashboardPageName,
 } from '@/renderer/src/components/dashboard/types'
+import { toDashboardPageName } from '@/renderer/src/components/dashboard/types'
 
 /**
  * Compute a collision-free default page name of the form `Page N`. Exists
@@ -26,8 +27,8 @@ export function nextPageName(
   // Preserve the familiar "next number" starting point, then step past any
   // suffix that a surviving page already occupies so the result is unique.
   let suffix = pages.length + 1
-  while (existingNames.has(`Page ${suffix}`)) {
+  while (existingNames.has(toDashboardPageName(`Page ${suffix}`))) {
     suffix += 1
   }
-  return `Page ${suffix}`
+  return toDashboardPageName(`Page ${suffix}`)
 }

--- a/src/renderer/src/components/dashboard/utils/resolveSeedPreviewType.test.ts
+++ b/src/renderer/src/components/dashboard/utils/resolveSeedPreviewType.test.ts
@@ -2,6 +2,10 @@ import { Activity } from 'lucide-react'
 import { describe, expect, it } from 'vitest'
 
 import type { WidgetDefinition } from '@/renderer/src/components/dashboard/types'
+import {
+  toGridColumnSpan,
+  toGridRowSpan,
+} from '@/renderer/src/components/dashboard/types'
 
 import { resolveSeedPreviewType } from './resolveSeedPreviewType'
 
@@ -11,8 +15,8 @@ const PLACEHOLDER_DEFINITION = {
   label: '',
   description: '',
   icon: Activity,
-  defaultSize: { w: 1, h: 1 },
-  minSize: { w: 1, h: 1 },
+  defaultSize: { w: toGridColumnSpan(1), h: toGridRowSpan(1) },
+  minSize: { w: toGridColumnSpan(1), h: toGridRowSpan(1) },
   Component: () => null,
 } as const
 

--- a/src/renderer/src/components/dashboard/utils/widgetPresets.ts
+++ b/src/renderer/src/components/dashboard/utils/widgetPresets.ts
@@ -8,6 +8,13 @@ import type {
   WidgetInstance,
   WidgetType,
 } from '@/renderer/src/components/dashboard/types'
+import {
+  toDashboardPageName,
+  toGridColumnSpan,
+  toGridColumnStart,
+  toGridRowSpan,
+  toGridRowStart,
+} from '@/renderer/src/components/dashboard/types'
 import { WIDGET_SIZES } from '@/renderer/src/components/dashboard/widgets/sizes'
 
 import { newDashboardPageId, newWidgetInstanceId } from './ids'
@@ -40,32 +47,72 @@ interface PageSpec {
 
 const PAGE_SPECS: readonly PageSpec[] = [
   {
-    name: 'Overview',
+    name: toDashboardPageName('Overview'),
     widgets: [
-      { type: 'welcome', x: 0, y: 0, w: 6, h: 3 },
-      { type: 'stats', x: 0, y: 3 },
+      {
+        type: 'welcome',
+        x: toGridColumnStart(0),
+        y: toGridRowStart(0),
+        w: toGridColumnSpan(6),
+        h: toGridRowSpan(3),
+      },
+      { type: 'stats', x: toGridColumnStart(0), y: toGridRowStart(3) },
       // health inherits its h=3 default (sizes.ts), occupying rows 3-5 at
       // x3-5, so coverage starts at row 6 to clear it. (At y=5 the vertical
       // compactor would push coverage to 6 on mount anyway; hand-author the
       // honest value rather than rely on runtime collision-resolution.)
-      { type: 'health', x: 3, y: 3 },
-      { type: 'coverage', x: 0, y: 6, w: 6, h: 3 },
+      { type: 'health', x: toGridColumnStart(3), y: toGridRowStart(3) },
+      {
+        type: 'coverage',
+        x: toGridColumnStart(0),
+        y: toGridRowStart(6),
+        w: toGridColumnSpan(6),
+        h: toGridRowSpan(3),
+      },
     ],
   },
   {
-    name: 'Discovery',
+    name: toDashboardPageName('Discovery'),
     widgets: [
-      { type: 'trending', x: 0, y: 0, w: 6, h: 4 },
-      { type: 'whats-new', x: 0, y: 4, w: 6, h: 3 },
+      {
+        type: 'trending',
+        x: toGridColumnStart(0),
+        y: toGridRowStart(0),
+        w: toGridColumnSpan(6),
+        h: toGridRowSpan(4),
+      },
+      {
+        type: 'whats-new',
+        x: toGridColumnStart(0),
+        y: toGridRowStart(4),
+        w: toGridColumnSpan(6),
+        h: toGridRowSpan(3),
+      },
     ],
   },
   {
-    name: 'Actions',
-    widgets: [{ type: 'quick-actions', x: 0, y: 0, w: 6, h: 3 }],
+    name: toDashboardPageName('Actions'),
+    widgets: [
+      {
+        type: 'quick-actions',
+        x: toGridColumnStart(0),
+        y: toGridRowStart(0),
+        w: toGridColumnSpan(6),
+        h: toGridRowSpan(3),
+      },
+    ],
   },
   {
-    name: 'Personal',
-    widgets: [{ type: 'bookmarks', x: 0, y: 0, w: 6, h: 4 }],
+    name: toDashboardPageName('Personal'),
+    widgets: [
+      {
+        type: 'bookmarks',
+        x: toGridColumnStart(0),
+        y: toGridRowStart(0),
+        w: toGridColumnSpan(6),
+        h: toGridRowSpan(4),
+      },
+    ],
   },
 ]
 

--- a/src/renderer/src/components/dashboard/utils/widgetPreviewSize.test.ts
+++ b/src/renderer/src/components/dashboard/utils/widgetPreviewSize.test.ts
@@ -1,13 +1,20 @@
 import { describe, expect, it } from 'vitest'
 
 import type { WidgetSize } from '@/renderer/src/components/dashboard/types'
+import {
+  toGridColumnSpan,
+  toGridRowSpan,
+} from '@/renderer/src/components/dashboard/types'
 
 import { widgetPreviewSize } from './widgetPreviewSize'
 
 describe('widgetPreviewSize', () => {
   it('sizes a default 3x2 widget to a wide preview box', () => {
     // Arrange
-    const defaultSize: WidgetSize = { w: 3, h: 2 }
+    const defaultSize: WidgetSize = {
+      w: toGridColumnSpan(3),
+      h: toGridRowSpan(2),
+    }
 
     // Act
     const box = widgetPreviewSize(defaultSize)
@@ -18,7 +25,10 @@ describe('widgetPreviewSize', () => {
 
   it('sizes a full-width 6x3 widget to a large preview box', () => {
     // Arrange
-    const defaultSize: WidgetSize = { w: 6, h: 3 }
+    const defaultSize: WidgetSize = {
+      w: toGridColumnSpan(6),
+      h: toGridRowSpan(3),
+    }
 
     // Act
     const box = widgetPreviewSize(defaultSize)
@@ -29,7 +39,10 @@ describe('widgetPreviewSize', () => {
 
   it('sizes a single 1x1 cell with no inter-cell margin', () => {
     // Arrange
-    const defaultSize: WidgetSize = { w: 1, h: 1 }
+    const defaultSize: WidgetSize = {
+      w: toGridColumnSpan(1),
+      h: toGridRowSpan(1),
+    }
 
     // Act
     const box = widgetPreviewSize(defaultSize)

--- a/src/renderer/src/components/dashboard/widgets/AgentHeatmapWidget.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/widgets/AgentHeatmapWidget.browser.test.tsx
@@ -12,6 +12,7 @@ import type {
   SymlinkInfo,
   SymlinkStatus,
 } from '@/shared/types'
+import { toSkillCount, toSymlinkCount } from '@/shared/types'
 
 /**
  * Build a minimal Agent fixture. Only `id`/`name`/`exists` matter to the
@@ -26,8 +27,8 @@ function makeAgent(id: AgentId, name: AgentName, exists: boolean): Agent {
     name,
     path: `/Users/test/.${id}/skills`,
     exists,
-    skillCount: 0,
-    localSkillCount: 0,
+    skillCount: toSkillCount(0),
+    localSkillCount: toSkillCount(0),
   }
 }
 
@@ -64,7 +65,9 @@ function makeSkill(name: string, symlinks: SymlinkInfo[]): Skill {
     name,
     description: `${name} description`,
     path: `/Users/test/.agents/skills/${name}`,
-    symlinkCount: symlinks.filter((link) => link.status === 'valid').length,
+    symlinkCount: toSymlinkCount(
+      symlinks.filter((link) => link.status === 'valid').length,
+    ),
     symlinks,
     isSource: true,
     isOrphan: false,

--- a/src/renderer/src/components/dashboard/widgets/BookmarksWidget.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/widgets/BookmarksWidget.browser.test.tsx
@@ -5,6 +5,7 @@ import { render } from 'vitest-browser-react'
 
 import '@/renderer/src/styles/globals.css'
 import type { RepositoryId, SkillName } from '@/shared/types'
+import { toHttpUrl } from '@/shared/types'
 
 /**
  * Render the real BookmarksWidget reducer with one bookmark.
@@ -27,7 +28,7 @@ async function renderBookmarksWidget(name: SkillName = 'very-long-skill-name') {
     addBookmark({
       name,
       repo: 'laststance/skills' as RepositoryId,
-      url: 'https://skills.sh/very-long-skill-name',
+      url: toHttpUrl('https://skills.sh/very-long-skill-name'),
     }),
   )
 
@@ -88,7 +89,7 @@ describe('BookmarksWidget', () => {
       addBookmark({
         name: 'task',
         repo: 'vercel-labs/skills' as RepositoryId,
-        url: 'https://skills.sh/task',
+        url: toHttpUrl('https://skills.sh/task'),
       }),
     )
 
@@ -119,7 +120,7 @@ describe('BookmarksWidget', () => {
       addBookmark({
         name: 'repo-less-skill',
         repo: '',
-        url: 'https://skills.sh/repo-less-skill',
+        url: toHttpUrl('https://skills.sh/repo-less-skill'),
       }),
     )
 

--- a/src/renderer/src/components/dashboard/widgets/CoverageWidget.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/widgets/CoverageWidget.browser.test.tsx
@@ -5,6 +5,7 @@ import { render } from 'vitest-browser-react'
 
 import '@/renderer/src/styles/globals.css'
 import type { Agent, AgentId, AgentName, Skill } from '@/shared/types'
+import { toSkillCount, toSymlinkCount } from '@/shared/types'
 
 /**
  * Build an Agent fixture letting each test vary the coverage-relevant fields.
@@ -26,8 +27,8 @@ function makeAgent(
     name,
     path: `/Users/test/.${id}/skills`,
     exists,
-    skillCount,
-    localSkillCount,
+    skillCount: toSkillCount(skillCount),
+    localSkillCount: toSkillCount(localSkillCount),
   }
 }
 
@@ -41,7 +42,7 @@ function makeSkill(name: string): Skill {
     name,
     description: `${name} description`,
     path: `/Users/test/.agents/skills/${name}`,
-    symlinkCount: 0,
+    symlinkCount: toSymlinkCount(0),
     symlinks: [],
     isSource: true,
     isOrphan: false,

--- a/src/renderer/src/components/dashboard/widgets/CoverageWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/CoverageWidget.tsx
@@ -6,6 +6,7 @@ import { selectAgentItems } from '@/renderer/src/redux/slices/agentsSlice'
 import { selectSkillsItems } from '@/renderer/src/redux/slices/skillsSlice'
 import { selectAgent } from '@/renderer/src/redux/slices/uiSlice'
 import type { Agent, AgentId, SkillCount } from '@/shared/types'
+import { toSkillCount } from '@/shared/types'
 
 // ----------------------------------------------------------------------------
 // Pure helpers
@@ -40,7 +41,7 @@ function buildCoverageRows(
   totalSourceSkills: SkillCount,
 ): CoverageRow[] {
   return agents.map((agent) => {
-    const total = agent.skillCount + agent.localSkillCount
+    const total = toSkillCount(agent.skillCount + agent.localSkillCount)
     const ratio =
       totalSourceSkills > 0
         ? Math.min(1, agent.skillCount / totalSourceSkills)
@@ -140,7 +141,7 @@ export const CoverageWidget = function CoverageWidget(): React.ReactElement {
   const agents = useAppSelector(selectAgentItems)
   const skills = useAppSelector(selectSkillsItems)
 
-  const rows = buildCoverageRows(agents, skills.length)
+  const rows = buildCoverageRows(agents, toSkillCount(skills.length))
 
   const handleSelect = (agentId: AgentId): void => {
     dispatch(selectAgent(agentId))

--- a/src/renderer/src/components/dashboard/widgets/HealthWidget.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/widgets/HealthWidget.browser.test.tsx
@@ -5,6 +5,7 @@ import { render } from 'vitest-browser-react'
 
 import '@/renderer/src/styles/globals.css'
 import type { Skill, SymlinkInfo } from '@/shared/types'
+import { toSymlinkCount } from '@/shared/types'
 
 /**
  * Builds a SymlinkInfo fixture for HealthWidget display-state tests.
@@ -36,8 +37,9 @@ function makeSkill(symlinks: SymlinkInfo[]): Skill {
     name: 'task',
     description: 'Task skill',
     path: '/Users/test/.agents/skills/task',
-    symlinkCount: symlinks.filter((symlink) => symlink.status === 'valid')
-      .length,
+    symlinkCount: toSymlinkCount(
+      symlinks.filter((symlink) => symlink.status === 'valid').length,
+    ),
     symlinks,
     isSource: true,
     isOrphan: false,

--- a/src/renderer/src/components/dashboard/widgets/HealthWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/HealthWidget.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/renderer/src/redux/slices/uiSlice'
 import { pluralize } from '@/renderer/src/utils/pluralize'
 import type { Skill, SymlinkCount } from '@/shared/types'
+import { toSymlinkCount } from '@/shared/types'
 
 // ----------------------------------------------------------------------------
 // Pure helpers
@@ -37,14 +38,14 @@ interface HealthTotals {
  */
 function tallySymlinks(skills: readonly Skill[]): HealthTotals {
   const totals: HealthTotals = {
-    valid: 0,
-    broken: 0,
-    inaccessible: 0,
-    missing: 0,
+    valid: toSymlinkCount(0),
+    broken: toSymlinkCount(0),
+    inaccessible: toSymlinkCount(0),
+    missing: toSymlinkCount(0),
   }
   for (const skill of skills) {
     for (const link of skill.symlinks) {
-      totals[link.status] += 1
+      totals[link.status] = toSymlinkCount(totals[link.status] + 1)
     }
   }
   return totals

--- a/src/renderer/src/components/dashboard/widgets/LeaderboardWidget.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/widgets/LeaderboardWidget.browser.test.tsx
@@ -10,7 +10,14 @@ import type {
   SkillSearchResult,
   LeaderboardData,
 } from '@/shared/types'
-import { repositoryId } from '@/shared/types'
+import {
+  repositoryId,
+  toHttpUrl,
+  toInstallCount,
+  toSearchQuery,
+  toSkillRank,
+  toUnixTimestampMs,
+} from '@/shared/types'
 
 // The widget dispatches `loadLeaderboard(filter)` on mount, whose thunk reads
 // `window.electron.marketplace.leaderboard`. Browser-mode tests replace the
@@ -41,11 +48,11 @@ afterEach(() => {
  */
 function makeSkill(rank: number, name: string): SkillSearchResult {
   return {
-    rank,
+    rank: toSkillRank(rank),
     name,
     repo: repositoryId(`owner/${name}`),
-    url: `https://skills.sh/${name}`,
-    installCount: 100,
+    url: toHttpUrl(`https://skills.sh/${name}`),
+    installCount: toInstallCount(100),
   }
 }
 
@@ -71,7 +78,7 @@ async function renderLeaderboard(
       ? {
           marketplace: {
             status: 'idle' as const,
-            searchQuery: '',
+            searchQuery: toSearchQuery(''),
             searchResults: [],
             selectedSkill: null,
             previewSkill: null,
@@ -104,7 +111,7 @@ describe('LeaderboardWidget', () => {
     // Arrange: the filter has never resolved — status loading, no skills yet.
     const loadingEntry: LeaderboardData = {
       skills: [],
-      lastFetched: 0,
+      lastFetched: toUnixTimestampMs(0),
       filter: 'trending',
       status: 'loading',
     }
@@ -141,7 +148,7 @@ describe('LeaderboardWidget', () => {
     mockLeaderboard.mockRejectedValue(new Error('network down'))
     const erroredEntry: LeaderboardData = {
       skills: [],
-      lastFetched: 0,
+      lastFetched: toUnixTimestampMs(0),
       filter: 'trending',
       status: 'error',
       error: 'network down',
@@ -160,7 +167,7 @@ describe('LeaderboardWidget', () => {
     // Arrange: a successful load that returned no skills.
     const emptyEntry: LeaderboardData = {
       skills: [],
-      lastFetched: Date.now(),
+      lastFetched: toUnixTimestampMs(Date.now()),
       filter: 'trending',
       status: 'idle',
     }
@@ -178,7 +185,7 @@ describe('LeaderboardWidget', () => {
     // Arrange: a successful load with two ranked skills.
     const loadedEntry: LeaderboardData = {
       skills: [makeSkill(1, 'alpha-skill'), makeSkill(2, 'beta-skill')],
-      lastFetched: Date.now(),
+      lastFetched: toUnixTimestampMs(Date.now()),
       filter: 'trending',
       status: 'idle',
     }
@@ -202,7 +209,7 @@ describe('LeaderboardWidget', () => {
         makeSkill(4, 'four-skill'),
         makeSkill(5, 'five-skill'),
       ],
-      lastFetched: Date.now(),
+      lastFetched: toUnixTimestampMs(Date.now()),
       filter: 'trending',
       status: 'idle',
     }

--- a/src/renderer/src/components/dashboard/widgets/MarketplaceSkillRow.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/widgets/MarketplaceSkillRow.browser.test.tsx
@@ -3,7 +3,12 @@ import { render } from 'vitest-browser-react'
 
 import '@/renderer/src/styles/globals.css'
 import type { SkillSearchResult } from '@/shared/types'
-import { repositoryId } from '@/shared/types'
+import {
+  repositoryId,
+  toHttpUrl,
+  toInstallCount,
+  toSkillRank,
+} from '@/shared/types'
 
 import { MarketplaceSkillRow } from './MarketplaceSkillRow'
 
@@ -22,10 +27,10 @@ function makeSkill(
   overrides: Partial<SkillSearchResult> = {},
 ): SkillSearchResult {
   return {
-    rank: 1,
+    rank: toSkillRank(1),
     name: 'task',
     repo: repositoryId('vercel-labs/skills'),
-    url: 'https://skills.sh/task',
+    url: toHttpUrl('https://skills.sh/task'),
     ...overrides,
   }
 }
@@ -34,11 +39,11 @@ describe('MarketplaceSkillRow', () => {
   it('opens the skill on skills.sh in a new browser tab when the row is clicked', async () => {
     // Arrange: a fully-populated trending skill row.
     const skill = makeSkill({
-      rank: 1,
+      rank: toSkillRank(1),
       name: 'task',
       repo: repositoryId('vercel-labs/skills'),
-      url: 'https://skills.sh/task',
-      installCount: 2480,
+      url: toHttpUrl('https://skills.sh/task'),
+      installCount: toInstallCount(2480),
     })
 
     // Act
@@ -70,10 +75,10 @@ describe('MarketplaceSkillRow', () => {
   it('shows a dash for the install count when the skill has no install data', async () => {
     // Arrange: a CLI-search-style result with no installCount field.
     const skill = makeSkill({
-      rank: 7,
+      rank: toSkillRank(7),
       name: 'review',
       repo: repositoryId('anthropics/skills'),
-      url: 'https://skills.sh/review',
+      url: toHttpUrl('https://skills.sh/review'),
     })
 
     // Act

--- a/src/renderer/src/components/dashboard/widgets/StatsWidget.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/widgets/StatsWidget.browser.test.tsx
@@ -5,6 +5,7 @@ import { render } from 'vitest-browser-react'
 
 import '@/renderer/src/styles/globals.css'
 import type { Agent, AgentId, AgentName, Skill } from '@/shared/types'
+import { toSkillCount, toSymlinkCount } from '@/shared/types'
 
 /**
  * Build an Agent fixture letting each test vary the `exists` flag that gates the
@@ -19,8 +20,8 @@ function makeAgent(id: AgentId, name: AgentName, exists: boolean): Agent {
     name,
     path: `/Users/test/.${id}/skills`,
     exists,
-    skillCount: 0,
-    localSkillCount: 0,
+    skillCount: toSkillCount(0),
+    localSkillCount: toSkillCount(0),
   }
 }
 
@@ -35,7 +36,7 @@ function makeSkill(name: string, symlinkCount: number): Skill {
     name,
     description: `${name} description`,
     path: `/Users/test/.agents/skills/${name}`,
-    symlinkCount,
+    symlinkCount: toSymlinkCount(symlinkCount),
     symlinks: [],
     isSource: true,
     isOrphan: false,

--- a/src/renderer/src/components/dashboard/widgets/StatsWidget.tsx
+++ b/src/renderer/src/components/dashboard/widgets/StatsWidget.tsx
@@ -5,6 +5,7 @@ import { useAppSelector } from '@/renderer/src/redux/hooks'
 import { selectAgentItems } from '@/renderer/src/redux/slices/agentsSlice'
 import { selectSkillsItems } from '@/renderer/src/redux/slices/skillsSlice'
 import type { AgentCount, SkillCount } from '@/shared/types'
+import { toAgentCount, toSkillCount } from '@/shared/types'
 
 // ----------------------------------------------------------------------------
 // Pure helpers — derived outside the component so they're trivially testable
@@ -20,7 +21,7 @@ import type { AgentCount, SkillCount } from '@/shared/types'
 function countLinkedSkills(
   items: ReadonlyArray<{ symlinkCount: number }>,
 ): SkillCount {
-  return items.filter((skill) => skill.symlinkCount > 0).length
+  return toSkillCount(items.filter((skill) => skill.symlinkCount > 0).length)
 }
 
 /**
@@ -33,7 +34,7 @@ function countLinkedSkills(
 function countActiveAgents(
   items: ReadonlyArray<{ exists: boolean }>,
 ): AgentCount {
-  return items.filter((agent) => agent.exists).length
+  return toAgentCount(items.filter((agent) => agent.exists).length)
 }
 
 // ----------------------------------------------------------------------------

--- a/src/renderer/src/components/dashboard/widgets/TrendingWidget.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/widgets/TrendingWidget.browser.test.tsx
@@ -5,7 +5,14 @@ import { render } from 'vitest-browser-react'
 
 import '@/renderer/src/styles/globals.css'
 import type { SkillSearchResult, LeaderboardData } from '@/shared/types'
-import { repositoryId } from '@/shared/types'
+import {
+  repositoryId,
+  toHttpUrl,
+  toInstallCount,
+  toSearchQuery,
+  toSkillRank,
+  toUnixTimestampMs,
+} from '@/shared/types'
 
 // TrendingWidget mounts LeaderboardWidget, which dispatches
 // `loadLeaderboard('trending')` on mount; the thunk reads
@@ -36,11 +43,11 @@ afterEach(() => {
  */
 function makeSkill(rank: number, name: string): SkillSearchResult {
   return {
-    rank,
+    rank: toSkillRank(rank),
     name,
     repo: repositoryId(`owner/${name}`),
-    url: `https://skills.sh/${name}`,
-    installCount: 100,
+    url: toHttpUrl(`https://skills.sh/${name}`),
+    installCount: toInstallCount(100),
   }
 }
 
@@ -61,7 +68,7 @@ async function renderTrending(entry: LeaderboardData | null) {
       ? {
           marketplace: {
             status: 'idle' as const,
-            searchQuery: '',
+            searchQuery: toSearchQuery(''),
             searchResults: [],
             selectedSkill: null,
             previewSkill: null,
@@ -88,7 +95,7 @@ describe('TrendingWidget', () => {
     // Arrange: a successful trending load that returned no skills.
     const emptyEntry: LeaderboardData = {
       skills: [],
-      lastFetched: Date.now(),
+      lastFetched: toUnixTimestampMs(Date.now()),
       filter: 'trending',
       status: 'idle',
     }
@@ -111,7 +118,7 @@ describe('TrendingWidget', () => {
     mockLeaderboard.mockRejectedValue(new Error('network down'))
     const erroredEntry: LeaderboardData = {
       skills: [],
-      lastFetched: 0,
+      lastFetched: toUnixTimestampMs(0),
       filter: 'trending',
       status: 'error',
       error: 'network down',
@@ -131,7 +138,7 @@ describe('TrendingWidget', () => {
     // Arrange: a successful trending load with two ranked skills.
     const loadedEntry: LeaderboardData = {
       skills: [makeSkill(1, 'alpha-skill'), makeSkill(2, 'beta-skill')],
-      lastFetched: Date.now(),
+      lastFetched: toUnixTimestampMs(Date.now()),
       filter: 'trending',
       status: 'idle',
     }
@@ -159,7 +166,7 @@ describe('TrendingWidget', () => {
         makeSkill(8, 'eight-skill'),
         makeSkill(9, 'nine-skill'),
       ],
-      lastFetched: Date.now(),
+      lastFetched: toUnixTimestampMs(Date.now()),
       filter: 'trending',
       status: 'idle',
     }

--- a/src/renderer/src/components/dashboard/widgets/WelcomeWidget.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/widgets/WelcomeWidget.browser.test.tsx
@@ -10,6 +10,13 @@ import type {
   WidgetInstance,
   WidgetInstanceId,
 } from '@/renderer/src/components/dashboard/types'
+import {
+  toDashboardPageName,
+  toGridColumnSpan,
+  toGridColumnStart,
+  toGridRowSpan,
+  toGridRowStart,
+} from '@/renderer/src/components/dashboard/types'
 
 /**
  * Build a dashboard page that holds a single welcome widget so the real
@@ -20,15 +27,15 @@ import type {
 function makeWelcomePage(widgetId: WidgetInstanceId): DashboardPage {
   return {
     id: 'p_welcome' as DashboardPageId,
-    name: 'Overview',
+    name: toDashboardPageName('Overview'),
     widgets: [
       {
         id: widgetId,
         type: 'welcome',
-        x: 0,
-        y: 0,
-        w: 6,
-        h: 2,
+        x: toGridColumnStart(0),
+        y: toGridRowStart(0),
+        w: toGridColumnSpan(6),
+        h: toGridRowSpan(2),
       },
     ],
   }
@@ -47,10 +54,10 @@ function makeWelcomeInstance(widgetId: WidgetInstanceId): WidgetInstance {
   return {
     id: widgetId,
     type: 'welcome',
-    x: 0,
-    y: 0,
-    w: 6,
-    h: 2,
+    x: toGridColumnStart(0),
+    y: toGridRowStart(0),
+    w: toGridColumnSpan(6),
+    h: toGridRowSpan(2),
   }
 }
 

--- a/src/renderer/src/components/dashboard/widgets/WhatsNewWidget.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/widgets/WhatsNewWidget.browser.test.tsx
@@ -5,6 +5,7 @@ import { render } from 'vitest-browser-react'
 
 import '@/renderer/src/styles/globals.css'
 import type { SkillSearchResult, LeaderboardData } from '@/shared/types'
+import { toSearchQuery, toUnixTimestampMs } from '@/shared/types'
 
 // WhatsNewWidget wraps LeaderboardWidget pinned to the `hot` feed. On mount the
 // inner widget dispatches `loadLeaderboard('hot')`, whose thunk reads
@@ -46,7 +47,7 @@ async function renderWhatsNew(entry: LeaderboardData | null) {
       ? {
           marketplace: {
             status: 'idle' as const,
-            searchQuery: '',
+            searchQuery: toSearchQuery(''),
             searchResults: [],
             selectedSkill: null,
             previewSkill: null,
@@ -73,7 +74,7 @@ describe('WhatsNewWidget', () => {
     // Arrange: a successful `hot` load that returned no skills.
     const emptyHotEntry: LeaderboardData = {
       skills: [],
-      lastFetched: Date.now(),
+      lastFetched: toUnixTimestampMs(Date.now()),
       filter: 'hot',
       status: 'idle',
     }
@@ -95,7 +96,7 @@ describe('WhatsNewWidget', () => {
     mockLeaderboard.mockRejectedValue(new Error('network down'))
     const erroredHotEntry: LeaderboardData = {
       skills: [],
-      lastFetched: 0,
+      lastFetched: toUnixTimestampMs(0),
       filter: 'hot',
       status: 'error',
       error: 'network down',

--- a/src/renderer/src/components/dashboard/widgets/sizes.ts
+++ b/src/renderer/src/components/dashboard/widgets/sizes.ts
@@ -2,6 +2,10 @@ import type {
   WidgetSize,
   WidgetType,
 } from '@/renderer/src/components/dashboard/types'
+import {
+  toGridColumnSpan,
+  toGridRowSpan,
+} from '@/renderer/src/components/dashboard/types'
 
 // ============================================================================
 // Widget size metadata
@@ -32,43 +36,43 @@ export const WIDGET_SIZES: Readonly<
   Record<WidgetType, { defaultSize: WidgetSize; minSize: WidgetSize }>
 > = {
   welcome: {
-    defaultSize: { w: 6, h: 3 },
-    minSize: { w: 4, h: 2 },
+    defaultSize: { w: toGridColumnSpan(6), h: toGridRowSpan(3) },
+    minSize: { w: toGridColumnSpan(4), h: toGridRowSpan(2) },
   },
   stats: {
-    defaultSize: { w: 3, h: 2 },
-    minSize: { w: 2, h: 2 },
+    defaultSize: { w: toGridColumnSpan(3), h: toGridRowSpan(2) },
+    minSize: { w: toGridColumnSpan(2), h: toGridRowSpan(2) },
   },
   health: {
-    defaultSize: { w: 3, h: 3 },
-    minSize: { w: 2, h: 3 },
+    defaultSize: { w: toGridColumnSpan(3), h: toGridRowSpan(3) },
+    minSize: { w: toGridColumnSpan(2), h: toGridRowSpan(3) },
   },
   coverage: {
-    defaultSize: { w: 6, h: 3 },
-    minSize: { w: 4, h: 2 },
+    defaultSize: { w: toGridColumnSpan(6), h: toGridRowSpan(3) },
+    minSize: { w: toGridColumnSpan(4), h: toGridRowSpan(2) },
   },
   bookmarks: {
-    defaultSize: { w: 3, h: 3 },
-    minSize: { w: 2, h: 2 },
+    defaultSize: { w: toGridColumnSpan(3), h: toGridRowSpan(3) },
+    minSize: { w: toGridColumnSpan(2), h: toGridRowSpan(2) },
   },
   trending: {
-    defaultSize: { w: 6, h: 4 },
-    minSize: { w: 3, h: 3 },
+    defaultSize: { w: toGridColumnSpan(6), h: toGridRowSpan(4) },
+    minSize: { w: toGridColumnSpan(3), h: toGridRowSpan(3) },
   },
   'whats-new': {
-    defaultSize: { w: 3, h: 3 },
-    minSize: { w: 2, h: 2 },
+    defaultSize: { w: toGridColumnSpan(3), h: toGridRowSpan(3) },
+    minSize: { w: toGridColumnSpan(2), h: toGridRowSpan(2) },
   },
   'quick-actions': {
-    defaultSize: { w: 6, h: 3 },
-    minSize: { w: 3, h: 3 },
+    defaultSize: { w: toGridColumnSpan(6), h: toGridRowSpan(3) },
+    minSize: { w: toGridColumnSpan(3), h: toGridRowSpan(3) },
   },
   'agent-heatmap': {
-    defaultSize: { w: 6, h: 4 },
-    minSize: { w: 4, h: 3 },
+    defaultSize: { w: toGridColumnSpan(6), h: toGridRowSpan(4) },
+    minSize: { w: toGridColumnSpan(4), h: toGridRowSpan(3) },
   },
   'activity-timeline': {
-    defaultSize: { w: 6, h: 4 },
-    minSize: { w: 3, h: 3 },
+    defaultSize: { w: toGridColumnSpan(6), h: toGridRowSpan(4) },
+    minSize: { w: toGridColumnSpan(3), h: toGridRowSpan(3) },
   },
 } as const

--- a/src/renderer/src/components/layout/DetailPanel.browser.test.tsx
+++ b/src/renderer/src/components/layout/DetailPanel.browser.test.tsx
@@ -7,7 +7,7 @@ import { selectSkill } from '@/renderer/src/redux/slices/skillsSlice'
 import { setActiveTab } from '@/renderer/src/redux/slices/uiSlice'
 import { DEFAULT_SETTINGS } from '@/shared/settings'
 import type { Skill } from '@/shared/types'
-import { repositoryId } from '@/shared/types'
+import { repositoryId, toHttpUrl, toSymlinkCount } from '@/shared/types'
 
 // Replace the three routed panels with marker stubs so DetailPanel renders in
 // isolation — the real children fetch via IPC on mount, which is irrelevant to
@@ -72,12 +72,12 @@ function makeSelectableSkill(): Skill {
     name: 'demo-skill',
     description: '',
     path: '/skills/demo-skill',
-    symlinkCount: 0,
+    symlinkCount: toSymlinkCount(0),
     symlinks: [],
     isSource: true,
     isOrphan: false,
     source: repositoryId('owner/repo'),
-    sourceUrl: 'https://github.com/owner/repo.git',
+    sourceUrl: toHttpUrl('https://github.com/owner/repo.git'),
   }
 }
 

--- a/src/renderer/src/components/layout/MainContent.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.browser.test.tsx
@@ -17,7 +17,19 @@ import type {
   SkillName,
   SymlinkInfo,
 } from '@/shared/types'
-import { repositoryId, tombstoneId } from '@/shared/types'
+import {
+  repositoryId,
+  toBatchItemCount,
+  toBatchItemIndex,
+  toFileSizeBytes,
+  toHttpUrl,
+  toIsoTimestamp,
+  toSearchQuery,
+  toSkillCount,
+  toSkillRank,
+  toSymlinkCount,
+  tombstoneId,
+} from '@/shared/types'
 
 const mockGetAll = vi.fn()
 const mockOnDeleteProgress = vi.fn(
@@ -34,7 +46,7 @@ const directoryIdentity: FilesystemEntryIdentity = {
   kind: 'directory',
   dev: 1,
   ino: 2,
-  size: 96,
+  size: toFileSizeBytes(96),
   ctimeMs: 3,
   mtimeMs: 4,
 }
@@ -271,12 +283,12 @@ function makeSourceSkill(name: string, source: string): Skill {
     description: '',
     path: `/skills/${name}` as never,
     filesystemIdentity: directoryIdentity,
-    symlinkCount: 0,
+    symlinkCount: toSymlinkCount(0),
     symlinks: [],
     isSource: true,
     isOrphan: false,
     source: repositoryId(source),
-    sourceUrl: `https://github.com/${source}.git`,
+    sourceUrl: toHttpUrl(`https://github.com/${source}.git`),
   }
 }
 
@@ -292,7 +304,7 @@ function makeAgentLocalSkill(name: string, agentId: AgentId): Skill {
     name: name,
     description: '',
     path: `/home/user/.${agentId}/skills/${name}` as never,
-    symlinkCount: 0,
+    symlinkCount: toSymlinkCount(0),
     symlinks: [
       {
         agentId,
@@ -357,7 +369,7 @@ describe('MainContent Installed search count display', () => {
     )
 
     // Act
-    store.dispatch(setSearchQuery('alpha'))
+    store.dispatch(setSearchQuery(toSearchQuery('alpha')))
 
     // Assert
     await expect
@@ -369,7 +381,7 @@ describe('MainContent Installed search count display', () => {
       .toBeInTheDocument()
 
     // Act
-    store.dispatch(setSearchQuery(''))
+    store.dispatch(setSearchQuery(toSearchQuery('')))
     store.dispatch(setSelectedSources([repositoryId('pbakaus/impeccable')]))
 
     // Assert
@@ -382,7 +394,7 @@ describe('MainContent Installed search count display', () => {
       .toBeInTheDocument()
 
     // Act
-    store.dispatch(setSearchQuery('missing'))
+    store.dispatch(setSearchQuery(toSearchQuery('missing')))
 
     // Assert
     await expect
@@ -562,7 +574,7 @@ describe('MainContent keyboard shortcuts (Cmd+A)', () => {
         description: '',
         path: '/skills/task' as never,
         filesystemIdentity: directoryIdentity,
-        symlinkCount: 0,
+        symlinkCount: toSymlinkCount(0),
         symlinks: [],
         isSource: true,
         isOrphan: false,
@@ -572,7 +584,7 @@ describe('MainContent keyboard shortcuts (Cmd+A)', () => {
         description: '',
         path: '/skills/tdd' as never,
         filesystemIdentity: directoryIdentity,
-        symlinkCount: 0,
+        symlinkCount: toSymlinkCount(0),
         symlinks: [],
         isSource: true,
         isOrphan: false,
@@ -644,7 +656,7 @@ describe('MainContent keyboard shortcuts (Cmd+A)', () => {
         description: '',
         path: '/skills/task' as never,
         filesystemIdentity: directoryIdentity,
-        symlinkCount: 0,
+        symlinkCount: toSymlinkCount(0),
         symlinks: [],
         isSource: true,
         isOrphan: false,
@@ -654,7 +666,7 @@ describe('MainContent keyboard shortcuts (Cmd+A)', () => {
         description: '',
         path: '/skills/tdd' as never,
         filesystemIdentity: directoryIdentity,
-        symlinkCount: 0,
+        symlinkCount: toSymlinkCount(0),
         symlinks: [],
         isSource: true,
         isOrphan: false,
@@ -872,7 +884,7 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
       description: '',
       path: `/home/user/.agents/skills/${folderName}`,
       filesystemIdentity: directoryIdentity,
-      symlinkCount: 0,
+      symlinkCount: toSymlinkCount(0),
       symlinks: [],
       isSource: true,
       isOrphan: false,
@@ -896,14 +908,14 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
           skillName: 'brainstorming',
           outcome: 'deleted',
           tombstoneId: tombstoneId('1729180800000-brainstorming-a1b2c3d4'),
-          symlinksRemoved: 0,
+          symlinksRemoved: toSymlinkCount(0),
           cascadeAgents: [],
         },
         {
           skillName: 'local-skill',
           outcome: 'deleted',
           tombstoneId: tombstoneId('1729180800000-local-skill-e5f6a7b8'),
-          symlinksRemoved: 0,
+          symlinksRemoved: toSymlinkCount(0),
           cascadeAgents: [],
         },
       ],
@@ -972,7 +984,7 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
           skillName: metadataName,
           outcome: 'deleted',
           tombstoneId: tombstoneId('1729180800000-metadata-title-a1b2c3d4'),
-          symlinksRemoved: 1,
+          symlinksRemoved: toSymlinkCount(1),
           cascadeAgents: ['cursor'],
         },
       ],
@@ -1031,7 +1043,7 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
           skillName,
           outcome: 'deleted',
           tombstoneId: tombstoneId('1729180800000-snapshot-delete-a1b2c3d4'),
-          symlinksRemoved: 0,
+          symlinksRemoved: toSymlinkCount(0),
           cascadeAgents: [],
         },
       ],
@@ -1076,7 +1088,7 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
       description: '',
       path: '/home/user/.agents/skills/snapshot-unlink',
       filesystemIdentity: directoryIdentity,
-      symlinkCount: 1,
+      symlinkCount: toSymlinkCount(1),
       symlinks: [
         {
           agentId: 'cursor',
@@ -1113,8 +1125,8 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
             name: 'Cursor',
             path: '/home/user/.cursor/skills',
             exists: true,
-            skillCount: 1,
-            localSkillCount: 0,
+            skillCount: toSkillCount(1),
+            localSkillCount: toSkillCount(0),
           },
         ],
         'req-agent',
@@ -1155,7 +1167,7 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
       name: orphanSkillName,
       description: '',
       path: '/Users/me/.agents/skills/abandoned',
-      symlinkCount: 0,
+      symlinkCount: toSymlinkCount(0),
       symlinks: [
         {
           agentId: 'devin',
@@ -1174,7 +1186,7 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
         {
           skillName: orphanSkillName,
           outcome: 'orphan-cleared',
-          symlinksRemoved: 1,
+          symlinksRemoved: toSymlinkCount(1),
           cascadeAgents: ['devin'],
         },
       ],
@@ -1237,7 +1249,7 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
       description: '',
       path: '/Users/me/.agents/skills/source-task',
       filesystemIdentity: directoryIdentity,
-      symlinkCount: 0,
+      symlinkCount: toSymlinkCount(0),
       symlinks: [],
       isSource: true,
       isOrphan: false,
@@ -1246,7 +1258,7 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
       name: orphanSkillName,
       description: '',
       path: '/Users/me/.agents/skills/abandoned',
-      symlinkCount: 0,
+      symlinkCount: toSymlinkCount(0),
       symlinks: [
         {
           agentId: 'devin',
@@ -1274,7 +1286,7 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
         {
           skillName: orphanSkillName,
           outcome: 'orphan-cleared',
-          symlinksRemoved: 1,
+          symlinksRemoved: toSymlinkCount(1),
           cascadeAgents: ['devin'],
         },
       ],
@@ -1324,7 +1336,7 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
       description: '',
       path: '/Users/me/.agents/skills/source-stale-task',
       filesystemIdentity: directoryIdentity,
-      symlinkCount: 0,
+      symlinkCount: toSymlinkCount(0),
       symlinks: [],
       isSource: true,
       isOrphan: false,
@@ -1333,7 +1345,7 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
       name: orphanSkillName,
       description: '',
       path: '/Users/me/.agents/skills/abandoned',
-      symlinkCount: 0,
+      symlinkCount: toSymlinkCount(0),
       symlinks: [
         {
           agentId: 'devin',
@@ -1364,7 +1376,7 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
         {
           skillName: orphanSkillName,
           outcome: 'orphan-cleared',
-          symlinksRemoved: 1,
+          symlinksRemoved: toSymlinkCount(1),
           cascadeAgents: ['devin'],
         },
       ],
@@ -1414,7 +1426,7 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
       description: '',
       path: '/Users/me/.agents/skills/source-task',
       filesystemIdentity: directoryIdentity,
-      symlinkCount: 0,
+      symlinkCount: toSymlinkCount(0),
       symlinks: [],
       isSource: true,
       isOrphan: false,
@@ -1423,7 +1435,7 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
       name: orphanSkillName,
       description: '',
       path: '/Users/me/.agents/skills/stale-abandoned',
-      symlinkCount: 0,
+      symlinkCount: toSymlinkCount(0),
       symlinks: [
         {
           agentId: 'devin',
@@ -1442,7 +1454,7 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
           skillName: sourceSkillName,
           outcome: 'deleted',
           tombstoneId: tombstoneId('source-task-delete'),
-          symlinksRemoved: 0,
+          symlinksRemoved: toSymlinkCount(0),
           cascadeAgents: [],
         },
       ],
@@ -1495,7 +1507,7 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
       description: '',
       path: '/Users/me/.agents/skills/source-task',
       filesystemIdentity: directoryIdentity,
-      symlinkCount: 0,
+      symlinkCount: toSymlinkCount(0),
       symlinks: [],
       isSource: true,
       isOrphan: false,
@@ -1504,7 +1516,7 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
       name: orphanSkillName,
       description: '',
       path: '/Users/me/.agents/skills/abandoned',
-      symlinkCount: 0,
+      symlinkCount: toSymlinkCount(0),
       symlinks: [
         {
           agentId: 'devin',
@@ -1565,7 +1577,7 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
       name: orphanSkillName,
       description: '',
       path: '/Users/me/.agents/skills/abandoned',
-      symlinkCount: 0,
+      symlinkCount: toSymlinkCount(0),
       symlinks: [
         {
           agentId: 'devin',
@@ -1619,7 +1631,7 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
       name: orphanSkillName,
       description: '',
       path: '/Users/me/.agents/skills/stale-abandoned',
-      symlinkCount: 0,
+      symlinkCount: toSymlinkCount(0),
       symlinks: [
         {
           agentId: 'devin',
@@ -1675,7 +1687,7 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
       name: sourceSkillName,
       description: '',
       path: '/Users/me/.agents/skills/source-missing-identity',
-      symlinkCount: 0,
+      symlinkCount: toSymlinkCount(0),
       symlinks: [],
       isSource: true,
       isOrphan: false,
@@ -1729,8 +1741,8 @@ describe('MainContent SkillTypeFilter dropdown options', () => {
             name: 'Cursor',
             path: '/Users/me/.cursor/skills',
             exists: true,
-            skillCount: 0,
-            localSkillCount: 0,
+            skillCount: toSkillCount(0),
+            localSkillCount: toSkillCount(0),
           },
         ],
         'req-id',
@@ -1773,8 +1785,8 @@ describe('MainContent SkillTypeFilter dropdown options', () => {
             name: 'Cursor',
             path: '/Users/me/.cursor/skills',
             exists: true,
-            skillCount: 0,
-            localSkillCount: 0,
+            skillCount: toSkillCount(0),
+            localSkillCount: toSkillCount(0),
           },
         ],
         'req-id',
@@ -1813,8 +1825,8 @@ describe('MainContent SkillTypeFilter dropdown options', () => {
             name: 'Cursor',
             path: '/Users/me/.cursor/skills',
             exists: true,
-            skillCount: 0,
-            localSkillCount: 0,
+            skillCount: toSkillCount(0),
+            localSkillCount: toSkillCount(0),
           },
         ],
         'req-id',
@@ -1857,7 +1869,7 @@ describe('MainContent SkillTypeFilter dropdown options', () => {
       name: 'cursor-unique',
       description: '',
       path: '/skills/cursor-unique',
-      symlinkCount: 1,
+      symlinkCount: toSymlinkCount(1),
       symlinks: [
         {
           agentId: 'cursor',
@@ -1876,7 +1888,7 @@ describe('MainContent SkillTypeFilter dropdown options', () => {
       name: 'shared-two',
       description: '',
       path: '/skills/shared-two',
-      symlinkCount: 2,
+      symlinkCount: toSymlinkCount(2),
       symlinks: [
         {
           agentId: 'cursor',
@@ -1907,8 +1919,8 @@ describe('MainContent SkillTypeFilter dropdown options', () => {
             name: 'Cursor',
             path: '/Users/me/.cursor/skills',
             exists: true,
-            skillCount: 0,
-            localSkillCount: 0,
+            skillCount: toSkillCount(0),
+            localSkillCount: toSkillCount(0),
           },
         ],
         'req-id',
@@ -1947,7 +1959,7 @@ describe('MainContent SkillTypeFilter dropdown options', () => {
       name: 'orphan-one',
       description: '',
       path: '/skills/orphan-one',
-      symlinkCount: 1,
+      symlinkCount: toSymlinkCount(1),
       symlinks: [
         {
           agentId: 'cursor',
@@ -1966,7 +1978,7 @@ describe('MainContent SkillTypeFilter dropdown options', () => {
       description: '',
       path: '/skills/linked-one',
       filesystemIdentity: directoryIdentity,
-      symlinkCount: 1,
+      symlinkCount: toSymlinkCount(1),
       symlinks: [
         {
           agentId: 'cursor',
@@ -1989,8 +2001,8 @@ describe('MainContent SkillTypeFilter dropdown options', () => {
             name: 'Cursor',
             path: '/Users/me/.cursor/skills',
             exists: true,
-            skillCount: 0,
-            localSkillCount: 0,
+            skillCount: toSkillCount(0),
+            localSkillCount: toSkillCount(0),
           },
         ],
         'req-id',
@@ -2031,8 +2043,8 @@ describe('MainContent SkillTypeFilter dropdown options', () => {
             name: 'Cursor',
             path: '/Users/me/.cursor/skills',
             exists: true,
-            skillCount: 0,
-            localSkillCount: 0,
+            skillCount: toSkillCount(0),
+            localSkillCount: toSkillCount(0),
           },
         ],
         'req-id',
@@ -2139,8 +2151,8 @@ describe('MainContent filter pills (Agent + Source orthogonal)', () => {
             name: 'Claude Code',
             path: '/Users/me/.claude/skills',
             exists: true,
-            skillCount: 0,
-            localSkillCount: 0,
+            skillCount: toSkillCount(0),
+            localSkillCount: toSkillCount(0),
           },
         ],
         'req-id',
@@ -2176,8 +2188,8 @@ describe('MainContent filter pills (Agent + Source orthogonal)', () => {
             name: 'Claude Code',
             path: '/Users/me/.claude/skills',
             exists: true,
-            skillCount: 0,
-            localSkillCount: 0,
+            skillCount: toSkillCount(0),
+            localSkillCount: toSkillCount(0),
           },
         ],
         'req-id',
@@ -2288,10 +2300,10 @@ describe('MainContent toolbar quick actions', () => {
       await import('@/renderer/src/redux/slices/marketplaceSlice')
     store.dispatch(
       setPreviewSkill({
-        rank: 1,
+        rank: toSkillRank(1),
         name: 'task',
         repo: repositoryId('vercel-labs/skills'),
-        url: 'https://skills.sh/task',
+        url: toHttpUrl('https://skills.sh/task'),
       }),
     )
 
@@ -2319,8 +2331,8 @@ describe('MainContent filter pill clear actions', () => {
             name: 'Cursor',
             path: '/Users/me/.cursor/skills',
             exists: true,
-            skillCount: 0,
-            localSkillCount: 0,
+            skillCount: toSkillCount(0),
+            localSkillCount: toSkillCount(0),
           },
         ],
         'req-id',
@@ -2450,8 +2462,8 @@ describe('MainContent skill-type exclude toggles', () => {
             name: 'Cursor',
             path: '/Users/me/.cursor/skills',
             exists: true,
-            skillCount: 0,
-            localSkillCount: 0,
+            skillCount: toSkillCount(0),
+            localSkillCount: toSkillCount(0),
           },
         ],
         'req-id',
@@ -2555,7 +2567,10 @@ describe('MainContent delete progress wiring', () => {
     expect(typeof progressCallback).toBe('function')
 
     // Act
-    progressCallback?.({ current: 3, total: 12 })
+    progressCallback?.({
+      current: toBatchItemIndex(3),
+      total: toBatchItemCount(12),
+    })
 
     // Assert
     expect(store.getState().skills.bulkProgress).toEqual({
@@ -2581,7 +2596,7 @@ describe('MainContent stale-source delete summary', () => {
       description: '',
       path: '/Users/me/.agents/skills/fresh-source',
       filesystemIdentity: directoryIdentity,
-      symlinkCount: 0,
+      symlinkCount: toSymlinkCount(0),
       symlinks: [],
       isSource: true,
       isOrphan: false,
@@ -2590,7 +2605,7 @@ describe('MainContent stale-source delete summary', () => {
       name: staleName,
       description: '',
       path: '/Users/me/.agents/skills/stale-source',
-      symlinkCount: 0,
+      symlinkCount: toSymlinkCount(0),
       symlinks: [],
       isSource: true,
       isOrphan: false,
@@ -2601,7 +2616,7 @@ describe('MainContent stale-source delete summary', () => {
           skillName: deletableName,
           outcome: 'deleted',
           tombstoneId: tombstoneId('1729180800000-fresh-source-a1b2c3d4'),
-          symlinksRemoved: 0,
+          symlinksRemoved: toSymlinkCount(0),
           cascadeAgents: [],
         },
       ],
@@ -2661,7 +2676,7 @@ describe('MainContent undo bulk delete', () => {
       description: '',
       path: `/Users/me/.agents/skills/undo-skill-${index}` as never,
       filesystemIdentity: directoryIdentity,
-      symlinkCount: 0,
+      symlinkCount: toSymlinkCount(0),
       symlinks: [],
       isSource: true,
       isOrphan: false,
@@ -2672,7 +2687,7 @@ describe('MainContent undo bulk delete', () => {
         skillName: skill.name,
         outcome: 'deleted',
         tombstoneId: tombstoneIds[index],
-        symlinksRemoved: 0,
+        symlinksRemoved: toSymlinkCount(0),
         cascadeAgents: [],
       })),
     } satisfies BulkDeleteResult)
@@ -2798,7 +2813,7 @@ describe('MainContent toolbar primary action guards', () => {
       description: '',
       path: '/home/user/.agents/skills/protected-link',
       filesystemIdentity: directoryIdentity,
-      symlinkCount: 1,
+      symlinkCount: toSymlinkCount(1),
       symlinks: [
         {
           agentId: 'cursor',
@@ -2820,8 +2835,8 @@ describe('MainContent toolbar primary action guards', () => {
             name: 'Cursor',
             path: '/home/user/.cursor/skills',
             exists: true,
-            skillCount: 1,
-            localSkillCount: 0,
+            skillCount: toSkillCount(1),
+            localSkillCount: toSkillCount(0),
           },
         ],
         'req-agent',
@@ -2857,7 +2872,7 @@ describe('MainContent toolbar primary action guards', () => {
       description: '',
       path: '/home/user/.agents/skills/stale-unlink',
       filesystemIdentity: directoryIdentity,
-      symlinkCount: 1,
+      symlinkCount: toSymlinkCount(1),
       symlinks: [
         {
           agentId: 'cursor',
@@ -2880,8 +2895,8 @@ describe('MainContent toolbar primary action guards', () => {
             name: 'Cursor',
             path: '/home/user/.cursor/skills',
             exists: true,
-            skillCount: 1,
-            localSkillCount: 0,
+            skillCount: toSkillCount(1),
+            localSkillCount: toSkillCount(0),
           },
         ],
         'req-agent',
@@ -2928,7 +2943,7 @@ describe('MainContent bulk unlink result toasts', () => {
       description: '',
       path: '/home/user/.agents/skills/linked-skill',
       filesystemIdentity: directoryIdentity,
-      symlinkCount: 1,
+      symlinkCount: toSymlinkCount(1),
       symlinks: [
         {
           agentId: 'cursor',
@@ -2950,8 +2965,8 @@ describe('MainContent bulk unlink result toasts', () => {
             name: 'Cursor',
             path: '/home/user/.cursor/skills',
             exists: true,
-            skillCount: 1,
-            localSkillCount: 0,
+            skillCount: toSkillCount(1),
+            localSkillCount: toSkillCount(0),
           },
         ],
         'req-agent',
@@ -3046,7 +3061,7 @@ describe('MainContent bulk delete failure toasts', () => {
       description: '',
       path: '/Users/me/.agents/skills/kept-source',
       filesystemIdentity: directoryIdentity,
-      symlinkCount: 0,
+      symlinkCount: toSymlinkCount(0),
       symlinks: [],
       isSource: true,
       isOrphan: false,
@@ -3055,7 +3070,7 @@ describe('MainContent bulk delete failure toasts', () => {
       name: orphanSkillName,
       description: '',
       path: '/Users/me/.agents/skills/dropped-orphan',
-      symlinkCount: 0,
+      symlinkCount: toSymlinkCount(0),
       symlinks: [
         {
           agentId: 'devin',
@@ -3075,7 +3090,7 @@ describe('MainContent bulk delete failure toasts', () => {
           skillName: sourceSkillName,
           outcome: 'deleted',
           tombstoneId: tombstoneId('1729180800000-kept-source-a1b2c3d4'),
-          symlinksRemoved: 0,
+          symlinksRemoved: toSymlinkCount(0),
           cascadeAgents: [],
         },
       ],
@@ -3119,7 +3134,7 @@ describe('MainContent bulk delete failure toasts', () => {
       description: '',
       path: '/Users/me/.agents/skills/empty-result',
       filesystemIdentity: directoryIdentity,
-      symlinkCount: 0,
+      symlinkCount: toSymlinkCount(0),
       symlinks: [],
       isSource: true,
       isOrphan: false,
@@ -3162,7 +3177,7 @@ describe('MainContent bulk delete failure toasts', () => {
       description: '',
       path: '/Users/me/.agents/skills/all-error',
       filesystemIdentity: directoryIdentity,
-      symlinkCount: 0,
+      symlinkCount: toSymlinkCount(0),
       symlinks: [],
       isSource: true,
       isOrphan: false,
@@ -3216,7 +3231,7 @@ describe('MainContent bulk delete undo toast lifecycle', () => {
       description: '',
       path: '/Users/me/.agents/skills/dismiss-me',
       filesystemIdentity: directoryIdentity,
-      symlinkCount: 0,
+      symlinkCount: toSymlinkCount(0),
       symlinks: [],
       isSource: true,
       isOrphan: false,
@@ -3227,7 +3242,7 @@ describe('MainContent bulk delete undo toast lifecycle', () => {
           skillName: sourceSkillName,
           outcome: 'deleted',
           tombstoneId: tombstoneId('1729180800000-dismiss-me-a1b2c3d4'),
-          symlinksRemoved: 0,
+          symlinksRemoved: toSymlinkCount(0),
           cascadeAgents: [],
         },
       ],
@@ -3277,7 +3292,7 @@ describe('MainContent bulk delete undo toast lifecycle', () => {
       description: '',
       path: '/Users/me/.agents/skills/stale-dismiss-me',
       filesystemIdentity: directoryIdentity,
-      symlinkCount: 0,
+      symlinkCount: toSymlinkCount(0),
       symlinks: [],
       isSource: true,
       isOrphan: false,
@@ -3288,7 +3303,7 @@ describe('MainContent bulk delete undo toast lifecycle', () => {
           skillName: sourceSkillName,
           outcome: 'deleted',
           tombstoneId: tombstoneId('1729180800000-stale-dismiss-a1b2c3d4'),
-          symlinksRemoved: 0,
+          symlinksRemoved: toSymlinkCount(0),
           cascadeAgents: [],
         },
       ],
@@ -3312,7 +3327,7 @@ describe('MainContent bulk delete undo toast lifecycle', () => {
       kind: 'delete' as const,
       skillNames: ['newer-delete'] as SkillName[],
       tombstoneIds: [tombstoneId('1729180800000-newer-delete-a1b2c3d4')],
-      expiresAt: '2026-04-17T12:00:15.000Z',
+      expiresAt: toIsoTimestamp('2026-04-17T12:00:15.000Z'),
       summary: 'Deleted 1 skill. 0 symlinks removed.',
     }
     store.dispatch(setUndoToast(newerToast))
@@ -3340,7 +3355,7 @@ describe('MainContent bulk confirm cancellation', () => {
       description: '',
       path: '/Users/me/.agents/skills/cancel-me',
       filesystemIdentity: directoryIdentity,
-      symlinkCount: 0,
+      symlinkCount: toSymlinkCount(0),
       symlinks: [],
       isSource: true,
       isOrphan: false,

--- a/src/renderer/src/components/layout/MainContent.selectionToolbar.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.selectionToolbar.browser.test.tsx
@@ -6,6 +6,7 @@ import { render } from 'vitest-browser-react'
 import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
 import { DEFAULT_SETTINGS } from '@/shared/settings'
 import type { Agent, Skill, SkillName, SymlinkInfo } from '@/shared/types'
+import { toSkillCount, toSymlinkCount } from '@/shared/types'
 
 const mockUnlinkManyFromAgent = vi.fn()
 const mockOnDeleteProgress = vi.fn(() => () => {})
@@ -59,8 +60,8 @@ const CURSOR_AGENT: Agent = {
   name: 'Cursor',
   path: '/Users/test/.cursor/skills',
   exists: true,
-  skillCount: 3,
-  localSkillCount: 0,
+  skillCount: toSkillCount(3),
+  localSkillCount: toSkillCount(0),
 }
 
 /**
@@ -79,7 +80,7 @@ function makeCursorSkill(
     name,
     description: '',
     path: `/Users/test/.agents/skills/${slotName}`,
-    symlinkCount: status === 'missing' ? 0 : 1,
+    symlinkCount: toSymlinkCount(status === 'missing' ? 0 : 1),
     symlinks: [
       {
         agentId: 'cursor',

--- a/src/renderer/src/components/layout/MainContent.tsx
+++ b/src/renderer/src/components/layout/MainContent.tsx
@@ -141,6 +141,7 @@ import type {
   ToastId,
   TombstoneId,
 } from '@/shared/types'
+import { toIsoTimestamp } from '@/shared/types'
 
 /** One row of the skill-type include menu: the filter it selects plus its presentation. */
 interface SkillTypeFilterOption {
@@ -686,9 +687,9 @@ function useConfirmBulkDelete({
     const deletedNames = deleteItems
       .filter((item) => item.outcome === 'deleted')
       .map((item) => item.skillName)
-    const expiresAt: IsoTimestamp = new Date(
-      Date.now() + UNDO_WINDOW_MS,
-    ).toISOString()
+    const expiresAt: IsoTimestamp = toIsoTimestamp(
+      new Date(Date.now() + UNDO_WINDOW_MS).toISOString(),
+    )
     const toastId: ToastId = `bulk-delete-${Date.now()}`
     const handleToastDismissed = (): void => {
       dispatch(clearUndoToastIfCurrent(toastId))

--- a/src/renderer/src/components/layout/Sidebar.browser.test.tsx
+++ b/src/renderer/src/components/layout/Sidebar.browser.test.tsx
@@ -5,7 +5,7 @@ import { render } from 'vitest-browser-react'
 
 import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
 import { DEFAULT_SETTINGS } from '@/shared/settings'
-import { repositoryId } from '@/shared/types'
+import { repositoryId, toHttpUrl } from '@/shared/types'
 
 beforeEach(() => {
   // SidebarHeader reads the build-time `__APP_VERSION__` define; browser mode has
@@ -126,7 +126,7 @@ describe('Sidebar', () => {
       addBookmark({
         name: 'task',
         repo: repositoryId('vercel-labs/skills'),
-        url: 'https://skills.sh/task',
+        url: toHttpUrl('https://skills.sh/task'),
       }),
     )
 

--- a/src/renderer/src/components/layout/detailPanelHelpers.test.ts
+++ b/src/renderer/src/components/layout/detailPanelHelpers.test.ts
@@ -5,13 +5,14 @@ import { resolveDetailPanelContent } from '@/renderer/src/components/layout/deta
 import { MarketplaceDetailPanel } from '@/renderer/src/components/marketplace/MarketplaceDetailPanel'
 import { SkillDetail } from '@/renderer/src/components/skills/SkillDetail'
 import type { Skill } from '@/shared/types'
+import { toSymlinkCount } from '@/shared/types'
 
 // Minimal selected skill — only its identity is threaded through, never read here.
 const SELECTED_SKILL: Skill = {
   name: 'foo',
   description: 'foo skill',
   path: '/u/me/.agents/skills/foo',
-  symlinkCount: 0,
+  symlinkCount: toSymlinkCount(0),
   symlinks: [],
   isSource: true,
   isOrphan: false,

--- a/src/renderer/src/components/marketplace/InstallModal.browser.test.tsx
+++ b/src/renderer/src/components/marketplace/InstallModal.browser.test.tsx
@@ -3,7 +3,13 @@ import { Provider } from 'react-redux'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
-import { repositoryId } from '@/shared/types'
+import {
+  repositoryId,
+  toHttpUrl,
+  toInstallCount,
+  toSkillCount,
+  toSkillRank,
+} from '@/shared/types'
 import type { Agent, SkillSearchResult } from '@/shared/types'
 
 const mockInstall = vi.fn()
@@ -25,11 +31,11 @@ function makeSkill(
   overrides: Partial<SkillSearchResult> = {},
 ): SkillSearchResult {
   return {
-    rank: 1,
+    rank: toSkillRank(1),
     name: 'task',
     repo: repositoryId('vercel-labs/skills'),
-    url: 'https://skills.sh/vercel-labs/skills/task',
-    installCount: 100,
+    url: toHttpUrl('https://skills.sh/vercel-labs/skills/task'),
+    installCount: toInstallCount(100),
     ...overrides,
   }
 }
@@ -50,8 +56,8 @@ function makeAgent(
     name,
     path: `/home/user/.${id}/skills`,
     exists: true,
-    skillCount: 0,
-    localSkillCount: 0,
+    skillCount: toSkillCount(0),
+    localSkillCount: toSkillCount(0),
     ...rest,
   }
 }

--- a/src/renderer/src/components/marketplace/MarketplaceDashboard.browser.test.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceDashboard.browser.test.tsx
@@ -12,6 +12,12 @@ import type {
   Skill,
   SkillSearchResult,
 } from '@/shared/types'
+import {
+  toHttpUrl,
+  toSearchQuery,
+  toSkillRank,
+  toUnixTimestampMs,
+} from '@/shared/types'
 
 // MarketplaceDashboard is the right-pane summary shown when the Marketplace tab
 // is active with no skill previewed. It reads three slices (installed count,
@@ -51,10 +57,10 @@ function makeSearchResult(
   overrides: Partial<SkillSearchResult> = {},
 ): SkillSearchResult {
   return {
-    rank: 1,
+    rank: toSkillRank(1),
     name: 'task',
     repo: 'vercel-labs/skills' as RepositoryId,
-    url: 'https://skills.sh/task',
+    url: toHttpUrl('https://skills.sh/task'),
     installCount: undefined,
     ...overrides,
   }
@@ -69,7 +75,7 @@ function makeLeaderboardData(
 ): LeaderboardData {
   return {
     skills: [],
-    lastFetched: Date.now(),
+    lastFetched: toUnixTimestampMs(Date.now()),
     filter: 'trending',
     status: 'idle',
     ...overrides,
@@ -107,7 +113,7 @@ async function renderDashboard(preloadedState: {
     preloadedState: {
       marketplace: {
         status: 'idle',
-        searchQuery: '',
+        searchQuery: toSearchQuery(''),
         searchResults: [],
         selectedSkill: null,
         previewSkill: null,
@@ -160,10 +166,10 @@ describe('MarketplaceDashboard — trending preview selection', () => {
   it('selects a trending skill for preview when its row is clicked', async () => {
     // Arrange — one settled trending skill renders exactly one clickable row.
     const trendingSkill = makeSearchResult({
-      rank: 1,
+      rank: toSkillRank(1),
       name: 'task',
       repo: 'vercel-labs/skills' as RepositoryId,
-      url: 'https://skills.sh/task',
+      url: toHttpUrl('https://skills.sh/task'),
     })
     const { screen, store } = await renderDashboard({
       marketplace: {
@@ -171,7 +177,7 @@ describe('MarketplaceDashboard — trending preview selection', () => {
           trending: makeLeaderboardData({
             skills: [trendingSkill],
             status: 'idle',
-            lastFetched: Date.now(),
+            lastFetched: toUnixTimestampMs(Date.now()),
           }),
         },
       },
@@ -230,7 +236,7 @@ describe('MarketplaceDashboard — trending placeholders', () => {
           trending: makeLeaderboardData({
             skills: [],
             status: 'idle',
-            lastFetched: Date.now(),
+            lastFetched: toUnixTimestampMs(Date.now()),
           }),
         },
       },

--- a/src/renderer/src/components/marketplace/MarketplaceDetailPanel.browser.test.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceDetailPanel.browser.test.tsx
@@ -5,7 +5,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import type { SkillSearchResult } from '@/shared/types'
-import { repositoryId } from '@/shared/types'
+import {
+  repositoryId,
+  toHttpUrl,
+  toInstallCount,
+  toSkillRank,
+} from '@/shared/types'
 
 // MarketplaceDashboard (rendered by MarketplaceDetailPanel when nothing is
 // previewed) dispatches `loadLeaderboard('trending')` on mount, whose thunk
@@ -42,11 +47,11 @@ function makeSkill(
   overrides: Partial<SkillSearchResult> = {},
 ): SkillSearchResult {
   return {
-    rank: 1,
+    rank: toSkillRank(1),
     name: 'task',
     repo: repositoryId('vercel-labs/skills'),
-    url: 'https://skills.sh/task',
-    installCount: 123,
+    url: toHttpUrl('https://skills.sh/task'),
+    installCount: toInstallCount(123),
     ...overrides,
   }
 }

--- a/src/renderer/src/components/marketplace/MarketplaceSearch.browser.test.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceSearch.browser.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import { SEARCH_DEBOUNCE_MS } from '@/shared/constants'
-import { repositoryId } from '@/shared/types'
+import { repositoryId, toHttpUrl, toSkillRank } from '@/shared/types'
 import type { SkillSearchResult } from '@/shared/types'
 
 // The unit tests cover the debounce primitive and the reducer's latest-wins
@@ -41,10 +41,10 @@ afterEach(() => {
 })
 
 const sampleResult: SkillSearchResult = {
-  rank: 1,
+  rank: toSkillRank(1),
   name: 'task',
   repo: repositoryId('vercel-labs/skill-task'),
-  url: 'https://skills.sh/vercel-labs/skill-task',
+  url: toHttpUrl('https://skills.sh/vercel-labs/skill-task'),
 }
 
 /**

--- a/src/renderer/src/components/marketplace/MarketplaceSearch.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceSearch.tsx
@@ -10,6 +10,7 @@ import {
   clearSearchResults,
 } from '@/renderer/src/redux/slices/marketplaceSlice'
 import { SEARCH_DEBOUNCE_MS } from '@/shared/constants'
+import { toSearchQuery } from '@/shared/types'
 
 /**
  * Incremental search box for the marketplace. Searches as the user types: each
@@ -35,14 +36,14 @@ export const MarketplaceSearch =
     const runSearch = (query: string): void => {
       const trimmedQuery = query.trim()
       if (trimmedQuery === '') return
-      dispatch(setMarketplaceSearchQuery(trimmedQuery))
-      dispatch(searchSkills(trimmedQuery))
+      dispatch(setMarketplaceSearchQuery(toSearchQuery(trimmedQuery)))
+      dispatch(searchSkills(toSearchQuery(trimmedQuery)))
     }
 
     const debouncedSearch = useDebouncedCallback(runSearch, SEARCH_DEBOUNCE_MS)
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-      const value = e.target.value
+      const value = toSearchQuery(e.target.value)
       setLocalQuery(value)
       if (value.trim() === '') {
         // Clearing the box snaps back to the leaderboard immediately and

--- a/src/renderer/src/components/marketplace/MarketplaceSkillPreview.browser.test.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceSkillPreview.browser.test.tsx
@@ -5,7 +5,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import type { SkillSearchResult } from '@/shared/types'
-import { repositoryId } from '@/shared/types'
+import {
+  repositoryId,
+  toHttpUrl,
+  toInstallCount,
+  toSkillRank,
+} from '@/shared/types'
 
 /**
  * Build a minimal `SkillSearchResult` fixture and let callers override only the
@@ -19,11 +24,11 @@ function makeSkill(
   overrides: Partial<SkillSearchResult> = {},
 ): SkillSearchResult {
   return {
-    rank: 1,
+    rank: toSkillRank(1),
     name: 'task',
     repo: repositoryId('vercel-labs/skills'),
-    url: 'https://skills.sh/task',
-    installCount: 123,
+    url: toHttpUrl('https://skills.sh/task'),
+    installCount: toInstallCount(123),
     ...overrides,
   }
 }
@@ -340,7 +345,9 @@ describe('MarketplaceSkillPreview', () => {
       await import('@/renderer/src/redux/slices/marketplaceSlice')
     const { MarketplaceSkillPreview } =
       await import('./MarketplaceSkillPreview')
-    const externalSkill = makeSkill({ url: 'https://example.com/skill' })
+    const externalSkill = makeSkill({
+      url: toHttpUrl('https://example.com/skill'),
+    })
     store.dispatch(setPreviewSkill(externalSkill))
     const screen = await renderWithStore(
       <MarketplaceSkillPreview skill={externalSkill} />,

--- a/src/renderer/src/components/marketplace/MarketplaceSkillPreview.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceSkillPreview.tsx
@@ -9,6 +9,7 @@ import { useAppDispatch } from '@/renderer/src/redux/hooks'
 import { setPreviewSkill } from '@/renderer/src/redux/slices/marketplaceSlice'
 import { isAllowedSkillsUrl } from '@/shared/marketplaceUrlPolicy'
 import type { SkillSearchResult } from '@/shared/types'
+import { toHttpUrl } from '@/shared/types'
 
 interface MarketplaceSkillPreviewProps {
   skill: SkillSearchResult
@@ -66,7 +67,7 @@ export const MarketplaceSkillPreview = function MarketplaceSkillPreview({
       e: Electron.DidNavigateEvent | Electron.DidNavigateInPageEvent,
     ): void => {
       if (isAllowedSkillsUrl(e.url)) {
-        setCurrentUrl(e.url)
+        setCurrentUrl(toHttpUrl(e.url))
       }
     }
 

--- a/src/renderer/src/components/marketplace/SkillRowMarketplace.browser.test.tsx
+++ b/src/renderer/src/components/marketplace/SkillRowMarketplace.browser.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import type { RepositoryId, SkillSearchResult } from '@/shared/types'
+import { toHttpUrl, toInstallCount, toSkillRank } from '@/shared/types'
 
 beforeEach(() => {
   // SkillRowMarketplace doesn't call IPC directly, but SkillsMarketplace and
@@ -39,11 +40,11 @@ function makeSkill(
   overrides: Partial<SkillSearchResult> = {},
 ): SkillSearchResult {
   return {
-    rank: 1,
+    rank: toSkillRank(1),
     name: 'task',
     repo: 'vercel-labs/skills' as RepositoryId,
-    url: 'https://skills.sh/task',
-    installCount: 100,
+    url: toHttpUrl('https://skills.sh/task'),
+    installCount: toInstallCount(100),
     ...overrides,
   }
 }
@@ -220,7 +221,7 @@ describe('SkillRowMarketplace — open preview from row body', () => {
   it('opens the preview pane for the skill when its name row is clicked', async () => {
     // Arrange
     const skill = makeSkill({
-      rank: 1,
+      rank: toSkillRank(1),
       name: 'task',
       repo: 'vercel-labs/skills' as RepositoryId,
     })

--- a/src/renderer/src/components/marketplace/SkillsMarketplace.browser.test.tsx
+++ b/src/renderer/src/components/marketplace/SkillsMarketplace.browser.test.tsx
@@ -10,7 +10,15 @@ import type {
   RankingFilter,
   RepositoryId,
   Skill,
+  SearchQuery,
   SkillSearchResult,
+} from '@/shared/types'
+import {
+  toHttpUrl,
+  toSearchQuery,
+  toSkillRank,
+  toSymlinkCount,
+  toUnixTimestampMs,
 } from '@/shared/types'
 
 // SkillsMarketplace is the only screen that composes RankingTabs + search +
@@ -49,10 +57,10 @@ function makeSearchResult(
   overrides: Partial<SkillSearchResult> = {},
 ): SkillSearchResult {
   return {
-    rank: 1,
+    rank: toSkillRank(1),
     name: 'task',
     repo: 'vercel-labs/skills' as RepositoryId,
-    url: 'https://skills.sh/task',
+    url: toHttpUrl('https://skills.sh/task'),
     installCount: undefined,
     ...overrides,
   }
@@ -67,7 +75,7 @@ function makeLeaderboardData(
 ): LeaderboardData {
   return {
     skills: [],
-    lastFetched: Date.now(),
+    lastFetched: toUnixTimestampMs(Date.now()),
     filter: 'all-time',
     status: 'idle',
     ...overrides,
@@ -85,7 +93,7 @@ function makeLeaderboardData(
 async function renderMarketplace(preloadedState: {
   marketplace?: {
     status?: MarketplaceStatus
-    searchQuery?: string
+    searchQuery?: SearchQuery
     searchResults?: SkillSearchResult[]
     error?: string | null
     leaderboard?: Partial<Record<RankingFilter, LeaderboardData>>
@@ -108,7 +116,7 @@ async function renderMarketplace(preloadedState: {
     preloadedState: {
       marketplace: {
         status: 'idle',
-        searchQuery: '',
+        searchQuery: toSearchQuery(''),
         searchResults: [],
         selectedSkill: null,
         previewSkill: null,
@@ -159,7 +167,7 @@ describe('SkillsMarketplace — leaderboard view', () => {
     const loadingLeaderboard = {
       'all-time': makeLeaderboardData({
         skills: [],
-        lastFetched: 0,
+        lastFetched: toUnixTimestampMs(0),
         status: 'loading',
       }),
     }
@@ -192,7 +200,7 @@ describe('SkillsMarketplace — leaderboard view', () => {
     const erroredLeaderboard = {
       'all-time': makeLeaderboardData({
         skills: [],
-        lastFetched: 0,
+        lastFetched: toUnixTimestampMs(0),
         status: 'error',
         error: 'network down',
       }),
@@ -214,7 +222,7 @@ describe('SkillsMarketplace — leaderboard view', () => {
     const emptyLeaderboard = {
       'all-time': makeLeaderboardData({
         skills: [],
-        lastFetched: Date.now(),
+        lastFetched: toUnixTimestampMs(Date.now()),
         status: 'idle',
       }),
     }
@@ -238,7 +246,7 @@ describe('SkillsMarketplace — leaderboard view', () => {
     const oneSkillLeaderboard = {
       'all-time': makeLeaderboardData({
         skills: [makeSearchResult({ name: 'solo' })],
-        lastFetched: Date.now(),
+        lastFetched: toUnixTimestampMs(Date.now()),
         status: 'loading',
       }),
     }
@@ -261,7 +269,7 @@ describe('SkillsMarketplace — leaderboard view', () => {
       name: 'installed-one',
       description: 'desc',
       path: '/Users/me/.agents/skills/installed-one',
-      symlinkCount: 0,
+      symlinkCount: toSymlinkCount(0),
       symlinks: [],
       isSource: true,
       isOrphan: false,
@@ -270,7 +278,7 @@ describe('SkillsMarketplace — leaderboard view', () => {
     const leaderboardWithInstalled = {
       'all-time': makeLeaderboardData({
         skills: [makeSearchResult({ name: 'installed-one' })],
-        lastFetched: Date.now(),
+        lastFetched: toUnixTimestampMs(Date.now()),
         status: 'loading',
       }),
     }
@@ -295,7 +303,7 @@ describe('SkillsMarketplace — "Updated X ago" relative-time label', () => {
     const recentLeaderboard = {
       'all-time': makeLeaderboardData({
         skills: [makeSearchResult()],
-        lastFetched: Date.now() - 5_000,
+        lastFetched: toUnixTimestampMs(Date.now() - 5_000),
         status: 'loading',
       }),
     }
@@ -317,7 +325,7 @@ describe('SkillsMarketplace — "Updated X ago" relative-time label', () => {
     const fiveMinLeaderboard = {
       'all-time': makeLeaderboardData({
         skills: [makeSearchResult()],
-        lastFetched: Date.now() - 5 * 60 * 1_000,
+        lastFetched: toUnixTimestampMs(Date.now() - 5 * 60 * 1_000),
         status: 'loading',
       }),
     }
@@ -340,7 +348,7 @@ describe('SkillsMarketplace — "Updated X ago" relative-time label', () => {
     const threeHourLeaderboard = {
       'all-time': makeLeaderboardData({
         skills: [makeSearchResult()],
-        lastFetched: Date.now() - 3 * 60 * 60 * 1_000,
+        lastFetched: toUnixTimestampMs(Date.now() - 3 * 60 * 60 * 1_000),
         status: 'loading',
       }),
     }
@@ -362,7 +370,7 @@ describe('SkillsMarketplace — search results view', () => {
     const { screen } = await renderMarketplace({
       marketplace: {
         status: 'searching',
-        searchQuery: 'react',
+        searchQuery: toSearchQuery('react'),
         searchResults: [],
       },
     })
@@ -377,7 +385,7 @@ describe('SkillsMarketplace — search results view', () => {
     const { screen } = await renderMarketplace({
       marketplace: {
         status: 'idle',
-        searchQuery: 'nonexistent',
+        searchQuery: toSearchQuery('nonexistent'),
         searchResults: [],
       },
     })
@@ -392,9 +400,9 @@ describe('SkillsMarketplace — search results view', () => {
     // Arrange — two results exercise the plural "skills" count label and the
     // search-results SkillRowMarketplace map.
     const results = [
-      makeSearchResult({ rank: 1, name: 'react' }),
+      makeSearchResult({ rank: toSkillRank(1), name: 'react' }),
       makeSearchResult({
-        rank: 2,
+        rank: toSkillRank(2),
         name: 'react-query',
       }),
     ]
@@ -403,7 +411,7 @@ describe('SkillsMarketplace — search results view', () => {
     const { screen } = await renderMarketplace({
       marketplace: {
         status: 'idle',
-        searchQuery: 'react',
+        searchQuery: toSearchQuery('react'),
         searchResults: results,
       },
     })
@@ -422,7 +430,7 @@ describe('SkillsMarketplace — search results view', () => {
       name: 'react',
       description: 'desc',
       path: '/Users/me/.agents/skills/react',
-      symlinkCount: 0,
+      symlinkCount: toSymlinkCount(0),
       symlinks: [],
       isSource: true,
       isOrphan: false,
@@ -432,7 +440,7 @@ describe('SkillsMarketplace — search results view', () => {
     const { screen } = await renderMarketplace({
       marketplace: {
         status: 'idle',
-        searchQuery: 'react',
+        searchQuery: toSearchQuery('react'),
         searchResults: [makeSearchResult({ name: 'react' })],
       },
       skills: { items: [installedSkill] },
@@ -454,13 +462,13 @@ describe('SkillsMarketplace — ranking tab switch', () => {
     const bothTabsLeaderboard = {
       'all-time': makeLeaderboardData({
         skills: [makeSearchResult({ name: 'alltime-skill' })],
-        lastFetched: Date.now(),
+        lastFetched: toUnixTimestampMs(Date.now()),
         status: 'loading',
         filter: 'all-time',
       }),
       trending: makeLeaderboardData({
         skills: [makeSearchResult({ name: 'trending-skill' })],
-        lastFetched: Date.now(),
+        lastFetched: toUnixTimestampMs(Date.now()),
         status: 'loading',
         filter: 'trending',
       }),

--- a/src/renderer/src/components/sidebar/AgentDeleteDialog.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/AgentDeleteDialog.browser.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import type { Agent, FilesystemEntryIdentity, Skill } from '@/shared/types'
+import { toFileSizeBytes, toSkillCount, toSymlinkCount } from '@/shared/types'
 
 const mockRemoveAllFromAgent = vi.fn()
 const mockSkillsGetAll = vi.fn()
@@ -23,7 +24,7 @@ const directoryIdentity: FilesystemEntryIdentity = {
   kind: 'directory',
   dev: 1,
   ino: 2,
-  size: 96,
+  size: toFileSizeBytes(96),
   ctimeMs: 3,
   mtimeMs: 4,
 }
@@ -42,8 +43,8 @@ function makeAgent(overrides: Partial<Agent> = {}): Agent {
     name: 'Claude Code',
     path: '/Users/test/.claude/skills',
     exists: true,
-    skillCount: 3,
-    localSkillCount: 1,
+    skillCount: toSkillCount(3),
+    localSkillCount: toSkillCount(1),
     filesystemIdentity: directoryIdentity,
     ...overrides,
   }
@@ -165,7 +166,7 @@ describe('AgentDeleteDialog confirm action', () => {
       name: 'protected-task',
       description: 'Protected task',
       path: '/Users/test/.agents/skills/protected-task',
-      symlinkCount: 1,
+      symlinkCount: toSymlinkCount(1),
       symlinks: [
         {
           agentId: 'claude-code',

--- a/src/renderer/src/components/sidebar/AgentFoldersMenu.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/AgentFoldersMenu.browser.test.tsx
@@ -8,6 +8,7 @@ import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
 import type { AgentFolderGroup } from '@/renderer/src/redux/slices/uiSlice'
 import { DEFAULT_SETTINGS } from '@/shared/settings'
 import type { Agent, FilesystemEntryIdentity, Skill } from '@/shared/types'
+import { toFileSizeBytes, toSkillCount, toSymlinkCount } from '@/shared/types'
 
 const mockRemoveAllFromAgent = vi.fn()
 const mockRemoveEmptyFolder = vi.fn()
@@ -28,7 +29,7 @@ const directoryIdentity: FilesystemEntryIdentity = {
   kind: 'directory',
   dev: 1,
   ino: 2,
-  size: 96,
+  size: toFileSizeBytes(96),
   ctimeMs: 3,
   mtimeMs: 4,
 }
@@ -38,8 +39,8 @@ const cline: Agent = {
   name: 'Cline',
   path: '/Users/test/.cline/skills',
   exists: true,
-  skillCount: 2,
-  localSkillCount: 0,
+  skillCount: toSkillCount(2),
+  localSkillCount: toSkillCount(0),
   filesystemIdentity: directoryIdentity,
 }
 
@@ -53,7 +54,7 @@ const warp: Agent = {
 const unusedCline: Agent = {
   ...cline,
   exists: false,
-  skillCount: 0,
+  skillCount: toSkillCount(0),
   filesystemIdentity: undefined,
   emptyParentFolder: {
     path: '/Users/test/.cline',
@@ -64,7 +65,7 @@ const unusedCline: Agent = {
 const unusedWarp: Agent = {
   ...warp,
   exists: false,
-  skillCount: 0,
+  skillCount: toSkillCount(0),
   filesystemIdentity: undefined,
   emptyParentFolder: {
     path: '/Users/test/.warp',
@@ -270,7 +271,7 @@ describe('Hidden agent folder deletion', () => {
       name: 'protected-task',
       description: 'Protected source skill',
       path: '/Users/test/.agents/skills/protected-task',
-      symlinkCount: 1,
+      symlinkCount: toSymlinkCount(1),
       symlinks: [
         {
           agentId: 'cline',

--- a/src/renderer/src/components/sidebar/AgentItem.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/AgentItem.browser.test.tsx
@@ -6,6 +6,7 @@ import { render } from 'vitest-browser-react'
 import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
 import { DEFAULT_SETTINGS } from '@/shared/settings'
 import type { Agent, AgentId } from '@/shared/types'
+import { toSkillCount } from '@/shared/types'
 
 const mockSettingsSet = vi.fn()
 const mockRevealInFinder = vi.fn()
@@ -16,8 +17,8 @@ const FIXTURE_AGENT: Agent = {
   name: 'Claude Code',
   path: '/Users/test/.claude/skills',
   exists: true,
-  skillCount: 3,
-  localSkillCount: 0,
+  skillCount: toSkillCount(3),
+  localSkillCount: toSkillCount(0),
 }
 
 beforeEach(() => {

--- a/src/renderer/src/components/sidebar/AgentsSection.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/AgentsSection.browser.test.tsx
@@ -6,6 +6,7 @@ import { render } from 'vitest-browser-react'
 import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
 import { DEFAULT_SETTINGS } from '@/shared/settings'
 import type { Agent, AgentId } from '@/shared/types'
+import { toSkillCount } from '@/shared/types'
 
 const mockSettingsSet = vi.fn()
 const mockAgentsGetAll = vi.fn()
@@ -22,16 +23,16 @@ const FIXTURE_AGENTS: Agent[] = [
     name: 'Claude Code',
     path: '/Users/test/.claude/skills',
     exists: true,
-    skillCount: 3,
-    localSkillCount: 0,
+    skillCount: toSkillCount(3),
+    localSkillCount: toSkillCount(0),
   },
   {
     id: 'cursor',
     name: 'Cursor',
     path: '/Users/test/.cursor/skills',
     exists: true,
-    skillCount: 1,
-    localSkillCount: 0,
+    skillCount: toSkillCount(1),
+    localSkillCount: toSkillCount(0),
   },
 ]
 
@@ -40,8 +41,8 @@ const NOT_INSTALLED_AGENT: Agent = {
   name: 'Codex',
   path: '/Users/test/.codex/skills',
   exists: false,
-  skillCount: 0,
-  localSkillCount: 0,
+  skillCount: toSkillCount(0),
+  localSkillCount: toSkillCount(0),
 }
 
 beforeEach(() => {

--- a/src/renderer/src/components/sidebar/BookmarkDetailModal.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/BookmarkDetailModal.browser.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import type { BookmarkForDetail } from '@/renderer/src/redux/slices/uiSlice'
-import { repositoryId } from '@/shared/types'
+import { repositoryId, toHttpUrl, toIsoTimestamp } from '@/shared/types'
 
 /**
  * Build a not-yet-installed bookmark fixture so the detail modal shows its
@@ -19,8 +19,8 @@ function makeBookmark(
   return {
     name: 'task',
     repo: repositoryId('vercel-labs/skills'),
-    url: 'https://skills.sh/task',
-    bookmarkedAt: '2026-04-01T08:00:00.000Z',
+    url: toHttpUrl('https://skills.sh/task'),
+    bookmarkedAt: toIsoTimestamp('2026-04-01T08:00:00.000Z'),
     isInstalled: false,
     ...overrides,
   }
@@ -131,7 +131,7 @@ describe('BookmarkDetailModal remove', () => {
       addBookmark({
         name: 'task',
         repo: repositoryId('vercel-labs/skills'),
-        url: 'https://skills.sh/task',
+        url: toHttpUrl('https://skills.sh/task'),
       }),
     )
     const screen = await render(

--- a/src/renderer/src/components/sidebar/BookmarkItem.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/BookmarkItem.browser.test.tsx
@@ -6,7 +6,7 @@ import { render } from 'vitest-browser-react'
 
 import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
 import type { BookmarkForDetail } from '@/renderer/src/redux/slices/uiSlice'
-import { repositoryId } from '@/shared/types'
+import { repositoryId, toHttpUrl, toIsoTimestamp } from '@/shared/types'
 
 /**
  * Build a not-yet-installed sidebar bookmark fixture (so the Install affordance
@@ -21,8 +21,8 @@ function makeBookmark(
   return {
     name: 'task',
     repo: repositoryId('vercel-labs/skills'),
-    url: 'https://skills.sh/task',
-    bookmarkedAt: '2026-04-01T08:00:00.000Z',
+    url: toHttpUrl('https://skills.sh/task'),
+    bookmarkedAt: toIsoTimestamp('2026-04-01T08:00:00.000Z'),
     isInstalled: false,
     ...overrides,
   }

--- a/src/renderer/src/components/sidebar/BookmarksSection.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/BookmarksSection.browser.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
-import { repositoryId } from '@/shared/types'
+import { repositoryId, toHttpUrl } from '@/shared/types'
 
 beforeEach(() => {
   // BookmarksSection mounts BookmarkItem + BookmarkDetailModal, which can reach
@@ -73,14 +73,14 @@ describe('BookmarksSection', () => {
       addBookmark({
         name: 'task',
         repo: repositoryId('vercel-labs/skills'),
-        url: 'https://skills.sh/task',
+        url: toHttpUrl('https://skills.sh/task'),
       }),
     )
     store.dispatch(
       addBookmark({
         name: 'lint',
         repo: repositoryId('vercel-labs/skills'),
-        url: 'https://skills.sh/lint',
+        url: toHttpUrl('https://skills.sh/lint'),
       }),
     )
 

--- a/src/renderer/src/components/sidebar/CleanupAgentDialog.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/CleanupAgentDialog.browser.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import type { AgentId, SyncPreviewResult } from '@/shared/types'
+import { toAgentCount, toSkillCount, toSymlinkCount } from '@/shared/types'
 
 const mockSyncPreview = vi.fn()
 const mockSyncExecute = vi.fn()
@@ -18,10 +19,10 @@ vi.mock('sonner', () => ({
 }))
 
 const SCOPED_PREVIEW: SyncPreviewResult = {
-  totalSkills: 4,
-  totalAgents: 1,
-  toCreate: 2,
-  alreadySynced: 2,
+  totalSkills: toSkillCount(4),
+  totalAgents: toAgentCount(1),
+  toCreate: toSymlinkCount(2),
+  alreadySynced: toSymlinkCount(2),
   conflicts: [],
   forAgent: 'claude-code',
 }

--- a/src/renderer/src/components/sidebar/SourceCard.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/SourceCard.browser.test.tsx
@@ -4,6 +4,12 @@ import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import type { SyncPreviewResult } from '@/shared/types'
+import {
+  toAgentCount,
+  toSearchQuery,
+  toSkillCount,
+  toSymlinkCount,
+} from '@/shared/types'
 
 const mockSourceGetStats = vi.fn()
 const mockSkillsGetAll = vi.fn()
@@ -28,10 +34,10 @@ vi.mock('sonner', () => ({
 
 /** Minimal sync preview with a single create — opens the confirm dialog path. */
 const PREVIEW_WITH_WORK: SyncPreviewResult = {
-  totalSkills: 2,
-  totalAgents: 3,
-  toCreate: 4,
-  alreadySynced: 0,
+  totalSkills: toSkillCount(2),
+  totalAgents: toAgentCount(3),
+  toCreate: toSymlinkCount(4),
+  alreadySynced: toSymlinkCount(0),
   conflicts: [],
 }
 
@@ -120,7 +126,7 @@ describe('Sidebar → SourceCard navigation', () => {
       await import('@/renderer/src/redux/slices/uiSlice')
     store.dispatch(setActiveTab('marketplace'))
     store.dispatch(selectAgent('claude-code'))
-    store.dispatch(setSearchQuery('task'))
+    store.dispatch(setSearchQuery(toSearchQuery('task')))
 
     // Act
     await screen.getByText('~/.agents/skills').click()

--- a/src/renderer/src/components/sidebar/SourceCard.tsx
+++ b/src/renderer/src/components/sidebar/SourceCard.tsx
@@ -33,6 +33,7 @@ import {
   setSearchQuery,
   setSyncPreview,
 } from '@/renderer/src/redux/slices/uiSlice'
+import { toSearchQuery } from '@/shared/types'
 
 /**
  * Source directory card showing stats, refresh, and sync buttons
@@ -70,7 +71,7 @@ export const SourceCard = function SourceCard(): React.ReactElement {
     // so it leaves Marketplace before clearing filters.
     dispatch(setActiveTab('installed'))
     dispatch(selectAgent(null))
-    dispatch(setSearchQuery(''))
+    dispatch(setSearchQuery(toSearchQuery('')))
     // Drop the source-repo include filter too — the card's contract ("clear
     // all filters and show all skills") was previously half-kept, leaving a
     // repo narrow active after the click.

--- a/src/renderer/src/components/sidebar/SyncConfirmDialog.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/SyncConfirmDialog.browser.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import type { SyncExecuteResult, SyncPreviewResult } from '@/shared/types'
+import { toAgentCount, toSkillCount, toSymlinkCount } from '@/shared/types'
 
 const mockSyncExecute = vi.fn()
 
@@ -11,29 +12,29 @@ const mockSyncExecute = vi.fn()
 // shape that makes shouldShowSyncConfirm return true (toCreate > 0, no
 // conflicts, no forAgent), so the confirm dialog opens.
 const PREVIEW_READY_TO_SYNC: SyncPreviewResult = {
-  totalSkills: 5,
-  totalAgents: 3,
-  toCreate: 8,
-  alreadySynced: 2,
+  totalSkills: toSkillCount(5),
+  totalAgents: toAgentCount(3),
+  toCreate: toSymlinkCount(8),
+  alreadySynced: toSymlinkCount(2),
   conflicts: [],
 }
 
 // A scoped (forAgent) preview belongs to CleanupAgentDialog, not the global
 // confirm dialog — used to prove this dialog stays closed for it.
 const SCOPED_PREVIEW: SyncPreviewResult = {
-  totalSkills: 5,
-  totalAgents: 1,
-  toCreate: 4,
-  alreadySynced: 1,
+  totalSkills: toSkillCount(5),
+  totalAgents: toAgentCount(1),
+  toCreate: toSymlinkCount(4),
+  alreadySynced: toSymlinkCount(1),
   conflicts: [],
   forAgent: 'cursor',
 }
 
 const EXECUTE_RESULT: SyncExecuteResult = {
   success: true,
-  created: 8,
-  replaced: 0,
-  skipped: 2,
+  created: toSymlinkCount(8),
+  replaced: toSymlinkCount(0),
+  skipped: toSymlinkCount(2),
   errors: [],
   details: [],
 }

--- a/src/renderer/src/components/sidebar/SyncConflictDialog.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/SyncConflictDialog.browser.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import type { SyncExecuteResult, SyncPreviewResult } from '@/shared/types'
+import { toAgentCount, toSkillCount, toSymlinkCount } from '@/shared/types'
 
 const mockSyncExecute = vi.fn()
 
@@ -22,27 +23,27 @@ const CONFLICT_CURSOR = {
 } as const
 
 const GLOBAL_PREVIEW_WITH_CONFLICTS: SyncPreviewResult = {
-  totalSkills: 5,
-  totalAgents: 3,
-  toCreate: 8,
-  alreadySynced: 2,
+  totalSkills: toSkillCount(5),
+  totalAgents: toAgentCount(3),
+  toCreate: toSymlinkCount(8),
+  alreadySynced: toSymlinkCount(2),
   conflicts: [CONFLICT_CLAUDE, CONFLICT_CURSOR],
 }
 
 const SCOPED_PREVIEW_WITH_CONFLICTS: SyncPreviewResult = {
-  totalSkills: 5,
-  totalAgents: 1,
-  toCreate: 4,
-  alreadySynced: 1,
+  totalSkills: toSkillCount(5),
+  totalAgents: toAgentCount(1),
+  toCreate: toSymlinkCount(4),
+  alreadySynced: toSymlinkCount(1),
   conflicts: [CONFLICT_CLAUDE],
   forAgent: 'claude-code',
 }
 
 const EXECUTE_RESULT: SyncExecuteResult = {
   success: true,
-  created: 8,
-  replaced: 2,
-  skipped: 0,
+  created: toSymlinkCount(8),
+  replaced: toSymlinkCount(2),
+  skipped: toSymlinkCount(0),
   errors: [],
   details: [],
 }

--- a/src/renderer/src/components/sidebar/SyncResultDialog.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/SyncResultDialog.browser.test.tsx
@@ -5,6 +5,7 @@ import { render } from 'vitest-browser-react'
 
 import '@/renderer/src/styles/globals.css'
 import type { SyncExecuteResult } from '@/shared/types'
+import { toSymlinkCount } from '@/shared/types'
 
 const mockSkillsGetAll = vi.fn()
 const mockAgentsGetAll = vi.fn()
@@ -12,9 +13,9 @@ const mockSourceGetStats = vi.fn()
 
 const RESULT_WITH_CHANGES: SyncExecuteResult = {
   success: true,
-  created: 2,
-  replaced: 1,
-  skipped: 1,
+  created: toSymlinkCount(2),
+  replaced: toSymlinkCount(1),
+  skipped: toSymlinkCount(1),
   errors: [{ path: '/Users/me/.codex/skills/broken', error: 'EACCES' }],
   // One row per action so each badge label appears exactly once. The summary
   // counts above are independent of these rows (they drive the header + chips).
@@ -37,9 +38,9 @@ const RESULT_WITH_CHANGES: SyncExecuteResult = {
 
 const RESULT_NO_CHANGES: SyncExecuteResult = {
   success: true,
-  created: 0,
-  replaced: 0,
-  skipped: 3,
+  created: toSymlinkCount(0),
+  replaced: toSymlinkCount(0),
+  skipped: toSymlinkCount(3),
   errors: [],
   details: [
     { skillName: 'already-a', agentName: 'Claude Code', action: 'skipped' },
@@ -50,9 +51,9 @@ const RESULT_NO_CHANGES: SyncExecuteResult = {
 
 const RESULT_EMPTY_DETAILS: SyncExecuteResult = {
   success: true,
-  created: 0,
-  replaced: 0,
-  skipped: 0,
+  created: toSymlinkCount(0),
+  replaced: toSymlinkCount(0),
+  skipped: toSymlinkCount(0),
   errors: [],
   details: [],
 }

--- a/src/renderer/src/components/skills/AddSymlinkModal.browser.test.tsx
+++ b/src/renderer/src/components/skills/AddSymlinkModal.browser.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import type { Agent, Skill } from '@/shared/types'
+import { toSkillCount, toSymlinkCount } from '@/shared/types'
 
 const mockCreateSymlinks = vi.fn()
 const mockCopyToAgents = vi.fn()
@@ -40,8 +41,8 @@ function makeAgent(
     name,
     path: `/home/user/.${id}/skills`,
     exists: true,
-    skillCount: 0,
-    localSkillCount: 0,
+    skillCount: toSkillCount(0),
+    localSkillCount: toSkillCount(0),
     ...rest,
   }
 }
@@ -58,7 +59,7 @@ function makeSkill(overrides: Partial<Skill> = {}): Skill {
     name: 'task',
     description: 'Task management skill',
     path: '/home/user/.agents/skills/task',
-    symlinkCount: 0,
+    symlinkCount: toSymlinkCount(0),
     symlinks: [],
     isSource: true,
     isOrphan: false,

--- a/src/renderer/src/components/skills/BulkCopyToAgentsModal.browser.test.tsx
+++ b/src/renderer/src/components/skills/BulkCopyToAgentsModal.browser.test.tsx
@@ -9,6 +9,7 @@ import type {
   Skill,
   SkillName,
 } from '@/shared/types'
+import { toAgentCount, toSkillCount, toSymlinkCount } from '@/shared/types'
 
 const mockCopyToAgents = vi.fn()
 const mockSkillsGetAll = vi.fn()
@@ -44,8 +45,8 @@ function makeAgent(
     name,
     path: `/home/user/.${id}/skills`,
     exists: true,
-    skillCount: 0,
-    localSkillCount: 0,
+    skillCount: toSkillCount(0),
+    localSkillCount: toSkillCount(0),
     ...rest,
   }
 }
@@ -62,7 +63,7 @@ function makeSkill(name: string): Skill {
     name: name,
     description: `${name} skill`,
     path: `/home/user/.agents/skills/${name}`,
-    symlinkCount: 0,
+    symlinkCount: toSymlinkCount(0),
     symlinks: [],
     isSource: true,
     isOrphan: false,
@@ -81,7 +82,7 @@ function makeCopyResult(
 ): CopyToAgentsResult {
   return {
     success: true,
-    copied: 2,
+    copied: toAgentCount(2),
     failures: [],
     ...overrides,
   }
@@ -285,7 +286,9 @@ describe('BulkCopyToAgentsModal dismissal', () => {
 describe('BulkCopyToAgentsModal copy outcome', () => {
   it('shows a success toast and closes when every selected skill copies to every agent', async () => {
     // Arrange
-    mockCopyToAgents.mockResolvedValue(makeCopyResult({ copied: 1 }))
+    mockCopyToAgents.mockResolvedValue(
+      makeCopyResult({ copied: toAgentCount(1) }),
+    )
     const { screen, store } = await renderModal({
       skills: [makeSkill('task')],
       agents: [makeAgent({ id: 'cursor', name: 'Cursor' })],
@@ -317,7 +320,7 @@ describe('BulkCopyToAgentsModal copy outcome', () => {
     mockCopyToAgents.mockResolvedValue(
       makeCopyResult({
         success: false,
-        copied: 0,
+        copied: toAgentCount(0),
         failures: [{ agentId: 'cursor', error: 'Already exists' }],
       }),
     )

--- a/src/renderer/src/components/skills/CodePreview.browser.test.tsx
+++ b/src/renderer/src/components/skills/CodePreview.browser.test.tsx
@@ -6,6 +6,13 @@ import { render } from 'vitest-browser-react'
 import type { PreviewContent } from '@/renderer/src/hooks/useCodePreview'
 import { DEFAULT_SETTINGS, type Settings } from '@/shared/settings'
 import type { AbsolutePath, SkillFile } from '@/shared/types'
+import {
+  toFileExtension,
+  toFileName,
+  toFileSizeBytes,
+  toLineCount,
+  toPosixRelativePath,
+} from '@/shared/types'
 import '@/renderer/src/styles/globals.css'
 
 // Mock the data hook so each render deterministically drives loading / empty /
@@ -31,11 +38,11 @@ const SKILL_PATH = '/home/user/.agents/skills/tdd'
  */
 function makeFile(overrides: Partial<SkillFile> = {}): SkillFile {
   return {
-    name: 'SKILL.md',
+    name: toFileName('SKILL.md'),
     path: `${SKILL_PATH}/SKILL.md`,
-    relativePath: 'SKILL.md',
-    extension: '.md',
-    size: 1024,
+    relativePath: toPosixRelativePath('SKILL.md'),
+    extension: toFileExtension('.md'),
+    size: toFileSizeBytes(1024),
     previewable: 'text',
     ...overrides,
   }
@@ -144,9 +151,9 @@ describe('CodePreview', () => {
     // Arrange
     const skillFile = makeFile()
     const readmeFile = makeFile({
-      name: 'README.md',
+      name: toFileName('README.md'),
       path: `${SKILL_PATH}/README.md`,
-      relativePath: 'README.md',
+      relativePath: toPosixRelativePath('README.md'),
     })
     mockUseCodePreview.mockReturnValue(
       makeHookReturn({
@@ -173,9 +180,9 @@ describe('CodePreview', () => {
     const setActiveFileSpy = vi.fn(async () => {})
     const skillFile = makeFile()
     const readmeFile = makeFile({
-      name: 'README.md',
+      name: toFileName('README.md'),
       path: `${SKILL_PATH}/README.md`,
-      relativePath: 'README.md',
+      relativePath: toPosixRelativePath('README.md'),
     })
     mockUseCodePreview.mockReturnValue(
       makeHookReturn({
@@ -205,10 +212,10 @@ describe('CodePreview', () => {
         content: {
           kind: 'text',
           data: {
-            name: 'SKILL.md',
+            name: toFileName('SKILL.md'),
             content: 'const answer = 42\n',
-            extension: '.md',
-            lineCount: 1,
+            extension: toFileExtension('.md'),
+            lineCount: toLineCount(1),
           },
         },
       }),

--- a/src/renderer/src/components/skills/CopyToAgentsModal.browser.test.tsx
+++ b/src/renderer/src/components/skills/CopyToAgentsModal.browser.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import type { Agent, Skill, SymlinkInfo } from '@/shared/types'
+import { toSkillCount, toSymlinkCount } from '@/shared/types'
 
 const mockCopyToAgents = vi.fn()
 const mockGetAll = vi.fn()
@@ -34,8 +35,8 @@ function makeAgent(
     name,
     path: `/home/user/.${id}/skills`,
     exists: true,
-    skillCount: 0,
-    localSkillCount: 0,
+    skillCount: toSkillCount(0),
+    localSkillCount: toSkillCount(0),
     ...rest,
   }
 }
@@ -52,7 +53,7 @@ function makeSkill(symlinks: SymlinkInfo[]): Skill {
     name: 'task',
     description: 'Task management skill',
     path: '/home/user/.agents/skills/task',
-    symlinkCount: symlinks.length,
+    symlinkCount: toSymlinkCount(symlinks.length),
     symlinks,
     isSource: true,
     isOrphan: false,

--- a/src/renderer/src/components/skills/FileContent.browser.test.tsx
+++ b/src/renderer/src/components/skills/FileContent.browser.test.tsx
@@ -3,6 +3,14 @@ import { render } from 'vitest-browser-react'
 
 import type { PreviewContent } from '@/renderer/src/hooks/useCodePreview'
 import '@/renderer/src/styles/globals.css'
+import {
+  toDataUrl,
+  toFileExtension,
+  toFileName,
+  toFileSizeBytes,
+  toLineCount,
+  toMimeType,
+} from '@/shared/types'
 
 import * as shikiPreview from './shikiPreview'
 
@@ -29,10 +37,10 @@ function makeTextContent(
   return {
     kind: 'text',
     data: {
-      name: overrides.name ?? 'SKILL.md',
+      name: toFileName(overrides.name ?? 'SKILL.md'),
       content: content ?? '# Skill\n',
-      extension: overrides.extension ?? '.md',
-      lineCount: content?.split('\n').length ?? 1,
+      extension: toFileExtension(overrides.extension ?? '.md'),
+      lineCount: toLineCount(content?.split('\n').length ?? 1),
     },
   }
 }
@@ -56,7 +64,11 @@ function makeEmptyContent(): PreviewContent {
  * @returns PreviewContent for FileContent's `binary` branch.
  */
 function makeBinaryContent(fileName: string, size: number): PreviewContent {
-  return { kind: 'binary', fileName, size }
+  return {
+    kind: 'binary',
+    fileName: toFileName(fileName),
+    size: toFileSizeBytes(size),
+  }
 }
 
 /**
@@ -68,7 +80,12 @@ function makeBinaryContent(fileName: string, size: number): PreviewContent {
 function makeImageContent(name: string, dataUrl: string): PreviewContent {
   return {
     kind: 'image',
-    data: { name, dataUrl, mimeType: 'image/png', size: 70 },
+    data: {
+      name: toFileName(name),
+      dataUrl: toDataUrl(dataUrl),
+      mimeType: toMimeType('image/png'),
+      size: toFileSizeBytes(70),
+    },
   }
 }
 

--- a/src/renderer/src/components/skills/FileContent.codeTheme.browser.test.tsx
+++ b/src/renderer/src/components/skills/FileContent.codeTheme.browser.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import type { PreviewContent } from '@/renderer/src/hooks/useCodePreview'
+import { toFileExtension, toFileName, toLineCount } from '@/shared/types'
 import '@/renderer/src/styles/globals.css'
 
 // Mock the Shiki shorthand so this file can assert which theme pair FileContent
@@ -26,10 +27,10 @@ function makeCodeContent(content: string): PreviewContent {
   return {
     kind: 'text',
     data: {
-      name: 'example.ts',
+      name: toFileName('example.ts'),
       content,
-      extension: '.ts',
-      lineCount: content.split('\n').length,
+      extension: toFileExtension('.ts'),
+      lineCount: toLineCount(content.split('\n').length),
     },
   }
 }

--- a/src/renderer/src/components/skills/FileContent.shikiError.browser.test.tsx
+++ b/src/renderer/src/components/skills/FileContent.shikiError.browser.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import type { PreviewContent } from '@/renderer/src/hooks/useCodePreview'
+import { toFileExtension, toFileName, toLineCount } from '@/shared/types'
 import '@/renderer/src/styles/globals.css'
 
 // Force Shiki to fail so the preview must fall back to the plain-text renderer
@@ -22,10 +23,10 @@ function makeTextContent(content: string): PreviewContent {
   return {
     kind: 'text',
     data: {
-      name: 'mystery.unknownext',
+      name: toFileName('mystery.unknownext'),
       content,
-      extension: '.unknownext',
-      lineCount: 1,
+      extension: toFileExtension('.unknownext'),
+      lineCount: toLineCount(1),
     },
   }
 }

--- a/src/renderer/src/components/skills/FileTabs.browser.test.tsx
+++ b/src/renderer/src/components/skills/FileTabs.browser.test.tsx
@@ -4,6 +4,12 @@ import { render } from 'vitest-browser-react'
 
 import type { AbsolutePath, SkillFile } from '@/shared/types'
 import '@/renderer/src/styles/globals.css'
+import {
+  toFileExtension,
+  toFileName,
+  toFileSizeBytes,
+  toPosixRelativePath,
+} from '@/shared/types'
 
 import { FileTabs } from './FileTabs'
 
@@ -14,11 +20,11 @@ import { FileTabs } from './FileTabs'
  */
 function makeSkillFile(overrides: Partial<SkillFile> = {}): SkillFile {
   return {
-    name: 'SKILL.md',
+    name: toFileName('SKILL.md'),
     path: '/Users/me/.agents/skills/tdd/SKILL.md',
-    relativePath: 'SKILL.md',
-    extension: '.md',
-    size: 1024,
+    relativePath: toPosixRelativePath('SKILL.md'),
+    extension: toFileExtension('.md'),
+    size: toFileSizeBytes(1024),
     previewable: 'text',
     ...overrides,
   }
@@ -48,12 +54,12 @@ describe('FileTabs tab bar', () => {
     const files = [
       makeSkillFile({
         path: '/Users/me/.agents/skills/tdd/SKILL.md',
-        relativePath: 'SKILL.md',
+        relativePath: toPosixRelativePath('SKILL.md'),
       }),
       makeSkillFile({
-        name: 'run.md',
+        name: toFileName('run.md'),
         path: '/Users/me/.agents/skills/tdd/workflows/run.md',
-        relativePath: 'workflows/run.md',
+        relativePath: toPosixRelativePath('workflows/run.md'),
       }),
     ]
 
@@ -74,13 +80,13 @@ describe('FileTabs tab bar', () => {
     const files = [
       makeSkillFile({
         path: '/Users/me/.agents/skills/tdd/SKILL.md',
-        relativePath: 'SKILL.md',
+        relativePath: toPosixRelativePath('SKILL.md'),
       }),
       makeSkillFile({
-        name: 'helper.py',
+        name: toFileName('helper.py'),
         path: '/Users/me/.agents/skills/tdd/lib/helper.py',
-        relativePath: 'lib/helper.py',
-        extension: '.py',
+        relativePath: toPosixRelativePath('lib/helper.py'),
+        extension: toFileExtension('.py'),
       }),
     ]
 
@@ -100,10 +106,10 @@ describe('FileTabs tab bar', () => {
     // Arrange
     const files = [
       makeSkillFile({
-        name: 'diagram.png',
+        name: toFileName('diagram.png'),
         path: '/Users/me/.agents/skills/tdd/diagram.png',
-        relativePath: 'diagram.png',
-        extension: '.png',
+        relativePath: toPosixRelativePath('diagram.png'),
+        extension: toFileExtension('.png'),
         previewable: 'image',
       }),
     ]
@@ -120,10 +126,10 @@ describe('FileTabs tab bar', () => {
     // Arrange
     const files = [
       makeSkillFile({
-        name: 'NOTES.mdx',
+        name: toFileName('NOTES.mdx'),
         path: '/Users/me/.agents/skills/tdd/NOTES.mdx',
-        relativePath: 'NOTES.mdx',
-        extension: '.mdx',
+        relativePath: toPosixRelativePath('NOTES.mdx'),
+        extension: toFileExtension('.mdx'),
         previewable: 'text',
       }),
     ]
@@ -140,10 +146,10 @@ describe('FileTabs tab bar', () => {
     // Arrange
     const files = [
       makeSkillFile({
-        name: 'helper.py',
+        name: toFileName('helper.py'),
         path: '/Users/me/.agents/skills/tdd/lib/helper.py',
-        relativePath: 'lib/helper.py',
-        extension: '.py',
+        relativePath: toPosixRelativePath('lib/helper.py'),
+        extension: toFileExtension('.py'),
         previewable: 'text',
       }),
     ]

--- a/src/renderer/src/components/skills/SearchBox.browser.test.tsx
+++ b/src/renderer/src/components/skills/SearchBox.browser.test.tsx
@@ -4,7 +4,12 @@ import { describe, expect, it } from 'vitest'
 import { userEvent } from 'vitest/browser'
 import { render } from 'vitest-browser-react'
 
-import { repositoryId, type Skill } from '@/shared/types'
+import {
+  repositoryId,
+  toHttpUrl,
+  toSymlinkCount,
+  type Skill,
+} from '@/shared/types'
 
 /**
  * Build a store with only the slices SearchBox subscribes to: `ui` for the
@@ -45,14 +50,14 @@ function makeSkill(name: string, source?: string): Skill {
     name,
     description: '',
     path: `/skills/${name}`,
-    symlinkCount: 0,
+    symlinkCount: toSymlinkCount(0),
     symlinks: [],
     isSource: true,
     isOrphan: false,
     ...(source
       ? {
           source: repositoryId(source),
-          sourceUrl: `https://github.com/${source}.git`,
+          sourceUrl: toHttpUrl(`https://github.com/${source}.git`),
         }
       : {}),
   }

--- a/src/renderer/src/components/skills/SearchBox.tsx
+++ b/src/renderer/src/components/skills/SearchBox.tsx
@@ -19,6 +19,7 @@ import {
   setSearchScope,
   type SearchScope,
 } from '@/renderer/src/redux/slices/uiSlice'
+import { toSearchQuery } from '@/shared/types'
 
 /**
  * Map the active scope to the input's user-facing copy. Centralized so the
@@ -83,7 +84,7 @@ export const SearchBox = function SearchBox(): React.ReactElement {
   }
 
   const pickSuggestion = (suggestion: RepoSearchSuggestion): void => {
-    dispatch(setSearchQuery(suggestion))
+    dispatch(setSearchQuery(toSearchQuery(suggestion)))
     closeList()
   }
 
@@ -93,7 +94,7 @@ export const SearchBox = function SearchBox(): React.ReactElement {
   }
 
   const handleQueryChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    dispatch(setSearchQuery(e.target.value))
+    dispatch(setSearchQuery(toSearchQuery(e.target.value)))
     setIsListOpen(true)
     setActiveIndex(-1)
   }

--- a/src/renderer/src/components/skills/SelectionToolbar.browser.test.tsx
+++ b/src/renderer/src/components/skills/SelectionToolbar.browser.test.tsx
@@ -5,6 +5,12 @@ import { render } from 'vitest-browser-react'
 
 import type { AgentId } from '@/shared/constants'
 import type { Skill, SkillName, SymlinkInfo } from '@/shared/types'
+import {
+  toBatchItemCount,
+  toBatchItemIndex,
+  toSearchQuery,
+  toSymlinkCount,
+} from '@/shared/types'
 
 /**
  * Build a source skill fixture with one agent symlink slot for toolbar tests.
@@ -21,7 +27,7 @@ function makeCursorSkill(
     name,
     description: '',
     path: `/Users/test/.agents/skills/${name}`,
-    symlinkCount: status === 'missing' ? 0 : 1,
+    symlinkCount: toSymlinkCount(status === 'missing' ? 0 : 1),
     symlinks: [
       {
         agentId: 'cursor',
@@ -183,7 +189,7 @@ describe('SelectionToolbar', () => {
     })
 
     // Act — narrow the visible list so 'zeta-hidden' drops out of the filter
-    store.dispatch(setSearchQuery('alpha'))
+    store.dispatch(setSearchQuery(toSearchQuery('alpha')))
 
     // Assert — both advisory badges surface their counts
     await expect.element(screen.getByText('+1 hidden by filter')).toBeVisible()
@@ -201,7 +207,12 @@ describe('SelectionToolbar', () => {
       await import('@/renderer/src/redux/slices/skillsSlice')
 
     // Act — emit progress for a batch at the >= 10 threshold
-    store.dispatch(setBulkProgress({ current: 3, total: 12 }))
+    store.dispatch(
+      setBulkProgress({
+        current: toBatchItemIndex(3),
+        total: toBatchItemCount(12),
+      }),
+    )
 
     // Assert — the counter renders "current of total"
     await expect.element(screen.getByText('3 of 12')).toBeVisible()

--- a/src/renderer/src/components/skills/SelectionToolbar.tsx
+++ b/src/renderer/src/components/skills/SelectionToolbar.tsx
@@ -24,6 +24,7 @@ import {
   selectSelectedAgentId,
 } from '@/renderer/src/redux/slices/uiSlice'
 import { BULK_PROGRESS_THRESHOLD } from '@/shared/constants'
+import { toSkillCount } from '@/shared/types'
 
 import { getToolbarState } from './bulkDeleteHelpers'
 
@@ -109,8 +110,8 @@ export const SelectionToolbar = function SelectionToolbar({
       ? getToolbarState({
           view: selectedAgentId ? 'agent' : 'global',
           agentId: selectedAgentId,
-          count: selectedCount,
-          visibleCount: visibleSelectedCount,
+          count: toSkillCount(selectedCount),
+          visibleCount: toSkillCount(visibleSelectedCount),
           agentDisplayName,
         })
       : null

--- a/src/renderer/src/components/skills/SkillDetail.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillDetail.browser.test.tsx
@@ -12,6 +12,7 @@ import type {
   Skill,
   SymlinkInfo,
 } from '@/shared/types'
+import { toSkillCount, toSymlinkCount } from '@/shared/types'
 
 const SOURCE_PATH = '/home/user/.agents/skills/task'
 const CURSOR_PATH = '/home/user/.cursor/skills/task'
@@ -64,8 +65,8 @@ function makeAgent(overrides: Partial<Agent> = {}): Agent {
     name: 'Cursor',
     path: '/home/user/.cursor/skills',
     exists: true,
-    skillCount: 1,
-    localSkillCount: 0,
+    skillCount: toSkillCount(1),
+    localSkillCount: toSkillCount(0),
     ...overrides,
   }
 }
@@ -92,7 +93,7 @@ function makeSkill(): Skill {
     name: 'task',
     description: 'Task workflow',
     path: SOURCE_PATH,
-    symlinkCount: symlinks.length,
+    symlinkCount: toSymlinkCount(symlinks.length),
     symlinks,
     isSource: true,
     isOrphan: false,
@@ -111,7 +112,7 @@ function makeOverflowSkillFixture(): { agents: Agent[]; skill: Skill } {
       id,
       name,
       path: `/home/user/.${id}/skills`,
-      skillCount: 1,
+      skillCount: toSkillCount(1),
     }),
   )
   const symlinks: SymlinkInfo[] = OVERFLOW_AGENT_ROWS.map(({ id, name }) => ({
@@ -127,7 +128,7 @@ function makeOverflowSkillFixture(): { agents: Agent[]; skill: Skill } {
     agents,
     skill: {
       ...makeSkill(),
-      symlinkCount: symlinks.length,
+      symlinkCount: toSymlinkCount(symlinks.length),
       symlinks,
     },
   }

--- a/src/renderer/src/components/skills/SkillDetail.tsx
+++ b/src/renderer/src/components/skills/SkillDetail.tsx
@@ -18,6 +18,7 @@ import type {
   SymlinkCount,
   SymlinkInfo,
 } from '@/shared/types'
+import { toSymlinkCount } from '@/shared/types'
 
 import { CodePreview } from './CodePreview'
 import { SourceLink } from './SourceLink'
@@ -130,9 +131,9 @@ export const SkillDetail = function SkillDetail({
             skill={skill}
             // react-doctor-disable-next-line react-doctor/jsx-no-new-array-as-prop -- InfoView lives in a hidden <Activity>; deriving this array inline is a render micro-opt deferred to /simplify (P8).
             filteredSymlinks={filteredSymlinks}
-            validCount={validCount}
-            brokenCount={brokenCount}
-            inaccessibleCount={inaccessibleCount}
+            validCount={toSymlinkCount(validCount)}
+            brokenCount={toSymlinkCount(brokenCount)}
+            inaccessibleCount={toSymlinkCount(inaccessibleCount)}
             location={locationView}
           />
         </Activity>

--- a/src/renderer/src/components/skills/SkillItem.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillItem.browser.test.tsx
@@ -6,7 +6,12 @@ import { render } from 'vitest-browser-react'
 import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
 import { GSTACK_REPOSITORY_URL } from '@/shared/constants'
 import type { FilesystemEntryIdentity, Skill } from '@/shared/types'
-import { repositoryId } from '@/shared/types'
+import {
+  repositoryId,
+  toFileSizeBytes,
+  toHttpUrl,
+  toSymlinkCount,
+} from '@/shared/types'
 
 const mockGetAll = vi.fn()
 
@@ -30,7 +35,7 @@ const directoryIdentity: FilesystemEntryIdentity = {
   kind: 'directory',
   dev: 1,
   ino: 2,
-  size: 96,
+  size: toFileSizeBytes(96),
   ctimeMs: 3,
   mtimeMs: 4,
 }
@@ -47,7 +52,7 @@ function makeSkill(overrides: Partial<Skill> = {}): Skill {
     description: 'Task management skill',
     path: '/home/user/.agents/skills/task',
     filesystemIdentity: directoryIdentity,
-    symlinkCount: 0,
+    symlinkCount: toSymlinkCount(0),
     symlinks: [],
     isSource: true,
     isOrphan: false,
@@ -852,7 +857,7 @@ describe('SkillItem bookmark toggle', () => {
       makeSkill({
         name: 'task',
         source: repositoryId('vercel-labs/agent-skills'),
-        sourceUrl: 'https://github.com/vercel-labs/agent-skills.git',
+        sourceUrl: toHttpUrl('https://github.com/vercel-labs/agent-skills.git'),
       }),
     )
 
@@ -884,7 +889,7 @@ describe('SkillItem bookmark toggle', () => {
       addBookmark({
         name: 'task',
         repo: repositoryId('vercel-labs/agent-skills'),
-        url: 'https://github.com/vercel-labs/agent-skills',
+        url: toHttpUrl('https://github.com/vercel-labs/agent-skills'),
       }),
     )
 

--- a/src/renderer/src/components/skills/SkillItem.tsx
+++ b/src/renderer/src/components/skills/SkillItem.tsx
@@ -69,6 +69,7 @@ import type {
   SymlinkCount,
   SymlinkInfo,
 } from '@/shared/types'
+import { toSymlinkCount } from '@/shared/types'
 
 import { canBookmarkSkill, skillToBookmarkData } from './bookmarkHelpers'
 import { computeRangeSelection } from './bulkDeleteHelpers'
@@ -202,9 +203,9 @@ function getSymlinkStatusBuckets(
   symlinks: readonly SymlinkInfo[],
 ): SymlinkStatusBuckets {
   const buckets: SymlinkStatusBuckets = {
-    validCount: 0,
-    brokenCount: 0,
-    inaccessibleCount: 0,
+    validCount: toSymlinkCount(0),
+    brokenCount: toSymlinkCount(0),
+    inaccessibleCount: toSymlinkCount(0),
     validAgentNames: [],
     brokenAgentNames: [],
     inaccessibleAgentNames: [],
@@ -212,13 +213,13 @@ function getSymlinkStatusBuckets(
 
   for (const symlink of symlinks) {
     if (symlink.status === 'valid') {
-      buckets.validCount += 1
+      buckets.validCount = toSymlinkCount(buckets.validCount + 1)
       buckets.validAgentNames.push(symlink.agentName)
     } else if (symlink.status === 'broken') {
-      buckets.brokenCount += 1
+      buckets.brokenCount = toSymlinkCount(buckets.brokenCount + 1)
       buckets.brokenAgentNames.push(symlink.agentName)
     } else if (symlink.status === 'inaccessible') {
-      buckets.inaccessibleCount += 1
+      buckets.inaccessibleCount = toSymlinkCount(buckets.inaccessibleCount + 1)
       buckets.inaccessibleAgentNames.push(symlink.agentName)
     }
   }

--- a/src/renderer/src/components/skills/SkillsList.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillsList.browser.test.tsx
@@ -6,6 +6,7 @@ import { render } from 'vitest-browser-react'
 import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
 import { installLayoutStyles } from '@/renderer/src/test/installLayoutStyles'
 import type { Skill } from '@/shared/types'
+import { toSearchQuery, toSymlinkCount } from '@/shared/types'
 
 const mockGetAll = vi.fn()
 
@@ -37,7 +38,7 @@ function makeSkill(overrides: Partial<Skill> = {}): Skill {
     name: 'task',
     description: 'Task management skill',
     path: '/home/user/.agents/skills/task',
-    symlinkCount: 0,
+    symlinkCount: toSymlinkCount(0),
     symlinks: [],
     isSource: true,
     isOrphan: false,
@@ -380,7 +381,7 @@ describe('SkillsList search-empty branch', () => {
     const { setSearchQuery: dispatchSearchQuery } =
       await import('@/renderer/src/redux/slices/uiSlice')
     // Dispatch before render so the component mounts with the query already set
-    store.dispatch(dispatchSearchQuery('zzznomatch'))
+    store.dispatch(dispatchSearchQuery(toSearchQuery('zzznomatch')))
     const { SkillsList } = await import('./SkillsList')
     const screen = await render(
       <Provider store={store}>
@@ -410,7 +411,7 @@ describe('SkillsList search-empty branch', () => {
     })
     const { setSearchQuery: dispatchSearchQuery } =
       await import('@/renderer/src/redux/slices/uiSlice')
-    store.dispatch(dispatchSearchQuery('zzznomatch'))
+    store.dispatch(dispatchSearchQuery(toSearchQuery('zzznomatch')))
     const { SkillsList } = await import('./SkillsList')
     const screen = await render(
       <Provider store={store}>

--- a/src/renderer/src/components/skills/SkillsList.tsx
+++ b/src/renderer/src/components/skills/SkillsList.tsx
@@ -21,6 +21,7 @@ import {
   setSearchQuery,
 } from '@/renderer/src/redux/slices/uiSlice'
 import type { Skill } from '@/shared/types'
+import { toSearchQuery } from '@/shared/types'
 
 import { SkillItem } from './SkillItem'
 import { getEmptyListMessage } from './skillsListHelpers'
@@ -83,7 +84,7 @@ export const SkillsList = function SkillsList(): React.ReactElement {
 
   /** Resets the search query to empty; fired by the "Clear search" CTA in the search-miss empty state. */
   const handleClearSearch = (): void => {
-    dispatch(setSearchQuery(''))
+    dispatch(setSearchQuery(toSearchQuery('')))
   }
 
   /**

--- a/src/renderer/src/components/skills/UndoToast.browser.test.tsx
+++ b/src/renderer/src/components/skills/UndoToast.browser.test.tsx
@@ -7,7 +7,7 @@ import type {
   ToastId,
   TombstoneId,
 } from '@/shared/types'
-import { tombstoneId } from '@/shared/types'
+import { toIsoTimestamp, tombstoneId } from '@/shared/types'
 
 // `vi.hoisted` exposes the dismiss spy so the hoisted `vi.mock('sonner')`
 // factory can reference it. UndoToast's only external dependency is
@@ -30,7 +30,9 @@ const SUMMARY = 'Deleted 2 skills. 5 symlinks removed.'
  * @example futureIso(30) // 30s undo window
  */
 function futureIso(secondsFromNow: number): IsoTimestamp {
-  return new Date(Date.now() + secondsFromNow * 1_000).toISOString()
+  return toIsoTimestamp(
+    new Date(Date.now() + secondsFromNow * 1_000).toISOString(),
+  )
 }
 
 interface RenderOptions {
@@ -222,7 +224,10 @@ describe('UndoToast', () => {
     // button renders disabled and no restore can be triggered.
     const onUndo = vi.fn(async () => {})
     const expiredAt = new Date(Date.now() - 1_000).toISOString()
-    const { screen } = await renderUndoToast({ expiresAt: expiredAt, onUndo })
+    const { screen } = await renderUndoToast({
+      expiresAt: toIsoTimestamp(expiredAt),
+      onUndo,
+    })
     const undoButton = screen.getByRole('button', {
       name: 'Undo delete of 2 skills',
     })

--- a/src/renderer/src/components/skills/UnlinkDialog.browser.test.tsx
+++ b/src/renderer/src/components/skills/UnlinkDialog.browser.test.tsx
@@ -8,6 +8,7 @@ import type {
   Skill,
   SymlinkInfo,
 } from '@/shared/types'
+import { toFileSizeBytes, toSymlinkCount } from '@/shared/types'
 
 const mockUnlinkFromAgent = vi.fn()
 const mockSkillsGetAll = vi.fn()
@@ -29,7 +30,7 @@ const directoryIdentity: FilesystemEntryIdentity = {
   kind: 'directory',
   dev: 1,
   ino: 2,
-  size: 96,
+  size: toFileSizeBytes(96),
   ctimeMs: 3,
   mtimeMs: 4,
 }
@@ -45,7 +46,7 @@ function makeSkill(overrides: Partial<Skill> = {}): Skill {
     name: 'task',
     description: 'Task management skill',
     path: '/home/user/.agents/skills/task',
-    symlinkCount: 0,
+    symlinkCount: toSymlinkCount(0),
     symlinks: [],
     isSource: true,
     isOrphan: false,

--- a/src/renderer/src/components/skills/agentSelectionHelpers.test.ts
+++ b/src/renderer/src/components/skills/agentSelectionHelpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { Agent, SymlinkInfo } from '@/shared/types'
+import { toSkillCount } from '@/shared/types'
 
 import {
   buildCopyAgentOptionViewModel,
@@ -20,8 +21,8 @@ function makeAgent(overrides: Partial<Agent> & Pick<Agent, 'id'>): Agent {
     name: overrides.name ?? ('Agent' as Agent['name']),
     path: overrides.path ?? '/tmp/skills',
     exists: overrides.exists ?? true,
-    skillCount: overrides.skillCount ?? 0,
-    localSkillCount: overrides.localSkillCount ?? 0,
+    skillCount: toSkillCount(overrides.skillCount ?? 0),
+    localSkillCount: toSkillCount(overrides.localSkillCount ?? 0),
   }
 }
 

--- a/src/renderer/src/components/skills/bookmarkHelpers.test.ts
+++ b/src/renderer/src/components/skills/bookmarkHelpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { repositoryId } from '@/shared/types'
+import { repositoryId, toHttpUrl, toSymlinkCount } from '@/shared/types'
 import type { Skill } from '@/shared/types'
 
 import { canBookmarkSkill, skillToBookmarkData } from './bookmarkHelpers'
@@ -17,7 +17,7 @@ function makeSkill(overrides: Partial<Skill> = {}): Skill {
     name: 'test-skill',
     description: 'A test skill',
     path: '/home/user/.agents/skills/test-skill',
-    symlinkCount: 0,
+    symlinkCount: toSymlinkCount(0),
     symlinks: [],
     isSource: true,
     isOrphan: false,
@@ -65,7 +65,7 @@ describe('skillToBookmarkData', () => {
     // Arrange
     const skill = makeSkill({
       source: repositoryId('pbakaus/impeccable'),
-      sourceUrl: 'https://github.com/pbakaus/impeccable.git',
+      sourceUrl: toHttpUrl('https://github.com/pbakaus/impeccable.git'),
     })
 
     // Act
@@ -82,7 +82,7 @@ describe('skillToBookmarkData', () => {
     // Arrange
     const skill = makeSkill({
       source: repositoryId('laststance/skills'),
-      sourceUrl: 'https://github.com/laststance/skills',
+      sourceUrl: toHttpUrl('https://github.com/laststance/skills'),
     })
 
     // Act

--- a/src/renderer/src/components/skills/bookmarkHelpers.ts
+++ b/src/renderer/src/components/skills/bookmarkHelpers.ts
@@ -1,4 +1,5 @@
 import type { HttpUrl, RepositoryId, Skill } from '@/shared/types'
+import { toHttpUrl } from '@/shared/types'
 
 /**
  * Whether a skill can be bookmarked from the Installed tab.
@@ -32,5 +33,5 @@ export function skillToBookmarkData(skill: Skill): {
   const url = skill.sourceUrl
     ? skill.sourceUrl.replace(/\.git$/, '')
     : `https://github.com/${repo}`
-  return { repo, url }
+  return { repo, url: toHttpUrl(url) }
 }

--- a/src/renderer/src/components/skills/bulkDeleteCopy.test.ts
+++ b/src/renderer/src/components/skills/bulkDeleteCopy.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { repositoryId } from '@/shared/types'
+import { repositoryId, toSkillCount } from '@/shared/types'
 
 import { renderBulkDeleteDescription } from './bulkDeleteCopy'
 
@@ -147,7 +147,7 @@ describe('renderBulkDeleteDescription', () => {
       totalCount: 2,
       sourceSummary: {
         repositoryIds: [repositoryId('vercel-labs/skills')],
-        localHiddenCount: 0,
+        localHiddenCount: toSkillCount(0),
       },
     })
 
@@ -168,7 +168,7 @@ describe('renderBulkDeleteDescription', () => {
       totalCount: 2,
       sourceSummary: {
         repositoryIds: [longRepo],
-        localHiddenCount: 0,
+        localHiddenCount: toSkillCount(0),
       },
     })
 
@@ -187,7 +187,7 @@ describe('renderBulkDeleteDescription', () => {
           repositoryId('vercel-labs/skills'),
           repositoryId('pbakaus/impeccable'),
         ],
-        localHiddenCount: 0,
+        localHiddenCount: toSkillCount(0),
       },
     })
 
@@ -203,7 +203,7 @@ describe('renderBulkDeleteDescription', () => {
       totalCount: 2,
       sourceSummary: {
         repositoryIds: [],
-        localHiddenCount: 2,
+        localHiddenCount: toSkillCount(2),
       },
     })
 
@@ -219,7 +219,7 @@ describe('renderBulkDeleteDescription', () => {
       totalCount: 2,
       sourceSummary: {
         repositoryIds: [],
-        localHiddenCount: 1,
+        localHiddenCount: toSkillCount(1),
       },
     })
 
@@ -235,7 +235,7 @@ describe('renderBulkDeleteDescription', () => {
       totalCount: 2,
       sourceSummary: {
         repositoryIds: [repositoryId('vercel-labs/skills')],
-        localHiddenCount: 1,
+        localHiddenCount: toSkillCount(1),
       },
     })
 
@@ -253,7 +253,7 @@ describe('renderBulkDeleteDescription', () => {
       totalCount: 2,
       sourceSummary: {
         repositoryIds: [],
-        localHiddenCount: 0,
+        localHiddenCount: toSkillCount(0),
       },
     })
 

--- a/src/renderer/src/components/skills/bulkDeleteHelpers.test.ts
+++ b/src/renderer/src/components/skills/bulkDeleteHelpers.test.ts
@@ -5,7 +5,7 @@ import type {
   BulkUnlinkResult,
   SkillName,
 } from '@/shared/types'
-import { tombstoneId } from '@/shared/types'
+import { toSkillCount, toSymlinkCount, tombstoneId } from '@/shared/types'
 
 import {
   computeRangeSelection,
@@ -21,8 +21,8 @@ describe('getToolbarState', () => {
     const result = getToolbarState({
       view: 'global',
       agentId: null,
-      count: 1,
-      visibleCount: 1,
+      count: toSkillCount(1),
+      visibleCount: toSkillCount(1),
     })
 
     // Assert
@@ -37,8 +37,8 @@ describe('getToolbarState', () => {
     const result = getToolbarState({
       view: 'global',
       agentId: null,
-      count: 7,
-      visibleCount: 7,
+      count: toSkillCount(7),
+      visibleCount: toSkillCount(7),
     })
 
     // Assert
@@ -53,8 +53,8 @@ describe('getToolbarState', () => {
     const result = getToolbarState({
       view: 'agent',
       agentId: 'cursor',
-      count: 1,
-      visibleCount: 1,
+      count: toSkillCount(1),
+      visibleCount: toSkillCount(1),
     })
 
     // Assert
@@ -68,8 +68,8 @@ describe('getToolbarState', () => {
     const result = getToolbarState({
       view: 'agent',
       agentId: 'cursor',
-      count: 1,
-      visibleCount: 1,
+      count: toSkillCount(1),
+      visibleCount: toSkillCount(1),
       agentDisplayName: 'Cursor',
     })
 
@@ -83,8 +83,8 @@ describe('getToolbarState', () => {
     const result = getToolbarState({
       view: 'agent',
       agentId: 'cursor',
-      count: 4,
-      visibleCount: 4,
+      count: toSkillCount(4),
+      visibleCount: toSkillCount(4),
     })
 
     // Assert
@@ -98,8 +98,8 @@ describe('getToolbarState', () => {
     const result = getToolbarState({
       view: 'agent',
       agentId: 'cursor',
-      count: 4,
-      visibleCount: 4,
+      count: toSkillCount(4),
+      visibleCount: toSkillCount(4),
       agentDisplayName: 'Cursor',
     })
 
@@ -113,8 +113,8 @@ describe('getToolbarState', () => {
     const result = getToolbarState({
       view: 'global',
       agentId: null,
-      count: 5, // user has 5 selected globally
-      visibleCount: 0, // but search filter leaves none visible
+      count: toSkillCount(5), // user has 5 selected globally
+      visibleCount: toSkillCount(0), // but search filter leaves none visible
     })
 
     // Assert
@@ -129,8 +129,8 @@ describe('getToolbarState', () => {
     const result = getToolbarState({
       view: 'agent',
       agentId: 'cursor',
-      count: 3,
-      visibleCount: 0,
+      count: toSkillCount(3),
+      visibleCount: toSkillCount(0),
       agentDisplayName: 'Cursor',
     })
 
@@ -148,8 +148,8 @@ describe('getToolbarState', () => {
     const result = getToolbarState({
       view: 'global',
       agentId: null,
-      count: 5,
-      visibleCount: 2,
+      count: toSkillCount(5),
+      visibleCount: toSkillCount(2),
     })
 
     // Assert
@@ -170,13 +170,13 @@ describe('countOrphanSymlinksRemoved', () => {
         {
           skillName: 'abandoned',
           outcome: 'orphan-cleared',
-          symlinksRemoved: 2,
+          symlinksRemoved: toSymlinkCount(2),
           cascadeAgents: ['cursor'],
         },
         {
           skillName: 'half-cleared',
           outcome: 'error',
-          symlinksRemoved: 1,
+          symlinksRemoved: toSymlinkCount(1),
           cascadeAgents: ['claude-code'],
           error: { message: 'EACCES', code: 'EACCES' },
         },
@@ -199,7 +199,7 @@ describe('countOrphanSymlinksRemoved', () => {
           skillName: 'task',
           outcome: 'deleted',
           tombstoneId: tombstoneId('1-task-aaaa'),
-          symlinksRemoved: 5,
+          symlinksRemoved: toSymlinkCount(5),
           cascadeAgents: ['cursor'],
         },
         {
@@ -227,14 +227,14 @@ describe('formatCascadeSummary', () => {
           skillName: 'task',
           outcome: 'deleted',
           tombstoneId: tombstoneId('1-task-aaaa'),
-          symlinksRemoved: 2,
+          symlinksRemoved: toSymlinkCount(2),
           cascadeAgents: ['cursor', 'claude-code'],
         },
         {
           skillName: 'theme-generator',
           outcome: 'deleted',
           tombstoneId: tombstoneId('1-theme-generator-bbbb'),
-          symlinksRemoved: 1,
+          symlinksRemoved: toSymlinkCount(1),
           cascadeAgents: ['cursor'],
         },
       ],
@@ -255,7 +255,7 @@ describe('formatCascadeSummary', () => {
           skillName: 'task',
           outcome: 'deleted',
           tombstoneId: tombstoneId('1-task-aaaa'),
-          symlinksRemoved: 1,
+          symlinksRemoved: toSymlinkCount(1),
           cascadeAgents: [],
         },
         {
@@ -281,7 +281,7 @@ describe('formatCascadeSummary', () => {
           skillName: 'task',
           outcome: 'deleted',
           tombstoneId: tombstoneId('1-task-aaaa'),
-          symlinksRemoved: 0,
+          symlinksRemoved: toSymlinkCount(0),
           cascadeAgents: [],
         },
       ],
@@ -302,7 +302,7 @@ describe('formatCascadeSummary', () => {
           skillName: 'task',
           outcome: 'deleted',
           tombstoneId: tombstoneId('1-task-aaaa'),
-          symlinksRemoved: 1,
+          symlinksRemoved: toSymlinkCount(1),
           cascadeAgents: [],
         },
       ],
@@ -326,13 +326,13 @@ describe('formatCascadeSummary', () => {
           skillName: 'task',
           outcome: 'deleted',
           tombstoneId: tombstoneId('1-task-aaaa'),
-          symlinksRemoved: 1,
+          symlinksRemoved: toSymlinkCount(1),
           cascadeAgents: ['cursor'],
         },
         {
           skillName: 'abandoned',
           outcome: 'orphan-cleared',
-          symlinksRemoved: 2,
+          symlinksRemoved: toSymlinkCount(2),
           cascadeAgents: ['cursor', 'codex'],
         },
       ],
@@ -359,13 +359,13 @@ describe('formatCascadeSummary', () => {
         {
           skillName: 'abandoned-a',
           outcome: 'orphan-cleared',
-          symlinksRemoved: 1,
+          symlinksRemoved: toSymlinkCount(1),
           cascadeAgents: ['cursor'],
         },
         {
           skillName: 'abandoned-b',
           outcome: 'orphan-cleared',
-          symlinksRemoved: 3,
+          symlinksRemoved: toSymlinkCount(3),
           cascadeAgents: ['cursor', 'codex', 'claude-code'],
         },
       ],
@@ -387,7 +387,7 @@ describe('formatCascadeSummary', () => {
         {
           skillName: 'abandoned',
           outcome: 'orphan-cleared',
-          symlinksRemoved: 2,
+          symlinksRemoved: toSymlinkCount(2),
           cascadeAgents: ['cursor', 'codex'],
         },
         {
@@ -415,7 +415,7 @@ describe('formatCascadeSummary', () => {
           skillName: 'abandoned',
           outcome: 'error',
           error: { message: 'Source skill exists', code: 'ESTALE' },
-          symlinksRemoved: 2,
+          symlinksRemoved: toSymlinkCount(2),
           cascadeAgents: ['codex', 'cursor'],
         },
       ],

--- a/src/renderer/src/components/skills/bulkDeleteHelpers.ts
+++ b/src/renderer/src/components/skills/bulkDeleteHelpers.ts
@@ -11,6 +11,7 @@ import type {
   SkillName,
   SymlinkCount,
 } from '@/shared/types'
+import { toSymlinkCount } from '@/shared/types'
 
 /**
  * Which toolbar variant is rendering:
@@ -86,7 +87,9 @@ export const getToolbarState = ({
   // filter, while the adjacent selection summary owns the total hidden count.
   const actionCount = visibleCount
   // ToolbarCountKind exhaustively buckets every visible count into zero, single, or multi copy.
-  const countKind: ToolbarCountKind = match(actionCount)
+  // Matched as `number`, not SkillCount: ts-pattern narrows a branded operand to
+  // `never` after the first `.with`, which kills the 0 / 1 literal arms.
+  const countKind: ToolbarCountKind = match<number>(actionCount)
     .with(0, () => 'zero' as const)
     .with(1, () => 'single' as const)
     .with(P.number, () => 'multi' as const)
@@ -162,14 +165,16 @@ export const getToolbarState = ({
 export const countOrphanSymlinksRemoved = (
   result: BulkDeleteResult,
 ): SymlinkCount =>
-  result.items.reduce((total, item) => {
-    if (item.outcome === 'orphan-cleared') return total + item.symlinksRemoved
-    if (item.outcome === 'error' && item.cascadeAgents) {
-      /* v8 ignore next -- error rows always include symlinksRemoved when cascadeAgents is set; the main-process spread couples them (`cascadeAgents.length > 0 ? { symlinksRemoved, cascadeAgents } : {}`), so no normal app flow leaves symlinksRemoved undefined here and this `?? 0` fallback never executes */
-      return total + (item.symlinksRemoved ?? 0)
-    }
-    return total
-  }, 0)
+  toSymlinkCount(
+    result.items.reduce((total, item) => {
+      if (item.outcome === 'orphan-cleared') return total + item.symlinksRemoved
+      if (item.outcome === 'error' && item.cascadeAgents) {
+        /* v8 ignore next -- error rows always include symlinksRemoved when cascadeAgents is set; the main-process spread couples them (`cascadeAgents.length > 0 ? { symlinksRemoved, cascadeAgents } : {}`), so no normal app flow leaves symlinksRemoved undefined here and this `?? 0` fallback never executes */
+        return total + (item.symlinksRemoved ?? 0)
+      }
+      return total
+    }, 0),
+  )
 
 /**
  * Build the summary string shown in the toast body after a bulk DELETE.

--- a/src/renderer/src/components/skills/copyToAgentsWithToast.test.ts
+++ b/src/renderer/src/components/skills/copyToAgentsWithToast.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { copyToAgents } from '@/renderer/src/redux/slices/skillsSlice'
 import type { AbsolutePath, Skill, SkillName } from '@/shared/types'
+import { toSymlinkCount } from '@/shared/types'
 
 // `copyToAgentsWithToast` is the shared "dispatch → match-fulfilled →
 // 3-branch toast → refreshAllData" helper used by AddSymlinkModal and
@@ -45,7 +46,7 @@ function makeSkill(name: SkillName = 'tdd-workflow'): Skill {
     name,
     description: `${name} description`,
     path: `/Users/test/.agents/skills/${name}`,
-    symlinkCount: 0,
+    symlinkCount: toSymlinkCount(0),
     symlinks: [],
     isSource: true,
     isOrphan: false,

--- a/src/renderer/src/components/skills/filePreviewLanguage.test.ts
+++ b/src/renderer/src/components/skills/filePreviewLanguage.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
+import { toFileExtension, toFileName } from '@/shared/types'
+
 import {
   isMarkdownPreview,
   languageForPreview,
@@ -38,15 +40,21 @@ describe('filePreviewLanguage', () => {
   it('highlights a preview file with the Shiki language that matches its extension', () => {
     // Arrange — known preview files spanning TS, TSX, JS, and JSON.
     // Act
-    const tsLanguage = languageForPreview({ name: 'file.ts', extension: '.ts' })
-    const tsxLanguage = languageForPreview({
-      name: 'file.tsx',
-      extension: '.tsx',
+    const tsLanguage = languageForPreview({
+      name: toFileName('file.ts'),
+      extension: toFileExtension('.ts'),
     })
-    const jsLanguage = languageForPreview({ name: 'file.js', extension: '.js' })
+    const tsxLanguage = languageForPreview({
+      name: toFileName('file.tsx'),
+      extension: toFileExtension('.tsx'),
+    })
+    const jsLanguage = languageForPreview({
+      name: toFileName('file.js'),
+      extension: toFileExtension('.js'),
+    })
     const jsonLanguage = languageForPreview({
-      name: 'file.json',
-      extension: '.json',
+      name: toFileName('file.json'),
+      extension: toFileExtension('.json'),
     })
 
     // Assert
@@ -60,8 +68,8 @@ describe('filePreviewLanguage', () => {
     // Arrange — a preview file with an extension Shiki does not recognize.
     // Act
     const language = languageForPreview({
-      name: 'notes.custom',
-      extension: '.custom',
+      name: toFileName('notes.custom'),
+      extension: toFileExtension('.custom'),
     })
 
     // Assert
@@ -71,7 +79,10 @@ describe('filePreviewLanguage', () => {
   it('highlights an extensionless Makefile with Make syntax', () => {
     // Arrange — a Makefile has no extension, so the language must come from its name.
     // Act
-    const language = languageForPreview({ name: 'Makefile', extension: '' })
+    const language = languageForPreview({
+      name: toFileName('Makefile'),
+      extension: toFileExtension(''),
+    })
 
     // Assert
     expect(language).toBe('make')
@@ -81,8 +92,8 @@ describe('filePreviewLanguage', () => {
     // Arrange — a Dockerfile has no extension, so the language must come from its name.
     // Act
     const language = languageForPreview({
-      name: 'Dockerfile',
-      extension: '',
+      name: toFileName('Dockerfile'),
+      extension: toFileExtension(''),
     })
 
     // Assert
@@ -95,40 +106,52 @@ describe('filePreviewLanguage', () => {
     // look-alikes (.tsx, a ".md.txt" name, and missing/null/undefined
     // extensions that should NOT be Markdown).
     // Act
-    const dotMd = isMarkdownPreview({ name: 'SKILL.md', extension: '.md' })
+    const dotMd = isMarkdownPreview({
+      name: toFileName('SKILL.md'),
+      extension: '.md',
+    })
     const dotMarkdown = isMarkdownPreview({
-      name: 'README.markdown',
+      name: toFileName('README.markdown'),
       extension: '.markdown',
     })
     const dotMdown = isMarkdownPreview({
-      name: 'README.mdown',
+      name: toFileName('README.mdown'),
       extension: '.mdown',
     })
-    const upperDotMd = isMarkdownPreview({ name: 'SKILL.MD', extension: '.MD' })
-    const mixedDotMd = isMarkdownPreview({ name: 'Skill.Md', extension: '.Md' })
-    const bareMd = isMarkdownPreview({ name: 'SKILL.md', extension: 'md' })
+    const upperDotMd = isMarkdownPreview({
+      name: toFileName('SKILL.MD'),
+      extension: '.MD',
+    })
+    const mixedDotMd = isMarkdownPreview({
+      name: toFileName('Skill.Md'),
+      extension: '.Md',
+    })
+    const bareMd = isMarkdownPreview({
+      name: toFileName('SKILL.md'),
+      extension: 'md',
+    })
     const extensionlessReadme = isMarkdownPreview({
-      name: 'README',
+      name: toFileName('README'),
       extension: '',
     })
     const tsxFile = isMarkdownPreview({
-      name: 'component.tsx',
+      name: toFileName('component.tsx'),
       extension: '.tsx',
     })
     const mdDotTxtFile = isMarkdownPreview({
-      name: 'readme.md.txt',
+      name: toFileName('readme.md.txt'),
       extension: '.txt',
     })
     const extensionlessNotes = isMarkdownPreview({
-      name: 'notes',
+      name: toFileName('notes'),
       extension: '',
     })
     const nullExtensionNotes = isMarkdownPreview({
-      name: 'notes',
+      name: toFileName('notes'),
       extension: null,
     })
     const undefinedExtensionNotes = isMarkdownPreview({
-      name: 'notes',
+      name: toFileName('notes'),
       extension: undefined,
     })
 

--- a/src/renderer/src/components/skills/reviewedDestructiveTargets.test.ts
+++ b/src/renderer/src/components/skills/reviewedDestructiveTargets.test.ts
@@ -5,6 +5,7 @@ import type {
   Skill,
   SymlinkInfo,
 } from '@/shared/types'
+import { toFileSizeBytes, toSymlinkCount } from '@/shared/types'
 
 import {
   buildAgentUnlinkTargets,
@@ -23,7 +24,7 @@ function makeSkill(name: string, symlinks: SymlinkInfo[]): Skill {
     name,
     description: 'desc',
     path: '/Users/me/.agents/skills/task',
-    symlinkCount: 0,
+    symlinkCount: toSymlinkCount(0),
     symlinks,
     isSource: true,
     isOrphan: false,
@@ -126,7 +127,7 @@ describe('partitionGlobalDeleteTargets — protected names', () => {
       name: 'task',
       description: 'desc',
       path: '/Users/me/.agents/skills/task',
-      symlinkCount: 0,
+      symlinkCount: toSymlinkCount(0),
       symlinks: [],
       isSource: true,
       isOrphan: false,
@@ -164,7 +165,7 @@ describe('partitionGlobalDeleteTargets — protected names', () => {
       name: 'abandoned',
       description: 'desc',
       path: '/Users/me/.agents/skills/abandoned',
-      symlinkCount: 0,
+      symlinkCount: toSymlinkCount(0),
       symlinks: [
         {
           agentId: 'codex',
@@ -201,7 +202,7 @@ describe('partitionGlobalDeleteTargets — protected names', () => {
       kind: 'directory',
       dev: 1,
       ino: 2,
-      size: 96,
+      size: toFileSizeBytes(96),
       ctimeMs: 3,
       mtimeMs: 4,
     }
@@ -210,7 +211,7 @@ describe('partitionGlobalDeleteTargets — protected names', () => {
         name: 'locked',
         description: 'desc',
         path: '/Users/me/.agents/skills/locked',
-        symlinkCount: 0,
+        symlinkCount: toSymlinkCount(0),
         symlinks: [],
         isSource: true,
         isOrphan: false,
@@ -220,7 +221,7 @@ describe('partitionGlobalDeleteTargets — protected names', () => {
         description: 'desc',
         path: '/Users/me/.agents/skills/unlocked',
         filesystemIdentity: identity,
-        symlinkCount: 0,
+        symlinkCount: toSymlinkCount(0),
         symlinks: [],
         isSource: true,
         isOrphan: false,
@@ -253,7 +254,7 @@ describe('partitionGlobalDeleteTargets', () => {
       name: 'abandoned',
       description: 'desc',
       path: '/Users/me/.agents/skills/abandoned',
-      symlinkCount: 0,
+      symlinkCount: toSymlinkCount(0),
       symlinks: [
         {
           agentId: 'codex',

--- a/src/renderer/src/components/skills/sourceLinkHelpers.test.ts
+++ b/src/renderer/src/components/skills/sourceLinkHelpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { repositoryId } from '@/shared/types'
+import { repositoryId, toHttpUrl } from '@/shared/types'
 
 import { getSourceLinkModel } from './sourceLinkHelpers'
 
@@ -18,7 +18,10 @@ describe('getSourceLinkModel', () => {
     it('still marks a skill as local when a sourceUrl exists but the source repo is missing', () => {
       // Arrange — a stray sourceUrl with no owning source repo.
       // Act
-      const model = getSourceLinkModel(undefined, 'https://github.com/x/y')
+      const model = getSourceLinkModel(
+        undefined,
+        toHttpUrl('https://github.com/x/y'),
+      )
 
       // Assert
       expect(model).toEqual({ kind: 'local' })
@@ -50,7 +53,10 @@ describe('getSourceLinkModel', () => {
     it('shows the source repo as plain text when the URL is an empty string', () => {
       // Arrange — a source repo id with an empty URL.
       // Act
-      const model = getSourceLinkModel(repositoryId('pbakaus/impeccable'), '')
+      const model = getSourceLinkModel(
+        repositoryId('pbakaus/impeccable'),
+        toHttpUrl(''),
+      )
 
       // Assert
       expect(model).toEqual({
@@ -66,7 +72,7 @@ describe('getSourceLinkModel', () => {
       // Act
       const model = getSourceLinkModel(
         repositoryId('pbakaus/impeccable'),
-        'https://github.com/pbakaus/impeccable.git',
+        toHttpUrl('https://github.com/pbakaus/impeccable.git'),
       )
 
       // Assert
@@ -82,7 +88,7 @@ describe('getSourceLinkModel', () => {
       // Act
       const model = getSourceLinkModel(
         repositoryId('pbakaus/impeccable'),
-        'https://github.com/pbakaus/impeccable',
+        toHttpUrl('https://github.com/pbakaus/impeccable'),
       )
 
       // Assert
@@ -98,7 +104,7 @@ describe('getSourceLinkModel', () => {
       // Act
       const model = getSourceLinkModel(
         repositoryId('foo/bar.git-assets'),
-        'https://github.com/foo/bar.git-assets',
+        toHttpUrl('https://github.com/foo/bar.git-assets'),
       )
 
       // Assert

--- a/src/renderer/src/components/skills/sourceLinkHelpers.ts
+++ b/src/renderer/src/components/skills/sourceLinkHelpers.ts
@@ -1,4 +1,5 @@
 import type { HttpUrl, RepositoryId } from '@/shared/types'
+import { toHttpUrl } from '@/shared/types'
 
 /**
  * Discriminated render model for `SourceLink`.
@@ -40,5 +41,5 @@ export function getSourceLinkModel(
   if (!source) return { kind: 'local' }
   const href = sourceUrl ? sourceUrl.replace(/\.git$/, '') : undefined
   if (!href) return { kind: 'text', source }
-  return { kind: 'link', source, href }
+  return { kind: 'link', source, href: toHttpUrl(href) }
 }

--- a/src/renderer/src/hooks/useCodePreview.browser.test.tsx
+++ b/src/renderer/src/hooks/useCodePreview.browser.test.tsx
@@ -6,6 +6,15 @@ import type {
   SkillFile,
   SkillFileContent,
 } from '@/shared/types'
+import {
+  toDataUrl,
+  toFileExtension,
+  toFileName,
+  toFileSizeBytes,
+  toLineCount,
+  toMimeType,
+  toPosixRelativePath,
+} from '@/shared/types'
 
 const listMock = vi.fn<(skillPath: string) => Promise<SkillFile[]>>()
 const readMock = vi.fn<(filePath: string) => Promise<SkillFileContent | null>>()
@@ -20,11 +29,11 @@ const readBinaryMock =
  */
 function makeFile(overrides: Partial<SkillFile> = {}): SkillFile {
   return {
-    name: 'SKILL.md',
+    name: toFileName('SKILL.md'),
     path: '/skills/tdd/SKILL.md',
-    relativePath: 'SKILL.md',
-    extension: '.md',
-    size: 100,
+    relativePath: toPosixRelativePath('SKILL.md'),
+    extension: toFileExtension('.md'),
+    size: toFileSizeBytes(100),
     previewable: 'text',
     ...overrides,
   }
@@ -39,10 +48,10 @@ function makeTextContent(
   overrides: Partial<SkillFileContent> = {},
 ): SkillFileContent {
   return {
-    name: 'SKILL.md',
+    name: toFileName('SKILL.md'),
     content: 'hello',
-    extension: '.md',
-    lineCount: 1,
+    extension: toFileExtension('.md'),
+    lineCount: toLineCount(1),
     ...overrides,
   }
 }
@@ -113,12 +122,15 @@ describe('useCodePreview', () => {
     // Arrange
     const first = makeFile()
     const second = makeFile({
-      name: 'notes.md',
+      name: toFileName('notes.md'),
       path: '/skills/tdd/notes.md',
-      relativePath: 'notes.md',
+      relativePath: toPosixRelativePath('notes.md'),
     })
     const firstBody = makeTextContent()
-    const secondBody = makeTextContent({ name: 'notes.md', content: 'notes' })
+    const secondBody = makeTextContent({
+      name: toFileName('notes.md'),
+      content: 'notes',
+    })
     listMock.mockResolvedValue([first, second])
     readMock.mockImplementation(async (p) =>
       p === first.path ? firstBody : secondBody,
@@ -199,11 +211,14 @@ describe('useCodePreview', () => {
     // Arrange
     const first = makeFile()
     const second = makeFile({
-      name: 'notes.md',
+      name: toFileName('notes.md'),
       path: '/skills/tdd/notes.md',
-      relativePath: 'notes.md',
+      relativePath: toPosixRelativePath('notes.md'),
     })
-    const secondBody = makeTextContent({ name: 'notes.md', content: 'notes' })
+    const secondBody = makeTextContent({
+      name: toFileName('notes.md'),
+      content: 'notes',
+    })
 
     listMock.mockResolvedValue([first, second])
 
@@ -259,17 +274,20 @@ describe('useCodePreview', () => {
     // Arrange
     const first = makeFile()
     const second = makeFile({
-      name: 'notes.md',
+      name: toFileName('notes.md'),
       path: '/skills/tdd/notes.md',
-      relativePath: 'notes.md',
+      relativePath: toPosixRelativePath('notes.md'),
     })
     const third = makeFile({
-      name: 'other.md',
+      name: toFileName('other.md'),
       path: '/skills/tdd/other.md',
-      relativePath: 'other.md',
+      relativePath: toPosixRelativePath('other.md'),
     })
     const firstBody = makeTextContent()
-    const thirdBody = makeTextContent({ name: 'other.md', content: 'third' })
+    const thirdBody = makeTextContent({
+      name: toFileName('other.md'),
+      content: 'third',
+    })
     listMock.mockResolvedValue([first, second, third])
 
     // read(first) resolves normally for the initial auto-select.
@@ -321,7 +339,9 @@ describe('useCodePreview', () => {
     // Act
     // Now resolve the hanging read(second). Guard must drop its result.
     await act(async () => {
-      resolveSecond?.(makeTextContent({ name: 'notes.md', content: 'stale' }))
+      resolveSecond?.(
+        makeTextContent({ name: toFileName('notes.md'), content: 'stale' }),
+      )
       await slowPromise
     })
 
@@ -334,12 +354,12 @@ describe('useCodePreview', () => {
     // Arrange
     const fileA = makeFile({
       path: '/skills/a/SKILL.md',
-      relativePath: 'SKILL.md',
+      relativePath: toPosixRelativePath('SKILL.md'),
     })
     const fileB = makeFile({
-      name: 'b.md',
+      name: toFileName('b.md'),
       path: '/skills/b/SKILL.md',
-      relativePath: 'SKILL.md',
+      relativePath: toPosixRelativePath('SKILL.md'),
     })
     const bodyA = makeTextContent({ content: 'A' })
     const bodyB = makeTextContent({ content: 'B' })
@@ -403,9 +423,9 @@ describe('useCodePreview', () => {
     // bar the user can still click through.
     const first = makeFile()
     const second = makeFile({
-      name: 'notes.md',
+      name: toFileName('notes.md'),
       path: '/skills/tdd/notes.md',
-      relativePath: 'notes.md',
+      relativePath: toPosixRelativePath('notes.md'),
     })
     listMock.mockResolvedValue([first, second])
     readMock.mockRejectedValue(new Error('EIO'))
@@ -425,10 +445,10 @@ describe('useCodePreview', () => {
   test('keeps the tab list usable when an image read rejects after the list loaded', async () => {
     // Arrange -- same contract on the binary branch of loadContentForFile.
     const image = makeFile({
-      name: 'logo.png',
+      name: toFileName('logo.png'),
       path: '/skills/tdd/logo.png',
-      relativePath: 'logo.png',
-      extension: '.png',
+      relativePath: toPosixRelativePath('logo.png'),
+      extension: toFileExtension('.png'),
       previewable: 'image',
     })
     listMock.mockResolvedValue([image])
@@ -451,11 +471,14 @@ describe('useCodePreview', () => {
     // failure lands after the user is already looking at `second`.
     const first = makeFile()
     const second = makeFile({
-      name: 'notes.md',
+      name: toFileName('notes.md'),
       path: '/skills/tdd/notes.md',
-      relativePath: 'notes.md',
+      relativePath: toPosixRelativePath('notes.md'),
     })
-    const secondBody = makeTextContent({ name: 'notes.md', content: 'notes' })
+    const secondBody = makeTextContent({
+      name: toFileName('notes.md'),
+      content: 'notes',
+    })
 
     listMock.mockResolvedValue([first, second])
 
@@ -511,9 +534,9 @@ describe('useCodePreview', () => {
     // old content would caption `first`'s text with `second`'s tab.
     const first = makeFile()
     const second = makeFile({
-      name: 'notes.md',
+      name: toFileName('notes.md'),
       path: '/skills/tdd/notes.md',
-      relativePath: 'notes.md',
+      relativePath: toPosixRelativePath('notes.md'),
     })
     const firstBody = makeTextContent()
     listMock.mockResolvedValue([first, second])
@@ -546,10 +569,10 @@ describe('useCodePreview', () => {
     // Arrange -- same contract on the binary branch of loadContentForFile.
     const first = makeFile()
     const image = makeFile({
-      name: 'logo.png',
+      name: toFileName('logo.png'),
       path: '/skills/tdd/logo.png',
-      relativePath: 'logo.png',
-      extension: '.png',
+      relativePath: toPosixRelativePath('logo.png'),
+      extension: toFileExtension('.png'),
       previewable: 'image',
     })
     const firstBody = makeTextContent()
@@ -677,17 +700,17 @@ describe('useCodePreview', () => {
   it('previews an image file through the binary reader without calling the text reader', async () => {
     // Arrange
     const image = makeFile({
-      name: 'logo.png',
+      name: toFileName('logo.png'),
       path: '/skills/tdd/logo.png',
-      relativePath: 'logo.png',
-      extension: '.png',
+      relativePath: toPosixRelativePath('logo.png'),
+      extension: toFileExtension('.png'),
       previewable: 'image',
     })
     const binary: SkillBinaryContent = {
-      name: 'logo.png',
-      dataUrl: 'data:image/png;base64,AAA',
-      mimeType: 'image/png',
-      size: 10,
+      name: toFileName('logo.png'),
+      dataUrl: toDataUrl('data:image/png;base64,AAA'),
+      mimeType: toMimeType('image/png'),
+      size: toFileSizeBytes(10),
     }
     listMock.mockResolvedValue([image])
     readBinaryMock.mockResolvedValue(binary)
@@ -706,11 +729,11 @@ describe('useCodePreview', () => {
   it('shows a placeholder instead of reading content for an oversized file', async () => {
     // Arrange
     const big = makeFile({
-      name: 'dump.bin',
+      name: toFileName('dump.bin'),
       path: '/skills/tdd/dump.bin',
-      relativePath: 'dump.bin',
-      extension: '.bin',
-      size: 999_999,
+      relativePath: toPosixRelativePath('dump.bin'),
+      extension: toFileExtension('.bin'),
+      size: toFileSizeBytes(999_999),
       previewable: 'binary',
     })
     listMock.mockResolvedValue([big])
@@ -734,16 +757,16 @@ describe('useCodePreview', () => {
   it('drops the abandoned skill files when the user switches skills before the first list resolves', async () => {
     // Arrange
     const fileA = makeFile({
-      name: 'a.md',
+      name: toFileName('a.md'),
       path: '/skills/a/a.md',
-      relativePath: 'a.md',
+      relativePath: toPosixRelativePath('a.md'),
     })
     const fileB = makeFile({
-      name: 'b.md',
+      name: toFileName('b.md'),
       path: '/skills/b/b.md',
-      relativePath: 'b.md',
+      relativePath: toPosixRelativePath('b.md'),
     })
-    const bodyB = makeTextContent({ name: 'b.md', content: 'B' })
+    const bodyB = makeTextContent({ name: toFileName('b.md'), content: 'B' })
 
     // Skill A's list() hangs on an external promise so its effect is still
     // mid-`await` when the user switches to skill B. Skill B resolves normally.
@@ -846,10 +869,10 @@ describe('useCodePreview', () => {
   it('shows an empty preview when an image file read returns null because the image vanished mid-load', async () => {
     // Arrange
     const image = makeFile({
-      name: 'logo.png',
+      name: toFileName('logo.png'),
       path: '/skills/tdd/logo.png',
-      relativePath: 'logo.png',
-      extension: '.png',
+      relativePath: toPosixRelativePath('logo.png'),
+      extension: toFileExtension('.png'),
       previewable: 'image',
     })
     listMock.mockResolvedValue([image])

--- a/src/renderer/src/hooks/useMarketplaceProgress.test.ts
+++ b/src/renderer/src/hooks/useMarketplaceProgress.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { InstallProgress } from '@/shared/types'
+import { toProgressPercent } from '@/shared/types'
 
 // The hook drives Redux through `useAppDispatch`; capturing dispatch lets us
 // assert the exact action emitted for each forwarded install-progress IPC event.
@@ -78,7 +79,7 @@ describe('useMarketplaceProgress', () => {
     const progress: InstallProgress = {
       phase: 'cloning',
       message: 'Cloning skill repository…',
-      percent: 42,
+      percent: toProgressPercent(42),
     }
 
     // Act — mount registers the listener, then a progress event arrives
@@ -107,7 +108,7 @@ describe('useMarketplaceProgress', () => {
     const complete: InstallProgress = {
       phase: 'complete',
       message: 'Installed',
-      percent: 100,
+      percent: toProgressPercent(100),
     }
 
     // Act — two sequential progress events arrive over the same subscription

--- a/src/renderer/src/hooks/useUpdateNotification.test.ts
+++ b/src/renderer/src/hooks/useUpdateNotification.test.ts
@@ -5,7 +5,12 @@ import type {
   UpdateErrorPayload,
   UpdateInfo,
 } from '@/shared/types'
-import { semanticVersion } from '@/shared/types'
+import {
+  semanticVersion,
+  toByteCount,
+  toBytesPerSecond,
+  toProgressPercent,
+} from '@/shared/types'
 
 // The hook drives Redux through `useAppDispatch`; capturing dispatch lets us
 // assert the exact action emitted for each forwarded auto-update IPC event.
@@ -178,10 +183,10 @@ describe('useUpdateNotification', () => {
     const apiStub = createUpdateApiStub()
     vi.stubGlobal('window', { electron: { update: apiStub.update } })
     const progress: DownloadProgress = {
-      percent: 45.2,
-      bytesPerSecond: 524288,
-      total: 10485760,
-      transferred: 4739174,
+      percent: toProgressPercent(45.2),
+      bytesPerSecond: toBytesPerSecond(524288),
+      total: toByteCount(10485760),
+      transferred: toByteCount(4739174),
     }
     const { useUpdateNotification } = await import('./useUpdateNotification')
 

--- a/src/renderer/src/lib/syncHelpers.test.ts
+++ b/src/renderer/src/lib/syncHelpers.test.ts
@@ -2,6 +2,7 @@ import { AlertTriangle, CheckCircle2, XCircle } from 'lucide-react'
 import { describe, expect, it } from 'vitest'
 
 import type { SyncExecuteResult, SyncPreviewResult } from '@/shared/types'
+import { toAgentCount, toSkillCount, toSymlinkCount } from '@/shared/types'
 
 import {
   getSyncResultPresentation,
@@ -15,9 +16,9 @@ function buildResult(
 ): SyncExecuteResult {
   return {
     success: true,
-    created: 0,
-    replaced: 0,
-    skipped: 0,
+    created: toSymlinkCount(0),
+    replaced: toSymlinkCount(0),
+    skipped: toSymlinkCount(0),
     errors: [],
     details: [],
     ...overrides,
@@ -29,10 +30,10 @@ function buildPreview(
   overrides: Partial<SyncPreviewResult> = {},
 ): SyncPreviewResult {
   return {
-    totalSkills: 5,
-    totalAgents: 10,
-    toCreate: 0,
-    alreadySynced: 0,
+    totalSkills: toSkillCount(5),
+    totalAgents: toAgentCount(10),
+    toCreate: toSymlinkCount(0),
+    alreadySynced: toSymlinkCount(0),
     conflicts: [],
     ...overrides,
   }
@@ -50,7 +51,7 @@ describe('shouldShowSyncConfirm', () => {
 
   it('opens the sync confirm dialog when there are new symlinks to create and no conflicts', () => {
     // Arrange
-    const preview = buildPreview({ toCreate: 8 })
+    const preview = buildPreview({ toCreate: toSymlinkCount(8) })
     // Act
     const shouldShow = shouldShowSyncConfirm(preview)
     // Assert
@@ -59,7 +60,10 @@ describe('shouldShowSyncConfirm', () => {
 
   it('keeps the sync confirm dialog hidden when everything is already synced', () => {
     // Arrange
-    const preview = buildPreview({ toCreate: 0, alreadySynced: 50 })
+    const preview = buildPreview({
+      toCreate: toSymlinkCount(0),
+      alreadySynced: toSymlinkCount(50),
+    })
     // Act
     const shouldShow = shouldShowSyncConfirm(preview)
     // Assert
@@ -69,7 +73,7 @@ describe('shouldShowSyncConfirm', () => {
   it('defers to the conflict dialog instead of the confirm dialog when conflicts exist', () => {
     // Arrange
     const preview = buildPreview({
-      toCreate: 3,
+      toCreate: toSymlinkCount(3),
       conflicts: [
         {
           skillName: 'test-skill',
@@ -87,7 +91,7 @@ describe('shouldShowSyncConfirm', () => {
 
   it('keeps the sync confirm dialog hidden when there is nothing to create and no conflicts', () => {
     // Arrange
-    const preview = buildPreview({ toCreate: 0, conflicts: [] })
+    const preview = buildPreview({ toCreate: toSymlinkCount(0), conflicts: [] })
     // Act
     const shouldShow = shouldShowSyncConfirm(preview)
     // Assert
@@ -109,9 +113,9 @@ describe('shouldShowSyncResult', () => {
     // Arrange
     const result: SyncExecuteResult = {
       success: true,
-      created: 3,
-      replaced: 0,
-      skipped: 2,
+      created: toSymlinkCount(3),
+      replaced: toSymlinkCount(0),
+      skipped: toSymlinkCount(2),
       errors: [],
       details: [
         { skillName: 'my-skill', agentName: 'Claude Code', action: 'created' },
@@ -127,9 +131,9 @@ describe('shouldShowSyncResult', () => {
     // Arrange
     const result: SyncExecuteResult = {
       success: false,
-      created: 0,
-      replaced: 0,
-      skipped: 0,
+      created: toSymlinkCount(0),
+      replaced: toSymlinkCount(0),
+      skipped: toSymlinkCount(0),
       errors: [{ path: '/test', error: 'fail' }],
       details: [
         {
@@ -162,7 +166,7 @@ describe('getSyncResultPresentation', () => {
 
   it('shows a green success state counting the symlinks created', () => {
     // Arrange
-    const createdOnlyResult = buildResult({ created: 3 })
+    const createdOnlyResult = buildResult({ created: toSymlinkCount(3) })
     // Act
     const { HeaderIcon, iconColor, description } =
       getSyncResultPresentation(createdOnlyResult)
@@ -174,7 +178,7 @@ describe('getSyncResultPresentation', () => {
 
   it('pluralizes "symlink" in the singular when exactly one was created', () => {
     // Arrange
-    const oneCreatedResult = buildResult({ created: 1 })
+    const oneCreatedResult = buildResult({ created: toSymlinkCount(1) })
     // Act
     const { description } = getSyncResultPresentation(oneCreatedResult)
     // Assert
@@ -183,7 +187,7 @@ describe('getSyncResultPresentation', () => {
 
   it('pluralizes "conflict" in the singular when exactly one was replaced', () => {
     // Arrange
-    const oneReplacedResult = buildResult({ replaced: 1 })
+    const oneReplacedResult = buildResult({ replaced: toSymlinkCount(1) })
     // Act
     const { description } = getSyncResultPresentation(oneReplacedResult)
     // Assert
@@ -193,8 +197,8 @@ describe('getSyncResultPresentation', () => {
   it('combines created, replaced, and failed counts into one comma-separated summary', () => {
     // Arrange
     const mixedResult = buildResult({
-      created: 2,
-      replaced: 3,
+      created: toSymlinkCount(2),
+      replaced: toSymlinkCount(3),
       errors: [{ path: '/a', error: 'x' }],
     })
     // Act
@@ -222,7 +226,7 @@ describe('getSyncResultPresentation', () => {
   it('shows an amber partial-failure state when some changes succeeded and some failed', () => {
     // Arrange
     const partialFailureResult = buildResult({
-      created: 2,
+      created: toSymlinkCount(2),
       errors: [{ path: '/a', error: 'boom' }],
     })
     // Act
@@ -236,7 +240,7 @@ describe('getSyncResultPresentation', () => {
   it('counts a replaced conflict as a success so it shows the amber partial state alongside errors', () => {
     // Arrange
     const replacedWithErrorResult = buildResult({
-      replaced: 1,
+      replaced: toSymlinkCount(1),
       errors: [{ path: '/a', error: 'boom' }],
     })
     // Act
@@ -250,7 +254,7 @@ describe('getSyncResultPresentation', () => {
 
   it('shows a green success state saying nothing changed when everything was already up to date', () => {
     // Arrange
-    const skippedOnlyResult = buildResult({ skipped: 5 })
+    const skippedOnlyResult = buildResult({ skipped: toSymlinkCount(5) })
     // Act
     const { HeaderIcon, iconColor, description } =
       getSyncResultPresentation(skippedOnlyResult)

--- a/src/renderer/src/redux/listener.lockRescan.test.ts
+++ b/src/renderer/src/redux/listener.lockRescan.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
 import { LOCK_RESCAN_GRACE_MS, UNDO_WINDOW_MS } from '@/shared/constants'
 import type { ToastId, TombstoneId } from '@/shared/types'
-import { tombstoneId } from '@/shared/types'
+import { toIsoTimestamp, tombstoneId } from '@/shared/types'
 
 /**
  * Integration tests for the post-delete lock rescan in listener.ts.
@@ -58,7 +58,9 @@ function undoToastPayload(kind: 'delete' | 'unlink', id: string) {
       kind === 'delete'
         ? [tombstoneId('1700000000000-old-skill-aaaaaaaa')]
         : ([] as TombstoneId[]),
-    expiresAt: new Date(Date.now() + UNDO_WINDOW_MS).toISOString(),
+    expiresAt: toIsoTimestamp(
+      new Date(Date.now() + UNDO_WINDOW_MS).toISOString(),
+    ),
     summary: 'Deleted 1 skill.',
   }
 }

--- a/src/renderer/src/redux/migrations.ts
+++ b/src/renderer/src/redux/migrations.ts
@@ -3,6 +3,10 @@ import type {
   WidgetType,
 } from '@/renderer/src/components/dashboard/types'
 import {
+  toGridColumnSpan,
+  toGridRowSpan,
+} from '@/renderer/src/components/dashboard/types'
+import {
   COLOR_PRESET_CHROMA,
   PERSIST_STATE_VERSION,
   THEME_PRESETS,
@@ -45,7 +49,7 @@ export interface MigratableState {
  * floor will silently violate the registry constraint after upgrade.
  */
 export const V2_WIDGET_MIN_SIZES = {
-  'quick-actions': { w: 3, h: 3 },
+  'quick-actions': { w: toGridColumnSpan(3), h: toGridRowSpan(3) },
 } as const satisfies Partial<Record<WidgetType, WidgetSize>>
 
 /**
@@ -57,7 +61,7 @@ export const V2_WIDGET_MIN_SIZES = {
  * here, AND ship a migration.
  */
 export const V4_WIDGET_MIN_SIZES = {
-  health: { w: 2, h: 3 },
+  health: { w: toGridColumnSpan(2), h: toGridRowSpan(3) },
 } as const satisfies Partial<Record<WidgetType, WidgetSize>>
 
 /**

--- a/src/renderer/src/redux/selectors.test.ts
+++ b/src/renderer/src/redux/selectors.test.ts
@@ -4,7 +4,12 @@ import type {
   ExcludableSkillTypeFilter,
   SkillTypeFilter,
 } from '@/renderer/src/redux/slices/uiSlice'
-import { repositoryId } from '@/shared/types'
+import {
+  repositoryId,
+  toHttpUrl,
+  toIsoTimestamp,
+  toSymlinkCount,
+} from '@/shared/types'
 import type {
   AgentId,
   BookmarkedSkill,
@@ -155,7 +160,7 @@ const makeSkill = (
   path: isLocal
     ? `/home/user/.${agentId}/skills/${name}`
     : `/home/user/.agents/skills/${name}`,
-  symlinkCount: isLocal || status === 'missing' ? 0 : 1,
+  symlinkCount: toSymlinkCount(isLocal || status === 'missing' ? 0 : 1),
   symlinks: [
     {
       agentId: agentId,
@@ -173,7 +178,7 @@ const makeSkill = (
   ...(source
     ? {
         source: repositoryId(source),
-        sourceUrl: `https://github.com/${source}.git`,
+        sourceUrl: toHttpUrl(`https://github.com/${source}.git`),
       }
     : {}),
 })
@@ -215,8 +220,9 @@ const makeMultiSlotSkill = (
     name,
     description: `${name} skill`,
     path: `/home/user/.agents/skills/${name}`,
-    symlinkCount: symlinks.filter((s) => s.status === 'valid' && !s.isLocal)
-      .length,
+    symlinkCount: toSymlinkCount(
+      symlinks.filter((s) => s.status === 'valid' && !s.isLocal).length,
+    ),
     symlinks,
     isSource: !options.isOrphan,
     isOrphan: options.isOrphan ?? false,
@@ -380,7 +386,7 @@ describe('selectFilteredSkills', () => {
       name: 'broken-skill',
       description: 'broken',
       path: '/home/user/.agents/skills/broken-skill',
-      symlinkCount: 1,
+      symlinkCount: toSymlinkCount(1),
       symlinks: [
         {
           agentId: 'cursor',
@@ -414,7 +420,7 @@ describe('selectFilteredSkills', () => {
       name: 'unlinked-skill',
       description: 'unlinked',
       path: '/home/user/.agents/skills/unlinked-skill',
-      symlinkCount: 0,
+      symlinkCount: toSymlinkCount(0),
       symlinks: [
         {
           agentId: 'cursor',
@@ -646,7 +652,7 @@ describe('selectFilteredSkills', () => {
       name: 'orphan-one',
       description: 'orphan',
       path: '/home/user/.agents/skills/orphan-one',
-      symlinkCount: 1,
+      symlinkCount: toSymlinkCount(1),
       symlinks: [
         {
           agentId: 'cursor',
@@ -687,7 +693,7 @@ describe('selectFilteredSkills', () => {
       name: 'orphan-agent-a',
       description: 'orphan stranded in agent A',
       path: '/home/user/.agents/skills/orphan-agent-a',
-      symlinkCount: 1,
+      symlinkCount: toSymlinkCount(1),
       symlinks: [
         {
           agentId: 'claude-code',
@@ -1189,8 +1195,8 @@ describe('selectFilteredSkills', () => {
 const makeBookmark = (name: string, repo: string): BookmarkedSkill => ({
   name,
   repo: repositoryId(repo),
-  url: `https://skills.sh/${name}`,
-  bookmarkedAt: '2026-04-01T00:00:00.000Z',
+  url: toHttpUrl(`https://skills.sh/${name}`),
+  bookmarkedAt: toIsoTimestamp('2026-04-01T00:00:00.000Z'),
 })
 
 describe('selectBookmarksWithInstallStatus', () => {

--- a/src/renderer/src/redux/selectors.ts
+++ b/src/renderer/src/redux/selectors.ts
@@ -15,6 +15,7 @@ import type {
   SkillName,
   SymlinkInfo,
 } from '@/shared/types'
+import { toSkillCount } from '@/shared/types'
 
 import { selectBookmarkItems } from './slices/bookmarkSlice'
 import { selectProtectedNamesSet } from './slices/protectSlice'
@@ -284,10 +285,13 @@ export const selectFilteredSkillCount = createSelector(
 export const selectRepoFacetOptions = createSelector(
   [selectVisibleByAgentAndType],
   (visibleByAgentAndType): RepoFacetOption[] => {
-    const sourceCounts = new Map<RepositoryId, number>()
+    const sourceCounts = new Map<RepositoryId, SkillCount>()
     for (const skill of visibleByAgentAndType) {
       if (!skill.source) continue
-      sourceCounts.set(skill.source, (sourceCounts.get(skill.source) ?? 0) + 1)
+      sourceCounts.set(
+        skill.source,
+        toSkillCount((sourceCounts.get(skill.source) ?? 0) + 1),
+      )
     }
     return [...sourceCounts.entries()]
       .sort(([sourceA], [sourceB]) => sourceA.localeCompare(sourceB))
@@ -419,8 +423,8 @@ export const selectSourceFilterViewModel = createSelector(
   [selectVisibleByAgentAndType, selectSelectedSources, selectRepoFacetOptions],
   (visibleSkills, selectedSources, facetOptions): SourceFilterViewModel => {
     const facetSourceSet = new Set(facetOptions.map((option) => option.source))
-    const countBySource = new Map<RepositoryId, number>(
-      facetOptions.map((option): [RepositoryId, number] => [
+    const countBySource = new Map<RepositoryId, SkillCount>(
+      facetOptions.map((option): [RepositoryId, SkillCount] => [
         option.source,
         option.count,
       ]),
@@ -438,7 +442,7 @@ export const selectSourceFilterViewModel = createSelector(
       .sort((a, b) => a.localeCompare(b))
       .map((source) => ({
         source,
-        count: countBySource.get(source) ?? 0,
+        count: countBySource.get(source) ?? toSkillCount(0),
         checked: selectedSet.has(source),
       }))
 
@@ -479,7 +483,7 @@ export const selectSourceFilterViewModel = createSelector(
         facetOptions.length > 0 &&
         facetOptions.every((option) => selectedSet.has(option.source)),
       hasNoRepositories: facetOptions.length === 0,
-      localHiddenCount,
+      localHiddenCount: toSkillCount(localHiddenCount),
     }
   },
 )

--- a/src/renderer/src/redux/slices/agentsSlice.test.ts
+++ b/src/renderer/src/redux/slices/agentsSlice.test.ts
@@ -2,6 +2,7 @@ import { configureStore } from '@reduxjs/toolkit'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { Agent } from '@/shared/types'
+import { toFileSizeBytes, toSkillCount } from '@/shared/types'
 
 const mockGetAll = vi.fn()
 const mockRemoveAllFromAgent = vi.fn()
@@ -10,7 +11,7 @@ const directoryIdentity = {
   kind: 'directory' as const,
   dev: 1,
   ino: 2,
-  size: 96,
+  size: toFileSizeBytes(96),
   ctimeMs: 3,
   mtimeMs: 4,
 }
@@ -64,8 +65,8 @@ const sampleAgent: Agent = {
   name: 'Claude Code',
   path: '/home/user/.claude/skills',
   exists: true,
-  skillCount: 3,
-  localSkillCount: 0,
+  skillCount: toSkillCount(3),
+  localSkillCount: toSkillCount(0),
   filesystemIdentity: directoryIdentity,
 }
 

--- a/src/renderer/src/redux/slices/bookmarkSlice.test.ts
+++ b/src/renderer/src/redux/slices/bookmarkSlice.test.ts
@@ -1,7 +1,7 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { describe, expect, it } from 'vitest'
 
-import { repositoryId } from '@/shared/types'
+import { repositoryId, toHttpUrl } from '@/shared/types'
 
 async function createTestStore() {
   const { default: bookmarkReducer } = await import('./bookmarkSlice')
@@ -30,7 +30,7 @@ describe('bookmarkSlice', () => {
       addBookmark({
         name: 'task',
         repo: repositoryId('vercel-labs/skills'),
-        url: 'https://skills.sh/task',
+        url: toHttpUrl('https://skills.sh/task'),
       }),
     )
 
@@ -53,7 +53,7 @@ describe('bookmarkSlice', () => {
       addBookmark({
         name: 'task',
         repo: repositoryId('vercel-labs/skills'),
-        url: 'https://skills.sh/task',
+        url: toHttpUrl('https://skills.sh/task'),
       }),
     )
 
@@ -69,7 +69,7 @@ describe('bookmarkSlice', () => {
     const payload = {
       name: 'task',
       repo: repositoryId('vercel-labs/skills'),
-      url: 'https://skills.sh/task',
+      url: toHttpUrl('https://skills.sh/task'),
     }
 
     // Act
@@ -90,14 +90,14 @@ describe('bookmarkSlice', () => {
       addBookmark({
         name: 'task',
         repo: repositoryId('vercel-labs/skills'),
-        url: 'https://skills.sh/task',
+        url: toHttpUrl('https://skills.sh/task'),
       }),
     )
     store.dispatch(
       addBookmark({
         name: 'tdd',
         repo: repositoryId('pbakaus/impeccable'),
-        url: 'https://skills.sh/tdd',
+        url: toHttpUrl('https://skills.sh/tdd'),
       }),
     )
 
@@ -113,14 +113,14 @@ describe('bookmarkSlice', () => {
       addBookmark({
         name: 'task',
         repo: repositoryId('vercel-labs/skills'),
-        url: 'https://skills.sh/task',
+        url: toHttpUrl('https://skills.sh/task'),
       }),
     )
     store.dispatch(
       addBookmark({
         name: 'tdd',
         repo: repositoryId('pbakaus/impeccable'),
-        url: 'https://skills.sh/tdd',
+        url: toHttpUrl('https://skills.sh/tdd'),
       }),
     )
 
@@ -141,7 +141,7 @@ describe('bookmarkSlice', () => {
       addBookmark({
         name: 'task',
         repo: repositoryId('vercel-labs/skills'),
-        url: 'https://skills.sh/task',
+        url: toHttpUrl('https://skills.sh/task'),
       }),
     )
 
@@ -162,7 +162,7 @@ describe('bookmarkSlice', () => {
       addBookmark({
         name: 'task',
         repo: repositoryId('vercel-labs/skills'),
-        url: 'https://skills.sh/task',
+        url: toHttpUrl('https://skills.sh/task'),
       }),
     )
 
@@ -180,7 +180,7 @@ describe('bookmarkSlice', () => {
       addBookmark({
         name: 'task',
         repo: repositoryId('vercel-labs/skills'),
-        url: 'https://skills.sh/task',
+        url: toHttpUrl('https://skills.sh/task'),
       }),
     )
 

--- a/src/renderer/src/redux/slices/bookmarkSlice.ts
+++ b/src/renderer/src/redux/slices/bookmarkSlice.ts
@@ -3,6 +3,7 @@ import { createSelector, createSlice } from '@reduxjs/toolkit'
 
 import type { RootState } from '@/renderer/src/redux/store'
 import type { BookmarkedSkill, SkillName } from '@/shared/types'
+import { toIsoTimestamp } from '@/shared/types'
 
 /**
  * Payload for the `addBookmark` action — every BookmarkedSkill field
@@ -41,7 +42,7 @@ const bookmarkSlice = createSlice({
       if (!exists) {
         state.items.push({
           ...action.payload,
-          bookmarkedAt: new Date().toISOString(),
+          bookmarkedAt: toIsoTimestamp(new Date().toISOString()),
         })
       }
     },

--- a/src/renderer/src/redux/slices/dashboardSlice.test.ts
+++ b/src/renderer/src/redux/slices/dashboardSlice.test.ts
@@ -6,6 +6,13 @@ import type {
   DashboardPageId,
   WidgetInstanceId,
 } from '@/renderer/src/components/dashboard/types'
+import {
+  toDashboardPageName,
+  toGridColumnSpan,
+  toGridColumnStart,
+  toGridRowSpan,
+  toGridRowStart,
+} from '@/renderer/src/components/dashboard/types'
 
 // Dynamic import keeps the slice out of the module graph until each test
 // needs it — matches the pattern established by `bookmarkSlice.test.ts` and
@@ -200,7 +207,7 @@ describe('dashboardSlice', () => {
       const { addWidget } = await import('./dashboardSlice')
       const firstPage: DashboardPage = {
         id: 'p_first' as DashboardPageId,
-        name: 'First',
+        name: toDashboardPageName('First'),
         widgets: [],
       }
       const store = await createTestStoreWithDashboard({
@@ -241,8 +248,20 @@ describe('dashboardSlice', () => {
         updateLayout({
           pageId: overviewPage.id,
           layout: [
-            { i: draggedWidget.id, x: 3, y: 5, w: 4, h: 2 },
-            { i: 'ghost_layout_id', x: 0, y: 0, w: 1, h: 1 },
+            {
+              i: draggedWidget.id,
+              x: toGridColumnStart(3),
+              y: toGridRowStart(5),
+              w: toGridColumnSpan(4),
+              h: toGridRowSpan(2),
+            },
+            {
+              i: 'ghost_layout_id',
+              x: toGridColumnStart(0),
+              y: toGridRowStart(0),
+              w: toGridColumnSpan(1),
+              h: toGridRowSpan(1),
+            },
           ],
         }),
       )
@@ -268,7 +287,15 @@ describe('dashboardSlice', () => {
       store.dispatch(
         updateLayout({
           pageId: overviewPage.id,
-          layout: [{ i: overviewPage.widgets[0].id, x: 9, y: 9, w: 1, h: 1 }],
+          layout: [
+            {
+              i: overviewPage.widgets[0].id,
+              x: toGridColumnStart(9),
+              y: toGridRowStart(9),
+              w: toGridColumnSpan(1),
+              h: toGridRowSpan(1),
+            },
+          ],
         }),
       )
 
@@ -296,7 +323,15 @@ describe('dashboardSlice', () => {
       store.dispatch(
         updateLayout({
           pageId: 'p_deleted_page' as DashboardPageId,
-          layout: [{ i: overviewBefore.widgets[0].id, x: 2, y: 2, w: 2, h: 2 }],
+          layout: [
+            {
+              i: overviewBefore.widgets[0].id,
+              x: toGridColumnStart(2),
+              y: toGridRowStart(2),
+              w: toGridColumnSpan(2),
+              h: toGridRowSpan(2),
+            },
+          ],
         }),
       )
 
@@ -421,7 +456,10 @@ describe('dashboardSlice', () => {
 
       // Act
       store.dispatch(
-        renamePage({ pageId: discoveryPage.id, name: 'Exploration' }),
+        renamePage({
+          pageId: discoveryPage.id,
+          name: toDashboardPageName('Exploration'),
+        }),
       )
 
       // Assert
@@ -469,7 +507,7 @@ describe('dashboardSlice', () => {
       const { addPage, removePage } = await import('./dashboardSlice')
       const store = await createTestStore()
       // Create a single page manually (skipping seed) to isolate the guard.
-      store.dispatch(addPage({ name: 'Solo' }))
+      store.dispatch(addPage({ name: toDashboardPageName('Solo') }))
       const solePage = store.getState().dashboard.pages[0]
 
       // Act
@@ -490,7 +528,7 @@ describe('dashboardSlice', () => {
       store.dispatch(
         renamePage({
           pageId: 'p_not_a_real_id' as DashboardPageId,
-          name: 'Renamed',
+          name: toDashboardPageName('Renamed'),
         }),
       )
 
@@ -562,7 +600,7 @@ describe('dashboardSlice', () => {
       const store = await createTestStore()
       store.dispatch(seedDefaultsIfEmpty())
       store.dispatch(toggleEditMode())
-      store.dispatch(addPage({ name: 'Custom' }))
+      store.dispatch(addPage({ name: toDashboardPageName('Custom') }))
       expect(store.getState().dashboard.pages.length).toBe(5)
       expect(store.getState().dashboard.isEditMode).toBe(true)
 

--- a/src/renderer/src/redux/slices/dashboardSlice.ts
+++ b/src/renderer/src/redux/slices/dashboardSlice.ts
@@ -13,6 +13,10 @@ import type {
   WidgetInstanceId,
   WidgetType,
 } from '@/renderer/src/components/dashboard/types'
+import {
+  toGridColumnStart,
+  toGridRowStart,
+} from '@/renderer/src/components/dashboard/types'
 import { findEmptySpot } from '@/renderer/src/components/dashboard/utils/findEmptySpot'
 import {
   newDashboardPageId,
@@ -167,8 +171,8 @@ const dashboardSlice = createSlice({
       const newWidget: WidgetInstance = {
         id: newWidgetInstanceId(),
         type: action.payload.type,
-        x: spot?.x ?? 0,
-        y: spot?.y ?? 0,
+        x: toGridColumnStart(spot?.x ?? 0),
+        y: toGridRowStart(spot?.y ?? 0),
         w: sizes.defaultSize.w,
         h: sizes.defaultSize.h,
       }

--- a/src/renderer/src/redux/slices/marketplaceSlice.test.ts
+++ b/src/renderer/src/redux/slices/marketplaceSlice.test.ts
@@ -1,7 +1,13 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { repositoryId } from '@/shared/types'
+import {
+  repositoryId,
+  toHttpUrl,
+  toProgressPercent,
+  toSearchQuery,
+  toSkillRank,
+} from '@/shared/types'
 import type { InstallProgress, SkillSearchResult } from '@/shared/types'
 
 const mockSearch = vi.fn()
@@ -28,10 +34,10 @@ async function createTestStore() {
 }
 
 const sampleResult: SkillSearchResult = {
-  rank: 1,
+  rank: toSkillRank(1),
   name: 'task',
   repo: repositoryId('vercel-labs/skill-task'),
-  url: 'https://skills.sh/vercel-labs/skill-task',
+  url: toHttpUrl('https://skills.sh/vercel-labs/skill-task'),
 }
 
 describe('marketplaceSlice', () => {
@@ -62,7 +68,7 @@ describe('marketplaceSlice', () => {
     const store = await createTestStore()
 
     // Act
-    store.dispatch(setMarketplaceSearchQuery('react'))
+    store.dispatch(setMarketplaceSearchQuery(toSearchQuery('react')))
 
     // Assert
     expect(store.getState().marketplace.searchQuery).toBe('react')
@@ -115,8 +121,8 @@ describe('marketplaceSlice', () => {
       await import('./marketplaceSlice')
     const store = await createTestStore()
     mockSearch.mockRejectedValue(new Error('fail'))
-    store.dispatch(setMarketplaceSearchQuery('test'))
-    await store.dispatch(searchSkills('test'))
+    store.dispatch(setMarketplaceSearchQuery(toSearchQuery('test')))
+    await store.dispatch(searchSkills(toSearchQuery('test')))
     expect(store.getState().marketplace.status).toBe('error')
 
     // Act
@@ -132,7 +138,7 @@ describe('marketplaceSlice', () => {
     const { setMarketplaceSearchQuery, clearSearchResults } =
       await import('./marketplaceSlice')
     const store = await createTestStore()
-    store.dispatch(setMarketplaceSearchQuery('react'))
+    store.dispatch(setMarketplaceSearchQuery(toSearchQuery('react')))
 
     // Act
     store.dispatch(clearSearchResults())
@@ -149,7 +155,7 @@ describe('marketplaceSlice', () => {
     const progress: InstallProgress = {
       phase: 'cloning',
       message: 'Cloning vercel-labs/skill-task',
-      percent: 40,
+      percent: toProgressPercent(40),
     }
 
     // Act + Assert — a progress update from the CLI surfaces in the panel
@@ -175,8 +181,8 @@ describe('marketplaceSlice', () => {
       await import('./marketplaceSlice')
 
     // Act
-    store.dispatch(setMarketplaceSearchQuery('react'))
-    const promise = store.dispatch(searchSkills('react'))
+    store.dispatch(setMarketplaceSearchQuery(toSearchQuery('react')))
+    const promise = store.dispatch(searchSkills(toSearchQuery('react')))
 
     // Assert
     expect(store.getState().marketplace.status).toBe('searching')
@@ -194,8 +200,8 @@ describe('marketplaceSlice', () => {
 
     // Act — the box holds the query before its results land (the real flow:
     // MarketplaceSearch commits the query, then dispatches the search).
-    store.dispatch(setMarketplaceSearchQuery('task'))
-    await store.dispatch(searchSkills('task'))
+    store.dispatch(setMarketplaceSearchQuery(toSearchQuery('task')))
+    await store.dispatch(searchSkills(toSearchQuery('task')))
 
     // Assert
     const state = store.getState().marketplace
@@ -212,8 +218,8 @@ describe('marketplaceSlice', () => {
       await import('./marketplaceSlice')
 
     // Act
-    store.dispatch(setMarketplaceSearchQuery('test'))
-    await store.dispatch(searchSkills('test'))
+    store.dispatch(setMarketplaceSearchQuery(toSearchQuery('test')))
+    await store.dispatch(searchSkills(toSearchQuery('test')))
 
     // Assert
     expect(store.getState().marketplace.status).toBe('error')
@@ -229,8 +235,8 @@ describe('marketplaceSlice', () => {
       await import('./marketplaceSlice')
 
     // Act
-    store.dispatch(setMarketplaceSearchQuery('test'))
-    await store.dispatch(searchSkills('test'))
+    store.dispatch(setMarketplaceSearchQuery(toSearchQuery('test')))
+    await store.dispatch(searchSkills(toSearchQuery('test')))
 
     // Assert
     expect(store.getState().marketplace.status).toBe('error')
@@ -265,10 +271,10 @@ describe('marketplaceSlice', () => {
 
     // Act — fire "rea", then "react" (the box now holds "react"). Resolve
     // "react" first, then let the stale "rea" response arrive afterwards.
-    store.dispatch(setMarketplaceSearchQuery('rea'))
-    const reaSearch = store.dispatch(searchSkills('rea'))
-    store.dispatch(setMarketplaceSearchQuery('react'))
-    const reactSearch = store.dispatch(searchSkills('react'))
+    store.dispatch(setMarketplaceSearchQuery(toSearchQuery('rea')))
+    const reaSearch = store.dispatch(searchSkills(toSearchQuery('rea')))
+    store.dispatch(setMarketplaceSearchQuery(toSearchQuery('react')))
+    const reactSearch = store.dispatch(searchSkills(toSearchQuery('react')))
     resolveReact([reactResult])
     await reactSearch
     resolveRea([reaResult])
@@ -302,10 +308,10 @@ describe('marketplaceSlice', () => {
       await import('./marketplaceSlice')
 
     // Act
-    store.dispatch(setMarketplaceSearchQuery('rea'))
-    const reaSearch = store.dispatch(searchSkills('rea'))
-    store.dispatch(setMarketplaceSearchQuery('react'))
-    const reactSearch = store.dispatch(searchSkills('react'))
+    store.dispatch(setMarketplaceSearchQuery(toSearchQuery('rea')))
+    const reaSearch = store.dispatch(searchSkills(toSearchQuery('rea')))
+    store.dispatch(setMarketplaceSearchQuery(toSearchQuery('react')))
+    const reactSearch = store.dispatch(searchSkills(toSearchQuery('react')))
     resolveReact([sampleResult])
     await reactSearch
     rejectRea(new Error('rea timed out'))
@@ -332,8 +338,8 @@ describe('marketplaceSlice', () => {
       await import('./marketplaceSlice')
 
     // Act — fire "react", clear the box, then let the response arrive.
-    store.dispatch(setMarketplaceSearchQuery('react'))
-    const search = store.dispatch(searchSkills('react'))
+    store.dispatch(setMarketplaceSearchQuery(toSearchQuery('react')))
+    const search = store.dispatch(searchSkills(toSearchQuery('react')))
     store.dispatch(clearSearchResults())
     resolveSearch([sampleResult])
     await search
@@ -352,8 +358,8 @@ describe('marketplaceSlice', () => {
     const store = await createTestStore()
     const { searchSkills, setMarketplaceSearchQuery, clearSearchResults } =
       await import('./marketplaceSlice')
-    store.dispatch(setMarketplaceSearchQuery('react'))
-    store.dispatch(searchSkills('react'))
+    store.dispatch(setMarketplaceSearchQuery(toSearchQuery('react')))
+    store.dispatch(searchSkills(toSearchQuery('react')))
     expect(store.getState().marketplace.status).toBe('searching')
 
     // Act
@@ -371,8 +377,8 @@ describe('marketplaceSlice', () => {
     const store = await createTestStore()
     const { searchSkills, setMarketplaceSearchQuery, clearSearchResults } =
       await import('./marketplaceSlice')
-    store.dispatch(setMarketplaceSearchQuery('react'))
-    await store.dispatch(searchSkills('react'))
+    store.dispatch(setMarketplaceSearchQuery(toSearchQuery('react')))
+    await store.dispatch(searchSkills(toSearchQuery('react')))
     expect(store.getState().marketplace.error).toBe('skills CLI offline')
 
     // Act — empty the box.

--- a/src/renderer/src/redux/slices/marketplaceSlice.ts
+++ b/src/renderer/src/redux/slices/marketplaceSlice.ts
@@ -11,6 +11,7 @@ import type {
   InstallProgress,
   MarketplaceStatus,
 } from '@/shared/types'
+import { toSearchQuery, toUnixTimestampMs } from '@/shared/types'
 
 /** Cache TTL: 30 minutes in milliseconds */
 const CACHE_TTL_MS = 30 * 60 * 1000
@@ -45,7 +46,7 @@ interface MarketplaceState {
 
 const initialState: MarketplaceState = {
   status: 'idle',
-  searchQuery: '',
+  searchQuery: toSearchQuery(''),
   searchResults: [],
   selectedSkill: null,
   previewSkill: null,
@@ -161,7 +162,7 @@ const marketplaceSlice = createSlice({
     },
     clearSearchResults: (state) => {
       state.searchResults = []
-      state.searchQuery = ''
+      state.searchQuery = toSearchQuery('')
       // Emptying the box returns to the leaderboard, so reset BOTH halves of the
       // status/error pair: the input spinner keys off `status`, but the error
       // banner renders on `error` itself — clearing only one leaves the last
@@ -224,7 +225,7 @@ const marketplaceSlice = createSlice({
         // background refresh of a populated tab doesn't flash an empty skeleton.
         state.leaderboard[filter] = {
           skills: existing?.skills ?? [],
-          lastFetched: existing?.lastFetched ?? 0,
+          lastFetched: toUnixTimestampMs(existing?.lastFetched ?? 0),
           filter,
           status: 'loading',
         }
@@ -233,7 +234,7 @@ const marketplaceSlice = createSlice({
         const { skills, filter } = action.payload
         state.leaderboard[filter] = {
           skills,
-          lastFetched: Date.now(),
+          lastFetched: toUnixTimestampMs(Date.now()),
           filter,
           status: 'idle',
         }
@@ -248,7 +249,7 @@ const marketplaceSlice = createSlice({
         } else {
           state.leaderboard[filter] = {
             skills: [],
-            lastFetched: 0,
+            lastFetched: toUnixTimestampMs(0),
             filter,
             status: 'error',
             error: action.error.message || 'Failed to load leaderboard',

--- a/src/renderer/src/redux/slices/protectSlice.test.ts
+++ b/src/renderer/src/redux/slices/protectSlice.test.ts
@@ -2,6 +2,7 @@ import { configureStore } from '@reduxjs/toolkit'
 import { describe, expect, test } from 'vitest'
 
 import type { Skill } from '@/shared/types'
+import { toFileSizeBytes, toSymlinkCount } from '@/shared/types'
 
 /**
  * Build a source-skill row the way `scanSourceSkills` does: named, and carrying
@@ -20,11 +21,11 @@ function makeScannedSkill(name: Skill['name'], ino: number): Skill {
       kind: 'directory',
       dev: 1,
       ino,
-      size: 96,
+      size: toFileSizeBytes(96),
       ctimeMs: 100,
       mtimeMs: 100,
     },
-    symlinkCount: 0,
+    symlinkCount: toSymlinkCount(0),
     symlinks: [],
     isSource: true,
     isOrphan: false,

--- a/src/renderer/src/redux/slices/skillsSlice.test.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.test.ts
@@ -16,7 +16,13 @@ import type {
   SymlinkInfo,
   TombstoneId,
 } from '@/shared/types'
-import { tombstoneId } from '@/shared/types'
+import {
+  toBatchItemCount,
+  toBatchItemIndex,
+  toFileSizeBytes,
+  toSymlinkCount,
+  tombstoneId,
+} from '@/shared/types'
 
 const mockGetAll = vi.fn()
 const mockUnlinkFromAgent = vi.fn()
@@ -33,7 +39,7 @@ const directoryIdentity: FilesystemEntryIdentity = {
   kind: 'directory',
   dev: 1,
   ino: 2,
-  size: 96,
+  size: toFileSizeBytes(96),
   ctimeMs: 3,
   mtimeMs: 4,
 }
@@ -70,7 +76,7 @@ const sampleSkill: Skill = {
   description: 'Task management skill',
   path: '/home/user/.agents/skills/task',
   filesystemIdentity: directoryIdentity,
-  symlinkCount: 1,
+  symlinkCount: toSymlinkCount(1),
   symlinks: [
     {
       agentId: 'claude-code',
@@ -933,7 +939,12 @@ describe('skillsSlice bulk selection reducers (v2.4)', () => {
     const store = await createTestStore()
 
     // Act + Assert — setting a counter shows progress
-    store.dispatch(setBulkProgress({ current: 3, total: 10 }))
+    store.dispatch(
+      setBulkProgress({
+        current: toBatchItemIndex(3),
+        total: toBatchItemCount(10),
+      }),
+    )
     expect(store.getState().skills.bulkProgress).toEqual({
       current: 3,
       total: 10,
@@ -1004,14 +1015,14 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
           skillName: 'task',
           outcome: 'deleted',
           tombstoneId: tombstoneId('1-task-aaaaaaaa'),
-          symlinksRemoved: 2,
+          symlinksRemoved: toSymlinkCount(2),
           cascadeAgents: [],
         },
         {
           skillName: 'theme-generator',
           outcome: 'deleted',
           tombstoneId: tombstoneId('1-theme-generator-bbbbbbbb'),
-          symlinksRemoved: 0,
+          symlinksRemoved: toSymlinkCount(0),
           cascadeAgents: [],
         },
         {
@@ -1033,7 +1044,7 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
           skillName: 'metadata-title',
           outcome: 'deleted',
           tombstoneId: tombstoneId('1-metadata-title-aaaaaaaa'),
-          symlinksRemoved: 1,
+          symlinksRemoved: toSymlinkCount(1),
           cascadeAgents: [],
         },
       ],
@@ -1073,7 +1084,7 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
           skillName: 'task',
           outcome: 'deleted',
           tombstoneId: tombstoneId('1-task-aaaaaaaa'),
-          symlinksRemoved: 1,
+          symlinksRemoved: toSymlinkCount(1),
           cascadeAgents: [],
         },
       ],
@@ -1081,7 +1092,12 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
     const { deleteSelectedSkills, toggleSelection, setBulkProgress } =
       await import('./skillsSlice')
     store.dispatch(toggleSelection('task'))
-    store.dispatch(setBulkProgress({ current: 1, total: 1 }))
+    store.dispatch(
+      setBulkProgress({
+        current: toBatchItemIndex(1),
+        total: toBatchItemCount(1),
+      }),
+    )
 
     // Act
     await store.dispatch(deleteSelectedSkills([deleteTarget('task')]))
@@ -1104,7 +1120,7 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
         {
           skillName: 'task',
           outcome: 'orphan-cleared',
-          symlinksRemoved: 1,
+          symlinksRemoved: toSymlinkCount(1),
           cascadeAgents: ['claude-code'],
         },
       ],
@@ -1112,7 +1128,12 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
     const { deleteSelectedSkills, toggleSelection, setBulkProgress } =
       await import('./skillsSlice')
     store.dispatch(toggleSelection('task'))
-    store.dispatch(setBulkProgress({ current: 1, total: 1 }))
+    store.dispatch(
+      setBulkProgress({
+        current: toBatchItemIndex(1),
+        total: toBatchItemCount(1),
+      }),
+    )
 
     // Act
     await store.dispatch(deleteSelectedSkills([deleteTarget('task')]))
@@ -1196,7 +1217,7 @@ describe('skillsSlice clearSelectedOrphanSymlinks thunk', () => {
         {
           skillName: 'task',
           outcome: 'orphan-cleared',
-          symlinksRemoved: 1,
+          symlinksRemoved: toSymlinkCount(1),
           cascadeAgents: ['codex'],
         },
       ],
@@ -1213,7 +1234,7 @@ describe('skillsSlice clearSelectedOrphanSymlinks thunk', () => {
         {
           skillName: 'task',
           outcome: 'orphan-cleared',
-          symlinksRemoved: 1,
+          symlinksRemoved: toSymlinkCount(1),
           cascadeAgents: ['codex'],
         },
       ],
@@ -1221,7 +1242,12 @@ describe('skillsSlice clearSelectedOrphanSymlinks thunk', () => {
     const { clearSelectedOrphanSymlinks, setBulkProgress, toggleSelection } =
       await import('./skillsSlice')
     store.dispatch(toggleSelection('task'))
-    store.dispatch(setBulkProgress({ current: 1, total: 1 }))
+    store.dispatch(
+      setBulkProgress({
+        current: toBatchItemIndex(1),
+        total: toBatchItemCount(1),
+      }),
+    )
 
     // Act
     await store.dispatch(
@@ -1591,8 +1617,8 @@ describe('skillsSlice undoLastBulkDelete thunk', () => {
         calls.push(id)
         return {
           outcome: 'restored',
-          symlinksRestored: 1,
-          symlinksSkipped: 0,
+          symlinksRestored: toSymlinkCount(1),
+          symlinksSkipped: toSymlinkCount(0),
         } satisfies RestoreDeletedSkillResult
       },
     )
@@ -1616,8 +1642,8 @@ describe('skillsSlice undoLastBulkDelete thunk', () => {
     mockRestoreDeletedSkill
       .mockResolvedValueOnce({
         outcome: 'restored',
-        symlinksRestored: 1,
-        symlinksSkipped: 0,
+        symlinksRestored: toSymlinkCount(1),
+        symlinksSkipped: toSymlinkCount(0),
       } satisfies RestoreDeletedSkillResult)
       .mockResolvedValueOnce({
         outcome: 'error',
@@ -1793,7 +1819,12 @@ describe('skillsSlice named selectors', () => {
       selectBulkProgress,
     } = await import('./skillsSlice')
     store.dispatch(setBulkCopyModalOpen(true))
-    store.dispatch(setBulkProgress({ current: 2, total: 5 }))
+    store.dispatch(
+      setBulkProgress({
+        current: toBatchItemIndex(2),
+        total: toBatchItemCount(5),
+      }),
+    )
 
     // Act
     const bulkCopyModalOpen = selectBulkCopyModalOpen(

--- a/src/renderer/src/redux/slices/skillsSlice.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.ts
@@ -19,6 +19,7 @@ import type {
   SymlinkInfo,
   TombstoneId,
 } from '@/shared/types'
+import { toAgentCount } from '@/shared/types'
 
 /**
  * Redux state for the Installed Skills feature area.
@@ -360,7 +361,7 @@ export const bulkCopyToAgents = createAsyncThunk<
         // and keep going; the aggregate surfaces it as a partial failure.
         perSkill.push({
           skillName: item.skillName,
-          copied: 0,
+          copied: toAgentCount(0),
           failures: agentIds.map((agentId) => ({
             agentId,
             /* v8 ignore next -- copyToAgents IPC rejects with Error objects in normal flow; the 'Copy failed' arm only runs for a non-Error throw */

--- a/src/renderer/src/redux/slices/uiSlice.test.ts
+++ b/src/renderer/src/redux/slices/uiSlice.test.ts
@@ -16,13 +16,24 @@ import type {
   SyncPreviewResult,
   TombstoneId,
 } from '@/shared/types'
-import { repositoryId, tombstoneId } from '@/shared/types'
+import {
+  repositoryId,
+  toAgentCount,
+  toFileSizeBytes,
+  toHttpUrl,
+  toHumanFileSize,
+  toIsoTimestamp,
+  toSearchQuery,
+  toSkillCount,
+  toSymlinkCount,
+  tombstoneId,
+} from '@/shared/types'
 
 const directoryIdentity: FilesystemEntryIdentity = {
   kind: 'directory',
   dev: 1,
   ino: 2,
-  size: 96,
+  size: toFileSizeBytes(96),
   ctimeMs: 3,
   mtimeMs: 4,
 }
@@ -110,10 +121,10 @@ async function createCombinedStore() {
 
 /** Sample preview result with conflicts for testing */
 const previewWithConflicts: SyncPreviewResult = {
-  totalSkills: 5,
-  totalAgents: 2,
-  toCreate: 3,
-  alreadySynced: 4,
+  totalSkills: toSkillCount(5),
+  totalAgents: toAgentCount(2),
+  toCreate: toSymlinkCount(3),
+  alreadySynced: toSymlinkCount(4),
   conflicts: [
     {
       skillName: 'agent-browser',
@@ -126,10 +137,10 @@ const previewWithConflicts: SyncPreviewResult = {
 
 /** Sample preview result without conflicts */
 const previewNoConflicts: SyncPreviewResult = {
-  totalSkills: 3,
-  totalAgents: 2,
-  toCreate: 6,
-  alreadySynced: 0,
+  totalSkills: toSkillCount(3),
+  totalAgents: toAgentCount(2),
+  toCreate: toSymlinkCount(6),
+  alreadySynced: toSymlinkCount(0),
   conflicts: [],
 }
 
@@ -150,8 +161,8 @@ describe('uiSlice hidden agents deletion review', () => {
             name: 'Cline',
             path: '/home/user/.cline/skills',
             exists: true,
-            skillCount: 1,
-            localSkillCount: 0,
+            skillCount: toSkillCount(1),
+            localSkillCount: toSkillCount(0),
             filesystemIdentity: directoryIdentity,
           },
         ],
@@ -434,9 +445,9 @@ describe('uiSlice sync thunks', () => {
     mockSyncPreview.mockResolvedValue(previewWithConflicts)
     mockSyncExecute.mockResolvedValue({
       success: true,
-      created: 3,
-      replaced: 1,
-      skipped: 4,
+      created: toSymlinkCount(3),
+      replaced: toSymlinkCount(1),
+      skipped: toSymlinkCount(4),
       errors: [],
       details: [
         { skillName: 'skill-a', agentName: 'Claude Code', action: 'created' },
@@ -482,9 +493,9 @@ describe('uiSlice sync thunks', () => {
     // Arrange
     mockSyncExecute.mockResolvedValue({
       success: true,
-      created: 1,
-      replaced: 0,
-      skipped: 0,
+      created: toSymlinkCount(1),
+      replaced: toSymlinkCount(0),
+      skipped: toSymlinkCount(0),
       errors: [],
       details: [
         { skillName: 's', agentName: 'Claude Code', action: 'created' },
@@ -506,9 +517,9 @@ describe('uiSlice sync thunks', () => {
     // Arrange — populate syncResult via a completed sync
     mockSyncExecute.mockResolvedValue({
       success: true,
-      created: 1,
-      replaced: 0,
-      skipped: 0,
+      created: toSymlinkCount(1),
+      replaced: toSymlinkCount(0),
+      skipped: toSymlinkCount(0),
       errors: [],
       details: [
         { skillName: 's', agentName: 'Claude Code', action: 'created' },
@@ -555,8 +566,8 @@ describe('uiSlice bookmark detail modal', () => {
   const sampleBookmark = {
     name: 'task',
     repo: repositoryId('vercel-labs/skills'),
-    url: 'https://github.com/vercel-labs/skills',
-    bookmarkedAt: '2026-04-01T08:00:00.000Z',
+    url: toHttpUrl('https://github.com/vercel-labs/skills'),
+    bookmarkedAt: toIsoTimestamp('2026-04-01T08:00:00.000Z'),
     isInstalled: false,
   }
 
@@ -615,7 +626,7 @@ describe('uiSlice undoToast (v2.4 bulk delete)', () => {
       kind === 'delete'
         ? [tombstoneId('1-task-aaaaaaaa'), tombstoneId('1-browser-bbbbbbbb')]
         : ([] as TombstoneId[]),
-    expiresAt: '2026-04-17T12:00:15.000Z',
+    expiresAt: toIsoTimestamp('2026-04-17T12:00:15.000Z'),
     summary:
       kind === 'delete'
         ? 'Deleted 2 skills. 4 symlinks removed.'
@@ -1133,7 +1144,7 @@ describe('uiSlice atomic-clear contract on context switch', () => {
         kind: 'delete',
         skillNames: ['a'],
         tombstoneIds: [tombstoneId('1-a-aaaaaaaa')],
-        expiresAt: '2026-04-17T12:00:15.000Z',
+        expiresAt: toIsoTimestamp('2026-04-17T12:00:15.000Z'),
         summary: 'Deleted 1 skill.',
       }),
     )
@@ -1397,14 +1408,14 @@ describe('uiSlice source filter (selectedSources)', () => {
       name,
       description: `${name} skill`,
       path: `/home/user/.agents/skills/${name}`,
-      symlinkCount: 0,
+      symlinkCount: toSymlinkCount(0),
       symlinks: [],
       isSource: true,
       isOrphan: false,
       ...(source
         ? {
             source: repositoryId(source),
-            sourceUrl: `https://github.com/${source}.git`,
+            sourceUrl: toHttpUrl(`https://github.com/${source}.git`),
           }
         : {}),
     }
@@ -1649,7 +1660,7 @@ describe('uiSlice search box', () => {
     const { setSearchQuery } = await import('./uiSlice')
 
     // Act
-    store.dispatch(setSearchQuery('browser'))
+    store.dispatch(setSearchQuery(toSearchQuery('browser')))
 
     // Assert
     expect(store.getState().ui.searchQuery).toBe('browser')
@@ -1796,9 +1807,9 @@ describe('uiSlice source stats refresh', () => {
   /** Sample source-directory stats for the refresh thunk */
   const sampleStats = {
     path: '/Users/me/.agents/skills',
-    skillCount: 15,
-    totalSize: '2.4 MB',
-    lastModified: '2026-04-10T08:00:00.000Z',
+    skillCount: toSkillCount(15),
+    totalSize: toHumanFileSize('2.4 MB'),
+    lastModified: toIsoTimestamp('2026-04-10T08:00:00.000Z'),
   } satisfies SourceStats
 
   it('spins the Refresh button while the source-stats request is in flight', async () => {
@@ -1877,7 +1888,7 @@ describe('uiSlice selectors read the live ui state', () => {
     } = await import('./uiSlice')
     // selectAgent resets skill-type filters, so set the type filters afterwards.
     store.dispatch(selectAgent('claude-code'))
-    store.dispatch(setSearchQuery('browser'))
+    store.dispatch(setSearchQuery(toSearchQuery('browser')))
     store.dispatch(setSearchScope('repo'))
     store.dispatch(setSelectedSources([repositoryId('vercel-labs/skills')]))
     store.dispatch(toggleSortOrder())
@@ -1916,9 +1927,9 @@ describe('uiSlice selectors read the live ui state', () => {
     // Arrange — execute a sync so isSyncing settles false and syncResult fills
     mockSyncExecute.mockResolvedValue({
       success: true,
-      created: 2,
-      replaced: 0,
-      skipped: 0,
+      created: toSymlinkCount(2),
+      replaced: toSymlinkCount(0),
+      skipped: toSymlinkCount(0),
       errors: [],
       details: [
         { skillName: 's', agentName: 'Claude Code', action: 'created' },
@@ -1961,8 +1972,8 @@ describe('uiSlice selectors read the live ui state', () => {
       setSelectedBookmarkForDetail({
         name: 'task',
         repo: repositoryId('vercel-labs/skills'),
-        url: 'https://github.com/vercel-labs/skills',
-        bookmarkedAt: '2026-04-01T08:00:00.000Z',
+        url: toHttpUrl('https://github.com/vercel-labs/skills'),
+        bookmarkedAt: toIsoTimestamp('2026-04-01T08:00:00.000Z'),
         isInstalled: false,
       }),
     )

--- a/src/renderer/src/redux/slices/uiSlice.ts
+++ b/src/renderer/src/redux/slices/uiSlice.ts
@@ -23,6 +23,7 @@ import type {
   ToastId,
   TombstoneId,
 } from '@/shared/types'
+import { toSearchQuery } from '@/shared/types'
 
 import type {
   DeleteSelectedSkillTarget,
@@ -236,7 +237,7 @@ interface UiState {
 
 const initialState: UiState = {
   activeTab: 'installed',
-  searchQuery: '',
+  searchQuery: toSearchQuery(''),
   searchScope: 'name',
   selectedSources: [],
   sourceStats: null,

--- a/src/renderer/src/redux/slices/updateSlice.test.ts
+++ b/src/renderer/src/redux/slices/updateSlice.test.ts
@@ -1,7 +1,12 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { describe, expect, it } from 'vitest'
 
-import { semanticVersion } from '@/shared/types'
+import {
+  semanticVersion,
+  toByteCount,
+  toBytesPerSecond,
+  toProgressPercent,
+} from '@/shared/types'
 
 async function createTestStore() {
   const { default: updateReducer } = await import('./updateSlice')
@@ -120,10 +125,10 @@ describe('updateSlice', () => {
     // Act
     store.dispatch(
       setProgress({
-        percent: 42,
-        bytesPerSecond: 1024,
-        total: 10000,
-        transferred: 4200,
+        percent: toProgressPercent(42),
+        bytesPerSecond: toBytesPerSecond(1024),
+        total: toByteCount(10000),
+        transferred: toByteCount(4200),
       }),
     )
 
@@ -206,10 +211,10 @@ describe('updateSlice', () => {
     store.dispatch(setDownloading())
     store.dispatch(
       setProgress({
-        percent: 50,
-        bytesPerSecond: 2048,
-        total: 10000,
-        transferred: 5000,
+        percent: toProgressPercent(50),
+        bytesPerSecond: toBytesPerSecond(2048),
+        total: toByteCount(10000),
+        transferred: toByteCount(5000),
       }),
     )
 

--- a/src/renderer/src/redux/slices/updateSlice.ts
+++ b/src/renderer/src/redux/slices/updateSlice.ts
@@ -8,6 +8,7 @@ import type {
   UpdateInfo,
   UpdateStatus,
 } from '@/shared/types'
+import { toProgressPercent } from '@/shared/types'
 
 /**
  * Redux state tracking the auto-update lifecycle.
@@ -32,7 +33,7 @@ const initialState: UpdateState = {
   status: 'idle',
   version: null,
   releaseNotes: null,
-  progress: 0,
+  progress: toProgressPercent(0),
   error: null,
   dismissed: false,
 }
@@ -65,7 +66,7 @@ const updateSlice = createSlice({
       state.status = 'ready'
       state.version = action.payload.version
       state.releaseNotes = action.payload.releaseNotes ?? null
-      state.progress = 100
+      state.progress = toProgressPercent(100)
     },
     setError: (state, action: PayloadAction<string>) => {
       state.status = 'error'

--- a/src/renderer/src/utils/getDeletableAgentFolders.test.ts
+++ b/src/renderer/src/utils/getDeletableAgentFolders.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { Agent } from '@/shared/types'
+import { toFileSizeBytes, toSkillCount } from '@/shared/types'
 
 import { getDeletableAgentFolders } from './getDeletableAgentFolders'
 
@@ -9,13 +10,13 @@ const hiddenAgent: Agent = {
   name: 'Cursor',
   path: '/Users/test/.cursor/skills',
   exists: true,
-  skillCount: 0,
-  localSkillCount: 0,
+  skillCount: toSkillCount(0),
+  localSkillCount: toSkillCount(0),
   filesystemIdentity: {
     kind: 'directory',
     dev: 1,
     ino: 2,
-    size: 96,
+    size: toFileSizeBytes(96),
     ctimeMs: 3,
     mtimeMs: 4,
   },
@@ -78,7 +79,7 @@ describe('hidden-agent bulk-delete eligibility', () => {
           kind: 'symlink',
           dev: 1,
           ino: 2,
-          size: 20,
+          size: toFileSizeBytes(20),
           ctimeMs: 3,
           mtimeMs: 4,
         },
@@ -101,7 +102,7 @@ describe('not-installed agent empty-parent eligibility', () => {
       kind: 'directory',
       dev: 1,
       ino: 2,
-      size: 96,
+      size: toFileSizeBytes(96),
       ctimeMs: 3,
       mtimeMs: 4,
     },

--- a/src/renderer/src/utils/getLocationViewModel.test.ts
+++ b/src/renderer/src/utils/getLocationViewModel.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { AgentId, Skill, SymlinkInfo } from '@/shared/types'
+import { toSymlinkCount } from '@/shared/types'
 
 import { getLocationViewModel } from './getLocationViewModel'
 
@@ -26,7 +27,9 @@ const makeSkill = (
   name: 'foo',
   description: 'foo skill',
   path,
-  symlinkCount: symlinks.filter((s) => s.status === 'valid').length,
+  symlinkCount: toSymlinkCount(
+    symlinks.filter((s) => s.status === 'valid').length,
+  ),
   symlinks,
   isSource,
   isOrphan: false,

--- a/src/renderer/src/utils/summarizeBulkCopyResult.test.ts
+++ b/src/renderer/src/utils/summarizeBulkCopyResult.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { PerSkillCopyOutcome } from '@/shared/types'
+import { toAgentCount } from '@/shared/types'
 
 import { summarizeBulkCopyResult } from './summarizeBulkCopyResult'
 
@@ -8,8 +9,8 @@ describe('summarizeBulkCopyResult', () => {
   it('reports success and lists the copied skills when every target succeeds', () => {
     // Arrange — two skills, each copied to both ticked agents
     const perSkill: PerSkillCopyOutcome[] = [
-      { skillName: 'alpha', copied: 2, failures: [] },
-      { skillName: 'beta', copied: 2, failures: [] },
+      { skillName: 'alpha', copied: toAgentCount(2), failures: [] },
+      { skillName: 'beta', copied: toAgentCount(2), failures: [] },
     ]
 
     // Act
@@ -26,7 +27,7 @@ describe('summarizeBulkCopyResult', () => {
   it('uses singular wording for one skill copied to one agent', () => {
     // Arrange — one skill, one ticked agent
     const perSkill: PerSkillCopyOutcome[] = [
-      { skillName: 'alpha', copied: 1, failures: [] },
+      { skillName: 'alpha', copied: toAgentCount(1), failures: [] },
     ]
 
     // Act
@@ -43,10 +44,10 @@ describe('summarizeBulkCopyResult', () => {
   it('warns and lists the per-target failures when some copies fail', () => {
     // Arrange — alpha lands on the one agent, beta collides on it
     const perSkill: PerSkillCopyOutcome[] = [
-      { skillName: 'alpha', copied: 1, failures: [] },
+      { skillName: 'alpha', copied: toAgentCount(1), failures: [] },
       {
         skillName: 'beta',
-        copied: 0,
+        copied: toAgentCount(0),
         failures: [{ agentId: 'codex', error: 'Already exists' }],
       },
     ]
@@ -65,10 +66,10 @@ describe('summarizeBulkCopyResult', () => {
   it('uses plural "copies" wording when several targets fail but some still copy', () => {
     // Arrange — alpha fully copies to both agents, beta collides on both
     const perSkill: PerSkillCopyOutcome[] = [
-      { skillName: 'alpha', copied: 2, failures: [] },
+      { skillName: 'alpha', copied: toAgentCount(2), failures: [] },
       {
         skillName: 'beta',
-        copied: 0,
+        copied: toAgentCount(0),
         failures: [
           { agentId: 'codex', error: 'Already exists' },
           { agentId: 'cursor', error: 'Already exists' },
@@ -93,7 +94,7 @@ describe('summarizeBulkCopyResult', () => {
     const perSkill: PerSkillCopyOutcome[] = [
       {
         skillName: 'alpha',
-        copied: 0,
+        copied: toAgentCount(0),
         failures: [{ agentId: 'codex', error: 'Already exists' }],
       },
     ]
@@ -114,12 +115,12 @@ describe('summarizeBulkCopyResult', () => {
     const perSkill: PerSkillCopyOutcome[] = [
       {
         skillName: 'alpha',
-        copied: 0,
+        copied: toAgentCount(0),
         failures: [{ agentId: 'codex', error: 'Already exists' }],
       },
       {
         skillName: 'beta',
-        copied: 0,
+        copied: toAgentCount(0),
         failures: [{ agentId: 'codex', error: 'Already exists' }],
       },
     ]
@@ -139,7 +140,7 @@ describe('summarizeBulkCopyResult', () => {
   it('falls back to a generic error when nothing copied and no failures were reported', () => {
     // Arrange — defensive path: a skill came back copied:0 with no failure rows
     const perSkill: PerSkillCopyOutcome[] = [
-      { skillName: 'alpha', copied: 0, failures: [] },
+      { skillName: 'alpha', copied: toAgentCount(0), failures: [] },
     ]
 
     // Act

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -10,6 +10,7 @@ import {
   WINDOW_OPACITY_MODE_OPTIONS,
 } from './constants'
 import type { AgentId } from './types'
+import { toPixelHeight, toPixelWidth } from './types'
 
 /**
  * Defense-in-depth floor for a persisted startup window size. Set well
@@ -150,8 +151,16 @@ export const CODE_FONT_SIZE_SCHEMA = z
  */
 const windowSizeSchema = z
   .object({
-    width: z.number().int().min(WINDOW_SIZE_MIN_DIMENSION),
-    height: z.number().int().min(WINDOW_SIZE_MIN_DIMENSION),
+    width: z
+      .number()
+      .int()
+      .min(WINDOW_SIZE_MIN_DIMENSION)
+      .transform(toPixelWidth),
+    height: z
+      .number()
+      .int()
+      .min(WINDOW_SIZE_MIN_DIMENSION)
+      .transform(toPixelHeight),
   })
   .optional()
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -75,7 +75,7 @@ export type PosixRelativePath = Brand<string, 'PosixRelativePath'>
 /**
  * Construct a {@link PosixRelativePath} from a raw string at a trust boundary
  * (a preview file-tree walk or IPC payload).
- * @example toPosixRelativePath('x')
+ * @example toPosixRelativePath('lib/helper.py')
  */
 export const toPosixRelativePath = (value: string): PosixRelativePath =>
   value as PosixRelativePath
@@ -89,7 +89,7 @@ export type FileExtension = Brand<string, 'FileExtension'>
 /**
  * Construct a {@link FileExtension} from a raw string at a trust boundary
  * (a path parse or IPC payload).
- * @example toFileExtension('x')
+ * @example toFileExtension('.md')
  */
 export const toFileExtension = (value: string): FileExtension =>
   value as FileExtension
@@ -103,7 +103,7 @@ export type MimeType = Brand<string, 'MimeType'>
 /**
  * Construct a {@link MimeType} from a raw string at a trust boundary
  * (a file sniff or IPC payload).
- * @example toMimeType('x')
+ * @example toMimeType('image/png')
  */
 export const toMimeType = (value: string): MimeType => value as MimeType
 
@@ -116,7 +116,7 @@ export type HttpUrl = Brand<string, 'HttpUrl'>
 /**
  * Construct a {@link HttpUrl} from a raw string at a trust boundary
  * (registry JSON, CLI output, or a fixture).
- * @example toHttpUrl('x')
+ * @example toHttpUrl('https://github.com/vercel-labs/skills.git')
  */
 export const toHttpUrl = (value: string): HttpUrl => value as HttpUrl
 
@@ -129,7 +129,7 @@ export type IsoTimestamp = Brand<string, 'IsoTimestamp'>
 /**
  * Construct a {@link IsoTimestamp} from a raw string at a trust boundary
  * (`Date#toISOString`, stored state, or IPC).
- * @example toIsoTimestamp('x')
+ * @example toIsoTimestamp('2026-04-01T08:00:00.000Z')
  */
 export const toIsoTimestamp = (value: string): IsoTimestamp =>
   value as IsoTimestamp
@@ -143,7 +143,7 @@ export type UnixTimestampMs = Brand<number, 'UnixTimestampMs'>
 /**
  * Construct a {@link UnixTimestampMs} from a raw number at a trust boundary
  * (`Date#getTime`, `fs.Stats`, or IPC).
- * @example toUnixTimestampMs(1)
+ * @example toUnixTimestampMs(1713045600000)
  */
 export const toUnixTimestampMs = (value: number): UnixTimestampMs =>
   value as UnixTimestampMs
@@ -157,7 +157,7 @@ export type HumanFileSize = Brand<string, 'HumanFileSize'>
 /**
  * Construct a {@link HumanFileSize} from a raw string at a trust boundary
  * (a byte formatter).
- * @example toHumanFileSize('x')
+ * @example toHumanFileSize('2.4 MB')
  */
 export const toHumanFileSize = (value: string): HumanFileSize =>
   value as HumanFileSize
@@ -173,7 +173,7 @@ export type PixelWidth = Brand<number, 'PixelWidth'>
 /**
  * Construct a {@link PixelWidth} from a raw number at a trust boundary
  * (an image decode or a layout measurement).
- * @example toPixelWidth(1)
+ * @example toPixelWidth(1280)
  */
 export const toPixelWidth = (value: number): PixelWidth => value as PixelWidth
 
@@ -188,7 +188,7 @@ export type PixelHeight = Brand<number, 'PixelHeight'>
 /**
  * Construct a {@link PixelHeight} from a raw number at a trust boundary
  * (an image decode or a layout measurement).
- * @example toPixelHeight(1)
+ * @example toPixelHeight(800)
  */
 export const toPixelHeight = (value: number): PixelHeight =>
   value as PixelHeight
@@ -202,7 +202,7 @@ export type FileName = Brand<string, 'FileName'>
 /**
  * Construct a {@link FileName} from a raw string at a trust boundary
  * (`path.basename` or a directory read).
- * @example toFileName('x')
+ * @example toFileName('SKILL.md')
  */
 export const toFileName = (value: string): FileName => value as FileName
 
@@ -215,7 +215,7 @@ export type DataUrl = Brand<string, 'DataUrl'>
 /**
  * Construct a {@link DataUrl} from a raw string at a trust boundary
  * (a base64 encode of file bytes).
- * @example toDataUrl('x')
+ * @example toDataUrl('data:image/png;base64,iVBORw0KGgo...')
  */
 export const toDataUrl = (value: string): DataUrl => value as DataUrl
 
@@ -228,7 +228,7 @@ export type FileSizeBytes = Brand<number, 'FileSizeBytes'>
 /**
  * Construct a {@link FileSizeBytes} from a raw number at a trust boundary
  * (`fs.Stats#size` or IPC).
- * @example toFileSizeBytes(1)
+ * @example toFileSizeBytes(48201)
  */
 export const toFileSizeBytes = (value: number): FileSizeBytes =>
   value as FileSizeBytes
@@ -242,7 +242,7 @@ export type LineCount = Brand<number, 'LineCount'>
 /**
  * Construct a {@link LineCount} from a raw number at a trust boundary
  * (a newline split of file contents).
- * @example toLineCount(1)
+ * @example toLineCount(42)
  */
 export const toLineCount = (value: number): LineCount => value as LineCount
 
@@ -255,7 +255,7 @@ export type SkillCount = Brand<number, 'SkillCount'>
 /**
  * Construct a {@link SkillCount} from a raw number at a trust boundary
  * (a scan result or IPC payload).
- * @example toSkillCount(1)
+ * @example toSkillCount(15)
  */
 export const toSkillCount = (value: number): SkillCount => value as SkillCount
 
@@ -268,7 +268,7 @@ export type AgentCount = Brand<number, 'AgentCount'>
 /**
  * Construct a {@link AgentCount} from a raw number at a trust boundary
  * (a scan result or IPC payload).
- * @example toAgentCount(1)
+ * @example toAgentCount(3)
  */
 export const toAgentCount = (value: number): AgentCount => value as AgentCount
 
@@ -281,7 +281,7 @@ export type ByteCount = Brand<number, 'ByteCount'>
 /**
  * Construct a {@link ByteCount} from a raw number at a trust boundary
  * (a download progress event).
- * @example toByteCount(1)
+ * @example toByteCount(10485760)
  */
 export const toByteCount = (value: number): ByteCount => value as ByteCount
 
@@ -294,7 +294,7 @@ export type BytesPerSecond = Brand<number, 'BytesPerSecond'>
 /**
  * Construct a {@link BytesPerSecond} from a raw number at a trust boundary
  * (a download progress event).
- * @example toBytesPerSecond(1)
+ * @example toBytesPerSecond(524288)
  */
 export const toBytesPerSecond = (value: number): BytesPerSecond =>
   value as BytesPerSecond
@@ -308,7 +308,7 @@ export type ProgressPercent = Brand<number, 'ProgressPercent'>
 /**
  * Construct a {@link ProgressPercent} from a raw number at a trust boundary
  * (a download progress event).
- * @example toProgressPercent(1)
+ * @example toProgressPercent(45.2)
  */
 export const toProgressPercent = (value: number): ProgressPercent =>
   value as ProgressPercent
@@ -322,7 +322,7 @@ export type BatchItemIndex = Brand<number, 'BatchItemIndex'>
 /**
  * Construct a {@link BatchItemIndex} from a raw number at a trust boundary
  * (a bulk-operation loop counter).
- * @example toBatchItemIndex(1)
+ * @example toBatchItemIndex(3)
  */
 export const toBatchItemIndex = (value: number): BatchItemIndex =>
   value as BatchItemIndex
@@ -336,7 +336,7 @@ export type BatchItemCount = Brand<number, 'BatchItemCount'>
 /**
  * Construct a {@link BatchItemCount} from a raw number at a trust boundary
  * (a bulk-operation input length).
- * @example toBatchItemCount(1)
+ * @example toBatchItemCount(12)
  */
 export const toBatchItemCount = (value: number): BatchItemCount =>
   value as BatchItemCount
@@ -359,7 +359,7 @@ export type SymlinkCount = Brand<number, 'SymlinkCount'>
 /**
  * Construct a {@link SymlinkCount} from a raw number at a trust boundary
  * (a symlink slot tally).
- * @example toSymlinkCount(1)
+ * @example toSymlinkCount(12)
  */
 export const toSymlinkCount = (value: number): SymlinkCount =>
   value as SymlinkCount
@@ -388,7 +388,7 @@ export type InstallCount = Brand<number, 'InstallCount'>
 /**
  * Construct a {@link InstallCount} from a raw number at a trust boundary
  * (marketplace registry JSON).
- * @example toInstallCount(1)
+ * @example toInstallCount(2480)
  */
 export const toInstallCount = (value: number): InstallCount =>
   value as InstallCount
@@ -404,7 +404,7 @@ export type SearchQuery = Brand<string, 'SearchQuery'>
 /**
  * Construct a {@link SearchQuery} from a raw string at a trust boundary
  * (a search input's onChange).
- * @example toSearchQuery('x')
+ * @example toSearchQuery('react hooks')
  */
 export const toSearchQuery = (value: string): SearchQuery =>
   value as SearchQuery

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -9,13 +9,19 @@ export type { FilePreviewKind } from './fileTypes'
 // These types replace raw `string` / `number` at domain boundaries so signatures
 // communicate WHAT a value represents, not just its runtime shape.
 //
-// Plain aliases (`type X = string` / `type X = number`) are documentation-only:
-// TypeScript's structural typing makes them mutually assignable, so `PixelWidth`
-// and `PixelHeight` (or `SymlinkCount` and `InstallCount`) are exchange-safe at
-// the API surface. If nominal/compile-time exchange prevention is later needed,
-// migrate to the `Brand<T, B>` utility below (e.g., `Brand<number, 'PixelWidth'>`)
-// — branded types require an explicit construction site but reject accidental
-// swaps between structurally identical values.
+// Domain primitives are branded via the `Brand<T, B>` utility below, so
+// structurally identical values like `PixelWidth` and `PixelHeight` (or
+// `SymlinkCount` and `InstallCount`) cannot be swapped by mistake. Each brand
+// ships a constructor beside it: build the branded value once at the trust
+// boundary (an IPC payload, a scan result, a DOM measurement), then pass it down.
+//
+// Constructors are named `to<TypeName>` because the bare camelCase form collides
+// with local bindings — `skillName` is a local in 35 files, `skillCount` in 22,
+// `searchQuery` in 16. {@link repositoryId} and {@link semanticVersion} predate
+// this rule and keep their names; every new brand uses the prefix.
+//
+// `SkillName` and `AbsolutePath` are still plain aliases. They carry ~560 call
+// sites between them and are branded in follow-up passes.
 // ============================================================================
 
 /**
@@ -64,43 +70,97 @@ export interface FilesystemEntryIdentity {
  * regardless of the host OS. Always relative to some known root.
  * @example "lib/helper.py"
  */
-export type PosixRelativePath = string
+export type PosixRelativePath = Brand<string, 'PosixRelativePath'>
+
+/**
+ * Construct a {@link PosixRelativePath} from a raw string at a trust boundary
+ * (a preview file-tree walk or IPC payload).
+ * @example toPosixRelativePath('x')
+ */
+export const toPosixRelativePath = (value: string): PosixRelativePath =>
+  value as PosixRelativePath
 
 /**
  * File extension as surfaced by Node's `path.extname` (with leading dot, lowercase).
  * @example ".md"
  */
-export type FileExtension = string
+export type FileExtension = Brand<string, 'FileExtension'>
+
+/**
+ * Construct a {@link FileExtension} from a raw string at a trust boundary
+ * (a path parse or IPC payload).
+ * @example toFileExtension('x')
+ */
+export const toFileExtension = (value: string): FileExtension =>
+  value as FileExtension
 
 /**
  * IANA MIME type string.
  * @example "image/png"
  */
-export type MimeType = string
+export type MimeType = Brand<string, 'MimeType'>
+
+/**
+ * Construct a {@link MimeType} from a raw string at a trust boundary
+ * (a file sniff or IPC payload).
+ * @example toMimeType('x')
+ */
+export const toMimeType = (value: string): MimeType => value as MimeType
 
 /**
  * HTTP(S) URL string.
  * @example "https://github.com/vercel-labs/skills.git"
  */
-export type HttpUrl = string
+export type HttpUrl = Brand<string, 'HttpUrl'>
+
+/**
+ * Construct a {@link HttpUrl} from a raw string at a trust boundary
+ * (registry JSON, CLI output, or a fixture).
+ * @example toHttpUrl('x')
+ */
+export const toHttpUrl = (value: string): HttpUrl => value as HttpUrl
 
 /**
  * ISO 8601 timestamp string (UTC with milliseconds).
  * @example "2026-04-01T08:00:00.000Z"
  */
-export type IsoTimestamp = string
+export type IsoTimestamp = Brand<string, 'IsoTimestamp'>
+
+/**
+ * Construct a {@link IsoTimestamp} from a raw string at a trust boundary
+ * (`Date#toISOString`, stored state, or IPC).
+ * @example toIsoTimestamp('x')
+ */
+export const toIsoTimestamp = (value: string): IsoTimestamp =>
+  value as IsoTimestamp
 
 /**
  * Unix timestamp in milliseconds since epoch (Date.now() output).
  * @example 1713045600000
  */
-export type UnixTimestampMs = number
+export type UnixTimestampMs = Brand<number, 'UnixTimestampMs'>
+
+/**
+ * Construct a {@link UnixTimestampMs} from a raw number at a trust boundary
+ * (`Date#getTime`, `fs.Stats`, or IPC).
+ * @example toUnixTimestampMs(1)
+ */
+export const toUnixTimestampMs = (value: number): UnixTimestampMs =>
+  value as UnixTimestampMs
 
 /**
  * Human-readable byte-size string (from `humanFileSize()` in main).
  * @example "2.4 MB"
  */
-export type HumanFileSize = string
+export type HumanFileSize = Brand<string, 'HumanFileSize'>
+
+/**
+ * Construct a {@link HumanFileSize} from a raw string at a trust boundary
+ * (a byte formatter).
+ * @example toHumanFileSize('x')
+ */
+export const toHumanFileSize = (value: string): HumanFileSize =>
+  value as HumanFileSize
 
 /**
  * CSS-pixel width. Matches what `BrowserWindow.getContentBounds()` returns
@@ -108,7 +168,14 @@ export type HumanFileSize = string
  * callers do not multiply by `devicePixelRatio`.
  * @example 1280
  */
-export type PixelWidth = number
+export type PixelWidth = Brand<number, 'PixelWidth'>
+
+/**
+ * Construct a {@link PixelWidth} from a raw number at a trust boundary
+ * (an image decode or a layout measurement).
+ * @example toPixelWidth(1)
+ */
+export const toPixelWidth = (value: number): PixelWidth => value as PixelWidth
 
 /**
  * CSS-pixel height. Matches what `BrowserWindow.getContentBounds()` returns
@@ -116,73 +183,163 @@ export type PixelWidth = number
  * callers do not multiply by `devicePixelRatio`.
  * @example 800
  */
-export type PixelHeight = number
+export type PixelHeight = Brand<number, 'PixelHeight'>
+
+/**
+ * Construct a {@link PixelHeight} from a raw number at a trust boundary
+ * (an image decode or a layout measurement).
+ * @example toPixelHeight(1)
+ */
+export const toPixelHeight = (value: number): PixelHeight =>
+  value as PixelHeight
 
 /**
  * @description File basename or display name including its extension when one exists.
  * @example "SKILL.md"
  */
-export type FileName = string
+export type FileName = Brand<string, 'FileName'>
+
+/**
+ * Construct a {@link FileName} from a raw string at a trust boundary
+ * (`path.basename` or a directory read).
+ * @example toFileName('x')
+ */
+export const toFileName = (value: string): FileName => value as FileName
 
 /**
  * @description Base64 data URL that can be assigned directly to media `src` attributes.
  * @example "data:image/png;base64,iVBORw0KGgo..."
  */
-export type DataUrl = string
+export type DataUrl = Brand<string, 'DataUrl'>
+
+/**
+ * Construct a {@link DataUrl} from a raw string at a trust boundary
+ * (a base64 encode of file bytes).
+ * @example toDataUrl('x')
+ */
+export const toDataUrl = (value: string): DataUrl => value as DataUrl
 
 /**
  * @description Raw file size in bytes as reported by filesystem readers.
  * @example 48201
  */
-export type FileSizeBytes = number
+export type FileSizeBytes = Brand<number, 'FileSizeBytes'>
+
+/**
+ * Construct a {@link FileSizeBytes} from a raw number at a trust boundary
+ * (`fs.Stats#size` or IPC).
+ * @example toFileSizeBytes(1)
+ */
+export const toFileSizeBytes = (value: number): FileSizeBytes =>
+  value as FileSizeBytes
 
 /**
  * @description Number of text lines in a previewed file.
  * @example 42
  */
-export type LineCount = number
+export type LineCount = Brand<number, 'LineCount'>
+
+/**
+ * Construct a {@link LineCount} from a raw number at a trust boundary
+ * (a newline split of file contents).
+ * @example toLineCount(1)
+ */
+export const toLineCount = (value: number): LineCount => value as LineCount
 
 /**
  * @description Count of skill records, directories, or skill-like entries.
  * @example 15
  */
-export type SkillCount = number
+export type SkillCount = Brand<number, 'SkillCount'>
+
+/**
+ * Construct a {@link SkillCount} from a raw number at a trust boundary
+ * (a scan result or IPC payload).
+ * @example toSkillCount(1)
+ */
+export const toSkillCount = (value: number): SkillCount => value as SkillCount
 
 /**
  * @description Count of agents included in a scan, sync, or dashboard operation.
  * @example 3
  */
-export type AgentCount = number
+export type AgentCount = Brand<number, 'AgentCount'>
+
+/**
+ * Construct a {@link AgentCount} from a raw number at a trust boundary
+ * (a scan result or IPC payload).
+ * @example toAgentCount(1)
+ */
+export const toAgentCount = (value: number): AgentCount => value as AgentCount
 
 /**
  * @description Raw byte count transferred or expected by a download operation.
  * @example 10485760
  */
-export type ByteCount = number
+export type ByteCount = Brand<number, 'ByteCount'>
+
+/**
+ * Construct a {@link ByteCount} from a raw number at a trust boundary
+ * (a download progress event).
+ * @example toByteCount(1)
+ */
+export const toByteCount = (value: number): ByteCount => value as ByteCount
 
 /**
  * @description Download throughput measured in bytes per second.
  * @example 524288
  */
-export type BytesPerSecond = number
+export type BytesPerSecond = Brand<number, 'BytesPerSecond'>
+
+/**
+ * Construct a {@link BytesPerSecond} from a raw number at a trust boundary
+ * (a download progress event).
+ * @example toBytesPerSecond(1)
+ */
+export const toBytesPerSecond = (value: number): BytesPerSecond =>
+  value as BytesPerSecond
 
 /**
  * @description Completion percentage in the inclusive 0..100 range.
  * @example 45.2
  */
-export type ProgressPercent = number
+export type ProgressPercent = Brand<number, 'ProgressPercent'>
+
+/**
+ * Construct a {@link ProgressPercent} from a raw number at a trust boundary
+ * (a download progress event).
+ * @example toProgressPercent(1)
+ */
+export const toProgressPercent = (value: number): ProgressPercent =>
+  value as ProgressPercent
 
 /**
  * @description 1-based index of the item currently processed in a batch operation.
  * @example 3
  */
-export type BatchItemIndex = number
+export type BatchItemIndex = Brand<number, 'BatchItemIndex'>
+
+/**
+ * Construct a {@link BatchItemIndex} from a raw number at a trust boundary
+ * (a bulk-operation loop counter).
+ * @example toBatchItemIndex(1)
+ */
+export const toBatchItemIndex = (value: number): BatchItemIndex =>
+  value as BatchItemIndex
 
 /**
  * @description Total item count in a batch operation.
  * @example 12
  */
-export type BatchItemCount = number
+export type BatchItemCount = Brand<number, 'BatchItemCount'>
+
+/**
+ * Construct a {@link BatchItemCount} from a raw number at a trust boundary
+ * (a bulk-operation input length).
+ * @example toBatchItemCount(1)
+ */
+export const toBatchItemCount = (value: number): BatchItemCount =>
+  value as BatchItemCount
 
 /**
  * A non-negative count of agent symlink records. Used in three senses:
@@ -197,13 +354,28 @@ export type BatchItemCount = number
  * install counts) at sync IPC boundaries and skill-list rendering.
  * @example 12
  */
-export type SymlinkCount = number
+export type SymlinkCount = Brand<number, 'SymlinkCount'>
+
+/**
+ * Construct a {@link SymlinkCount} from a raw number at a trust boundary
+ * (a symlink slot tally).
+ * @example toSymlinkCount(1)
+ */
+export const toSymlinkCount = (value: number): SymlinkCount =>
+  value as SymlinkCount
 
 /**
  * 1-indexed rank of a skill in a leaderboard listing. `1` is the top result.
  * @example 1
  */
-export type SkillRank = number
+export type SkillRank = Brand<number, 'SkillRank'>
+
+/**
+ * Construct a {@link SkillRank} from a raw number at a trust boundary
+ * (marketplace registry ordering).
+ * @example toSkillRank(1)
+ */
+export const toSkillRank = (value: number): SkillRank => value as SkillRank
 
 /**
  * Total install count for a skill, scraped from skills.sh and surfaced in
@@ -211,7 +383,15 @@ export type SkillRank = number
  * lack telemetry data.
  * @example 2480
  */
-export type InstallCount = number
+export type InstallCount = Brand<number, 'InstallCount'>
+
+/**
+ * Construct a {@link InstallCount} from a raw number at a trust boundary
+ * (marketplace registry JSON).
+ * @example toInstallCount(1)
+ */
+export const toInstallCount = (value: number): InstallCount =>
+  value as InstallCount
 
 /**
  * Free-form marketplace search text typed by the user.
@@ -219,7 +399,15 @@ export type InstallCount = number
  * the alias exists so signatures read "search text" rather than "any string".
  * @example "react hooks"
  */
-export type SearchQuery = string
+export type SearchQuery = Brand<string, 'SearchQuery'>
+
+/**
+ * Construct a {@link SearchQuery} from a raw string at a trust boundary
+ * (a search input's onChange).
+ * @example toSearchQuery('x')
+ */
+export const toSearchQuery = (value: string): SearchQuery =>
+  value as SearchQuery
 
 /**
  * Sonner toast id returned by `toast.custom(...)` and passed to `toast.dismiss(...)`.


### PR DESCRIPTION
## Summary

Converts 29 plain domain aliases (`type PixelWidth = number`) into branded types
(`Brand<number, 'PixelWidth'>`) and ships a constructor beside each one. Before
this change TypeScript's structural typing made `PixelWidth` and `PixelHeight`
(or `SymlinkCount` and `InstallCount`) freely interchangeable — the aliases were
documentation, not a guarantee.

**Constructors are named `to<TypeName>`**, not the bare camelCase form. The bare
form collides with local bindings that already exist across the tree —
`skillName` is a local in 35 files, `skillCount` in 22, `searchQuery` in 16 —
and each collision is a `TS2349 (this expression is not callable)` at the shadow
site. Measured: 8 files errored with the bare names, **0 with the `to` prefix**.
{@link repositoryId} and {@link semanticVersion} predate the rule and keep their
names; renaming them would touch 181 sites across 42 files and buy nothing. The
rationale lives in the `src/shared/types.ts` header so the next brand follows it.

### Three latent contract bugs the brands surfaced

The plain aliases were hiding real type errors, not just theoretical ones:

1. `CreateSymlinksResult.created` was typed as a skill count. It counts
   **symlinks** — now `SymlinkCount` (`src/main/ipc/skills.ts`).
2. `CopyToAgentsResult.copied` was typed as a skill count. It counts
   **agents** — now `AgentCount` (same file).
3. `parseTrashTimestampPrefix` branded its `null` arm instead of its value:
   `Number.isFinite(parsed) ? parsed : toUnixTimestampMs(null)`. Now
   `? toUnixTimestampMs(parsed) : null` (`src/main/services/trashService.ts:2181`).

### Where the branding happens

Values are branded **once at the trust boundary**, then passed down — not at
each consumer. Three boundary decisions worth calling out:

- **Zod `.transform()` is the brand site for persisted values**
  (`src/shared/settings.ts`). The same parse that validates also brands, so
  `windowSize` arrives branded from disk. Identity at runtime; the JSON
  round-trip is unchanged, and `SettingsSchema.parse({ ...current, ...partial })`
  still accepts the branded snapshot back because a brand widens to its base type.
- **ts-pattern cannot literal-narrow a branded operand.** `.with(toSkillCount(0), …)`
  compiles, but the *second* `.with(toSkillCount(1), …)` fails with
  `Argument of type 'SkillCount' is not assignable to parameter of type
  'PatternMatcher<never>'` — matching against a non-literal branded value
  exhausts the union. Fixed with `match<number>(actionCount)` plus a comment
  at the site (`bulkDeleteHelpers.ts`).
- **`page.evaluate` erases brands.** Values round-tripped out of the renderer
  arrive structurally, so `expectIronRuleRefusal` takes the structured-clone
  shape rather than `RemoveAllFromAgentResult`. This follows the precedent
  already in the suite: `E2EFilesystemIdentity` is redeclared locally at
  `e2e/spec/unlink-agent.e2e.ts:40` for exactly this reason.

Test fixtures brand **inside** the fixture rather than typing the parameter —
branding the param first produced TS2304 and would have forced wraps at 20+ DAMP
call sites for no added safety.

`SkillName` (292 refs) and `AbsolutePath` (270 refs) are still plain aliases and
are branded in follow-up passes; the header records that.

## Test Plan

- [x] `pnpm validate` — exit 0, all 7 legs green (198 test files, 2617 tests).
      `fallow:dead-code` passing proves every one of the 29 new factories is
      actually reachable (`.fallowrc.jsonc` has no exemption for
      `src/shared/types.ts`).
- [x] `pnpm test:e2e` — 86 passed, exit 0
- [x] `npx tsc -p tsconfig.json --noEmit` — clean
- [x] `npx tsc -p e2e/tsconfig.json --noEmit` — clean (e2e has its own tsconfig;
      `pnpm typecheck` does not cover it)
- [x] `pnpm lint` — clean
- [x] tsc (both projects) + lint re-run **after** lint-staged's prettier pass

## Security Checklist

- [x] This change does not widen renderer access to Node.js, Electron, or direct filesystem APIs. — N/A, type-level only; no new API surface.
- [x] New IPC or filesystem behavior validates untrusted renderer input in the main process. — N/A. No IPC payload shape changes; the `ipc/skills.ts` and `ipc/window.ts` edits brand values that were already returned. The one `settings.ts` runtime touch is a Zod `.transform()` that runs **after** `.int().min()` validation, so it neither adds nor relaxes a check.
- [x] Dependency, workflow, or release changes preserve least-privilege permissions and pinned third-party Actions. — N/A, no dependency, workflow, or release files touched.
- [x] Security-sensitive behavior is documented or linked from `SECURITY.md` when relevant. — N/A, no security-sensitive behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - ダッシュボードのウィジェット配置・サイズが一貫して扱われ、追加・編集時のレイアウトが安定しました。
  - ダッシュボードページ名や検索語、URL、各種件数・進捗値の扱いを統一しました。
  - ウィンドウサイズや表示領域の計算がピクセル単位で適切に処理されるようになりました。
  - マーケットプレイス検索結果、ブックマーク、ファイル情報、更新進捗などの表示データの整合性を向上しました。

- **テスト**
  - ダッシュボード、検索、同期、ファイルプレビュー、更新処理などのテストデータを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->