### PR TITLE
refactor(types): brand SkillName and route every construction through toSkillName

### DIFF
--- a/.storybook/fixtures.ts
+++ b/.storybook/fixtures.ts
@@ -13,6 +13,7 @@ import {
   toLineCount,
   toPosixRelativePath,
   toSkillCount,
+  toSkillName,
   toSkillRank,
   toSymlinkCount,
   tombstoneId,
@@ -81,7 +82,7 @@ export const storyAgents: Agent[] = [
  */
 export const storySkills: Skill[] = [
   {
-    name: 'design-review',
+    name: toSkillName('design-review'),
     description:
       'Designer-eye QA for spacing, hierarchy, interaction polish, and screenshots.',
     path: '/Users/raphtalia/.agents/skills/design-review',
@@ -118,7 +119,7 @@ export const storySkills: Skill[] = [
     ],
   },
   {
-    name: 'qa-electron',
+    name: toSkillName('qa-electron'),
     description:
       'Runs Electron UI verification through Playwright and the debug port.',
     path: '/Users/raphtalia/.agents/skills/qa-electron',
@@ -154,7 +155,7 @@ export const storySkills: Skill[] = [
     ],
   },
   {
-    name: 'open-to-dia',
+    name: toSkillName('open-to-dia'),
     description: 'Local macOS launcher skill for opening current URLs in Dia.',
     path: '/Users/raphtalia/.codex/skills/open-to-dia',
     symlinkCount: toSymlinkCount(0),
@@ -171,7 +172,7 @@ export const storySkills: Skill[] = [
     ],
   },
   {
-    name: 'retired-skill',
+    name: toSkillName('retired-skill'),
     description: 'Source folder removed; remaining links need cleanup.',
     path: '/Users/raphtalia/.agents/skills/retired-skill',
     symlinkCount: toSymlinkCount(0),
@@ -208,28 +209,28 @@ export const storySkills: Skill[] = [
 export const storyMarketplaceSkills: SkillSearchResult[] = [
   {
     rank: toSkillRank(1),
-    name: 'task',
+    name: toSkillName('task'),
     repo: repositoryId('vercel-labs/skills'),
     url: toHttpUrl('https://skills.sh/task'),
     installCount: toInstallCount(2480),
   },
   {
     rank: toSkillRank(2),
-    name: 'browser-use',
+    name: toSkillName('browser-use'),
     repo: repositoryId('browser-use/skills'),
     url: toHttpUrl('https://skills.sh/browser-use'),
     installCount: toInstallCount(1630),
   },
   {
     rank: toSkillRank(3),
-    name: 'code-review',
+    name: toSkillName('code-review'),
     repo: repositoryId('laststance/gstack'),
     url: toHttpUrl('https://skills.sh/code-review'),
     installCount: toInstallCount(820),
   },
   {
     rank: toSkillRank(4),
-    name: 'azure-ai',
+    name: toSkillName('azure-ai'),
     repo: repositoryId('microsoft/azure-skills'),
     url: toHttpUrl('https://skills.sh/azure-ai'),
     installCount: toInstallCount(312),
@@ -238,13 +239,13 @@ export const storyMarketplaceSkills: SkillSearchResult[] = [
 
 export const storyBookmarks: BookmarkedSkill[] = [
   {
-    name: 'task',
+    name: toSkillName('task'),
     repo: repositoryId('vercel-labs/skills'),
     url: toHttpUrl('https://skills.sh/task'),
     bookmarkedAt: toIsoTimestamp(now),
   },
   {
-    name: 'browser-use',
+    name: toSkillName('browser-use'),
     repo: repositoryId('browser-use/skills'),
     url: toHttpUrl('https://skills.sh/browser-use'),
     bookmarkedAt: toIsoTimestamp(now),
@@ -310,7 +311,7 @@ export const storySyncPreview: SyncPreviewResult = {
   alreadySynced: toSymlinkCount(8),
   conflicts: [
     {
-      skillName: 'qa-electron',
+      skillName: toSkillName('qa-electron'),
       agentId: 'cursor',
       agentName: 'Cursor',
       agentSkillPath: '/Users/raphtalia/.cursor/skills/qa-electron',
@@ -330,11 +331,23 @@ export const storySyncResult: SyncExecuteResult = {
     },
   ],
   details: [
-    { skillName: 'design-review', agentName: 'Codex', action: 'created' },
-    { skillName: 'qa-electron', agentName: 'Cursor', action: 'replaced' },
-    { skillName: 'task', agentName: 'Claude Code', action: 'skipped' },
     {
-      skillName: 'retired-skill',
+      skillName: toSkillName('design-review'),
+      agentName: 'Codex',
+      action: 'created',
+    },
+    {
+      skillName: toSkillName('qa-electron'),
+      agentName: 'Cursor',
+      action: 'replaced',
+    },
+    {
+      skillName: toSkillName('task'),
+      agentName: 'Claude Code',
+      action: 'skipped',
+    },
+    {
+      skillName: toSkillName('retired-skill'),
       agentName: 'Cursor',
       action: 'error',
       error: 'Broken symlink already removed',

--- a/src/main/ipc/skills.unlinkFromAgent.integration.test.ts
+++ b/src/main/ipc/skills.unlinkFromAgent.integration.test.ts
@@ -24,6 +24,7 @@ import type {
   FilesystemEntryIdentity,
   SkillName,
 } from '@/shared/types'
+import { toSkillName } from '@/shared/types'
 
 const handleMock = vi.fn()
 const trashItemMock = vi.fn()
@@ -218,7 +219,7 @@ describe('skills:unlinkFromAgent handler', () => {
 
   it('bulk unlink removes reviewed slot when metadata name differs from folder basename', async () => {
     // Arrange
-    const metadataName = 'metadata-title-bulk' as SkillName
+    const metadataName = toSkillName('metadata-title-bulk')
     const slotName = 'folder-basename-bulk'
     const sourcePath = join(tempHome, '.agents', 'skills', slotName)
     const cursorSkillsDir = join(tempHome, '.cursor', 'skills')

--- a/src/main/services/dirScanner.ts
+++ b/src/main/services/dirScanner.ts
@@ -6,6 +6,7 @@ import { SOURCE_DIR } from '@/main/constants'
 import { errorCode, isMissingPathError } from '@/main/utils/errorCode'
 import { extractErrorMessage } from '@/main/utils/errors'
 import type { AbsolutePath, SkillName } from '@/shared/types'
+import { toSkillName } from '@/shared/types'
 
 import { probeSkillDir } from './skillValidation'
 
@@ -72,7 +73,7 @@ export async function listSourceSkillDirs(): Promise<SourceSkillDirListing> {
     const probe = await probeSkillDir(skillPath)
     if (probe === 'not-a-skill') continue
     results.push({
-      name: dir.name,
+      name: toSkillName(dir.name),
       path: skillPath,
       isUnreadable: probe === 'unreadable',
     })

--- a/src/main/services/leaderboardService.ts
+++ b/src/main/services/leaderboardService.ts
@@ -3,6 +3,7 @@ import {
   repositoryId,
   toHttpUrl,
   toInstallCount,
+  toSkillName,
   toSkillRank,
 } from '@/shared/types'
 import type {
@@ -120,7 +121,7 @@ export function parseLeaderboardHtml(html: string): SkillSearchResult[] {
 
     results.push({
       rank: toSkillRank(rank++),
-      name,
+      name: toSkillName(name),
       repo: repositoryId(repo),
       url: toHttpUrl(`https://skills.sh/${repo}/${skillSlug}`),
       installCount: toInstallCount(installCount),

--- a/src/main/services/metadataParser.ts
+++ b/src/main/services/metadataParser.ts
@@ -2,6 +2,7 @@ import { readFile } from 'fs/promises'
 import { join, basename } from 'path'
 
 import type { AbsolutePath, SkillMetadata } from '@/shared/types'
+import { toSkillName } from '@/shared/types'
 
 /**
  * Parse SKILL.md frontmatter to extract metadata
@@ -22,13 +23,13 @@ export async function parseSkillMetadata(
     const frontmatter = extractFrontmatter(content)
 
     return {
-      name: frontmatter.name || dirName,
+      name: toSkillName(frontmatter.name || dirName),
       description: frontmatter.description || '',
     }
   } catch {
     // SKILL.md not found or unreadable
     return {
-      name: dirName,
+      name: toSkillName(dirName),
       description: '',
     }
   }

--- a/src/main/services/skillLockService.test.ts
+++ b/src/main/services/skillLockService.test.ts
@@ -21,7 +21,7 @@ import {
   vi,
 } from 'vitest'
 
-import type { SkillName } from '@/shared/types'
+import { toSkillName } from '@/shared/types'
 
 // Stamped synchronously at module load: `main/constants` computes SOURCE_DIR
 // and TRASH_DIR from homedir() at import time, so the value has to exist
@@ -215,7 +215,7 @@ describe('scanStaleLockEntries', () => {
     // CTA for a record the trash is in the middle of removing.
     const { scanStaleLockEntries, queuePrune } = await serviceModule
     await writeLock(['evicted-skill'])
-    queuePrune('evicted-skill')
+    queuePrune(toSkillName('evicted-skill'))
 
     // Act
     const result = await scanStaleLockEntries()
@@ -592,7 +592,7 @@ describe('pruneLockEntries', () => {
     await makeSourceSkill('kept-skill')
 
     // Act
-    const result = await pruneLockEntries(['gone-skill'] as SkillName[])
+    const result = await pruneLockEntries([toSkillName('gone-skill')])
 
     // Assert
     expect(result).toEqual({
@@ -612,7 +612,7 @@ describe('pruneLockEntries', () => {
     await writeLock(['CE:Review'])
 
     // Act
-    await pruneLockEntries(['CE:Review'] as SkillName[])
+    await pruneLockEntries([toSkillName('CE:Review')])
 
     // Assert
     expect(removeSkillsMock).toHaveBeenCalledWith(['CE:Review'])
@@ -628,7 +628,7 @@ describe('pruneLockEntries', () => {
     await makeSourceSkill('reinstalled')
 
     // Act
-    const result = await pruneLockEntries(['reinstalled'] as SkillName[])
+    const result = await pruneLockEntries([toSkillName('reinstalled')])
 
     // Assert
     expect(removeSkillsMock).not.toHaveBeenCalled()
@@ -651,7 +651,7 @@ describe('pruneLockEntries', () => {
     await makeTombstone('same-name')
 
     // Act
-    const result = await pruneLockEntries(['same-name'] as SkillName[])
+    const result = await pruneLockEntries([toSkillName('same-name')])
 
     // Assert
     expect(removeSkillsMock).not.toHaveBeenCalled()
@@ -676,7 +676,7 @@ describe('pruneLockEntries', () => {
     await writeFile(join(agentOwnedDir, 'SKILL.md'), '# local\n', 'utf-8')
 
     // Act
-    const result = await pruneLockEntries(['agent-owned'] as SkillName[])
+    const result = await pruneLockEntries([toSkillName('agent-owned')])
 
     // Assert
     expect(removeSkillsMock).not.toHaveBeenCalled()
@@ -702,7 +702,7 @@ describe('pruneLockEntries', () => {
     )
 
     // Act
-    const result = await pruneLockEntries(['linked-only'] as SkillName[])
+    const result = await pruneLockEntries([toSkillName('linked-only')])
 
     // Assert
     expect(removeSkillsMock).toHaveBeenCalledWith(['linked-only'])
@@ -724,9 +724,9 @@ describe('pruneLockEntries', () => {
 
     // Act
     const result = await pruneLockEntries([
-      'first-skill',
-      'second-skill',
-    ] as SkillName[])
+      toSkillName('first-skill'),
+      toSkillName('second-skill'),
+    ])
 
     // Assert
     expect(removeSkillsMock).not.toHaveBeenCalled()
@@ -747,7 +747,7 @@ describe('pruneLockEntries', () => {
     removeSkillsMock.mockResolvedValue({ success: true })
 
     // Act
-    const result = await pruneLockEntries(['stubborn-record'] as SkillName[])
+    const result = await pruneLockEntries([toSkillName('stubborn-record')])
 
     // Assert
     expect(result).toEqual({
@@ -763,7 +763,7 @@ describe('pruneLockEntries', () => {
     await writeLock(['unrelated'])
 
     // Act
-    const result = await pruneLockEntries(['already-pruned'] as SkillName[])
+    const result = await pruneLockEntries([toSkillName('already-pruned')])
 
     // Assert
     expect(removeSkillsMock).not.toHaveBeenCalled()
@@ -775,7 +775,7 @@ describe('pruneLockEntries', () => {
     await mkdir(lockPath, { recursive: true })
 
     // Act
-    const result = await pruneLockEntries(['whatever'])
+    const result = await pruneLockEntries([toSkillName('whatever')])
 
     // Assert: without the lock there is no way to prove a removal is safe.
     expect(result).toEqual({
@@ -797,7 +797,7 @@ describe('pruneLockEntries', () => {
     })
 
     // Act
-    const result = await pruneLockEntries(['half-written'])
+    const result = await pruneLockEntries([toSkillName('half-written')])
 
     // Assert: unverifiable is reported as failed, never as pruned.
     expect(result).toEqual({
@@ -816,7 +816,7 @@ describe('pruneLockEntries', () => {
     await symlink('.trash', trashDir)
 
     // Act
-    const result = await pruneLockEntries(['gone-from-disk'] as SkillName[])
+    const result = await pruneLockEntries([toSkillName('gone-from-disk')])
 
     // Assert: `skipped` means "nothing to do here" and the UI reports it as a
     // benign no-op. This record is still stale and still needs the user's
@@ -838,7 +838,7 @@ describe('pruneLockEntries', () => {
     await symlink('unreadable', join(sourceDir, 'unreadable'))
 
     // Act
-    const result = await pruneLockEntries(['unreadable'] as SkillName[])
+    const result = await pruneLockEntries([toSkillName('unreadable')])
 
     // Assert: `skipped` would tell the user the skill came back and hide the
     // record. It is still stale and still unverifiable, so it goes to `failed`.
@@ -860,7 +860,7 @@ describe('pruneLockEntries', () => {
     await writeLock(['Ambiguous', 'ambiguous'])
 
     // Act
-    const result = await pruneLockEntries(['Ambiguous'] as SkillName[])
+    const result = await pruneLockEntries([toSkillName('Ambiguous')])
 
     // Assert
     expect(removeSkillsMock).not.toHaveBeenCalled()
@@ -884,9 +884,9 @@ describe('pruneLockEntries', () => {
 
     // Act
     const result = await pruneLockEntries([
-      'unreadable',
-      'gone-from-disk',
-    ] as SkillName[])
+      toSkillName('unreadable'),
+      toSkillName('gone-from-disk'),
+    ])
 
     // Assert
     expect(result).toEqual({
@@ -927,7 +927,7 @@ describe('resolveLockKeyForDirectory', () => {
     })
 
     // Act
-    const pruning = pruneLockEntries(['gone-from-disk'] as SkillName[])
+    const pruning = pruneLockEntries([toSkillName('gone-from-disk')])
     await lockIsTruncated
     const resolved = await resolveLockKeyForDirectory('ce-review')
     await pruning
@@ -947,9 +947,9 @@ describe('queuePrune', () => {
     await writeLock(['bulk-a', 'bulk-b', 'bulk-c'])
 
     // Act
-    queuePrune('bulk-a')
-    queuePrune('bulk-b')
-    queuePrune('bulk-c')
+    queuePrune(toSkillName('bulk-a'))
+    queuePrune(toSkillName('bulk-b'))
+    queuePrune(toSkillName('bulk-c'))
     await flushPruneQueue()
 
     // Assert
@@ -970,7 +970,7 @@ describe('queuePrune', () => {
     await writeLock(['debounced-skill'])
 
     // Act
-    queuePrune('debounced-skill')
+    queuePrune(toSkillName('debounced-skill'))
 
     // Assert: wait on the effect, not the call. `removeSkillsMock` is async and
     // rewrites the lock in its body, so waiting for the invocation alone lets
@@ -990,7 +990,7 @@ describe('queuePrune', () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     // Act
-    queuePrune('stubborn-skill')
+    queuePrune(toSkillName('stubborn-skill'))
     await flushPruneQueue()
 
     // Assert

--- a/src/main/services/skillLockService.ts
+++ b/src/main/services/skillLockService.ts
@@ -17,6 +17,7 @@ import type {
   StaleLockScanResult,
   UnprunableLockEntry,
 } from '@/shared/types'
+import { toSkillName } from '@/shared/types'
 
 import { skillsCliService } from './skillsCliService'
 
@@ -266,7 +267,10 @@ async function readSkillLockKeys(): Promise<LockReadResult> {
     if (parsed.data.version > SUPPORTED_LOCK_VERSION) {
       return { status: 'unavailable' }
     }
-    return { status: 'ok', keys: Object.keys(parsed.data.skills) }
+    return {
+      status: 'ok',
+      keys: Object.keys(parsed.data.skills).map(toSkillName),
+    }
   } catch (error) {
     console.error('skillLockService: lock is not valid JSON', {
       message: extractErrorMessage(error),

--- a/src/main/services/skillScanner.test.ts
+++ b/src/main/services/skillScanner.test.ts
@@ -2,6 +2,8 @@ import { basename, join } from 'node:path'
 
 import { beforeEach, describe, expect, it, test, vi } from 'vitest'
 
+import { toSkillName } from '@/shared/types'
+
 /**
  * Create a minimal Dirent-like object for readdir mocks.
  * @param name - Entry name
@@ -1553,7 +1555,7 @@ describe('getSkill single-skill lookup', () => {
     const { getSkill } = await import('./skillScanner')
 
     // Act
-    const skill = await getSkill('theme-generator')
+    const skill = await getSkill(toSkillName('theme-generator'))
 
     // Assert
     expect(skill).not.toBeNull()
@@ -1575,7 +1577,7 @@ describe('getSkill single-skill lookup', () => {
     const { getSkill } = await import('./skillScanner')
 
     // Act
-    const skill = await getSkill('not-a-dir')
+    const skill = await getSkill(toSkillName('not-a-dir'))
 
     // Assert
     expect(skill).toBeNull()
@@ -1587,7 +1589,7 @@ describe('getSkill single-skill lookup', () => {
     const { getSkill } = await import('./skillScanner')
 
     // Act
-    const skill = await getSkill('missing-skill')
+    const skill = await getSkill(toSkillName('missing-skill'))
 
     // Assert
     expect(skill).toBeNull()

--- a/src/main/services/skillScanner.ts
+++ b/src/main/services/skillScanner.ts
@@ -10,6 +10,7 @@ import {
   toHumanFileSize,
   toIsoTimestamp,
   toSkillCount,
+  toSkillName,
   toSymlinkCount,
 } from '@/shared/types'
 import type {
@@ -144,7 +145,8 @@ async function scanAgentSymlinkStatusHits(
       try {
         const entries = await readdir(agent.path, { withFileTypes: true })
         const candidates = entries.filter(
-          (entry) => entry.isSymbolicLink() && !sourceNames.has(entry.name),
+          (entry) =>
+            entry.isSymbolicLink() && !sourceNames.has(toSkillName(entry.name)),
         )
         return Promise.all(
           candidates.map(async (link) => {
@@ -153,7 +155,13 @@ async function scanAgentSymlinkStatusHits(
               checkSymlinkTargetFromKnownLink(linkPath),
               readSymlinkTargetIfPresent(linkPath),
             ])
-            return { agent, name: link.name, linkPath, status, targetPath }
+            return {
+              agent,
+              name: toSkillName(link.name),
+              linkPath,
+              status,
+              targetPath,
+            }
           }),
         )
       } catch {
@@ -178,7 +186,12 @@ async function readSkillLock(): Promise<Map<SkillName, SkillLockEntry>> {
     // and display attribution has to read the same file prune writes to.
     const content = await readFile(getSkillLockPath(), 'utf-8')
     const parsed = JSON.parse(content) as SkillLockContent
-    return new Map(Object.entries(parsed.skills ?? {}))
+    return new Map(
+      Object.entries(parsed.skills ?? {}).map(([name, entry]) => [
+        toSkillName(name),
+        entry,
+      ]),
+    )
   } catch {
     return new Map()
   }
@@ -272,7 +285,8 @@ export async function scanSkills(): Promise<Skill[]> {
   // Attach source info from lock file
   for (const skill of allSkills) {
     const dirName = basename(skill.path)
-    const lock = lockEntries.get(dirName) ?? lockEntries.get(skill.name)
+    const lock =
+      lockEntries.get(toSkillName(dirName)) ?? lockEntries.get(skill.name)
     if (lock) {
       skill.source = repositoryId(lock.source)
       skill.sourceUrl = lock.sourceUrl
@@ -554,7 +568,7 @@ async function scanAllLocalSkills(): Promise<Skill[]> {
         path: skillPath,
         filesystemIdentity,
         symlinkCount: toSymlinkCount(0), // Local skills have 0 symlinks
-        symlinks: createMissingSymlinkSlots(dirName),
+        symlinks: createMissingSymlinkSlots(toSkillName(dirName)),
         isSource: false,
         isOrphan: false,
       }

--- a/src/main/services/skillsCliService.test.ts
+++ b/src/main/services/skillsCliService.test.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from 'events'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { SKILLS_CLI_VERSION } from '@/shared/constants'
-import { repositoryId, toSearchQuery } from '@/shared/types'
+import { repositoryId, toSearchQuery, toSkillName } from '@/shared/types'
 import type { InstallProgress } from '@/shared/types'
 
 /**
@@ -108,7 +108,7 @@ describe('skillsCliService.cancel', () => {
     const prune = simulateCli({ autoClose: false })
     const { skillsCliService } = await import('./skillsCliService')
     const searching = skillsCliService.search(toSearchQuery('a'))
-    const pruning = skillsCliService.removeSkills(['old-skill'])
+    const pruning = skillsCliService.removeSkills([toSkillName('old-skill')])
 
     // Act
     skillsCliService.cancel()
@@ -329,7 +329,7 @@ describe('skillsCliService.install', () => {
       repo: repositoryId('vercel-labs/skills'),
       global: true,
       agents: [],
-      skills: ['task'],
+      skills: [toSkillName('task')],
     })
 
     // Assert
@@ -358,7 +358,7 @@ describe('skillsCliService.install', () => {
       repo: repositoryId('vercel-labs/skills'),
       global: true,
       agents: ['claude-code', 'cursor'],
-      skills: ['task'],
+      skills: [toSkillName('task')],
     })
 
     // Assert
@@ -391,7 +391,7 @@ describe('skillsCliService.install', () => {
       repo: repositoryId('vercel-labs/skills'),
       global: false,
       agents: [],
-      skills: ['task'],
+      skills: [toSkillName('task')],
     })
 
     // Assert — local scope means the CLI is invoked without `--global`.
@@ -518,7 +518,7 @@ describe('skillsCliService.install failure and progress', () => {
       repo: repositoryId('vercel-labs/skills'),
       global: true,
       agents: [],
-      skills: ['task'],
+      skills: [toSkillName('task')],
     })
     fake.stderr.emit('data', Buffer.from('permission denied'))
     fake.emit('close', 1)
@@ -546,7 +546,7 @@ describe('skillsCliService.install failure and progress', () => {
       repo: repositoryId('vercel-labs/skills'),
       global: true,
       agents: [],
-      skills: ['task'],
+      skills: [toSkillName('task')],
     })
     fake.emit('close', 1)
     await installPromise
@@ -575,7 +575,7 @@ describe('skillsCliService.install failure and progress', () => {
       repo: repositoryId('vercel-labs/skills'),
       global: true,
       agents: [],
-      skills: ['task'],
+      skills: [toSkillName('task')],
     })
     fake.stdout.emit('data', Buffer.from('Downloading repository archive'))
     fake.stdout.emit('data', Buffer.from('Installing skill files now'))
@@ -688,7 +688,10 @@ describe('skillsCliService.removeSkills', () => {
     const { skillsCliService } = await import('./skillsCliService')
 
     // Act
-    await skillsCliService.removeSkills(['alpha', 'beta'])
+    await skillsCliService.removeSkills([
+      toSkillName('alpha'),
+      toSkillName('beta'),
+    ])
 
     // Assert
     expect(spawnMock).toHaveBeenCalledTimes(1)
@@ -717,7 +720,7 @@ describe('skillsCliService.removeSkills', () => {
     const { skillsCliService } = await import('./skillsCliService')
 
     // Act
-    const result = await skillsCliService.removeSkills(['--all'])
+    const result = await skillsCliService.removeSkills([toSkillName('--all')])
 
     // Assert
     expect(spawnMock).not.toHaveBeenCalled()
@@ -730,7 +733,10 @@ describe('skillsCliService.removeSkills', () => {
     const { skillsCliService } = await import('./skillsCliService')
 
     // Act
-    await skillsCliService.removeSkills(['--all', 'real-skill'])
+    await skillsCliService.removeSkills([
+      toSkillName('--all'),
+      toSkillName('real-skill'),
+    ])
 
     // Assert
     expect(spawnMock).toHaveBeenCalledWith(
@@ -761,7 +767,7 @@ describe('skillsCliService.removeSkills', () => {
     const { skillsCliService } = await import('./skillsCliService')
 
     // Act
-    const pruning = skillsCliService.removeSkills(['old-skill'])
+    const pruning = skillsCliService.removeSkills([toSkillName('old-skill')])
     await vi.advanceTimersByTimeAsync(SEARCH_CEILING_MS)
 
     // Assert — still running where a search would already have been killed.
@@ -790,7 +796,7 @@ describe('skillsCliService.removeSkills', () => {
 
     // Act
     const pruning = skillsCliService
-      .removeSkills(['old-skill'])
+      .removeSkills([toSkillName('old-skill')])
       .then((value) => {
         hasResolved = true
         return value
@@ -821,7 +827,7 @@ describe('skillsCliService.removeSkills', () => {
     const { skillsCliService } = await import('./skillsCliService')
 
     // Act — no close event ever arrives.
-    const pruning = skillsCliService.removeSkills(['old-skill'])
+    const pruning = skillsCliService.removeSkills([toSkillName('old-skill')])
     await vi.advanceTimersByTimeAsync(LOCK_WRITE_CEILING_MS + KILL_GRACE_MS)
     const result = await pruning
 
@@ -844,7 +850,7 @@ describe('skillsCliService.removeSkills', () => {
     })
 
     // Act
-    await skillsCliService.removeSkills(['alpha'])
+    await skillsCliService.removeSkills([toSkillName('alpha')])
 
     // Assert
     expect(progressEvents).toEqual([])

--- a/src/main/services/skillsCliService.ts
+++ b/src/main/services/skillsCliService.ts
@@ -8,7 +8,12 @@ import { match, P } from 'ts-pattern'
 import { parseFormattedCount } from '@/main/services/leaderboardService'
 import { REPO_PATTERN, SKILL_NAME_PATTERN } from '@/main/utils/skillIdentifiers'
 import { AGENT_DEFINITIONS, SKILLS_CLI_VERSION } from '@/shared/constants'
-import { repositoryId, toHttpUrl, toSkillRank } from '@/shared/types'
+import {
+  repositoryId,
+  toHttpUrl,
+  toSkillName,
+  toSkillRank,
+} from '@/shared/types'
 import type {
   SkillSearchResult,
   InstallOptions,
@@ -435,7 +440,7 @@ class SkillsCliService extends EventEmitter {
 
         const searchResult: SkillSearchResult = {
           rank: toSkillRank(rank++),
-          name,
+          name: toSkillName(name),
           repo: repositoryId(repo),
           url: toHttpUrl(urlMatch?.[1] || `https://skills.sh/${repo}/${name}`),
         }

--- a/src/main/services/symlinkChecker.test.ts
+++ b/src/main/services/symlinkChecker.test.ts
@@ -2,6 +2,8 @@ import { dirname, join, resolve } from 'node:path'
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { toSkillName } from '@/shared/types'
+
 /**
  * Create a mock Stats-like object for lstat results.
  * @param options - Whether the entry is a symbolic link or directory
@@ -245,7 +247,7 @@ describe('checkSkillSymlinks', () => {
 
     // Act
     const { checkSkillSymlinks } = await import('./symlinkChecker')
-    const results = await checkSkillSymlinks('my-skill')
+    const results = await checkSkillSymlinks(toSkillName('my-skill'))
 
     // Assert
     expect(results).toHaveLength(2)
@@ -270,7 +272,7 @@ describe('checkSkillSymlinks', () => {
 
     // Act
     const { checkSkillSymlinks } = await import('./symlinkChecker')
-    const results = await checkSkillSymlinks('locked-skill')
+    const results = await checkSkillSymlinks(toSkillName('locked-skill'))
 
     // Assert
     const claude = results.find((r) => r.agentId === 'claude-code')!
@@ -297,7 +299,7 @@ describe('checkSkillSymlinks', () => {
 
     // Act
     const { checkSkillSymlinks } = await import('./symlinkChecker')
-    const results = await checkSkillSymlinks('partial-skill')
+    const results = await checkSkillSymlinks(toSkillName('partial-skill'))
 
     // Assert
     const claude = results.find((r) => r.agentId === 'claude-code')!
@@ -319,7 +321,7 @@ describe('checkSkillSymlinks', () => {
 
     // Act
     const { checkSkillSymlinks } = await import('./symlinkChecker')
-    const results = await checkSkillSymlinks('good-skill')
+    const results = await checkSkillSymlinks(toSkillName('good-skill'))
 
     // Assert
     const claude = results.find((r) => r.agentId === 'claude-code')!
@@ -341,7 +343,7 @@ describe('checkSkillSymlinks', () => {
 
     // Act
     const { checkSkillSymlinks } = await import('./symlinkChecker')
-    const results = await checkSkillSymlinks('local-skill')
+    const results = await checkSkillSymlinks(toSkillName('local-skill'))
 
     // Assert
     const claude = results.find((r) => r.agentId === 'claude-code')!
@@ -377,7 +379,7 @@ describe('checkSkillSymlinks', () => {
 
     // Act
     const { checkSkillSymlinks } = await import('./symlinkChecker')
-    const results = await checkSkillSymlinks('nonexistent-skill')
+    const results = await checkSkillSymlinks(toSkillName('nonexistent-skill'))
 
     // Assert
     const claude = results.find((r) => r.agentId === 'claude-code')!
@@ -403,7 +405,7 @@ describe('checkSkillSymlinks', () => {
 
     // Act
     const { checkSkillSymlinks } = await import('./symlinkChecker')
-    const results = await checkSkillSymlinks('good-skill')
+    const results = await checkSkillSymlinks(toSkillName('good-skill'))
 
     // Assert
     expect(results).toHaveLength(2)
@@ -440,7 +442,7 @@ describe('checkSkillSymlinks', () => {
 
     // Act
     const { checkSkillSymlinks } = await import('./symlinkChecker')
-    const results = await checkSkillSymlinks('good-skill')
+    const results = await checkSkillSymlinks(toSkillName('good-skill'))
 
     // Assert
     expect(results).toHaveLength(2)
@@ -460,7 +462,7 @@ describe('checkSkillSymlinks', () => {
 
     // Act
     const { checkSkillSymlinks } = await import('./symlinkChecker')
-    const results = await checkSkillSymlinks('any-skill')
+    const results = await checkSkillSymlinks(toSkillName('any-skill'))
 
     // Assert
     const claude = results.find((r) => r.agentId === 'claude-code')!
@@ -485,7 +487,7 @@ describe('checkSkillSymlinks', () => {
 
     // Act
     const { checkSkillSymlinks } = await import('./symlinkChecker')
-    const results = await checkSkillSymlinks('stray-file-skill')
+    const results = await checkSkillSymlinks(toSkillName('stray-file-skill'))
 
     // Assert
     const claude = results.find((r) => r.agentId === 'claude-code')!
@@ -526,7 +528,9 @@ describe('checkSkillSymlinks', () => {
 
     // Act
     const { checkSkillSymlinks } = await import('./symlinkChecker')
-    const results = await checkSkillSymlinks('vanishing-local-skill')
+    const results = await checkSkillSymlinks(
+      toSkillName('vanishing-local-skill'),
+    )
 
     // Assert
     const claude = results.find((r) => r.agentId === 'claude-code')!

--- a/src/main/services/trashService.durability.test.ts
+++ b/src/main/services/trashService.durability.test.ts
@@ -19,6 +19,7 @@ import type {
   FilesystemEntryIdentity,
   SkillName,
 } from '@/shared/types'
+import { toSkillName } from '@/shared/types'
 
 import { filesystemIdentityFromStats } from './filesystemIdentity'
 
@@ -196,7 +197,7 @@ describe('moveToTrash durability across a kill', () => {
     // tombstone at this instant, a kill here hands startupCleanup a manifestless
     // entry to sweep and the skill is gone for good.
     const { moveToTrash } = await trashServicePromise
-    const skillName: SkillName = 'killed-mid-move'
+    const skillName: SkillName = toSkillName('killed-mid-move')
     const sourcePath = await makeSourceSkill(skillName)
     await symlink(sourcePath, join(sharedAgentCursor, skillName))
     const reviewedIdentity = await reviewedIdentityFor(sourcePath)
@@ -254,7 +255,7 @@ describe('moveToTrash durability across a kill', () => {
     // in the trash is all that is left. It has to end up under a name the
     // marker readers scan, not under the staged name they ignore.
     const { moveToTrash, TrashError } = await trashServicePromise
-    const skillName: SkillName = 'stranded-skill'
+    const skillName: SkillName = toSkillName('stranded-skill')
     const sourcePath = await makeSourceSkill(skillName)
     const reviewedIdentity = await reviewedIdentityFor(sourcePath)
     fsHooks.onManifestWrite = async () => {}
@@ -293,7 +294,7 @@ describe('moveToTrash durability across a kill', () => {
     // and the trash entry holds nothing — so pointing the user at the entry
     // would send them to an empty path during a data-loss incident.
     const { moveToTrash } = await trashServicePromise
-    const skillName: SkillName = 'stranded-beside-original'
+    const skillName: SkillName = toSkillName('stranded-beside-original')
     const sourcePath = await makeSourceSkill(skillName)
     const reviewedIdentity = await reviewedIdentityFor(sourcePath)
     fsHooks.failCrossDeviceMove = true
@@ -375,7 +376,7 @@ describe('moveToTrash durability across a kill', () => {
     // nothing sweeps — so the error has to name that path rather than a
     // tombstone path that was never created.
     const { moveToTrash } = await trashServicePromise
-    const skillName: SkillName = 'unpublishable-skill'
+    const skillName: SkillName = toSkillName('unpublishable-skill')
     const sourcePath = await makeSourceSkill(skillName)
     const reviewedIdentity = await reviewedIdentityFor(sourcePath)
     const consoleErrorSpy = vi

--- a/src/main/services/trashService.integration.test.ts
+++ b/src/main/services/trashService.integration.test.ts
@@ -27,7 +27,7 @@ import type {
   FilesystemEntryIdentity,
   SkillName,
 } from '@/shared/types'
-import { toFileSizeBytes } from '@/shared/types'
+import { toFileSizeBytes, toSkillName } from '@/shared/types'
 
 import { filesystemIdentityFromStats } from './filesystemIdentity'
 import type { MoveToTrashResult } from './trashService'
@@ -201,7 +201,7 @@ describe('trashService (integration)', () => {
   ): Promise<MoveToTrashResult> {
     const reviewedSkillPath = join(sharedSourceDir, skillName)
     return moveToTrash(
-      skillName,
+      toSkillName(skillName),
       reviewedSkillPath,
       filesystemIdentityFromStats(await lstat(reviewedSkillPath)),
     )
@@ -226,7 +226,7 @@ describe('trashService (integration)', () => {
   ): Promise<MoveToTrashResult> {
     const reviewedSkillPath = join(agentBaseDir, skillName)
     return moveToTrash(
-      skillName,
+      toSkillName(skillName),
       reviewedSkillPath,
       filesystemIdentityFromStats(await lstat(reviewedSkillPath)),
     )
@@ -290,7 +290,7 @@ describe('trashService (integration)', () => {
     const { moveToTrash } = await trashServicePromise
 
     // Arrange
-    const metadataName = 'metadata-title-source' as SkillName
+    const metadataName = toSkillName('metadata-title-source')
     const folderName = 'folder-basename-source'
     const sourcePath = await makeSourceSkill(folderName)
     const decoyPath = await makeSourceSkill(metadataName)
@@ -380,7 +380,7 @@ describe('trashService (integration)', () => {
 
     // Act + Assert
     await expect(
-      moveToTrash(skillName as SkillName, sourcePath, reviewedIdentity),
+      moveToTrash(toSkillName(skillName), sourcePath, reviewedIdentity),
     ).rejects.toMatchObject({ code: 'ESTALE' })
     await expect(readFile(join(sourcePath, 'SKILL.md'), 'utf-8')).resolves.toBe(
       '# replacement\n',
@@ -401,7 +401,7 @@ describe('trashService (integration)', () => {
 
     // Act + Assert
     await expect(
-      moveToTrash(skillName as SkillName, localPath, reviewedIdentity),
+      moveToTrash(toSkillName(skillName), localPath, reviewedIdentity),
     ).rejects.toMatchObject({ code: 'ESTALE' })
     await expect(readFile(join(localPath, 'SKILL.md'), 'utf-8')).resolves.toBe(
       '# replacement\n',
@@ -511,7 +511,7 @@ describe('trashService (integration)', () => {
     // Act + Assert
     await expect(
       moveToTrash(
-        skillName,
+        toSkillName(skillName),
         join(sharedSourceDir, skillName),
         missingDirectoryIdentity,
       ),

--- a/src/main/services/trashService.orphanRace.test.ts
+++ b/src/main/services/trashService.orphanRace.test.ts
@@ -20,7 +20,7 @@ import { basename, dirname, join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest'
 
 import type { FilesystemEntryIdentity } from '@/shared/types'
-import { toFileSizeBytes } from '@/shared/types'
+import { toFileSizeBytes, toSkillName } from '@/shared/types'
 
 import { filesystemIdentityFromStats } from './filesystemIdentity'
 
@@ -208,7 +208,7 @@ describe('trashService orphan cleanup guarded commit', () => {
     // Act / Assert
     await expect(
       moveToTrash(
-        skillName,
+        toSkillName(skillName),
         sourcePath,
         await reviewedIdentityForPath(sourcePath),
       ),
@@ -283,7 +283,7 @@ describe('trashService orphan cleanup guarded commit', () => {
     // Act / Assert
     await expect(
       moveToTrash(
-        skillName,
+        toSkillName(skillName),
         sourcePath,
         await reviewedIdentityForPath(sourcePath),
       ),
@@ -506,7 +506,7 @@ describe('trashService orphan cleanup guarded commit', () => {
     // Act / Assert
     await expect(
       moveToTrash(
-        skillName,
+        toSkillName(skillName),
         sourcePath,
         await reviewedIdentityForPath(sourcePath),
       ),
@@ -585,7 +585,7 @@ describe('trashService orphan cleanup guarded commit', () => {
     // Act / Assert
     await expect(
       moveToTrash(
-        skillName,
+        toSkillName(skillName),
         sourcePath,
         await reviewedIdentityForPath(sourcePath),
       ),
@@ -688,7 +688,7 @@ describe('trashService orphan cleanup guarded commit', () => {
     let surfacedError: unknown
     try {
       await moveToTrash(
-        skillName,
+        toSkillName(skillName),
         sourcePath,
         await reviewedIdentityForPath(sourcePath),
       )
@@ -780,7 +780,7 @@ describe('trashService orphan cleanup guarded commit', () => {
     // Act / Assert
     await expect(
       moveToTrash(
-        skillName,
+        toSkillName(skillName),
         sourcePath,
         await reviewedIdentityForPath(sourcePath),
       ),
@@ -856,7 +856,7 @@ describe('trashService orphan cleanup guarded commit', () => {
     // Act / Assert
     await expect(
       moveToTrash(
-        skillName,
+        toSkillName(skillName),
         localPath,
         await reviewedIdentityForPath(localPath),
       ),
@@ -934,7 +934,7 @@ describe('trashService orphan cleanup guarded commit', () => {
 
     // Act
     const moveError = await moveToTrash(
-      skillName,
+      toSkillName(skillName),
       localPath,
       await reviewedIdentityForPath(localPath),
     ).catch((error: unknown) => error)
@@ -1008,7 +1008,7 @@ describe('trashService orphan cleanup guarded commit', () => {
 
     // Act
     const moveError = await moveToTrash(
-      skillName,
+      toSkillName(skillName),
       localPath,
       await reviewedIdentityForPath(localPath),
     ).catch((error: unknown) => error)
@@ -1039,7 +1039,7 @@ describe('trashService orphan cleanup guarded commit', () => {
     // Act / Assert
     await expect(
       moveToTrash(
-        'null-byte-skill',
+        toSkillName('null-byte-skill'),
         nullBytePath as never,
         missingDirectoryIdentityForOrphanTests,
       ),
@@ -1059,7 +1059,7 @@ describe('trashService orphan cleanup guarded commit', () => {
     // Act / Assert
     await expect(
       moveToTrash(
-        'stray-skill',
+        toSkillName('stray-skill'),
         strayPath as never,
         await reviewedIdentityForPath(strayPath),
       ),
@@ -1083,7 +1083,7 @@ describe('trashService orphan cleanup guarded commit', () => {
     // Act / Assert
     await expect(
       moveToTrash(
-        'symlinked-source',
+        toSkillName('symlinked-source'),
         realSourcePath as never,
         reviewedIdentity,
       ),
@@ -1109,7 +1109,7 @@ describe('trashService orphan cleanup guarded commit', () => {
     // Act / Assert
     await expect(
       moveToTrash(
-        'no-skill-md',
+        toSkillName('no-skill-md'),
         invalidSkillPath as never,
         await reviewedIdentityForPath(invalidSkillPath),
       ),
@@ -1148,7 +1148,7 @@ describe('trashService orphan cleanup guarded commit', () => {
     // Act / Assert
     await expect(
       moveToTrash(
-        skillName,
+        toSkillName(skillName),
         sourcePath,
         await reviewedIdentityForPath(sourcePath),
       ),
@@ -1188,7 +1188,7 @@ describe('trashService orphan cleanup guarded commit', () => {
     // Act / Assert
     await expect(
       moveToTrash(
-        skillName,
+        toSkillName(skillName),
         sourcePath,
         await reviewedIdentityForPath(sourcePath),
       ),
@@ -1230,7 +1230,7 @@ describe('trashService orphan cleanup guarded commit', () => {
 
     // Act
     const result = await moveToTrash(
-      skillName,
+      toSkillName(skillName),
       sourcePath,
       await reviewedIdentityForPath(sourcePath),
     )
@@ -1302,7 +1302,7 @@ describe('trashService orphan cleanup guarded commit', () => {
     // Act / Assert
     await expect(
       moveToTrash(
-        skillName,
+        toSkillName(skillName),
         sourcePath,
         await reviewedIdentityForPath(sourcePath),
       ),
@@ -1349,7 +1349,7 @@ describe('trashService orphan cleanup guarded commit', () => {
     // Act / Assert
     await expect(
       moveToTrash(
-        skillName,
+        toSkillName(skillName),
         sourcePath,
         await reviewedIdentityForPath(sourcePath),
       ),
@@ -1408,7 +1408,7 @@ describe('trashService orphan cleanup guarded commit', () => {
     // Act / Assert
     await expect(
       moveToTrash(
-        skillName,
+        toSkillName(skillName),
         sourcePath,
         await reviewedIdentityForPath(sourcePath),
       ),
@@ -1464,7 +1464,7 @@ describe('trashService orphan cleanup guarded commit', () => {
     // Act / Assert
     await expect(
       moveToTrash(
-        skillName,
+        toSkillName(skillName),
         sourcePath,
         await reviewedIdentityForPath(sourcePath),
       ),
@@ -1539,7 +1539,7 @@ describe('trashService orphan cleanup guarded commit', () => {
     // Act / Assert
     await expect(
       moveToTrash(
-        skillName,
+        toSkillName(skillName),
         sourcePath,
         await reviewedIdentityForPath(sourcePath),
       ),
@@ -1724,7 +1724,7 @@ describe('trashService orphan cleanup guarded commit', () => {
     // Act / Assert
     await expect(
       moveToTrash(
-        skillName,
+        toSkillName(skillName),
         localPath,
         await reviewedIdentityForPath(localPath),
       ),
@@ -1774,7 +1774,7 @@ describe('trashService orphan cleanup guarded commit', () => {
 
     // Act
     const result = await moveToTrash(
-      skillName,
+      toSkillName(skillName),
       localPath,
       await reviewedIdentityForPath(localPath),
     )
@@ -1856,7 +1856,7 @@ describe('trashService orphan cleanup guarded commit', () => {
 
     // Act
     const strandError = await moveToTrash(
-      skillName,
+      toSkillName(skillName),
       localPath,
       await reviewedIdentityForPath(localPath),
     ).catch((error: unknown) => error)
@@ -2396,7 +2396,7 @@ describe('trashService orphan cleanup guarded commit', () => {
 
     // Act
     const result = await moveToTrash(
-      skillName,
+      toSkillName(skillName),
       sourcePath,
       await reviewedIdentityForPath(sourcePath),
     )
@@ -2455,7 +2455,7 @@ describe('trashService orphan cleanup guarded commit', () => {
     // Act / Assert
     await expect(
       moveToTrash(
-        skillName,
+        toSkillName(skillName),
         sourcePath as never,
         await reviewedIdentityForPath(sourcePath),
       ),
@@ -2506,7 +2506,7 @@ describe('trashService orphan cleanup guarded commit', () => {
 
     // Act
     const result = await moveToTrash(
-      skillName,
+      toSkillName(skillName),
       sourcePath,
       await reviewedIdentityForPath(sourcePath),
     )
@@ -2555,7 +2555,7 @@ describe('trashService orphan cleanup guarded commit', () => {
 
     // Act
     const result = await moveToTrash(
-      skillName,
+      toSkillName(skillName),
       sourcePath,
       await reviewedIdentityForPath(sourcePath),
     )
@@ -2606,7 +2606,7 @@ describe('trashService orphan cleanup guarded commit', () => {
 
     // Act
     const result = await moveToTrash(
-      skillName,
+      toSkillName(skillName),
       sourcePath,
       await reviewedIdentityForPath(sourcePath),
     )
@@ -2652,7 +2652,7 @@ describe('trashService orphan cleanup guarded commit', () => {
 
     // Act
     const result = await moveToTrash(
-      skillName,
+      toSkillName(skillName),
       sourcePath,
       await reviewedIdentityForPath(sourcePath),
     )
@@ -2701,7 +2701,7 @@ describe('trashService orphan cleanup guarded commit', () => {
     // Act / Assert
     await expect(
       moveToTrash(
-        skillName,
+        toSkillName(skillName),
         sourcePath as never,
         await reviewedIdentityForPath(sourcePath),
       ),
@@ -2755,7 +2755,7 @@ describe('trashService orphan cleanup guarded commit', () => {
 
     // Act
     const result = await moveToTrash(
-      skillName,
+      toSkillName(skillName),
       sourcePath,
       await reviewedIdentityForPath(sourcePath),
     )
@@ -2809,7 +2809,7 @@ describe('trashService orphan cleanup guarded commit', () => {
 
     // Act
     const result = await moveToTrash(
-      skillName,
+      toSkillName(skillName),
       sourcePath,
       await reviewedIdentityForPath(sourcePath),
     )
@@ -2849,7 +2849,7 @@ describe('trashService orphan cleanup guarded commit', () => {
 
     // Act
     const result = await moveToTrash(
-      skillName,
+      toSkillName(skillName),
       sourcePath,
       await reviewedIdentityForPath(sourcePath),
     )
@@ -2905,7 +2905,7 @@ describe('trashService orphan cleanup guarded commit', () => {
     // Act / Assert
     await expect(
       moveToTrash(
-        skillName,
+        toSkillName(skillName),
         sourcePath as never,
         await reviewedIdentityForPath(sourcePath),
       ),
@@ -2952,7 +2952,7 @@ describe('trashService orphan cleanup guarded commit', () => {
     // Act / Assert
     await expect(
       moveToTrash(
-        skillName,
+        toSkillName(skillName),
         sourcePath as never,
         await reviewedIdentityForPath(sourcePath),
       ),
@@ -2978,7 +2978,7 @@ describe('trashService orphan cleanup guarded commit', () => {
       const reviewedIdentity = await reviewedIdentityForPath(sourcePath)
       const { __getTrashDirForTests, moveToTrash } =
         await import('./trashService')
-      await moveToTrash(skillName, sourcePath, reviewedIdentity)
+      await moveToTrash(toSkillName(skillName), sourcePath, reviewedIdentity)
       expect(await readdir(__getTrashDirForTests())).toHaveLength(1)
 
       // Act
@@ -3010,7 +3010,7 @@ describe('trashService orphan cleanup guarded commit', () => {
       const reviewedIdentity = await reviewedIdentityForPath(localPath)
       const { __getTrashDirForTests, moveToTrash } =
         await import('./trashService')
-      await moveToTrash(skillName, localPath, reviewedIdentity)
+      await moveToTrash(toSkillName(skillName), localPath, reviewedIdentity)
       expect(await readdir(__getTrashDirForTests())).toHaveLength(1)
 
       // Act
@@ -3422,7 +3422,7 @@ describe('trashService orphan cleanup guarded commit', () => {
 
     // Act
     const result = await moveToTrash(
-      skillName,
+      toSkillName(skillName),
       localPath,
       await reviewedIdentityForPath(localPath),
     )
@@ -3486,7 +3486,7 @@ describe('trashService orphan cleanup guarded commit', () => {
     // Act / Assert
     await expect(
       moveToTrash(
-        skillName,
+        toSkillName(skillName),
         localPath as never,
         await reviewedIdentityForPath(localPath),
       ),
@@ -3532,7 +3532,7 @@ describe('trashService orphan cleanup guarded commit', () => {
     // Act / Assert
     await expect(
       moveToTrash(
-        skillName,
+        toSkillName(skillName),
         localPath as never,
         await reviewedIdentityForPath(localPath),
       ),
@@ -3596,7 +3596,7 @@ describe('trashService orphan cleanup guarded commit', () => {
     // Act / Assert
     await expect(
       moveToTrash(
-        skillName,
+        toSkillName(skillName),
         localPath as never,
         await reviewedIdentityForPath(localPath),
       ),
@@ -3649,7 +3649,7 @@ describe('trashService orphan cleanup guarded commit', () => {
 
     // Act / Assert
     await expect(
-      moveToTrash(skillName, localPath as never, reviewedIdentity),
+      moveToTrash(toSkillName(skillName), localPath as never, reviewedIdentity),
     ).rejects.toMatchObject({
       message: expect.stringMatching(/already deleted/i),
       code: 'ENOENT',
@@ -3808,7 +3808,7 @@ describe('trashService orphan cleanup guarded commit', () => {
 
     // Act / Assert
     await expect(
-      moveToTrash(skillName, sourcePath, reviewedIdentity),
+      moveToTrash(toSkillName(skillName), sourcePath, reviewedIdentity),
     ).rejects.toMatchObject({
       message: expect.stringMatching(/Failed to inspect reviewed skill folder/),
       code: 'EACCES',
@@ -3853,7 +3853,7 @@ describe('trashService orphan cleanup guarded commit', () => {
     // Act / Assert
     await expect(
       moveToTrash(
-        skillName,
+        toSkillName(skillName),
         sourcePath,
         await reviewedIdentityForPath(sourcePath),
       ),
@@ -3935,7 +3935,7 @@ describe('trashService orphan cleanup guarded commit', () => {
     let surfacedError: unknown
     try {
       await moveToTrash(
-        skillName,
+        toSkillName(skillName),
         sourcePath,
         await reviewedIdentityForPath(sourcePath),
       )
@@ -4018,7 +4018,7 @@ describe('trashService orphan cleanup guarded commit', () => {
     let surfacedError: unknown
     try {
       await moveToTrash(
-        skillName,
+        toSkillName(skillName),
         localPath,
         await reviewedIdentityForPath(localPath),
       )

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -18,7 +18,12 @@ import { errorCode, isMissingPathError } from '@/main/utils/errorCode'
 import { extractErrorMessage } from '@/main/utils/errors'
 import { fsyncPath } from '@/main/utils/fsyncPath'
 import { UNDO_WINDOW_MS } from '@/shared/constants'
-import { toSymlinkCount, toUnixTimestampMs, tombstoneId } from '@/shared/types'
+import {
+  toSkillName,
+  toSymlinkCount,
+  toUnixTimestampMs,
+  tombstoneId,
+} from '@/shared/types'
 import type {
   AbsolutePath,
   AgentId,
@@ -194,7 +199,7 @@ function skillNameFromPathBasename(absolutePath: AbsolutePath): SkillName {
   ) {
     throw new TrashError('Reviewed skill path has an invalid basename')
   }
-  return name
+  return toSkillName(name)
 }
 
 /**

--- a/src/renderer/src/components/dashboard/LockPruneBanner.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/LockPruneBanner.browser.test.tsx
@@ -5,6 +5,7 @@ import { render } from 'vitest-browser-react'
 
 import '@/renderer/src/styles/globals.css'
 import type { UnprunableLockEntry } from '@/shared/types'
+import { toSkillName } from '@/shared/types'
 
 /**
  * Render the announcement with real reducers so dismissal and the CTA go
@@ -43,7 +44,7 @@ async function renderBanner(
   store.dispatch(fetchStaleLockEntries.pending('req-lock', undefined))
   store.dispatch(
     fetchStaleLockEntries.fulfilled(
-      { status: 'ok', names: staleLockNames, unprunable },
+      { status: 'ok', names: staleLockNames.map(toSkillName), unprunable },
       'req-lock',
       undefined,
     ),
@@ -82,7 +83,7 @@ describe('LockPruneBanner', () => {
   test('stays hidden when every stale record is blocked from being pruned', async () => {
     // Arrange / Act
     const { screen } = await renderBanner([], false, [
-      { name: 'agent-copy-skill', reason: 'agent-copy' },
+      { name: toSkillName('agent-copy-skill'), reason: 'agent-copy' },
     ])
 
     // Assert
@@ -97,7 +98,7 @@ describe('LockPruneBanner', () => {
     // something is blocked; only a mix proves the sentence counts the prunable
     // subset rather than every record needing attention.
     const { screen } = await renderBanner(['plain-stale'], false, [
-      { name: 'agent-copy-skill', reason: 'agent-copy' },
+      { name: toSkillName('agent-copy-skill'), reason: 'agent-copy' },
     ])
 
     // Assert

--- a/src/renderer/src/components/dashboard/LockPruneDialog.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/LockPruneDialog.browser.test.tsx
@@ -5,6 +5,7 @@ import { render } from 'vitest-browser-react'
 
 import '@/renderer/src/styles/globals.css'
 import type { StaleLockScanResult } from '@/shared/types'
+import { toSkillName } from '@/shared/types'
 
 const mockToastSuccess = vi.fn()
 const mockToastError = vi.fn()
@@ -68,7 +69,14 @@ async function renderDialog(
   store.dispatch(fetchStaleLockEntries.pending('req-lock', undefined))
   store.dispatch(
     fetchStaleLockEntries.fulfilled(
-      { status: 'ok', names: staleLockNames, unprunable },
+      {
+        status: 'ok',
+        names: staleLockNames.map(toSkillName),
+        unprunable: unprunable.map((entry) => ({
+          ...entry,
+          name: toSkillName(entry.name),
+        })),
+      },
       'req-lock',
       undefined,
     ),
@@ -139,7 +147,7 @@ describe('LockPruneDialog', () => {
     })
     mockScanStaleLockEntries.mockResolvedValue({
       status: 'ok',
-      names: ['stubborn'],
+      names: [toSkillName('stubborn')],
       unprunable: [],
     })
     const { screen, store } = await renderDialog(['stubborn'])
@@ -159,7 +167,7 @@ describe('LockPruneDialog', () => {
     mockPruneLockEntries.mockRejectedValue(new Error('IPC channel closed'))
     mockScanStaleLockEntries.mockResolvedValue({
       status: 'ok',
-      names: ['old-skill'],
+      names: [toSkillName('old-skill')],
       unprunable: [],
     })
     const { screen, store } = await renderDialog(['old-skill'])
@@ -191,7 +199,11 @@ describe('LockPruneDialog', () => {
     store.dispatch(fetchStaleLockEntries.pending('req-late', undefined))
     store.dispatch(
       fetchStaleLockEntries.fulfilled(
-        { status: 'ok', names: ['old-skill', 'just-appeared'], unprunable: [] },
+        {
+          status: 'ok',
+          names: [toSkillName('old-skill'), toSkillName('just-appeared')],
+          unprunable: [],
+        },
         'req-late',
         undefined,
       ),
@@ -311,8 +323,10 @@ describe('LockPruneDialog', () => {
       fetchStaleLockEntries.fulfilled(
         {
           status: 'ok',
-          names: ['plain-stale'],
-          unprunable: [{ name: 'agent-copy-skill', reason: 'agent-copy' }],
+          names: [toSkillName('plain-stale')],
+          unprunable: [
+            { name: toSkillName('agent-copy-skill'), reason: 'agent-copy' },
+          ],
         },
         'req-lock-2',
         undefined,

--- a/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/SymlinkCleanupDialog.browser.test.tsx
@@ -5,7 +5,7 @@ import { render } from 'vitest-browser-react'
 
 import '@/renderer/src/styles/globals.css'
 import type { Agent, Skill, SkillName, SymlinkInfo } from '@/shared/types'
-import { toSkillCount, toSymlinkCount } from '@/shared/types'
+import { toSkillCount, toSkillName, toSymlinkCount } from '@/shared/types'
 
 const mockGetSkills = vi.fn()
 const mockGetAgents = vi.fn()
@@ -216,7 +216,7 @@ describe('SymlinkCleanupDialog', () => {
     const destructivePath =
       '/Users/test/.cursor/skills/readable-task -> /Users/test/.agents/skills/readable-task'
     mockGetSkills.mockResolvedValueOnce([
-      makeSkillWithBrokenSlot('readable-task', 'cursor'),
+      makeSkillWithBrokenSlot(toSkillName('readable-task'), 'cursor'),
     ])
 
     // Act
@@ -238,7 +238,9 @@ describe('SymlinkCleanupDialog', () => {
     // Arrange
     mockGetSkills
       .mockRejectedValueOnce(new Error('Transient scanner failure'))
-      .mockResolvedValueOnce([makeSkillWithBrokenSlot('retry-task', 'cursor')])
+      .mockResolvedValueOnce([
+        makeSkillWithBrokenSlot(toSkillName('retry-task'), 'cursor'),
+      ])
     const screen = await renderOpenedDialog()
 
     // Act
@@ -259,9 +261,11 @@ describe('SymlinkCleanupDialog', () => {
   it('stops cleanup when the fresh scan no longer matches the reviewed plan', async () => {
     // Arrange
     mockGetSkills
-      .mockResolvedValueOnce([makeSkillWithBrokenSlot('stale-task', 'cursor')])
+      .mockResolvedValueOnce([
+        makeSkillWithBrokenSlot(toSkillName('stale-task'), 'cursor'),
+      ])
       .mockResolvedValueOnce([])
-    const selectedSkillName = 'stale-list-row' as SkillName
+    const selectedSkillName = toSkillName('stale-list-row')
     const { screen, store } = await renderOpenedDialogWithStore()
     const { toggleSelection } =
       await import('@/renderer/src/redux/slices/skillsSlice')
@@ -288,9 +292,11 @@ describe('SymlinkCleanupDialog', () => {
   it('stops cleanup when a same-id broken slot points at a new target', async () => {
     // Arrange
     mockGetSkills
-      .mockResolvedValueOnce([makeSkillWithBrokenSlot('stale-task', 'cursor')])
       .mockResolvedValueOnce([
-        makeSkillWithBrokenSlot('stale-task', 'cursor', {
+        makeSkillWithBrokenSlot(toSkillName('stale-task'), 'cursor'),
+      ])
+      .mockResolvedValueOnce([
+        makeSkillWithBrokenSlot(toSkillName('stale-task'), 'cursor', {
           targetPath: '/Users/test/.agents/skills/other-target',
         }),
       ])
@@ -313,13 +319,15 @@ describe('SymlinkCleanupDialog', () => {
   it('keeps only failed rows selected after partial unlink failure refreshes the plan', async () => {
     // Arrange
     const firstPlan = [
-      makeSkillWithBrokenSlot('fixed-task', 'cursor'),
-      makeSkillWithBrokenSlot('failed-task', 'codex'),
+      makeSkillWithBrokenSlot(toSkillName('fixed-task'), 'cursor'),
+      makeSkillWithBrokenSlot(toSkillName('failed-task'), 'codex'),
     ]
     mockGetSkills
       .mockResolvedValueOnce(firstPlan)
       .mockResolvedValueOnce(firstPlan)
-      .mockResolvedValueOnce([makeSkillWithBrokenSlot('failed-task', 'codex')])
+      .mockResolvedValueOnce([
+        makeSkillWithBrokenSlot(toSkillName('failed-task'), 'codex'),
+      ])
     mockClearBrokenSymlinkSlots.mockImplementation(
       async (options: {
         items: Array<{ agentId: string; linkName: string; linkPath: string }>
@@ -366,7 +374,9 @@ describe('SymlinkCleanupDialog', () => {
 
   it('keeps cleanup success when post-cleanup refresh fails', async () => {
     // Arrange
-    const firstPlan = [makeSkillWithBrokenSlot('refresh-failed-task', 'cursor')]
+    const firstPlan = [
+      makeSkillWithBrokenSlot(toSkillName('refresh-failed-task'), 'cursor'),
+    ]
     mockGetSkills
       .mockResolvedValueOnce(firstPlan)
       .mockResolvedValueOnce(firstPlan)
@@ -427,8 +437,12 @@ describe('SymlinkCleanupDialog', () => {
 
   it('keeps dashboard refresh warnings when rescan finds more cleanup items', async () => {
     // Arrange
-    const firstPlan = [makeSkillWithBrokenSlot('refresh-ready-task', 'cursor')]
-    const nextPlan = [makeSkillWithBrokenSlot('next-refresh-task', 'codex')]
+    const firstPlan = [
+      makeSkillWithBrokenSlot(toSkillName('refresh-ready-task'), 'cursor'),
+    ]
+    const nextPlan = [
+      makeSkillWithBrokenSlot(toSkillName('next-refresh-task'), 'codex'),
+    ]
     mockGetSkills
       .mockResolvedValueOnce(firstPlan)
       .mockResolvedValueOnce(firstPlan)
@@ -476,12 +490,14 @@ describe('SymlinkCleanupDialog', () => {
 
   it('requires rescan when a failed row keeps its id but changes target after cleanup', async () => {
     // Arrange
-    const firstPlan = [makeSkillWithBrokenSlot('failed-task', 'codex')]
+    const firstPlan = [
+      makeSkillWithBrokenSlot(toSkillName('failed-task'), 'codex'),
+    ]
     mockGetSkills
       .mockResolvedValueOnce(firstPlan)
       .mockResolvedValueOnce(firstPlan)
       .mockResolvedValueOnce([
-        makeSkillWithBrokenSlot('failed-task', 'codex', {
+        makeSkillWithBrokenSlot(toSkillName('failed-task'), 'codex', {
           targetPath: '/Users/test/.agents/skills/other-failed-target',
         }),
       ])
@@ -517,7 +533,9 @@ describe('SymlinkCleanupDialog', () => {
   it('requires rescan when a row fails and the post-cleanup skills refresh rejects', async () => {
     // Arrange — open scan + pre-clean fetch succeed; the post-cleanup
     // fetchSkills (the plan source) rejects so no post-cleanup plan exists.
-    const firstPlan = [makeSkillWithBrokenSlot('refresh-reject-task', 'codex')]
+    const firstPlan = [
+      makeSkillWithBrokenSlot(toSkillName('refresh-reject-task'), 'codex'),
+    ]
     mockGetSkills
       .mockResolvedValueOnce(firstPlan)
       .mockResolvedValueOnce(firstPlan)
@@ -562,7 +580,9 @@ describe('SymlinkCleanupDialog', () => {
     // fetchSkills then resolves a fresh plan, but the agent registry is offline
     // only on that rescan: its warning surfaces solely if the rescan refreshes
     // every dashboard source, which a pre-mutation stale rescan never does.
-    const firstPlan = [makeSkillWithBrokenSlot('stale-refresh-task', 'codex')]
+    const firstPlan = [
+      makeSkillWithBrokenSlot(toSkillName('stale-refresh-task'), 'codex'),
+    ]
     mockGetSkills
       .mockResolvedValueOnce(firstPlan)
       .mockResolvedValueOnce(firstPlan)
@@ -617,7 +637,9 @@ describe('SymlinkCleanupDialog', () => {
     // surfaces solely if the rescan refreshes every dashboard source, which the
     // error phase does only because its summary records the post-cleanup
     // refresh failure.
-    const firstPlan = [makeSkillWithBrokenSlot('error-refresh-task', 'codex')]
+    const firstPlan = [
+      makeSkillWithBrokenSlot(toSkillName('error-refresh-task'), 'codex'),
+    ]
     mockGetSkills
       .mockResolvedValueOnce(firstPlan)
       .mockResolvedValueOnce(firstPlan)
@@ -662,7 +684,9 @@ describe('SymlinkCleanupDialog', () => {
   it('keeps cleanup success when only the post-cleanup skills refresh rejects', async () => {
     // Arrange — same fetchSkills rejection, but the cleanup row succeeds, so
     // the happy path must still report completion (not a stale rescan prompt).
-    const firstPlan = [makeSkillWithBrokenSlot('refresh-reject-ok', 'codex')]
+    const firstPlan = [
+      makeSkillWithBrokenSlot(toSkillName('refresh-reject-ok'), 'codex'),
+    ]
     mockGetSkills
       .mockResolvedValueOnce(firstPlan)
       .mockResolvedValueOnce(firstPlan)
@@ -711,12 +735,14 @@ describe('SymlinkCleanupDialog', () => {
   it('keeps same-name broken slot failures attached to the failed agent row', async () => {
     // Arrange
     const firstPlan = [
-      makeSkillWithBrokenSlots('shared-task', ['cursor', 'codex']),
+      makeSkillWithBrokenSlots(toSkillName('shared-task'), ['cursor', 'codex']),
     ]
     mockGetSkills
       .mockResolvedValueOnce(firstPlan)
       .mockResolvedValueOnce(firstPlan)
-      .mockResolvedValueOnce([makeSkillWithBrokenSlot('shared-task', 'codex')])
+      .mockResolvedValueOnce([
+        makeSkillWithBrokenSlot(toSkillName('shared-task'), 'codex'),
+      ])
     mockClearBrokenSymlinkSlots.mockImplementation(
       async (options: {
         items: Array<{ agentId: string; linkName: string; linkPath: string }>
@@ -770,7 +796,9 @@ describe('SymlinkCleanupDialog', () => {
         outcome: 'unlinked'
       }>
     }) => void = () => undefined
-    const firstPlan = [makeSkillWithBrokenSlot('pending-task', 'cursor')]
+    const firstPlan = [
+      makeSkillWithBrokenSlot(toSkillName('pending-task'), 'cursor'),
+    ]
     mockGetSkills
       .mockResolvedValueOnce(firstPlan)
       .mockResolvedValueOnce(firstPlan)
@@ -824,9 +852,9 @@ describe('SymlinkCleanupDialog', () => {
 
   it('clears stale Installed-list selection when dashboard cleanup starts', async () => {
     // Arrange
-    const selectedSkillName = 'stale-list-row' as SkillName
+    const selectedSkillName = toSkillName('stale-list-row')
     const cleanupPlan = [
-      makeSkillWithBrokenSlot('dialog-cleanup-task', 'cursor'),
+      makeSkillWithBrokenSlot(toSkillName('dialog-cleanup-task'), 'cursor'),
     ]
     mockGetSkills
       .mockResolvedValueOnce(cleanupPlan)
@@ -865,7 +893,7 @@ describe('SymlinkCleanupDialog', () => {
 
   it('surfaces orphan-only IPC failures without calling source delete', async () => {
     // Arrange
-    const orphanPlan = [makeOrphanSkill('abandoned-task', 'codex')]
+    const orphanPlan = [makeOrphanSkill(toSkillName('abandoned-task'), 'codex')]
     mockGetSkills
       .mockResolvedValueOnce(orphanPlan)
       .mockResolvedValueOnce(orphanPlan)
@@ -923,7 +951,7 @@ describe('SymlinkCleanupDialog', () => {
   it('shows link-folder identity before metadata name for broken cleanup rows', async () => {
     // Arrange
     const mismatchPlan = [
-      makeSkillWithBrokenSlot('metadata-title', 'cursor', {
+      makeSkillWithBrokenSlot(toSkillName('metadata-title'), 'cursor', {
         linkPath: '/Users/test/.cursor/skills/link-folder-name',
         targetPath: '/Users/test/.agents/skills/missing-target',
       }),
@@ -1004,7 +1032,7 @@ describe('SymlinkCleanupDialog', () => {
   it('closes the dialog and discards the reviewed plan when cancelled', async () => {
     // Arrange
     mockGetSkills.mockResolvedValueOnce([
-      makeSkillWithBrokenSlot('cancel-task', 'cursor'),
+      makeSkillWithBrokenSlot(toSkillName('cancel-task'), 'cursor'),
     ])
     const { screen, store } = await renderOpenedDialogWithStore()
     await expect
@@ -1024,7 +1052,7 @@ describe('SymlinkCleanupDialog', () => {
   it('deselects then reselects a single row from its row checkbox', async () => {
     // Arrange
     mockGetSkills.mockResolvedValueOnce([
-      makeSkillWithBrokenSlot('toggle-task', 'cursor'),
+      makeSkillWithBrokenSlot(toSkillName('toggle-task'), 'cursor'),
     ])
     const screen = await renderOpenedDialog()
     const rowCheckbox = screen.getByRole('checkbox', {
@@ -1054,8 +1082,8 @@ describe('SymlinkCleanupDialog', () => {
   it('clears then restores every row in a section from the section checkbox', async () => {
     // Arrange — two broken rows share one "Broken agent links" section.
     mockGetSkills.mockResolvedValueOnce([
-      makeSkillWithBrokenSlot('section-a', 'cursor'),
-      makeSkillWithBrokenSlot('section-b', 'codex'),
+      makeSkillWithBrokenSlot(toSkillName('section-a'), 'cursor'),
+      makeSkillWithBrokenSlot(toSkillName('section-b'), 'codex'),
     ])
     const screen = await renderOpenedDialog()
     const rowA = screen.getByRole('checkbox', {
@@ -1096,7 +1124,9 @@ describe('SymlinkCleanupDialog', () => {
     // complete-with-rescan state. The rescan then refreshes every source, and
     // its fetchSkills rejection must surface as a scan error (not a silent
     // swallow) because the full-refresh scan re-throws the skills rejection.
-    const firstPlan = [makeSkillWithBrokenSlot('rescan-reject-task', 'cursor')]
+    const firstPlan = [
+      makeSkillWithBrokenSlot(toSkillName('rescan-reject-task'), 'cursor'),
+    ]
     mockGetSkills
       .mockResolvedValueOnce(firstPlan)
       .mockResolvedValueOnce(firstPlan)
@@ -1134,8 +1164,8 @@ describe('SymlinkCleanupDialog', () => {
     // Arrange — two skills both have a broken slot on Cursor, so the unlink IPC
     // returns two Cursor results that must collapse into a single agent group.
     const firstPlan = [
-      makeSkillWithBrokenSlot('grouped-a', 'cursor'),
-      makeSkillWithBrokenSlot('grouped-b', 'cursor'),
+      makeSkillWithBrokenSlot(toSkillName('grouped-a'), 'cursor'),
+      makeSkillWithBrokenSlot(toSkillName('grouped-b'), 'cursor'),
     ]
     mockGetSkills
       .mockResolvedValueOnce(firstPlan)
@@ -1174,7 +1204,9 @@ describe('SymlinkCleanupDialog', () => {
     // Arrange — the unlink IPC throws instead of returning per-row outcomes, so
     // the executor's catch path must still refresh the dashboard and surface a
     // generic cleanup error.
-    const firstPlan = [makeSkillWithBrokenSlot('throwing-task', 'cursor')]
+    const firstPlan = [
+      makeSkillWithBrokenSlot(toSkillName('throwing-task'), 'cursor'),
+    ]
     mockGetSkills
       .mockResolvedValueOnce(firstPlan)
       .mockResolvedValueOnce(firstPlan)

--- a/src/renderer/src/components/dashboard/lockPruneCopy.test.ts
+++ b/src/renderer/src/components/dashboard/lockPruneCopy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest'
 
-import type { SkillName, UnprunableLockEntry } from '@/shared/types'
+import type { UnprunableLockEntry } from '@/shared/types'
+import { toSkillName } from '@/shared/types'
 
 import {
   describeLockPruneTarget,
@@ -122,9 +123,12 @@ describe('selectRemovableNames', () => {
   test('drops a consented name the scan blocked while the dialog was open', () => {
     // Arrange — the record the user read is still in the snapshot, but a scan
     // has since found an agent copy behind it.
-    const consentedNames = ['plain-stale', 'agent-copy-skill'] as SkillName[]
+    const consentedNames = [
+      toSkillName('plain-stale'),
+      toSkillName('agent-copy-skill'),
+    ]
     const unprunableEntries: UnprunableLockEntry[] = [
-      { name: 'agent-copy-skill', reason: 'agent-copy' },
+      { name: toSkillName('agent-copy-skill'), reason: 'agent-copy' },
     ]
 
     // Act
@@ -136,7 +140,7 @@ describe('selectRemovableNames', () => {
 
   test('sends every consented name when the scan blocked none of them', () => {
     // Arrange
-    const consentedNames = ['one', 'two'] as SkillName[]
+    const consentedNames = [toSkillName('one'), toSkillName('two')]
 
     // Act
     const removable = selectRemovableNames(consentedNames, [])
@@ -147,10 +151,13 @@ describe('selectRemovableNames', () => {
 
   test('sends nothing when every consented name turned out to be blocked', () => {
     // Arrange — the dialog still has to render, as pure explanation.
-    const consentedNames = ['collided', 'agent-copy-skill'] as SkillName[]
+    const consentedNames = [
+      toSkillName('collided'),
+      toSkillName('agent-copy-skill'),
+    ]
     const unprunableEntries: UnprunableLockEntry[] = [
-      { name: 'collided', reason: 'name-collision' },
-      { name: 'agent-copy-skill', reason: 'agent-copy' },
+      { name: toSkillName('collided'), reason: 'name-collision' },
+      { name: toSkillName('agent-copy-skill'), reason: 'agent-copy' },
     ]
 
     // Act
@@ -163,9 +170,9 @@ describe('selectRemovableNames', () => {
   test('ignores a blocked record that was never in the consent snapshot', () => {
     // Arrange — the scan reports the whole lock; the dialog only ever deletes
     // what the user actually read.
-    const consentedNames = ['plain-stale'] as SkillName[]
+    const consentedNames = [toSkillName('plain-stale')]
     const unprunableEntries: UnprunableLockEntry[] = [
-      { name: 'never-shown', reason: 'agent-copy' },
+      { name: toSkillName('never-shown'), reason: 'agent-copy' },
     ]
 
     // Act

--- a/src/renderer/src/components/dashboard/utils/buildSymlinkCleanupPlan.test.ts
+++ b/src/renderer/src/components/dashboard/utils/buildSymlinkCleanupPlan.test.ts
@@ -9,7 +9,7 @@ import type {
   SymlinkInfo,
   SymlinkStatus,
 } from '@/shared/types'
-import { toSymlinkCount } from '@/shared/types'
+import { toSkillName, toSymlinkCount } from '@/shared/types'
 
 import {
   buildSymlinkCleanupPlan,
@@ -51,7 +51,7 @@ function makeSymlink(overrides: Partial<SymlinkInfo> = {}): SymlinkInfo {
  * makeSkill({ name: 'browser' }).name // => 'browser'
  */
 function makeSkill(overrides: Partial<Skill> = {}): Skill {
-  const name: SkillName = overrides.name ?? 'task'
+  const name: SkillName = toSkillName(overrides.name ?? 'task')
   const symlinks = overrides.symlinks ?? [makeSymlink()]
 
   return {
@@ -74,7 +74,7 @@ describe('buildSymlinkCleanupPlan', () => {
     // Arrange
     const skills = [
       makeSkill({
-        name: 'healthy',
+        name: toSkillName('healthy'),
         symlinks: [makeSymlink({ status: 'valid' })],
       }),
     ]
@@ -96,7 +96,7 @@ describe('buildSymlinkCleanupPlan', () => {
     // Arrange
     const skills = [
       makeSkill({
-        name: 'abandoned',
+        name: toSkillName('abandoned'),
         path: '/Users/test/.cursor/skills/abandoned',
         isSource: false,
         isOrphan: true,
@@ -155,7 +155,7 @@ describe('buildSymlinkCleanupPlan', () => {
     // Arrange
     const skills = [
       makeSkill({
-        name: 'metadata-title',
+        name: toSkillName('metadata-title'),
         path: '/Users/test/.agents/skills/metadata-title',
         isOrphan: false,
         symlinks: [
@@ -197,7 +197,7 @@ describe('buildSymlinkCleanupPlan', () => {
     // Arrange
     const skills = [
       makeSkill({
-        name: 'mixed',
+        name: toSkillName('mixed'),
         symlinks: [
           makeSymlink({
             agentId: 'cursor',
@@ -233,7 +233,7 @@ describe('buildSymlinkCleanupPlan', () => {
     // Arrange
     const skills = [
       makeSkill({
-        name: 'task',
+        name: toSkillName('task'),
         symlinks: [
           makeSymlink({
             agentId: 'cursor',
@@ -264,7 +264,7 @@ describe('buildSymlinkCleanupPlan', () => {
   it('escapes cleanup id segments so separators cannot collide', () => {
     // Arrange
     const agentId = 'cursor' as AgentId
-    const linkName = 'name:with/slash' as SkillName
+    const linkName = toSkillName('name:with/slash')
 
     // Act
     const itemId = createBrokenSlotCleanupItemId(agentId, linkName)
@@ -275,7 +275,7 @@ describe('buildSymlinkCleanupPlan', () => {
 
   it('keeps orphan cleanup id literals stable for persisted row state', () => {
     // Arrange
-    const skillName = 'name:with/slash' as SkillName
+    const skillName = toSkillName('name:with/slash')
 
     // Act
     const itemId = createOrphanCleanupItemId(skillName)

--- a/src/renderer/src/components/dashboard/utils/buildSymlinkCleanupPlan.ts
+++ b/src/renderer/src/components/dashboard/utils/buildSymlinkCleanupPlan.ts
@@ -15,6 +15,7 @@ import {
   toAgentCount,
   toIsoTimestamp,
   toSkillCount,
+  toSkillName,
   toSymlinkCount,
 } from '@/shared/types'
 
@@ -121,7 +122,7 @@ export function createBrokenSlotCleanupItemId(
 export function getLinkNameFromPath(linkPath: AbsolutePath): SkillName {
   const normalizedPath = linkPath.replaceAll('\\', '/')
   const pathSegments = normalizedPath.split('/').filter(Boolean)
-  return pathSegments[pathSegments.length - 1] ?? normalizedPath
+  return toSkillName(pathSegments[pathSegments.length - 1] ?? normalizedPath)
 }
 
 /**

--- a/src/renderer/src/components/dashboard/widgets/AgentHeatmapWidget.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/widgets/AgentHeatmapWidget.browser.test.tsx
@@ -12,7 +12,7 @@ import type {
   SymlinkInfo,
   SymlinkStatus,
 } from '@/shared/types'
-import { toSkillCount, toSymlinkCount } from '@/shared/types'
+import { toSkillCount, toSkillName, toSymlinkCount } from '@/shared/types'
 
 /**
  * Build a minimal Agent fixture. Only `id`/`name`/`exists` matter to the
@@ -62,7 +62,7 @@ function makeSymlink(
  */
 function makeSkill(name: string, symlinks: SymlinkInfo[]): Skill {
   return {
-    name,
+    name: toSkillName(name),
     description: `${name} description`,
     path: `/Users/test/.agents/skills/${name}`,
     symlinkCount: toSymlinkCount(

--- a/src/renderer/src/components/dashboard/widgets/BookmarksWidget.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/widgets/BookmarksWidget.browser.test.tsx
@@ -5,14 +5,16 @@ import { render } from 'vitest-browser-react'
 
 import '@/renderer/src/styles/globals.css'
 import type { RepositoryId, SkillName } from '@/shared/types'
-import { toHttpUrl } from '@/shared/types'
+import { toHttpUrl, toSkillName } from '@/shared/types'
 
 /**
  * Render the real BookmarksWidget reducer with one bookmark.
  * @param name - Skill name shown in the widget row.
  * @returns Render screen plus the backing Redux store.
  */
-async function renderBookmarksWidget(name: SkillName = 'very-long-skill-name') {
+async function renderBookmarksWidget(
+  name: SkillName = toSkillName('very-long-skill-name'),
+) {
   const [{ default: bookmarkReducer, addBookmark }, { BookmarksWidget }] =
     await Promise.all([
       import('@/renderer/src/redux/slices/bookmarkSlice'),
@@ -61,7 +63,7 @@ describe('BookmarksWidget', () => {
 
   it('still removes the bookmark through the compact control', async () => {
     // Arrange
-    const { screen, store } = await renderBookmarksWidget('task')
+    const { screen, store } = await renderBookmarksWidget(toSkillName('task'))
     const removeButton = screen
       .getByRole('button', { name: /Remove bookmark task/i })
       .element() as HTMLButtonElement
@@ -87,7 +89,7 @@ describe('BookmarksWidget', () => {
     })
     store.dispatch(
       addBookmark({
-        name: 'task',
+        name: toSkillName('task'),
         repo: 'vercel-labs/skills' as RepositoryId,
         url: toHttpUrl('https://skills.sh/task'),
       }),
@@ -118,7 +120,7 @@ describe('BookmarksWidget', () => {
     })
     store.dispatch(
       addBookmark({
-        name: 'repo-less-skill',
+        name: toSkillName('repo-less-skill'),
         repo: '',
         url: toHttpUrl('https://skills.sh/repo-less-skill'),
       }),

--- a/src/renderer/src/components/dashboard/widgets/CoverageWidget.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/widgets/CoverageWidget.browser.test.tsx
@@ -5,7 +5,7 @@ import { render } from 'vitest-browser-react'
 
 import '@/renderer/src/styles/globals.css'
 import type { Agent, AgentId, AgentName, Skill } from '@/shared/types'
-import { toSkillCount, toSymlinkCount } from '@/shared/types'
+import { toSkillCount, toSkillName, toSymlinkCount } from '@/shared/types'
 
 /**
  * Build an Agent fixture letting each test vary the coverage-relevant fields.
@@ -39,7 +39,7 @@ function makeAgent(
  */
 function makeSkill(name: string): Skill {
   return {
-    name,
+    name: toSkillName(name),
     description: `${name} description`,
     path: `/Users/test/.agents/skills/${name}`,
     symlinkCount: toSymlinkCount(0),

--- a/src/renderer/src/components/dashboard/widgets/HealthWidget.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/widgets/HealthWidget.browser.test.tsx
@@ -5,7 +5,7 @@ import { render } from 'vitest-browser-react'
 
 import '@/renderer/src/styles/globals.css'
 import type { Skill, SymlinkInfo } from '@/shared/types'
-import { toSymlinkCount } from '@/shared/types'
+import { toSkillName, toSymlinkCount } from '@/shared/types'
 
 /**
  * Builds a SymlinkInfo fixture for HealthWidget display-state tests.
@@ -34,7 +34,7 @@ function makeSymlink(status: SymlinkInfo['status']): SymlinkInfo {
  */
 function makeSkill(symlinks: SymlinkInfo[]): Skill {
   return {
-    name: 'task',
+    name: toSkillName('task'),
     description: 'Task skill',
     path: '/Users/test/.agents/skills/task',
     symlinkCount: toSymlinkCount(
@@ -87,7 +87,14 @@ async function renderHealthWidget(
   store.dispatch(
     fetchStaleLockEntries.fulfilled(
       scanStatus === 'ok'
-        ? { status: 'ok', names: staleLockNames, unprunable }
+        ? {
+            status: 'ok',
+            names: staleLockNames.map(toSkillName),
+            unprunable: unprunable.map((entry) => ({
+              ...entry,
+              name: toSkillName(entry.name),
+            })),
+          }
         : { status: 'unavailable' },
       'req-lock',
       undefined,

--- a/src/renderer/src/components/dashboard/widgets/LeaderboardWidget.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/widgets/LeaderboardWidget.browser.test.tsx
@@ -15,6 +15,7 @@ import {
   toHttpUrl,
   toInstallCount,
   toSearchQuery,
+  toSkillName,
   toSkillRank,
   toUnixTimestampMs,
 } from '@/shared/types'
@@ -49,7 +50,7 @@ afterEach(() => {
 function makeSkill(rank: number, name: string): SkillSearchResult {
   return {
     rank: toSkillRank(rank),
-    name,
+    name: toSkillName(name),
     repo: repositoryId(`owner/${name}`),
     url: toHttpUrl(`https://skills.sh/${name}`),
     installCount: toInstallCount(100),

--- a/src/renderer/src/components/dashboard/widgets/MarketplaceSkillRow.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/widgets/MarketplaceSkillRow.browser.test.tsx
@@ -7,6 +7,7 @@ import {
   repositoryId,
   toHttpUrl,
   toInstallCount,
+  toSkillName,
   toSkillRank,
 } from '@/shared/types'
 
@@ -28,7 +29,7 @@ function makeSkill(
 ): SkillSearchResult {
   return {
     rank: toSkillRank(1),
-    name: 'task',
+    name: toSkillName('task'),
     repo: repositoryId('vercel-labs/skills'),
     url: toHttpUrl('https://skills.sh/task'),
     ...overrides,
@@ -40,7 +41,7 @@ describe('MarketplaceSkillRow', () => {
     // Arrange: a fully-populated trending skill row.
     const skill = makeSkill({
       rank: toSkillRank(1),
-      name: 'task',
+      name: toSkillName('task'),
       repo: repositoryId('vercel-labs/skills'),
       url: toHttpUrl('https://skills.sh/task'),
       installCount: toInstallCount(2480),
@@ -76,7 +77,7 @@ describe('MarketplaceSkillRow', () => {
     // Arrange: a CLI-search-style result with no installCount field.
     const skill = makeSkill({
       rank: toSkillRank(7),
-      name: 'review',
+      name: toSkillName('review'),
       repo: repositoryId('anthropics/skills'),
       url: toHttpUrl('https://skills.sh/review'),
     })

--- a/src/renderer/src/components/dashboard/widgets/StatsWidget.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/widgets/StatsWidget.browser.test.tsx
@@ -5,7 +5,7 @@ import { render } from 'vitest-browser-react'
 
 import '@/renderer/src/styles/globals.css'
 import type { Agent, AgentId, AgentName, Skill } from '@/shared/types'
-import { toSkillCount, toSymlinkCount } from '@/shared/types'
+import { toSkillCount, toSkillName, toSymlinkCount } from '@/shared/types'
 
 /**
  * Build an Agent fixture letting each test vary the `exists` flag that gates the
@@ -33,7 +33,7 @@ function makeAgent(id: AgentId, name: AgentName, exists: boolean): Agent {
  */
 function makeSkill(name: string, symlinkCount: number): Skill {
   return {
-    name,
+    name: toSkillName(name),
     description: `${name} description`,
     path: `/Users/test/.agents/skills/${name}`,
     symlinkCount: toSymlinkCount(symlinkCount),

--- a/src/renderer/src/components/dashboard/widgets/TrendingWidget.browser.test.tsx
+++ b/src/renderer/src/components/dashboard/widgets/TrendingWidget.browser.test.tsx
@@ -10,6 +10,7 @@ import {
   toHttpUrl,
   toInstallCount,
   toSearchQuery,
+  toSkillName,
   toSkillRank,
   toUnixTimestampMs,
 } from '@/shared/types'
@@ -44,7 +45,7 @@ afterEach(() => {
 function makeSkill(rank: number, name: string): SkillSearchResult {
   return {
     rank: toSkillRank(rank),
-    name,
+    name: toSkillName(name),
     repo: repositoryId(`owner/${name}`),
     url: toHttpUrl(`https://skills.sh/${name}`),
     installCount: toInstallCount(100),

--- a/src/renderer/src/components/layout/DetailPanel.browser.test.tsx
+++ b/src/renderer/src/components/layout/DetailPanel.browser.test.tsx
@@ -7,7 +7,12 @@ import { selectSkill } from '@/renderer/src/redux/slices/skillsSlice'
 import { setActiveTab } from '@/renderer/src/redux/slices/uiSlice'
 import { DEFAULT_SETTINGS } from '@/shared/settings'
 import type { Skill } from '@/shared/types'
-import { repositoryId, toHttpUrl, toSymlinkCount } from '@/shared/types'
+import {
+  repositoryId,
+  toHttpUrl,
+  toSkillName,
+  toSymlinkCount,
+} from '@/shared/types'
 
 // Replace the three routed panels with marker stubs so DetailPanel renders in
 // isolation — the real children fetch via IPC on mount, which is irrelevant to
@@ -69,7 +74,7 @@ async function renderDetailPanel() {
  */
 function makeSelectableSkill(): Skill {
   return {
-    name: 'demo-skill',
+    name: toSkillName('demo-skill'),
     description: '',
     path: '/skills/demo-skill',
     symlinkCount: toSymlinkCount(0),

--- a/src/renderer/src/components/layout/MainContent.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.browser.test.tsx
@@ -26,6 +26,7 @@ import {
   toIsoTimestamp,
   toSearchQuery,
   toSkillCount,
+  toSkillName,
   toSkillRank,
   toSymlinkCount,
   tombstoneId,
@@ -279,7 +280,7 @@ async function waitForBulkSelectReady(
  */
 function makeSourceSkill(name: string, source: string): Skill {
   return {
-    name: name,
+    name: toSkillName(name),
     description: '',
     path: `/skills/${name}` as never,
     filesystemIdentity: directoryIdentity,
@@ -301,7 +302,7 @@ function makeSourceSkill(name: string, source: string): Skill {
  */
 function makeAgentLocalSkill(name: string, agentId: AgentId): Skill {
   return {
-    name: name,
+    name: toSkillName(name),
     description: '',
     path: `/home/user/.${agentId}/skills/${name}` as never,
     symlinkCount: toSymlinkCount(0),
@@ -460,7 +461,7 @@ describe('MainContent hosts the shared InstallModal', () => {
     // Exactly the payload BookmarkItem/BookmarkDetailModal dispatch from the sidebar.
     store.dispatch(
       selectSkillForInstall({
-        name: 'task',
+        name: toSkillName('task'),
         repo: repositoryId('vercel-labs/skills'),
       }),
     )
@@ -526,8 +527,8 @@ describe('MainContent bulk-select toggle button', () => {
       await import('@/renderer/src/redux/slices/skillsSlice')
 
     store.dispatch(enterBulkSelectMode())
-    store.dispatch(toggleSelection('task'))
-    store.dispatch(toggleSelection('tdd'))
+    store.dispatch(toggleSelection(toSkillName('task')))
+    store.dispatch(toggleSelection(toSkillName('tdd')))
     expect(store.getState().skills.selectedSkillNames.length).toBe(2)
 
     // Act
@@ -570,7 +571,7 @@ describe('MainContent keyboard shortcuts (Cmd+A)', () => {
       await import('@/renderer/src/redux/slices/skillsSlice')
     const skillFixtures = [
       {
-        name: 'task' as SkillName,
+        name: toSkillName('task'),
         description: '',
         path: '/skills/task' as never,
         filesystemIdentity: directoryIdentity,
@@ -580,7 +581,7 @@ describe('MainContent keyboard shortcuts (Cmd+A)', () => {
         isOrphan: false,
       },
       {
-        name: 'tdd' as SkillName,
+        name: toSkillName('tdd'),
         description: '',
         path: '/skills/tdd' as never,
         filesystemIdentity: directoryIdentity,
@@ -652,7 +653,7 @@ describe('MainContent keyboard shortcuts (Cmd+A)', () => {
       await import('@/renderer/src/redux/slices/skillsSlice')
     const skillFixtures = [
       {
-        name: 'task' as SkillName,
+        name: toSkillName('task'),
         description: '',
         path: '/skills/task' as never,
         filesystemIdentity: directoryIdentity,
@@ -662,7 +663,7 @@ describe('MainContent keyboard shortcuts (Cmd+A)', () => {
         isOrphan: false,
       },
       {
-        name: 'tdd' as SkillName,
+        name: toSkillName('tdd'),
         description: '',
         path: '/skills/tdd' as never,
         filesystemIdentity: directoryIdentity,
@@ -721,7 +722,7 @@ describe('MainContent keyboard shortcuts (Esc 2-step)', () => {
       await import('@/renderer/src/redux/slices/skillsSlice')
 
     store.dispatch(enterBulkSelectMode())
-    store.dispatch(toggleSelection('task'))
+    store.dispatch(toggleSelection(toSkillName('task')))
     expect(store.getState().skills.selectedSkillNames.length).toBe(1)
 
     await waitForBulkSelectReady(screen)
@@ -772,7 +773,7 @@ describe('MainContent keyboard shortcuts (Esc 2-step)', () => {
       await import('@/renderer/src/redux/slices/skillsSlice')
 
     store.dispatch(enterBulkSelectMode())
-    store.dispatch(toggleSelection('task'))
+    store.dispatch(toggleSelection(toSkillName('task')))
     // Same race as the Cmd+A editable-target test: wait for bulk-mode commit
     // so the Escape guard is exercised via the editable-target branch.
     await waitForBulkSelectReady(screen)
@@ -810,14 +811,14 @@ describe('MainContent keyboard shortcuts (Esc 2-step)', () => {
       await import('@/renderer/src/redux/slices/marketplaceSlice')
 
     store.dispatch(enterBulkSelectMode())
-    store.dispatch(toggleSelection('task'))
+    store.dispatch(toggleSelection(toSkillName('task')))
     await waitForBulkSelectReady(screen)
 
     // Open the shared InstallModal (exactly the sidebar bookmark install path),
     // then wait for the Radix dialog to mount with data-state="open".
     store.dispatch(
       selectSkillForInstall({
-        name: 'task',
+        name: toSkillName('task'),
         repo: repositoryId('vercel-labs/skills'),
       }),
     )
@@ -842,7 +843,7 @@ describe('MainContent keyboard shortcuts (Esc 2-step)', () => {
     const { toggleSelection } =
       await import('@/renderer/src/redux/slices/skillsSlice')
     store.dispatch(enterBulkSelectMode())
-    store.dispatch(toggleSelection('task'))
+    store.dispatch(toggleSelection(toSkillName('task')))
     await waitForBulkSelectReady(screen)
 
     const openMenu = document.createElement('div')
@@ -905,14 +906,14 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
     const result: BulkDeleteResult = {
       items: [
         {
-          skillName: 'brainstorming',
+          skillName: toSkillName('brainstorming'),
           outcome: 'deleted',
           tombstoneId: tombstoneId('1729180800000-brainstorming-a1b2c3d4'),
           symlinksRemoved: toSymlinkCount(0),
           cascadeAgents: [],
         },
         {
-          skillName: 'local-skill',
+          skillName: toSkillName('local-skill'),
           outcome: 'deleted',
           tombstoneId: tombstoneId('1729180800000-local-skill-e5f6a7b8'),
           symlinksRemoved: toSymlinkCount(0),
@@ -923,21 +924,21 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
     mockSkillsDeleteSkills.mockResolvedValue(result)
 
     const selectedSkills = [
-      makeSkill('brainstorming', true),
-      makeSkill('local-skill', false),
+      makeSkill(toSkillName('brainstorming'), true),
+      makeSkill(toSkillName('local-skill'), false),
     ]
     store.dispatch(fetchSkills.fulfilled(selectedSkills, 'req-id'))
     store.dispatch(enterBulkSelectMode())
     store.dispatch(
       setBulkConfirm({
         kind: 'delete',
-        skillNames: ['brainstorming', 'local-skill'],
+        skillNames: [toSkillName('brainstorming'), toSkillName('local-skill')],
         agentId: null,
         agentName: null,
         sourceSummary: null,
         ...partitionGlobalDeleteTargets(selectedSkills, [
-          'brainstorming',
-          'local-skill',
+          toSkillName('brainstorming'),
+          toSkillName('local-skill'),
         ]),
       }),
     )
@@ -976,8 +977,8 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
       await import('@/renderer/src/redux/slices/uiSlice')
     const { fetchSkills } =
       await import('@/renderer/src/redux/slices/skillsSlice')
-    const metadataName = 'metadata-title' as SkillName
-    const folderName = 'folder-basename' as SkillName
+    const metadataName = toSkillName('metadata-title')
+    const folderName = toSkillName('folder-basename')
     mockSkillsDeleteSkills.mockResolvedValue({
       items: [
         {
@@ -1027,8 +1028,12 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
       await import('@/renderer/src/redux/slices/uiSlice')
     const { fetchSkills, toggleSelection } =
       await import('@/renderer/src/redux/slices/skillsSlice')
-    const skillName = 'snapshot-delete' as SkillName
-    const originalSkill = makeSkill(skillName, false, 'reviewed-folder')
+    const skillName = toSkillName('snapshot-delete')
+    const originalSkill = makeSkill(
+      skillName,
+      false,
+      toSkillName('reviewed-folder'),
+    )
     const replacementSkill: Skill = {
       ...originalSkill,
       path: '/home/user/.agents/skills/replacement-folder',
@@ -1082,7 +1087,7 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
       await import('@/renderer/src/redux/slices/uiSlice')
     const { fetchSkills, toggleSelection } =
       await import('@/renderer/src/redux/slices/skillsSlice')
-    const skillName = 'snapshot-unlink' as SkillName
+    const skillName = toSkillName('snapshot-unlink')
     const originalSkill: Skill = {
       name: skillName,
       description: '',
@@ -1162,7 +1167,7 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
       await import('@/renderer/src/redux/slices/uiSlice')
     const { fetchSkills } =
       await import('@/renderer/src/redux/slices/skillsSlice')
-    const orphanSkillName = 'abandoned' as SkillName
+    const orphanSkillName = toSkillName('abandoned')
     const orphanSkill: Skill = {
       name: orphanSkillName,
       description: '',
@@ -1242,8 +1247,8 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
       await import('@/renderer/src/redux/slices/uiSlice')
     const { fetchSkills, toggleSelection } =
       await import('@/renderer/src/redux/slices/skillsSlice')
-    const sourceSkillName = 'source-task' as SkillName
-    const orphanSkillName = 'abandoned' as SkillName
+    const sourceSkillName = toSkillName('source-task')
+    const orphanSkillName = toSkillName('abandoned')
     const sourceSkill: Skill = {
       name: sourceSkillName,
       description: '',
@@ -1329,8 +1334,8 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
       await import('@/renderer/src/redux/slices/uiSlice')
     const { fetchSkills, toggleSelection } =
       await import('@/renderer/src/redux/slices/skillsSlice')
-    const sourceSkillName = 'source-stale-task' as SkillName
-    const orphanSkillName = 'abandoned' as SkillName
+    const sourceSkillName = toSkillName('source-stale-task')
+    const orphanSkillName = toSkillName('abandoned')
     const sourceSkill: Skill = {
       name: sourceSkillName,
       description: '',
@@ -1419,8 +1424,8 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
       await import('@/renderer/src/redux/slices/uiSlice')
     const { fetchSkills, toggleSelection } =
       await import('@/renderer/src/redux/slices/skillsSlice')
-    const sourceSkillName = 'source-task' as SkillName
-    const orphanSkillName = 'stale-abandoned' as SkillName
+    const sourceSkillName = toSkillName('source-task')
+    const orphanSkillName = toSkillName('stale-abandoned')
     const sourceSkill: Skill = {
       name: sourceSkillName,
       description: '',
@@ -1500,8 +1505,8 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
       await import('@/renderer/src/redux/slices/uiSlice')
     const { fetchSkills, toggleSelection } =
       await import('@/renderer/src/redux/slices/skillsSlice')
-    const sourceSkillName = 'source-task' as SkillName
-    const orphanSkillName = 'abandoned' as SkillName
+    const sourceSkillName = toSkillName('source-task')
+    const orphanSkillName = toSkillName('abandoned')
     const sourceSkill: Skill = {
       name: sourceSkillName,
       description: '',
@@ -1572,7 +1577,7 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
       await import('@/renderer/src/redux/slices/uiSlice')
     const { fetchSkills, toggleSelection } =
       await import('@/renderer/src/redux/slices/skillsSlice')
-    const orphanSkillName = 'abandoned' as SkillName
+    const orphanSkillName = toSkillName('abandoned')
     const orphanSkill: Skill = {
       name: orphanSkillName,
       description: '',
@@ -1626,7 +1631,7 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
       await import('@/renderer/src/redux/slices/uiSlice')
     const { fetchSkills } =
       await import('@/renderer/src/redux/slices/skillsSlice')
-    const orphanSkillName = 'stale-abandoned' as SkillName
+    const orphanSkillName = toSkillName('stale-abandoned')
     const staleOrphanSkill: Skill = {
       name: orphanSkillName,
       description: '',
@@ -1682,7 +1687,7 @@ describe('MainContent bulk delete — uniform delete pipeline', () => {
       await import('@/renderer/src/redux/slices/uiSlice')
     const { fetchSkills } =
       await import('@/renderer/src/redux/slices/skillsSlice')
-    const sourceSkillName = 'source-missing-identity' as SkillName
+    const sourceSkillName = toSkillName('source-missing-identity')
     const staleSourceSkill: Skill = {
       name: sourceSkillName,
       description: '',
@@ -1866,7 +1871,7 @@ describe('MainContent SkillTypeFilter dropdown options', () => {
 
     // A skill available to exactly one agent (a lone valid slot in cursor).
     const uniqueSkill: Skill = {
-      name: 'cursor-unique',
+      name: toSkillName('cursor-unique'),
       description: '',
       path: '/skills/cursor-unique',
       symlinkCount: toSymlinkCount(1),
@@ -1885,7 +1890,7 @@ describe('MainContent SkillTypeFilter dropdown options', () => {
     }
     // A skill shared by two agents — visible in the cursor view, but NOT unique.
     const sharedSkill: Skill = {
-      name: 'shared-two',
+      name: toSkillName('shared-two'),
       description: '',
       path: '/skills/shared-two',
       symlinkCount: toSymlinkCount(2),
@@ -1956,7 +1961,7 @@ describe('MainContent SkillTypeFilter dropdown options', () => {
       await import('@/renderer/src/redux/slices/skillsSlice')
 
     const orphanSkill: Skill = {
-      name: 'orphan-one',
+      name: toSkillName('orphan-one'),
       description: '',
       path: '/skills/orphan-one',
       symlinkCount: toSymlinkCount(1),
@@ -1974,7 +1979,7 @@ describe('MainContent SkillTypeFilter dropdown options', () => {
       isOrphan: true,
     }
     const linkedSkill: Skill = {
-      name: 'linked-one',
+      name: toSkillName('linked-one'),
       description: '',
       path: '/skills/linked-one',
       filesystemIdentity: directoryIdentity,
@@ -2301,7 +2306,7 @@ describe('MainContent toolbar quick actions', () => {
     store.dispatch(
       setPreviewSkill({
         rank: toSkillRank(1),
-        name: 'task',
+        name: toSkillName('task'),
         repo: repositoryId('vercel-labs/skills'),
         url: toHttpUrl('https://skills.sh/task'),
       }),
@@ -2549,7 +2554,7 @@ describe('MainContent bulk copy action', () => {
       fetchSkills.fulfilled([makeSourceSkill('alpha', 'org/repo')], 'req-id'),
     )
     store.dispatch(enterBulkSelectMode())
-    store.dispatch(toggleSelection('alpha'))
+    store.dispatch(toggleSelection(toSkillName('alpha')))
 
     // Act
     await screen.getByRole('button', { name: 'Open bulk copy' }).click()
@@ -2589,8 +2594,8 @@ describe('MainContent stale-source delete summary', () => {
       await import('@/renderer/src/redux/slices/uiSlice')
     const { fetchSkills } =
       await import('@/renderer/src/redux/slices/skillsSlice')
-    const deletableName = 'fresh-source' as SkillName
-    const staleName = 'stale-source' as SkillName
+    const deletableName = toSkillName('fresh-source')
+    const staleName = toSkillName('stale-source')
     const deletableSkill: Skill = {
       name: deletableName,
       description: '',
@@ -2672,7 +2677,7 @@ describe('MainContent undo bulk delete', () => {
     const { fetchSkills } =
       await import('@/renderer/src/redux/slices/skillsSlice')
     const skills: Skill[] = tombstoneIds.map((_, index) => ({
-      name: `undo-skill-${index}`,
+      name: toSkillName(`undo-skill-${index}`),
       description: '',
       path: `/Users/me/.agents/skills/undo-skill-${index}` as never,
       filesystemIdentity: directoryIdentity,
@@ -2807,7 +2812,7 @@ describe('MainContent toolbar primary action guards', () => {
       await import('@/renderer/src/redux/slices/skillsSlice')
     const { addProtection } =
       await import('@/renderer/src/redux/slices/protectSlice')
-    const skillName = 'protected-link' as SkillName
+    const skillName = toSkillName('protected-link')
     const protectedSkill: Skill = {
       name: skillName,
       description: '',
@@ -2866,7 +2871,7 @@ describe('MainContent toolbar primary action guards', () => {
       await import('@/renderer/src/redux/slices/uiSlice')
     const { fetchSkills, toggleSelection } =
       await import('@/renderer/src/redux/slices/skillsSlice')
-    const skillName = 'stale-unlink' as SkillName
+    const skillName = toSkillName('stale-unlink')
     const staleSkill: Skill = {
       name: skillName,
       description: '',
@@ -2937,7 +2942,7 @@ describe('MainContent bulk unlink result toasts', () => {
       await import('@/renderer/src/redux/slices/uiSlice')
     const { fetchSkills, toggleSelection } =
       await import('@/renderer/src/redux/slices/skillsSlice')
-    const skillName = 'linked-skill' as SkillName
+    const skillName = toSkillName('linked-skill')
     const linkedSkill: Skill = {
       name: skillName,
       description: '',
@@ -3054,8 +3059,8 @@ describe('MainContent bulk delete failure toasts', () => {
       await import('@/renderer/src/redux/slices/uiSlice')
     const { fetchSkills } =
       await import('@/renderer/src/redux/slices/skillsSlice')
-    const sourceSkillName = 'kept-source' as SkillName
-    const orphanSkillName = 'dropped-orphan' as SkillName
+    const sourceSkillName = toSkillName('kept-source')
+    const orphanSkillName = toSkillName('dropped-orphan')
     const sourceSkill: Skill = {
       name: sourceSkillName,
       description: '',
@@ -3128,7 +3133,7 @@ describe('MainContent bulk delete failure toasts', () => {
       await import('@/renderer/src/redux/slices/uiSlice')
     const { fetchSkills } =
       await import('@/renderer/src/redux/slices/skillsSlice')
-    const sourceSkillName = 'empty-result' as SkillName
+    const sourceSkillName = toSkillName('empty-result')
     const sourceSkill: Skill = {
       name: sourceSkillName,
       description: '',
@@ -3171,7 +3176,7 @@ describe('MainContent bulk delete failure toasts', () => {
       await import('@/renderer/src/redux/slices/uiSlice')
     const { fetchSkills } =
       await import('@/renderer/src/redux/slices/skillsSlice')
-    const sourceSkillName = 'all-error' as SkillName
+    const sourceSkillName = toSkillName('all-error')
     const sourceSkill: Skill = {
       name: sourceSkillName,
       description: '',
@@ -3225,7 +3230,7 @@ describe('MainContent bulk delete undo toast lifecycle', () => {
       await import('@/renderer/src/redux/slices/uiSlice')
     const { fetchSkills } =
       await import('@/renderer/src/redux/slices/skillsSlice')
-    const sourceSkillName = 'dismiss-me' as SkillName
+    const sourceSkillName = toSkillName('dismiss-me')
     const sourceSkill: Skill = {
       name: sourceSkillName,
       description: '',
@@ -3286,7 +3291,7 @@ describe('MainContent bulk delete undo toast lifecycle', () => {
       await import('@/renderer/src/redux/slices/uiSlice')
     const { fetchSkills } =
       await import('@/renderer/src/redux/slices/skillsSlice')
-    const sourceSkillName = 'stale-dismiss-me' as SkillName
+    const sourceSkillName = toSkillName('stale-dismiss-me')
     const sourceSkill: Skill = {
       name: sourceSkillName,
       description: '',
@@ -3325,7 +3330,7 @@ describe('MainContent bulk delete undo toast lifecycle', () => {
     const newerToast = {
       id: 'bulk-delete-newer',
       kind: 'delete' as const,
-      skillNames: ['newer-delete'] as SkillName[],
+      skillNames: [toSkillName('newer-delete')],
       tombstoneIds: [tombstoneId('1729180800000-newer-delete-a1b2c3d4')],
       expiresAt: toIsoTimestamp('2026-04-17T12:00:15.000Z'),
       summary: 'Deleted 1 skill. 0 symlinks removed.',
@@ -3349,7 +3354,7 @@ describe('MainContent bulk confirm cancellation', () => {
       await import('@/renderer/src/redux/slices/uiSlice')
     const { fetchSkills } =
       await import('@/renderer/src/redux/slices/skillsSlice')
-    const sourceSkillName = 'cancel-me' as SkillName
+    const sourceSkillName = toSkillName('cancel-me')
     const sourceSkill: Skill = {
       name: sourceSkillName,
       description: '',

--- a/src/renderer/src/components/layout/MainContent.selectionToolbar.browser.test.tsx
+++ b/src/renderer/src/components/layout/MainContent.selectionToolbar.browser.test.tsx
@@ -6,7 +6,7 @@ import { render } from 'vitest-browser-react'
 import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
 import { DEFAULT_SETTINGS } from '@/shared/settings'
 import type { Agent, Skill, SkillName, SymlinkInfo } from '@/shared/types'
-import { toSkillCount, toSymlinkCount } from '@/shared/types'
+import { toSkillCount, toSkillName, toSymlinkCount } from '@/shared/types'
 
 const mockUnlinkManyFromAgent = vi.fn()
 const mockOnDeleteProgress = vi.fn(() => () => {})
@@ -184,8 +184,8 @@ describe('MainContent SelectionToolbar integration', () => {
       await import('@/renderer/src/redux/slices/uiSlice')
     const { fetchSkills, toggleSelection } =
       await import('@/renderer/src/redux/slices/skillsSlice')
-    const metadataName = 'valid-toolbar-task' as SkillName
-    const slotName = 'valid-toolbar-folder' as SkillName
+    const metadataName = toSkillName('valid-toolbar-task')
+    const slotName = toSkillName('valid-toolbar-folder')
 
     // Arrange
     store.dispatch(fetchAgents.fulfilled([CURSOR_AGENT], 'agents-req'))
@@ -193,8 +193,11 @@ describe('MainContent SelectionToolbar integration', () => {
       fetchSkills.fulfilled(
         [
           makeCursorSkill(metadataName, 'valid', slotName),
-          makeCursorSkill('broken-toolbar-task', 'broken'),
-          makeCursorSkill('inaccessible-toolbar-task', 'inaccessible'),
+          makeCursorSkill(toSkillName('broken-toolbar-task'), 'broken'),
+          makeCursorSkill(
+            toSkillName('inaccessible-toolbar-task'),
+            'inaccessible',
+          ),
         ],
         'skills-req',
       ),
@@ -202,7 +205,7 @@ describe('MainContent SelectionToolbar integration', () => {
     store.dispatch(selectAgent('cursor'))
     store.dispatch(enterBulkSelectMode())
     store.dispatch(toggleSelection(metadataName))
-    store.dispatch(toggleSelection('broken-toolbar-task'))
+    store.dispatch(toggleSelection(toSkillName('broken-toolbar-task')))
 
     // Act
     await expect

--- a/src/renderer/src/components/layout/Sidebar.browser.test.tsx
+++ b/src/renderer/src/components/layout/Sidebar.browser.test.tsx
@@ -5,7 +5,7 @@ import { render } from 'vitest-browser-react'
 
 import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
 import { DEFAULT_SETTINGS } from '@/shared/settings'
-import { repositoryId, toHttpUrl } from '@/shared/types'
+import { repositoryId, toHttpUrl, toSkillName } from '@/shared/types'
 
 beforeEach(() => {
   // SidebarHeader reads the build-time `__APP_VERSION__` define; browser mode has
@@ -124,7 +124,7 @@ describe('Sidebar', () => {
     // Act
     store.dispatch(
       addBookmark({
-        name: 'task',
+        name: toSkillName('task'),
         repo: repositoryId('vercel-labs/skills'),
         url: toHttpUrl('https://skills.sh/task'),
       }),

--- a/src/renderer/src/components/layout/detailPanelHelpers.test.ts
+++ b/src/renderer/src/components/layout/detailPanelHelpers.test.ts
@@ -5,11 +5,11 @@ import { resolveDetailPanelContent } from '@/renderer/src/components/layout/deta
 import { MarketplaceDetailPanel } from '@/renderer/src/components/marketplace/MarketplaceDetailPanel'
 import { SkillDetail } from '@/renderer/src/components/skills/SkillDetail'
 import type { Skill } from '@/shared/types'
-import { toSymlinkCount } from '@/shared/types'
+import { toSkillName, toSymlinkCount } from '@/shared/types'
 
 // Minimal selected skill — only its identity is threaded through, never read here.
 const SELECTED_SKILL: Skill = {
-  name: 'foo',
+  name: toSkillName('foo'),
   description: 'foo skill',
   path: '/u/me/.agents/skills/foo',
   symlinkCount: toSymlinkCount(0),

--- a/src/renderer/src/components/marketplace/InstallModal.browser.test.tsx
+++ b/src/renderer/src/components/marketplace/InstallModal.browser.test.tsx
@@ -8,6 +8,7 @@ import {
   toHttpUrl,
   toInstallCount,
   toSkillCount,
+  toSkillName,
   toSkillRank,
 } from '@/shared/types'
 import type { Agent, SkillSearchResult } from '@/shared/types'
@@ -32,7 +33,7 @@ function makeSkill(
 ): SkillSearchResult {
   return {
     rank: toSkillRank(1),
-    name: 'task',
+    name: toSkillName('task'),
     repo: repositoryId('vercel-labs/skills'),
     url: toHttpUrl('https://skills.sh/vercel-labs/skills/task'),
     installCount: toInstallCount(100),

--- a/src/renderer/src/components/marketplace/MarketplaceDashboard.browser.test.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceDashboard.browser.test.tsx
@@ -15,6 +15,7 @@ import type {
 import {
   toHttpUrl,
   toSearchQuery,
+  toSkillName,
   toSkillRank,
   toUnixTimestampMs,
 } from '@/shared/types'
@@ -58,7 +59,7 @@ function makeSearchResult(
 ): SkillSearchResult {
   return {
     rank: toSkillRank(1),
-    name: 'task',
+    name: toSkillName('task'),
     repo: 'vercel-labs/skills' as RepositoryId,
     url: toHttpUrl('https://skills.sh/task'),
     installCount: undefined,
@@ -167,7 +168,7 @@ describe('MarketplaceDashboard — trending preview selection', () => {
     // Arrange — one settled trending skill renders exactly one clickable row.
     const trendingSkill = makeSearchResult({
       rank: toSkillRank(1),
-      name: 'task',
+      name: toSkillName('task'),
       repo: 'vercel-labs/skills' as RepositoryId,
       url: toHttpUrl('https://skills.sh/task'),
     })

--- a/src/renderer/src/components/marketplace/MarketplaceDetailPanel.browser.test.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceDetailPanel.browser.test.tsx
@@ -9,6 +9,7 @@ import {
   repositoryId,
   toHttpUrl,
   toInstallCount,
+  toSkillName,
   toSkillRank,
 } from '@/shared/types'
 
@@ -41,14 +42,14 @@ afterEach(() => {
  * @param overrides - Partial overrides for the fixture.
  * @returns A valid `SkillSearchResult`.
  * @example
- * makeSkill({ name: 'lint' as SkillName })
+ * makeSkill({ name: toSkillName('lint') })
  */
 function makeSkill(
   overrides: Partial<SkillSearchResult> = {},
 ): SkillSearchResult {
   return {
     rank: toSkillRank(1),
-    name: 'task',
+    name: toSkillName('task'),
     repo: repositoryId('vercel-labs/skills'),
     url: toHttpUrl('https://skills.sh/task'),
     installCount: toInstallCount(123),
@@ -137,7 +138,7 @@ describe('MarketplaceDetailPanel routing', () => {
     const { setPreviewSkill } =
       await import('@/renderer/src/redux/slices/marketplaceSlice')
     const { MarketplaceDetailPanel } = await import('./MarketplaceDetailPanel')
-    store.dispatch(setPreviewSkill(makeSkill({ name: 'lint' })))
+    store.dispatch(setPreviewSkill(makeSkill({ name: toSkillName('lint') })))
 
     // Act
     const screen = await renderWithStore(<MarketplaceDetailPanel />, store)

--- a/src/renderer/src/components/marketplace/MarketplaceSearch.browser.test.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceSearch.browser.test.tsx
@@ -4,7 +4,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import { SEARCH_DEBOUNCE_MS } from '@/shared/constants'
-import { repositoryId, toHttpUrl, toSkillRank } from '@/shared/types'
+import {
+  repositoryId,
+  toHttpUrl,
+  toSkillName,
+  toSkillRank,
+} from '@/shared/types'
 import type { SkillSearchResult } from '@/shared/types'
 
 // The unit tests cover the debounce primitive and the reducer's latest-wins
@@ -42,7 +47,7 @@ afterEach(() => {
 
 const sampleResult: SkillSearchResult = {
   rank: toSkillRank(1),
-  name: 'task',
+  name: toSkillName('task'),
   repo: repositoryId('vercel-labs/skill-task'),
   url: toHttpUrl('https://skills.sh/vercel-labs/skill-task'),
 }

--- a/src/renderer/src/components/marketplace/MarketplaceSkillPreview.browser.test.tsx
+++ b/src/renderer/src/components/marketplace/MarketplaceSkillPreview.browser.test.tsx
@@ -9,6 +9,7 @@ import {
   repositoryId,
   toHttpUrl,
   toInstallCount,
+  toSkillName,
   toSkillRank,
 } from '@/shared/types'
 
@@ -25,7 +26,7 @@ function makeSkill(
 ): SkillSearchResult {
   return {
     rank: toSkillRank(1),
-    name: 'task',
+    name: toSkillName('task'),
     repo: repositoryId('vercel-labs/skills'),
     url: toHttpUrl('https://skills.sh/task'),
     installCount: toInstallCount(123),
@@ -130,7 +131,7 @@ describe('MarketplaceSkillPreview', () => {
       await import('@/renderer/src/redux/slices/marketplaceSlice')
     const { MarketplaceSkillPreview } =
       await import('./MarketplaceSkillPreview')
-    const skill = makeSkill({ name: 'lint' })
+    const skill = makeSkill({ name: toSkillName('lint') })
     store.dispatch(setPreviewSkill(skill))
     const screen = await renderWithStore(
       <MarketplaceSkillPreview skill={skill} />,

--- a/src/renderer/src/components/marketplace/SkillRowMarketplace.browser.test.tsx
+++ b/src/renderer/src/components/marketplace/SkillRowMarketplace.browser.test.tsx
@@ -4,7 +4,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import type { RepositoryId, SkillSearchResult } from '@/shared/types'
-import { toHttpUrl, toInstallCount, toSkillRank } from '@/shared/types'
+import {
+  toHttpUrl,
+  toInstallCount,
+  toSkillName,
+  toSkillRank,
+} from '@/shared/types'
 
 beforeEach(() => {
   // SkillRowMarketplace doesn't call IPC directly, but SkillsMarketplace and
@@ -41,7 +46,7 @@ function makeSkill(
 ): SkillSearchResult {
   return {
     rank: toSkillRank(1),
-    name: 'task',
+    name: toSkillName('task'),
     repo: 'vercel-labs/skills' as RepositoryId,
     url: toHttpUrl('https://skills.sh/task'),
     installCount: toInstallCount(100),
@@ -128,7 +133,7 @@ describe('SkillRowMarketplace — installed row has no destructive action', () =
 
   it('shows an Installed badge whose hint spells out the npx remove --global command', async () => {
     // Arrange
-    const skill = makeSkill({ name: 'lint' })
+    const skill = makeSkill({ name: toSkillName('lint') })
 
     // Act
     const { screen } = await renderRow(skill, true)
@@ -222,7 +227,7 @@ describe('SkillRowMarketplace — open preview from row body', () => {
     // Arrange
     const skill = makeSkill({
       rank: toSkillRank(1),
-      name: 'task',
+      name: toSkillName('task'),
       repo: 'vercel-labs/skills' as RepositoryId,
     })
     const { screen, store } = await renderRow(skill, false)
@@ -246,7 +251,7 @@ describe('SkillRowMarketplace — open preview from row body', () => {
 describe('SkillRowMarketplace — stage install from row', () => {
   it('stages the skill for installation when Install is clicked', async () => {
     // Arrange
-    const skill = makeSkill({ name: 'lint' })
+    const skill = makeSkill({ name: toSkillName('lint') })
     const { screen, store } = await renderRow(skill, false)
 
     // Act

--- a/src/renderer/src/components/marketplace/SkillsMarketplace.browser.test.tsx
+++ b/src/renderer/src/components/marketplace/SkillsMarketplace.browser.test.tsx
@@ -16,6 +16,7 @@ import type {
 import {
   toHttpUrl,
   toSearchQuery,
+  toSkillName,
   toSkillRank,
   toSymlinkCount,
   toUnixTimestampMs,
@@ -58,7 +59,7 @@ function makeSearchResult(
 ): SkillSearchResult {
   return {
     rank: toSkillRank(1),
-    name: 'task',
+    name: toSkillName('task'),
     repo: 'vercel-labs/skills' as RepositoryId,
     url: toHttpUrl('https://skills.sh/task'),
     installCount: undefined,
@@ -245,7 +246,7 @@ describe('SkillsMarketplace — leaderboard view', () => {
     // UI does not show (it gates on an empty list).
     const oneSkillLeaderboard = {
       'all-time': makeLeaderboardData({
-        skills: [makeSearchResult({ name: 'solo' })],
+        skills: [makeSearchResult({ name: toSkillName('solo') })],
         lastFetched: toUnixTimestampMs(Date.now()),
         status: 'loading',
       }),
@@ -266,7 +267,7 @@ describe('SkillsMarketplace — leaderboard view', () => {
     // Arrange — the skill name matches an installed skill, so the row shows the
     // Installed badge instead of an Install button.
     const installedSkill = {
-      name: 'installed-one',
+      name: toSkillName('installed-one'),
       description: 'desc',
       path: '/Users/me/.agents/skills/installed-one',
       symlinkCount: toSymlinkCount(0),
@@ -277,7 +278,7 @@ describe('SkillsMarketplace — leaderboard view', () => {
     // `status: 'loading'` aborts the mount refetch so the seeded skill survives.
     const leaderboardWithInstalled = {
       'all-time': makeLeaderboardData({
-        skills: [makeSearchResult({ name: 'installed-one' })],
+        skills: [makeSearchResult({ name: toSkillName('installed-one') })],
         lastFetched: toUnixTimestampMs(Date.now()),
         status: 'loading',
       }),
@@ -400,10 +401,10 @@ describe('SkillsMarketplace — search results view', () => {
     // Arrange — two results exercise the plural "skills" count label and the
     // search-results SkillRowMarketplace map.
     const results = [
-      makeSearchResult({ rank: toSkillRank(1), name: 'react' }),
+      makeSearchResult({ rank: toSkillRank(1), name: toSkillName('react') }),
       makeSearchResult({
         rank: toSkillRank(2),
-        name: 'react-query',
+        name: toSkillName('react-query'),
       }),
     ]
 
@@ -427,7 +428,7 @@ describe('SkillsMarketplace — search results view', () => {
   it('marks a search-result row as installed when its name is in the installed set', async () => {
     // Arrange — the result name matches an installed skill.
     const installedSkill = {
-      name: 'react',
+      name: toSkillName('react'),
       description: 'desc',
       path: '/Users/me/.agents/skills/react',
       symlinkCount: toSymlinkCount(0),
@@ -441,7 +442,7 @@ describe('SkillsMarketplace — search results view', () => {
       marketplace: {
         status: 'idle',
         searchQuery: toSearchQuery('react'),
-        searchResults: [makeSearchResult({ name: 'react' })],
+        searchResults: [makeSearchResult({ name: toSkillName('react') })],
       },
       skills: { items: [installedSkill] },
     })
@@ -461,13 +462,13 @@ describe('SkillsMarketplace — ranking tab switch', () => {
     // the assertion proves the view actually swapped.
     const bothTabsLeaderboard = {
       'all-time': makeLeaderboardData({
-        skills: [makeSearchResult({ name: 'alltime-skill' })],
+        skills: [makeSearchResult({ name: toSkillName('alltime-skill') })],
         lastFetched: toUnixTimestampMs(Date.now()),
         status: 'loading',
         filter: 'all-time',
       }),
       trending: makeLeaderboardData({
-        skills: [makeSearchResult({ name: 'trending-skill' })],
+        skills: [makeSearchResult({ name: toSkillName('trending-skill') })],
         lastFetched: toUnixTimestampMs(Date.now()),
         status: 'loading',
         filter: 'trending',

--- a/src/renderer/src/components/sidebar/AgentDeleteDialog.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/AgentDeleteDialog.browser.test.tsx
@@ -4,7 +4,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import type { Agent, FilesystemEntryIdentity, Skill } from '@/shared/types'
-import { toFileSizeBytes, toSkillCount, toSymlinkCount } from '@/shared/types'
+import {
+  toFileSizeBytes,
+  toSkillCount,
+  toSkillName,
+  toSymlinkCount,
+} from '@/shared/types'
 
 const mockRemoveAllFromAgent = vi.fn()
 const mockSkillsGetAll = vi.fn()
@@ -163,7 +168,7 @@ describe('AgentDeleteDialog confirm action', () => {
     })
     const agent = makeAgent({ name: 'Claude Code' as Agent['name'] })
     const protectedSkill: Skill = {
-      name: 'protected-task',
+      name: toSkillName('protected-task'),
       description: 'Protected task',
       path: '/Users/test/.agents/skills/protected-task',
       symlinkCount: toSymlinkCount(1),
@@ -186,7 +191,7 @@ describe('AgentDeleteDialog confirm action', () => {
     const { addProtection } =
       await import('@/renderer/src/redux/slices/protectSlice')
     store.dispatch(fetchSkills.fulfilled([protectedSkill], 'skills-request'))
-    store.dispatch(addProtection({ name: 'protected-task' }))
+    store.dispatch(addProtection({ name: toSkillName('protected-task') }))
 
     // Act
     await screen.getByRole('button', { name: /^Delete$/i }).click()

--- a/src/renderer/src/components/sidebar/AgentFoldersMenu.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/AgentFoldersMenu.browser.test.tsx
@@ -8,7 +8,12 @@ import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
 import type { AgentFolderGroup } from '@/renderer/src/redux/slices/uiSlice'
 import { DEFAULT_SETTINGS } from '@/shared/settings'
 import type { Agent, FilesystemEntryIdentity, Skill } from '@/shared/types'
-import { toFileSizeBytes, toSkillCount, toSymlinkCount } from '@/shared/types'
+import {
+  toFileSizeBytes,
+  toSkillCount,
+  toSkillName,
+  toSymlinkCount,
+} from '@/shared/types'
 
 const mockRemoveAllFromAgent = vi.fn()
 const mockRemoveEmptyFolder = vi.fn()
@@ -268,7 +273,7 @@ describe('Hidden agent folder deletion', () => {
     const { addProtection } =
       await import('@/renderer/src/redux/slices/protectSlice')
     const protectedSkill: Skill = {
-      name: 'protected-task',
+      name: toSkillName('protected-task'),
       description: 'Protected source skill',
       path: '/Users/test/.agents/skills/protected-task',
       symlinkCount: toSymlinkCount(1),
@@ -286,7 +291,7 @@ describe('Hidden agent folder deletion', () => {
       isOrphan: false,
     }
     store.dispatch(fetchSkills.fulfilled([protectedSkill], 'protected-skills'))
-    store.dispatch(addProtection({ name: 'protected-task' }))
+    store.dispatch(addProtection({ name: toSkillName('protected-task') }))
     mockRemoveAllFromAgent.mockResolvedValue({
       success: true,
       removedCount: 1,

--- a/src/renderer/src/components/sidebar/BookmarkDetailModal.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/BookmarkDetailModal.browser.test.tsx
@@ -4,7 +4,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import type { BookmarkForDetail } from '@/renderer/src/redux/slices/uiSlice'
-import { repositoryId, toHttpUrl, toIsoTimestamp } from '@/shared/types'
+import {
+  repositoryId,
+  toHttpUrl,
+  toIsoTimestamp,
+  toSkillName,
+} from '@/shared/types'
 
 /**
  * Build a not-yet-installed bookmark fixture so the detail modal shows its
@@ -17,7 +22,7 @@ function makeBookmark(
   overrides: Partial<BookmarkForDetail> = {},
 ): BookmarkForDetail {
   return {
-    name: 'task',
+    name: toSkillName('task'),
     repo: repositoryId('vercel-labs/skills'),
     url: toHttpUrl('https://skills.sh/task'),
     bookmarkedAt: toIsoTimestamp('2026-04-01T08:00:00.000Z'),
@@ -129,7 +134,7 @@ describe('BookmarkDetailModal remove', () => {
       await import('@/renderer/src/redux/slices/bookmarkSlice')
     store.dispatch(
       addBookmark({
-        name: 'task',
+        name: toSkillName('task'),
         repo: repositoryId('vercel-labs/skills'),
         url: toHttpUrl('https://skills.sh/task'),
       }),

--- a/src/renderer/src/components/sidebar/BookmarkItem.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/BookmarkItem.browser.test.tsx
@@ -6,7 +6,12 @@ import { render } from 'vitest-browser-react'
 
 import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
 import type { BookmarkForDetail } from '@/renderer/src/redux/slices/uiSlice'
-import { repositoryId, toHttpUrl, toIsoTimestamp } from '@/shared/types'
+import {
+  repositoryId,
+  toHttpUrl,
+  toIsoTimestamp,
+  toSkillName,
+} from '@/shared/types'
 
 /**
  * Build a not-yet-installed sidebar bookmark fixture (so the Install affordance
@@ -19,7 +24,7 @@ function makeBookmark(
   overrides: Partial<BookmarkForDetail> = {},
 ): BookmarkForDetail {
   return {
-    name: 'task',
+    name: toSkillName('task'),
     repo: repositoryId('vercel-labs/skills'),
     url: toHttpUrl('https://skills.sh/task'),
     bookmarkedAt: toIsoTimestamp('2026-04-01T08:00:00.000Z'),

--- a/src/renderer/src/components/sidebar/BookmarksSection.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/BookmarksSection.browser.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
-import { repositoryId, toHttpUrl } from '@/shared/types'
+import { repositoryId, toHttpUrl, toSkillName } from '@/shared/types'
 
 beforeEach(() => {
   // BookmarksSection mounts BookmarkItem + BookmarkDetailModal, which can reach
@@ -71,14 +71,14 @@ describe('BookmarksSection', () => {
       await import('@/renderer/src/redux/slices/bookmarkSlice')
     store.dispatch(
       addBookmark({
-        name: 'task',
+        name: toSkillName('task'),
         repo: repositoryId('vercel-labs/skills'),
         url: toHttpUrl('https://skills.sh/task'),
       }),
     )
     store.dispatch(
       addBookmark({
-        name: 'lint',
+        name: toSkillName('lint'),
         repo: repositoryId('vercel-labs/skills'),
         url: toHttpUrl('https://skills.sh/lint'),
       }),

--- a/src/renderer/src/components/sidebar/SyncConflictDialog.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/SyncConflictDialog.browser.test.tsx
@@ -4,19 +4,24 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import type { SyncExecuteResult, SyncPreviewResult } from '@/shared/types'
-import { toAgentCount, toSkillCount, toSymlinkCount } from '@/shared/types'
+import {
+  toAgentCount,
+  toSkillCount,
+  toSkillName,
+  toSymlinkCount,
+} from '@/shared/types'
 
 const mockSyncExecute = vi.fn()
 
 const CONFLICT_CLAUDE = {
-  skillName: 'tdd-workflow',
+  skillName: toSkillName('tdd-workflow'),
   agentId: 'claude-code',
   agentName: 'Claude Code',
   agentSkillPath: '/Users/me/.claude/skills/tdd-workflow',
 } as const
 
 const CONFLICT_CURSOR = {
-  skillName: 'theme-generator',
+  skillName: toSkillName('theme-generator'),
   agentId: 'cursor',
   agentName: 'Cursor',
   agentSkillPath: '/Users/me/.cursor/skills/theme-generator',

--- a/src/renderer/src/components/sidebar/SyncResultDialog.browser.test.tsx
+++ b/src/renderer/src/components/sidebar/SyncResultDialog.browser.test.tsx
@@ -5,7 +5,7 @@ import { render } from 'vitest-browser-react'
 
 import '@/renderer/src/styles/globals.css'
 import type { SyncExecuteResult } from '@/shared/types'
-import { toSymlinkCount } from '@/shared/types'
+import { toSkillName, toSymlinkCount } from '@/shared/types'
 
 const mockSkillsGetAll = vi.fn()
 const mockAgentsGetAll = vi.fn()
@@ -20,15 +20,23 @@ const RESULT_WITH_CHANGES: SyncExecuteResult = {
   // One row per action so each badge label appears exactly once. The summary
   // counts above are independent of these rows (they drive the header + chips).
   details: [
-    { skillName: 'tdd-workflow', agentName: 'Claude Code', action: 'created' },
-    { skillName: 'commit-helper', agentName: 'Codex', action: 'replaced' },
     {
-      skillName: 'already-there',
+      skillName: toSkillName('tdd-workflow'),
+      agentName: 'Claude Code',
+      action: 'created',
+    },
+    {
+      skillName: toSkillName('commit-helper'),
+      agentName: 'Codex',
+      action: 'replaced',
+    },
+    {
+      skillName: toSkillName('already-there'),
       agentName: 'Devin Desktop',
       action: 'skipped',
     },
     {
-      skillName: 'broken',
+      skillName: toSkillName('broken'),
       agentName: 'Codex',
       action: 'error',
       error: 'EACCES',
@@ -43,9 +51,21 @@ const RESULT_NO_CHANGES: SyncExecuteResult = {
   skipped: toSymlinkCount(3),
   errors: [],
   details: [
-    { skillName: 'already-a', agentName: 'Claude Code', action: 'skipped' },
-    { skillName: 'already-b', agentName: 'Cursor', action: 'skipped' },
-    { skillName: 'already-c', agentName: 'Codex', action: 'skipped' },
+    {
+      skillName: toSkillName('already-a'),
+      agentName: 'Claude Code',
+      action: 'skipped',
+    },
+    {
+      skillName: toSkillName('already-b'),
+      agentName: 'Cursor',
+      action: 'skipped',
+    },
+    {
+      skillName: toSkillName('already-c'),
+      agentName: 'Codex',
+      action: 'skipped',
+    },
   ],
 }
 

--- a/src/renderer/src/components/skills/AddSymlinkModal.browser.test.tsx
+++ b/src/renderer/src/components/skills/AddSymlinkModal.browser.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import type { Agent, Skill } from '@/shared/types'
-import { toSkillCount, toSymlinkCount } from '@/shared/types'
+import { toSkillCount, toSkillName, toSymlinkCount } from '@/shared/types'
 
 const mockCreateSymlinks = vi.fn()
 const mockCopyToAgents = vi.fn()
@@ -52,11 +52,11 @@ function makeAgent(
  * @param overrides - Partial skill overrides.
  * @returns Complete Skill object.
  * @example
- * makeSkill({ name: 'task' as SkillName })
+ * makeSkill({ name: toSkillName('task') })
  */
 function makeSkill(overrides: Partial<Skill> = {}): Skill {
   return {
-    name: 'task',
+    name: toSkillName('task'),
     description: 'Task management skill',
     path: '/home/user/.agents/skills/task',
     symlinkCount: toSymlinkCount(0),
@@ -286,9 +286,9 @@ describe('AddSymlinkModal actions', () => {
 
   it('clears selected agents when the modal closes externally and reopens', async () => {
     // Arrange
-    const firstSkill = makeSkill({ name: 'task' })
+    const firstSkill = makeSkill({ name: toSkillName('task') })
     const secondSkill = makeSkill({
-      name: 'review',
+      name: toSkillName('review'),
       path: '/home/user/.agents/skills/review',
     })
     const { screen, store } = await renderModal({

--- a/src/renderer/src/components/skills/BulkCopyToAgentsModal.browser.test.tsx
+++ b/src/renderer/src/components/skills/BulkCopyToAgentsModal.browser.test.tsx
@@ -9,7 +9,12 @@ import type {
   Skill,
   SkillName,
 } from '@/shared/types'
-import { toAgentCount, toSkillCount, toSymlinkCount } from '@/shared/types'
+import {
+  toAgentCount,
+  toSkillCount,
+  toSkillName,
+  toSymlinkCount,
+} from '@/shared/types'
 
 const mockCopyToAgents = vi.fn()
 const mockSkillsGetAll = vi.fn()
@@ -60,7 +65,7 @@ function makeAgent(
  */
 function makeSkill(name: string): Skill {
   return {
-    name: name,
+    name: toSkillName(name),
     description: `${name} skill`,
     path: `/home/user/.agents/skills/${name}`,
     symlinkCount: toSymlinkCount(0),
@@ -184,7 +189,7 @@ describe('BulkCopyToAgentsModal target selection', () => {
     const { screen } = await renderModal({
       skills: [makeSkill('task')],
       agents: [makeAgent({ id: 'cursor', name: 'Cursor' })],
-      selectedNames: ['task'],
+      selectedNames: [toSkillName('task')],
     })
     const cursorCheckbox = screen.getByRole('checkbox', { name: /Cursor/i })
     await expect.element(cursorCheckbox).not.toBeChecked()
@@ -206,7 +211,7 @@ describe('BulkCopyToAgentsModal target selection', () => {
         makeAgent({ id: 'cursor', name: 'Cursor' }),
         makeAgent({ id: 'codex', name: 'Codex' }),
       ],
-      selectedNames: ['task'],
+      selectedNames: [toSkillName('task')],
     })
     const cursorCheckbox = screen.getByRole('checkbox', { name: /Cursor/i })
     const codexCheckbox = screen.getByRole('checkbox', { name: /Codex/i })
@@ -226,7 +231,7 @@ describe('BulkCopyToAgentsModal dismissal', () => {
     const { screen, store } = await renderModal({
       skills: [makeSkill('task')],
       agents: [makeAgent({ id: 'cursor', name: 'Cursor' })],
-      selectedNames: ['task'],
+      selectedNames: [toSkillName('task')],
     })
     await screen.getByRole('checkbox', { name: /Cursor/i }).click()
 
@@ -242,7 +247,7 @@ describe('BulkCopyToAgentsModal dismissal', () => {
     const { store } = await renderModal({
       skills: [makeSkill('task')],
       agents: [makeAgent({ id: 'cursor', name: 'Cursor' })],
-      selectedNames: ['task'],
+      selectedNames: [toSkillName('task')],
     })
 
     // Act — Escape drives Radix onOpenChange(false) -> handleDialogOpenChange
@@ -262,7 +267,7 @@ describe('BulkCopyToAgentsModal dismissal', () => {
     const { screen, store } = await renderModal({
       skills: [makeSkill('task')],
       agents: [makeAgent({ id: 'cursor', name: 'Cursor' })],
-      selectedNames: ['task'],
+      selectedNames: [toSkillName('task')],
     })
     await screen.getByRole('checkbox', { name: /Cursor/i }).click()
     await screen.getByRole('button', { name: /Copy/i }).click()
@@ -292,7 +297,7 @@ describe('BulkCopyToAgentsModal copy outcome', () => {
     const { screen, store } = await renderModal({
       skills: [makeSkill('task')],
       agents: [makeAgent({ id: 'cursor', name: 'Cursor' })],
-      selectedNames: ['task'],
+      selectedNames: [toSkillName('task')],
     })
     await screen.getByRole('checkbox', { name: /Cursor/i }).click()
 
@@ -327,7 +332,7 @@ describe('BulkCopyToAgentsModal copy outcome', () => {
     const { screen } = await renderModal({
       skills: [makeSkill('task')],
       agents: [makeAgent({ id: 'cursor', name: 'Cursor' })],
-      selectedNames: ['task'],
+      selectedNames: [toSkillName('task')],
     })
     await screen.getByRole('checkbox', { name: /Cursor/i }).click()
 
@@ -348,7 +353,7 @@ describe('BulkCopyToAgentsModal copy outcome', () => {
     const { screen, store } = await renderModal({
       skills: [makeSkill('task')],
       agents: [makeAgent({ id: 'cursor', name: 'Cursor' })],
-      selectedNames: ['task'],
+      selectedNames: [toSkillName('task')],
     })
     await screen.getByRole('checkbox', { name: /Cursor/i }).click()
     const { bulkCopyToAgents } =
@@ -364,7 +369,7 @@ describe('BulkCopyToAgentsModal copy outcome', () => {
     // copying), driving the modal's fulfilled.match else branch.
     store.dispatch(
       bulkCopyToAgents({
-        items: [{ skillName: 'task', sourcePath: '/x' }],
+        items: [{ skillName: toSkillName('task'), sourcePath: '/x' }],
         agentIds: ['cursor'],
       }),
     )

--- a/src/renderer/src/components/skills/CopyToAgentsModal.browser.test.tsx
+++ b/src/renderer/src/components/skills/CopyToAgentsModal.browser.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import type { Agent, Skill, SymlinkInfo } from '@/shared/types'
-import { toSkillCount, toSymlinkCount } from '@/shared/types'
+import { toSkillCount, toSkillName, toSymlinkCount } from '@/shared/types'
 
 const mockCopyToAgents = vi.fn()
 const mockGetAll = vi.fn()
@@ -50,7 +50,7 @@ function makeAgent(
  */
 function makeSkill(symlinks: SymlinkInfo[]): Skill {
   return {
-    name: 'task',
+    name: toSkillName('task'),
     description: 'Task management skill',
     path: '/home/user/.agents/skills/task',
     symlinkCount: toSymlinkCount(symlinks.length),

--- a/src/renderer/src/components/skills/SearchBox.browser.test.tsx
+++ b/src/renderer/src/components/skills/SearchBox.browser.test.tsx
@@ -7,6 +7,7 @@ import { render } from 'vitest-browser-react'
 import {
   repositoryId,
   toHttpUrl,
+  toSkillName,
   toSymlinkCount,
   type Skill,
 } from '@/shared/types'
@@ -47,7 +48,7 @@ async function renderSearchBox() {
  */
 function makeSkill(name: string, source?: string): Skill {
   return {
-    name,
+    name: toSkillName(name),
     description: '',
     path: `/skills/${name}`,
     symlinkCount: toSymlinkCount(0),

--- a/src/renderer/src/components/skills/SelectionToolbar.browser.test.tsx
+++ b/src/renderer/src/components/skills/SelectionToolbar.browser.test.tsx
@@ -9,6 +9,7 @@ import {
   toBatchItemCount,
   toBatchItemIndex,
   toSearchQuery,
+  toSkillName,
   toSymlinkCount,
 } from '@/shared/types'
 
@@ -107,7 +108,7 @@ describe('SelectionToolbar', () => {
   it('shows "Select all visible ⌘A" in zero-selection state when bulk mode is entered', async () => {
     // Arrange — bulk mode active, nothing selected yet (zero-selection state)
     const options = {
-      skills: [makeCursorSkill('alpha', 'valid')],
+      skills: [makeCursorSkill(toSkillName('alpha'), 'valid')],
       selectedNames: [],
       agentId: null,
     }
@@ -132,8 +133,8 @@ describe('SelectionToolbar', () => {
   it('Clear empties the selection and transitions toolbar to zero-selection state', async () => {
     // Arrange — global view with one ticked skill so the toolbar is shown
     const { screen, store } = await renderToolbar({
-      skills: [makeCursorSkill('alpha', 'valid')],
-      selectedNames: ['alpha'],
+      skills: [makeCursorSkill(toSkillName('alpha'), 'valid')],
+      selectedNames: [toSkillName('alpha')],
       agentId: null,
     })
     await expect
@@ -158,10 +159,10 @@ describe('SelectionToolbar', () => {
     // Arrange — global view, two rows, only one currently ticked
     const { screen, store } = await renderToolbar({
       skills: [
-        makeCursorSkill('alpha', 'valid'),
-        makeCursorSkill('beta', 'valid'),
+        makeCursorSkill(toSkillName('alpha'), 'valid'),
+        makeCursorSkill(toSkillName('beta'), 'valid'),
       ],
-      selectedNames: ['alpha'],
+      selectedNames: [toSkillName('alpha')],
       agentId: null,
     })
 
@@ -180,11 +181,15 @@ describe('SelectionToolbar', () => {
     // ineligible) on screen, plus one hidden by the search filter.
     const { screen, store, setSearchQuery } = await renderToolbar({
       skills: [
-        makeCursorSkill('alpha-valid', 'valid'),
-        makeCursorSkill('alpha-broken', 'broken'),
-        makeCursorSkill('zeta-hidden', 'valid'),
+        makeCursorSkill(toSkillName('alpha-valid'), 'valid'),
+        makeCursorSkill(toSkillName('alpha-broken'), 'broken'),
+        makeCursorSkill(toSkillName('zeta-hidden'), 'valid'),
       ],
-      selectedNames: ['alpha-valid', 'alpha-broken', 'zeta-hidden'],
+      selectedNames: [
+        toSkillName('alpha-valid'),
+        toSkillName('alpha-broken'),
+        toSkillName('zeta-hidden'),
+      ],
       agentId: 'cursor',
     })
 
@@ -199,8 +204,8 @@ describe('SelectionToolbar', () => {
   it('shows the bulk progress counter for large batches', async () => {
     // Arrange — global view with one ticked skill
     const { screen, store } = await renderToolbar({
-      skills: [makeCursorSkill('alpha', 'valid')],
-      selectedNames: ['alpha'],
+      skills: [makeCursorSkill(toSkillName('alpha'), 'valid')],
+      selectedNames: [toSkillName('alpha')],
       agentId: null,
     })
     const { setBulkProgress } =
@@ -222,8 +227,8 @@ describe('SelectionToolbar', () => {
     // Arrange — global view with a copy callback supplied
     const onCopyAction = vi.fn()
     const { screen } = await renderToolbar({
-      skills: [makeCursorSkill('alpha', 'valid')],
-      selectedNames: ['alpha'],
+      skills: [makeCursorSkill(toSkillName('alpha'), 'valid')],
+      selectedNames: [toSkillName('alpha')],
       agentId: null,
       onCopyAction,
     })
@@ -241,8 +246,8 @@ describe('SelectionToolbar', () => {
   it('shows a destructive Delete action in global view', async () => {
     // Arrange — global view renders the destructive Delete primary action
     const { screen, onPrimaryAction } = await renderToolbar({
-      skills: [makeCursorSkill('alpha', 'valid')],
-      selectedNames: ['alpha'],
+      skills: [makeCursorSkill(toSkillName('alpha'), 'valid')],
+      selectedNames: [toSkillName('alpha')],
       agentId: null,
     })
     const deleteButton = screen.getByRole('button', {
@@ -259,8 +264,8 @@ describe('SelectionToolbar', () => {
   it('shows a non-destructive Unlink action in agent view', async () => {
     // Arrange — agent view with a single eligible valid row
     const { screen, onPrimaryAction } = await renderToolbar({
-      skills: [makeCursorSkill('alpha', 'valid')],
-      selectedNames: ['alpha'],
+      skills: [makeCursorSkill(toSkillName('alpha'), 'valid')],
+      selectedNames: [toSkillName('alpha')],
       agentId: 'cursor',
       agentDisplayName: 'Cursor',
     })
@@ -279,8 +284,8 @@ describe('SelectionToolbar', () => {
     // Arrange — global view with one ticked skill (bulk copy keeps the toolbar
     // mounted: unlike delete/unlink, its pending state does NOT exit bulk mode)
     const { screen, store } = await renderToolbar({
-      skills: [makeCursorSkill('alpha', 'valid')],
-      selectedNames: ['alpha'],
+      skills: [makeCursorSkill(toSkillName('alpha'), 'valid')],
+      selectedNames: [toSkillName('alpha')],
       agentId: null,
     })
     const { bulkCopyToAgents } =

--- a/src/renderer/src/components/skills/SkillDetail.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillDetail.browser.test.tsx
@@ -12,7 +12,7 @@ import type {
   Skill,
   SymlinkInfo,
 } from '@/shared/types'
-import { toSkillCount, toSymlinkCount } from '@/shared/types'
+import { toSkillCount, toSkillName, toSymlinkCount } from '@/shared/types'
 
 const SOURCE_PATH = '/home/user/.agents/skills/task'
 const CURSOR_PATH = '/home/user/.cursor/skills/task'
@@ -90,7 +90,7 @@ function makeSkill(): Skill {
   ]
 
   return {
-    name: 'task',
+    name: toSkillName('task'),
     description: 'Task workflow',
     path: SOURCE_PATH,
     symlinkCount: toSymlinkCount(symlinks.length),

--- a/src/renderer/src/components/skills/SkillItem.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillItem.browser.test.tsx
@@ -10,6 +10,7 @@ import {
   repositoryId,
   toFileSizeBytes,
   toHttpUrl,
+  toSkillName,
   toSymlinkCount,
 } from '@/shared/types'
 
@@ -44,11 +45,11 @@ const directoryIdentity: FilesystemEntryIdentity = {
  * Build a minimal Skill fixture.
  * @param overrides - Partial Skill overrides
  * @returns Complete Skill object
- * @example makeSkill({ name: 'browse' as SkillName })
+ * @example makeSkill({ name: toSkillName('browse') })
  */
 function makeSkill(overrides: Partial<Skill> = {}): Skill {
   return {
-    name: 'task',
+    name: toSkillName('task'),
     description: 'Task management skill',
     path: '/home/user/.agents/skills/task',
     filesystemIdentity: directoryIdentity,
@@ -138,7 +139,9 @@ describe('SkillItem bulk-select checkbox visibility', () => {
 
   it('labels the unticked bulk checkbox "Select {name}" for screen readers', async () => {
     // Arrange
-    const { screen, store } = await renderSkillItem(makeSkill({ name: 'task' }))
+    const { screen, store } = await renderSkillItem(
+      makeSkill({ name: toSkillName('task') }),
+    )
     const { enterBulkSelectMode } =
       await import('@/renderer/src/redux/slices/uiSlice')
 
@@ -153,7 +156,9 @@ describe('SkillItem bulk-select checkbox visibility', () => {
 
   it('flips the checkbox label to "Deselect {name}" once the skill is ticked', async () => {
     // Arrange
-    const { screen, store } = await renderSkillItem(makeSkill({ name: 'task' }))
+    const { screen, store } = await renderSkillItem(
+      makeSkill({ name: toSkillName('task') }),
+    )
     const { enterBulkSelectMode } =
       await import('@/renderer/src/redux/slices/uiSlice')
     const { toggleSelection } =
@@ -161,7 +166,7 @@ describe('SkillItem bulk-select checkbox visibility', () => {
 
     // Act
     store.dispatch(enterBulkSelectMode())
-    store.dispatch(toggleSelection('task'))
+    store.dispatch(toggleSelection(toSkillName('task')))
 
     // Assert
     await expect
@@ -364,7 +369,7 @@ describe('SkillItem delete button', () => {
     // Arrange
     const { screen } = await renderSkillItem(
       makeSkill({
-        name: 'brainstorming',
+        name: toSkillName('brainstorming'),
         source: repositoryId('vercel-labs/agent-skills'),
       }),
     )
@@ -380,7 +385,9 @@ describe('SkillItem delete button', () => {
 
   it('offers a "Delete {name}" button for a plain skill', async () => {
     // Arrange
-    const { screen } = await renderSkillItem(makeSkill({ name: 'local-skill' }))
+    const { screen } = await renderSkillItem(
+      makeSkill({ name: toSkillName('local-skill') }),
+    )
 
     // Act
     // (no interaction — assert the delete affordance is present)
@@ -395,7 +402,7 @@ describe('SkillItem delete button', () => {
     // Arrange
     const { screen, store } = await renderSkillItem(
       makeSkill({
-        name: 'brainstorming',
+        name: toSkillName('brainstorming'),
         source: repositoryId('vercel-labs/agent-skills'),
       }),
     )
@@ -433,7 +440,7 @@ describe('SkillItem delete button', () => {
   it('opens the trash confirm dialog when deleting a plain skill', async () => {
     // Arrange
     const { screen, store } = await renderSkillItem(
-      makeSkill({ name: 'local-skill' }),
+      makeSkill({ name: toSkillName('local-skill') }),
     )
 
     // Act
@@ -464,7 +471,7 @@ describe('SkillItem delete button', () => {
   it('does not open the inspector pane when the delete button is clicked', async () => {
     // Arrange
     const { screen, store } = await renderSkillItem(
-      makeSkill({ name: 'brainstorming' }),
+      makeSkill({ name: toSkillName('brainstorming') }),
     )
 
     // Act
@@ -636,7 +643,7 @@ describe('SkillItem G-Stack badge', () => {
     // hidden on every gstack sibling, which is the whole bug being fixed.
     const { screen, store } = await renderSkillItem(
       makeSkill({
-        name: 'ship',
+        name: toSkillName('ship'),
         path: '/Users/me/.claude/skills/ship',
         isSource: false,
         symlinks: [
@@ -675,7 +682,7 @@ describe('SkillItem G-Stack badge', () => {
     // would only surface here.
     const { screen, store } = await renderSkillItem(
       makeSkill({
-        name: 'custom',
+        name: toSkillName('custom'),
         path: '/Users/me/.claude/skills/custom',
         isSource: false,
         symlinks: [
@@ -709,7 +716,9 @@ describe('SkillItem bulk-select checkbox stopPropagation', () => {
 
   it('ticks the row for bulk select without opening the inspector pane', async () => {
     // Arrange
-    const { screen, store } = await renderSkillItem(makeSkill({ name: 'task' }))
+    const { screen, store } = await renderSkillItem(
+      makeSkill({ name: toSkillName('task') }),
+    )
     const { enterBulkSelectMode } =
       await import('@/renderer/src/redux/slices/uiSlice')
 
@@ -729,7 +738,9 @@ describe('SkillItem bulk-select checkbox stopPropagation', () => {
     // Seed three visible rows so the range slice is meaningful, then plant an
     // anchor on 'alpha' (toggleSelection records the anchor). The rendered row
     // is the middle one ('task'); a shift-click on it should sweep alpha→task.
-    const { screen, store } = await renderSkillItem(makeSkill({ name: 'task' }))
+    const { screen, store } = await renderSkillItem(
+      makeSkill({ name: toSkillName('task') }),
+    )
     const { enterBulkSelectMode } =
       await import('@/renderer/src/redux/slices/uiSlice')
     const { fetchSkills, toggleSelection } =
@@ -737,15 +748,15 @@ describe('SkillItem bulk-select checkbox stopPropagation', () => {
     store.dispatch(
       fetchSkills.fulfilled(
         [
-          makeSkill({ name: 'alpha' }),
-          makeSkill({ name: 'task' }),
-          makeSkill({ name: 'zeta' }),
+          makeSkill({ name: toSkillName('alpha') }),
+          makeSkill({ name: toSkillName('task') }),
+          makeSkill({ name: toSkillName('zeta') }),
         ],
         'req-id',
       ),
     )
     store.dispatch(enterBulkSelectMode())
-    store.dispatch(toggleSelection('alpha'))
+    store.dispatch(toggleSelection(toSkillName('alpha')))
     // Precondition: anchor planted, so the shift branch will actually run.
     expect(store.getState().skills.selectionAnchor).toBe('alpha')
 
@@ -775,7 +786,7 @@ describe('SkillItem unlink button', () => {
   it('stages the symlink for removal when unlinking a valid skill in agent view', async () => {
     // Arrange
     const validSkill = makeSkill({
-      name: 'task',
+      name: toSkillName('task'),
       symlinks: [
         {
           agentId: 'cursor',
@@ -815,7 +826,7 @@ describe('SkillItem unlink button', () => {
     // has no source symlink, so handleUnlinkClick must fall back to
     // selectedLocalSkillInfo. The X button reads "Delete ... from ...".
     const localSkill = makeSkill({
-      name: 'task',
+      name: toSkillName('task'),
       symlinks: [
         {
           agentId: 'cursor',
@@ -855,7 +866,7 @@ describe('SkillItem bookmark toggle', () => {
     // Arrange
     const { screen, store } = await renderSkillItem(
       makeSkill({
-        name: 'task',
+        name: toSkillName('task'),
         source: repositoryId('vercel-labs/agent-skills'),
         sourceUrl: toHttpUrl('https://github.com/vercel-labs/agent-skills.git'),
       }),
@@ -879,7 +890,7 @@ describe('SkillItem bookmark toggle', () => {
     // Arrange
     const { screen, store } = await renderSkillItem(
       makeSkill({
-        name: 'task',
+        name: toSkillName('task'),
         source: repositoryId('vercel-labs/agent-skills'),
       }),
     )
@@ -887,7 +898,7 @@ describe('SkillItem bookmark toggle', () => {
       await import('@/renderer/src/redux/slices/bookmarkSlice')
     store.dispatch(
       addBookmark({
-        name: 'task',
+        name: toSkillName('task'),
         repo: repositoryId('vercel-labs/agent-skills'),
         url: toHttpUrl('https://github.com/vercel-labs/agent-skills'),
       }),
@@ -908,7 +919,7 @@ describe('SkillItem card click', () => {
     // Arrange
     const { screen, store } = await renderSkillItem(
       makeSkill({
-        name: 'task',
+        name: toSkillName('task'),
         description: 'Task management skill',
       }),
     )
@@ -935,7 +946,7 @@ describe('SkillItem G-Stack badge click', () => {
     try {
       const { screen, store } = await renderSkillItem(
         makeSkill({
-          name: 'task',
+          name: toSkillName('task'),
           symlinks: [
             {
               agentId: 'claude-code',
@@ -976,7 +987,7 @@ describe('SkillItem copy context menu', () => {
     // Arrange
     // Copy is only offered in agent view for a usable (valid, non-local) skill.
     const validSkill = makeSkill({
-      name: 'task',
+      name: toSkillName('task'),
       symlinks: [
         {
           agentId: 'cursor',
@@ -1017,7 +1028,9 @@ describe('SkillItem copy context menu', () => {
     // Arrange
     // Global view: showCopyButton is false, so onContextMenu returns early and
     // no menu item is ever rendered.
-    const { screen } = await renderSkillItem(makeSkill({ name: 'task' }))
+    const { screen } = await renderSkillItem(
+      makeSkill({ name: toSkillName('task') }),
+    )
     const card = screen.getByText('Task management skill').element()
 
     // Act
@@ -1035,7 +1048,9 @@ describe('SkillItem copy context menu', () => {
 describe('SkillItem partial-failure flash', () => {
   it('flashes a red left edge for the matching row then clears it after the timeout', async () => {
     // Arrange
-    const { screen } = await renderSkillItem(makeSkill({ name: 'task' }))
+    const { screen } = await renderSkillItem(
+      makeSkill({ name: toSkillName('task') }),
+    )
     const { flashFailedRows } =
       await import('@/renderer/src/utils/bulkOpVisuals')
     const card = screen.getByText('Task management skill').element()
@@ -1045,7 +1060,7 @@ describe('SkillItem partial-failure flash', () => {
 
     // Act
     // Fire the per-row failure event MainContent uses after a partial bulk op.
-    flashFailedRows(['task'])
+    flashFailedRows([toSkillName('task')])
 
     // Assert
     // The red edge appears immediately for this row's name...
@@ -1062,7 +1077,9 @@ describe('SkillItem partial-failure flash', () => {
 
   it('ignores a failure event addressed to a different row', async () => {
     // Arrange
-    const { screen } = await renderSkillItem(makeSkill({ name: 'task' }))
+    const { screen } = await renderSkillItem(
+      makeSkill({ name: toSkillName('task') }),
+    )
     const { flashFailedRows } =
       await import('@/renderer/src/utils/bulkOpVisuals')
     const card = screen.getByText('Task management skill').element()
@@ -1071,7 +1088,7 @@ describe('SkillItem partial-failure flash', () => {
     // Act
     // A different skill's failure must not paint this row red (early return on
     // the skillName guard).
-    flashFailedRows(['other-skill'])
+    flashFailedRows([toSkillName('other-skill')])
 
     // Assert
     await expect
@@ -1083,7 +1100,9 @@ describe('SkillItem partial-failure flash', () => {
 describe('SkillItem protection', () => {
   it('shows a "Lock {name}" button when the skill is not protected', async () => {
     // Arrange — default store has protect.items=[], so the skill is unlocked.
-    const { screen } = await renderSkillItem(makeSkill({ name: 'task' }))
+    const { screen } = await renderSkillItem(
+      makeSkill({ name: toSkillName('task') }),
+    )
 
     // Act
     // (no interaction — assert the lock affordance label matches the unlocked state)
@@ -1096,7 +1115,9 @@ describe('SkillItem protection', () => {
 
   test('records the skill directory behind the lock so a later rename keeps it locked', async () => {
     // Arrange — the row carries the identity `scanSourceSkills` captured.
-    const { screen, store } = await renderSkillItem(makeSkill({ name: 'task' }))
+    const { screen, store } = await renderSkillItem(
+      makeSkill({ name: toSkillName('task') }),
+    )
 
     // Act
     await screen.getByRole('button', { name: /^Lock task$/i }).click()
@@ -1112,7 +1133,7 @@ describe('SkillItem protection', () => {
     // Arrange — agent-linked symlinks and orphans reach the list with no
     // `filesystemIdentity`; only `scanSourceSkills` records one.
     const { screen, store } = await renderSkillItem(
-      makeSkill({ name: 'task', filesystemIdentity: undefined }),
+      makeSkill({ name: toSkillName('task'), filesystemIdentity: undefined }),
     )
 
     // Act
@@ -1126,12 +1147,14 @@ describe('SkillItem protection', () => {
   it('labels a protected skill and offers an Unlock action', async () => {
     // Arrange — dispatch addProtection before rendering so ProtectButton
     // receives isProtected=true and renders the Lock icon.
-    const { screen, store } = await renderSkillItem(makeSkill({ name: 'task' }))
+    const { screen, store } = await renderSkillItem(
+      makeSkill({ name: toSkillName('task') }),
+    )
     const { addProtection } =
       await import('@/renderer/src/redux/slices/protectSlice')
 
     // Act
-    store.dispatch(addProtection({ name: 'task' }))
+    store.dispatch(addProtection({ name: toSkillName('task') }))
 
     // Assert — text makes protection scannable while the lock remains actionable.
     await expect
@@ -1144,12 +1167,14 @@ describe('SkillItem protection', () => {
 
   it('explains that delete is unavailable while the skill is protected', async () => {
     // Arrange
-    const { screen, store } = await renderSkillItem(makeSkill({ name: 'task' }))
+    const { screen, store } = await renderSkillItem(
+      makeSkill({ name: toSkillName('task') }),
+    )
     const { addProtection } =
       await import('@/renderer/src/redux/slices/protectSlice')
 
     // Act — protect the skill so the destructive action becomes unavailable.
-    store.dispatch(addProtection({ name: 'task' }))
+    store.dispatch(addProtection({ name: toSkillName('task') }))
 
     // Assert — keep the stable action slot visible, expose its ARIA state, and name why.
     const deleteButton = screen.getByRole('button', {
@@ -1161,13 +1186,15 @@ describe('SkillItem protection', () => {
 
   it('removes the Protected label and enables delete after unlocking', async () => {
     // Arrange — start locked, then unlock.
-    const { screen, store } = await renderSkillItem(makeSkill({ name: 'task' }))
+    const { screen, store } = await renderSkillItem(
+      makeSkill({ name: toSkillName('task') }),
+    )
     const { addProtection, removeProtection } =
       await import('@/renderer/src/redux/slices/protectSlice')
-    store.dispatch(addProtection({ name: 'task' }))
+    store.dispatch(addProtection({ name: toSkillName('task') }))
 
     // Act
-    store.dispatch(removeProtection('task'))
+    store.dispatch(removeProtection(toSkillName('task')))
 
     // Assert — the visible status clears and the same destructive slot is usable.
     const deleteButton = screen.getByRole('button', { name: /^Delete task$/i })
@@ -1181,7 +1208,7 @@ describe('SkillItem protection', () => {
   it('hides the agent-view unlink button when the skill is locked', async () => {
     // Arrange
     const linkedSkill = makeSkill({
-      name: 'task',
+      name: toSkillName('task'),
       symlinks: [
         {
           agentId: 'cursor',
@@ -1200,7 +1227,7 @@ describe('SkillItem protection', () => {
 
     // Act
     store.dispatch(selectAgent('cursor'))
-    store.dispatch(addProtection({ name: 'task' }))
+    store.dispatch(addProtection({ name: toSkillName('task') }))
 
     // Assert
     await expect
@@ -1218,7 +1245,7 @@ describe('SkillItem protection', () => {
   it('hides the agent-view local delete button when the skill is locked', async () => {
     // Arrange
     const localSkill = makeSkill({
-      name: 'task',
+      name: toSkillName('task'),
       symlinks: [
         {
           agentId: 'cursor',
@@ -1236,7 +1263,7 @@ describe('SkillItem protection', () => {
 
     // Act
     store.dispatch(selectAgent('cursor'))
-    store.dispatch(addProtection({ name: 'task' }))
+    store.dispatch(addProtection({ name: toSkillName('task') }))
 
     // Assert
     await expect
@@ -1254,7 +1281,7 @@ describe('SkillItem protection', () => {
   it('restores the agent-view unlink button when the skill is unlocked', async () => {
     // Arrange
     const linkedSkill = makeSkill({
-      name: 'task',
+      name: toSkillName('task'),
       symlinks: [
         {
           agentId: 'cursor',
@@ -1271,10 +1298,10 @@ describe('SkillItem protection', () => {
     const { addProtection, removeProtection } =
       await import('@/renderer/src/redux/slices/protectSlice')
     store.dispatch(selectAgent('cursor'))
-    store.dispatch(addProtection({ name: 'task' }))
+    store.dispatch(addProtection({ name: toSkillName('task') }))
 
     // Act
-    store.dispatch(removeProtection('task'))
+    store.dispatch(removeProtection(toSkillName('task')))
 
     // Assert
     await expect

--- a/src/renderer/src/components/skills/SkillsList.browser.test.tsx
+++ b/src/renderer/src/components/skills/SkillsList.browser.test.tsx
@@ -6,7 +6,7 @@ import { render } from 'vitest-browser-react'
 import { TooltipProvider } from '@/renderer/src/components/ui/tooltip'
 import { installLayoutStyles } from '@/renderer/src/test/installLayoutStyles'
 import type { Skill } from '@/shared/types'
-import { toSearchQuery, toSymlinkCount } from '@/shared/types'
+import { toSearchQuery, toSkillName, toSymlinkCount } from '@/shared/types'
 
 const mockGetAll = vi.fn()
 
@@ -31,11 +31,11 @@ afterEach(() => {
  * branch (no agent selected → keeps `isSource: true` items).
  * @param overrides - Partial Skill overrides
  * @returns Complete Skill object
- * @example makeSkill({ name: 'task' as SkillName })
+ * @example makeSkill({ name: toSkillName('task') })
  */
 function makeSkill(overrides: Partial<Skill> = {}): Skill {
   return {
-    name: 'task',
+    name: toSkillName('task'),
     description: 'Task management skill',
     path: '/home/user/.agents/skills/task',
     symlinkCount: toSymlinkCount(0),
@@ -254,7 +254,7 @@ describe('SkillsList loading branch — scroll-preservation regression', () => {
     // Act
     const screen = await renderSkillsList({
       loading: true,
-      items: [makeSkill({ name: 'task' })],
+      items: [makeSkill({ name: toSkillName('task') })],
     })
 
     // Assert
@@ -269,7 +269,7 @@ describe('SkillsList scrollbar gutter layout', () => {
     mockGetAll.mockReturnValue(new Promise(() => {}))
     const visibleSkills = Array.from({ length: 8 }, (_value, index) =>
       makeSkill({
-        name: `skill-${index}`,
+        name: toSkillName(`skill-${index}`),
         description: `Skill ${index} with enough body copy to use the normal installed card height.`,
       }),
     )
@@ -301,7 +301,7 @@ describe('SkillsList scrollbar gutter layout', () => {
     mockGetAll.mockReturnValue(new Promise(() => {}))
     const visibleSkills = [
       makeSkill({
-        name: 'single-skill',
+        name: toSkillName('single-skill'),
         description: 'A short list should not need vertical scrolling.',
       }),
     ]
@@ -376,7 +376,7 @@ describe('SkillsList search-empty branch', () => {
     // items intact so we stay out of the "No skills installed" branch.
     mockGetAll.mockReturnValue(new Promise(() => {}))
     const store = await createStore({
-      items: [makeSkill({ name: 'git-workflow' })],
+      items: [makeSkill({ name: toSkillName('git-workflow') })],
     })
     const { setSearchQuery: dispatchSearchQuery } =
       await import('@/renderer/src/redux/slices/uiSlice')
@@ -407,7 +407,7 @@ describe('SkillsList search-empty branch', () => {
     // Arrange — one installed skill with an active search that matches nothing
     mockGetAll.mockReturnValue(new Promise(() => {}))
     const store = await createStore({
-      items: [makeSkill({ name: 'git-workflow' })],
+      items: [makeSkill({ name: toSkillName('git-workflow') })],
     })
     const { setSearchQuery: dispatchSearchQuery } =
       await import('@/renderer/src/redux/slices/uiSlice')
@@ -445,7 +445,7 @@ describe('SkillsList filtered-empty branch', () => {
     // empty-installed and the rendered list. Default UI filters (no search, no
     // source, no agent, type=all) make getEmptyListMessage fall to its catch-all.
     mockGetAll.mockResolvedValue([
-      makeSkill({ name: 'hidden-skill', isSource: false }),
+      makeSkill({ name: toSkillName('hidden-skill'), isSource: false }),
     ])
 
     // Act

--- a/src/renderer/src/components/skills/UndoToast.browser.test.tsx
+++ b/src/renderer/src/components/skills/UndoToast.browser.test.tsx
@@ -7,7 +7,7 @@ import type {
   ToastId,
   TombstoneId,
 } from '@/shared/types'
-import { toIsoTimestamp, tombstoneId } from '@/shared/types'
+import { toIsoTimestamp, toSkillName, tombstoneId } from '@/shared/types'
 
 // `vi.hoisted` exposes the dismiss spy so the hoisted `vi.mock('sonner')`
 // factory can reference it. UndoToast's only external dependency is
@@ -48,7 +48,9 @@ async function renderUndoToast(options: RenderOptions = {}) {
   const { UndoToast } = await import('./UndoToast')
   const screen = await render(
     <UndoToast
-      skillNames={options.skillNames ?? (['task', 'theme'] as SkillName[])}
+      skillNames={
+        options.skillNames ?? [toSkillName('task'), toSkillName('theme')]
+      }
       tombstoneIds={options.tombstoneIds ?? [TOMBSTONE_A, TOMBSTONE_B]}
       expiresAt={options.expiresAt ?? futureIso(30)}
       summary={options.summary ?? SUMMARY}
@@ -81,7 +83,7 @@ describe('UndoToast', () => {
   it('offers an Undo button labelled with the count of skills being restored', async () => {
     // Arrange
     const { screen } = await renderUndoToast({
-      skillNames: ['task', 'theme'] as SkillName[],
+      skillNames: [toSkillName('task'), toSkillName('theme')],
     })
 
     // Act
@@ -148,7 +150,7 @@ describe('UndoToast', () => {
         }),
     )
     const { screen } = await renderUndoToast({
-      skillNames: ['task', 'theme'] as SkillName[],
+      skillNames: [toSkillName('task'), toSkillName('theme')],
       onUndo: pendingUndo,
     })
 
@@ -186,7 +188,7 @@ describe('UndoToast', () => {
   it('uses singular grammar when exactly one skill is being restored', async () => {
     // Arrange
     const { screen } = await renderUndoToast({
-      skillNames: ['task'] as SkillName[],
+      skillNames: [toSkillName('task')],
       tombstoneIds: [TOMBSTONE_A],
     })
 

--- a/src/renderer/src/components/skills/UnlinkDialog.browser.test.tsx
+++ b/src/renderer/src/components/skills/UnlinkDialog.browser.test.tsx
@@ -8,7 +8,7 @@ import type {
   Skill,
   SymlinkInfo,
 } from '@/shared/types'
-import { toFileSizeBytes, toSymlinkCount } from '@/shared/types'
+import { toFileSizeBytes, toSkillName, toSymlinkCount } from '@/shared/types'
 
 const mockUnlinkFromAgent = vi.fn()
 const mockSkillsGetAll = vi.fn()
@@ -39,11 +39,11 @@ const directoryIdentity: FilesystemEntryIdentity = {
  * Build a minimal Skill fixture for unlink-dialog tests.
  * @param overrides - Partial Skill overrides.
  * @returns Complete Skill object.
- * @example makeSkill({ name: 'task' as SkillName })
+ * @example makeSkill({ name: toSkillName('task') })
  */
 function makeSkill(overrides: Partial<Skill> = {}): Skill {
   return {
-    name: 'task',
+    name: toSkillName('task'),
     description: 'Task management skill',
     path: '/home/user/.agents/skills/task',
     symlinkCount: toSymlinkCount(0),
@@ -153,7 +153,7 @@ async function renderUnlinkDialog(
 describe('UnlinkDialog variant copy', () => {
   it('shows "Remove from Agent" copy for a live valid link', async () => {
     // Arrange
-    const skill = makeSkill({ name: 'task' })
+    const skill = makeSkill({ name: toSkillName('task') })
     const symlink = makeSymlink({ status: 'valid', agentName: 'Cursor' })
 
     // Act
@@ -170,7 +170,7 @@ describe('UnlinkDialog variant copy', () => {
 
   it('shows "Delete from Agent" trash copy for a local skill folder', async () => {
     // Arrange
-    const skill = makeSkill({ name: 'task' })
+    const skill = makeSkill({ name: toSkillName('task') })
     const symlink = makeSymlink({
       isLocal: true,
       status: 'valid',
@@ -193,7 +193,7 @@ describe('UnlinkDialog variant copy', () => {
 
   it('shows "Remove Broken Link" copy for a dangling broken symlink', async () => {
     // Arrange
-    const skill = makeSkill({ name: 'task' })
+    const skill = makeSkill({ name: toSkillName('task') })
     const symlink = makeSymlink({ status: 'broken', isLocal: false })
 
     // Act
@@ -212,7 +212,7 @@ describe('UnlinkDialog variant copy', () => {
     // Arrange
     // 'missing' is defensively mapped to the broken variant so it can never
     // fall through to the live-link "remove" copy.
-    const skill = makeSkill({ name: 'task' })
+    const skill = makeSkill({ name: toSkillName('task') })
     const symlink = makeSymlink({
       status: 'missing',
       isLocal: false,
@@ -230,7 +230,7 @@ describe('UnlinkDialog variant copy', () => {
 
   it('shows "Manual Review Required" copy for an inaccessible target', async () => {
     // Arrange
-    const skill = makeSkill({ name: 'task' })
+    const skill = makeSkill({ name: toSkillName('task') })
     const symlink = makeSymlink({ status: 'inaccessible', isLocal: false })
 
     // Act
@@ -250,7 +250,7 @@ describe('UnlinkDialog confirm action', () => {
   it('shows a success toast and clears the target after removing a valid link', async () => {
     // Arrange
     mockUnlinkFromAgent.mockResolvedValue({ success: true })
-    const skill = makeSkill({ name: 'task' })
+    const skill = makeSkill({ name: toSkillName('task') })
     const symlink = makeSymlink({ status: 'valid', agentName: 'Cursor' })
     const { screen, store } = await renderUnlinkDialog({ skill, symlink })
     await expect
@@ -276,7 +276,7 @@ describe('UnlinkDialog confirm action', () => {
       success: false,
       error: 'EPERM: operation not permitted',
     })
-    const skill = makeSkill({ name: 'task' })
+    const skill = makeSkill({ name: toSkillName('task') })
     const symlink = makeSymlink({ status: 'valid', agentName: 'Cursor' })
     const { screen } = await renderUnlinkDialog({ skill, symlink })
     await expect
@@ -298,7 +298,7 @@ describe('UnlinkDialog confirm action', () => {
     // A rejected thunk with no error message must still surface a toast so the
     // user is never left without feedback after a failed unlink.
     mockUnlinkFromAgent.mockRejectedValue(new Error())
-    const skill = makeSkill({ name: 'task' })
+    const skill = makeSkill({ name: toSkillName('task') })
     const symlink = makeSymlink({ status: 'valid', agentName: 'Cursor' })
     const { screen } = await renderUnlinkDialog({ skill, symlink })
     await expect
@@ -317,7 +317,7 @@ describe('UnlinkDialog confirm action', () => {
 
   it('warns and never calls the IPC bridge for an inaccessible target on confirm', async () => {
     // Arrange
-    const skill = makeSkill({ name: 'task' })
+    const skill = makeSkill({ name: toSkillName('task') })
     const symlink = makeSymlink({ status: 'inaccessible', isLocal: false })
     const { screen, store } = await renderUnlinkDialog({ skill, symlink })
     await expect
@@ -349,7 +349,7 @@ describe('UnlinkDialog confirm action', () => {
 describe('UnlinkDialog cancel behavior', () => {
   it('clears the unlink target when cancelled while idle', async () => {
     // Arrange
-    const skill = makeSkill({ name: 'task' })
+    const skill = makeSkill({ name: toSkillName('task') })
     const symlink = makeSymlink({ status: 'valid' })
     const { screen, store } = await renderUnlinkDialog({ skill, symlink })
     await expect
@@ -367,7 +367,7 @@ describe('UnlinkDialog cancel behavior', () => {
     // Arrange
     // While unlinking is true the dialog must refuse to close so the user
     // cannot abandon an in-progress destructive operation.
-    const skill = makeSkill({ name: 'task' })
+    const skill = makeSkill({ name: toSkillName('task') })
     const symlink = makeSymlink({ status: 'valid' })
     const { screen, store } = await renderUnlinkDialog({ skill, symlink })
     const { unlinkSkillFromAgent } =

--- a/src/renderer/src/components/skills/UnlinkDialog.tsx
+++ b/src/renderer/src/components/skills/UnlinkDialog.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/renderer/src/redux/slices/skillsSlice'
 import { refreshAllData } from '@/renderer/src/redux/thunks'
 import type { SkillName, SymlinkInfo } from '@/shared/types'
+import { toSkillName } from '@/shared/types'
 
 /**
  * Three exhaustive states the dialog has to cover:
@@ -117,7 +118,7 @@ export const UnlinkDialog = function UnlinkDialog(): React.ReactElement {
     : 'valid'
   const copy = getUnlinkCopy(
     variant,
-    skillToUnlink?.skill.name ?? '',
+    toSkillName(skillToUnlink?.skill.name ?? ''),
     skillToUnlink?.symlink.agentName ?? '',
   )
 

--- a/src/renderer/src/components/skills/UnlinkDialog.tsx
+++ b/src/renderer/src/components/skills/UnlinkDialog.tsx
@@ -118,7 +118,7 @@ export const UnlinkDialog = function UnlinkDialog(): React.ReactElement {
     : 'valid'
   const copy = getUnlinkCopy(
     variant,
-    toSkillName(skillToUnlink?.skill.name ?? ''),
+    skillToUnlink?.skill.name ?? toSkillName(''),
     skillToUnlink?.symlink.agentName ?? '',
   )
 

--- a/src/renderer/src/components/skills/bookmarkHelpers.test.ts
+++ b/src/renderer/src/components/skills/bookmarkHelpers.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { repositoryId, toHttpUrl, toSymlinkCount } from '@/shared/types'
+import {
+  repositoryId,
+  toHttpUrl,
+  toSkillName,
+  toSymlinkCount,
+} from '@/shared/types'
 import type { Skill } from '@/shared/types'
 
 import { canBookmarkSkill, skillToBookmarkData } from './bookmarkHelpers'
@@ -14,7 +19,7 @@ import { canBookmarkSkill, skillToBookmarkData } from './bookmarkHelpers'
  */
 function makeSkill(overrides: Partial<Skill> = {}): Skill {
   return {
-    name: 'test-skill',
+    name: toSkillName('test-skill'),
     description: 'A test skill',
     path: '/home/user/.agents/skills/test-skill',
     symlinkCount: toSymlinkCount(0),

--- a/src/renderer/src/components/skills/bulkDeleteHelpers.test.ts
+++ b/src/renderer/src/components/skills/bulkDeleteHelpers.test.ts
@@ -5,7 +5,12 @@ import type {
   BulkUnlinkResult,
   SkillName,
 } from '@/shared/types'
-import { toSkillCount, toSymlinkCount, tombstoneId } from '@/shared/types'
+import {
+  toSkillCount,
+  toSkillName,
+  toSymlinkCount,
+  tombstoneId,
+} from '@/shared/types'
 
 import {
   computeRangeSelection,
@@ -168,13 +173,13 @@ describe('countOrphanSymlinksRemoved', () => {
     const result: BulkDeleteResult = {
       items: [
         {
-          skillName: 'abandoned',
+          skillName: toSkillName('abandoned'),
           outcome: 'orphan-cleared',
           symlinksRemoved: toSymlinkCount(2),
           cascadeAgents: ['cursor'],
         },
         {
-          skillName: 'half-cleared',
+          skillName: toSkillName('half-cleared'),
           outcome: 'error',
           symlinksRemoved: toSymlinkCount(1),
           cascadeAgents: ['claude-code'],
@@ -196,14 +201,14 @@ describe('countOrphanSymlinksRemoved', () => {
     const result: BulkDeleteResult = {
       items: [
         {
-          skillName: 'task',
+          skillName: toSkillName('task'),
           outcome: 'deleted',
           tombstoneId: tombstoneId('1-task-aaaa'),
           symlinksRemoved: toSymlinkCount(5),
           cascadeAgents: ['cursor'],
         },
         {
-          skillName: 'locked',
+          skillName: toSkillName('locked'),
           outcome: 'error',
           error: { message: 'EACCES', code: 'EACCES' },
         },
@@ -224,14 +229,14 @@ describe('formatCascadeSummary', () => {
     const result: BulkDeleteResult = {
       items: [
         {
-          skillName: 'task',
+          skillName: toSkillName('task'),
           outcome: 'deleted',
           tombstoneId: tombstoneId('1-task-aaaa'),
           symlinksRemoved: toSymlinkCount(2),
           cascadeAgents: ['cursor', 'claude-code'],
         },
         {
-          skillName: 'theme-generator',
+          skillName: toSkillName('theme-generator'),
           outcome: 'deleted',
           tombstoneId: tombstoneId('1-theme-generator-bbbb'),
           symlinksRemoved: toSymlinkCount(1),
@@ -252,14 +257,14 @@ describe('formatCascadeSummary', () => {
     const result: BulkDeleteResult = {
       items: [
         {
-          skillName: 'task',
+          skillName: toSkillName('task'),
           outcome: 'deleted',
           tombstoneId: tombstoneId('1-task-aaaa'),
           symlinksRemoved: toSymlinkCount(1),
           cascadeAgents: [],
         },
         {
-          skillName: 'locked',
+          skillName: toSkillName('locked'),
           outcome: 'error',
           error: { message: 'EACCES', code: 'EACCES' },
         },
@@ -278,7 +283,7 @@ describe('formatCascadeSummary', () => {
     const result: BulkDeleteResult = {
       items: [
         {
-          skillName: 'task',
+          skillName: toSkillName('task'),
           outcome: 'deleted',
           tombstoneId: tombstoneId('1-task-aaaa'),
           symlinksRemoved: toSymlinkCount(0),
@@ -299,7 +304,7 @@ describe('formatCascadeSummary', () => {
     const result: BulkDeleteResult = {
       items: [
         {
-          skillName: 'task',
+          skillName: toSkillName('task'),
           outcome: 'deleted',
           tombstoneId: tombstoneId('1-task-aaaa'),
           symlinksRemoved: toSymlinkCount(1),
@@ -323,14 +328,14 @@ describe('formatCascadeSummary', () => {
     const result: BulkDeleteResult = {
       items: [
         {
-          skillName: 'task',
+          skillName: toSkillName('task'),
           outcome: 'deleted',
           tombstoneId: tombstoneId('1-task-aaaa'),
           symlinksRemoved: toSymlinkCount(1),
           cascadeAgents: ['cursor'],
         },
         {
-          skillName: 'abandoned',
+          skillName: toSkillName('abandoned'),
           outcome: 'orphan-cleared',
           symlinksRemoved: toSymlinkCount(2),
           cascadeAgents: ['cursor', 'codex'],
@@ -357,13 +362,13 @@ describe('formatCascadeSummary', () => {
     const result: BulkDeleteResult = {
       items: [
         {
-          skillName: 'abandoned-a',
+          skillName: toSkillName('abandoned-a'),
           outcome: 'orphan-cleared',
           symlinksRemoved: toSymlinkCount(1),
           cascadeAgents: ['cursor'],
         },
         {
-          skillName: 'abandoned-b',
+          skillName: toSkillName('abandoned-b'),
           outcome: 'orphan-cleared',
           symlinksRemoved: toSymlinkCount(3),
           cascadeAgents: ['cursor', 'codex', 'claude-code'],
@@ -385,13 +390,13 @@ describe('formatCascadeSummary', () => {
     const result: BulkDeleteResult = {
       items: [
         {
-          skillName: 'abandoned',
+          skillName: toSkillName('abandoned'),
           outcome: 'orphan-cleared',
           symlinksRemoved: toSymlinkCount(2),
           cascadeAgents: ['cursor', 'codex'],
         },
         {
-          skillName: 'locked',
+          skillName: toSkillName('locked'),
           outcome: 'error',
           error: { message: 'EACCES', code: 'EACCES' },
         },
@@ -412,7 +417,7 @@ describe('formatCascadeSummary', () => {
     const result: BulkDeleteResult = {
       items: [
         {
-          skillName: 'abandoned',
+          skillName: toSkillName('abandoned'),
           outcome: 'error',
           error: { message: 'Source skill exists', code: 'ESTALE' },
           symlinksRemoved: toSymlinkCount(2),
@@ -434,8 +439,8 @@ describe('formatUnlinkSummary', () => {
     // Arrange
     const result: BulkUnlinkResult = {
       items: [
-        { skillName: 'task', outcome: 'unlinked' },
-        { skillName: 'theme', outcome: 'unlinked' },
+        { skillName: toSkillName('task'), outcome: 'unlinked' },
+        { skillName: toSkillName('theme'), outcome: 'unlinked' },
       ],
     }
 
@@ -450,8 +455,12 @@ describe('formatUnlinkSummary', () => {
     // Arrange
     const result: BulkUnlinkResult = {
       items: [
-        { skillName: 'task', outcome: 'unlinked' },
-        { skillName: 'locked', outcome: 'error', error: { message: 'EACCES' } },
+        { skillName: toSkillName('task'), outcome: 'unlinked' },
+        {
+          skillName: toSkillName('locked'),
+          outcome: 'error',
+          error: { message: 'EACCES' },
+        },
       ],
     }
 
@@ -465,7 +474,7 @@ describe('formatUnlinkSummary', () => {
   it('uses singular "skill" wording when only one skill is unlinked', () => {
     // Arrange
     const result: BulkUnlinkResult = {
-      items: [{ skillName: 'task', outcome: 'unlinked' }],
+      items: [{ skillName: toSkillName('task'), outcome: 'unlinked' }],
     }
 
     // Act
@@ -477,11 +486,21 @@ describe('formatUnlinkSummary', () => {
 })
 
 describe('computeRangeSelection', () => {
-  const visible: SkillName[] = ['alpha', 'browser', 'task', 'theme', 'zebra']
+  const visible: SkillName[] = [
+    toSkillName('alpha'),
+    toSkillName('browser'),
+    toSkillName('task'),
+    toSkillName('theme'),
+    toSkillName('zebra'),
+  ]
 
   it('shift-selects every row between an earlier anchor and a later click, inclusive', () => {
     // Arrange / Act
-    const range = computeRangeSelection('task', 'zebra', visible)
+    const range = computeRangeSelection(
+      toSkillName('task'),
+      toSkillName('zebra'),
+      visible,
+    )
 
     // Assert
     expect(range).toEqual(['task', 'theme', 'zebra'])
@@ -489,7 +508,11 @@ describe('computeRangeSelection', () => {
 
   it('shift-selects the same inclusive range when the anchor sits below the clicked row', () => {
     // Arrange / Act
-    const range = computeRangeSelection('zebra', 'task', visible)
+    const range = computeRangeSelection(
+      toSkillName('zebra'),
+      toSkillName('task'),
+      visible,
+    )
 
     // Assert
     expect(range).toEqual(['task', 'theme', 'zebra'])
@@ -497,7 +520,11 @@ describe('computeRangeSelection', () => {
 
   it('selects just the clicked row when the anchor and target are the same row', () => {
     // Arrange / Act
-    const range = computeRangeSelection('task', 'task', visible)
+    const range = computeRangeSelection(
+      toSkillName('task'),
+      toSkillName('task'),
+      visible,
+    )
 
     // Assert
     expect(range).toEqual(['task'])
@@ -505,7 +532,7 @@ describe('computeRangeSelection', () => {
 
   it('selects just the clicked row when there is no prior anchor', () => {
     // Arrange / Act
-    const range = computeRangeSelection(null, 'task', visible)
+    const range = computeRangeSelection(null, toSkillName('task'), visible)
 
     // Assert
     expect(range).toEqual(['task'])
@@ -513,7 +540,11 @@ describe('computeRangeSelection', () => {
 
   it('selects just the clicked row when the anchor was filtered out by search', () => {
     // Arrange / Act
-    const range = computeRangeSelection('removed-by-search', 'zebra', visible)
+    const range = computeRangeSelection(
+      toSkillName('removed-by-search'),
+      toSkillName('zebra'),
+      visible,
+    )
 
     // Assert
     expect(range).toEqual(['zebra'])
@@ -521,7 +552,11 @@ describe('computeRangeSelection', () => {
 
   it('selects just the clicked row when the clicked target is not in the visible list', () => {
     // Arrange / Act
-    const range = computeRangeSelection('task', 'missing', visible)
+    const range = computeRangeSelection(
+      toSkillName('task'),
+      toSkillName('missing'),
+      visible,
+    )
 
     // Assert
     expect(range).toEqual(['missing'])
@@ -529,7 +564,11 @@ describe('computeRangeSelection', () => {
 
   it('shift-selects the whole visible list when spanning from the first row to the last', () => {
     // Arrange / Act
-    const range = computeRangeSelection('alpha', 'zebra', visible)
+    const range = computeRangeSelection(
+      toSkillName('alpha'),
+      toSkillName('zebra'),
+      visible,
+    )
 
     // Assert
     expect(range).toEqual(visible)

--- a/src/renderer/src/components/skills/copyToAgentsWithToast.test.ts
+++ b/src/renderer/src/components/skills/copyToAgentsWithToast.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { copyToAgents } from '@/renderer/src/redux/slices/skillsSlice'
 import type { AbsolutePath, Skill, SkillName } from '@/shared/types'
-import { toSymlinkCount } from '@/shared/types'
+import { toSkillName, toSymlinkCount } from '@/shared/types'
 
 // `copyToAgentsWithToast` is the shared "dispatch → match-fulfilled →
 // 3-branch toast → refreshAllData" helper used by AddSymlinkModal and
@@ -41,7 +41,7 @@ const dispatchMock = vi.fn()
  * @returns Skill fixture sufficient for copyToAgentsWithToast unit tests.
  * @example makeSkill('tdd-workflow').name // => 'tdd-workflow'
  */
-function makeSkill(name: SkillName = 'tdd-workflow'): Skill {
+function makeSkill(name: SkillName = toSkillName('tdd-workflow')): Skill {
   return {
     name,
     description: `${name} description`,
@@ -78,7 +78,7 @@ describe('copyToAgentsWithToast', () => {
 
     // Act
     await copyToAgentsWithToast(dispatchMock, {
-      skill: makeSkill('tdd-workflow'),
+      skill: makeSkill(toSkillName('tdd-workflow')),
       sourcePath: sampleSourcePath,
       agentIds: ['claude-code', 'codex'],
     })
@@ -109,7 +109,7 @@ describe('copyToAgentsWithToast', () => {
 
     // Act
     await copyToAgentsWithToast(dispatchMock, {
-      skill: makeSkill('tdd-workflow'),
+      skill: makeSkill(toSkillName('tdd-workflow')),
       sourcePath: sampleSourcePath,
       agentIds: ['claude-code', 'cursor', 'codex'],
     })
@@ -136,7 +136,7 @@ describe('copyToAgentsWithToast', () => {
 
     // Act
     await copyToAgentsWithToast(dispatchMock, {
-      skill: makeSkill('tdd-workflow'),
+      skill: makeSkill(toSkillName('tdd-workflow')),
       sourcePath: sampleSourcePath,
       agentIds: ['claude-code'],
     })
@@ -159,7 +159,7 @@ describe('copyToAgentsWithToast', () => {
 
     // Act
     await copyToAgentsWithToast(dispatchMock, {
-      skill: makeSkill('tdd-workflow'),
+      skill: makeSkill(toSkillName('tdd-workflow')),
       sourcePath: sampleSourcePath,
       agentIds: ['claude-code'],
     })
@@ -181,7 +181,7 @@ describe('copyToAgentsWithToast', () => {
 
     // Act
     await copyToAgentsWithToast(dispatchMock, {
-      skill: makeSkill('tdd-workflow'),
+      skill: makeSkill(toSkillName('tdd-workflow')),
       sourcePath: sampleSourcePath,
       agentIds: ['claude-code'],
     })

--- a/src/renderer/src/components/skills/reviewedDestructiveTargets.test.ts
+++ b/src/renderer/src/components/skills/reviewedDestructiveTargets.test.ts
@@ -5,7 +5,7 @@ import type {
   Skill,
   SymlinkInfo,
 } from '@/shared/types'
-import { toFileSizeBytes, toSymlinkCount } from '@/shared/types'
+import { toFileSizeBytes, toSkillName, toSymlinkCount } from '@/shared/types'
 
 import {
   buildAgentUnlinkTargets,
@@ -21,7 +21,7 @@ import {
  */
 function makeSkill(name: string, symlinks: SymlinkInfo[]): Skill {
   return {
-    name,
+    name: toSkillName(name),
     description: 'desc',
     path: '/Users/me/.agents/skills/task',
     symlinkCount: toSymlinkCount(0),
@@ -48,7 +48,11 @@ describe('buildAgentUnlinkTargets', () => {
     ]
 
     // Act
-    const result = buildAgentUnlinkTargets(skills, ['task'], 'cursor')
+    const result = buildAgentUnlinkTargets(
+      skills,
+      [toSkillName('task')],
+      'cursor',
+    )
 
     // Assert
     expect(result.targets).toEqual([
@@ -77,7 +81,11 @@ describe('buildAgentUnlinkTargets', () => {
     ]
 
     // Act
-    const result = buildAgentUnlinkTargets(skills, ['task'], 'cursor')
+    const result = buildAgentUnlinkTargets(
+      skills,
+      [toSkillName('task')],
+      'cursor',
+    )
 
     // Assert — no unlink target produced; the name is flagged for a rescan
     expect(result.targets).toEqual([])
@@ -100,7 +108,11 @@ describe('buildAgentUnlinkTargets', () => {
     ]
 
     // Act
-    const result = buildAgentUnlinkTargets(skills, ['task'], 'cursor')
+    const result = buildAgentUnlinkTargets(
+      skills,
+      [toSkillName('task')],
+      'cursor',
+    )
 
     // Assert
     expect(result.targets).toEqual([])
@@ -112,7 +124,11 @@ describe('buildAgentUnlinkTargets', () => {
     const skills: Skill[] = []
 
     // Act
-    const result = buildAgentUnlinkTargets(skills, ['vanished'], 'cursor')
+    const result = buildAgentUnlinkTargets(
+      skills,
+      [toSkillName('vanished')],
+      'cursor',
+    )
 
     // Assert
     expect(result.targets).toEqual([])
@@ -124,7 +140,7 @@ describe('partitionGlobalDeleteTargets — protected names', () => {
   it('routes a protected skill to protectedErrors and excludes it from delete targets', () => {
     // Arrange — a normal source skill selected for deletion, but locked by the user.
     const sourceSkill: Skill = {
-      name: 'task',
+      name: toSkillName('task'),
       description: 'desc',
       path: '/Users/me/.agents/skills/task',
       symlinkCount: toSymlinkCount(0),
@@ -136,8 +152,8 @@ describe('partitionGlobalDeleteTargets — protected names', () => {
     // Act
     const result = partitionGlobalDeleteTargets(
       [sourceSkill],
-      ['task'],
-      new Set(['task']),
+      [toSkillName('task')],
+      new Set([toSkillName('task')]),
     )
 
     // Assert — protected skill is in protectedErrors, not deleteTargets
@@ -162,7 +178,7 @@ describe('partitionGlobalDeleteTargets — protected names', () => {
     // The orphan check runs after the protected check, so a locked orphan
     // must never reach orphan-cleanup records.
     const orphanSkill: Skill = {
-      name: 'abandoned',
+      name: toSkillName('abandoned'),
       description: 'desc',
       path: '/Users/me/.agents/skills/abandoned',
       symlinkCount: toSymlinkCount(0),
@@ -183,8 +199,8 @@ describe('partitionGlobalDeleteTargets — protected names', () => {
     // Act
     const result = partitionGlobalDeleteTargets(
       [orphanSkill],
-      ['abandoned'],
-      new Set(['abandoned']),
+      [toSkillName('abandoned')],
+      new Set([toSkillName('abandoned')]),
     )
 
     // Assert — protection intercepts before orphan path
@@ -208,7 +224,7 @@ describe('partitionGlobalDeleteTargets — protected names', () => {
     }
     const skills: Skill[] = [
       {
-        name: 'locked',
+        name: toSkillName('locked'),
         description: 'desc',
         path: '/Users/me/.agents/skills/locked',
         symlinkCount: toSymlinkCount(0),
@@ -217,7 +233,7 @@ describe('partitionGlobalDeleteTargets — protected names', () => {
         isOrphan: false,
       },
       {
-        name: 'unlocked',
+        name: toSkillName('unlocked'),
         description: 'desc',
         path: '/Users/me/.agents/skills/unlocked',
         filesystemIdentity: identity,
@@ -231,8 +247,8 @@ describe('partitionGlobalDeleteTargets — protected names', () => {
     // Act
     const result = partitionGlobalDeleteTargets(
       skills,
-      ['locked', 'unlocked'],
-      new Set(['locked']),
+      [toSkillName('locked'), toSkillName('unlocked')],
+      new Set([toSkillName('locked')]),
     )
 
     // Assert — only the locked skill is skipped; unlocked proceeds to deleteTargets
@@ -251,7 +267,7 @@ describe('partitionGlobalDeleteTargets', () => {
     // the same skill name (isLocal true), and a broken slot whose target
     // vanished (targetPath undefined). Only the first should be cleaned up.
     const orphanSkill: Skill = {
-      name: 'abandoned',
+      name: toSkillName('abandoned'),
       description: 'desc',
       path: '/Users/me/.agents/skills/abandoned',
       symlinkCount: toSymlinkCount(0),
@@ -286,7 +302,9 @@ describe('partitionGlobalDeleteTargets', () => {
     const skills: Skill[] = [orphanSkill]
 
     // Act
-    const result = partitionGlobalDeleteTargets(skills, ['abandoned'])
+    const result = partitionGlobalDeleteTargets(skills, [
+      toSkillName('abandoned'),
+    ])
 
     // Assert — exactly one reviewed orphan record holding only the codex slot;
     // the local-folder slot and the targetless slot are filtered out, and no

--- a/src/renderer/src/lib/syncHelpers.test.ts
+++ b/src/renderer/src/lib/syncHelpers.test.ts
@@ -2,7 +2,12 @@ import { AlertTriangle, CheckCircle2, XCircle } from 'lucide-react'
 import { describe, expect, it } from 'vitest'
 
 import type { SyncExecuteResult, SyncPreviewResult } from '@/shared/types'
-import { toAgentCount, toSkillCount, toSymlinkCount } from '@/shared/types'
+import {
+  toAgentCount,
+  toSkillCount,
+  toSkillName,
+  toSymlinkCount,
+} from '@/shared/types'
 
 import {
   getSyncResultPresentation,
@@ -76,7 +81,7 @@ describe('shouldShowSyncConfirm', () => {
       toCreate: toSymlinkCount(3),
       conflicts: [
         {
-          skillName: 'test-skill',
+          skillName: toSkillName('test-skill'),
           agentId: 'claude' as never,
           agentName: 'Claude' as never,
           agentSkillPath: '/home/user/.claude/skills/test-skill',
@@ -118,7 +123,11 @@ describe('shouldShowSyncResult', () => {
       skipped: toSymlinkCount(2),
       errors: [],
       details: [
-        { skillName: 'my-skill', agentName: 'Claude Code', action: 'created' },
+        {
+          skillName: toSkillName('my-skill'),
+          agentName: 'Claude Code',
+          action: 'created',
+        },
       ],
     }
     // Act
@@ -137,7 +146,7 @@ describe('shouldShowSyncResult', () => {
       errors: [{ path: '/test', error: 'fail' }],
       details: [
         {
-          skillName: 'fail-skill',
+          skillName: toSkillName('fail-skill'),
           agentName: 'Cursor',
           action: 'error',
           error: 'fail',

--- a/src/renderer/src/redux/listener.lockRescan.test.ts
+++ b/src/renderer/src/redux/listener.lockRescan.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
 import { LOCK_RESCAN_GRACE_MS, UNDO_WINDOW_MS } from '@/shared/constants'
 import type { ToastId, TombstoneId } from '@/shared/types'
-import { toIsoTimestamp, tombstoneId } from '@/shared/types'
+import { toIsoTimestamp, toSkillName, tombstoneId } from '@/shared/types'
 
 /**
  * Integration tests for the post-delete lock rescan in listener.ts.
@@ -53,7 +53,7 @@ function undoToastPayload(kind: 'delete' | 'unlink', id: string) {
   return {
     id: id as ToastId,
     kind,
-    skillNames: ['old-skill'],
+    skillNames: [toSkillName('old-skill')],
     tombstoneIds:
       kind === 'delete'
         ? [tombstoneId('1700000000000-old-skill-aaaaaaaa')]

--- a/src/renderer/src/redux/migrations.ts
+++ b/src/renderer/src/redux/migrations.ts
@@ -11,6 +11,7 @@ import {
   PERSIST_STATE_VERSION,
   THEME_PRESETS,
 } from '@/shared/constants'
+import { toSkillName } from '@/shared/types'
 
 import type { ProtectedSkill } from './slices/protectSlice'
 import type { ThemeState } from './slices/themeSlice'
@@ -261,7 +262,7 @@ function migrateV4ToV5(state: MigratableState): void {
     // would sit in the list forever.
     items: legacy.items
       .filter((name) => typeof name === 'string')
-      .map((name): ProtectedSkill => ({ name })),
+      .map((name): ProtectedSkill => ({ name: toSkillName(name) })),
   }
 }
 

--- a/src/renderer/src/redux/selectors.test.ts
+++ b/src/renderer/src/redux/selectors.test.ts
@@ -8,6 +8,7 @@ import {
   repositoryId,
   toHttpUrl,
   toIsoTimestamp,
+  toSkillName,
   toSymlinkCount,
 } from '@/shared/types'
 import type {
@@ -155,7 +156,7 @@ const makeSkill = (
   source?: string,
   status: SymlinkInfo['status'] = 'valid',
 ): Skill => ({
-  name,
+  name: toSkillName(name),
   description: `${name} skill`,
   path: isLocal
     ? `/home/user/.${agentId}/skills/${name}`
@@ -217,7 +218,7 @@ const makeMultiSlotSkill = (
     }
   })
   return {
-    name,
+    name: toSkillName(name),
     description: `${name} skill`,
     path: `/home/user/.agents/skills/${name}`,
     symlinkCount: toSymlinkCount(
@@ -383,7 +384,7 @@ describe('selectFilteredSkills', () => {
     // symlink in the agent dir.
     // Arrange
     const skill: Skill = {
-      name: 'broken-skill',
+      name: toSkillName('broken-skill'),
       description: 'broken',
       path: '/home/user/.agents/skills/broken-skill',
       symlinkCount: toSymlinkCount(1),
@@ -417,7 +418,7 @@ describe('selectFilteredSkills', () => {
     // up, so it must not pollute the per-agent list.
     // Arrange
     const skill: Skill = {
-      name: 'unlinked-skill',
+      name: toSkillName('unlinked-skill'),
       description: 'unlinked',
       path: '/home/user/.agents/skills/unlinked-skill',
       symlinkCount: toSymlinkCount(0),
@@ -649,7 +650,7 @@ describe('selectFilteredSkills', () => {
     // a broken symlink under cursor. The Orphan filter must surface only the
     // orphan.
     const orphanSkill: Skill = {
-      name: 'orphan-one',
+      name: toSkillName('orphan-one'),
       description: 'orphan',
       path: '/home/user/.agents/skills/orphan-one',
       symlinkCount: toSymlinkCount(1),
@@ -690,7 +691,7 @@ describe('selectFilteredSkills', () => {
     // agent B. Pass 1 (agent-slot gate) drops the row before Pass 2
     // (skill.isOrphan check) ever runs.
     const orphanForAgentA: Skill = {
-      name: 'orphan-agent-a',
+      name: toSkillName('orphan-agent-a'),
       description: 'orphan stranded in agent A',
       path: '/home/user/.agents/skills/orphan-agent-a',
       symlinkCount: toSymlinkCount(1),
@@ -1193,7 +1194,7 @@ describe('selectFilteredSkills', () => {
 })
 
 const makeBookmark = (name: string, repo: string): BookmarkedSkill => ({
-  name,
+  name: toSkillName(name),
   repo: repositoryId(repo),
   url: toHttpUrl(`https://skills.sh/${name}`),
   bookmarkedAt: toIsoTimestamp('2026-04-01T00:00:00.000Z'),
@@ -1379,7 +1380,7 @@ describe('selectBulkSelectableVisibleSkillNames', () => {
     const state = buildState({
       skills: [protectedSkill, availableSkill],
       selectedAgentId: 'cursor',
-      protectedSkillNames: ['protected-skill'],
+      protectedSkillNames: [toSkillName('protected-skill')],
     })
 
     // Act
@@ -1399,7 +1400,7 @@ describe('selectBulkSelectableVisibleSkillNames', () => {
     const state = buildState({
       skills: [protectedSkill],
       selectedAgentId: null,
-      protectedSkillNames: ['protected-skill'],
+      protectedSkillNames: [toSkillName('protected-skill')],
     })
 
     // Act
@@ -1424,7 +1425,11 @@ describe('selectSelectedCount', () => {
   it('counts every ticked skill even when some are scrolled out of the visible list', () => {
     // Arrange
     const state = buildState({
-      selectedSkillNames: ['a', 'b', 'c'],
+      selectedSkillNames: [
+        toSkillName('a'),
+        toSkillName('b'),
+        toSkillName('c'),
+      ],
     })
 
     // Act & Assert
@@ -1442,7 +1447,11 @@ describe('selectSelectedVisibleNames', () => {
     ]
     const state = buildState({
       skills,
-      selectedSkillNames: ['task', 'alpha', 'ghost'],
+      selectedSkillNames: [
+        toSkillName('task'),
+        toSkillName('alpha'),
+        toSkillName('ghost'),
+      ],
     })
 
     // Act & Assert — visible order is alphabetical (alpha, browser, task);
@@ -1459,7 +1468,7 @@ describe('selectSelectedVisibleNames', () => {
     const state = buildState({
       skills,
       searchQuery: 'task',
-      selectedSkillNames: ['something-else'],
+      selectedSkillNames: [toSkillName('something-else')],
     })
 
     // Act & Assert
@@ -1477,7 +1486,11 @@ describe('selectSelectedVisibleCount', () => {
     ]
     const state = buildState({
       skills,
-      selectedSkillNames: ['alpha', 'task', 'hidden'],
+      selectedSkillNames: [
+        toSkillName('alpha'),
+        toSkillName('task'),
+        toSkillName('hidden'),
+      ],
     })
 
     // Act & Assert
@@ -1494,7 +1507,11 @@ describe('selectHiddenSelectedCount', () => {
     ]
     const state = buildState({
       skills,
-      selectedSkillNames: ['alpha', 'hidden-1', 'hidden-2'],
+      selectedSkillNames: [
+        toSkillName('alpha'),
+        toSkillName('hidden-1'),
+        toSkillName('hidden-2'),
+      ],
     })
 
     // Act & Assert
@@ -1509,7 +1526,7 @@ describe('selectHiddenSelectedCount', () => {
     ]
     const state = buildState({
       skills,
-      selectedSkillNames: ['alpha', 'browser'],
+      selectedSkillNames: [toSkillName('alpha'), toSkillName('browser')],
     })
 
     // Act & Assert
@@ -1525,7 +1542,10 @@ describe('selectHiddenSelectedCount', () => {
     const state = buildState({
       skills,
       selectedAgentId: 'cursor',
-      selectedSkillNames: ['valid-task', 'broken-task'],
+      selectedSkillNames: [
+        toSkillName('valid-task'),
+        toSkillName('broken-task'),
+      ],
     })
 
     // Act & Assert
@@ -1543,7 +1563,11 @@ describe('selectVisibleIneligibleSelectedCount', () => {
     const state = buildState({
       skills,
       selectedAgentId: 'cursor',
-      selectedSkillNames: ['valid-task', 'broken-task', 'hidden-task'],
+      selectedSkillNames: [
+        toSkillName('valid-task'),
+        toSkillName('broken-task'),
+        toSkillName('hidden-task'),
+      ],
     })
 
     // Act & Assert
@@ -1555,16 +1579,16 @@ describe('selectAnyInFlightRemovalSet', () => {
   it('marks the rows of an active bulk delete as fading via Set membership', () => {
     // Arrange
     const state = buildState({
-      inFlightDeleteNames: ['skill-a', 'skill-b'],
+      inFlightDeleteNames: [toSkillName('skill-a'), toSkillName('skill-b')],
     })
 
     // Act
     const inFlightSet = selectAnyInFlightRemovalSet(state as never)
 
     // Assert
-    expect(inFlightSet.has('skill-a')).toBe(true)
-    expect(inFlightSet.has('skill-b')).toBe(true)
-    expect(inFlightSet.has('skill-c')).toBe(false)
+    expect(inFlightSet.has(toSkillName('skill-a'))).toBe(true)
+    expect(inFlightSet.has(toSkillName('skill-b'))).toBe(true)
+    expect(inFlightSet.has(toSkillName('skill-c'))).toBe(false)
     expect(inFlightSet.size).toBe(2)
   })
 
@@ -1575,7 +1599,7 @@ describe('selectAnyInFlightRemovalSet', () => {
     })
     const otherIdleState = buildState({
       inFlightDeleteNames: [],
-      selectedSkillNames: ['unrelated'],
+      selectedSkillNames: [toSkillName('unrelated')],
     })
 
     // Act
@@ -1594,21 +1618,21 @@ describe('selectSelectedSkillNamesSet', () => {
   it('exposes the ticked skill names as a Set for fast membership checks', () => {
     // Arrange
     const state = buildState({
-      selectedSkillNames: ['x', 'y'],
+      selectedSkillNames: [toSkillName('x'), toSkillName('y')],
     })
 
     // Act
     const result = selectSelectedSkillNamesSet(state as never)
 
     // Assert
-    expect(result.has('x')).toBe(true)
+    expect(result.has(toSkillName('x'))).toBe(true)
     expect(result.size).toBe(2)
   })
 
   it('returns the same Set reference on repeat reads so consumers do not re-render needlessly', () => {
     // Arrange
     const state = buildState({
-      selectedSkillNames: ['x'],
+      selectedSkillNames: [toSkillName('x')],
     })
 
     // Act
@@ -1630,7 +1654,7 @@ describe('selectSelectedVisibleSkillObjects', () => {
     ]
     const state = buildState({
       skills,
-      selectedSkillNames: ['gamma', 'alpha'],
+      selectedSkillNames: [toSkillName('gamma'), toSkillName('alpha')],
     })
 
     // Act
@@ -1646,7 +1670,7 @@ describe('selectSelectedVisibleSkillObjects', () => {
     const skills = [makeSkill('alpha', 'claude-code')]
     const state = buildState({
       skills,
-      selectedSkillNames: ['alpha', 'ghost'],
+      selectedSkillNames: [toSkillName('alpha'), toSkillName('ghost')],
     })
 
     // Act
@@ -1664,7 +1688,7 @@ describe('selectSelectedVisibleSkillObjects', () => {
     ]
     const state = buildState({
       skills,
-      selectedSkillNames: ['alpha', 'beta'],
+      selectedSkillNames: [toSkillName('alpha'), toSkillName('beta')],
       searchQuery: 'alpha',
     })
 

--- a/src/renderer/src/redux/slices/bookmarkSlice.test.ts
+++ b/src/renderer/src/redux/slices/bookmarkSlice.test.ts
@@ -1,7 +1,7 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { describe, expect, it } from 'vitest'
 
-import { repositoryId, toHttpUrl } from '@/shared/types'
+import { repositoryId, toHttpUrl, toSkillName } from '@/shared/types'
 
 async function createTestStore() {
   const { default: bookmarkReducer } = await import('./bookmarkSlice')
@@ -28,7 +28,7 @@ describe('bookmarkSlice', () => {
     // Act
     store.dispatch(
       addBookmark({
-        name: 'task',
+        name: toSkillName('task'),
         repo: repositoryId('vercel-labs/skills'),
         url: toHttpUrl('https://skills.sh/task'),
       }),
@@ -51,7 +51,7 @@ describe('bookmarkSlice', () => {
     // Act
     store.dispatch(
       addBookmark({
-        name: 'task',
+        name: toSkillName('task'),
         repo: repositoryId('vercel-labs/skills'),
         url: toHttpUrl('https://skills.sh/task'),
       }),
@@ -67,7 +67,7 @@ describe('bookmarkSlice', () => {
     const { addBookmark } = await import('./bookmarkSlice')
     const store = await createTestStore()
     const payload = {
-      name: 'task',
+      name: toSkillName('task'),
       repo: repositoryId('vercel-labs/skills'),
       url: toHttpUrl('https://skills.sh/task'),
     }
@@ -88,14 +88,14 @@ describe('bookmarkSlice', () => {
     // Act
     store.dispatch(
       addBookmark({
-        name: 'task',
+        name: toSkillName('task'),
         repo: repositoryId('vercel-labs/skills'),
         url: toHttpUrl('https://skills.sh/task'),
       }),
     )
     store.dispatch(
       addBookmark({
-        name: 'tdd',
+        name: toSkillName('tdd'),
         repo: repositoryId('pbakaus/impeccable'),
         url: toHttpUrl('https://skills.sh/tdd'),
       }),
@@ -111,21 +111,21 @@ describe('bookmarkSlice', () => {
     const store = await createTestStore()
     store.dispatch(
       addBookmark({
-        name: 'task',
+        name: toSkillName('task'),
         repo: repositoryId('vercel-labs/skills'),
         url: toHttpUrl('https://skills.sh/task'),
       }),
     )
     store.dispatch(
       addBookmark({
-        name: 'tdd',
+        name: toSkillName('tdd'),
         repo: repositoryId('pbakaus/impeccable'),
         url: toHttpUrl('https://skills.sh/tdd'),
       }),
     )
 
     // Act
-    store.dispatch(removeBookmark('task'))
+    store.dispatch(removeBookmark(toSkillName('task')))
 
     // Assert
     const items = store.getState().bookmarks.items
@@ -139,14 +139,14 @@ describe('bookmarkSlice', () => {
     const store = await createTestStore()
     store.dispatch(
       addBookmark({
-        name: 'task',
+        name: toSkillName('task'),
         repo: repositoryId('vercel-labs/skills'),
         url: toHttpUrl('https://skills.sh/task'),
       }),
     )
 
     // Act
-    store.dispatch(removeBookmark('nonexistent'))
+    store.dispatch(removeBookmark(toSkillName('nonexistent')))
 
     // Assert
     expect(store.getState().bookmarks.items).toHaveLength(1)
@@ -160,7 +160,7 @@ describe('bookmarkSlice', () => {
     // Act
     store.dispatch(
       addBookmark({
-        name: 'task',
+        name: toSkillName('task'),
         repo: repositoryId('vercel-labs/skills'),
         url: toHttpUrl('https://skills.sh/task'),
       }),
@@ -178,15 +178,21 @@ describe('bookmarkSlice', () => {
     const store = await createTestStore()
     store.dispatch(
       addBookmark({
-        name: 'task',
+        name: toSkillName('task'),
         repo: repositoryId('vercel-labs/skills'),
         url: toHttpUrl('https://skills.sh/task'),
       }),
     )
 
     // Act
-    const isTaskBookmarked = selectIsBookmarked(store.getState(), 'task')
-    const isOtherBookmarked = selectIsBookmarked(store.getState(), 'other')
+    const isTaskBookmarked = selectIsBookmarked(
+      store.getState(),
+      toSkillName('task'),
+    )
+    const isOtherBookmarked = selectIsBookmarked(
+      store.getState(),
+      toSkillName('other'),
+    )
 
     // Assert
     expect(isTaskBookmarked).toBe(true)

--- a/src/renderer/src/redux/slices/marketplaceSlice.test.ts
+++ b/src/renderer/src/redux/slices/marketplaceSlice.test.ts
@@ -6,6 +6,7 @@ import {
   toHttpUrl,
   toProgressPercent,
   toSearchQuery,
+  toSkillName,
   toSkillRank,
 } from '@/shared/types'
 import type { InstallProgress, SkillSearchResult } from '@/shared/types'
@@ -35,7 +36,7 @@ async function createTestStore() {
 
 const sampleResult: SkillSearchResult = {
   rank: toSkillRank(1),
-  name: 'task',
+  name: toSkillName('task'),
   repo: repositoryId('vercel-labs/skill-task'),
   url: toHttpUrl('https://skills.sh/vercel-labs/skill-task'),
 }
@@ -249,10 +250,13 @@ describe('marketplaceSlice', () => {
     // out-of-order IPC reply (the CLI runs searches concurrently).
     let resolveRea!: (value: SkillSearchResult[]) => void
     let resolveReact!: (value: SkillSearchResult[]) => void
-    const reaResult: SkillSearchResult = { ...sampleResult, name: 'rea-hit' }
+    const reaResult: SkillSearchResult = {
+      ...sampleResult,
+      name: toSkillName('rea-hit'),
+    }
     const reactResult: SkillSearchResult = {
       ...sampleResult,
-      name: 'react-hit',
+      name: toSkillName('react-hit'),
     }
     mockSearch
       .mockReturnValueOnce(
@@ -568,7 +572,7 @@ describe('marketplaceSlice', () => {
     // Arrange
     const trendingResult: SkillSearchResult = {
       ...sampleResult,
-      name: 'trending-skill',
+      name: toSkillName('trending-skill'),
     }
     mockLeaderboard
       .mockResolvedValueOnce([sampleResult])

--- a/src/renderer/src/redux/slices/protectSlice.test.ts
+++ b/src/renderer/src/redux/slices/protectSlice.test.ts
@@ -2,7 +2,7 @@ import { configureStore } from '@reduxjs/toolkit'
 import { describe, expect, test } from 'vitest'
 
 import type { Skill } from '@/shared/types'
-import { toFileSizeBytes, toSymlinkCount } from '@/shared/types'
+import { toFileSizeBytes, toSkillName, toSymlinkCount } from '@/shared/types'
 
 /**
  * Build a source-skill row the way `scanSourceSkills` does: named, and carrying
@@ -55,7 +55,7 @@ describe('protectSlice', () => {
     const store = await createTestStore()
 
     // Act
-    store.dispatch(addProtection({ name: 'task' }))
+    store.dispatch(addProtection({ name: toSkillName('task') }))
 
     // Assert
     expect(store.getState().protect.items).toEqual([{ name: 'task' }])
@@ -67,8 +67,8 @@ describe('protectSlice', () => {
     const store = await createTestStore()
 
     // Act
-    store.dispatch(addProtection({ name: 'task' }))
-    store.dispatch(addProtection({ name: 'task' }))
+    store.dispatch(addProtection({ name: toSkillName('task') }))
+    store.dispatch(addProtection({ name: toSkillName('task') }))
 
     // Assert
     expect(store.getState().protect.items).toHaveLength(1)
@@ -80,8 +80,8 @@ describe('protectSlice', () => {
     const store = await createTestStore()
 
     // Act
-    store.dispatch(addProtection({ name: 'task' }))
-    store.dispatch(addProtection({ name: 'browse' }))
+    store.dispatch(addProtection({ name: toSkillName('task') }))
+    store.dispatch(addProtection({ name: toSkillName('browse') }))
 
     // Assert
     expect(store.getState().protect.items).toHaveLength(2)
@@ -91,11 +91,11 @@ describe('protectSlice', () => {
     // Arrange
     const { addProtection, removeProtection } = await import('./protectSlice')
     const store = await createTestStore()
-    store.dispatch(addProtection({ name: 'task' }))
-    store.dispatch(addProtection({ name: 'browse' }))
+    store.dispatch(addProtection({ name: toSkillName('task') }))
+    store.dispatch(addProtection({ name: toSkillName('browse') }))
 
     // Act
-    store.dispatch(removeProtection('task'))
+    store.dispatch(removeProtection(toSkillName('task')))
 
     // Assert
     const items = store.getState().protect.items
@@ -107,10 +107,10 @@ describe('protectSlice', () => {
     // Arrange
     const { addProtection, removeProtection } = await import('./protectSlice')
     const store = await createTestStore()
-    store.dispatch(addProtection({ name: 'task' }))
+    store.dispatch(addProtection({ name: toSkillName('task') }))
 
     // Act
-    store.dispatch(removeProtection('nonexistent'))
+    store.dispatch(removeProtection(toSkillName('nonexistent')))
 
     // Assert
     expect(store.getState().protect.items).toHaveLength(1)
@@ -120,11 +120,17 @@ describe('protectSlice', () => {
     // Arrange
     const { addProtection, selectIsProtected } = await import('./protectSlice')
     const store = await createTestStore()
-    store.dispatch(addProtection({ name: 'task' }))
+    store.dispatch(addProtection({ name: toSkillName('task') }))
 
     // Act
-    const isTaskProtected = selectIsProtected(store.getState(), 'task')
-    const isOtherProtected = selectIsProtected(store.getState(), 'other')
+    const isTaskProtected = selectIsProtected(
+      store.getState(),
+      toSkillName('task'),
+    )
+    const isOtherProtected = selectIsProtected(
+      store.getState(),
+      toSkillName('other'),
+    )
 
     // Assert
     expect(isTaskProtected).toBe(true)
@@ -136,16 +142,16 @@ describe('protectSlice', () => {
     const { addProtection, selectProtectedNamesSet } =
       await import('./protectSlice')
     const store = await createTestStore()
-    store.dispatch(addProtection({ name: 'task' }))
-    store.dispatch(addProtection({ name: 'browse' }))
+    store.dispatch(addProtection({ name: toSkillName('task') }))
+    store.dispatch(addProtection({ name: toSkillName('browse') }))
 
     // Act
     const set = selectProtectedNamesSet(store.getState())
 
     // Assert
-    expect(set.has('task')).toBe(true)
-    expect(set.has('browse')).toBe(true)
-    expect(set.has('other')).toBe(false)
+    expect(set.has(toSkillName('task'))).toBe(true)
+    expect(set.has(toSkillName('browse'))).toBe(true)
+    expect(set.has(toSkillName('other'))).toBe(false)
   })
 })
 
@@ -156,12 +162,18 @@ describe('protectSlice rename reconciliation', () => {
     const { fetchSkills } = await import('./skillsSlice')
     const store = await createTestStore()
     store.dispatch(
-      addProtection({ name: 'task', identity: { dev: 1, ino: 10 } }),
+      addProtection({
+        name: toSkillName('task'),
+        identity: { dev: 1, ino: 10 },
+      }),
     )
 
     // Act — next scan finds the same inode under a new name.
     store.dispatch(
-      fetchSkills.fulfilled([makeScannedSkill('todo', 10)], 'scan-1'),
+      fetchSkills.fulfilled(
+        [makeScannedSkill(toSkillName('todo'), 10)],
+        'scan-1',
+      ),
     )
 
     // Assert — the lock followed the rename instead of stranding on "task".
@@ -175,11 +187,14 @@ describe('protectSlice rename reconciliation', () => {
     const { addProtection } = await import('./protectSlice')
     const { fetchSkills } = await import('./skillsSlice')
     const store = await createTestStore()
-    store.dispatch(addProtection({ name: 'task' }))
+    store.dispatch(addProtection({ name: toSkillName('task') }))
 
     // Act
     store.dispatch(
-      fetchSkills.fulfilled([makeScannedSkill('task', 10)], 'scan-1'),
+      fetchSkills.fulfilled(
+        [makeScannedSkill(toSkillName('task'), 10)],
+        'scan-1',
+      ),
     )
 
     // Assert
@@ -194,12 +209,18 @@ describe('protectSlice rename reconciliation', () => {
     const { fetchSkills } = await import('./skillsSlice')
     const store = await createTestStore()
     store.dispatch(
-      addProtection({ name: 'task', identity: { dev: 1, ino: 10 } }),
+      addProtection({
+        name: toSkillName('task'),
+        identity: { dev: 1, ino: 10 },
+      }),
     )
 
     // Act
     store.dispatch(
-      fetchSkills.fulfilled([makeScannedSkill('browse', 20)], 'scan-1'),
+      fetchSkills.fulfilled(
+        [makeScannedSkill(toSkillName('browse'), 20)],
+        'scan-1',
+      ),
     )
 
     // Assert — silently unlocking on a transient empty scan is the bug this
@@ -216,16 +237,25 @@ describe('protectSlice rename reconciliation', () => {
     const { fetchSkills } = await import('./skillsSlice')
     const store = await createTestStore()
     store.dispatch(
-      addProtection({ name: 'task', identity: { dev: 1, ino: 10 } }),
+      addProtection({
+        name: toSkillName('task'),
+        identity: { dev: 1, ino: 10 },
+      }),
     )
     store.dispatch(
-      addProtection({ name: 'browse', identity: { dev: 1, ino: 20 } }),
+      addProtection({
+        name: toSkillName('browse'),
+        identity: { dev: 1, ino: 20 },
+      }),
     )
 
     // Act
     store.dispatch(
       fetchSkills.fulfilled(
-        [makeScannedSkill('browse', 10), makeScannedSkill('write', 20)],
+        [
+          makeScannedSkill(toSkillName('browse'), 10),
+          makeScannedSkill(toSkillName('write'), 20),
+        ],
         'scan-1',
       ),
     )
@@ -246,15 +276,24 @@ describe('protectSlice rename reconciliation', () => {
     const { fetchSkills } = await import('./skillsSlice')
     const store = await createTestStore()
     store.dispatch(
-      addProtection({ name: 'task', identity: { dev: 1, ino: 10 } }),
+      addProtection({
+        name: toSkillName('task'),
+        identity: { dev: 1, ino: 10 },
+      }),
     )
     store.dispatch(
-      addProtection({ name: 'browse', identity: { dev: 1, ino: 20 } }),
+      addProtection({
+        name: toSkillName('browse'),
+        identity: { dev: 1, ino: 20 },
+      }),
     )
 
     // Act
     store.dispatch(
-      fetchSkills.fulfilled([makeScannedSkill('browse', 10)], 'scan-1'),
+      fetchSkills.fulfilled(
+        [makeScannedSkill(toSkillName('browse'), 10)],
+        'scan-1',
+      ),
     )
 
     // Assert — inode 10 follows its rename onto "browse" and the lock on the
@@ -272,15 +311,24 @@ describe('protectSlice rename reconciliation', () => {
     const { fetchSkills } = await import('./skillsSlice')
     const store = await createTestStore()
     store.dispatch(
-      addProtection({ name: 'browse', identity: { dev: 1, ino: 20 } }),
+      addProtection({
+        name: toSkillName('browse'),
+        identity: { dev: 1, ino: 20 },
+      }),
     )
     store.dispatch(
-      addProtection({ name: 'task', identity: { dev: 1, ino: 10 } }),
+      addProtection({
+        name: toSkillName('task'),
+        identity: { dev: 1, ino: 10 },
+      }),
     )
 
     // Act
     store.dispatch(
-      fetchSkills.fulfilled([makeScannedSkill('browse', 10)], 'scan-1'),
+      fetchSkills.fulfilled(
+        [makeScannedSkill(toSkillName('browse'), 10)],
+        'scan-1',
+      ),
     )
 
     // Assert — insertion order is an accident of when the user clicked Lock;
@@ -297,13 +345,19 @@ describe('protectSlice rename reconciliation', () => {
     const { fetchSkills } = await import('./skillsSlice')
     const store = await createTestStore()
     store.dispatch(
-      addProtection({ name: 'foo', identity: { dev: 1, ino: 10 } }),
+      addProtection({
+        name: toSkillName('foo'),
+        identity: { dev: 1, ino: 10 },
+      }),
     )
-    store.dispatch(addProtection({ name: 'bar' }))
+    store.dispatch(addProtection({ name: toSkillName('bar') }))
 
     // Act
     store.dispatch(
-      fetchSkills.fulfilled([makeScannedSkill('bar', 10)], 'scan-1'),
+      fetchSkills.fulfilled(
+        [makeScannedSkill(toSkillName('bar'), 10)],
+        'scan-1',
+      ),
     )
 
     // Assert — one skill, one lock. Two entries sharing an inode would both
@@ -320,13 +374,19 @@ describe('protectSlice rename reconciliation', () => {
     const { fetchSkills } = await import('./skillsSlice')
     const store = await createTestStore()
     store.dispatch(
-      addProtection({ name: 'task', identity: { dev: 1, ino: 10 } }),
+      addProtection({
+        name: toSkillName('task'),
+        identity: { dev: 1, ino: 10 },
+      }),
     )
     const before = selectProtectedNamesSet(store.getState())
 
     // Act
     store.dispatch(
-      fetchSkills.fulfilled([makeScannedSkill('task', 10)], 'scan-1'),
+      fetchSkills.fulfilled(
+        [makeScannedSkill(toSkillName('task'), 10)],
+        'scan-1',
+      ),
     )
 
     // Assert — a rebuilt Set on every scan would re-render the whole list.

--- a/src/renderer/src/redux/slices/skillLockSlice.test.ts
+++ b/src/renderer/src/redux/slices/skillLockSlice.test.ts
@@ -1,6 +1,8 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { describe, expect, test } from 'vitest'
 
+import { toSkillName } from '@/shared/types'
+
 import skillLockReducer, {
   fetchStaleLockEntries,
   pruneStaleLockEntries,
@@ -37,7 +39,11 @@ describe('skillLockSlice', () => {
     store.dispatch(fetchStaleLockEntries.pending('req-1', undefined))
     store.dispatch(
       fetchStaleLockEntries.fulfilled(
-        { status: 'ok', names: ['old-skill', 'another-skill'], unprunable: [] },
+        {
+          status: 'ok',
+          names: [toSkillName('old-skill'), toSkillName('another-skill')],
+          unprunable: [],
+        },
         'req-1',
         undefined,
       ),
@@ -59,7 +65,7 @@ describe('skillLockSlice', () => {
     store.dispatch(fetchStaleLockEntries.pending('req-1', undefined))
     store.dispatch(
       fetchStaleLockEntries.fulfilled(
-        { status: 'ok', names: ['old-skill'], unprunable: [] },
+        { status: 'ok', names: [toSkillName('old-skill')], unprunable: [] },
         'req-1',
         undefined,
       ),
@@ -102,7 +108,11 @@ describe('skillLockSlice', () => {
     store.dispatch(fetchStaleLockEntries.pending('req-1', undefined))
     store.dispatch(
       fetchStaleLockEntries.fulfilled(
-        { status: 'ok', names: ['pruned-ok', 'stubborn'], unprunable: [] },
+        {
+          status: 'ok',
+          names: [toSkillName('pruned-ok'), toSkillName('stubborn')],
+          unprunable: [],
+        },
         'req-1',
         undefined,
       ),
@@ -112,13 +122,20 @@ describe('skillLockSlice', () => {
     // `pending` first: the reducer only applies a prune result whose requestId
     // is the one still in flight, so a bare `fulfilled` would be ignored.
     store.dispatch(
-      pruneStaleLockEntries.pending('req-2', ['pruned-ok', 'stubborn']),
+      pruneStaleLockEntries.pending('req-2', [
+        toSkillName('pruned-ok'),
+        toSkillName('stubborn'),
+      ]),
     )
     store.dispatch(
       pruneStaleLockEntries.fulfilled(
-        { pruned: ['pruned-ok'], skipped: [], failed: ['stubborn'] },
+        {
+          pruned: [toSkillName('pruned-ok')],
+          skipped: [],
+          failed: [toSkillName('stubborn')],
+        },
         'req-2',
-        ['pruned-ok', 'stubborn'],
+        [toSkillName('pruned-ok'), toSkillName('stubborn')],
       ),
     )
 
@@ -132,7 +149,9 @@ describe('skillLockSlice', () => {
     const store = createTestStore()
 
     // Act
-    store.dispatch(pruneStaleLockEntries.pending('req-1', ['old-skill']))
+    store.dispatch(
+      pruneStaleLockEntries.pending('req-1', [toSkillName('old-skill')]),
+    )
 
     // Assert
     expect(selectIsPruningLockEntries(readState(store))).toBe(true)
@@ -141,12 +160,14 @@ describe('skillLockSlice', () => {
   test('clears the in-flight flag when the prune request fails outright', async () => {
     // Arrange
     const store = createTestStore()
-    store.dispatch(pruneStaleLockEntries.pending('req-1', ['old-skill']))
+    store.dispatch(
+      pruneStaleLockEntries.pending('req-1', [toSkillName('old-skill')]),
+    )
 
     // Act
     store.dispatch(
       pruneStaleLockEntries.rejected(new Error('IPC exploded'), 'req-1', [
-        'old-skill',
+        toSkillName('old-skill'),
       ]),
     )
 
@@ -164,7 +185,7 @@ describe('skillLockSlice', () => {
     store.dispatch(fetchStaleLockEntries.pending('req-fresh', undefined))
     store.dispatch(
       fetchStaleLockEntries.fulfilled(
-        { status: 'ok', names: ['current-truth'], unprunable: [] },
+        { status: 'ok', names: [toSkillName('current-truth')], unprunable: [] },
         'req-fresh',
         undefined,
       ),
@@ -173,7 +194,11 @@ describe('skillLockSlice', () => {
     // Act
     store.dispatch(
       fetchStaleLockEntries.fulfilled(
-        { status: 'ok', names: ['long-gone', 'also-gone'], unprunable: [] },
+        {
+          status: 'ok',
+          names: [toSkillName('long-gone'), toSkillName('also-gone')],
+          unprunable: [],
+        },
         'req-slow',
         undefined,
       ),
@@ -194,7 +219,7 @@ describe('skillLockSlice', () => {
     store.dispatch(fetchStaleLockEntries.pending('req-fresh', undefined))
     store.dispatch(
       fetchStaleLockEntries.fulfilled(
-        { status: 'ok', names: ['current-truth'], unprunable: [] },
+        { status: 'ok', names: [toSkillName('current-truth')], unprunable: [] },
         'req-fresh',
         undefined,
       ),
@@ -218,11 +243,17 @@ describe('skillLockSlice', () => {
     // after the rewrite began, so it is the newer truth; the prune's `failed`
     // is the pre-prune view and would drop the record the scan just found.
     const store = createTestStore()
-    store.dispatch(pruneStaleLockEntries.pending('req-prune', ['old-skill']))
+    store.dispatch(
+      pruneStaleLockEntries.pending('req-prune', [toSkillName('old-skill')]),
+    )
     store.dispatch(fetchStaleLockEntries.pending('req-mid-prune', undefined))
     store.dispatch(
       fetchStaleLockEntries.fulfilled(
-        { status: 'ok', names: ['old-skill', 'newly-stale'], unprunable: [] },
+        {
+          status: 'ok',
+          names: [toSkillName('old-skill'), toSkillName('newly-stale')],
+          unprunable: [],
+        },
         'req-mid-prune',
         undefined,
       ),
@@ -231,9 +262,9 @@ describe('skillLockSlice', () => {
     // Act
     store.dispatch(
       pruneStaleLockEntries.fulfilled(
-        { pruned: [], skipped: [], failed: ['old-skill'] },
+        { pruned: [], skipped: [], failed: [toSkillName('old-skill')] },
         'req-prune',
-        ['old-skill'],
+        [toSkillName('old-skill')],
       ),
     )
 
@@ -251,7 +282,9 @@ describe('skillLockSlice', () => {
     // reporting survivors afterwards would list names behind a status that says
     // we cannot stand behind any count — the list is what the dialog renders.
     const store = createTestStore()
-    store.dispatch(pruneStaleLockEntries.pending('req-prune', ['old-skill']))
+    store.dispatch(
+      pruneStaleLockEntries.pending('req-prune', [toSkillName('old-skill')]),
+    )
     store.dispatch(fetchStaleLockEntries.pending('req-mid-prune', undefined))
     store.dispatch(
       fetchStaleLockEntries.rejected(
@@ -263,9 +296,9 @@ describe('skillLockSlice', () => {
     // Act
     store.dispatch(
       pruneStaleLockEntries.fulfilled(
-        { pruned: [], skipped: [], failed: ['old-skill'] },
+        { pruned: [], skipped: [], failed: [toSkillName('old-skill')] },
         'req-prune',
-        ['old-skill'],
+        [toSkillName('old-skill')],
       ),
     )
 
@@ -282,7 +315,7 @@ describe('skillLockSlice', () => {
     store.dispatch(fetchStaleLockEntries.pending('req-1', undefined))
     store.dispatch(
       fetchStaleLockEntries.fulfilled(
-        { status: 'ok', names: ['old-skill'], unprunable: [] },
+        { status: 'ok', names: [toSkillName('old-skill')], unprunable: [] },
         'req-1',
         undefined,
       ),
@@ -293,7 +326,11 @@ describe('skillLockSlice', () => {
     store.dispatch(fetchStaleLockEntries.pending('req-2', undefined))
     store.dispatch(
       fetchStaleLockEntries.fulfilled(
-        { status: 'ok', names: ['old-skill', 'just-appeared'], unprunable: [] },
+        {
+          status: 'ok',
+          names: [toSkillName('old-skill'), toSkillName('just-appeared')],
+          unprunable: [],
+        },
         'req-2',
         undefined,
       ),
@@ -314,13 +351,19 @@ describe('skillLockSlice', () => {
     // report the delegated delete as finished — that re-enables the confirm
     // button while the CLI is still recursively removing directories.
     const store = createTestStore()
-    store.dispatch(pruneStaleLockEntries.pending('req-prune', ['old-skill']))
+    store.dispatch(
+      pruneStaleLockEntries.pending('req-prune', [toSkillName('old-skill')]),
+    )
 
     // Act
     store.dispatch(fetchStaleLockEntries.pending('req-scan', undefined))
     store.dispatch(
       fetchStaleLockEntries.fulfilled(
-        { status: 'ok', names: ['old-skill', 'newly-found'], unprunable: [] },
+        {
+          status: 'ok',
+          names: [toSkillName('old-skill'), toSkillName('newly-found')],
+          unprunable: [],
+        },
         'req-scan',
         undefined,
       ),
@@ -333,11 +376,17 @@ describe('skillLockSlice', () => {
   test('ends the prune normally after a scan took over the record list', async () => {
     // Arrange
     const store = createTestStore()
-    store.dispatch(pruneStaleLockEntries.pending('req-prune', ['old-skill']))
+    store.dispatch(
+      pruneStaleLockEntries.pending('req-prune', [toSkillName('old-skill')]),
+    )
     store.dispatch(fetchStaleLockEntries.pending('req-scan', undefined))
     store.dispatch(
       fetchStaleLockEntries.fulfilled(
-        { status: 'ok', names: ['old-skill', 'newly-found'], unprunable: [] },
+        {
+          status: 'ok',
+          names: [toSkillName('old-skill'), toSkillName('newly-found')],
+          unprunable: [],
+        },
         'req-scan',
         undefined,
       ),
@@ -346,9 +395,9 @@ describe('skillLockSlice', () => {
     // Act
     store.dispatch(
       pruneStaleLockEntries.fulfilled(
-        { pruned: ['old-skill'], skipped: [], failed: [] },
+        { pruned: [toSkillName('old-skill')], skipped: [], failed: [] },
         'req-prune',
-        ['old-skill'],
+        [toSkillName('old-skill')],
       ),
     )
 
@@ -367,15 +416,19 @@ describe('skillLockSlice', () => {
     // report "done" would re-enable a destructive button while the CLI is
     // still recursively deleting.
     const store = createTestStore()
-    store.dispatch(pruneStaleLockEntries.pending('req-first', ['old-skill']))
-    store.dispatch(pruneStaleLockEntries.pending('req-second', ['old-skill']))
+    store.dispatch(
+      pruneStaleLockEntries.pending('req-first', [toSkillName('old-skill')]),
+    )
+    store.dispatch(
+      pruneStaleLockEntries.pending('req-second', [toSkillName('old-skill')]),
+    )
 
     // Act
     store.dispatch(
       pruneStaleLockEntries.fulfilled(
-        { pruned: ['old-skill'], skipped: [], failed: [] },
+        { pruned: [toSkillName('old-skill')], skipped: [], failed: [] },
         'req-first',
-        ['old-skill'],
+        [toSkillName('old-skill')],
       ),
     )
 
@@ -386,13 +439,17 @@ describe('skillLockSlice', () => {
   test('leaves the newer prune running when an older one fails first', async () => {
     // Arrange
     const store = createTestStore()
-    store.dispatch(pruneStaleLockEntries.pending('req-first', ['old-skill']))
-    store.dispatch(pruneStaleLockEntries.pending('req-second', ['old-skill']))
+    store.dispatch(
+      pruneStaleLockEntries.pending('req-first', [toSkillName('old-skill')]),
+    )
+    store.dispatch(
+      pruneStaleLockEntries.pending('req-second', [toSkillName('old-skill')]),
+    )
 
     // Act
     store.dispatch(
       pruneStaleLockEntries.rejected(new Error('IPC down'), 'req-first', [
-        'old-skill',
+        toSkillName('old-skill'),
       ]),
     )
 
@@ -409,7 +466,7 @@ describe('skillLockSlice', () => {
     store.dispatch(fetchStaleLockEntries.pending('req-1', undefined))
     store.dispatch(
       fetchStaleLockEntries.fulfilled(
-        { status: 'ok', names: ['old-skill'], unprunable: [] },
+        { status: 'ok', names: [toSkillName('old-skill')], unprunable: [] },
         'req-1',
         undefined,
       ),
@@ -419,7 +476,11 @@ describe('skillLockSlice', () => {
     store.dispatch(fetchStaleLockEntries.pending('req-2', undefined))
     store.dispatch(
       fetchStaleLockEntries.fulfilled(
-        { status: 'ok', names: ['different-skill'], unprunable: [] },
+        {
+          status: 'ok',
+          names: [toSkillName('different-skill')],
+          unprunable: [],
+        },
         'req-2',
         undefined,
       ),
@@ -441,19 +502,21 @@ describe('skillLockSlice', () => {
     // it land would repopulate the widget with records that are now gone.
     const store = createTestStore()
     store.dispatch(fetchStaleLockEntries.pending('req-before-prune', undefined))
-    store.dispatch(pruneStaleLockEntries.pending('req-prune', ['old-skill']))
+    store.dispatch(
+      pruneStaleLockEntries.pending('req-prune', [toSkillName('old-skill')]),
+    )
     store.dispatch(
       pruneStaleLockEntries.fulfilled(
-        { pruned: ['old-skill'], skipped: [], failed: [] },
+        { pruned: [toSkillName('old-skill')], skipped: [], failed: [] },
         'req-prune',
-        ['old-skill'],
+        [toSkillName('old-skill')],
       ),
     )
 
     // Act
     store.dispatch(
       fetchStaleLockEntries.fulfilled(
-        { status: 'ok', names: ['old-skill'], unprunable: [] },
+        { status: 'ok', names: [toSkillName('old-skill')], unprunable: [] },
         'req-before-prune',
         undefined,
       ),
@@ -474,8 +537,10 @@ describe('skillLockSlice', () => {
       fetchStaleLockEntries.fulfilled(
         {
           status: 'ok',
-          names: ['removable'],
-          unprunable: [{ name: 'agent-owned', reason: 'agent-copy' }],
+          names: [toSkillName('removable')],
+          unprunable: [
+            { name: toSkillName('agent-owned'), reason: 'agent-copy' },
+          ],
         },
         'req-1',
         undefined,
@@ -506,8 +571,8 @@ describe('skillLockSlice', () => {
           status: 'ok',
           names: [],
           unprunable: [
-            { name: 'ambiguous', reason: 'name-collision' },
-            { name: 'Ambiguous', reason: 'name-collision' },
+            { name: toSkillName('ambiguous'), reason: 'name-collision' },
+            { name: toSkillName('Ambiguous'), reason: 'name-collision' },
           ],
         },
         'req-1',
@@ -532,7 +597,9 @@ describe('skillLockSlice', () => {
         {
           status: 'ok',
           names: [],
-          unprunable: [{ name: 'agent-owned', reason: 'agent-copy' }],
+          unprunable: [
+            { name: toSkillName('agent-owned'), reason: 'agent-copy' },
+          ],
         },
         'req-1',
         undefined,
@@ -564,8 +631,10 @@ describe('skillLockSlice', () => {
       fetchStaleLockEntries.fulfilled(
         {
           status: 'ok',
-          names: ['removable'],
-          unprunable: [{ name: 'agent-owned', reason: 'agent-copy' }],
+          names: [toSkillName('removable')],
+          unprunable: [
+            { name: toSkillName('agent-owned'), reason: 'agent-copy' },
+          ],
         },
         'req-1',
         undefined,
@@ -573,12 +642,14 @@ describe('skillLockSlice', () => {
     )
 
     // Act
-    store.dispatch(pruneStaleLockEntries.pending('prune-1', ['removable']))
+    store.dispatch(
+      pruneStaleLockEntries.pending('prune-1', [toSkillName('removable')]),
+    )
     store.dispatch(
       pruneStaleLockEntries.fulfilled(
-        { pruned: [], skipped: [], failed: ['removable'] },
+        { pruned: [], skipped: [], failed: [toSkillName('removable')] },
         'prune-1',
-        ['removable'],
+        [toSkillName('removable')],
       ),
     )
 

--- a/src/renderer/src/redux/slices/skillsSlice.test.ts
+++ b/src/renderer/src/redux/slices/skillsSlice.test.ts
@@ -20,6 +20,7 @@ import {
   toBatchItemCount,
   toBatchItemIndex,
   toFileSizeBytes,
+  toSkillName,
   toSymlinkCount,
   tombstoneId,
 } from '@/shared/types'
@@ -72,7 +73,7 @@ async function createTestStore() {
 
 /** Sample skill for testing */
 const sampleSkill: Skill = {
-  name: 'task',
+  name: toSkillName('task'),
   description: 'Task management skill',
   path: '/home/user/.agents/skills/task',
   filesystemIdentity: directoryIdentity,
@@ -93,13 +94,13 @@ const sampleSkill: Skill = {
 
 const secondSkill: Skill = {
   ...sampleSkill,
-  name: 'theme-generator',
+  name: toSkillName('theme-generator'),
   path: '/home/user/.agents/skills/theme-generator',
 }
 
 const thirdSkill: Skill = {
   ...sampleSkill,
-  name: 'browser',
+  name: toSkillName('browser'),
   path: '/home/user/.agents/skills/browser',
 }
 
@@ -594,7 +595,7 @@ describe('skillsSlice bulkCopyToAgents thunk', () => {
   const item = (
     name: string,
   ): { skillName: SkillName; sourcePath: AbsolutePath } => ({
-    skillName: name,
+    skillName: toSkillName(name),
     sourcePath: `/Users/me/.agents/skills/${name}`,
   })
 
@@ -730,7 +731,7 @@ describe('skillsSlice bulkCopyToAgents thunk', () => {
     })
     const store = await createTestStore()
     const { bulkCopyToAgents, selectAll } = await import('./skillsSlice')
-    store.dispatch(selectAll(['alpha', 'beta']))
+    store.dispatch(selectAll([toSkillName('alpha'), toSkillName('beta')]))
 
     // Act
     await store.dispatch(
@@ -812,7 +813,7 @@ describe('skillsSlice bulk selection reducers (v2.4)', () => {
     const store = await createTestStore()
 
     // Act
-    store.dispatch(toggleSelection('task'))
+    store.dispatch(toggleSelection(toSkillName('task')))
 
     // Assert
     expect(store.getState().skills.selectedSkillNames).toEqual(['task'])
@@ -825,8 +826,8 @@ describe('skillsSlice bulk selection reducers (v2.4)', () => {
     const store = await createTestStore()
 
     // Act
-    store.dispatch(toggleSelection('task'))
-    store.dispatch(toggleSelection('task'))
+    store.dispatch(toggleSelection(toSkillName('task')))
+    store.dispatch(toggleSelection(toSkillName('task')))
 
     // Assert
     expect(store.getState().skills.selectedSkillNames).toEqual([])
@@ -840,8 +841,14 @@ describe('skillsSlice bulk selection reducers (v2.4)', () => {
     const store = await createTestStore()
 
     // Act
-    store.dispatch(toggleSelection('task'))
-    store.dispatch(selectRange(['task', 'theme', 'browser']))
+    store.dispatch(toggleSelection(toSkillName('task')))
+    store.dispatch(
+      selectRange([
+        toSkillName('task'),
+        toSkillName('theme'),
+        toSkillName('browser'),
+      ]),
+    )
 
     // Assert
     expect(store.getState().skills.selectedSkillNames).toEqual([
@@ -859,9 +866,15 @@ describe('skillsSlice bulk selection reducers (v2.4)', () => {
     const store = await createTestStore()
 
     // Act
-    store.dispatch(toggleSelection('task'))
-    store.dispatch(toggleSelection('browser'))
-    store.dispatch(selectRange(['task', 'theme', 'browser']))
+    store.dispatch(toggleSelection(toSkillName('task')))
+    store.dispatch(toggleSelection(toSkillName('browser')))
+    store.dispatch(
+      selectRange([
+        toSkillName('task'),
+        toSkillName('theme'),
+        toSkillName('browser'),
+      ]),
+    )
 
     // Assert
     expect(store.getState().skills.selectedSkillNames).toEqual([
@@ -877,8 +890,14 @@ describe('skillsSlice bulk selection reducers (v2.4)', () => {
     const store = await createTestStore()
 
     // Act
-    store.dispatch(toggleSelection('zebra'))
-    store.dispatch(selectAll(['task', 'theme', 'browser']))
+    store.dispatch(toggleSelection(toSkillName('zebra')))
+    store.dispatch(
+      selectAll([
+        toSkillName('task'),
+        toSkillName('theme'),
+        toSkillName('browser'),
+      ]),
+    )
 
     // Assert
     expect(store.getState().skills.selectedSkillNames).toEqual([
@@ -893,7 +912,7 @@ describe('skillsSlice bulk selection reducers (v2.4)', () => {
     // Arrange — a prior single click pinned 'task' as the range anchor
     const { toggleSelection, selectRange } = await import('./skillsSlice')
     const store = await createTestStore()
-    store.dispatch(toggleSelection('task'))
+    store.dispatch(toggleSelection(toSkillName('task')))
 
     // Act — an empty range payload (no spanned rows) must not move the anchor
     store.dispatch(selectRange([]))
@@ -910,7 +929,7 @@ describe('skillsSlice bulk selection reducers (v2.4)', () => {
     const store = await createTestStore()
 
     // Act
-    store.dispatch(toggleSelection('task'))
+    store.dispatch(toggleSelection(toSkillName('task')))
     store.dispatch(selectAll([]))
 
     // Assert
@@ -924,8 +943,8 @@ describe('skillsSlice bulk selection reducers (v2.4)', () => {
     const store = await createTestStore()
 
     // Act
-    store.dispatch(toggleSelection('task'))
-    store.dispatch(toggleSelection('theme'))
+    store.dispatch(toggleSelection(toSkillName('task')))
+    store.dispatch(toggleSelection(toSkillName('theme')))
     store.dispatch(clearSelection())
 
     // Assert
@@ -995,9 +1014,9 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
     // Act — include a ghost name that is NOT in state.items; reconciliation should drop it
     const promise = store.dispatch(
       deleteSelectedSkills([
-        deleteTarget('task'),
-        deleteTarget('theme-generator'),
-        deleteTarget('already-gone'),
+        deleteTarget(toSkillName('task')),
+        deleteTarget(toSkillName('theme-generator')),
+        deleteTarget(toSkillName('already-gone')),
       ]),
     )
 
@@ -1012,21 +1031,21 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
     resolve({
       items: [
         {
-          skillName: 'task',
+          skillName: toSkillName('task'),
           outcome: 'deleted',
           tombstoneId: tombstoneId('1-task-aaaaaaaa'),
           symlinksRemoved: toSymlinkCount(2),
           cascadeAgents: [],
         },
         {
-          skillName: 'theme-generator',
+          skillName: toSkillName('theme-generator'),
           outcome: 'deleted',
           tombstoneId: tombstoneId('1-theme-generator-bbbbbbbb'),
           symlinksRemoved: toSymlinkCount(0),
           cascadeAgents: [],
         },
         {
-          skillName: 'already-gone',
+          skillName: toSkillName('already-gone'),
           outcome: 'error',
           error: { message: 'Not present' },
         },
@@ -1041,7 +1060,7 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
     mockDeleteSkills.mockResolvedValue({
       items: [
         {
-          skillName: 'metadata-title',
+          skillName: toSkillName('metadata-title'),
           outcome: 'deleted',
           tombstoneId: tombstoneId('1-metadata-title-aaaaaaaa'),
           symlinksRemoved: toSymlinkCount(1),
@@ -1055,7 +1074,7 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
     await store.dispatch(
       deleteSelectedSkills([
         {
-          skillName: 'metadata-title',
+          skillName: toSkillName('metadata-title'),
           skillPath: '/home/user/.agents/skills/folder-basename',
           filesystemIdentity: directoryIdentity,
         },
@@ -1081,7 +1100,7 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
     mockDeleteSkills.mockResolvedValue({
       items: [
         {
-          skillName: 'task',
+          skillName: toSkillName('task'),
           outcome: 'deleted',
           tombstoneId: tombstoneId('1-task-aaaaaaaa'),
           symlinksRemoved: toSymlinkCount(1),
@@ -1091,7 +1110,7 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
     } satisfies BulkDeleteResult)
     const { deleteSelectedSkills, toggleSelection, setBulkProgress } =
       await import('./skillsSlice')
-    store.dispatch(toggleSelection('task'))
+    store.dispatch(toggleSelection(toSkillName('task')))
     store.dispatch(
       setBulkProgress({
         current: toBatchItemIndex(1),
@@ -1100,7 +1119,9 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
     )
 
     // Act
-    await store.dispatch(deleteSelectedSkills([deleteTarget('task')]))
+    await store.dispatch(
+      deleteSelectedSkills([deleteTarget(toSkillName('task'))]),
+    )
 
     // Assert
     const state = store.getState().skills
@@ -1118,7 +1139,7 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
     mockDeleteSkills.mockResolvedValue({
       items: [
         {
-          skillName: 'task',
+          skillName: toSkillName('task'),
           outcome: 'orphan-cleared',
           symlinksRemoved: toSymlinkCount(1),
           cascadeAgents: ['claude-code'],
@@ -1127,7 +1148,7 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
     } satisfies BulkDeleteResult)
     const { deleteSelectedSkills, toggleSelection, setBulkProgress } =
       await import('./skillsSlice')
-    store.dispatch(toggleSelection('task'))
+    store.dispatch(toggleSelection(toSkillName('task')))
     store.dispatch(
       setBulkProgress({
         current: toBatchItemIndex(1),
@@ -1136,7 +1157,9 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
     )
 
     // Act
-    await store.dispatch(deleteSelectedSkills([deleteTarget('task')]))
+    await store.dispatch(
+      deleteSelectedSkills([deleteTarget(toSkillName('task'))]),
+    )
 
     // Assert
     const state = store.getState().skills
@@ -1155,7 +1178,9 @@ describe('skillsSlice deleteSelectedSkills thunk', () => {
     const { deleteSelectedSkills } = await import('./skillsSlice')
 
     // Act
-    await store.dispatch(deleteSelectedSkills([deleteTarget('task')]))
+    await store.dispatch(
+      deleteSelectedSkills([deleteTarget(toSkillName('task'))]),
+    )
 
     // Assert
     const state = store.getState().skills
@@ -1186,7 +1211,7 @@ describe('skillsSlice clearSelectedOrphanSymlinks thunk', () => {
     const promise = store.dispatch(
       clearSelectedOrphanSymlinks([
         {
-          skillName: 'task',
+          skillName: toSkillName('task'),
           agents: [
             {
               agentId: 'codex',
@@ -1196,7 +1221,7 @@ describe('skillsSlice clearSelectedOrphanSymlinks thunk', () => {
           ],
         },
         {
-          skillName: 'ghost',
+          skillName: toSkillName('ghost'),
           agents: [
             {
               agentId: 'cursor',
@@ -1215,7 +1240,7 @@ describe('skillsSlice clearSelectedOrphanSymlinks thunk', () => {
     resolve({
       items: [
         {
-          skillName: 'task',
+          skillName: toSkillName('task'),
           outcome: 'orphan-cleared',
           symlinksRemoved: toSymlinkCount(1),
           cascadeAgents: ['codex'],
@@ -1232,7 +1257,7 @@ describe('skillsSlice clearSelectedOrphanSymlinks thunk', () => {
     mockClearOrphanSymlinks.mockResolvedValue({
       items: [
         {
-          skillName: 'task',
+          skillName: toSkillName('task'),
           outcome: 'orphan-cleared',
           symlinksRemoved: toSymlinkCount(1),
           cascadeAgents: ['codex'],
@@ -1241,7 +1266,7 @@ describe('skillsSlice clearSelectedOrphanSymlinks thunk', () => {
     } satisfies ClearOrphanSymlinksResult)
     const { clearSelectedOrphanSymlinks, setBulkProgress, toggleSelection } =
       await import('./skillsSlice')
-    store.dispatch(toggleSelection('task'))
+    store.dispatch(toggleSelection(toSkillName('task')))
     store.dispatch(
       setBulkProgress({
         current: toBatchItemIndex(1),
@@ -1253,7 +1278,7 @@ describe('skillsSlice clearSelectedOrphanSymlinks thunk', () => {
     await store.dispatch(
       clearSelectedOrphanSymlinks([
         {
-          skillName: 'task',
+          skillName: toSkillName('task'),
           agents: [
             {
               agentId: 'codex',
@@ -1281,7 +1306,7 @@ describe('skillsSlice clearSelectedOrphanSymlinks thunk', () => {
     mockClearOrphanSymlinks.mockResolvedValue({
       items: [
         {
-          skillName: 'task',
+          skillName: toSkillName('task'),
           outcome: 'error',
           error: { message: 'Rescan before cleanup.' },
         },
@@ -1289,13 +1314,13 @@ describe('skillsSlice clearSelectedOrphanSymlinks thunk', () => {
     } satisfies ClearOrphanSymlinksResult)
     const { clearSelectedOrphanSymlinks, toggleSelection } =
       await import('./skillsSlice')
-    store.dispatch(toggleSelection('task'))
+    store.dispatch(toggleSelection(toSkillName('task')))
 
     // Act
     await store.dispatch(
       clearSelectedOrphanSymlinks([
         {
-          skillName: 'task',
+          skillName: toSkillName('task'),
           agents: [
             {
               agentId: 'codex',
@@ -1326,7 +1351,7 @@ describe('skillsSlice clearSelectedOrphanSymlinks thunk', () => {
     await store.dispatch(
       clearSelectedOrphanSymlinks([
         {
-          skillName: 'task',
+          skillName: toSkillName('task'),
           agents: [
             {
               agentId: 'codex',
@@ -1372,15 +1397,15 @@ describe('skillsSlice clearSelectedBrokenSymlinkSlots thunk', () => {
             // linkName (on-disk basename) intentionally differs from
             // displaySkillName to prove reconciliation matches the live
             // skill.name ('task'), not the symlink basename.
-            linkName: 'task-symlink',
-            displaySkillName: 'task',
+            linkName: toSkillName('task-symlink'),
+            displaySkillName: toSkillName('task'),
             linkPath: '/home/user/.codex/skills/task-symlink',
             targetPath: '/home/user/.agents/skills/task',
           },
           {
             agentId: 'cursor',
-            linkName: 'ghost',
-            displaySkillName: 'ghost',
+            linkName: toSkillName('ghost'),
+            displaySkillName: toSkillName('ghost'),
             linkPath: '/home/user/.cursor/skills/ghost',
             targetPath: '/home/user/.agents/skills/ghost',
           },
@@ -1396,7 +1421,7 @@ describe('skillsSlice clearSelectedBrokenSymlinkSlots thunk', () => {
       items: [
         {
           agentId: 'codex' as AgentId,
-          skillName: 'task',
+          skillName: toSkillName('task'),
           linkPath: '/home/user/.codex/skills/task',
           outcome: 'unlinked',
         },
@@ -1413,7 +1438,7 @@ describe('skillsSlice clearSelectedBrokenSymlinkSlots thunk', () => {
       items: [
         {
           agentId: 'codex' as AgentId,
-          skillName: 'task',
+          skillName: toSkillName('task'),
           linkPath: '/home/user/.codex/skills/task',
           outcome: 'unlinked',
         },
@@ -1427,8 +1452,8 @@ describe('skillsSlice clearSelectedBrokenSymlinkSlots thunk', () => {
         items: [
           {
             agentId: 'codex',
-            linkName: 'task',
-            displaySkillName: 'task',
+            linkName: toSkillName('task'),
+            displaySkillName: toSkillName('task'),
             linkPath: '/home/user/.codex/skills/task',
             targetPath: '/home/user/.agents/skills/task',
           },
@@ -1457,8 +1482,8 @@ describe('skillsSlice clearSelectedBrokenSymlinkSlots thunk', () => {
         items: [
           {
             agentId: 'codex',
-            linkName: 'task',
-            displaySkillName: 'task',
+            linkName: toSkillName('task'),
+            displaySkillName: toSkillName('task'),
             linkPath: '/home/user/.codex/skills/task',
             targetPath: '/home/user/.agents/skills/task',
           },
@@ -1496,9 +1521,9 @@ describe('skillsSlice unlinkSelectedFromAgent thunk', () => {
       unlinkSelectedFromAgent({
         agentId: 'cursor',
         selectedNames: [
-          unlinkTarget('task'),
-          unlinkTarget('browser'),
-          unlinkTarget('ghost'),
+          unlinkTarget(toSkillName('task')),
+          unlinkTarget(toSkillName('browser')),
+          unlinkTarget(toSkillName('ghost')),
         ],
       }),
     )
@@ -1512,8 +1537,8 @@ describe('skillsSlice unlinkSelectedFromAgent thunk', () => {
 
     resolve({
       items: [
-        { skillName: 'task', outcome: 'unlinked' },
-        { skillName: 'browser', outcome: 'unlinked' },
+        { skillName: toSkillName('task'), outcome: 'unlinked' },
+        { skillName: toSkillName('browser'), outcome: 'unlinked' },
       ],
     })
     await promise
@@ -1523,7 +1548,9 @@ describe('skillsSlice unlinkSelectedFromAgent thunk', () => {
     // Arrange
     const store = await createTestStore()
     mockUnlinkManyFromAgent.mockResolvedValue({
-      items: [{ skillName: 'metadata-title', outcome: 'unlinked' }],
+      items: [
+        { skillName: toSkillName('metadata-title'), outcome: 'unlinked' },
+      ],
     } satisfies BulkUnlinkResult)
     const { unlinkSelectedFromAgent } = await import('./skillsSlice')
 
@@ -1533,7 +1560,7 @@ describe('skillsSlice unlinkSelectedFromAgent thunk', () => {
         agentId: 'cursor',
         selectedNames: [
           {
-            skillName: 'metadata-title',
+            skillName: toSkillName('metadata-title'),
             linkPath: '/home/user/.cursor/skills/folder-basename',
             targetPath: '/home/user/.agents/skills/folder-basename',
           },
@@ -1559,17 +1586,17 @@ describe('skillsSlice unlinkSelectedFromAgent thunk', () => {
     const store = await createTestStore()
     await seedItems(store, [sampleSkill])
     mockUnlinkManyFromAgent.mockResolvedValue({
-      items: [{ skillName: 'task', outcome: 'unlinked' }],
+      items: [{ skillName: toSkillName('task'), outcome: 'unlinked' }],
     } satisfies BulkUnlinkResult)
     const { unlinkSelectedFromAgent, toggleSelection } =
       await import('./skillsSlice')
-    store.dispatch(toggleSelection('task'))
+    store.dispatch(toggleSelection(toSkillName('task')))
 
     // Act
     await store.dispatch(
       unlinkSelectedFromAgent({
         agentId: 'cursor',
-        selectedNames: [unlinkTarget('task')],
+        selectedNames: [unlinkTarget(toSkillName('task'))],
       }),
     )
 
@@ -1592,7 +1619,7 @@ describe('skillsSlice unlinkSelectedFromAgent thunk', () => {
     await store.dispatch(
       unlinkSelectedFromAgent({
         agentId: 'cursor',
-        selectedNames: [unlinkTarget('task')],
+        selectedNames: [unlinkTarget(toSkillName('task'))],
       }),
     )
 
@@ -1750,7 +1777,7 @@ describe('skillsSlice named selectors', () => {
       selectSelectedCopyAgentIds,
       selectSelectionAnchor,
     } = await import('./skillsSlice')
-    store.dispatch(toggleSelection('task'))
+    store.dispatch(toggleSelection(toSkillName('task')))
     store.dispatch(toggleCopyAgentSelection('codex'))
 
     // Act
@@ -1782,12 +1809,14 @@ describe('skillsSlice named selectors', () => {
       selectBulkCopying,
     } = await import('./skillsSlice')
     store.dispatch(
-      deleteSelectedSkills.pending('del-1', [deleteTarget('task')]),
+      deleteSelectedSkills.pending('del-1', [
+        deleteTarget(toSkillName('task')),
+      ]),
     )
     store.dispatch(
       unlinkSelectedFromAgent.pending('unlink-1', {
         agentId: 'cursor',
-        selectedNames: [unlinkTarget('task')],
+        selectedNames: [unlinkTarget(toSkillName('task'))],
       }),
     )
     store.dispatch(

--- a/src/renderer/src/redux/slices/uiSlice.test.ts
+++ b/src/renderer/src/redux/slices/uiSlice.test.ts
@@ -10,7 +10,6 @@ import type {
   ClearOrphanSymlinksResult,
   FilesystemEntryIdentity,
   Skill,
-  SkillName,
   SourceStats,
   SyncExecuteResult,
   SyncPreviewResult,
@@ -25,6 +24,7 @@ import {
   toIsoTimestamp,
   toSearchQuery,
   toSkillCount,
+  toSkillName,
   toSymlinkCount,
   tombstoneId,
 } from '@/shared/types'
@@ -127,7 +127,7 @@ const previewWithConflicts: SyncPreviewResult = {
   alreadySynced: toSymlinkCount(4),
   conflicts: [
     {
-      skillName: 'agent-browser',
+      skillName: toSkillName('agent-browser'),
       agentId: 'cursor',
       agentName: 'Cursor',
       agentSkillPath: '/home/user/.cursor/skills/agent-browser',
@@ -450,7 +450,11 @@ describe('uiSlice sync thunks', () => {
       skipped: toSymlinkCount(4),
       errors: [],
       details: [
-        { skillName: 'skill-a', agentName: 'Claude Code', action: 'created' },
+        {
+          skillName: toSkillName('skill-a'),
+          agentName: 'Claude Code',
+          action: 'created',
+        },
       ],
     } satisfies SyncExecuteResult)
     const store = await createTestStore()
@@ -498,7 +502,11 @@ describe('uiSlice sync thunks', () => {
       skipped: toSymlinkCount(0),
       errors: [],
       details: [
-        { skillName: 's', agentName: 'Claude Code', action: 'created' },
+        {
+          skillName: toSkillName('s'),
+          agentName: 'Claude Code',
+          action: 'created',
+        },
       ],
     } satisfies SyncExecuteResult)
     const store = await createTestStore()
@@ -522,7 +530,11 @@ describe('uiSlice sync thunks', () => {
       skipped: toSymlinkCount(0),
       errors: [],
       details: [
-        { skillName: 's', agentName: 'Claude Code', action: 'created' },
+        {
+          skillName: toSkillName('s'),
+          agentName: 'Claude Code',
+          action: 'created',
+        },
       ],
     } satisfies SyncExecuteResult)
     const store = await createTestStore()
@@ -564,7 +576,7 @@ describe('uiSlice sync thunks', () => {
 
 describe('uiSlice bookmark detail modal', () => {
   const sampleBookmark = {
-    name: 'task',
+    name: toSkillName('task'),
     repo: repositoryId('vercel-labs/skills'),
     url: toHttpUrl('https://github.com/vercel-labs/skills'),
     bookmarkedAt: toIsoTimestamp('2026-04-01T08:00:00.000Z'),
@@ -621,7 +633,7 @@ describe('uiSlice undoToast (v2.4 bulk delete)', () => {
   const makeToast = (kind: 'delete' | 'unlink' = 'delete') => ({
     id: 'toast-1',
     kind,
-    skillNames: ['task', 'browser'],
+    skillNames: [toSkillName('task'), toSkillName('browser')],
     tombstoneIds:
       kind === 'delete'
         ? [tombstoneId('1-task-aaaaaaaa'), tombstoneId('1-browser-bbbbbbbb')]
@@ -679,7 +691,7 @@ describe('uiSlice undoToast (v2.4 bulk delete)', () => {
     const newerToast = {
       ...makeToast(),
       id: 'toast-2',
-      skillNames: ['newer-task'] as SkillName[],
+      skillNames: [toSkillName('newer-task')],
       summary: 'Deleted 1 skill. 0 symlinks removed.',
     }
     store.dispatch(setUndoToast(olderToast))
@@ -758,7 +770,9 @@ describe('uiSlice undoToast (v2.4 bulk delete)', () => {
     )
 
     // Act
-    const promise = store.dispatch(deleteSelectedSkills([deleteTarget('task')]))
+    const promise = store.dispatch(
+      deleteSelectedSkills([deleteTarget(toSkillName('task'))]),
+    )
 
     // Assert
     expect(store.getState().ui.undoToast).toBeNull()
@@ -785,7 +799,7 @@ describe('uiSlice undoToast (v2.4 bulk delete)', () => {
     const promise = store.dispatch(
       clearSelectedOrphanSymlinks([
         {
-          skillName: 'task',
+          skillName: toSkillName('task'),
           agents: [
             {
               agentId: 'codex',
@@ -824,8 +838,8 @@ describe('uiSlice undoToast (v2.4 bulk delete)', () => {
         items: [
           {
             agentId: 'codex',
-            linkName: 'task',
-            displaySkillName: 'task',
+            linkName: toSkillName('task'),
+            displaySkillName: toSkillName('task'),
             linkPath: '/home/user/.codex/skills/task',
             targetPath: '/home/user/.agents/skills/task',
           },
@@ -858,7 +872,7 @@ describe('uiSlice undoToast (v2.4 bulk delete)', () => {
     const promise = store.dispatch(
       unlinkSelectedFromAgent({
         agentId: 'cursor',
-        selectedNames: [unlinkTarget('task')],
+        selectedNames: [unlinkTarget(toSkillName('task'))],
       }),
     )
 
@@ -975,7 +989,9 @@ describe('uiSlice bulkSelectMode', () => {
     )
 
     // Act
-    const promise = store.dispatch(deleteSelectedSkills([deleteTarget('task')]))
+    const promise = store.dispatch(
+      deleteSelectedSkills([deleteTarget(toSkillName('task'))]),
+    )
 
     // Assert
     expect(store.getState().ui.bulkSelectMode).toBe(false)
@@ -1001,7 +1017,7 @@ describe('uiSlice bulkSelectMode', () => {
     const promise = store.dispatch(
       clearSelectedOrphanSymlinks([
         {
-          skillName: 'task',
+          skillName: toSkillName('task'),
           agents: [
             {
               agentId: 'codex',
@@ -1039,8 +1055,8 @@ describe('uiSlice bulkSelectMode', () => {
         items: [
           {
             agentId: 'codex',
-            linkName: 'task',
-            displaySkillName: 'task',
+            linkName: toSkillName('task'),
+            displaySkillName: toSkillName('task'),
             linkPath: '/home/user/.codex/skills/task',
             targetPath: '/home/user/.agents/skills/task',
           },
@@ -1072,7 +1088,7 @@ describe('uiSlice bulkSelectMode', () => {
     const promise = store.dispatch(
       unlinkSelectedFromAgent({
         agentId: 'cursor',
-        selectedNames: [unlinkTarget('task')],
+        selectedNames: [unlinkTarget(toSkillName('task'))],
       }),
     )
 
@@ -1142,7 +1158,7 @@ describe('uiSlice atomic-clear contract on context switch', () => {
       setUndoToast({
         id: 'toast-seed',
         kind: 'delete',
-        skillNames: ['a'],
+        skillNames: [toSkillName('a')],
         tombstoneIds: [tombstoneId('1-a-aaaaaaaa')],
         expiresAt: toIsoTimestamp('2026-04-17T12:00:15.000Z'),
         summary: 'Deleted 1 skill.',
@@ -1151,11 +1167,11 @@ describe('uiSlice atomic-clear contract on context switch', () => {
     store.dispatch(
       setBulkConfirm({
         kind: 'delete',
-        skillNames: ['a'],
+        skillNames: [toSkillName('a')],
         agentId: null,
         agentName: null,
         sourceSummary: null,
-        deleteTargets: [deleteTarget('a')],
+        deleteTargets: [deleteTarget(toSkillName('a'))],
         orphanRecords: [],
         staleDeleteErrors: [],
         orphanErrors: [],
@@ -1237,7 +1253,9 @@ describe('uiSlice atomic-clear contract on context switch', () => {
     )
 
     // Act
-    const promise = store.dispatch(deleteSelectedSkills([deleteTarget('a')]))
+    const promise = store.dispatch(
+      deleteSelectedSkills([deleteTarget(toSkillName('a'))]),
+    )
 
     // Assert
     expect(store.getState().ui).toMatchObject({
@@ -1264,7 +1282,9 @@ describe('uiSlice atomic-clear contract on context switch', () => {
     )
 
     // Act
-    const promise = store.dispatch(deleteSelectedSkills([deleteTarget('a')]))
+    const promise = store.dispatch(
+      deleteSelectedSkills([deleteTarget(toSkillName('a'))]),
+    )
 
     // Assert
     expect(store.getState().ui.symlinkCleanupDialogOpen).toBe(true)
@@ -1289,7 +1309,7 @@ describe('uiSlice atomic-clear contract on context switch', () => {
     const promise = store.dispatch(
       unlinkSelectedFromAgent({
         agentId: 'cursor',
-        selectedNames: [unlinkTarget('a')],
+        selectedNames: [unlinkTarget(toSkillName('a'))],
       }),
     )
 
@@ -1321,7 +1341,7 @@ describe('uiSlice atomic-clear contract on context switch', () => {
     const promise = store.dispatch(
       unlinkSelectedFromAgent({
         agentId: 'cursor',
-        selectedNames: [unlinkTarget('a')],
+        selectedNames: [unlinkTarget(toSkillName('a'))],
       }),
     )
 
@@ -1368,7 +1388,9 @@ describe('uiSlice bulkSelectMode on rejection', () => {
     mockDeleteSkills.mockRejectedValue(new Error('FS error'))
 
     // Act
-    await store.dispatch(deleteSelectedSkills([deleteTarget('task')]))
+    await store.dispatch(
+      deleteSelectedSkills([deleteTarget(toSkillName('task'))]),
+    )
 
     // Assert
     expect(store.getState().ui.bulkSelectMode).toBe(false)
@@ -1386,7 +1408,7 @@ describe('uiSlice bulkSelectMode on rejection', () => {
     await store.dispatch(
       unlinkSelectedFromAgent({
         agentId: 'cursor',
-        selectedNames: [unlinkTarget('task')],
+        selectedNames: [unlinkTarget(toSkillName('task'))],
       }),
     )
 
@@ -1405,7 +1427,7 @@ describe('uiSlice source filter (selectedSources)', () => {
    */
   function skillWithSource(name: string, source?: string): Skill {
     return {
-      name,
+      name: toSkillName(name),
       description: `${name} skill`,
       path: `/home/user/.agents/skills/${name}`,
       symlinkCount: toSymlinkCount(0),
@@ -1746,11 +1768,11 @@ describe('uiSlice bulk confirm dialog', () => {
     store.dispatch(
       setBulkConfirm({
         kind: 'delete',
-        skillNames: ['task'],
+        skillNames: [toSkillName('task')],
         agentId: null,
         agentName: null,
         sourceSummary: null,
-        deleteTargets: [deleteTarget('task')],
+        deleteTargets: [deleteTarget(toSkillName('task'))],
         orphanRecords: [],
         staleDeleteErrors: [],
         orphanErrors: [],
@@ -1932,7 +1954,11 @@ describe('uiSlice selectors read the live ui state', () => {
       skipped: toSymlinkCount(0),
       errors: [],
       details: [
-        { skillName: 's', agentName: 'Claude Code', action: 'created' },
+        {
+          skillName: toSkillName('s'),
+          agentName: 'Claude Code',
+          action: 'created',
+        },
       ],
     } satisfies SyncExecuteResult)
     const store = await createTestStore()
@@ -1970,7 +1996,7 @@ describe('uiSlice selectors read the live ui state', () => {
     } = await import('./uiSlice')
     store.dispatch(
       setSelectedBookmarkForDetail({
-        name: 'task',
+        name: toSkillName('task'),
         repo: repositoryId('vercel-labs/skills'),
         url: toHttpUrl('https://github.com/vercel-labs/skills'),
         bookmarkedAt: toIsoTimestamp('2026-04-01T08:00:00.000Z'),
@@ -1980,11 +2006,11 @@ describe('uiSlice selectors read the live ui state', () => {
     store.dispatch(
       setBulkConfirm({
         kind: 'delete',
-        skillNames: ['task'],
+        skillNames: [toSkillName('task')],
         agentId: null,
         agentName: null,
         sourceSummary: null,
-        deleteTargets: [deleteTarget('task')],
+        deleteTargets: [deleteTarget(toSkillName('task'))],
         orphanRecords: [],
         staleDeleteErrors: [],
         orphanErrors: [],

--- a/src/renderer/src/redux/store.test.ts
+++ b/src/renderer/src/redux/store.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { THEME_PRESETS } from '@/shared/constants'
+import { toSkillName } from '@/shared/types'
 
 import type { MigratableState } from './migrations'
 import { toggleSelection } from './slices/skillsSlice'
@@ -285,7 +286,7 @@ describe('store wiring (singleton assembly)', () => {
   it('clears the skill selection when the active tab changes (listener middleware is prepended)', async () => {
     // Arrange — tick a skill so the selection is non-empty before the context switch
     const { store } = await import('./store')
-    store.dispatch(toggleSelection('alpha-skill'))
+    store.dispatch(toggleSelection(toSkillName('alpha-skill')))
     expect(store.getState().skills.selectedSkillNames).toEqual(['alpha-skill'])
 
     // Act — switching tabs is a hard context change the cross-slice listener reacts to

--- a/src/renderer/src/utils/getLocationViewModel.test.ts
+++ b/src/renderer/src/utils/getLocationViewModel.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { AgentId, Skill, SymlinkInfo } from '@/shared/types'
-import { toSymlinkCount } from '@/shared/types'
+import { toSkillName, toSymlinkCount } from '@/shared/types'
 
 import { getLocationViewModel } from './getLocationViewModel'
 
@@ -24,7 +24,7 @@ const makeSkill = (
   symlinks: SymlinkInfo[],
   isSource = true,
 ): Skill => ({
-  name: 'foo',
+  name: toSkillName('foo'),
   description: 'foo skill',
   path,
   symlinkCount: toSymlinkCount(

--- a/src/renderer/src/utils/summarizeBulkCopyResult.test.ts
+++ b/src/renderer/src/utils/summarizeBulkCopyResult.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { PerSkillCopyOutcome } from '@/shared/types'
-import { toAgentCount } from '@/shared/types'
+import { toAgentCount, toSkillName } from '@/shared/types'
 
 import { summarizeBulkCopyResult } from './summarizeBulkCopyResult'
 
@@ -9,8 +9,12 @@ describe('summarizeBulkCopyResult', () => {
   it('reports success and lists the copied skills when every target succeeds', () => {
     // Arrange — two skills, each copied to both ticked agents
     const perSkill: PerSkillCopyOutcome[] = [
-      { skillName: 'alpha', copied: toAgentCount(2), failures: [] },
-      { skillName: 'beta', copied: toAgentCount(2), failures: [] },
+      {
+        skillName: toSkillName('alpha'),
+        copied: toAgentCount(2),
+        failures: [],
+      },
+      { skillName: toSkillName('beta'), copied: toAgentCount(2), failures: [] },
     ]
 
     // Act
@@ -27,7 +31,11 @@ describe('summarizeBulkCopyResult', () => {
   it('uses singular wording for one skill copied to one agent', () => {
     // Arrange — one skill, one ticked agent
     const perSkill: PerSkillCopyOutcome[] = [
-      { skillName: 'alpha', copied: toAgentCount(1), failures: [] },
+      {
+        skillName: toSkillName('alpha'),
+        copied: toAgentCount(1),
+        failures: [],
+      },
     ]
 
     // Act
@@ -44,9 +52,13 @@ describe('summarizeBulkCopyResult', () => {
   it('warns and lists the per-target failures when some copies fail', () => {
     // Arrange — alpha lands on the one agent, beta collides on it
     const perSkill: PerSkillCopyOutcome[] = [
-      { skillName: 'alpha', copied: toAgentCount(1), failures: [] },
       {
-        skillName: 'beta',
+        skillName: toSkillName('alpha'),
+        copied: toAgentCount(1),
+        failures: [],
+      },
+      {
+        skillName: toSkillName('beta'),
         copied: toAgentCount(0),
         failures: [{ agentId: 'codex', error: 'Already exists' }],
       },
@@ -66,9 +78,13 @@ describe('summarizeBulkCopyResult', () => {
   it('uses plural "copies" wording when several targets fail but some still copy', () => {
     // Arrange — alpha fully copies to both agents, beta collides on both
     const perSkill: PerSkillCopyOutcome[] = [
-      { skillName: 'alpha', copied: toAgentCount(2), failures: [] },
       {
-        skillName: 'beta',
+        skillName: toSkillName('alpha'),
+        copied: toAgentCount(2),
+        failures: [],
+      },
+      {
+        skillName: toSkillName('beta'),
         copied: toAgentCount(0),
         failures: [
           { agentId: 'codex', error: 'Already exists' },
@@ -93,7 +109,7 @@ describe('summarizeBulkCopyResult', () => {
     // Arrange — the one skill collides on its one target
     const perSkill: PerSkillCopyOutcome[] = [
       {
-        skillName: 'alpha',
+        skillName: toSkillName('alpha'),
         copied: toAgentCount(0),
         failures: [{ agentId: 'codex', error: 'Already exists' }],
       },
@@ -114,12 +130,12 @@ describe('summarizeBulkCopyResult', () => {
     // Arrange — both skills collide on the same single target
     const perSkill: PerSkillCopyOutcome[] = [
       {
-        skillName: 'alpha',
+        skillName: toSkillName('alpha'),
         copied: toAgentCount(0),
         failures: [{ agentId: 'codex', error: 'Already exists' }],
       },
       {
-        skillName: 'beta',
+        skillName: toSkillName('beta'),
         copied: toAgentCount(0),
         failures: [{ agentId: 'codex', error: 'Already exists' }],
       },
@@ -140,7 +156,11 @@ describe('summarizeBulkCopyResult', () => {
   it('falls back to a generic error when nothing copied and no failures were reported', () => {
     // Arrange — defensive path: a skill came back copied:0 with no failure rows
     const perSkill: PerSkillCopyOutcome[] = [
-      { skillName: 'alpha', copied: toAgentCount(0), failures: [] },
+      {
+        skillName: toSkillName('alpha'),
+        copied: toAgentCount(0),
+        failures: [],
+      },
     ]
 
     // Act

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -20,8 +20,7 @@ export type { FilePreviewKind } from './fileTypes'
 // `searchQuery` in 16. {@link repositoryId} and {@link semanticVersion} predate
 // this rule and keep their names; every new brand uses the prefix.
 //
-// `SkillName` and `AbsolutePath` are still plain aliases. They carry ~560 call
-// sites between them and are branded in follow-up passes.
+// `AbsolutePath` is still a plain alias and is branded in a follow-up pass.
 // ============================================================================
 
 /**
@@ -38,7 +37,14 @@ export type Brand<T, B extends string> = T & { readonly __brand: B }
  * Human-readable skill identifier matching the directory name.
  * @example "tdd-workflow"
  */
-export type SkillName = string
+export type SkillName = Brand<string, 'SkillName'>
+
+/**
+ * Construct a {@link SkillName} from a raw string at a trust boundary
+ * (a directory read, a scan result, or an IPC payload).
+ * @example toSkillName('tdd-workflow')
+ */
+export const toSkillName = (value: string): SkillName => value as SkillName
 
 /**
  * Absolute filesystem path (platform-native, not POSIX-normalized).


### PR DESCRIPTION
## Summary

Brands `SkillName` (`type SkillName = Brand<string, 'SkillName'>`) and routes every construction through the `toSkillName` factory. This is PR D2 of the plain-alias branding series (D1 = #325, 29 aliases; D3 = `AbsolutePath`).

Two changes ship together, both required by the same rule:

**1. The brand + its trust boundaries.** While `SkillName` was a plain alias, every place an external string became a skill's identity was invisible. The brand makes each one a compile error, so this PR names them all. Nine production files now call `toSkillName` exactly where untrusted data enters:

| Site | The untrusted input |
| --- | --- |
| `leaderboardService.parseLeaderboardHtml` | scraped skills.sh HTML |
| `skillsCliService` search parser | `npx skills` stdout |
| `redux/migrations.ts` `migrateV4ToV5` | persisted localStorage written by an older app version |
| `skillLockService.readSkillLockKeys` | the keys of the parsed lock JSON |
| `skillScanner.readSkillLock` | the `Map` keys built from lock-file entries |
| `skillScanner.scanAgentSymlinkStatusHits` | a `readdir` entry name promoted to a skill's identity |
| `dirScanner.listSourceSkillDirs` | a `readdir` Dirent name |
| `metadataParser.parseSkillMetadata` | SKILL.md frontmatter (or the directory name on a read failure) |
| `trashService.skillNameFromPathBasename` | a path basename |
| `buildSymlinkCleanupPlan.getLinkNameFromPath` | the last segment of a link path |

Lookups are branded at the call site rather than retyped: `lockEntries.get(toSkillName(basename(skill.path)))` and `sourceNames.has(toSkillName(entry.name))` both draw their keys from the same provenance class as the map's keys — a directory read or the lock JSON — so the lookups stay sound.

**2. 70 pre-existing `as SkillName` casts replaced with `toSkillName(...)`** (47 scalar, 23 array) across 15 files. `~/.claude/rules/ts-rules.md` says "MUST: Do not type cast (`as`) unless absolutely necessary" — once a real constructor exists, every cast is unnecessary by definition. 65 of the 70 sit in files this PR already touches; leaving them would put two competing construction paths in the same test file. The single remaining `as SkillName` lives inside `toSkillName` itself.

Test fixtures brand **at the seam** rather than retyping helper parameters — `staleLockNames.map(toSkillName)` inside the helper, so call sites keep passing plain string literals. Same call as D1.

Runtime behavior is unchanged: `Brand<T, B>` is `T & { readonly __brand: B }`, the factory is an identity function, and JSON round-trips are byte-identical.

`fe3188a` is a follow-up from the `/open-code-review-delegate` pass: the codemod had written `toSkillName(skillToUnlink?.skill.name ?? '')` in `UnlinkDialog.tsx`, which re-brands a value that is already a `SkillName` because the `??` widened the expression to `string`. Moved to `skill.name ?? toSkillName('')` so the factory sits on the only raw operand.

Follow-up: `AbsolutePath` (the last plain alias) in PR D3.

## Test Plan

- [x] `pnpm validate` — exit 0 (lint, test, typecheck, fallow:dead-code, fallow:dupes, fallow:health, storybook:build); 198 test files / 2617 tests
- [x] `pnpm test:e2e` — exit 0, 86 passed
- [x] `npx tsc -p tsconfig.json --noEmit` — 0 errors
- [x] `npx tsc -p e2e/tsconfig.json --noEmit` — 0 errors (e2e has its own tsconfig; `pnpm typecheck` skips it)
- [x] Re-verified typecheck + lint after lint-staged's prettier pass

`fallow:dead-code` passing is the proof that the new exported factory is reachable, not orphaned.

## Security Checklist

- [x] This change does not widen renderer access to Node.js, Electron, or direct filesystem APIs. — no renderer/preload boundary is touched; the production edits are in `src/main/services/`, two renderer pure helpers, and type definitions.
- [x] New IPC or filesystem behavior validates untrusted renderer input in the main process. — N/A: no IPC payload shape changed. The `toSkillName` calls brand values that were already being returned; no validation was added or relaxed. The brand is a compile-time marker, not a runtime check.
- [x] Dependency, workflow, or release changes preserve least-privilege permissions and pinned third-party Actions. — N/A: no dependency, workflow, or release file is modified.
- [x] Security-sensitive behavior is documented or linked from `SECURITY.md` when relevant. — N/A: type-level change, identity at runtime.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - スキル名の扱いを一貫して正規化し、スキャン、検索、ロック、ブックマーク、同期など各機能で同じ名前として正しく認識できるよう改善しました。
  - 既存データの移行時にもスキル名を適切に整えることで、保護設定や関連情報の不整合を防ぎます。
- **品質向上**
  - スキル名に関する入力や表示の整合性を高め、各種操作で予期しない照合エラーが発生しにくくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->