### PR TITLE
fix: exclude development artifacts from release packages

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -5,15 +5,11 @@ directories:
   output: dist
 
 files:
-  - '!website/**'
+  # Ship runtime output and the Dock icon; builder adds production dependencies.
+  - 'out/**'
+  - 'resources/icon.icns'
   - '!**/.vercel/**'
   - '!**/.env{,.*}'
-  - '!**/.vscode/*'
-  - '!src/*'
-  - '!electron.vite.config.ts'
-  - '!{.eslintignore,.eslintrc.json,.prettierrc,.env,.env.*,tsconfig.json,tsconfig.node.json}'
-  - '!{README.md,CHANGELOG.md,CONTRIBUTING.md}'
-  - '!{.github,.idea,.vscode,dev-app-update.yml,CONTRIBUTING.md}'
 
 extraResources:
   # Build resources are excluded from app files; copy offline gallery assets explicitly.

--- a/scripts/verify-packaged-backgrounds.mjs
+++ b/scripts/verify-packaged-backgrounds.mjs
@@ -232,6 +232,7 @@ async function verifyBundle(expectedArchitecture, requestedBundle) {
           packaged: app.isPackaged,
           architecture: process.arch,
           appPath: app.getAppPath(),
+          packageEntries: (await fileSystem.readdir(app.getAppPath())).sort(),
           executablePath: process.execPath,
           sharpPath,
           sharpVersion: sharp.versions.sharp,
@@ -254,6 +255,13 @@ async function verifyBundle(expectedArchitecture, requestedBundle) {
     )
     assert.equal(identity.packaged, true)
     assert.equal(identity.architecture, expectedArchitecture)
+    // A fresh QA run must never make recordings, caches or source files distributable.
+    assert.deepEqual(identity.packageEntries, [
+      'node_modules',
+      'out',
+      'package.json',
+      'resources',
+    ])
     assert.deepEqual(identity.decoded, {
       width: 1920,
       height: 1080,


### PR DESCRIPTION
## Summary

The exclusion-only packaging configuration implicitly included every workspace file. The release candidate contained QA recordings, prototypes, symbol caches and generated reports in its application archive. Limit application files to compiled output and the Dock icon while keeping production dependencies and the existing explicit background resources.

The existing packaged background smoke check now asserts the exact archive-root entries for both architectures, so future local tooling directories cannot silently enter a release.

## Test Plan

- [x] `VITEST_MAX_WORKERS=1 pnpm validate --max-parallel 1`
- [x] Following `pnpm test:e2e` — 107 tests passed.
- [x] Unsigned arm64 packaging probe: only `node_modules`, `out`, `package.json`, and `resources`; Dock icon and background resources present.
- [x] Signed/notarized arm64 and x64 packaged background smoke checks; both Gatekeeper and stapler validations passed.

## Security Checklist

- [x] Limits release contents to an explicit list; preserves environment-file and Vercel exclusions.
- [x] Keeps Main/preload/renderer permissions unchanged.
- [x] Packaging regression check uses isolated HOME/userData and both actual bundle paths.

Release follow-up to #338 for v0.31.0. The rejected candidate was not published.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * アプリ配布パッケージに必要なファイルを明示的に含めるよう調整しました。
  * macOSでDockアイコンが正しく含まれるようになりました。
  * 配布パッケージに不要な録画データ、キャッシュ、ソースファイルなどが含まれていないことを自動検証するよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
