### PR TITLE
fix: address CodeRabbit CLI review findings across the marathon diff

### DIFF
--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -14,7 +14,7 @@ If any of these files don't exist, **proceed silently**. Don't flag their absenc
 
 Single-context repo (most repos):
 
-```
+```text
 /
 ├── CONTEXT.md
 ├── docs/adr/
@@ -25,7 +25,7 @@ Single-context repo (most repos):
 
 Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
 
-```
+```text
 /
 ├── CONTEXT-MAP.md
 ├── docs/adr/                          ← system-wide decisions

--- a/src/main/services/trashService.durability.test.ts
+++ b/src/main/services/trashService.durability.test.ts
@@ -272,12 +272,11 @@ describe('moveToTrash durability across a kill', () => {
     // Assert
     expect(moveError).toBeInstanceOf(TrashError)
     const publishedEntryNames = await readdir(sharedTrashDir)
-    expect(
-      publishedEntryNames.filter(
-        (entryName) => tombstoneIdSchema.safeParse(entryName).success,
-      ),
-    ).toHaveLength(1)
-    const publishedEntryDir = join(sharedTrashDir, publishedEntryNames[0])
+    const tombstoneNames = publishedEntryNames.filter(
+      (entryName) => tombstoneIdSchema.safeParse(entryName).success,
+    )
+    expect(tombstoneNames).toHaveLength(1)
+    const publishedEntryDir = join(sharedTrashDir, tombstoneNames[0])
     expect(existsSync(join(publishedEntryDir, 'source', 'SKILL.md'))).toBe(true)
     expect(existsSync(join(publishedEntryDir, '.manual-recovery'))).toBe(true)
     expect(moveError).toMatchObject({

--- a/src/main/services/trashService.ts
+++ b/src/main/services/trashService.ts
@@ -435,6 +435,13 @@ async function writeManifestThenPublish(
   // Rename is atomic, so a failure here leaves the staged entry intact rather
   // than a half-published tombstone.
   await fs.rename(stagingDir, entryDir)
+  // Last step, and it must stay unable to reject: past the rename the tombstone
+  // exists, so a throw here would run a rollback that assumes `stagingDir` is
+  // still whole and would report a recovery path that no longer exists.
+  // {@link fsyncPath} swallows its own failures for exactly this reason -- a
+  // flush error only weakens the power-cut guarantee, it does not undo a delete
+  // that worked. Do not make it propagate without moving this call out of the
+  // caller's try.
   await fsyncPath(TRASH_DIR)
 }
 

--- a/src/renderer/src/components/dashboard/DashboardPageTabs.tsx
+++ b/src/renderer/src/components/dashboard/DashboardPageTabs.tsx
@@ -180,10 +180,10 @@ const PageTab = function PageTab({
 }: PageTabProps): React.ReactElement {
   const dispatch = useAppDispatch()
   const renameInputRef = useRef<HTMLInputElement>(null)
-  // react-doctor-disable-next-line react-doctor/no-derived-useState -- intentional edit buffer: draftName starts from page.name then diverges during inline rename, and is re-synced when rename mode opens (useCycleEffect below).
   // Plain `string`, not {@link DashboardPageName}: a half-typed keystroke is
   // raw input, and branding it here would assert the contract on the way IN.
   // {@link commitRename} is the construction site, once the value is final.
+  // react-doctor-disable-next-line react-doctor/no-derived-useState -- intentional edit buffer: draftName starts from page.name then diverges during inline rename, and is re-synced when rename mode opens (useCycleEffect below).
   const [draftName, setDraftName] = useState<string>(page.name)
   // Controls the styled destructive-confirm dialog for page deletion.
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)

--- a/src/renderer/src/components/dashboard/DashboardPageTabs.tsx
+++ b/src/renderer/src/components/dashboard/DashboardPageTabs.tsx
@@ -181,7 +181,10 @@ const PageTab = function PageTab({
   const dispatch = useAppDispatch()
   const renameInputRef = useRef<HTMLInputElement>(null)
   // react-doctor-disable-next-line react-doctor/no-derived-useState -- intentional edit buffer: draftName starts from page.name then diverges during inline rename, and is re-synced when rename mode opens (useCycleEffect below).
-  const [draftName, setDraftName] = useState(page.name)
+  // Plain `string`, not {@link DashboardPageName}: a half-typed keystroke is
+  // raw input, and branding it here would assert the contract on the way IN.
+  // {@link commitRename} is the construction site, once the value is final.
+  const [draftName, setDraftName] = useState<string>(page.name)
   // Controls the styled destructive-confirm dialog for page deletion.
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
 
@@ -240,9 +243,7 @@ const PageTab = function PageTab({
         ref={renameInputRef}
         type="text"
         value={draftName}
-        onChange={(event) =>
-          setDraftName(toDashboardPageName(event.target.value))
-        }
+        onChange={(event) => setDraftName(event.target.value)}
         onBlur={commitRename}
         onKeyDown={(event) => {
           if (event.key === 'Enter') {

--- a/src/renderer/src/hooks/useCodePreview.browser.test.tsx
+++ b/src/renderer/src/hooks/useCodePreview.browser.test.tsx
@@ -676,6 +676,35 @@ describe('useCodePreview', () => {
     expect(result.current.activeFile).toBe(fileB.path)
   })
 
+  test("clears the previous skill's tabs when the next skill's list fails", async () => {
+    // Arrange -- the reverse order of the test below: skill B lists fine, then
+    // skill A is unreadable. `files` survives a skill switch, so a failure that
+    // left it alone would hand the caller skill B's tabs under skill A's path.
+    const fileB = makeFile({ path: toAbsolutePath('/skills/b/SKILL.md') })
+    listMock.mockImplementation(async (p) => {
+      if (p === '/outside/skills/a')
+        throw new Error('Path traversal attempt detected')
+      return [fileB]
+    })
+    readMock.mockResolvedValue(makeTextContent({ content: 'B' }))
+
+    const { useCodePreview } = await import('./useCodePreview')
+    const { result, rerender } = await renderHook(
+      (props?: { path: string }) =>
+        useCodePreview(toAbsolutePath(props?.path ?? '/skills/b')),
+      { initialProps: { path: '/skills/b' } },
+    )
+    await expect.poll(() => result.current.files).toEqual([fileB])
+
+    // Act
+    rerender({ path: '/outside/skills/a' })
+
+    // Assert
+    await expect.poll(() => result.current.loadFailed).toBe(true)
+    expect(result.current.files).toEqual([])
+    expect(result.current.activeFile).toBeNull()
+  })
+
   test("drops a previous skill's load failure when a readable skill is opened", async () => {
     // Arrange -- skill A is unreadable, skill B lists fine.
     const fileB = makeFile({ path: toAbsolutePath('/skills/b/SKILL.md') })

--- a/src/renderer/src/hooks/useCodePreview.ts
+++ b/src/renderer/src/hooks/useCodePreview.ts
@@ -132,6 +132,13 @@ export function useCodePreview(skillPath: AbsolutePath): UseCodePreviewReturn {
       if (isStaleSkill()) return
       setLoadedPath(skillPath)
       if (!listSucceeded) {
+        // Drop the PREVIOUS skill's list: `files` survives a skill switch, so
+        // without this the hook keeps returning tabs -- and an `activeFile`
+        // derived from `files[0]` -- belonging to a different skill than the
+        // one it just failed to read. The unavailable pane hides that today,
+        // but the returned state has to be honest on its own, and the arm
+        // below reasons about `files` being empty here.
+        setFiles([])
         setLoadFailed(true)
         return
       }

--- a/src/renderer/src/redux/slices/skillLockSlice.ts
+++ b/src/renderer/src/redux/slices/skillLockSlice.ts
@@ -117,9 +117,12 @@ const skillLockSlice = createSlice({
       .addCase(fetchStaleLockEntries.fulfilled, (state, action) => {
         // Superseded by a newer scan, or invalidated by a prune.
         if (action.meta.requestId !== state.scanRequestId) return
-        // This scan read the lock after the prune started writing it, so its
-        // answer outranks whatever that prune is about to report. It does not
-        // touch `pruneRequestId`: that prune still has to be able to end itself.
+        // Set unconditionally rather than only when a prune is in flight:
+        // `pruneStaleLockEntries.pending` clears the flag, so the only scans
+        // still carrying `true` are the ones that finished AFTER a prune began
+        // -- exactly the scans whose answer outranks what that prune is about
+        // to report. It does not touch `pruneRequestId`: that prune still has
+        // to be able to end itself.
         state.staleNamesSupersededByScan = true
         if (action.payload.status === 'ok') {
           state.status = 'ok'


### PR DESCRIPTION
## Summary

`coderabbit review --agent --base-commit 7c6497b` over the whole marathon range
(238 files, 99 commits, 22 merged PRs) returned **9 findings: 1 major, 3 minor,
5 trivial**. Five are fixed here; four are declined with evidence below.

### Fixed
**`useCodePreview` — clear `files` when the next skill's list rejects** (minor)
`files` survives a skill switch, so a failed load left the hook returning the
PREVIOUS skill's tabs and an `activeFile` derived from `files[0]`. Nothing
renders wrong today — `loadFailed` outranks `activeFile` in
`resolvePreviewPaneState` — but the returned state was dishonest, and the
sibling arm's comment already asserted `files` was empty here. Adds the
uncovered direction as a test (B loads, then A fails); the existing pair only
covered A-fails-then-B-loads. Mutation-verified: the test fails without the fix.

**`DashboardPageTabs` — keep the in-progress rename buffer a plain `string`** (trivial)
Branding every keystroke with `toDashboardPageName` asserts the contract on the
way *in* — the same trust inversion the `AbsolutePath` series (#325 → #327)
removed from `folder:*`. `commitRename` stays the sole construction site.

**`trashService.durability.test.ts` — index the filtered array** (minor)
The assertion filtered to tombstone-shaped names, then read `[0]` off the
*unfiltered* `readdir` result. A non-tombstone entry sorting first would have
pointed every following assertion at the wrong directory.

**`skillLockSlice` — the comment described a conditional the code doesn't have** (trivial)
`staleNamesSupersededByScan` is set unconditionally; `prune.pending` clearing it
is what makes only post-prune scans retain `true`.

**`trashService` — pin the invariant the publish rollback rests on** (hardening)
A throw after `fs.rename` would run a rollback that assumes `stagingDir` is
still whole and report a recovery path that no longer exists. `fsyncPath`
swallows its own failures for exactly that reason; nothing said so at the call
site where it matters. Comment only.

**`docs/agents/domain.md`** — language on the two opening directory-tree fences (trivial).

### Declined, each verified against current code

**F5 — the only `major`.** Replace `Object.defineProperty(window, 'electron')`
with `vi.stubGlobal`. Declined: `listener.test.ts:59`'s `beforeEach` already
does `Reflect.deleteProperty(window, 'electron')`, with a comment naming this
exact hazard — the leak is closed deterministically. And
`vi.stubGlobal('window', { electron })` would replace the whole `window`
object, breaking the five `matchMedia` stubs in the same file. The charitable
reading (`vi.stubGlobal('electron', …)`) fixes nothing the teardown doesn't,
so it is churn across nine call sites with no behavior change.

**F9 — `minor`, data-loss-shaped.** "Separate `rename` success from `fsync`
failure so a flush error doesn't trigger the caller's rollback." Declined:
**`fsyncPath` never throws.** Its entire body is a `try`/`catch` that only
warns, and `errorCode` / `extractErrorMessage` are total (a property read and
an `instanceof`). The hazard was designed out one level down, with a JSDoc
naming this reasoning. The finding read `writeManifestThenPublish` in isolation
and assumed propagation. The comment added above pins that dependency.

**F2 — `join()` → `resolve()` for `SOURCE_DIR` / `AGENTS[].path`.** Declined:
`join` already normalizes `..`, `//`, and trailing slashes for any absolute
`homedir()`, so both produce the same string. `resolve` only adds
cwd-dependence on a relative `$HOME`, and neither resolves the macOS firmlinks
that stage 3 of `isSharedAgentPath` exists to catch.

**F3 — replace `{@link tombstoneIdSchema}` with backticks.** Declined at rule
level: the repo convention mandates `{@link Symbol}` precisely because the Go
To Definition for JSDoc extension resolves unimported symbols.

## Test Plan

- [x] `pnpm validate`
- [x] `pnpm test:e2e`
- `pnpm validate` — all 7 legs pass **sequentially**: lint, typecheck,
  dead-code (0), dupes (0), health (0), storybook:build, test **198/198 files,
  2625/2625 tests**. The parallel `run-p` run flaked one untouched file
  (`agentsSlice.test.ts`, `Test timed out in 5000ms`) — passes in isolation;
  known CPU-contention flake, not a regression.
- `pnpm test:e2e` — **86/86 passed**.
- New test mutation-verified: removing `setFiles([])` fails it.
- `coderabbit review --agent --base-commit a65f5a6` on the fix delta —
  **0 findings** across all 7 changed files.

**CodeRabbit bot round 1 (`e75464b`) — 1 finding, SKIPPED (factually incorrect).**
`docs/agents/domain.md:17` "the fence opened at 17 is never closed before the
line-26 paragraph." Line 24 **is** the closing fence: no info string, length
>= the opener, which is exactly CommonMark's closing-fence rule. The diff on
this PR only adds the `text` tag to lines 17 and 28; 24 and 39 are unchanged
context. Verified against GitHub's own GFM renderer (`POST /markdown`,
`mode: gfm`) on this file: two **separate** multiline code blocks (6 lines
ending `└── src/`, 10 lines ending `└── docs/adr/`), with the
"Multi-context repo" paragraph rendered as prose outside both. The suggested
diff would insert a stray fence after line 24 and *open* a block at that
paragraph — breaking the rendering the finding meant to protect.

## Security Checklist

- [x] This change does not widen renderer access to Node.js, Electron, or direct filesystem APIs. No preload, IPC, or `contextBridge` surface is touched; `trashService.ts` is comment-only.
- [x] New IPC or filesystem behavior validates untrusted renderer input in the main process. No new IPC or filesystem behavior. `DashboardPageTabs` stops branding each keystroke, but `toDashboardPageName` is a pure cast — the real guard is `commitRename`'s `trim()` + `length > 0`, which is unchanged, and the value is renderer-local Redux state, never an IPC argument.
- [x] Dependency, workflow, or release changes preserve least-privilege permissions and pinned third-party Actions. No dependency, workflow, or release files are touched.
- [x] Security-sensitive behavior is documented or linked from `SECURITY.md` when relevant. The one data-loss-adjacent invariant (`fsyncPath` must stay unable to reject, or `writeManifestThenPublish`'s rollback reports a recovery path that no longer exists) is now pinned in a comment at the call site that depends on it. Not `SECURITY.md` material — it is a durability contract, not a trust boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - ダッシュボードのページ名変更時、入力途中の文字列をそのまま編集できるようになりました。
  - コードプレビューでファイル一覧の読み込みに失敗した場合、以前のタブや選択状態が残らず、空の状態として表示されるようになりました。
  - 古いロック情報のスキャン結果が、クリーンアップ処理中でも正しく反映されるようになりました。

- **ドキュメント**
  - リポジトリ構成例のコードブロック表示を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
